### PR TITLE
Implement --mnum-interval for frequency of automatically placed measure numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Option --mnum-interval for changing frequency of automatically-placed measure numbers (@earboxer)
 
 ## [3.3.0] - 2021-02-25
 * Support for `@glyph.name`

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -59,8 +59,6 @@ enum option_FOOTER { FOOTER_none = 0, FOOTER_auto, FOOTER_encoded, FOOTER_always
 
 enum option_HEADER { HEADER_none = 0, HEADER_auto, HEADER_encoded };
 
-enum option_MEASURENUMBER { MEASURENUMBER_system = 0, MEASURENUMBER_interval };
-
 enum option_SYSTEMDIVIDER { SYSTEMDIVIDER_none = 0, SYSTEMDIVIDER_auto, SYSTEMDIVIDER_left, SYSTEMDIVIDER_left_right };
 
 //----------------------------------------------------------------------------
@@ -105,7 +103,6 @@ public:
     static std::map<int, std::string> s_condense;
     static std::map<int, std::string> s_footer;
     static std::map<int, std::string> s_header;
-    static std::map<int, std::string> s_measureNumber;
     static std::map<int, std::string> s_systemDivider;
 
 protected:
@@ -567,7 +564,7 @@ public:
     OptionDbl m_lyricTopMinMargin;
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
-    OptionIntMap m_measureNumber;
+    OptionInt m_measureNumber;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -564,7 +564,7 @@ public:
     OptionDbl m_lyricTopMinMargin;
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
-    OptionInt m_measureNumber;
+    OptionInt m_mnumInterval;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -33,9 +33,6 @@ std::map<int, std::string> Option::s_footer
 std::map<int, std::string> Option::s_header
     = { { HEADER_none, "none" }, { HEADER_auto, "auto" }, { HEADER_encoded, "encoded" } };
 
-std::map<int, std::string> Option::s_measureNumber
-    = { { MEASURENUMBER_system, "system" }, { MEASURENUMBER_interval, "interval" } };
-
 std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" }, { SYSTEMDIVIDER_auto, "auto" },
     { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
@@ -896,8 +893,8 @@ Options::Options()
     m_measureMinWidth.Init(15, 1, 30);
     this->Register(&m_measureMinWidth, "minMeasureWidth", &m_generalLayout);
 
-    m_measureNumber.SetInfo("Measure number", "The measure numbering rule (unused)");
-    m_measureNumber.Init(MEASURENUMBER_system, &Option::s_measureNumber);
+    m_measureNumber.SetInfo("Measure Number Interval", "How frequently to place measure numbers");
+    m_measureNumber.Init(0, 0, 64, false);
     this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
 
     m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -893,9 +893,9 @@ Options::Options()
     m_measureMinWidth.Init(15, 1, 30);
     this->Register(&m_measureMinWidth, "minMeasureWidth", &m_generalLayout);
 
-    m_measureNumber.SetInfo("Measure Number Interval", "How frequently to place measure numbers");
-    m_measureNumber.Init(0, 0, 64, false);
-    this->Register(&m_measureNumber, "measureNumber", &m_generalLayout);
+    m_mnumInterval.SetInfo("Measure Number Interval", "How frequently to place measure numbers");
+    m_mnumInterval.Init(0, 0, 64, false);
+    this->Register(&m_mnumInterval, "mnumInterval", &m_generalLayout);
 
     m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation",
         "The default horizontal distance between the dots and the inner barline of a repeat barline");

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -919,8 +919,15 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
         if (mnum) {
             // this should be an option
             Measure *systemStart = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE));
-            // Draw non-generated measure numbers, and system starting measure numbers > 1.
-            if ((measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1") || !mnum->IsGenerated()) {
+
+            // Draw non-generated measure numbers
+            // If mnumInterval is 0, draw system starting measure numbers > 1,
+            // otherwise, draw every (mnumInterval)th measure number.
+            int mnumInterval = m_options->m_measureNumber.GetValue();
+            if ((mnumInterval == 0 && measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1")
+                || !mnum->IsGenerated()
+                || (mnumInterval >= 1 && (std::atoi(measure->GetN().c_str()) % mnumInterval == 0))
+            ) {
                 DrawMNum(dc, mnum, measure);
             }
         }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -923,7 +923,7 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
             // Draw non-generated measure numbers
             // If mnumInterval is 0, draw system starting measure numbers > 1,
             // otherwise, draw every (mnumInterval)th measure number.
-            int mnumInterval = m_options->m_measureNumber.GetValue();
+            int mnumInterval = m_options->m_mnumInterval.GetValue();
             if ((mnumInterval == 0 && measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1")
                 || !mnum->IsGenerated()
                 || (mnumInterval >= 1 && (std::atoi(measure->GetN().c_str()) % mnumInterval == 0))


### PR DESCRIPTION
see https://github.com/rism-digital/verovio/issues/1153#issuecomment-540940279

Examples

* `verovio --mnum-interval 1 file.mei` -- show every measure number
* `verovio --mnum-interval 10 file.mei` -- show every 10th measure number (like https://github.com/rism-digital/verovio/issues/1153#issuecomment-540050375)
* and with the value 0, it has the same behavior as master.