### PR TITLE
Mixed beams flipping over

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1422,14 +1422,14 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
 
     // process highest-level beam
     if (!params->m_beam) {
-        params->m_beam = this;
-        params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
-        params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
-        params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
-        if (m_drawingPlace != BEAMPLACE_mixed)
+        if (m_drawingPlace != BEAMPLACE_mixed) {
+            params->m_beam = this;
+            params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
+            params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
+            params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
             params->m_overlapMargin
                 = CalcLayerOverlap(params->m_doc, params->m_directionBias, params->m_y1, params->m_y2);
-
+        }
         return FUNCTOR_CONTINUE;
     }
 
@@ -1452,6 +1452,8 @@ int Beam::AdjustBeamsEnd(FunctorParams *functorParams)
     assert(params);
 
     if (params->m_beam != this) return FUNCTOR_CONTINUE;
+
+    if (m_drawingPlace == BEAMPLACE_mixed) return FUNCTOR_CONTINUE;
 
     Layer *parentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     if (parentLayer) {


### PR DESCRIPTION
This PR fixes mixed beams which are shifted and flip over. Here is an example from the test library:

| CrossStaff 14 before  | CrossStaff 14 after |
| ------------- | ------------- |
| ![Crossstaff14-before](https://user-images.githubusercontent.com/63608463/119127233-5ad66d80-ba34-11eb-9312-939763acde7a.png)  | ![Crosstaff14-after](https://user-images.githubusercontent.com/63608463/119127379-8b1e0c00-ba34-11eb-938c-4cbe0ce180a6.png)  |

**MEI**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Cross-staff content and note head position</title>
            <respStmt>
               <persName role="editor">Laurent Pugin</persName>
               <persName role="encoder">Craig Sapp</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date>2020-11-30</date>
            <pubPlace>
               <ref target="https://github.com/rism-digtial/verovio/issues/98" />
            </pubPlace>
         </pubStmt>
         <notesStmt>
            <annot />
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.1.0" label="1">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp symbol="brace" bar.thru="true">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="3f" meter.count="2" meter.unit="4" />
                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="3f" meter.count="2" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="5">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note xml:id="note-000000167757583" dots="1" dur="16" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                              <note dur="32" oct="5" pname="d" stem.dir="up" accid.ges="n" />
                           </beam>
                           <note xml:id="note-000000110649015" dots="1" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="n" />
                        </layer>
                        <layer n="2">
                           <note dur="2" oct="4" pname="a" stem.dir="up">
                              <accid accid="f" func="caution" />
                           </note>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam>
                              <note dur="8" staff="1" oct="4" pname="a">
                                 <accid accid="f" func="caution" />
                              </note>
                              <note dur="8" oct="3" pname="b" accid="n" />
                              <note dur="8" oct="4" pname="d" accid.ges="n" />
                              <note dur="8" oct="3" pname="b" accid.ges="n" />
                           </beam>
                        </layer>
                        <layer n="2">
                           <note dur="2" oct="3" pname="f" stem.dir="down" accid.ges="n" />
                        </layer>
                     </staff>
                     <slur staff="1" startid="#note-000000167757583" endid="#note-000000110649015" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
