### PR TITLE
Develop clef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for double treble clefs and additional SMuFL clefs (@rettinghaus)
 
 ## [3.3.0] - 2021-02-25
 * Support for `@glyph.name`

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -62,7 +62,7 @@ public:
     /**
      * Retrieves the appropriate SMuFL code for a data_CLEFSHAPE
      */
-    wchar_t GetClefGlyph() const;
+    wchar_t GetClefGlyph(data_NOTATIONTYPE) const;
 
     //----------//
     // Functors //

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_CLEF_H__
 #define __VRV_CLEF_H__
 
+#include "atts_externalsymbols.h"
 #include "atts_shared.h"
 #include "layerelement.h"
 
@@ -25,6 +26,7 @@ class ScoreDefInterface;
 class Clef : public LayerElement,
              public AttClefShape,
              public AttColor,
+             public AttExtSym,
              public AttLineLoc,
              public AttOctaveDisplacement,
              public AttVisibility {
@@ -61,6 +63,11 @@ public:
      * Return a clef id based on the various parameters
      */
     static int ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place);
+
+    /**
+     * Retrieves the appropriate SMuFL code for a data_CLEFSHAPE
+     */
+    wchar_t GetClefGlyph() const;
 
     //----------//
     // Functors //

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -60,11 +60,6 @@ public:
     //----------------//
 
     /**
-     * Return a clef id based on the various parameters
-     */
-    static int ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place);
-
-    /**
      * Retrieves the appropriate SMuFL code for a data_CLEFSHAPE
      */
     wchar_t GetClefGlyph() const;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -36,6 +36,7 @@ class Gliss;
 class Hairpin;
 class Harm;
 class InstrDef;
+class KeySig;
 class Label;
 class LabelAbbr;
 class Layer;
@@ -237,6 +238,14 @@ private:
      * Creates the layer if not found.
      */
     Layer *SelectLayer(int layerNb, Staff *staff);
+
+    /*
+     * @name Methods for converting the content of MusicXML attributes.
+     */
+    ///@{
+    Clef *ConvertClef(const pugi::xml_node &clef);
+    KeySig *ConvertKey(const pugi::xml_node &key);
+    ///@}
 
     /*
      * Remove the last ClassId element on top of m_elementStack.

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -194,7 +194,7 @@ private:
     void ReadMusicXmlBackup(pugi::xml_node, Measure *measure, const std::string &measureNum);
     void ReadMusicXmlBarLine(pugi::xml_node, Measure *measure, const std::string &measureNum);
     void ReadMusicXmlDirection(pugi::xml_node, Measure *measure, const std::string &measureNum, const int staffOffset);
-    void ReadMusicXmlFigures(pugi::xml_node node, Measure *measure, const std::string &measureNum);
+    void ReadMusicXmlFigures(pugi::xml_node, Measure *measure, const std::string &measureNum);
     void ReadMusicXmlForward(pugi::xml_node, Measure *measure, const std::string &measureNum);
     void ReadMusicXmlHarmony(pugi::xml_node, Measure *measure, const std::string &measureNum);
     void ReadMusicXmlNote(

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -51,7 +51,7 @@ class Tie;
 class Trill;
 
 //----------------------------------------------------------------------------
-// namespace for local MusicXml classes
+// namespace for local MusicXML classes
 //----------------------------------------------------------------------------
 
 namespace musicxml {
@@ -172,7 +172,7 @@ private:
     void ReadMusicXmlTitle(pugi::xml_node title);
 
     /*
-     * @name Top level methods for reading MusicXml part and measure elements.
+     * @name Top level methods for reading MusicXML part and measure elements.
      */
     ///@{
     bool ReadMusicXmlPart(pugi::xml_node node, Section *section, int nbStaves, int staffOffset);
