### PR TITLE
Fix for the beams with first element rest

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1008,8 +1008,8 @@ void BeamSegment::CalcPartialFlagPlace()
 
 void BeamSegment::CalcSetValues()
 {
-    this->m_startingX = m_beamElementCoordRefs.at(0)->m_x;
-    this->m_startingY = m_beamElementCoordRefs.at(0)->m_yBeam;
+    this->m_startingX = m_firstNoteOrChord->m_x;
+    this->m_startingY = m_firstNoteOrChord->m_yBeam;
 
     for (auto coord : m_beamElementCoordRefs) {
         coord->m_yBeam = this->m_startingY + this->m_beamSlope * (coord->m_x - this->m_startingX);


### PR DESCRIPTION
- changed code to use firstNoteOrChord instead of the first reference, which could be a rest (closes #2175)