### PR TITLE
Improve octave bracket end position

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -651,7 +651,7 @@ void View::DrawOctave(
                     offset += dotCount * (dotDiameter + drawingUnit) - drawingUnit;
                 }
             }
-            x2 += offset;
+            x2 += offset + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         }
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -637,21 +637,9 @@ void View::DrawOctave(
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
         if (octave->HasEndid()) {
-            int offset = 0;
-            if (!octave->GetEnd()->Is({ CHORD, NOTE, REST })) {
-                offset = m_doc->GetGlyphWidth(SMUFL_E0A2_noteheadWhole, staff->m_drawingStaffSize, false) / 2;
+            if (octave->GetEnd()->HasContentBB()) {
+                x2 += octave->GetEnd()->GetContentX2();
             }
-            else {
-                offset = octave->GetEnd()->GetDrawingRadius(m_doc);
-                if (DurationInterface *durationInterface = octave->GetEnd()->GetDurationInterface();
-                    (durationInterface != NULL) && durationInterface->HasDots()) {
-                    const int drawingUnit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-                    const int dotDiameter = std::max(ToDeviceContextX(0.8 * drawingUnit), 4);
-                    const int dotCount = durationInterface->GetDots();
-                    offset += dotCount * (dotDiameter + drawingUnit) - drawingUnit;
-                }
-            }
-            x2 += offset + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         }
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -637,7 +637,21 @@ void View::DrawOctave(
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
         if (octave->HasEndid()) {
-            x2 += (m_doc->GetGlyphWidth(SMUFL_E0A2_noteheadWhole, staff->m_drawingStaffSize, false) / 2);
+            int offset = 0;
+            if (!octave->GetEnd()->Is({ CHORD, NOTE, REST })) {
+                offset = m_doc->GetGlyphWidth(SMUFL_E0A2_noteheadWhole, staff->m_drawingStaffSize, false) / 2;
+            }
+            else {
+                offset = octave->GetEnd()->GetDrawingRadius(m_doc);
+                if (DurationInterface *durationInterface = octave->GetEnd()->GetDurationInterface();
+                    (durationInterface != NULL) && durationInterface->HasDots()) {
+                    const int drawingUnit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+                    const int dotDiameter = std::max(ToDeviceContextX(0.8 * drawingUnit), 4);
+                    const int dotCount = durationInterface->GetDots();
+                    offset += dotCount * (dotDiameter + drawingUnit) - drawingUnit;
+                }
+            }
+            x2 += offset;
         }
     }
 


### PR DESCRIPTION
This PR improves rendering of octave brackets ending on notes to include dots for horizontal positioning. 

old:
![old](https://user-images.githubusercontent.com/7693447/117652990-293be780-b194-11eb-9670-c7b14b549cc6.png)
new:
![new](https://user-images.githubusercontent.com/7693447/117951741-be65ea00-b314-11eb-96b5-986c861983c6.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Octave brackets ending on dotted notes</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2021-05-10">2021-05-10</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1a" dur="2" oct.ges="6" oct="5" pname="e" />
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                     <octave startid="#n1a" endid="#n2a" dis="8" dis.place="above" />
                  </measure>
                  <measure right="dbl">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n2a" dur="2" oct.ges="7" oct="6" pname="c" />
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1b" dur="2" oct.ges="6" oct="5" pname="e" />
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                     <octave startid="#n1b" endid="#n2b" dis="8" dis.place="above" />
                  </measure>
                  <measure right="dbl">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n2b" dots="1" dur="2" oct.ges="7" oct="6" pname="c" />
                           <rest dur="4" />
                        </layer>
                     </staff>
                  </measure>
               </section>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1c" dur="2" oct.ges="6" oct="5" pname="e" />
                           <beam>
                              <note dur="8" oct.ges="6" oct="5" pname="f" />
                              <note dur="8" oct.ges="6" oct="5" pname="a" />
                              <note dur="8" oct.ges="6" oct="5" pname="g" />
                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                     <octave startid="#n1c" endid="#n2c" dis="8" dis.place="above" />
                  </measure>
                  <measure right="dbl">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n2c" dots="2" dur="2" oct.ges="7" oct="6" pname="c" />
                           <rest dur="8" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```