### PR TITLE
Update MusicXML import

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -433,7 +433,7 @@ private:
      */
     std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
     /* stack of clef changes to be inserted to all layers of a given staff */
-    std::vector<musicxml::ClefChange> m_ClefChangeStack;
+    std::vector<musicxml::ClefChange> m_clefChangeStack;
     /* stack of new arpeggios that get more notes added. */
     std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio> > m_ArpeggioStack;
     /* a map for the measure counts storing the index of each measure created */

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -111,7 +111,8 @@ class ScoreDef : public ScoreDefElement,
                  public ObjectListInterface,
                  public AttDistances,
                  public AttEndings,
-                 public AttOptimization {
+                 public AttOptimization,
+                 public AttTimeBase {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1028,6 +1028,7 @@ void MEIOutput::WriteScoreDef(pugi::xml_node currentNode, ScoreDef *scoreDef)
     scoreDef->WriteDistances(currentNode);
     scoreDef->WriteEndings(currentNode);
     scoreDef->WriteOptimization(currentNode);
+    scoreDef->WriteTimeBase(currentNode);
 }
 
 void MEIOutput::WriteRunningElement(pugi::xml_node currentNode, RunningElement *runningElement)
@@ -3571,6 +3572,7 @@ bool MEIInput::ReadScoreDef(Object *parent, pugi::xml_node scoreDef)
     vrvScoreDef->ReadDistances(scoreDef);
     vrvScoreDef->ReadEndings(scoreDef);
     vrvScoreDef->ReadOptimization(scoreDef);
+    vrvScoreDef->ReadTimeBase(scoreDef);
 
     if (!m_hasScoreDef && m_useScoreDefForDoc) {
         m_hasScoreDef = true;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2147,17 +2147,17 @@ void MusicXmlInput::ReadMusicXmlDirection(
         hairpinNumber = (hairpinNumber < 1) ? 1 : hairpinNumber;
         if (HasAttributeWithValue(wedge->node(), "type", "stop")) {
             // match wedge type=stop to open hairpin
-            std::vector<std::pair<Hairpin *, musicxml::OpenSpanner> >::iterator iter;
-            for (iter = m_hairpinStack.begin(); iter != m_hairpinStack.end(); ++iter) {
-                if (iter->second.m_dirN == hairpinNumber) {
-                    const int measureDifference = m_measureCounts.at(measure) - iter->second.m_lastMeasureCount;
+            std::vector<std::pair<Hairpin *, musicxml::OpenSpanner> >::reverse_iterator riter;
+            for (riter = m_hairpinStack.rbegin(); riter != m_hairpinStack.rend(); ++riter) {
+                if (riter->second.m_dirN == hairpinNumber) {
+                    const int measureDifference = m_measureCounts.at(measure) - riter->second.m_lastMeasureCount;
                     if (measureDifference >= 0) {
-                        iter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
+                        riter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp - 0.5));
                     }
                     if (wedge->node().attribute("spread")) {
-                        iter->first->SetOpening(wedge->node().attribute("spread").as_double() / 5);
+                        riter->first->SetOpening(wedge->node().attribute("spread").as_double() / 5);
                     }
-                    m_hairpinStack.erase(iter);
+                    m_hairpinStack.erase(std::next(riter).base());
                     return;
                 }
             }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1696,7 +1696,7 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         }
         else if (key.child("key-step")) {
             if (!keySig) keySig = new KeySig();
-            for (pugi::xml_node keyStep : key.node().children("key-step")) {
+            for (pugi::xml_node keyStep : key.children("key-step")) {
                 KeyAccid *keyAccid = new KeyAccid();
                 keyAccid->SetPname(ConvertStepToPitchName(keyStep.text().as_string()));
                 if (std::strncmp(keyStep.next_sibling().name(), "key-alter", 9) == 0) {
@@ -3016,7 +3016,6 @@ void MusicXmlInput::ReadMusicXmlNote(
         dynam->SetPlace(dynam->AttPlacement::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         std::string dynamStr;
         for (pugi::xml_node xmlDynamPart : xmlDynam.children()) {
-            LogWarning("%s",xmlDynamPart.name());
             if (std::string(xmlDynamPart.name()) == "other-dynamics") {
                 dynamStr += xmlDynamPart.text().as_string();
             }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1631,6 +1631,14 @@ void MusicXmlInput::ReadMusicXmlAttributes(
     assert(section);
     assert(measure);
 
+    // check for changes in divisions
+    pugi::xml_node divisions = node.child("divisions");
+    if (divisions) {
+        m_ppq = divisions.text().as_int();
+        // ToDo: add proper change in MEI
+        // scoreDef->SetPpq(m_ppq);
+    }
+
     // read clef changes as MEI clef and add them to the stack
     pugi::xml_node clef = node.child("clef");
     if (clef) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -522,7 +522,7 @@ void MusicXmlInput::TextRendition(const pugi::xpath_node_set words, ControlEleme
             element->AddChild(rend);
             textParent = rend;
         }
-        else if (soundNode && !soundNode.attribute("tempo")) {
+        else if (soundNode && !(soundNode.attribute("dynamics") || soundNode.attribute("tempo"))) {
             Rend *rend = new Rend();
             rend->SetHalign(HORIZONTALALIGNMENT_right);
             element->AddChild(rend);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -480,7 +480,7 @@ std::string MusicXmlInput::GetWordsOrDynamicsText(const pugi::xml_node node) con
     if (IsElement(node, "dynamics")) {
         std::string dynamStr;
         for (pugi::xml_node xmlDynamPart : node.children()) {
-            if (xmlDynamPart.text()) {
+            if (std::string(xmlDynamPart.name()) == "other-dynamics") {
                 dynamStr += xmlDynamPart.text().as_string();
             }
             else {
@@ -3007,7 +3007,8 @@ void MusicXmlInput::ReadMusicXmlNote(
         dynam->SetPlace(dynam->AttPlacement::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         std::string dynamStr;
         for (pugi::xml_node xmlDynamPart : xmlDynam.children()) {
-            if (xmlDynamPart.text()) {
+            LogWarning("%s",xmlDynamPart.name());
+            if (std::string(xmlDynamPart.name()) == "other-dynamics") {
                 dynamStr += xmlDynamPart.text().as_string();
             }
             else {

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -146,11 +146,17 @@ MeterSig *ScoreDefElement::GetMeterSigCopy()
 //----------------------------------------------------------------------------
 
 ScoreDef::ScoreDef()
-    : ScoreDefElement("scoredef-"), ObjectListInterface(), AttDistances(), AttEndings(), AttOptimization()
+    : ScoreDefElement("scoredef-")
+    , ObjectListInterface()
+    , AttDistances()
+    , AttEndings()
+    , AttOptimization()
+    , AttTimeBase()
 {
     RegisterAttClass(ATT_DISTANCES);
     RegisterAttClass(ATT_ENDINGS);
     RegisterAttClass(ATT_OPTIMIZATION);
+    RegisterAttClass(ATT_TIMEBASE);
 
     Reset();
 }


### PR DESCRIPTION
This PR adds support for changes in `divisions` in MusicXML (and outputs it to `scoreDef@ppq`). 
Also it improves hairpin import, alignment of dynamics and brings some code improvements.