### PR TITLE
Improve colliding barlines

### DIFF
--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -154,6 +154,11 @@ public:
     ///@}
 
     /**
+     * Return the width of the right barline based on the barline form
+     */
+    int GetRightBarLineWidth(Doc *doc);
+
+    /**
      * Return the width of the measure, including the barLine width
      */
     int GetWidth() const;

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1158,32 +1158,8 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
     for (iter = m_graceAligners.begin(); iter != m_graceAligners.end(); ++iter) {
         iter->second->SetGraceAligmentXPos(params->m_doc);
     }
-    int offset = 0;
-    if (m_type == ALIGNMENT_MEASURE_RIGHT_BARLINE) {
-        Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
-        if (measure) {
-            const int staffSize = 100;
-            const int drawingUnit = params->m_doc->GetDrawingUnit(staffSize);
-            const int barLineThickWidth = drawingUnit * params->m_doc->GetOptions()->m_thickBarlineThickness.GetValue();
-            const int barLineSeparation = drawingUnit * params->m_doc->GetOptions()->m_barLineSeparation.GetValue();
-            data_BARRENDITION rightBarLine = measure->GetDrawingRightBarLine();
-            switch (rightBarLine) {
-                case BARRENDITION_rptend:
-                case BARRENDITION_end: {
-                    offset = barLineThickWidth + barLineSeparation;
-                    break;
-                }
-                case BARRENDITION_dbl:
-                case BARRENDITION_dbldotted:
-                case BARRENDITION_dbldashed: {
-                    offset = barLineThickWidth / 2;
-                    break;
-                }
-                default: break;
-            }
-        }
-    }
-    SetXRel(offset + params->m_previousXRel + intervalXRel * DEFINITION_FACTOR);
+
+    SetXRel(params->m_previousXRel + intervalXRel * DEFINITION_FACTOR);
     params->m_previousTime = m_time;
     params->m_previousXRel = m_xRel;
 

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1163,13 +1163,14 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
         if (measure) {
             const int staffSize = 100;
-            const int barLineThickWidth = params->m_doc->GetDrawingUnit(staffSize)
-                * params->m_doc->GetOptions()->m_thickBarlineThickness.GetValue();
+            const int drawingUnit = params->m_doc->GetDrawingUnit(staffSize);
+            const int barLineThickWidth = drawingUnit * params->m_doc->GetOptions()->m_thickBarlineThickness.GetValue();
+            const int barLineSeparation = drawingUnit * params->m_doc->GetOptions()->m_barLineSeparation.GetValue();
             data_BARRENDITION rightBarLine = measure->GetDrawingRightBarLine();
             switch (rightBarLine) {
                 case BARRENDITION_rptend:
                 case BARRENDITION_end: {
-                    offset = barLineThickWidth;
+                    offset = barLineThickWidth + barLineSeparation;
                     break;
                 }
                 case BARRENDITION_dbl:

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1158,8 +1158,31 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
     for (iter = m_graceAligners.begin(); iter != m_graceAligners.end(); ++iter) {
         iter->second->SetGraceAligmentXPos(params->m_doc);
     }
-
-    SetXRel(params->m_previousXRel + intervalXRel * DEFINITION_FACTOR);
+    int offset = 0;
+    if (m_type == ALIGNMENT_MEASURE_RIGHT_BARLINE) {
+        Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
+        if (measure) {
+            const int staffSize = 100;
+            const int barLineThickWidth = params->m_doc->GetDrawingUnit(staffSize)
+                * params->m_doc->GetOptions()->m_thickBarlineThickness.GetValue();
+            data_BARRENDITION rightBarLine = measure->GetDrawingRightBarLine();
+            switch (rightBarLine) {
+                case BARRENDITION_rptend:
+                case BARRENDITION_end: {
+                    offset = barLineThickWidth;
+                    break;
+                }
+                case BARRENDITION_dbl:
+                case BARRENDITION_dbldotted:
+                case BARRENDITION_dbldashed: {
+                    offset = barLineThickWidth / 2;
+                    break;
+                }
+                default: break;
+            }
+        }
+    }
+    SetXRel(offset + params->m_previousXRel + intervalXRel * DEFINITION_FACTOR);
     params->m_previousTime = m_time;
     params->m_previousXRel = m_xRel;
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -254,6 +254,37 @@ int Measure::GetRightBarLineXRel() const
     return 0;
 }
 
+int Measure::GetRightBarLineWidth(Doc* doc)
+{
+    const BarLine *barline = GetRightBarLine();
+    if (!barline) return 0;
+
+    const int staffSize = 100;
+    const int barLineWidth = doc->GetDrawingBarLineWidth(staffSize);
+    const int barLineThickWidth = doc->GetDrawingUnit(staffSize) * doc->GetOptions()->m_thickBarlineThickness.GetValue();
+    const int barLineSeparation = doc->GetDrawingUnit(staffSize) * doc->GetOptions()->m_barLineSeparation.GetValue();
+
+    int width = 0;
+    switch (barline->GetForm()) {
+        case BARRENDITION_dbl:
+        case BARRENDITION_dbldashed: {
+            width = barLineSeparation + barLineWidth / 2;
+            break;
+        }
+        case BARRENDITION_rptend:
+        case BARRENDITION_end: {
+            width = barLineSeparation + barLineWidth + barLineThickWidth / 2;
+            break;
+        }
+        case BARRENDITION_rptboth: {
+            width = 2 * barLineSeparation + barLineWidth / 2 + barLineThickWidth;
+            break;
+        }
+        default: break;
+    }
+    return width;
+}
+
 int Measure::GetRightBarLineLeft() const
 {
     int x = GetRightBarLineXRel();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2305,7 +2305,8 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         objectX = measure;
         // if it is the first measure of the system use the left barline position
         if (system->GetFirst(MEASURE) == measure) x1 += measure->GetLeftBarLineXRel();
-        x2 = endingEndBoundary->GetMeasure()->GetDrawingX() + endingEndBoundary->GetMeasure()->GetRightBarLineXRel();
+        x2 = endingEndBoundary->GetMeasure()->GetDrawingX() + endingEndBoundary->GetMeasure()->GetRightBarLineXRel()
+            + endingEndBoundary->GetMeasure()->GetRightBarLineWidth(m_doc);
     }
     // Only the first parent is the same, this means that the ending is "open" at the end of the system
     else if (system == parentSystem1) {
@@ -2316,7 +2317,8 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         objectX = measure;
         // if it is the first measure of the system use the left barline position
         if (system->GetFirst(MEASURE) == ending->GetMeasure()) x1 += ending->GetMeasure()->GetLeftBarLineXRel();
-        x2 = measure->GetDrawingX() + measure->GetRightBarLineXRel();
+        x2 = measure->GetDrawingX() + measure->GetRightBarLineXRel()
+            + measure->GetRightBarLineWidth(m_doc);
         spanningType = SPANNING_START;
     }
     // We are in the system where the ending ends - draw it from the beginning of the system
@@ -2326,7 +2328,8 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         if (!Check(measure)) return;
         x1 = measure->GetDrawingX() + measure->GetLeftBarLineXRel();
         objectX = measure->GetLeftBarLine();
-        x2 = endingEndBoundary->GetMeasure()->GetDrawingX() + endingEndBoundary->GetMeasure()->GetRightBarLineXRel();
+        x2 = endingEndBoundary->GetMeasure()->GetDrawingX() + endingEndBoundary->GetMeasure()->GetRightBarLineXRel()
+            + endingEndBoundary->GetMeasure()->GetRightBarLineWidth(m_doc);
         spanningType = SPANNING_END;
     }
     // Rare case where neither the first note nor the last note are in the current system - draw the connector
