### PR TITLE
Fix for crash with multivalued artics

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -49,7 +49,7 @@ public:
      * Split the multi-valued artic attributes into distinct artic elements.
      * Applied by ConvertMarkupArtic functor.
      */
-    void SplitMultival();
+    void SplitMultival(Object *parent);
 
     void GetAllArtics(bool direction, std::vector<Artic *> &artics);
 

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -166,11 +166,6 @@ public:
     virtual int AdjustArtic(FunctorParams *functorParams);
 
     /**
-     * See Object::ConvertMarkupArtic
-     */
-    virtual int ConvertMarkupArticEnd(FunctorParams *functorParams);
-
-    /**
      * See Object::ConvertMarkupAnalytical
      */
     ///@{

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -61,11 +61,6 @@ public:
     //----------//
 
     /**
-     * See Object::ConvertMarkupArtic
-     */
-    virtual int ConvertMarkupArticEnd(FunctorParams *functorParams);
-
-    /**
      * See Object::ConvertToPageBased
      */
     virtual int ConvertToPageBased(FunctorParams *functorParams);

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1138,7 +1138,7 @@ public:
 class ConvertMarkupArticParams : public FunctorParams {
 public:
     ConvertMarkupArticParams() {}
-    std::vector<Artic *> m_articsToConvert;
+    std::vector<std::pair<Object *, Artic *> > m_articPairsToConvert;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -179,6 +179,11 @@ public:
     //----------//
     // Functors //
     //----------//
+    
+    /**
+     * See Object::ConvertMarkupArtic
+     */
+    virtual int ConvertMarkupArticEnd(FunctorParams *functorParams);
 
     /**
      * See Object::ConvertToCastOffMensural

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -253,11 +253,6 @@ public:
     virtual int ConvertMarkupAnalytical(FunctorParams *functorParams);
 
     /**
-     * See Object::ConvertMarkupArtic
-     */
-    virtual int ConvertMarkupArticEnd(FunctorParams *functorParams);
-
-    /**
      * See Object::CalcArtic
      */
     virtual int CalcArtic(FunctorParams *functorParams);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -9,6 +9,7 @@
 #define __VRV_DEF_H__
 
 #include <algorithm>
+#include <functional>
 #include <list>
 #include <map>
 #include <vector>

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -74,9 +74,8 @@ data_ARTICULATION Artic::GetArticFirst()
     return articList.front();
 }
 
-void Artic::SplitMultival()
+void Artic::SplitMultival(Object *parent)
 {
-    Object *parent = this->GetParent();
     assert(parent);
 
     std::vector<data_ARTICULATION> articList = this->GetArtic();
@@ -279,7 +278,7 @@ int Artic::ConvertMarkupArtic(FunctorParams *functorParams)
     ConvertMarkupArticParams *params = vrv_params_cast<ConvertMarkupArticParams *>(functorParams);
     assert(params);
 
-    if (this->GetArtic().size() > 1) params->m_articsToConvert.push_back(this);
+    if (this->GetArtic().size() > 1) params->m_articPairsToConvert.emplace_back(std::make_pair(GetParent(), this));
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -523,19 +523,6 @@ int Chord::ConvertMarkupAnalyticalEnd(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Chord::ConvertMarkupArticEnd(FunctorParams *functorParams)
-{
-    ConvertMarkupArticParams *params = vrv_params_cast<ConvertMarkupArticParams *>(functorParams);
-    assert(params);
-
-    for (auto &artic : params->m_articsToConvert) {
-        artic->SplitMultival();
-    }
-    params->m_articsToConvert.clear();
-
-    return FUNCTOR_CONTINUE;
-}
-
 int Chord::CalcArtic(FunctorParams *functorParams)
 {
     CalcArticParams *params = vrv_params_cast<CalcArticParams *>(functorParams);

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -107,19 +107,6 @@ bool EditorialElement::IsSupportedChild(Object *child)
 // EditorialElement functor methods
 //----------------------------------------------------------------------------
 
-int EditorialElement::ConvertMarkupArticEnd(FunctorParams *functorParams)
-{
-    ConvertMarkupArticParams *params = vrv_params_cast<ConvertMarkupArticParams *>(functorParams);
-    assert(params);
-
-    for (auto &artic : params->m_articsToConvert) {
-        artic->SplitMultival();
-    }
-    params->m_articsToConvert.clear();
-
-    return FUNCTOR_CONTINUE;
-}
-
 int EditorialElement::ConvertToPageBased(FunctorParams *functorParams)
 {
     ConvertToPageBasedParams *params = vrv_params_cast<ConvertToPageBasedParams *>(functorParams);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -490,6 +490,19 @@ void Layer::SetDrawingCautionValues(StaffDef *currentStaffDef)
 // Layer functor methods
 //----------------------------------------------------------------------------
 
+int Layer::ConvertMarkupArticEnd(FunctorParams *functorParams)
+{
+    ConvertMarkupArticParams *params = vrv_params_cast<ConvertMarkupArticParams *>(functorParams);
+    assert(params);
+
+    for (auto &[parent, artic] : params->m_articPairsToConvert) {
+        artic->SplitMultival(parent);
+    }
+    params->m_articPairsToConvert.clear();
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Layer::ConvertToCastOffMensural(FunctorParams *functorParams)
 {
     ConvertToCastOffMensuralParams *params = vrv_params_cast<ConvertToCastOffMensuralParams *>(functorParams);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -802,19 +802,6 @@ int Note::ConvertMarkupAnalytical(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Note::ConvertMarkupArticEnd(FunctorParams *functorParams)
-{
-    ConvertMarkupArticParams *params = vrv_params_cast<ConvertMarkupArticParams *>(functorParams);
-    assert(params);
-
-    for (auto &artic : params->m_articsToConvert) {
-        artic->SplitMultival();
-    }
-    params->m_articsToConvert.clear();
-
-    return FUNCTOR_CONTINUE;
-}
-
 int Note::CalcArtic(FunctorParams *functorParams)
 {
     CalcArticParams *params = vrv_params_cast<CalcArticParams *>(functorParams);


### PR DESCRIPTION
Fix for another crash in #2106

Crash was happening due to adding artic to note/chord, while we were processing their children in Proces():
https://github.com/rism-digital/verovio/blob/d6dadf7f280f5b5207f9aef8cb353de8d8c411ce/src/object.cpp#L853-L858
This led to iterator invalidation and caused a crash. I've moved ConvertMarkupArticEnd() to the Layer class, so that we can process artics after we've gone through all notes/chords in the layer and can safely process them.

Renders just fine:
![image](https://user-images.githubusercontent.com/1819669/114720289-92b90980-9d40-11eb-8511-37fcf8c3004f.png)
