### PR TITLE
Improve beam notehead collision

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -182,6 +182,12 @@ protected:
      */
     virtual void FilterList(ArrayOfObjects *childList);
 
+    /**
+     * Helper function to calculate overlap with layer elements that 
+     * are placed within the duration of the beam 
+     */
+    int CalcLayerOverlap(Doc *doc, int directionBias, int y1, int y2);
+
 private:
     //
 public:
@@ -205,6 +211,7 @@ public:
         m_closestNote = NULL;
         m_stem = NULL;
         m_overlapMargin = 0;
+        m_maxShortening = -1;
         m_beamRelativePlace = BEAMPLACE_NONE;
         m_partialFlagPlace = BEAMPLACE_NONE;
     }
@@ -232,6 +239,7 @@ public:
     int m_dur; // drawing duration
     int m_breaksec;
     int m_overlapMargin;
+    int m_maxShortening; // maximum allowed shortening in half units
     bool m_centered; // beam is centered on the line
     bool m_shortened; // stem is shortened because pointing oustide the staff
     data_BEAMPLACE m_beamRelativePlace;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1625,12 +1625,14 @@ public:
     {
         m_time = 0.0;
         m_duration = 0.0;
+        m_allLayersButCurrent = false;
         m_meterSig = meterSig;
         m_mensur = mensur;
         m_layer = layer;
     }
     double m_time;
     double m_duration;
+    bool m_allLayersButCurrent;
     ListOfObjects m_elements;
     MeterSig *m_meterSig;
     Mensur *m_mensur;

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -118,14 +118,16 @@ public:
     /**
      * Get the list of the layer elements for the duration of an element
      * Takes into account cross-staff situations.
+     * If excludeCurrent is specified, gets the list of layer elements for all layers except current
      */
-    ListOfObjects GetLayerElementsForTimeSpanOf(LayerElement *element);
+    ListOfObjects GetLayerElementsForTimeSpanOf(LayerElement *element, bool excludeCurrent = false);
 
     /**
      * Get the list of the layer elements used within a time span.
      * Takes into account cross-staff situations.
      */
-    ListOfObjects GetLayerElementsInTimeSpan(double time, double duration, Measure *measure, int staff);
+    ListOfObjects GetLayerElementsInTimeSpan(
+        double time, double duration, Measure *measure, int staff, bool excludeCurrent);
 
     Clef *GetCurrentClef() const;
     KeySig *GetCurrentKeySig() const;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1375,8 +1375,8 @@ int Beam::CalcLayerOverlap(Doc *doc, int directionBias, int y1, int y2)
     const int staffOffset = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const auto maxOverlap = std::max_element(elementOverlaps.begin(), elementOverlaps.end());
     int overlap = 0;
-    if (*maxOverlap > 0) {
-        overlap = *maxOverlap * directionBias;
+    if (*maxOverlap >= 0) {
+        overlap = ((*maxOverlap == 0) ? staffOffset : *maxOverlap) * directionBias;
     }
     else {
         int maxShorteningInHalfUnits = (std::abs(*maxOverlap) / staffOffset) * 2;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1272,9 +1272,12 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
     const int standardStemLen = STANDARD_STEMLENGTH * 2;
     // Check if the stem has to be shortened because outside the staff
     // In this case, Note::CalcStemLenInThirdUnits will return a value shorter than 2 * STANDARD_STEMLENGTH
-    const int stemLenInHalfUnits = m_closestNote->CalcStemLenInThirdUnits(staff) * 2 / 3;
+    int stemLenInHalfUnits = !m_maxShortening ? standardStemLen : m_closestNote->CalcStemLenInThirdUnits(staff) * 2 / 3;
     // Do not extend when not on the staff line
     if (stemLenInHalfUnits != standardStemLen) {
+        if ((m_maxShortening > 0) && ((stemLenInHalfUnits - standardStemLen) > m_maxShortening)) {
+            stemLenInHalfUnits = standardStemLen - m_maxShortening;
+        }
         this->m_shortened = true;
         extend = false;
     }
@@ -1340,6 +1343,51 @@ void BeamElementCoord::SetClosestNote(data_STEMDIRECTION stemDir)
     }
 }
 