@@ -2340,7 +2343,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         // We need the last measure of the system for x2
         measure = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
         if (!Check(measure)) return;
-        x2 = measure->GetDrawingX() + measure->GetRightBarLineXRel();
+        x2 = measure->GetDrawingX() + measure->GetRightBarLineXRel() + measure->GetRightBarLineWidth(m_doc);
         spanningType = SPANNING_MIDDLE;
     }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -854,7 +854,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
     else if (barLine->GetForm() == BARRENDITION_end) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbl) {
         // Narrow the bars a little bit - should be centered?

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -859,11 +859,11 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     else if (barLine->GetForm() == BARRENDITION_dbl) {
         // Narrow the bars a little bit - should be centered?
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x2, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbldashed) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength);
-        DrawVerticalSegmentedLine(dc, x2, line, barLineWidth, dashLength);
+        DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineWidth, dashLength);
     }
     else {
         // Use solid barline as fallback

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -789,7 +789,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
     const int barLineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barLineSeparation.GetValue();
-    //const int barLinesGap = barLineThickWidth;
+    const int barLinesGap = barLineThickWidth + barLineWidth;
     int x2 = x + barLineSeparation;
 
     // optimized for five line staves
@@ -838,12 +838,12 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
     else if (barLine->GetForm() == BARRENDITION_rptend) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLinesGap / 2, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptboth) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x2 + barLineSeparation + barLineThickWidth, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLinesGap / 2, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineSeparation + barLinesGap, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptstart) {
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
@@ -854,7 +854,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
     else if (barLine->GetForm() == BARRENDITION_end) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLinesGap / 2, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbl) {
         // Narrow the bars a little bit - should be centered?
@@ -899,8 +899,8 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
         DrawDot(dc, x2 - thickBarLineWidth / 2, yTop, staff->m_drawingStaffSize);
     }
     if (barLine->GetForm() == BARRENDITION_rptboth) {
-        DrawDot(dc, x2 + barLineSeparation, yBottom, staff->m_drawingStaffSize);
-        DrawDot(dc, x2 + barLineSeparation, yTop, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 + barLineSeparation + barLineWidth, yBottom, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 + barLineSeparation + barLineWidth, yTop, staff->m_drawingStaffSize);
     }
     if ((barLine->GetForm() == BARRENDITION_rptend) || (barLine->GetForm() == BARRENDITION_rptboth)) {
         DrawDot(dc, x1, yBottom, staff->m_drawingStaffSize);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -789,8 +789,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
     const int barLineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barLineSeparation.GetValue();
-    int x1 = x - barLineSeparation - barLineWidth;
-    int x2 = x + barLineSeparation + barLineWidth;
+    const int barSpace = barLineSeparation + barLineWidth;
+    const int barLinesGap = barLineThickWidth - barLineWidth;
+    int x2 = x + barSpace;
 
     // optimized for five line staves
     int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
@@ -801,10 +802,11 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     if (eraseIntersections && !dc->Is(BBOX_DEVICE_CONTEXT)) {
         System *system = dynamic_cast<System *>(barLine->GetFirstAncestor(SYSTEM));
         if (system) {
-            int minX = x1 - barLineWidth / 2;
-            int maxX = x1 + barLineWidth / 2;
+            int minX = x - barLineWidth / 2;
+            int maxX = x2 + barLineWidth / 2;
             if ((barLine->GetForm() == BARRENDITION_rptend) || (barLine->GetForm() == BARRENDITION_end)) {
-                maxX = x + barLineThickWidth / 2;
+                minX = x - barLineWidth / 2;
+                maxX = x2 + barLineThickWidth / 2;
             }
             else if (barLine->GetForm() == BARRENDITION_rptboth) {
                 maxX = x2 + barLineWidth / 2;
@@ -836,13 +838,13 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);
     }
     else if (barLine->GetForm() == BARRENDITION_rptend) {
-        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x + barSpace + barLineWidth, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptboth) {
-        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x2 + (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x + barSpace + barLinesGap / 2, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x + 2 * barSpace + barLinesGap, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptstart) {
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
@@ -852,8 +854,8 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
         barLine->SetEmptyBB();
     }
     else if (barLine->GetForm() == BARRENDITION_end) {
-        DrawVerticalSegmentedLine(dc, x1 - (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_dbl) {
         // Narrow the bars a little bit - should be centered?
@@ -882,18 +884,24 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
     const int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 5), 2);
     const int dotSeparation
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_repeatBarLineDotSeparation.GetValue();
-    const int xShift = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue() / 2
-        + m_doc->GetDrawingUnit(100) * m_options->m_barLineSeparation.GetValue()
-        + m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue() + dotSeparation + r;
-    const int x1 = x - xShift;
+    const int barLineWidth = m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue();
+    const int thickBarLineWidth = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue();
+    const int barLineSeparation = m_doc->GetDrawingUnit(100) * m_options->m_barLineSeparation.GetValue();
+    const int xShift = thickBarLineWidth + dotSeparation + barLineSeparation + r;
+
+    const int x1 = x - (dotSeparation + r) - barLineWidth;
     const int x2 = x + xShift;
 
     const int yBottom = staff->GetDrawingY() - staff->m_drawingLines * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
-    if ((barLine->GetForm() == BARRENDITION_rptstart) || (barLine->GetForm() == BARRENDITION_rptboth)) {
+    if (barLine->GetForm() == BARRENDITION_rptstart) {
         DrawDot(dc, x2, yBottom, staff->m_drawingStaffSize);
         DrawDot(dc, x2, yTop, staff->m_drawingStaffSize);
+    }
+    if (barLine->GetForm() == BARRENDITION_rptboth) {
+        DrawDot(dc, x2 + barLineSeparation + 2 * barLineWidth, yBottom, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 + barLineSeparation + 2 * barLineWidth, yTop, staff->m_drawingStaffSize);
     }
     if ((barLine->GetForm() == BARRENDITION_rptend) || (barLine->GetForm() == BARRENDITION_rptboth)) {
         DrawDot(dc, x1, yBottom, staff->m_drawingStaffSize);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -789,9 +789,8 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
     const int barLineThickWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_thickBarlineThickness.GetValue();
     const int barLineSeparation = m_doc->GetDrawingUnit(staffSize) * m_options->m_barLineSeparation.GetValue();
-    const int barSpace = barLineSeparation + barLineWidth;
-    const int barLinesGap = barLineThickWidth - barLineWidth;
-    int x2 = x + barSpace;
+    //const int barLinesGap = barLineThickWidth;
+    int x2 = x + barLineSeparation;
 
     // optimized for five line staves
     int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
@@ -839,16 +838,16 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     }
     else if (barLine->GetForm() == BARRENDITION_rptend) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x + barSpace + barLineWidth, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptboth) {
         DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
-        DrawVerticalSegmentedLine(dc, x + barSpace + barLinesGap / 2, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x + 2 * barSpace + barLinesGap, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineThickWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineSeparation + barLineThickWidth, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_rptstart) {
         DrawVerticalSegmentedLine(dc, x, line, barLineThickWidth);
-        DrawVerticalSegmentedLine(dc, x2 + (barLineThickWidth - barLineWidth) / 2, line, barLineWidth);
+        DrawVerticalSegmentedLine(dc, x2 + barLineThickWidth / 2, line, barLineWidth);
     }
     else if (barLine->GetForm() == BARRENDITION_invis) {
         barLine->SetEmptyBB();
@@ -887,7 +886,7 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
     const int barLineWidth = m_doc->GetDrawingUnit(100) * m_options->m_barLineWidth.GetValue();
     const int thickBarLineWidth = m_doc->GetDrawingUnit(100) * m_options->m_thickBarlineThickness.GetValue();
     const int barLineSeparation = m_doc->GetDrawingUnit(100) * m_options->m_barLineSeparation.GetValue();
-    const int xShift = thickBarLineWidth + dotSeparation + barLineSeparation + r;
+    const int xShift = thickBarLineWidth + dotSeparation + barLineSeparation + r + barLineWidth;
 
     const int x1 = x - (dotSeparation + r) - barLineWidth;
     const int x2 = x + xShift;
@@ -896,12 +895,12 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
     const int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
     if (barLine->GetForm() == BARRENDITION_rptstart) {
-        DrawDot(dc, x2, yBottom, staff->m_drawingStaffSize);
-        DrawDot(dc, x2, yTop, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 - thickBarLineWidth / 2 , yBottom, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 - thickBarLineWidth / 2, yTop, staff->m_drawingStaffSize);
     }
     if (barLine->GetForm() == BARRENDITION_rptboth) {
-        DrawDot(dc, x2 + barLineSeparation + 2 * barLineWidth, yBottom, staff->m_drawingStaffSize);
-        DrawDot(dc, x2 + barLineSeparation + 2 * barLineWidth, yTop, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 + barLineSeparation, yBottom, staff->m_drawingStaffSize);
+        DrawDot(dc, x2 + barLineSeparation, yTop, staff->m_drawingStaffSize);
     }
     if ((barLine->GetForm() == BARRENDITION_rptend) || (barLine->GetForm() == BARRENDITION_rptboth)) {
         DrawDot(dc, x1, yBottom, staff->m_drawingStaffSize);


### PR DESCRIPTION
closes #1921
Changed logic for all types of barlines to be consistent. Previously, double barlines would be drawn by extending to the right (i.e. second barline to be drawn after first one) while end barline was drawn in opposite direction (i.e. barline would be drawn inside the measure). 
With this change all barlines should start at the same point and extend outside, so there won't be collisions with elements inside the measure.

Before:
![image](https://user-images.githubusercontent.com/1819669/115584335-6454a480-a2d3-11eb-8530-fce1f28645dc.png)

After:
![image](https://user-images.githubusercontent.com/1819669/115584488-7cc4bf00-a2d3-11eb-9622-e2cd5c4f5a45.png)
