### PR TITLE
Bowed tremolos for MIDI

### DIFF
--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -41,8 +41,21 @@ public:
      */
     virtual bool IsSupportedChild(Object *object);
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * See Object::GenerateMIDI
+     */
+    virtual int GenerateMIDI(FunctorParams *functorParams);
+
 private:
-    //
+    /**
+     * Calculate the duration of an individual note in a measured tremolo
+     */
+    data_DURATION CalcIndividualNoteDuration();
+
 public:
     //
 private:

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1464,11 +1464,22 @@ public:
 //----------------------------------------------------------------------------
 
 /**
+ * Helper struct to store note sequences which replace notes in MIDI output due to expanded ornaments and tremolandi
+ */
+struct MIDINote {
+    char pitch;
+    double duration;
+};
+
+using MIDINoteSequence = std::list<MIDINote>;
+
+/**
  * member 0: MidiFile*: the MidiFile we are writing to
  * member 1: int: the midi track number
  * member 3: double: the score time from the start of the music to the start of the current measure
  * member 4: int: the semi tone transposition for the current track
  * member 5: int with the current tempo
+ * member 6: expanded notes due to ornaments and tremolandi
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1489,6 +1500,7 @@ public:
     double m_totalTime;
     int m_transSemi;
     int m_currentTempo;
+    std::map<Note *, MIDINoteSequence> m_expandedNotes;
     Functor *m_functor;
 };
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -215,7 +215,7 @@ public:
     void SetScoreTimeOffset(double scoreTime);
     void SetRealTimeOffsetSeconds(double timeInSeconds);
     void SetScoreTimeTiedDuration(double timeInSeconds);
-    void SetMIDIPitch(char pitch);
+    void CalcMIDIPitch(int shift);
     double GetScoreTimeOnset();
     double GetRealTimeOnsetMilliseconds();
     double GetScoreTimeOffset();

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -226,6 +226,11 @@ public:
      */
     virtual int AdjustSylSpacing(FunctorParams *functorParams);
 
+    /**
+     * See Object::GenerateMIDI
+     */
+    virtual int GenerateMIDI(FunctorParams *functorParams);
+
 private:
     /**
      * Add the ledger line dashes to the legderline array.

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -15,7 +15,9 @@
 //----------------------------------------------------------------------------
 
 #include "chord.h"
+#include "comparison.h"
 #include "editorial.h"
+#include "functorparams.h"
 #include "layer.h"
 #include "note.h"
 #include "vrv.h"
@@ -63,6 +65,86 @@ bool BTrem::IsSupportedChild(Object *child)
         return false;
     }
     return true;
+}
+
+int BTrem::GenerateMIDI(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    // Do nothing if the tremolo is unmeasured
+    if (this->GetForm() == bTremLog_FORM_unmeas) {
+        return FUNCTOR_CONTINUE;
+    }
+
+    // Calculate duration of individual note in tremolo
+    const data_DURATION individualNoteDur = CalcIndividualNoteDuration();
+    if (individualNoteDur == DURATION_NONE) return FUNCTOR_CONTINUE;
+    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur));
+
+    // Define lambda which expands one note into multiple individual notes of the same pitch
+    auto expandNote = [params, noteInQuarterDur](Object *obj) {
+        Note *note = vrv_cast<Note *>(obj);
+        assert(note);
+        note->CalcMIDIPitch(params->m_transSemi);
+        const char pitch = note->GetMIDIPitch();
+        const double totalInQuarterDur = note->GetScoreTimeDuration() + note->GetScoreTimeTiedDuration();
+        const int multiplicity = totalInQuarterDur / noteInQuarterDur;
+        (params->m_expandedNotes)[note] = MIDINoteSequence(multiplicity, { pitch, noteInQuarterDur });
+    };
+
+    // Apply expansion either to all notes in chord or to first note
+    Chord *chord = vrv_cast<Chord *>(this->FindDescendantByType(CHORD));
+    if (chord) {
+        ListOfObjects notes;
+        ClassIdComparison noteComparison(NOTE);
+        chord->FindAllDescendantByComparison(&notes, &noteComparison);
+        std::for_each(notes.begin(), notes.end(), expandNote);
+    }
+    else {
+        Object *note = this->FindDescendantByType(NOTE);
+        if (note) {
+            expandNote(note);
+        }
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+data_DURATION BTrem::CalcIndividualNoteDuration()
+{
+    // Check if duration is given by attribute
+    if (this->HasUnitdur()) {
+        return this->GetUnitdur();
+    }
+
+    // Otherwise consider duration and stem modifier of first child chord/note
+    data_DURATION childDur = DURATION_NONE;
+    data_STEMMODIFIER stemMod = STEMMODIFIER_NONE;
+    Chord *chord = vrv_cast<Chord *>(this->FindDescendantByType(CHORD));
+    if (chord) {
+        childDur = chord->GetDur();
+        stemMod = chord->GetStemMod();
+    }
+    else {
+        Note *note = vrv_cast<Note *>(this->FindDescendantByType(NOTE));
+        if (note) {
+            childDur = note->GetDur();
+            stemMod = note->GetStemMod();
+        }
+    }
+
+    // Calculate duration from number of slashes
+    if ((stemMod >= STEMMODIFIER_1slash) && (stemMod <= STEMMODIFIER_6slash)) {
+        if ((childDur >= DURATION_long) && (childDur <= DURATION_1024)) {
+            int value = std::max<int>(childDur, DURATION_4);
+            value += (stemMod - STEMMODIFIER_1slash + 1);
+            value = std::min<int>(value, DURATION_1024);
+            assert((value >= DURATION_8) && (value <= DURATION_1024));
+            return static_cast<data_DURATION>(value);
+        }
+    }
+    return DURATION_NONE;
 }
 
 } // namespace vrv

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -637,4 +637,14 @@ int Staff::AdjustSylSpacing(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Staff::GenerateMIDI(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    params->m_expandedNotes.clear();
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv


### PR DESCRIPTION
This PR implements bowed tremolos for MIDI output.

The param object of the `generateMIDI` functor now stores a map of notes being replaced by note sequences. Hopefully, this will be useful, if someday we decide that we also want trills or fingered tremolandi in MIDI.