### PR TITLE
Fix for the spanning hairpins touching barlines

### DIFF
--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -77,7 +77,7 @@ public:
      * Get left/right adjustments that needs to be done to the hairpin with set coordinates (leftX, rightX) for it not
      * to overlap with parent measure's barlines
      */
-    std::pair<int, int> GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX);
+    std::pair<int, int> GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX, int spanningType);
 
     //----------//
     // Functors //

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -186,13 +186,14 @@ std::pair<int, int> Hairpin::GetBarlineOverlapAdjustment(int doubleUnit, int lef
     if (spanningType == SPANNING_START_END || spanningType == SPANNING_END) {
         rightBarline = endMeasure->GetRightBarLine();
     }
-    else if (spanningType == SPANNING_START)
-    {
+    else if (spanningType == SPANNING_START) {
         System *startSystem = vrv_cast<System *>(GetStart()->GetFirstAncestor(SYSTEM));
-        ClassIdComparison cmp(MEASURE);
-        Measure *measure
-            = vrv_cast<Measure *>(startSystem->FindDescendantByComparison(&cmp, UNLIMITED_DEPTH, BACKWARD));
-        if (measure) rightBarline = measure->GetRightBarLine();
+        if (startSystem) {
+            ClassIdComparison cmp(MEASURE);
+            Measure *measure
+                = vrv_cast<Measure *>(startSystem->FindDescendantByComparison(&cmp, UNLIMITED_DEPTH, BACKWARD));
+            if (measure) rightBarline = measure->GetRightBarLine();
+        }
     }
     if (rightBarline) {
         int margin = doubleUnit;
@@ -203,8 +204,6 @@ std::pair<int, int> Hairpin::GetBarlineOverlapAdjustment(int doubleUnit, int lef
         }
         if (diff < margin) rightAdjustment = margin - diff;
     }
-
-    
 
     return { leftAdjustment, rightAdjustment };
 }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -524,14 +524,13 @@ void View::DrawHairpin(
     }
 
     // Store the full drawing length
-    if (spanningType == SPANNING_START_END) {
-        const auto [leftOverlap, rightOverlap]
-            = hairpin->GetBarlineOverlapAdjustment(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize), x1, x2);
-        x1 += leftOverlap;
-        x2 -= rightOverlap;
+    const auto [leftOverlap, rightOverlap] = hairpin->GetBarlineOverlapAdjustment(
+        m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize), x1, x2, spanningType);
+    x1 += leftOverlap;
+    x2 -= rightOverlap;
 
-        hairpin->SetDrawingLength(x2 - x1);
-    }
+    hairpin->SetDrawingLength(x2 - x1);
+
 
     hairpinLog_FORM form = hairpin->GetForm();
 


### PR DESCRIPTION
closes #1938 
- fixed code for hairpins to take into account spanningType and adjust accordingly

![image](https://user-images.githubusercontent.com/1819669/114867429-7c24b800-9dfd-11eb-8eef-d4b7f275b65c.png)
