### PR TITLE
Add handling of the other layer elements for beam collision

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -173,6 +173,7 @@ public:
         m_directionBias = 0;
         m_overlapMargin = 0;
         m_doc = doc;
+        m_isOtherLayer = false;
     }
 
     Object *m_beam;
@@ -181,6 +182,7 @@ public:
     int m_directionBias;
     int m_overlapMargin;
     Doc *m_doc;
+    bool m_isOtherLayer;
 };
 
 //----------------------------------------------------------------------------

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1441,6 +1441,20 @@ int Beam::AdjustBeamsEnd(FunctorParams *functorParams)
 
     if (params->m_beam != this) return FUNCTOR_CONTINUE;
 
+    Layer *parentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+    if (parentLayer) {
+        // find elements on the other layers for the duration of the current beam
+        auto otherLayersElements = parentLayer->GetLayerElementsForTimeSpanOf(this, true);
+        if (!otherLayersElements.empty()) {
+            // call AdjustBeams separately for each element to find possible overlaps
+            params->m_isOtherLayer = true;
+            for (auto element : otherLayersElements) {
+                element->AdjustBeams(params);
+            }
+            params->m_isOtherLayer = false;
+        }
+    }
+
     // set overlap margin for each coord in the beam
     if (params->m_overlapMargin) {
         std::for_each(m_beamSegment.m_beamElementCoordRefs.begin(), m_beamSegment.m_beamElementCoordRefs.end(),

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1300,7 +1300,9 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     assert(params);
 
     // ignore elements that are not in the beam or are direct children of the beam
-    if (!params->m_beam || (Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam) && !IsGraceNote()))
+    if (!params->m_beam
+        || (!params->m_isOtherLayer && Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam)
+            && !IsGraceNote()))
         return FUNCTOR_SIBLINGS;
     if (Is({ GRACEGRP, TUPLET, TUPLET_NUM, TUPLET_BRACKET, BTREM })) return FUNCTOR_CONTINUE;
 
@@ -1311,20 +1313,25 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
     int leftMargin = 0, rightMargin = 0;
 