@@ -181,13 +181,13 @@ private:
     ///@}
 
     /*
-     * Methods for reading the first MusicXml attributes element as MEI staffDef.
+     * Methods for reading the first MusicXML attributes element as MEI staffDef.
      * Returns the number of staves in the part.
      */
     int ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, StaffGrp *staffGrp, int staffOffset);
 
     /*
-     * @name Methods for reading the content of a MusicXml measure.
+     * @name Methods for reading the content of a MusicXML measure.
      */
     ///@{
     void ReadMusicXmlAttributes(pugi::xml_node, Section *section, Measure *measure, const std::string &measureNum);
@@ -223,7 +223,7 @@ private:
     void AddLayerElement(Layer *layer, LayerElement *element, int duration = 0);
 
     /*
-     * Returns the appropriate layer for a node looking at its MusicXml staff and voice elements.
+     * Returns the appropriate layer for a node looking at its MusicXML staff and voice elements.
      */
     Layer *SelectLayer(pugi::xml_node node, Measure *measure);
 

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -59,10 +59,15 @@ int Clef::GetClefLocOffset() const
     }
 
     int offset = 0;
-    if (GetShape() == CLEFSHAPE_G)
+    if (GetShape() == CLEFSHAPE_G) {
         offset = -4;
-    else if (GetShape() == CLEFSHAPE_F)
+    }
+    else if (GetShape() == CLEFSHAPE_GG) {
+        offset = 3;
+    }
+    else if (GetShape() == CLEFSHAPE_F) {
         offset = 4;
+    }
 
     offset += (GetLine() - 1) * 2;
 
@@ -71,6 +76,9 @@ int Clef::GetClefLocOffset() const
         disPlace = -1;
     else if (GetDisPlace() == STAFFREL_basic_below)
         disPlace = 1;
+
+    // ignore disPlace for gClef8vbOld
+    if (GetShape() == CLEFSHAPE_GG) disPlace = 0;
 
     if ((disPlace != 0) && (GetDis() != OCTAVE_DIS_NONE)) offset += (disPlace * (GetDis() - 1));
 

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -81,11 +81,6 @@ int Clef::GetClefLocOffset() const
 // Static methods for Clef
 //----------------------------------------------------------------------------
 
-int Clef::ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place)
-{
-    return place << 24 | octaveDis << 16 | line << 8 | shape;
-}
-
 wchar_t Clef::GetClefGlyph() const
 {
     // If there is glyph.num, prioritize it
@@ -99,45 +94,39 @@ wchar_t Clef::GetClefGlyph() const
         if (NULL != Resources::GetGlyph(code)) return code;
     }
 
-    wchar_t code = 0;
     // cmn clefs
-    int shapeOctaveDis = Clef::ClefId(this->GetShape(), 0, this->GetDis(), this->GetDisPlace());
-    // G clef
-    if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        code = SMUFL_E050_gClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        code = SMUFL_E052_gClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        code = SMUFL_E051_gClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        code = SMUFL_E053_gClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        code = SMUFL_E054_gClef15ma;
-    // C clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        code = SMUFL_E05C_cClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        code = SMUFL_E05D_cClef8vb;
-    else if (this->GetShape() == CLEFSHAPE_C)
-        code = SMUFL_E05C_cClef;
-    // F clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        code = SMUFL_E062_fClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        code = SMUFL_E064_fClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        code = SMUFL_E063_fClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        code = SMUFL_E065_fClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        code = SMUFL_E066_fClef15ma;
-    else if (this->GetShape() == CLEFSHAPE_F)
-        code = SMUFL_E062_fClef;
-    // Perc clef
-    else if (this->GetShape() == CLEFSHAPE_perc)
-        code = SMUFL_E069_unpitchedPercussionClef1;
+    switch (this->GetShape()) {
+        case CLEFSHAPE_G:
+            switch (this->GetDis()) {
+                case OCTAVE_DIS_8:
+                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va : SMUFL_E052_gClef8vb;
+                    break;
+                case OCTAVE_DIS_15:
+                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va : SMUFL_E051_gClef15mb;
+                    break;
+                default: return SMUFL_E050_gClef; break;
+            }
+        case CLEFSHAPE_GG: return SMUFL_E055_gClef8vbOld;
+        case CLEFSHAPE_F:
+            switch (this->GetDis()) {
+                case OCTAVE_DIS_8:
+                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E065_fClef8va : SMUFL_E064_fClef8vb;
+                    break;
+                case OCTAVE_DIS_15:
+                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E066_fClef15ma : SMUFL_E063_fClef15mb;
+                    break;
+                default: return SMUFL_E062_fClef; break;
+            }
+        case CLEFSHAPE_C:
+            switch (this->GetDis()) {
+                case OCTAVE_DIS_8: return SMUFL_E05D_cClef8vb; break;
+                default: return SMUFL_E05C_cClef; break;
+            }
+        case CLEFSHAPE_perc: return SMUFL_E069_unpitchedPercussionClef1;
+        default: break;
+    }
 