+int Beam::CalcLayerOverlap(Doc *doc, int directionBias, int y1, int y2)
+{
+    Layer *parentLayer = vrv_cast<Layer *>(GetFirstAncestor(LAYER));
+    if (!parentLayer) return 0;
+    // Check whether there are elements on other layer in the duration of the current beam. If there are none - stop
+    // here, there's nothing to be done
+    auto collidingElementsList = parentLayer->GetLayerElementsForTimeSpanOf(this, true);
+    if (collidingElementsList.empty()) return 0;
+
+    Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
+    assert(staff);
+
+    int leftMargin = 0;
+    int rightMargin = 0;
+    std::vector<int> elementOverlaps;
+    for (auto object : collidingElementsList) {
+        LayerElement *layerElement = vrv_cast<LayerElement *>(object);
+        if (directionBias > 0) {
+            leftMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y1;
+            rightMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y2;
+        }
+        else {
+            leftMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y1;
+            rightMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y2;
+        }
+        
+        elementOverlaps.emplace_back(std::max(leftMargin * directionBias, rightMargin * directionBias));
+    }
+
+    const int staffOffset = doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const auto maxOverlap = std::max_element(elementOverlaps.begin(), elementOverlaps.end());
+    int overlap = 0;
+    if (*maxOverlap > 0) {
+        overlap = *maxOverlap * directionBias;
+    }
+    else {
+        int maxShorteningInHalfUnits = (std::abs(*maxOverlap) / staffOffset) * 2;
+        if (maxShorteningInHalfUnits > 0) --maxShorteningInHalfUnits;
+        std::for_each(m_beamSegment.m_beamElementCoordRefs.begin(), m_beamSegment.m_beamElementCoordRefs.end(),
+            [maxShorteningInHalfUnits](
+                BeamElementCoord *coord) { coord->m_maxShortening = maxShorteningInHalfUnits; });
+    }
+    return overlap;
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------
@@ -1359,10 +1407,10 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
         params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
         params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
         params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
+        params->m_overlapMargin = CalcLayerOverlap(params->m_doc, params->m_directionBias, params->m_y1, params->m_y2);
+
         return FUNCTOR_CONTINUE;
     }
-
-    // const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
 
     const int leftMargin = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam - params->m_y1;
     const int rightMargin = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam - params->m_y2;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1361,16 +1361,24 @@ int Beam::CalcLayerOverlap(Doc *doc, int directionBias, int y1, int y2)
     for (auto object : collidingElementsList) {
         LayerElement *layerElement = vrv_cast<LayerElement *>(object);
         if (directionBias > 0) {
+            // make sure that there's actual overlap first
+            if ((layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) > y1)
+                && (layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) > y2))
+                continue;
             leftMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y1;
             rightMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y2;
         }
         else {
+            // make sure that there's actual overlap first
+            if ((layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) < y1)
+                && (layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) < y2))
+                continue;
             leftMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y1;
             rightMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y2;
         }
-        
         elementOverlaps.emplace_back(std::max(leftMargin * directionBias, rightMargin * directionBias));
     }
+    if (elementOverlaps.empty()) return 0;
 
     const int staffOffset = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const auto maxOverlap = std::max_element(elementOverlaps.begin(), elementOverlaps.end());

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1407,7 +1407,8 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
         params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
         params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
         params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
-        params->m_overlapMargin = CalcLayerOverlap(params->m_doc, params->m_directionBias, params->m_y1, params->m_y2);
+        if (m_drawingPlace != BEAMPLACE_mixed)
+            params->m_overlapMargin = CalcLayerOverlap(params->m_doc, params->m_directionBias, params->m_y1, params->m_y2);
 
         return FUNCTOR_CONTINUE;
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1796,7 +1796,12 @@ int LayerElement::LayerElementsInTimeSpan(FunctorParams *functorParams)
     assert(params);
 
     Layer *currentLayer = vrv_cast<Layer *>(GetFirstAncestor(LAYER));
-    if (!currentLayer || (currentLayer != params->m_layer) || IsScoreDefElement() || Is(MREST)) return FUNCTOR_SIBLINGS;
+    // Either get layer refernced by @m_layer or all layers but it, depending on the @m_allLayersButCurrent flag
+    if ((!params->m_allLayersButCurrent && (currentLayer != params->m_layer))
+        || (params->m_allLayersButCurrent && (currentLayer == params->m_layer))) {
+        return FUNCTOR_SIBLINGS;
+    }
+    if (!currentLayer || IsScoreDefElement() || Is(MREST)) return FUNCTOR_SIBLINGS;
     if (!GetDurationInterface() || Is(MSPACE) || Is(SPACE) || HasSameasLink()) return FUNCTOR_CONTINUE;
 
     const double duration = !GetParent()->Is(CHORD)


### PR DESCRIPTION
Improved beam positioning to avoid collisions with noteheads in multi-layer situations.
If there might be overlapping elements on the other layers we do not shorten beam stems in that duration, if that's enough to avoid collision. Otherwise, we get additional offset for the beam, to avoid said elements.
Before:
![image](https://user-images.githubusercontent.com/1819669/109618090-d0225880-7b3f-11eb-9076-d73755965209.png)

After:
![image](https://user-images.githubusercontent.com/1819669/109618039-c567c380-7b3f-11eb-9944-80b85f853c59.png)


