### PR TITLE
always set displace 1 for GG

### DIFF
--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -133,6 +133,7 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
                     // G clef doesn't exist in black notation, so should never get here, but just in case.
                     if (!this->GetDis()) return SMUFL_E901_mensuralGclefPetrucci;
             }
+            [[fallthrough]];
         default:
             // cmn clefs
             switch (this->GetShape()) {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -299,6 +299,7 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
         else if (clef->GetDisPlace() == STAFFREL_basic_below)
             disPlace = (clef->GetDis() == OCTAVE_DIS_8) ? 1 : 2;
     }
+    if  (clef->GetShape() == CLEFSHAPE_GG) disPlace = 1;
 
     octave -= disPlace;
 


### PR DESCRIPTION
Small fix for key accidental placement with GG clefs.

fixes #2120
