### PR TITLE
WIP:  Keep mRest duration converting from musicXML

### DIFF
--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -9,6 +9,7 @@
 #define __VRV_MREST_H__
 
 #include "atts_shared.h"
+#include "durationinterface.h"
 #include "layerelement.h"
 #include "positioninterface.h"
 
@@ -22,10 +23,10 @@ namespace vrv {
  * This class models the MEI <mRest> element.
  */
 class MRest : public LayerElement,
+              public DurationInterface,
               public PositionInterface,
               public AttColor,
               public AttCue,
-              public AttFermataPresent,
               public AttVisibility {
 public:
     /**
@@ -46,6 +47,7 @@ public:
      */
     ///@{
     virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
+    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
     ///@}
 
     //----------//

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1753,10 +1753,10 @@ void MEIOutput::WriteMRest(pugi::xml_node currentNode, MRest *mRest)
     assert(mRest);
 
     WriteLayerElement(currentNode, mRest);
+    WriteDurationInterface(currentNode, mRest);
     WritePositionInterface(currentNode, mRest);
     mRest->WriteColor(currentNode);
     mRest->WriteCue(currentNode);
-    mRest->WriteFermataPresent(currentNode);
     mRest->WriteVisibility(currentNode);
 }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2639,6 +2639,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             else {
                 MRest *mRest = new MRest();
                 element = mRest;
+                mRest->SetDurPpq(duration);
                 if (cue) mRest->SetCue(BOOLEAN_true);
                 if (!stepStr.empty()) mRest->SetPloc(ConvertStepToPitchName(stepStr));
                 if (!octaveStr.empty()) mRest->SetOloc(atoi(octaveStr.c_str()));

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -22,12 +22,12 @@ namespace vrv {
 // MRest
 //----------------------------------------------------------------------------
 
-MRest::MRest() : LayerElement("mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
+MRest::MRest() : LayerElement("mrest-"), DurationInterface(), PositionInterface(), AttColor(), AttCue(), AttVisibility()
 {
+    RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CUE);
-    RegisterAttClass(ATT_FERMATAPRESENT);
     RegisterAttClass(ATT_VISIBILITY);
 
     Reset();
@@ -38,10 +38,10 @@ MRest::~MRest() {}
 void MRest::Reset()
 {
     LayerElement::Reset();
+    DurationInterface::Reset();
     PositionInterface::Reset();
     ResetColor();
     ResetCue();
-    ResetFermataPresent();
     ResetVisibility();
 }
 


### PR DESCRIPTION
This is an attempt to solve #1453, by changing how the following XML is converted:

```xml
        <rest/>
        <duration>4</duration>
        <voice>1</voice>
        </note>
```

Currently, it doesn't seem to work ~~(The generated MEI is not having the dur.ppq set in the mRest)~~ (The generated MIDI hasn't been changed yet)

This may also need more thought with respect to https://github.com/rism-digital/verovio/issues/1568