-    return code;
+    return 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -81,7 +81,7 @@ int Clef::GetClefLocOffset() const
 // Static methods for Clef
 //----------------------------------------------------------------------------
 
-wchar_t Clef::GetClefGlyph() const
+wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
 {
     // If there is glyph.num, prioritize it
     if (HasGlyphNum()) {
@@ -94,36 +94,67 @@ wchar_t Clef::GetClefGlyph() const
         if (NULL != Resources::GetGlyph(code)) return code;
     }
 
-    // cmn clefs
-    switch (this->GetShape()) {
-        case CLEFSHAPE_G:
-            switch (this->GetDis()) {
-                case OCTAVE_DIS_8:
-                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va : SMUFL_E052_gClef8vb;
-                    break;
-                case OCTAVE_DIS_15:
-                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va : SMUFL_E051_gClef15mb;
-                    break;
-                default: return SMUFL_E050_gClef; break;
+    switch (notationtype) {
+        case NOTATIONTYPE_mensural:
+            //
+            if (notationtype == NOTATIONTYPE_mensural_black) {
+                if (this->GetShape() == CLEFSHAPE_G)
+                    // G clef doesn't exist in black notation, so should never get here, but just in case.
+                    return SMUFL_E901_mensuralGclefPetrucci;
+                else if (this->GetShape() == CLEFSHAPE_F)
+                    return SMUFL_E902_chantFclef;
+                else if (this->GetShape() == CLEFSHAPE_C)
+                    return SMUFL_E906_chantCclef;
             }
-        case CLEFSHAPE_GG: return SMUFL_E055_gClef8vbOld;
-        case CLEFSHAPE_F:
-            switch (this->GetDis()) {
-                case OCTAVE_DIS_8:
-                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E065_fClef8va : SMUFL_E064_fClef8vb;
-                    break;
-                case OCTAVE_DIS_15:
-                    return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E066_fClef15ma : SMUFL_E063_fClef15mb;
-                    break;
-                default: return SMUFL_E062_fClef; break;
+            else {
+                if (this->GetShape() == CLEFSHAPE_G)
+                    return SMUFL_E901_mensuralGclefPetrucci;
+                else if (this->GetShape() == CLEFSHAPE_F)
+                    return SMUFL_E904_mensuralFclefPetrucci;
+                else if (this->GetShape() == CLEFSHAPE_C)
+                    return SMUFL_E909_mensuralCclefPetrucciPosMiddle;
             }
-        case CLEFSHAPE_C:
-            switch (this->GetDis()) {
-                case OCTAVE_DIS_8: return SMUFL_E05D_cClef8vb; break;
-                default: return SMUFL_E05C_cClef; break;
+            break;
+        case NOTATIONTYPE_neume:
+            // neume clefs
+            return (this->GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;
+            break;
+        default:
+            // cmn clefs
+            switch (this->GetShape()) {
+                case CLEFSHAPE_G:
+                    switch (this->GetDis()) {
+                        case OCTAVE_DIS_8:
+                            return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va
+                                                                                 : SMUFL_E052_gClef8vb;
+                            break;
+                        case OCTAVE_DIS_15:
+                            return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va
+                                                                                 : SMUFL_E051_gClef15mb;
+                            break;
+                        default: return SMUFL_E050_gClef; break;
+                    }
+                case CLEFSHAPE_GG: return SMUFL_E055_gClef8vbOld;
+                case CLEFSHAPE_F:
+                    switch (this->GetDis()) {
+                        case OCTAVE_DIS_8:
+                            return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E065_fClef8va
+                                                                                 : SMUFL_E064_fClef8vb;
+                            break;
+                        case OCTAVE_DIS_15:
+                            return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E066_fClef15ma
+                                                                                 : SMUFL_E063_fClef15mb;
+                            break;
+                        default: return SMUFL_E062_fClef; break;
+                    }
+                case CLEFSHAPE_C:
+                    switch (this->GetDis()) {
+                        case OCTAVE_DIS_8: return SMUFL_E05D_cClef8vb; break;
+                        default: return SMUFL_E05C_cClef; break;
+                    }
+                case CLEFSHAPE_perc: return SMUFL_E069_unpitchedPercussionClef1;
+                default: break;
             }
-        case CLEFSHAPE_perc: return SMUFL_E069_unpitchedPercussionClef1;
-        default: break;
     }
 
     return 0;

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -103,20 +103,10 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
     }
 
     switch (notationtype) {
-        case NOTATIONTYPE_mensural_black:
-            // mensural clefs
-            switch (this->GetShape()) {
-                case CLEFSHAPE_G:
-                    // G clef doesn't exist in black notation, so should never get here, but just in case.
-                    return SMUFL_E901_mensuralGclefPetrucci;
-                    break;
-                case CLEFSHAPE_F:
-                    return SMUFL_E902_chantFclef;
-                    break;
-                default:
-                    return SMUFL_E906_chantCclef;
-                    break;
-            }
+        case NOTATIONTYPE_neume:
+            // neume clefs
+            return (this->GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;
+            break;
         case NOTATIONTYPE_mensural:
         case NOTATIONTYPE_mensural_white:
             // mensural clefs
@@ -131,10 +121,18 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
                     return SMUFL_E909_mensuralCclefPetrucciPosMiddle;
                     break;
             }
-        case NOTATIONTYPE_neume:
-            // neume clefs
-            return (this->GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;
-            break;
+        case NOTATIONTYPE_mensural_black:
+            switch (this->GetShape()) {
+                case CLEFSHAPE_C:
+                    return SMUFL_E906_chantCclef;
+                    break;
+                case CLEFSHAPE_F:
+                    return SMUFL_E902_chantFclef;
+                    break;
+                default:
+                    // G clef doesn't exist in black notation, so should never get here, but just in case.
+                    if (!this->GetDis()) return SMUFL_E901_mensuralGclefPetrucci;
+            }
         default:
             // cmn clefs
             switch (this->GetShape()) {

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -99,7 +99,45 @@ wchar_t Clef::GetClefGlyph() const
         if (NULL != Resources::GetGlyph(code)) return code;
     }
 
-    return NULL;
+    wchar_t code = 0;
+    // cmn clefs
+    int shapeOctaveDis = Clef::ClefId(this->GetShape(), 0, this->GetDis(), this->GetDisPlace());
+    // G clef
+    if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+        code = SMUFL_E050_gClef;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+        code = SMUFL_E052_gClef8vb;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
+        code = SMUFL_E051_gClef15mb;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
+        code = SMUFL_E053_gClef8va;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
+        code = SMUFL_E054_gClef15ma;
+    // C clef
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+        code = SMUFL_E05C_cClef;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+        code = SMUFL_E05D_cClef8vb;
+    else if (this->GetShape() == CLEFSHAPE_C)
+        code = SMUFL_E05C_cClef;
+    // F clef
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
+        code = SMUFL_E062_fClef;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
+        code = SMUFL_E064_fClef8vb;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
+        code = SMUFL_E063_fClef15mb;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
+        code = SMUFL_E065_fClef8va;
+    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
+        code = SMUFL_E066_fClef15ma;
+    else if (this->GetShape() == CLEFSHAPE_F)
+        code = SMUFL_E062_fClef;
+    // Perc clef
+    else if (this->GetShape() == CLEFSHAPE_perc)
+        code = SMUFL_E069_unpitchedPercussionClef1;
+
+    return code;
 }
 
 //----------------------------------------------------------------------------

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -103,26 +103,34 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
     }
 
     switch (notationtype) {
-        case NOTATIONTYPE_mensural:
-            //
-            if (notationtype == NOTATIONTYPE_mensural_black) {
-                if (this->GetShape() == CLEFSHAPE_G)
+        case NOTATIONTYPE_mensural_black:
+            // mensural clefs
+            switch (this->GetShape()) {
+                case CLEFSHAPE_G:
                     // G clef doesn't exist in black notation, so should never get here, but just in case.
                     return SMUFL_E901_mensuralGclefPetrucci;
-                else if (this->GetShape() == CLEFSHAPE_F)
+                    break;
+                case CLEFSHAPE_F:
                     return SMUFL_E902_chantFclef;
-                else if (this->GetShape() == CLEFSHAPE_C)
+                    break;
+                default:
                     return SMUFL_E906_chantCclef;
+                    break;
             }
-            else {
-                if (this->GetShape() == CLEFSHAPE_G)
+        case NOTATIONTYPE_mensural:
+        case NOTATIONTYPE_mensural_white:
+            // mensural clefs
+            switch (this->GetShape()) {
+                case CLEFSHAPE_G:
                     return SMUFL_E901_mensuralGclefPetrucci;
-                else if (this->GetShape() == CLEFSHAPE_F)
+                    break;
+                case CLEFSHAPE_F:
                     return SMUFL_E904_mensuralFclefPetrucci;
-                else if (this->GetShape() == CLEFSHAPE_C)
+                    break;
+                default:
                     return SMUFL_E909_mensuralCclefPetrucciPosMiddle;
+                    break;
             }
-            break;
         case NOTATIONTYPE_neume:
             // neume clefs
             return (this->GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -29,6 +29,7 @@ Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), 
 {
     RegisterAttClass(ATT_CLEFSHAPE);
     RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_EXTSYM);
     RegisterAttClass(ATT_LINELOC);
     RegisterAttClass(ATT_OCTAVEDISPLACEMENT);
     RegisterAttClass(ATT_VISIBILITY);
@@ -43,6 +44,7 @@ void Clef::Reset()
     LayerElement::Reset();
     ResetClefShape();
     ResetColor();
+    ResetExtSym();
     ResetLineLoc();
     ResetOctaveDisplacement();
     ResetVisibility();
@@ -82,6 +84,22 @@ int Clef::GetClefLocOffset() const
 int Clef::ClefId(data_CLEFSHAPE shape, char line, data_OCTAVE_DIS octaveDis, data_STAFFREL_basic place)
 {
     return place << 24 | octaveDis << 16 | line << 8 | shape;
+}
+
+wchar_t Clef::GetClefGlyph() const
+{
+    // If there is glyph.num, prioritize it
+    if (HasGlyphNum()) {
+        wchar_t code = GetGlyphNum();
+        if (NULL != Resources::GetGlyph(code)) return code;
+    }
+    // If there is glyph.name (second priority)
+    else if (HasGlyphName()) {
+        wchar_t code = Resources::GetGlyphCode(GetGlyphName());
+        if (NULL != Resources::GetGlyph(code)) return code;
+    }
+
+    return NULL;
 }
 
 //----------------------------------------------------------------------------

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1589,6 +1589,7 @@ void MEIOutput::WriteClef(pugi::xml_node currentNode, Clef *clef)
     WriteFacsimileInterface(currentNode, clef);
     clef->WriteClefShape(currentNode);
     clef->WriteColor(currentNode);
+    clef->WriteExtSym(currentNode);
     clef->WriteLineLoc(currentNode);
     clef->WriteOctaveDisplacement(currentNode);
     clef->WriteVisibility(currentNode);
@@ -4851,6 +4852,7 @@ bool MEIInput::ReadClef(Object *parent, pugi::xml_node clef)
 
     vrvClef->ReadClefShape(clef);
     vrvClef->ReadColor(clef);
+    vrvClef->ReadExtSym(clef);
     vrvClef->ReadLineLoc(clef);
     vrvClef->ReadOctaveDisplacement(clef);
     vrvClef->ReadVisibility(clef);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1352,7 +1352,6 @@ void MEIOutput::WritePedal(pugi::xml_node currentNode, Pedal *pedal)
     pedal->WritePedalVis(currentNode);
     pedal->WritePlacement(currentNode);
     pedal->WriteVerticalGroup(currentNode);
-    pedal->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WritePhrase(pugi::xml_node currentNode, Phrase *phrase)

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1193,6 +1193,9 @@ int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(pugi::xml_node node, Sta
                 Clef *meiClef = new Clef();
                 meiClef->SetColor(clef.node().attribute("color").as_string());
                 meiClef->SetVisible(ConvertWordToBool(clef.node().attribute("print-object").as_string()));
+                if (clef.node().attribute("id")) {
+                    meiClef->SetUuid(clef.node().attribute("id").as_string());
+                }
                 meiClef->SetShape(meiClef->AttClefShape::StrToClefshape(GetContent(clefSign).substr(0, 4)));
 
                 // clef line

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1003,21 +1003,6 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         }
         m_slurStopStack.clear();
     }
-    if (!m_openDashesStack.empty()) { // open dashes without ending
-        std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter;
-        for (iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
-            LogWarning(
-                "MusicXML import: dashes/extender lines for '%s' could not be closed", iter->first->GetUuid().c_str());
-        }
-        m_openDashesStack.clear();
-    }
-    if (!m_bracketStack.empty()) { // open brackets without ending
-        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> >::iterator iter;
-        for (iter = m_bracketStack.begin(); iter != m_bracketStack.end(); ++iter) {
-            LogWarning("MusicXML import: bracketSpan for '%s' could not be closed", iter->first->GetUuid().c_str());
-        }
-        m_bracketStack.clear();
-    }
     if (!m_glissStack.empty()) {
         std::vector<Gliss *>::iterator iter;
         for (iter = m_glissStack.begin(); iter != m_glissStack.end(); ++iter) {
@@ -1342,7 +1327,22 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, int 
         i++;
     }
 
-    // clean up stack of clefs and hairpins, since we don't need them to persist between parts
+    // clean up part specific stacks
+    if (!m_openDashesStack.empty()) { // open dashes without ending
+        std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter;
+        for (iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
+            LogWarning(
+                "MusicXML import: dashes/extender lines for '%s' could not be closed", iter->first->GetUuid().c_str());
+        }
+        m_openDashesStack.clear();
+    }
+    if (!m_bracketStack.empty()) { // open brackets without ending
+        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> >::iterator iter;
+        for (iter = m_bracketStack.begin(); iter != m_bracketStack.end(); ++iter) {
+            LogWarning("MusicXML import: bracketSpan for '%s' could not be closed", iter->first->GetUuid().c_str());
+        }
+        m_bracketStack.clear();
+    }
     if (!m_clefChangeStack.empty()) {
         for (musicxml::ClefChange iter : m_clefChangeStack) {
             if (iter.isFirst)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -588,46 +588,9 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         y = staff->GetDrawingY();
         x = element->GetDrawingX();
     }
-    int sym = 0;
+    wchar_t sym = clef->GetClefGlyph();
     bool isMensural = Att::IsMensuralType(staff->m_drawingNotationType);
     bool isNeume = staff->m_drawingNotationType == NOTATIONTYPE_neume;
-
-    // cmn clefs
-    int shapeOctaveDis = Clef::ClefId(clef->GetShape(), 0, clef->GetDis(), clef->GetDisPlace());
-    // G clef
-    if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E050_gClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E052_gClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        sym = SMUFL_E051_gClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        sym = SMUFL_E053_gClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_G, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        sym = SMUFL_E054_gClef15ma;
-    // C clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E05C_cClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_C, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E05D_cClef8vb;
-    else if (clef->GetShape() == CLEFSHAPE_C)
-        sym = SMUFL_E05C_cClef;
-    // F clef
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_NONE, STAFFREL_basic_NONE))
-        sym = SMUFL_E062_fClef;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_below))
-        sym = SMUFL_E064_fClef8vb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_below))
-        sym = SMUFL_E063_fClef15mb;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_8, STAFFREL_basic_above))
-        sym = SMUFL_E065_fClef8va;
-    else if (shapeOctaveDis == Clef::ClefId(CLEFSHAPE_F, 0, OCTAVE_DIS_15, STAFFREL_basic_above))
-        sym = SMUFL_E066_fClef15ma;
-    else if (clef->GetShape() == CLEFSHAPE_F)
-        sym = SMUFL_E062_fClef;
-    // Perc clef
-    else if (clef->GetShape() == CLEFSHAPE_perc)
-        sym = SMUFL_E069_unpitchedPercussionClef1;
 
     // mensural clefs
     if (isMensural) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -588,37 +588,8 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         y = staff->GetDrawingY();
         x = element->GetDrawingX();
     }