+    Beam *beam = vrv_cast<Beam *>(params->m_beam);
     if (params->m_directionBias > 0) {
-        leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1;
-        rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
+        leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
+            + (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+        rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
+            + (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
     }
     else {
-        leftMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1;
-        rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2;
+        leftMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
+            - (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+        rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
+            - (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
     }
 
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin
-            = (((overlapMargin + staffOffset - 1) / staffOffset + 1) * staffOffset) * params->m_directionBias;
+            = (((overlapMargin + staffOffset - 1) / staffOffset + 1.5) * staffOffset) * params->m_directionBias;
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- added logic to consider overlaps with elements from other layers in span of the beam

Before:
![image](https://user-images.githubusercontent.com/1819669/114892366-615e3d80-9e15-11eb-9295-3b85d0c37195.png)

After:
![image](https://user-images.githubusercontent.com/1819669/114891887-f1e84e00-9e14-11eb-9963-e03f5de1d2f2.png)

<details><summary>Example:</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-04-06" type="encoding-date">2021-04-06</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000000000026537">
         <appInfo xml:id="appinfo-0000000000002458">
            <application xml:id="application-0000000000026902" isodate="2021-04-12T11:24:50" version="3.4.0-dev-[undefined]">
               <name xml:id="name-0000000000017000">Verovio</name>
               <p xml:id="p-0000000000014354">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000000022374">
            <score xml:id="score-0000000000010470">
               <scoreDef xml:id="scoredef-0000000000015169">
                  <staffGrp xml:id="staffgrp-0000000000024338">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="2">
                        <label xml:id="label-0000000000000972">Piano</label>
                        <labelAbbr xml:id="labelAbbr-0000000000024076">Pno.</labelAbbr>
                        <instrDef xml:id="instrdef-0000000000000752" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="clef-0000000000007604" shape="G" line="2" />
                        <keySig xml:id="keysig-0000000000022815" sig="0" />
                        <meterSig xml:id="msig-0000000000022412" count="2" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000000021666">
                  <pb xml:id="pb-0000000000009385" />
                  <measure xml:id="measure-0000000000002600" n="1">
                     <staff xml:id="staff-0000000000019243" n="1">
                        <layer xml:id="layer-0000000000011697" n="1">
                           <beam xml:id="beam-0000000000012970">
                              <chord xml:id="chord-0000000000009513" dur.ppq="1" dur="16" stem.dir="up">
                                 <note xml:id="note-0000000000007950" oct="3" pname="b" />
                                 <note xml:id="note-0000000000014706" oct="4" pname="b" />
                              </chord>
                              <chord xml:id="chord-0000000000000169" dur.ppq="1" dur="16" stem.dir="up">
                                 <note xml:id="note-0000000000012154" oct="3" pname="b" />
                                 <note xml:id="note-0000000000020337" oct="4" pname="b" />
                              </chord>
                           </beam>
                           <beam xml:id="beam-0000000000018318">
                              <chord xml:id="chord-0000000000019848" dur.ppq="1" dur="16" stem.dir="up">
                                 <note xml:id="note-0000000000028554" oct="3" pname="b" />
                                 <note xml:id="note-0000000000023788" oct="4" pname="b" />
                              </chord>
                              <chord xml:id="chord-0000000000029237" dur.ppq="1" dur="16" stem.dir="up">
                                 <note xml:id="note-0000000000028953" oct="3" pname="b" />
                                 <note xml:id="note-0000000000026598" oct="4" pname="b" />
                              </chord>
                           </beam>
                        </layer>
                        <layer xml:id="layer-0000000000017909" n="2">
                           <beam xml:id="beam-0000000000012242">
                              <note xml:id="note-0000000000025033" dur.ppq="1" dur="16" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="note-0000000000018985" dur.ppq="1" dur="16" oct="4" pname="a" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000000000028523">
                              <note xml:id="note-0000000000006382" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="down" />
                              <note xml:id="note-0000000000029499" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef xml:id="scoredef-0000000000010092">
                     <meterSig xml:id="msig-0000000000017614" count="4" unit="4" />
                  </scoreDef>
                  <measure xml:id="measure-0000000000014277" right="end" n="2">
                     <staff xml:id="staff-0000000000007794" n="1">
                        <layer xml:id="layer-0000000000023716" n="1">
                           <beam xml:id="beam-0000000000014943">
                              <note xml:id="note-0000000000004582" dur.ppq="1" dur="16" oct="4" pname="c" stem.dir="up" />
                              <note xml:id="note-0000000000022490" dur.ppq="1" dur="16" oct="4" pname="d" stem.dir="up" />
                              <note xml:id="note-0000000000001109" dur.ppq="1" dur="16" oct="4" pname="e" stem.dir="up" />
                              <note xml:id="note-0000000000006159" dur.ppq="1" dur="16" oct="4" pname="f" stem.dir="up" />
                           </beam>
                           <beam xml:id="beam-0000000000005330">
                              <note xml:id="note-0000000000011363" dur.ppq="1" dur="16" oct="4" pname="g" stem.dir="up" />
                              <note xml:id="note-0000000000023312" dur.ppq="1" dur="16" oct="4" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000000021021" dur.ppq="1" dur="16" oct="4" pname="b" stem.dir="up" />
                              <note xml:id="note-0000000000031277" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer xml:id="layer-0000000000022279" n="2">
                           <beam xml:id="beam-0000000000002891">
                              <note xml:id="note-0000000000028726" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="down" />
                              <note xml:id="note-0000000000021952" dur.ppq="1" dur="16" oct="5" pname="d" stem.dir="down" />
                              <note xml:id="note-0000000000023541" dur.ppq="1" dur="16" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0000000000002503" dur.ppq="1" dur="16" oct="5" pname="f" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000000000020522">
                              <note xml:id="note-0000000000006634" dur.ppq="1" dur="16" oct="5" pname="g" stem.dir="down" />
                              <note xml:id="note-0000000000000165" dur.ppq="1" dur="16" oct="5" pname="a" stem.dir="down" />
                              <note xml:id="note-0000000000028785" dur.ppq="1" dur="16" oct="5" pname="b" stem.dir="down" />
                              <note xml:id="note-0000000000009538" dur.ppq="1" dur="16" oct="6" pname="c" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>