### PR TITLE
Develop svg ids

### DIFF
--- a/doc/verovio.conf
+++ b/doc/verovio.conf
@@ -28,13 +28,13 @@ DOXYFILE_ENCODING      = UTF-8
 # The PROJECT_NAME tag is a single word (or a sequence of words surrounded
 # by quotes) that should identify the project.
 
-PROJECT_NAME           = 
+PROJECT_NAME           = Verovio
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = develop
+PROJECT_NUMBER         = 
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description for a project that appears at the top of each page and should give viewer a quick idea about the purpose of the project. Keep the description short.
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -548,6 +548,8 @@ public:
 
     static void SeedUuid(unsigned int seed = 0);
 
+    static std::string GenerateRandUuid();
+
     static bool sortByUlx(Object *a, Object *b);
 
     //----------//

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -203,7 +203,7 @@ public:
      * Set the SVG to have 'raw' formatting, with no extraneous whitespace or newlines.
      */
     void SetFormatRaw(bool rawFormat) { m_formatRaw = rawFormat; }
-    
+
     /**
      * Removes the xlink: prefex on href attributes, necessary for some newer browsers.
      */
@@ -288,6 +288,8 @@ private:
     bool m_removeXlink;
     // indentation value (-1 for tabs)
     int m_indent;
+    // prefix to be added to font glyphs
+    std::string m_glyphPrefix;
 };
 
 } // namespace vrv

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -289,7 +289,7 @@ private:
     // indentation value (-1 for tabs)
     int m_indent;
     // prefix to be added to font glyphs
-    std::string m_glyphPrefix;
+    std::string m_glyphPostfixId;
 };
 
 } // namespace vrv

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -584,12 +584,7 @@ bool Object::DeleteChild(Object *child)
 
 void Object::GenerateUuid()
 {
-    int nr = std::rand();
-    char str[17];
-    // I do not want to use a stream for doing this!
-    snprintf(str, 17, "%016d", nr);
-
-    m_uuid = m_classid + std::string(str);
+    m_uuid = m_classid + Object::GenerateRandUuid();
 }
 
 void Object::ResetUuid()
@@ -919,6 +914,16 @@ void Object::SeedUuid(unsigned int seed)
     else {
         std::srand(seed);
     }
+}
+
+std::string Object::GenerateRandUuid()
+{
+    int nr = std::rand();
+    char str[17];
+    // I do not want to use a stream for doing this!
+    snprintf(str, 17, "%016d", nr);
+
+    return std::string(str);
 }
 
 bool Object::sortByUlx(Object *a, Object *b)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -70,7 +70,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext()
 
     m_outdata.clear();
 
-    m_glyphPrefix = Object::GenerateRandUuid();
+    m_glyphPostfixId = Object::GenerateRandUuid();
 }
 
 SvgDeviceContext::~SvgDeviceContext() {}
@@ -132,7 +132,7 @@ void SvgDeviceContext::Commit(bool xml_declaration)
 
             // copy all the nodes inside into the master document
             for (pugi::xml_node child = sourceDoc.first_child(); child; child = child.next_sibling()) {
-                std::string id = StringFormat("%s-%s", m_glyphPrefix.c_str(), child.attribute("id").value());
+                std::string id = StringFormat("%s-%s", m_glyphPostfixId.c_str(), child.attribute("id").value());
                 child.attribute("id").set_value(id.c_str());
                 defs.append_copy(child);
             }
@@ -884,7 +884,7 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");
         useChild.append_attribute(hrefAttrib.c_str())
-            = StringFormat("#%s-%s", m_glyphPrefix.c_str(), glyph->GetCodeStr().c_str()).c_str();
+            = StringFormat("#%s-%s", glyph->GetCodeStr().c_str(), m_glyphPostfixId.c_str()).c_str();
         useChild.append_attribute("x") = x;
         useChild.append_attribute("y") = y;
         useChild.append_attribute("height") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -132,7 +132,7 @@ void SvgDeviceContext::Commit(bool xml_declaration)
 
             // copy all the nodes inside into the master document
             for (pugi::xml_node child = sourceDoc.first_child(); child; child = child.next_sibling()) {
-                std::string id = StringFormat("%s-%s", m_glyphPostfixId.c_str(), child.attribute("id").value());
+                std::string id = StringFormat("%s-%s", child.attribute("id").value(), m_glyphPostfixId.c_str());
                 child.attribute("id").set_value(id.c_str());
                 defs.append_copy(child);
             }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -69,6 +69,8 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext()
     m_currentNode = m_svgNode;
 
     m_outdata.clear();
+
+    m_glyphPrefix = Object::GenerateRandUuid();
 }
 
 SvgDeviceContext::~SvgDeviceContext() {}
@@ -130,6 +132,8 @@ void SvgDeviceContext::Commit(bool xml_declaration)
 
             // copy all the nodes inside into the master document
             for (pugi::xml_node child = sourceDoc.first_child(); child; child = child.next_sibling()) {
+                std::string id = StringFormat("%s-%s", m_glyphPrefix.c_str(), child.attribute("id").value());
+                child.attribute("id").set_value(id.c_str());
                 defs.append_copy(child);
             }
         }
@@ -879,7 +883,8 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
 
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");
-        useChild.append_attribute(hrefAttrib.c_str()) = StringFormat("#%s", glyph->GetCodeStr().c_str()).c_str();
+        useChild.append_attribute(hrefAttrib.c_str())
+            = StringFormat("#%s-%s", m_glyphPrefix.c_str(), glyph->GetCodeStr().c_str()).c_str();
         useChild.append_attribute("x") = x;
         useChild.append_attribute("y") = y;
         useChild.append_attribute("height") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();


### PR DESCRIPTION
This PR adds random IDs to glyphs IDs in the SVG. So instead of
```xml
<symbol id="E050" viewBox="0 0 1000 1000" overflow="inherit">
```
we will now have 
```xml
<symbol id="0000001310519730-E050" viewBox="0 0 1000 1000" overflow="inherit">
```
This avoids conflicts when several SVG examples are included in a web-page, particularly when different fonts are being used. It used not to work and the PR fixes that particular issue.

It can be merged unless we hear against it.