-    wchar_t sym = clef->GetClefGlyph();
-    bool isMensural = Att::IsMensuralType(staff->m_drawingNotationType);
-    bool isNeume = staff->m_drawingNotationType == NOTATIONTYPE_neume;
 
-    // mensural clefs
-    if (isMensural) {
-        if (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black) {
-            if (sym == SMUFL_E050_gClef)
-                // G clef doesn't exist in black notation, so should never get here, but just in case.
-                sym = SMUFL_E901_mensuralGclefPetrucci;
-            else if (sym == SMUFL_E05C_cClef)
-                sym = SMUFL_E906_chantCclef;
-            else if (sym == SMUFL_E062_fClef)
-                sym = SMUFL_E902_chantFclef;
-        }
-        else {
-            if (sym == SMUFL_E050_gClef)
-                sym = SMUFL_E901_mensuralGclefPetrucci;
-            else if (sym == SMUFL_E05C_cClef)
-                sym = SMUFL_E909_mensuralCclefPetrucciPosMiddle;
-            else if (sym == SMUFL_E062_fClef)
-                sym = SMUFL_E904_mensuralFclefPetrucci;
-        }
-    }
-    // neume clefs
-    else if (isNeume) {
-        if (clef->GetShape() == CLEFSHAPE_C)
-            sym = SMUFL_E906_chantCclef;
-        else if (clef->GetShape() == CLEFSHAPE_F)
-            sym = SMUFL_E902_chantFclef;
-    }
+    wchar_t sym = clef->GetClefGlyph(staff->m_drawingNotationType);
 
     if (sym == 0) {
         clef->SetEmptyBB();


### PR DESCRIPTION
This PR: 
* adds support for `att.extSym` for clefs
* moves the clef selector from DrawClef to the object definition
* adds support for `CLEFSHAPE_GG` 
* improves clef and key import from MusicXML
* removes duplicated code from MusicXML import
* fixes error in MEI output with `@vGrp` on `pedal`