### PR TITLE
Adjust arpeggio positioning

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -150,6 +150,11 @@ public:
      * If staffN is provided, uses the AlignmentReference->GetN() to accelerate the search.
      */
     AlignmentReference *GetReferenceWithElement(LayerElement *element, int staffN = VRV_UNSET);
+    
+    /**
+     * Return pair of max and min Y value within alignment. Elements will be counted by alignment references. 
+     */
+    std::pair<int, int> GetAlignmentTopBottom();
 
     /**
      * Add an accidental to the accidSpace of the AlignmentReference holding it.

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -903,19 +903,21 @@ int Alignment::AdjustArpeg(FunctorParams *functorParams)
             ArrayOfAdjustmentTuples boundaries{ std::make_tuple(this, std::get<0>(*iter), adjust) };
             params->m_measureAligner->AdjustProportionally(boundaries);
             // After adjusting, make sure that arpeggio does not overlap with elements from the previous alignment
-            auto [currentMin, currentMax] = GetAlignmentTopBottom();
-            Note *topNote = NULL;
-            Note *bottomNote = NULL;
-            std::get<1>(*iter)->GetDrawingTopBottomNotes(topNote, bottomNote);
-            if (topNote && bottomNote) {
-                const int arpegMax = topNote->GetDrawingY() + drawingUnit / 2;
-                const int arpegMin = bottomNote->GetDrawingY() - drawingUnit / 2;
-                // Make sure that there is vertical overlap, otherwise do not shift arpeggo
-                if (((currentMin < arpegMin) && (currentMax > arpegMin))
-                    || ((currentMax > arpegMax) && (currentMin < arpegMax))) {
-                    std::get<0>(*iter)->SetXRel(std::get<0>(*iter)->GetXRel() + overlap + drawingUnit / 2);
+            if (m_type == ALIGNMENT_CLEF) {
+                auto [currentMin, currentMax] = GetAlignmentTopBottom();
+                Note *topNote = NULL;
+                Note *bottomNote = NULL;
+                std::get<1>(*iter)->GetDrawingTopBottomNotes(topNote, bottomNote);
+                if (topNote && bottomNote) {
+                    const int arpegMax = topNote->GetDrawingY() + drawingUnit / 2;
+                    const int arpegMin = bottomNote->GetDrawingY() - drawingUnit / 2;
+                    // Make sure that there is vertical overlap, otherwise do not shift arpeggo
+                    if (((currentMin < arpegMin) && (currentMax > arpegMin))
+                        || ((currentMax > arpegMax) && (currentMin < arpegMax))) {
+                        std::get<0>(*iter)->SetXRel(std::get<0>(*iter)->GetXRel() + overlap + drawingUnit / 2);
+                    }
                 }
-            }       
+            }
         }
 
         // We can remove it from the list

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -626,6 +626,27 @@ AlignmentReference *Alignment::GetReferenceWithElement(LayerElement *element, in
     return reference;
 }
 
+std::pair<int, int> Alignment::GetAlignmentTopBottom()
+{
+    int max = VRV_UNSET, min = VRV_UNSET;
+    // Iterate over each element in each alignment reference and find max/min Y value - these will serve as top/bottom
+    // values for the Alignment
+    for (auto child : *GetChildren()) {
+        AlignmentReference *reference = dynamic_cast<AlignmentReference *>(child);
+        for (auto element : *reference->GetChildren()) {
+            const int top = element->GetSelfTop();
+            if ((VRV_UNSET == max) || (top > max)) {
+                max = top;
+            }
+            const int bottom = element->GetSelfBottom();
+            if ((VRV_UNSET == min) || (bottom < min)) {
+                min = bottom;
+            }
+        }
+    }
+    return {min, max};
+}
+
 void Alignment::AddToAccidSpace(Accid *accid)
 {
     assert(accid);
@@ -873,13 +894,28 @@ int Alignment::AdjustArpeg(FunctorParams *functorParams)
             continue;
         }
 
-        int overlap = maxRight - std::get<1>(*iter)->GetCurrentFloatingPositioner()->GetSelfLeft();
+        const int overlap = maxRight - std::get<1>(*iter)->GetCurrentFloatingPositioner()->GetSelfLeft();
+        const int drawingUnit = params->m_doc->GetDrawingUnit(100);
         // HARDCODED
-        overlap += params->m_doc->GetDrawingUnit(100) / 2 * 3;
+        int adjust = overlap + drawingUnit / 2 * 3;
         // LogDebug("maxRight %d, %d %d", maxRight, std::get<2>(*iter), overlap);
-        if (overlap > 0) {
-            ArrayOfAdjustmentTuples boundaries{ std::make_tuple(this, std::get<0>(*iter), overlap) };
+        if (adjust > 0) {
+            ArrayOfAdjustmentTuples boundaries{ std::make_tuple(this, std::get<0>(*iter), adjust) };
             params->m_measureAligner->AdjustProportionally(boundaries);
+            // After adjusting, make sure that arpeggio does not overlap with elements from the previous alignment
+            auto [currentMin, currentMax] = GetAlignmentTopBottom();
+            Note *topNote = NULL;
+            Note *bottomNote = NULL;
+            std::get<1>(*iter)->GetDrawingTopBottomNotes(topNote, bottomNote);
+            if (topNote && bottomNote) {
+                const int arpegMax = topNote->GetDrawingY() + drawingUnit / 2;
+                const int arpegMin = bottomNote->GetDrawingY() - drawingUnit / 2;
+                // Make sure that there is vertical overlap, otherwise do not shift arpeggo
+                if (((currentMin < arpegMin) && (currentMax > arpegMin))
+                    || ((currentMax > arpegMax) && (currentMin < arpegMax))) {
+                    std::get<0>(*iter)->SetXRel(std::get<0>(*iter)->GetXRel() + overlap + drawingUnit / 2);
+                }
+            }       
         }
 
         // We can remove it from the list


### PR DESCRIPTION
Improvement for arpeggio positioning to avoid overlaps with elements from previous alignments.

Before:
![image](https://user-images.githubusercontent.com/1819669/115570203-99a6c580-a2c6-11eb-9eb5-b340287dcd34.png)

After:
![image](https://user-images.githubusercontent.com/1819669/115569602-0ff6f800-a2c6-11eb-961d-24f775a06c61.png)

<details><summary>MEI example:</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-04-01" type="encoding-date">2021-04-01</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000000000014575">
         <appInfo xml:id="appinfo-0000000000005094">
            <application xml:id="application-0000000000022354" isodate="2021-04-19T15:48:28" version="3.4.0-dev-[undefined]">
               <name xml:id="name-0000000000031239">Verovio</name>
               <p xml:id="p-0000000000019751">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000000023417">
            <score xml:id="score-0000000000011554">
               <scoreDef xml:id="scoredef-0000000000010233">
                  <staffGrp xml:id="staffgrp-0000000000032012">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="label-0000000000021622">Piano</label>
                        <labelAbbr xml:id="labelAbbr-0000000000019811">Pno.</labelAbbr>
                        <instrDef xml:id="instrdef-0000000000004887" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="clef-0000000000007253" shape="G" line="2" />
                        <keySig xml:id="keysig-0000000000030847" sig="3f" />
                        <meterSig xml:id="msig-0000000000021587" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000000018241">
                  <pb xml:id="pb-0000000000031939" />
                  <measure xml:id="measure-0000000000015635" n="1">
                     <staff xml:id="staff-0000000000017203" n="1">
                        <layer xml:id="layer-0000000000026038" n="1">
                           <note xml:id="note-0000000000019447" dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up" />
                           <clef xml:id="clef-0000000000027144" shape="F" line="4" />
                           <chord xml:id="chord-0000000000003953" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000011973" oct="4" pname="g" />
                              <note xml:id="note-0000000000027451" oct="5" pname="e" accid.ges="f" />
                           </chord>
                           <clef xml:id="clef-0000000000026084" shape="G" line="2" />
                           <note xml:id="note-0000000000030014" dur.ppq="1" dur="4" oct="3" pname="f" stem.dir="up" />
                           <clef xml:id="clef-0000000000015170" shape="C" line="3" />
                           <chord xml:id="chord-0000000000026142" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000029804" oct="4" pname="a" accid.ges="f" />
                              <note xml:id="note-0000000000028012" oct="5" pname="d" />
                           </chord>
                           <clef xml:id="clef-0000000000006105" shape="G" line="2" />
                        </layer>
                     </staff>
                     <arpeg xml:id="arpeg-0000000000032183" plist="#chord-0000000000003953" />
                     <arpeg xml:id="arpeg-0000000000023933" plist="#chord-0000000000026142" />
                  </measure>
                  <measure xml:id="measure-0000000000027691" n="2">
                     <staff xml:id="staff-0000000000005769" n="1">
                        <layer xml:id="layer-0000000000020032" n="1">
                           <note xml:id="note-0000000000016825" dur.ppq="1" dur="4" oct="3" pname="g" stem.dir="up" />
                           <clef xml:id="clef-0000000000004658" shape="C" line="4" />
                           <chord xml:id="chord-0000000000023626" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000004940" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0000000000024354" oct="5" pname="c" />
                           </chord>
                           <clef xml:id="clef-0000000000029605" shape="G" line="2" />
                           <note xml:id="note-0000000000011846" dur.ppq="1" dur="4" oct="3" pname="a" stem.dir="up" accid.ges="f" />
                           <clef xml:id="clef-0000000000012521" shape="G" line="2" dis="8" dis.place="below" />
                           <chord xml:id="chord-0000000000017181" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000010183" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0000000000018114" oct="5" pname="c" />
                           </chord>
                           <clef xml:id="clef-0000000000009977" shape="G" line="2" />
                        </layer>
                     </staff>
                     <arpeg xml:id="arpeg-0000000000007572" plist="#chord-0000000000023626" />
                     <arpeg xml:id="arpeg-0000000000015973" plist="#chord-0000000000017181" />
                  </measure>
                  <measure xml:id="measure-0000000000016572" n="3">
                     <staff xml:id="staff-0000000000015467" n="1">
                        <layer xml:id="layer-0000000000017994" n="1">
                           <note xml:id="note-0000000000029210" dur.ppq="1" dur="4" oct="3" pname="g" stem.dir="up" />
                           <clef xml:id="clef-0000000000007507" shape="C" line="1" />
                           <chord xml:id="chord-0000000000023202" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000027612" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0000000000026261" oct="5" pname="c" />
                           </chord>
                           <clef xml:id="clef-0000000000023398" shape="G" line="2" />
                           <note xml:id="note-0000000000015736" dur.ppq="1" dur="4" oct="3" pname="g" stem.dir="up" />
                           <clef xml:id="clef-0000000000001958" shape="C" line="5" />
                           <chord xml:id="chord-0000000000018720" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000000542" oct="4" pname="f" />
                              <note xml:id="note-0000000000001523" oct="4" pname="b">
                                 <accid xml:id="accid-0000000000026614" accid="n" />
                              </note>
                           </chord>
                           <clef xml:id="clef-0000000000014737" shape="G" line="2" />
                        </layer>
                     </staff>
                     <arpeg xml:id="arpeg-0000000000023367" plist="#chord-0000000000023202" />
                     <arpeg xml:id="arpeg-0000000000019593" plist="#chord-0000000000018720" />
                  </measure>
                  <measure xml:id="measure-0000000000019351" right="end" n="4">
                     <staff xml:id="staff-0000000000000033" n="1">
                        <layer xml:id="layer-0000000000009133" n="1">
                           <note xml:id="note-0000000000020354" dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up" />
                           <clef xml:id="clef-0000000000017716" shape="F" line="4" dis="8" dis.place="below" />
                           <chord xml:id="chord-0000000000006655" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="note-0000000000004475" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0000000000024135" oct="5" pname="c" />
                           </chord>
                           <clef xml:id="clef-0000000000024735" shape="G" line="2" dis="15" dis.place="below" />
                           <chord xml:id="chord-0000000000007400" dur.ppq="2" dur="2" stem.dir="down">
                              <note xml:id="note-0000000000022505" oct="5" pname="e">
                                 <accid xml:id="accid-0000000000011464" accid="n" />
                              </note>
                              <note xml:id="note-0000000000024922" oct="5" pname="g" />
                           </chord>
                        </layer>
                     </staff>
                     <arpeg xml:id="arpeg-0000000000027831" plist="#chord-0000000000006655" />
                     <arpeg xml:id="arpeg-0000000000025467" plist="#chord-0000000000007400" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>