### PR TITLE
Empty syllables (next try)

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1173,21 +1173,13 @@ void View::DrawSylConnector(
 
     // Invalid bounding boxes might occur for empty syllables without text child
     if (!syl->HasContentHorizontalBB()) return;
-
-    // Define lambda returning the next syllable with valid bounding box
-    auto nextValidSyl = [](Syl *syl) {
-        Syl *next = syl->m_nextWordSyl;
-        while (next && !next->HasContentHorizontalBB()) {
-            next = next->m_nextWordSyl;
-        }
-        return next;
-    };
+    if (syl->m_nextWordSyl && !syl->m_nextWordSyl->HasContentHorizontalBB()) return;
 
     // The both correspond to the current system, which means no system break in-between (simple case)
     if (spanningType == SPANNING_START_END) {
         x1 = syl->GetContentRight();
-        if (Syl *nextSyl = nextValidSyl(syl); nextSyl) {
-            x2 = nextSyl->GetContentLeft();
+        if (syl->m_nextWordSyl) {
+            x2 = syl->m_nextWordSyl->GetContentLeft();
         }
     }
     // Only the first parent is the same, this means that the syl is "open" at the end of the system
@@ -1208,8 +1200,8 @@ void View::DrawSylConnector(
             }
         }
         // Otherwise just adjust x2
-        if (Syl *nextSyl = nextValidSyl(syl); nextSyl) {
-            x2 = nextSyl->GetContentLeft();
+        if (syl->m_nextWordSyl) {
+            x2 = syl->m_nextWordSyl->GetContentLeft();
         }
         x1 -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     }


### PR DESCRIPTION
This PR fixes #2124 

We follow the approach suggested in the discussion of #2197 

Empty syllables will now be ignored during rendering. That is, an empty syllable between _Foo_ and _Bar_ gets rendered as

![EmptySyl](https://user-images.githubusercontent.com/63608463/118935540-f0e29900-b94b-11eb-832e-5fb4c05c2ee0.png)
