### PR TITLE
Update clang-format to c++11. Fixes #2163

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 Language:        Cpp
+Standard: Cpp11
 # BasedOnStyle:  WebKit
 AccessModifierOffset: -4
 AlignAfterOpenBracket: false
@@ -49,7 +50,6 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 SpacesBeforeTrailingComments: 1
 Cpp11BracedListStyle: false
-Standard:        Cpp03
 IndentWidth:     4
 TabWidth:        8
 UseTab:          Never

--- a/include/vrv/attdef.h
+++ b/include/vrv/attdef.h
@@ -21,7 +21,7 @@
 
 namespace vrv {
 
-typedef std::vector<std::pair<std::string, std::string> > ArrayOfStrAttr;
+typedef std::vector<std::pair<std::string, std::string>> ArrayOfStrAttr;
 
 #define VRV_UNSET -0x7FFFFFFF
 

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -219,8 +219,8 @@ public:
      */
     bool ExportTimemap(std::string &output);
     void PrepareJsonTimemap(std::string &output, std::map<double, double> &realTimeToScoreTime,
-        std::map<double, std::vector<std::string> > &realTimeToOnElements,
-        std::map<double, std::vector<std::string> > &realTimeToOffElements, std::map<double, int> &realTimeToTempo);
+        std::map<double, std::vector<std::string>> &realTimeToOnElements,
+        std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, int> &realTimeToTempo);
 
     /**
      * Set the initial scoreDef of each page.

--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -40,7 +40,7 @@ public:
     bool Chain(jsonxx::Array actions);
     bool Drag(std::string elementId, int x, int y);
     bool Insert(std::string elementType, std::string staffId, int ulx, int uly, int lrx, int lry,
-        std::vector<std::pair<std::string, std::string> > attributes);
+        std::vector<std::pair<std::string, std::string>> attributes);
     bool Merge(std::vector<std::string> elementIds);
     bool Set(std::string elementId, std::string attrType, std::string attrValue);
     bool SetText(std::string elementId, std::string text);
@@ -62,7 +62,7 @@ protected:
     bool ParseDragAction(jsonxx::Object param, std::string *elementId, int *x, int *y);
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *startId, std::string *endId);
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *staffId, int *ulx, int *uly,
-        int *lrx, int *lry, std::vector<std::pair<std::string, std::string> > *attributes);
+        int *lrx, int *lry, std::vector<std::pair<std::string, std::string>> *attributes);
     bool ParseMergeAction(jsonxx::Object param, std::vector<std::string> *elementIds);
     bool ParseSetAction(jsonxx::Object param, std::string *elementId, std::string *attrType, std::string *attrValue);
     bool ParseSetTextAction(jsonxx::Object param, std::string *elementId, std::string *text);

--- a/include/vrv/expansionmap.h
+++ b/include/vrv/expansionmap.h
@@ -55,7 +55,7 @@ private:
 
 public:
     /** The expansion map indicates which xmlId has been repeated (expanded) elsewhere */
-    std::map<std::string, std::vector<std::string> > m_map;
+    std::map<std::string, std::vector<std::string>> m_map;
 
 private:
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1172,7 +1172,7 @@ public:
 class ConvertMarkupArticParams : public FunctorParams {
 public:
     ConvertMarkupArticParams() {}
-    std::vector<std::pair<Object *, Artic *> > m_articPairsToConvert;
+    std::vector<std::pair<Object *, Artic *>> m_articPairsToConvert;
 };
 
 //----------------------------------------------------------------------------
@@ -1516,8 +1516,8 @@ public:
         m_functor = functor;
     }
     std::map<double, double> realTimeToScoreTime;
-    std::map<double, std::vector<std::string> > realTimeToOnElements;
-    std::map<double, std::vector<std::string> > realTimeToOffElements;
+    std::map<double, std::vector<std::string>> realTimeToOnElements;
+    std::map<double, std::vector<std::string>> realTimeToOffElements;
     std::map<double, int> realTimeToTempo;
     double m_scoreTimeOffset;
     double m_realTimeOffsetMilliseconds;

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -119,12 +119,12 @@ private:
     /*
      * ABC metadata stacks
      */
-    std::vector<std::pair<std::string, int> > m_composer; // C:
-    std::vector<std::pair<std::string, int> > m_history; // H:
-    std::vector<std::pair<std::string, int> > m_notes; // N:
-    std::vector<std::pair<std::string, int> > m_origin; // O:
-    std::vector<std::pair<std::string, int> > m_title; // T:
-    std::vector<std::pair<std::pair<std::string, int>, char> > m_info;
+    std::vector<std::pair<std::string, int>> m_composer; // C:
+    std::vector<std::pair<std::string, int>> m_history; // H:
+    std::vector<std::pair<std::string, int>> m_notes; // N:
+    std::vector<std::pair<std::string, int>> m_origin; // O:
+    std::vector<std::pair<std::string, int>> m_title; // T:
+    std::vector<std::pair<std::pair<std::string, int>, char>> m_info;
 
     std::vector<ControlElement *> m_tempoStack;
     std::vector<Harm *> m_harmStack;
@@ -143,7 +143,7 @@ private:
     /*
      * The stack of control elements to be added at the end of each measure
      */
-    std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
+    std::vector<std::pair<std::string, ControlElement *>> m_controlElements;
     /*
      * container for work entries
      */

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -569,17 +569,17 @@ protected:
     bool hasCenterParameter(hum::HTp token, const std::string &category, int &output);
     void prepareHeaderFooter();
     bool prepareHeader(
-        std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap);
+        std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap);
     bool prepareFooter(
-        std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap);
+        std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap);
     std::string processReferenceTemplate(const std::string &input,
-        std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap);
+        std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap);
     std::string processTemplateOperator(const std::string &value, const std::string &op);
