### PR TITLE
[WIP] get rid of shell script

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine
+          python -m pip install git setuptools wheel twine
 
       #===============================================#
       # sdist


### PR DESCRIPTION
As it is not best practice to start shell scripts from Python I replaced this in `setup.py`.  
@musicEnfanthen please have a look.
If we don't need `get_version.sh` for something else, I would remove it completely then.