### PR TITLE
Empty syllables

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -5419,7 +5419,17 @@ bool MEIInput::ReadSyl(Object *parent, pugi::xml_node syl)
 
     parent->AddChild(vrvSyl);
     ReadUnsupportedAttr(syl, vrvSyl);
-    return ReadTextChildren(vrvSyl, syl, vrvSyl);
+
+    bool ok = ReadTextChildren(vrvSyl, syl, vrvSyl);
+
+    // Ensure that there is one text child
+    if (ok && (vrvSyl->GetChildCount(TEXT) == 0)) {
+        Text *vrvText = new Text();
+        vrvText->SetText(L"");
+        vrvSyl->AddChild(vrvText);
+    }
+
+    return ok;
 }
 
 bool MEIInput::ReadSyllable(Object *parent, pugi::xml_node syllable)

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -229,10 +229,14 @@ void View::DrawLyricString(DeviceContext *dc, std::wstring str, int staffSize, s
         dc->ResetFont();
     }
 
-    // This should only be called in facsimile mode where a zone is specified but there is
-    // no text. This draws the bounds of the zone but leaves the space blank.
-    if (!wroteText && params) {
-        dc->DrawText("", L"", params->m_x, params->m_y, params->m_width, params->m_height);
+    // Handle empty text
+    if (!wroteText) {
+        if (params) {
+            dc->DrawText("", L"", params->m_x, params->m_y, params->m_width, params->m_height);
+        }
+        else {
+            dc->DrawText("", L"");
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes #2124

Unlike the [attempted fix](https://github.com/notengrafik/verovio/commit/dafce73ba535ff114cfa0cdbdd6740598202a201) by [th-we](https://github.com/th-we) (see issue) we take a different approach and always add a text element (with possibly empty text) to syl elements such that bounding boxes are calculated correctly.