-    std::string automaticHeaderLeft(std::vector<std::pair<std::string, std::string> > &biblist,
+    std::string automaticHeaderLeft(std::vector<std::pair<std::string, std::string>> &biblist,
         std::map<std::string, std::string> &refmap, int linecount);
     std::string automaticHeaderCenter(
-        std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap);
-    std::string automaticHeaderRight(std::vector<std::pair<std::string, std::string> > &biblist,
+        std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap);
+    std::string automaticHeaderRight(std::vector<std::pair<std::string, std::string>> &biblist,
         std::map<std::string, std::string> &refmap, int &linecount);
     void convertMensuralToken(
         std::vector<std::string> &elements, std::vector<void *> &pointers, hum::HTp token, int staffindex);
@@ -587,7 +587,7 @@ protected:
     void setStemLength(Note *note, hum::HTp token);
     void storeExpansionLists(Section *section, hum::HTp starting);
     int getStaffAdjustment(hum::HTp token);
-    void calculateNoteIdForSlur(std::string &idstring, std::vector<pair<int, int> > &sortednotes, int index);
+    void calculateNoteIdForSlur(std::string &idstring, std::vector<pair<int, int>> &sortednotes, int index);
     void promoteInstrumentNamesToGroup();
     void promoteInstrumentsForStaffGroup(StaffGrp *group);
     void promoteInstrumentAbbreviationsToGroup();
@@ -602,9 +602,9 @@ protected:
     void prepareInitialOttavas(hum::HTp measure);
     void linkFingeringToNote(Dir *dir, hum::HTp token, int xstaffindex);
     bool checkForTupletForcedBreak(const std::vector<hum::HTp> &duritems, int index);
-    void extractSlurNoteAttachmentInformation(std::vector<std::pair<int, bool> > &data, hum::HTp token, char slurtype);
+    void extractSlurNoteAttachmentInformation(std::vector<std::pair<int, bool>> &data, hum::HTp token, char slurtype);
     void extractPhraseNoteAttachmentInformation(
-        std::vector<std::pair<int, bool> > &data, hum::HTp token, char phrasetype);
+        std::vector<std::pair<int, bool>> &data, hum::HTp token, char phrasetype);
     bool getNoteStateSlur(hum::HTp token, int slurnumber);
     bool getNoteStatePhrase(hum::HTp token, int phrasenumber);
     void assignVerticalGroup(Pedal *ped, hum::HTp token);
@@ -707,11 +707,11 @@ protected:
     void createHeader();
     void insertTitle(pugi::xml_node &titleStmt, const std::vector<hum::HumdrumLine *> &references);
     void insertExtMeta(std::vector<hum::HumdrumLine *> &references);
