### PR TITLE
Fix for the extreme XRel for tempo

### DIFF
--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -107,7 +107,9 @@ int Tempo::AdjustTempo(FunctorParams *functorParams)
             align->GetLeftRight(staffN, left, right);
         }
 
-        m_drawingXRels[staffN] = left - start;
+        if (std::abs(left) != std::abs(VRV_UNSET)) {
+            m_drawingXRels[staffN] = left - start;
+        }
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- fixed a problem where tempo would have VRV_UNSET as XRel, leading to all of elements being squeezed into the start of the system