### PR TITLE
Develop minor fixes

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -25,6 +25,8 @@ namespace vrv {
 #define AxGREEN 255 << 8
 #define AxCYAN 255 << 8 | 255
 #define AxLIGHT_GREY 127 << 16 | 127 << 8 | 127
+#undef max
+#undef min
 
 /*  Polygon filling mode */
 enum { AxODDEVEN_RULE = 1, AxWINDING_RULE };

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -327,6 +327,7 @@ void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], 
     int adjust = 0;
     int dotsPosition = 0;
     for (auto object : objects) {
+        if (!object->HasSelfBB()) continue;
         // if we have possible overlap with dots, we need to move tie up/down to avoid it. This happens only for the
         // outter ties, so there should be no issue of inner tie moving up and colliding with other elements
         if (object->Is(DOTS)) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -772,7 +772,7 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
     }
     else if (spanningType == SPANNING_END) {
         // We need to recalcultate the y1 when going up (we need a start note)
-        if (up and note1) {
+        if (up && note1) {
             // Make it relative to the current (end) staff
             y1 = staff->GetDrawingY() + note1->GetDrawingYRel();
         }


### PR DESCRIPTION
devicecontextbase.h and view_control.cpp and changes to fix compilation on Windows (VS). 
Point min/max methods are being confused with macros min/max, which causes compilation error.
Similarly with 'and' - by default there's is no support for alternative names, so either header needs to be added or name changed to generic &&.
tie.cpp is irrelevant to the compilation, but there are cases where object not having  BB at that point might cause crash, so this should fix that problem.