-    void addPerson(std::vector<std::vector<std::string> > &respPeople, std::vector<hum::HumdrumLine *> &references,
+    void addPerson(std::vector<std::vector<std::string>> &respPeople, std::vector<hum::HumdrumLine *> &references,
         const std::string &key, const std::string &role);
-    void getRespPeople(std::vector<std::vector<std::string> > &respPeople, std::vector<hum::HumdrumLine *> &references);
-    void insertRespStmt(pugi::xml_node &titleStmt, std::vector<std::vector<std::string> > &respPeople);
-    void insertPeople(pugi::xml_node &work, std::vector<std::vector<std::string> > &respPeople);
+    void getRespPeople(std::vector<std::vector<std::string>> &respPeople, std::vector<hum::HumdrumLine *> &references);
+    void insertRespStmt(pugi::xml_node &titleStmt, std::vector<std::vector<std::string>> &respPeople);
+    void insertPeople(pugi::xml_node &work, std::vector<std::vector<std::string>> &respPeople);
 
     /// Templates ///////////////////////////////////////////////////////////
     template <class ELEMENT> void verticalRest(ELEMENT rest, const std::string &token);
@@ -735,9 +735,9 @@ protected:
     template <class ELEMENT> Mensur *getMensur(ELEMENT element, hum::HTp token = NULL);
     template <class ELEMENT>
     void insertPhrase(ELEMENT phrase, hum::HTp phrasestart, hum::HTp phraseend, Measure *startmeasure,
-        std::vector<pair<int, int> > &endchordsorted, std::vector<std::pair<int, int> > &startchordsorted,
-        std::vector<pair<int, bool> > &phrasestartnoteinfo, std::vector<pair<int, bool> > &phraseendnoteinfo, int ndex,
-        std::vector<std::vector<int> > &phraseindex, int i, int j, std::vector<int> &startpitches,
+        std::vector<pair<int, int>> &endchordsorted, std::vector<std::pair<int, int>> &startchordsorted,
+        std::vector<pair<int, bool>> &phrasestartnoteinfo, std::vector<pair<int, bool>> &phraseendnoteinfo, int ndex,
+        std::vector<std::vector<int>> &phraseindex, int i, int j, std::vector<int> &startpitches,
         std::vector<int> &endpitches, std::vector<bool> &indexused);
     template <class ELEMENT> void convertVerses(ELEMENT element, hum::HTp token);
     template <class ELEMENT>
@@ -848,7 +848,7 @@ private:
 
     // m_layertokens == Humdrum **kern tokens for each staff/layer to be
     // converted.
-    std::vector<std::vector<std::vector<hum::HTp> > > m_layertokens;
+    std::vector<std::vector<std::vector<hum::HTp>>> m_layertokens;
 
     // m_staffstarts == list of tracks in Humdrum file being parsed which
     // contain **kern, **mens data or whatever other data types
@@ -871,13 +871,13 @@ private:
     hum::HumNum m_omd = -1;
 
     // m_oclef == temporary variable for printing "original-clef" <app>
-    std::vector<std::pair<int, hum::HTp> > m_oclef;
+    std::vector<std::pair<int, hum::HTp>> m_oclef;
 
     // m_omet == temporary variable for printing "original-mensuration" <app>
-    std::vector<std::pair<int, hum::HTp> > m_omet;
+    std::vector<std::pair<int, hum::HTp>> m_omet;
 
     // m_okey == temporary variable for printing "original-key" <app>
-    std::vector<std::pair<int, hum::HTp> > m_okey;
+    std::vector<std::pair<int, hum::HTp>> m_okey;
 
     // m_staffstates == state variables for each staff.
     std::vector<humaux::StaffStateVariables> m_staffstates;
@@ -958,7 +958,7 @@ private:
 
     // m_spine_color == list of colors to apply to spine data
     // first dimension is the spine/track (staff), and second is subspine/subtrack (layer).
-    std::vector<std::vector<std::string> > m_spine_color;
+    std::vector<std::vector<std::string>> m_spine_color;
 
     // m_traspose == transposition to go from sounding to written pitch.
     std::vector<int> m_transpose;
@@ -1014,7 +1014,7 @@ private:
     std::vector<bool> m_ignore;
 
     // m_clef_buffer == used to identify clefs that should not be printed.
-    std::vector<std::tuple<bool, hum::HumNum, Clef *> > m_clef_buffer;
+    std::vector<std::tuple<bool, hum::HumNum, Clef *>> m_clef_buffer;
 
     // m_ftrem_slurs == used to store ftrem-generated slurs for later insertion
     // into measure element.

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -402,7 +402,7 @@ private:
     /* LastElementID */
     std::string m_ID;
     /* A map of stacks for piling open LayerElements (beams, tuplets, chords, btrem, ftrem) separately per layer */
-    std::map<Layer *, std::vector<LayerElement *> > m_elementStackMap;
+    std::map<Layer *, std::vector<LayerElement *>> m_elementStackMap;
     /* A maps of time stamps (score time) to indicate write pointer of a given layer */
     std::map<Layer *, int> m_layerEndTimes;
     /* To remember layer of last element (note) to handle chords */
@@ -411,24 +411,24 @@ private:
     Layer *m_currentLayer = NULL;
     bool m_isLayerInitialized = false;
     /* The stack for open slurs */
-    std::vector<std::pair<Slur *, musicxml::OpenSlur> > m_slurStack;
+    std::vector<std::pair<Slur *, musicxml::OpenSlur>> m_slurStack;
     /* The stack for slur stops that might come before the slur has been opened */
-    std::vector<std::pair<LayerElement *, musicxml::CloseSlur> > m_slurStopStack;
+    std::vector<std::pair<LayerElement *, musicxml::CloseSlur>> m_slurStopStack;
     /* The stack for open ties */
-    std::vector<std::pair<Tie *, Note *> > m_tieStack;
+    std::vector<std::pair<Tie *, Note *>> m_tieStack;
     /* The stack for tie stops that might come before that tie was opened */
     std::vector<Note *> m_tieStopStack;
     /* The stack for hairpins */
-    std::vector<std::pair<Hairpin *, musicxml::OpenSpanner> > m_hairpinStack;
+    std::vector<std::pair<Hairpin *, musicxml::OpenSpanner>> m_hairpinStack;
     /* The stack for hairpin stops that might occur before a hairpin was started staffNumber, tStamp2, (hairpinNumber,
      * measureCount) */
-    std::vector<std::tuple<int, double, musicxml::OpenSpanner> > m_hairpinStopStack;
-    std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> > m_bracketStack;
-    std::vector<std::pair<Trill *, musicxml::OpenSpanner> > m_trillStack;
+    std::vector<std::tuple<int, double, musicxml::OpenSpanner>> m_hairpinStopStack;
+    std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner>> m_bracketStack;
+    std::vector<std::pair<Trill *, musicxml::OpenSpanner>> m_trillStack;
     /* The stack of endings to be inserted at the end of XML import */
-    std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> > m_endingStack;
+    std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo>> m_endingStack;
     /* The stack of open dashes (direction-type) containing *ControlElement, OpenDashes */
-    std::vector<std::pair<ControlElement *, musicxml::OpenDashes> > m_openDashesStack;
+    std::vector<std::pair<ControlElement *, musicxml::OpenDashes>> m_openDashesStack;
     /* The stacks for ControlElements */
     std::vector<Dir *> m_dirStack;
     std::vector<Dynam *> m_dynamStack;
@@ -441,11 +441,11 @@ private:
      * The stack of floating elements (tie, slur, etc.) to be added at the
      * end of each measure
      */
-    std::vector<std::pair<std::string, ControlElement *> > m_controlElements;
+    std::vector<std::pair<std::string, ControlElement *>> m_controlElements;
     /* stack of clef changes to be inserted to all layers of a given staff */
     std::vector<musicxml::ClefChange> m_clefChangeStack;
     /* stack of new arpeggios that get more notes added. */
-    std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio> > m_ArpeggioStack;
+    std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio>> m_ArpeggioStack;
     /* a map for the measure counts storing the index of each measure created */
     std::map<Measure *, int> m_measureCounts;
     /* measure rests */

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -435,7 +435,7 @@ private:
  */
 
 class OptionJson : public Option {
-    using JsonPath = std::vector<std::reference_wrapper<jsonxx::Value> >;
+    using JsonPath = std::vector<std::reference_wrapper<jsonxx::Value>>;
 
 public:
     //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -315,7 +315,7 @@ public:
     /**
      * A list of dashes relative to the staff position.
      */
-    std::list<std::pair<int, int> > m_dashes;
+    std::list<std::pair<int, int>> m_dashes;
 
 protected:
     //

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -307,25 +307,25 @@ typedef std::vector<Comparison *> ArrayOfComparisons;
 
 typedef std::vector<Note *> ChordCluster;
 
-typedef std::vector<std::tuple<Alignment *, Alignment *, int> > ArrayOfAdjustmentTuples;
+typedef std::vector<std::tuple<Alignment *, Alignment *, int>> ArrayOfAdjustmentTuples;
 
-typedef std::vector<std::tuple<Alignment *, Arpeg *, int, bool> > ArrayOfAligmentArpegTuples;
+typedef std::vector<std::tuple<Alignment *, Arpeg *, int, bool>> ArrayOfAligmentArpegTuples;
 
 typedef std::vector<BeamElementCoord *> ArrayOfBeamElementCoords;
 
-typedef std::vector<std::pair<int, int> > ArrayOfIntPairs;
+typedef std::vector<std::pair<int, int>> ArrayOfIntPairs;
 
 typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceUuidPairs;
 
-typedef std::vector<std::pair<PlistInterface *, std::string> > ArrayOfPlistInterfaceUuidPairs;
+typedef std::vector<std::pair<PlistInterface *, std::string>> ArrayOfPlistInterfaceUuidPairs;
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 
-typedef std::list<std::pair<Object *, data_MEASUREBEAT> > ListOfObjectBeatPairs;
+typedef std::list<std::pair<Object *, data_MEASUREBEAT>> ListOfObjectBeatPairs;
 
-typedef std::list<std::pair<TimePointInterface *, ClassId> > ListOfPointingInterClassIdPairs;
+typedef std::list<std::pair<TimePointInterface *, ClassId>> ListOfPointingInterClassIdPairs;
 
-typedef std::list<std::pair<TimeSpanningInterface *, ClassId> > ListOfSpanningInterClassIdPairs;
+typedef std::list<std::pair<TimeSpanningInterface *, ClassId>> ListOfSpanningInterClassIdPairs;
 
 typedef std::vector<FloatingPositioner *> ArrayOfFloatingPositioners;
 
@@ -335,7 +335,7 @@ typedef std::vector<LedgerLine> ArrayOfLedgerLines;
 
 typedef std::vector<TextElement *> ArrayOfTextElements;
 
-typedef std::map<Staff *, std::list<int> > MapOfDotLocs;
+typedef std::map<Staff *, std::list<int>> MapOfDotLocs;
 
 typedef std::map<std::string, Option *> MapOfStrOptions;
 
@@ -343,9 +343,9 @@ typedef std::map<data_PITCHNAME, data_ACCIDENTAL_WRITTEN> MapOfPitchAccid;
 
 typedef std::map<int, GraceAligner *> MapOfIntGraceAligners;
 
-typedef std::vector<std::pair<std::wstring, bool> > ArrayOfStringDynamTypePairs;
+typedef std::vector<std::pair<std::wstring, bool>> ArrayOfStringDynamTypePairs;
 
-typedef std::map<std::string, std::function<Object *(void)> > MapOfStrConstructors;
+typedef std::map<std::string, std::function<Object *(void)>> MapOfStrConstructors;
 
 typedef std::map<std::string, ClassId> MapOfStrClassIds;
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -735,7 +735,7 @@ int Chord::CalcDots(FunctorParams *functorParams)
     assert(this->GetBottomNote());
 
     // Get note locations first
-    std::map<Staff *, std::set<int> > noteLocations;
+    std::map<Staff *, std::set<int>> noteLocations;
     for (rit = notes->rbegin(); rit != notes->rend(); ++rit) {
         Note *note = vrv_cast<Note *>(*rit);
         assert(note);

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -173,7 +173,7 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
 
 int Clef::AdjustBeams(FunctorParams *functorParams)
 {
-    const std::map<data_CLEFSHAPE, std::pair<wchar_t, double> > topToMiddleProportions
+    const std::map<data_CLEFSHAPE, std::pair<wchar_t, double>> topToMiddleProportions
         = { { CLEFSHAPE_G, { SMUFL_E050_gClef, 0.6 } }, { CLEFSHAPE_C, { SMUFL_E05C_cClef, 0.5 } },
               { CLEFSHAPE_F, { SMUFL_E062_fClef, 0.35 } } };
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -415,8 +415,8 @@ bool Doc::ExportTimemap(std::string &output)
 }
 
 void Doc::PrepareJsonTimemap(std::string &output, std::map<double, double> &realTimeToScoreTime,
-    std::map<double, std::vector<std::string> > &realTimeToOnElements,
-    std::map<double, std::vector<std::string> > &realTimeToOffElements, std::map<double, int> &realTimeToTempo)
+    std::map<double, std::vector<std::string>> &realTimeToOnElements,
+    std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, int> &realTimeToTempo)
 {
 
     int currentTempo = -1000;

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -81,7 +81,7 @@ bool EditorToolkitNeume::ParseEditorAction(const std::string &json_editorAction)
     else if (action == "insert") {
         std::string elementType, startId, endId, staffId;
         int ulx = 0, uly = 0, lrx = 0, lry = 0;
-        std::vector<std::pair<std::string, std::string> > attributes;
+        std::vector<std::pair<std::string, std::string>> attributes;
         if (this->ParseInsertAction(
                 json.get<jsonxx::Object>("param"), &elementType, &staffId, &ulx, &uly, &lrx, &lry, &attributes)) {
             return this->Insert(elementType, staffId, ulx, uly, lrx, lry, attributes);
@@ -571,7 +571,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 }
 
 bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, int ulx, int uly, int lrx, int lry,
-    std::vector<std::pair<std::string, std::string> > attributes)
+    std::vector<std::pair<std::string, std::string>> attributes)
 {
     if (!m_doc->GetDrawingPage()) {
         LogError("Could not get drawing page");
@@ -1076,7 +1076,7 @@ bool EditorToolkitNeume::SetText(std::string elementId, std::string text)
 {
     std::string status = "OK", message = "";
     std::wstring wtext;
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t> > conv;
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> conv;
     wtext = conv.from_bytes(text);
     if (!m_doc->GetDrawingPage()) {
         m_infoObject.import("status", "FAILURE");
@@ -1262,7 +1262,7 @@ bool EditorToolkitNeume::Split(std::string elementId, int x)
     int newUly = staff->GetZone()->GetUly()
         - ((x - staff->GetZone()->GetUlx()) * tan(staff->GetZone()->GetRotate() * M_PI / 180.0));
     int newLry = staff->GetZone()->GetLry(); // don't need to maintain height since we're setting rotate manually
-    std::vector<std::pair<std::string, std::string> > v;
+    std::vector<std::pair<std::string, std::string>> v;
 
     if (!this->Insert("staff", "auto", newUlx, newUly, newLrx, newLry, v)) {
         LogError("Failed to create a second staff.");
@@ -2565,7 +2565,7 @@ bool EditorToolkitNeume::ParseInsertAction(
 }
 
 bool EditorToolkitNeume::ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *staffId,
-    int *ulx, int *uly, int *lrx, int *lry, std::vector<std::pair<std::string, std::string> > *attributes)
+    int *ulx, int *uly, int *lrx, int *lry, std::vector<std::pair<std::string, std::string>> *attributes)
 {
     if (!param.has<jsonxx::String>("elementType")) return false;
     (*elementType) = param.get<jsonxx::String>("elementType");

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -1500,7 +1500,7 @@ void HumdrumInput::createHeader()
 {
     hum::HumdrumFile &infile = m_infiles[0];
     std::vector<hum::HumdrumLine *> references = infile.getReferenceRecords();
-    std::vector<std::vector<string> > respPeople;
+    std::vector<std::vector<string>> respPeople;
     getRespPeople(respPeople, references);
     pugi::xml_node meiHead = m_doc->m_header.append_child("meiHead");
 
@@ -1727,7 +1727,7 @@ string HumdrumInput::getDateString()
 //     This is for MEI 3.0 and no longer used, so should eventually be deleted.
 //
 
-void HumdrumInput::insertRespStmt(pugi::xml_node &titleStmt, std::vector<std::vector<string> > &respPeople)
+void HumdrumInput::insertRespStmt(pugi::xml_node &titleStmt, std::vector<std::vector<string>> &respPeople)
 {
     if (respPeople.size() == 0) {
         return;
@@ -1758,7 +1758,7 @@ void HumdrumInput::insertRespStmt(pugi::xml_node &titleStmt, std::vector<std::ve
 //   [3] = Line number for xml:id creation
 //
 
-void HumdrumInput::insertPeople(pugi::xml_node &work, std::vector<std::vector<string> > &respPeople)
+void HumdrumInput::insertPeople(pugi::xml_node &work, std::vector<std::vector<string>> &respPeople)
 {
     if (respPeople.size() == 0) {
         return;
@@ -1815,7 +1815,7 @@ void HumdrumInput::insertPeople(pugi::xml_node &work, std::vector<std::vector<st
 //
 
 void HumdrumInput::getRespPeople(
-    std::vector<std::vector<string> > &respPeople, std::vector<hum::HumdrumLine *> &references)
+    std::vector<std::vector<string>> &respPeople, std::vector<hum::HumdrumLine *> &references)
 {
 
     // precalculate a reference map here to make more O(N) rather than O(N^2)
@@ -1843,7 +1843,7 @@ void HumdrumInput::getRespPeople(
 // HumdrumInput::addPerson --
 //
 
-void HumdrumInput::addPerson(std::vector<std::vector<string> > &respPeople, std::vector<hum::HumdrumLine *> &references,
+void HumdrumInput::addPerson(std::vector<std::vector<string>> &respPeople, std::vector<hum::HumdrumLine *> &references,
     const std::string &key, const std::string &role)
 {
     for (int i = 0; i < (int)references.size(); ++i) {
@@ -2446,9 +2446,9 @@ bool HumdrumInput::processStaffDecoration(const std::string &decoration)
     // enumeration in the decoration is not monotonic covering every staff
     // in the score, then the results may have problems.
 
-    map<std::string, vector<int> > classToStaffMapping;
-    map<int, vector<int> > groupToStaffMapping;
-    map<int, vector<int> > partToStaffMapping;
+    map<std::string, vector<int>> classToStaffMapping;
+    map<int, vector<int>> groupToStaffMapping;
+    map<int, vector<int>> partToStaffMapping;
     map<int, int> trackToSpineMapping;
     map<int, int> staffToSpineMapping;
     map<int, int> staffToGroupMapping;
@@ -2619,7 +2619,7 @@ bool HumdrumInput::processStaffDecoration(const std::string &decoration)
     }
 
     // Now pair (), <> {}, and [] parentheses in the d string.
-    vector<pair<int, char> > stack;
+    vector<pair<int, char>> stack;
     pair<int, char> item;
     vector<int> pairing(d.size(), -1);
     for (int i = 0; i < (int)d.size(); ++i) {
@@ -2753,7 +2753,7 @@ bool HumdrumInput::processStaffDecoration(const std::string &decoration)
     vector<bool> barstart; // true if bar group starts at staff.
     vector<bool> barend; // true if bar group stops at staff.
 
-    vector<vector<int> > bargroups;
+    vector<vector<int>> bargroups;
     vector<string> groupstyle;
 
     groupstyle.resize(1);
@@ -2943,7 +2943,7 @@ bool HumdrumInput::processStaffDecoration(const std::string &decoration)
     }
 
     // Pull out all non-zero staff groups:
-    vector<vector<int> > newgroups;
+    vector<vector<int>> newgroups;
     vector<string> newstyles;
     for (int i = 0; i < (int)bargroups.size(); ++i) {
         if (bargroups[i].empty()) {
@@ -3218,7 +3218,7 @@ vector<int> HumdrumInput::getStaffNumbers(string &deco)
 void HumdrumInput::prepareHeaderFooter()
 {
     hum::HumdrumFile &infile = m_infiles[0];
-    std::vector<std::pair<std::string, std::string> > biblist;
+    std::vector<std::pair<std::string, std::string>> biblist;
 
     hum::HumRegex hre;
     std::vector<hum::HumdrumLine *> records = infile.getReferenceRecords();
@@ -3405,7 +3405,7 @@ std::string HumdrumInput::processTemplateOperator(const std::string &value, cons
 //
 
 std::string HumdrumInput::processReferenceTemplate(const std::string &input,
-    std::vector<std::pair<string, std::string> > &biblist, std::map<std::string, std::string> &refmap)
+    std::vector<std::pair<string, std::string>> &biblist, std::map<std::string, std::string> &refmap)
 {
     std::string text = input;
     hum::HumRegex hre;
@@ -3440,7 +3440,7 @@ std::string HumdrumInput::processReferenceTemplate(const std::string &input,
 //
 
 bool HumdrumInput::prepareFooter(
-    std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap)
+    std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap)
 {
 
     std::string footleft;
@@ -3615,7 +3615,7 @@ bool HumdrumInput::prepareFooter(
 //
 
 bool HumdrumInput::prepareHeader(
-    std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap)
+    std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap)
 {
     std::string headleft;
     std::string headcenter;
@@ -3763,7 +3763,7 @@ bool HumdrumInput::prepareHeader(
 //     an editor, then show on the top left automatically.
 //
 
-std::string HumdrumInput::automaticHeaderLeft(std::vector<std::pair<std::string, std::string> > &biblist,
+std::string HumdrumInput::automaticHeaderLeft(std::vector<std::pair<std::string, std::string>> &biblist,
     std::map<std::string, std::string> &refmap, int linecount)
 {
     std::string output;
@@ -3843,7 +3843,7 @@ std::string HumdrumInput::automaticHeaderLeft(std::vector<std::pair<std::string,
 //     on whether or not the composer's date are displayed.
 //
 
-std::string HumdrumInput::automaticHeaderRight(std::vector<std::pair<std::string, std::string> > &biblist,
+std::string HumdrumInput::automaticHeaderRight(std::vector<std::pair<std::string, std::string>> &biblist,
     std::map<std::string, std::string> &refmap, int &linecount)
 {
 
@@ -3890,7 +3890,7 @@ std::string HumdrumInput::automaticHeaderRight(std::vector<std::pair<std::string
 //
 
 std::string HumdrumInput::automaticHeaderCenter(
-    std::vector<std::pair<std::string, std::string> > &biblist, std::map<std::string, std::string> &refmap)
+    std::vector<std::pair<std::string, std::string>> &biblist, std::map<std::string, std::string> &refmap)
 {
     std::string output;
     std::string title;
@@ -6040,7 +6040,7 @@ void HumdrumInput::storeStaffLayerTokensForMeasure(int startline, int endline)
     hum::HumdrumFile &infile = m_infiles[0];
     const std::vector<hum::HTp> &staffstarts = m_staffstarts;
     const std::vector<int> &rkern = m_rkern;
-    std::vector<std::vector<std::vector<hum::HTp> > > &lt = m_layertokens;
+    std::vector<std::vector<std::vector<hum::HTp>>> &lt = m_layertokens;
 
     lt.clear();
     lt.resize(staffstarts.size());
@@ -7848,7 +7848,7 @@ bool HumdrumInput::checkForTremolo(
 
     hum::HumNum duration = notes[0]->getDuration();
     hum::HumNum testdur = duration;
-    std::vector<std::vector<int> > pitches(notes.size());
+    std::vector<std::vector<int>> pitches(notes.size());
     // std::vector<HumNum> durations(notes.size());
 
     bool firstHasTie = false;
@@ -7969,7 +7969,7 @@ bool HumdrumInput::checkForTremolo(
     }
 
     // Group separate tremolo groups within a single beam.
-    std::vector<std::vector<hum::HTp> > groupings;
+    std::vector<std::vector<hum::HTp>> groupings;
     if (hasInternalTrem) {
         groupings.reserve(16);
         groupings.resize(1);
@@ -13727,7 +13727,7 @@ void HumdrumInput::processSlurs(hum::HTp slurend)
 
     // slurstarts: indexed by slur end number (NB: 0 position not used).
     // pair contains the slur start enumeration and the start token.
-    std::vector<pair<int, hum::HTp> > slurstartlist;
+    std::vector<pair<int, hum::HTp>> slurstartlist;
     slurstartlist.resize(slurendcount + 1);
     for (int i = 1; i <= slurendcount; ++i) {
         slurstartlist[i].first = slurend->getSlurStartNumber(i);
@@ -13940,7 +13940,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
     // phraseindex contains a list of the indexes into phrasestarts,
     // with all identical phrase starts placed on the first
     // position that the note/chord is found in the phrasestarts list.
-    std::vector<std::vector<int> > phraseindex;
+    std::vector<std::vector<int>> phraseindex;
     phraseindex.resize(phrasestarts.size());
     for (int i = 0; i < (int)phrasestarts.size(); ++i) {
         for (int j = 0; j <= i; j++) {
@@ -13953,7 +13953,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
 
     std::vector<bool> indexused(32, false);
 
-    std::vector<pair<int, bool> > phraseendnoteinfo;
+    std::vector<pair<int, bool>> phraseendnoteinfo;
     extractPhraseNoteAttachmentInformation(phraseendnoteinfo, phraseend, '}');
 
     int endsubtokcount = phraseend->getSubtokenCount();
@@ -13967,7 +13967,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
             endpitches.push_back(hum::Convert::kernToBase7(subtok));
         }
     }
-    std::vector<pair<int, int> > endchordsorted;
+    std::vector<pair<int, int>> endchordsorted;
     endchordsorted.reserve(endsubtokcount);
     pair<int, int> v;
     for (int i = 0; i < endsubtokcount; ++i) {
@@ -13981,7 +13981,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
     std::vector<int> startpitches;
 
     for (int i = 0; i < (int)phraseindex.size(); ++i) {
-        std::vector<pair<int, bool> > phrasestartnoteinfo;
+        std::vector<pair<int, bool>> phrasestartnoteinfo;
         extractPhraseNoteAttachmentInformation(phrasestartnoteinfo, phrasestarts.at(i), '{');
 
         startsubtokcount = phrasestarts[i]->getSubtokenCount();
@@ -13995,7 +13995,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
                 startpitches.push_back(hum::Convert::kernToBase7(subtok));
             }
         }
-        std::vector<std::pair<int, int> > startchordsorted;
+        std::vector<std::pair<int, int>> startchordsorted;
         startchordsorted.reserve(startsubtokcount);
 
         pair<int, int> v;
@@ -14012,7 +14012,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
             }
             hum::HTp phrasestart = phrasestarts[phraseindex[i][j]];
 
-            std::vector<pair<int, bool> > phrasestartnoteinfo;
+            std::vector<pair<int, bool>> phrasestartnoteinfo;
             extractPhraseNoteAttachmentInformation(phrasestartnoteinfo, phrasestart, '{');
             if (!phrasestart) {
                 // should never occur...
@@ -14126,9 +14126,9 @@ bool HumdrumInput::phraseIsInvisible(hum::HTp token, int pindex)
 
 template <class ELEMENT>
 void HumdrumInput::insertPhrase(ELEMENT phrase, hum::HTp phrasestart, hum::HTp phraseend, Measure *startmeasure,
-    std::vector<pair<int, int> > &endchordsorted, std::vector<std::pair<int, int> > &startchordsorted,
-    std::vector<pair<int, bool> > &phrasestartnoteinfo, std::vector<pair<int, bool> > &phraseendnoteinfo, int ndex,
-    std::vector<std::vector<int> > &phraseindex, int i, int j, std::vector<int> &startpitches,
+    std::vector<pair<int, int>> &endchordsorted, std::vector<std::pair<int, int>> &startchordsorted,
+    std::vector<pair<int, bool>> &phrasestartnoteinfo, std::vector<pair<int, bool>> &phraseendnoteinfo, int ndex,
+    std::vector<std::vector<int>> &phraseindex, int i, int j, std::vector<int> &startpitches,
     std::vector<int> &endpitches, std::vector<bool> &indexused)
 {
 
@@ -14351,7 +14351,7 @@ void HumdrumInput::addTieLineStyle(Tie *element, hum::HTp token, int noteindex)
 //
 
 void HumdrumInput::extractSlurNoteAttachmentInformation(
-    std::vector<std::pair<int, bool> > &data, hum::HTp token, char slurtype)
+    std::vector<std::pair<int, bool>> &data, hum::HTp token, char slurtype)
 {
     // slurtype == '(' for slur start
     // slurtype == ')' for slur end
@@ -14389,7 +14389,7 @@ void HumdrumInput::extractSlurNoteAttachmentInformation(
 //
 
 void HumdrumInput::extractPhraseNoteAttachmentInformation(
-    std::vector<std::pair<int, bool> > &data, hum::HTp token, char phrasetype)
+    std::vector<std::pair<int, bool>> &data, hum::HTp token, char phrasetype)
 {
     // phrasetype == '{' for phrase start
     // phrasetype == '}' for phrase end
@@ -14456,7 +14456,7 @@ bool HumdrumInput::getNoteStatePhrase(hum::HTp token, int phrasenumber)
 // HumdrumInput::calculateNoteIdForSlur --
 //
 
-void HumdrumInput::calculateNoteIdForSlur(std::string &idstring, std::vector<pair<int, int> > &sortednotes, int index)
+void HumdrumInput::calculateNoteIdForSlur(std::string &idstring, std::vector<pair<int, int>> &sortednotes, int index)
 {
     int notecount = (int)sortednotes.size();
     hum::HumRegex hre;
@@ -15291,7 +15291,7 @@ void HumdrumInput::storeBreaksec(
     std::vector<int> &beamstate, std::vector<int> &beamnum, const std::vector<hum::HTp> &layerdata, bool grace)
 {
 
-    std::vector<std::vector<int> > beamednotes;
+    std::vector<std::vector<int>> beamednotes;
     int bnum = 0;
     for (int i = 0; i < (int)layerdata.size(); ++i) {
         if (!beamnum[i]) {
@@ -16199,7 +16199,7 @@ void HumdrumInput::assignTupletScalings(std::vector<humaux::HumdrumBeamAndTuplet
     }
 
     // tggroups is a list of only durational items, removing things like clefs and barlines.
-    vector<vector<humaux::HumdrumBeamAndTuplet *> > tggroups(maxgroup + 1);
+    vector<vector<humaux::HumdrumBeamAndTuplet *>> tggroups(maxgroup + 1);
     for (int i = 0; i < (int)tg.size(); ++i) {
         int group = tg[i].group;
         if (group <= 0) {
@@ -21243,7 +21243,7 @@ int HumdrumInput::characterCountInSubtoken(hum::HTp token, char symbol)
 
 void HumdrumInput::printMeasureTokens()
 {
-    std::vector<std::vector<std::vector<hum::HTp> > > &lt = m_layertokens;
+    std::vector<std::vector<std::vector<hum::HTp>>> &lt = m_layertokens;
     int i, j, k;
     cerr << endl;
     for (i = 0; i < (int)lt.size(); ++i) {
@@ -21421,7 +21421,7 @@ Tie *HumdrumInput::tieToPreviousItem(hum::HTp token, int subindex, hum::HumNum m
 
 std::vector<int> HumdrumInput::getStaffLayerCounts()
 {
-    std::vector<std::vector<std::vector<hum::HTp> > > &lt = m_layertokens;
+    std::vector<std::vector<std::vector<hum::HTp>>> &lt = m_layertokens;
     std::vector<int> output(lt.size(), 0);
 
     int i;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -427,7 +427,7 @@ void MusicXmlInput::OpenTie(Note *note, Tie *tie)
 void MusicXmlInput::CloseTie(Note *note)
 {
     // add all notes with identical pitch/oct to m_tieStopStack
-    std::vector<std::pair<Tie *, Note *> >::iterator iter;
+    std::vector<std::pair<Tie *, Note *>>::iterator iter;
     for (iter = m_tieStack.begin(); iter != m_tieStack.end(); ++iter) {
         if (note->GetPname() == iter->second->GetPname() && note->GetOct() == iter->second->GetOct()) {
             m_tieStopStack.push_back(note);
@@ -438,7 +438,7 @@ void MusicXmlInput::CloseTie(Note *note)
 void MusicXmlInput::OpenSlur(Measure *measure, int number, Slur *slur)
 {
     // try to match open slur with slur stops within that measure
-    std::vector<std::pair<LayerElement *, musicxml::CloseSlur> >::iterator iter;
+    std::vector<std::pair<LayerElement *, musicxml::CloseSlur>>::iterator iter;
     for (iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
         if ((iter->second.m_number == number) && ((iter->second.m_measureNum).compare(measure->GetN()) == 0)) {
             slur->SetEndid("#" + iter->first->GetUuid());
@@ -454,7 +454,7 @@ void MusicXmlInput::OpenSlur(Measure *measure, int number, Slur *slur)
 void MusicXmlInput::CloseSlur(Measure *measure, int number, LayerElement *element)
 {
     // try to match slur stop to open slurs by slur number
-    std::vector<std::pair<Slur *, musicxml::OpenSlur> >::reverse_iterator riter;
+    std::vector<std::pair<Slur *, musicxml::OpenSlur>>::reverse_iterator riter;
     for (riter = m_slurStack.rbegin(); riter != m_slurStack.rend(); ++riter) {
         if (riter->second.m_number == number) {
             riter->first->SetEndid("#" + element->GetUuid());
@@ -570,7 +570,7 @@ void MusicXmlInput::PrintMetronome(pugi::xml_node metronome, Tempo *tempo)
     }
 
     // build a sequence based on the elements present in the metronome
-    std::list<std::pair<MetronomeElements, std::string> > metronomeElements;
+    std::list<std::pair<MetronomeElements, std::string>> metronomeElements;
     for (pugi::xml_node child : metronome.children()) {
         if ("beat-unit-dot" == std::string(child.name())) {
             metronomeElements.emplace_back(std::make_pair(MetronomeElements::BEAT_UNIT_DOT, ""));
@@ -923,7 +923,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     // here we could check that there is only one staffGrp left in m_staffGrpStack
 
     Measure *measure = NULL;
-    std::vector<std::pair<std::string, ControlElement *> >::iterator iter;
+    std::vector<std::pair<std::string, ControlElement *>>::iterator iter;
     for (iter = m_controlElements.begin(); iter != m_controlElements.end(); ++iter) {
         if (!measure || (measure->GetN() != iter->first)) {
             AttNNumberLikeComparison comparisonMeasure(MEASURE, iter->first);
@@ -940,7 +940,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
 
     // manage endings stack: create new <ending> elements and move the corresponding measures into them
     if (!m_endingStack.empty()) {
-        std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo> >::iterator iter;
+        std::vector<std::pair<std::vector<Measure *>, musicxml::EndingInfo>>::iterator iter;
         for (iter = m_endingStack.begin(); iter != m_endingStack.end(); ++iter) {
             std::string logString = "";
             logString = logString + "MusicXML import: Ending number='" + iter->second.m_endingNumber.c_str()
@@ -986,14 +986,14 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         m_tieStack.clear();
     }
     if (!m_slurStack.empty()) { // There are slurs left open
-        std::vector<std::pair<Slur *, musicxml::OpenSlur> >::iterator iter;
+        std::vector<std::pair<Slur *, musicxml::OpenSlur>>::iterator iter;
         for (iter = m_slurStack.begin(); iter != m_slurStack.end(); ++iter) {
             LogWarning("MusicXML import: slur '%s' could not be ended", iter->first->GetUuid().c_str());
         }
         m_slurStack.clear();
     }
     if (!m_slurStopStack.empty()) { // There are slurs ends without opening
-        std::vector<std::pair<LayerElement *, musicxml::CloseSlur> >::iterator iter;
+        std::vector<std::pair<LayerElement *, musicxml::CloseSlur>>::iterator iter;
         for (iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
             LogWarning("MusicXML import: slur ending for element '%s' could not be "
                        "matched to a start element",
@@ -1009,7 +1009,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         m_glissStack.clear();
     }
     if (!m_trillStack.empty()) { // open trills without ending
-        std::vector<std::pair<Trill *, musicxml::OpenSpanner> >::iterator iter;
+        std::vector<std::pair<Trill *, musicxml::OpenSpanner>>::iterator iter;
         for (iter = m_trillStack.begin(); iter != m_trillStack.end(); ++iter) {
             LogWarning("MusicXML import: trill extender for '%s' could not be ended", iter->first->GetUuid().c_str());
         }
@@ -1327,7 +1327,7 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, int 
 
     // clean up part specific stacks
     if (!m_openDashesStack.empty()) { // open dashes without ending
-        std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter;
+        std::vector<std::pair<ControlElement *, musicxml::OpenDashes>>::iterator iter;
         for (iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
             LogWarning(
                 "MusicXML import: dashes/extender lines for '%s' could not be closed", iter->first->GetUuid().c_str());
@@ -1335,7 +1335,7 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, int 
         m_openDashesStack.clear();
     }
     if (!m_bracketStack.empty()) { // open brackets without ending
-        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> >::iterator iter;
+        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner>>::iterator iter;
         for (iter = m_bracketStack.begin(); iter != m_bracketStack.end(); ++iter) {
             LogWarning("MusicXML import: bracketSpan for '%s' could not be closed", iter->first->GetUuid().c_str());
         }
@@ -1452,7 +1452,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
     }
 
     // match open ties with close ties
-    std::vector<std::pair<Tie *, Note *> >::iterator iter = m_tieStack.begin();
+    std::vector<std::pair<Tie *, Note *>>::iterator iter = m_tieStack.begin();
     while (iter != m_tieStack.end()) {
         double lastScoreTimeOnset = 9999; // __DBL_MAX__;
         bool tieMatched = false;
@@ -1841,7 +1841,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         int staffNum = 1;
         if (staffNode) staffNum = staffNode.text().as_int() + staffOffset;
         if (HasAttributeWithValue(dashes.node(), "type", "stop")) {
-            std::vector<std::pair<ControlElement *, musicxml::OpenDashes> >::iterator iter = m_openDashesStack.begin();
+            std::vector<std::pair<ControlElement *, musicxml::OpenDashes>>::iterator iter = m_openDashesStack.begin();
             while (iter != m_openDashesStack.end()) {
                 if (iter->second.m_dirN == dashesNumber && iter->second.m_staffNum == staffNum) {
                     const int measureDifference = m_measureCounts.at(measure) - iter->second.m_measureCount;
@@ -1864,7 +1864,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             ControlElement *controlElement = nullptr;
             // find last ControlElement of type dynam or dir and activate extender
             // this is bad MusicXML and shouldn't happen
-            std::vector<std::pair<std::string, ControlElement *> >::reverse_iterator riter;
+            std::vector<std::pair<std::string, ControlElement *>>::reverse_iterator riter;
             for (riter = m_controlElements.rbegin(); riter != m_controlElements.rend(); ++riter) {
                 if (riter->second->Is(DYNAM)) {
                     Dynam *dynam = dynamic_cast<Dynam *>(riter->second);
@@ -2023,7 +2023,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         hairpinNumber = (hairpinNumber < 1) ? 1 : hairpinNumber;
         if (HasAttributeWithValue(wedge->node(), "type", "stop")) {
             // match wedge type=stop to open hairpin
-            std::vector<std::pair<Hairpin *, musicxml::OpenSpanner> >::reverse_iterator riter;
+            std::vector<std::pair<Hairpin *, musicxml::OpenSpanner>>::reverse_iterator riter;
             for (riter = m_hairpinStack.rbegin(); riter != m_hairpinStack.rend(); ++riter) {
                 if (riter->second.m_dirN == hairpinNumber) {
                     const int measureDifference = m_measureCounts.at(measure) - riter->second.m_lastMeasureCount;
@@ -2078,7 +2078,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
             hairpin->SetVgrp(defaultY);
             // match new hairpin to existing hairpin stop
-            std::vector<std::tuple<int, double, musicxml::OpenSpanner> >::iterator iter;
+            std::vector<std::tuple<int, double, musicxml::OpenSpanner>>::iterator iter;
             for (iter = m_hairpinStopStack.begin(); iter != m_hairpinStopStack.end(); ++iter) {
                 const int measureDifference = std::get<2>(*iter).m_lastMeasureCount - m_measureCounts.at(measure);
                 if (std::get<2>(*iter).m_dirN == hairpinNumber) {
@@ -2102,7 +2102,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         const int staffNum = (!staffNode) ? 1 : staffNode.text().as_int() + staffOffset;
         if (HasAttributeWithValue(xmlShift, "type", "stop")) {
             m_octDis[staffNum] = 0;
-            std::vector<std::pair<std::string, ControlElement *> >::iterator iter;
+            std::vector<std::pair<std::string, ControlElement *>>::iterator iter;
             for (iter = m_controlElements.begin(); iter != m_controlElements.end(); ++iter) {
                 if (iter->second->Is(OCTAVE)) {
                     Octave *octave = dynamic_cast<Octave *>(iter->second);
@@ -3086,7 +3086,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (!m_trillStack.empty() && notations.node().select_node("ornaments/wavy-line[@type='stop']")) {
         int extNumber
             = notations.node().select_node("ornaments/wavy-line[@type='stop']").node().attribute("number").as_int();
-        std::vector<std::pair<Trill *, musicxml::OpenSpanner> >::iterator iter = m_trillStack.begin();
+        std::vector<std::pair<Trill *, musicxml::OpenSpanner>>::iterator iter = m_trillStack.begin();
         while (iter != m_trillStack.end()) {
             const int measureDifference = m_measureCounts.at(measure) - iter->second.m_lastMeasureCount;
             if (atoi(((iter->first)->GetN()).c_str()) == extNumber) {
@@ -3145,7 +3145,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         const std::string direction = xmlArpeggiate.node().attribute("direction").as_string();
         bool added = false;
         if (!m_ArpeggioStack.empty()) { // check existing arpeggios
-            std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio> >::iterator iter;
+            std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio>>::iterator iter;
             for (iter = m_ArpeggioStack.begin(); iter != m_ArpeggioStack.end(); ++iter) {
                 if (iter->second.m_arpegN == arpegN && onset == iter->second.m_timeStamp) {
                     // don't add other chord notes, because the chord is already referenced.
@@ -3257,7 +3257,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         m_pedalStack.clear();
     }
     if (!m_bracketStack.empty()) {
-        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner> >::iterator iter;
+        std::vector<std::pair<BracketSpan *, musicxml::OpenSpanner>>::iterator iter;
         for (iter = m_bracketStack.begin(); iter != m_bracketStack.end(); ++iter) {
             if (!(iter->first)->HasStaff())
                 iter->first->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1476,7 +1476,7 @@ void Options::Sync()
 {
     if (!m_engravingDefaults.IsSet()) return;
     // override default or passed engravingDefaults with explicitly set values
-    std::list<std::pair<std::string, OptionDbl *> > engravingDefaults = {
+    std::list<std::pair<std::string, OptionDbl *>> engravingDefaults = {
         { "staffLineThickness", &m_staffLineWidth }, //
         { "stemThickness", &m_stemWidth }, //
         { "legerLineThickness", &m_ledgerLineThickness }, //

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -29,7 +29,7 @@
 namespace vrv {
 
 typedef std::map<RestLayer,
-    std::map<RestAccidental, std::map<RestLayerPlace, std::map<RestNotePlace, std::map<int, int> > > > >
+    std::map<RestAccidental, std::map<RestLayerPlace, std::map<RestNotePlace, std::map<int, int>>>>>
     RestOffsets;
 
 RestOffsets g_defaultRests{
@@ -453,7 +453,7 @@ std::pair<int, RestAccidental> Rest::GetElementLocation(Object *object, Layer *l
             (accid && accid->GetAccid() != 0) ? MeiAccidentalToRestAccidental(accid->GetAccid()) : RA_none };
     }
     if (object->Is(FTREM)) {
-        std::vector<std::pair<int, RestAccidental> > btremElements;
+        std::vector<std::pair<int, RestAccidental>> btremElements;
         for (int i = 0; i < object->GetChildCount(); ++i) {
             btremElements.emplace_back(GetElementLocation(object->GetChild(i), layer, isTopLayer));
         }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -343,7 +343,7 @@ void LedgerLine::AddDash(int left, int right)
 {
     assert(left < right);
 
-    std::list<std::pair<int, int> >::iterator iter;
+    std::list<std::pair<int, int>>::iterator iter;
 
     // First add the dash
     for (iter = m_dashes.begin(); iter != m_dashes.end(); ++iter) {
@@ -352,7 +352,7 @@ void LedgerLine::AddDash(int left, int right)
     m_dashes.insert(iter, std::make_pair(left, right));
 
     // Merge overlapping dashes
-    std::list<std::pair<int, int> >::iterator previous = m_dashes.begin();
+    std::list<std::pair<int, int>>::iterator previous = m_dashes.begin();
     iter = m_dashes.begin();
     ++iter;
     while (iter != m_dashes.end()) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1177,7 +1177,7 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, ArrayOfLedgerLines *
     dc->SetBrush(m_currentColour, AxSOLID);
 
     ArrayOfLedgerLines::iterator iter;
-    std::list<std::pair<int, int> >::iterator iterDashes;
+    std::list<std::pair<int, int>>::iterator iterDashes;
 
     // First add the dash
     for (iter = lines->begin(); iter != lines->end(); ++iter) {


### PR DESCRIPTION
Changes
```cpp
std::vector<std::vector<int> > tester;     // pre C++11 
```
to
```cpp
std::vector<std::vector<int>> tester;      // C++11 allowed syntax (<C++11 does not understand)
```