### PR TITLE
Code cleanup

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -43,7 +43,7 @@ public:
     /** Override the method since it is align to the staff */
     virtual bool IsRelativeToStaff() const { return true; }
 
-    data_ARTICULATION GetArticFirst();
+    data_ARTICULATION GetArticFirst() const;
 
     /**
      * Split the multi-valued artic attributes into distinct artic elements.
@@ -64,8 +64,8 @@ public:
      * Return the inside and outside part of an artic if any (NULL otherwiser)
      */
     ///@{
-    bool IsInsideArtic();
-    bool IsOutsideArtic() { return !IsInsideArtic(); };
+    bool IsInsideArtic() const;
+    bool IsOutsideArtic() const { return !IsInsideArtic(); };
     ///@}
 
     /**

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -80,7 +80,7 @@ public:
     /**
      * Retrieves the appropriate SMuFL code for a data_ARTICULATION with data_STAFFREL
      */
-    wchar_t GetArticGlyph(data_ARTICULATION artic, const data_STAFFREL &place);
+    wchar_t GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -118,123 +118,123 @@ public:
 
     /** @name Basic converters for reading */
     ///@{
-    double StrToDbl(std::string value) const;
-    int StrToInt(std::string value) const;
-    data_VU StrToVU(std::string value, bool logWarning = true) const;
+    double StrToDbl(const std::string &value) const;
+    int StrToInt(const std::string &value) const;
+    data_VU StrToVU(const std::string &value, bool logWarning = true) const;
     ///@}
 
     /** @name Converters for writing and reading */
     ///@{
     std::string ArticulationListToStr(data_ARTICULATION_List data) const;
-    data_ARTICULATION_List StrToArticulationList(std::string value, bool logWarning = true) const;
+    data_ARTICULATION_List StrToArticulationList(const std::string &value, bool logWarning = true) const;
 
     std::string BeatrptRendToStr(data_BEATRPT_REND data) const;
-    data_BEATRPT_REND StrToBeatrptRend(std::string value, bool logWarning = true) const;
+    data_BEATRPT_REND StrToBeatrptRend(const std::string &value, bool logWarning = true) const;
 
     std::string DurationToStr(data_DURATION data) const;
-    data_DURATION StrToDuration(std::string value, bool logWarning = true) const;
+    data_DURATION StrToDuration(const std::string &value, bool logWarning = true) const;
 
     std::string FontsizenumericToStr(data_FONTSIZENUMERIC data) const;
-    data_FONTSIZENUMERIC StrToFontsizenumeric(std::string value, bool logWarning = true) const;
+    data_FONTSIZENUMERIC StrToFontsizenumeric(const std::string &value, bool logWarning = true) const;
 
     std::string HexnumToStr(data_HEXNUM data) const;
     data_HEXNUM StrToHexnum(std::string value, bool logWarning = true) const;
 
     std::string KeysignatureToStr(data_KEYSIGNATURE data) const;
-    data_KEYSIGNATURE StrToKeysignature(std::string value, bool logWarning = true) const;
+    data_KEYSIGNATURE StrToKeysignature(const std::string &value, bool logWarning = true) const;
 
     std::string MeasurebeatToStr(data_MEASUREBEAT data) const;
     data_MEASUREBEAT StrToMeasurebeat(std::string value, bool logWarning = true) const;
 
     std::string MeasurementabsToStr(data_MEASUREMENTABS data) const { return VUToStr(data); }
-    data_MEASUREMENTABS StrToMeasurementabs(std::string value, bool logWarning = true) const
+    data_MEASUREMENTABS StrToMeasurementabs(const std::string &value, bool logWarning = true) const
     {
         return StrToVU(value, logWarning);
     }
 
     std::string MeasurementrelToStr(data_MEASUREMENTREL data) const { return VUToStr(data); }
-    data_MEASUREMENTREL StrToMeasurementrel(std::string value, bool logWarning = true) const
+    data_MEASUREMENTREL StrToMeasurementrel(const std::string &value, bool logWarning = true) const
     {
         return StrToVU(value, logWarning);
     }
 
     std::string ModusmaiorToStr(data_MODUSMAIOR data) const;
-    data_MODUSMAIOR StrToModusmaior(std::string value, bool logWarning = true) const;
+    data_MODUSMAIOR StrToModusmaior(const std::string &value, bool logWarning = true) const;
 
     std::string ModusminorToStr(data_MODUSMINOR data) const;
-    data_MODUSMINOR StrToModusminor(std::string value, bool logWarning = true) const;
+    data_MODUSMINOR StrToModusminor(const std::string &value, bool logWarning = true) const;
 
     std::string MidibpmToStr(data_MIDIBPM data) const { return IntToStr(data); }
-    data_MIDIBPM StrToMidibpm(std::string value) const { return StrToInt(value); }
+    data_MIDIBPM StrToMidibpm(const std::string &value) const { return StrToInt(value); }
 
     std::string MidichannelToStr(data_MIDICHANNEL data) const { return IntToStr(data); }
-    data_MIDICHANNEL StrToMidichannel(std::string value) const { return StrToInt(value); }
+    data_MIDICHANNEL StrToMidichannel(const std::string &value) const { return StrToInt(value); }
 
     std::string MidimspbToStr(data_MIDIMSPB data) const { return IntToStr(data); }
-    data_MIDIMSPB StrToMidimspb(std::string value) const { return StrToInt(value); }
+    data_MIDIMSPB StrToMidimspb(const std::string &value) const { return StrToInt(value); }
 
     std::string MidivalueToStr(data_MIDIVALUE data) const { return IntToStr(data); }
-    data_MIDIVALUE StrToMidivalue(std::string value) const { return StrToInt(value); }
+    data_MIDIVALUE StrToMidivalue(const std::string &value) const { return StrToInt(value); }
 
     std::string NcnameToStr(data_NCNAME data) const { return StrToStr(data); }
-    data_NCNAME StrToNcname(std::string value) const { return StrToStr(value); }
+    data_NCNAME StrToNcname(const std::string &value) const { return StrToStr(value); }
 
     std::string OctaveToStr(data_OCTAVE data) const { return IntToStr(data); }
-    data_OCTAVE StrToOctave(std::string value) const { return StrToInt(value); }
+    data_OCTAVE StrToOctave(const std::string &value) const { return StrToInt(value); }
 
     std::string OctaveDisToStr(data_OCTAVE_DIS data) const;
-    data_OCTAVE_DIS StrToOctaveDis(std::string value, bool logWarning = true) const;
+    data_OCTAVE_DIS StrToOctaveDis(const std::string &value, bool logWarning = true) const;
 
     std::string OrientationToStr(data_ORIENTATION data) const;
-    data_ORIENTATION StrToOrientation(std::string value, bool logWarning = true) const;
+    data_ORIENTATION StrToOrientation(const std::string &value, bool logWarning = true) const;
 
     std::string PercentToStr(data_PERCENT data) const;
-    data_PERCENT StrToPercent(std::string value, bool logWarning = true) const;
+    data_PERCENT StrToPercent(const std::string &value, bool logWarning = true) const;
 
     std::string PercentLimitedToStr(data_PERCENT_LIMITED_SIGNED data) const;
-    data_PERCENT_LIMITED StrToPercentLimited(std::string value, bool logWarning = true) const;
+    data_PERCENT_LIMITED StrToPercentLimited(const std::string &value, bool logWarning = true) const;
 
     std::string PercentLimitedSignedToStr(data_PERCENT_LIMITED data) const;
-    data_PERCENT_LIMITED_SIGNED StrToPercentLimitedSigned(std::string value, bool logWarning = true) const;
+    data_PERCENT_LIMITED_SIGNED StrToPercentLimitedSigned(const std::string &value, bool logWarning = true) const;
 
     std::string PitchnameToStr(data_PITCHNAME data) const;
-    data_PITCHNAME StrToPitchname(std::string value, bool logWarning = true) const;
+    data_PITCHNAME StrToPitchname(const std::string &value, bool logWarning = true) const;
 
     std::string ProlatioToStr(data_PROLATIO data) const;
-    data_PROLATIO StrToProlatio(std::string value, bool logWarning = true) const;
+    data_PROLATIO StrToProlatio(const std::string &value, bool logWarning = true) const;
 
     std::string TempusToStr(data_TEMPUS data) const;
-    data_TEMPUS StrToTempus(std::string value, bool logWarning = true) const;
+    data_TEMPUS StrToTempus(const std::string &value, bool logWarning = true) const;
 
     std::string TieToStr(data_TIE data) const;
-    data_TIE StrToTie(std::string value, bool logWarning = true) const;
+    data_TIE StrToTie(const std::string &value, bool logWarning = true) const;
 
     std::string XsdAnyURIListToStr(xsdAnyURI_List data) const;
-    xsdAnyURI_List StrToXsdAnyURIList(std::string value) const;
+    xsdAnyURI_List StrToXsdAnyURIList(const std::string &value) const;
 
     std::string XsdPositiveIntegerListToStr(xsdPositiveInteger_List data) const;
-    xsdPositiveInteger_List StrToXsdPositiveIntegerList(std::string value) const;
+    xsdPositiveInteger_List StrToXsdPositiveIntegerList(const std::string &value) const;
     ///@}
 
     /** @name Converters for writing and reading alternate data types not generated by LibMEI */
     ///@{
     std::string FontsizeToStr(data_FONTSIZE data) const;
-    data_FONTSIZE StrToFontsize(std::string value, bool logWarning = true) const;
+    data_FONTSIZE StrToFontsize(const std::string &value, bool logWarning = true) const;
 
     std::string LinewidthToStr(data_LINEWIDTH data) const;
-    data_LINEWIDTH StrToLinewidth(std::string value, bool logWarning = true) const;
+    data_LINEWIDTH StrToLinewidth(const std::string &value, bool logWarning = true) const;
 
     std::string MidivalueNameToStr(data_MIDIVALUE_NAME data) const;
-    data_MIDIVALUE_NAME StrToMidivalueName(std::string value, bool logWarning = true) const;
+    data_MIDIVALUE_NAME StrToMidivalueName(const std::string &value, bool logWarning = true) const;
 
     std::string MidivaluePanToStr(data_MIDIVALUE_PAN data) const;
-    data_MIDIVALUE_PAN StrToMidivaluePan(std::string value, bool logWarning = true) const;
+    data_MIDIVALUE_PAN StrToMidivaluePan(const std::string &value, bool logWarning = true) const;
     ///@}
 
     /** @name Converters for writing and reading alternate data types unsing other alternate data types */
     ///@{
     std::string PlacementToStr(data_PLACEMENT data) const;
-    data_PLACEMENT StrToPlacement(std::string value, bool logWarning = true) const;
+    data_PLACEMENT StrToPlacement(const std::string &value, bool logWarning = true) const;
     ///@}
 };
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -48,7 +48,7 @@ public:
     /**
      *
      */
-    const ArrayOfBeamElementCoords *GetElementCoordRefs();
+    const ArrayOfBeamElementCoords *GetElementCoordRefs() const;
 
     /**
      * Initializes the m_beamElementCoords vector objects.
@@ -221,7 +221,7 @@ public:
      * Return the encoded stem direction.
      * Access the value in the Stem element if already set.
      */
-    data_STEMDIRECTION GetStemDir();
+    data_STEMDIRECTION GetStemDir() const;
 
     void SetDrawingStemDir(
         data_STEMDIRECTION stemDir, Staff *staff, Doc *doc, BeamSegment *segment, BeamDrawingInterface *interface);

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -51,7 +51,7 @@ public:
      */
     ///@{
     void SetScoreTimeOnset(double scoreTime);
-    double GetScoreTimeOnset();
+    double GetScoreTimeOnset() const;
 
     //----------//
     // Functors //

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -318,13 +318,6 @@ public:
     void ConvertToUnCastOffMensuralDoc();
 
     /**
-     * Convert scoreDef / staffDef attributes (clef.*, key.*, meter.*, etc.) to corresponding elements
-     * By default, the element are used only for the rendering and not preserved in the MEI output
-     * Permanent conversion discard analytical markup and elements will be preserved in the MEI output.
-     */
-    void ConvertScoreDefMarkupDoc(bool permanent = false);
-
-    /**
      * Convert analytical encoding (@fermata, @tie) to correpsonding elements
      * By default, the element are used only for the rendering and not preserved in the MEI output
      * Permanent conversion discard analytical markup and elements will be preserved in the MEI output.

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -92,7 +92,7 @@ public:
     /**
      * Return true if the value is a mensural (DURATION_longa, brevis, etc.)
      */
-    bool IsMensuralDur();
+    bool IsMensuralDur() const;
 
     /**
      * Interface comparison operator.

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -114,8 +114,8 @@ public:
 
     wchar_t GetFlagGlyph(data_STEMDIRECTION stemDir) const;
 
-    Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code);
-    Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code);
+    Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const;
+    Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const;
 
     //----------//
     // Functors //

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -112,7 +112,7 @@ public:
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }
 
-    wchar_t GetFlagGlyph(data_STEMDIRECTION stemDir);
+    wchar_t GetFlagGlyph(data_STEMDIRECTION stemDir) const;
 
     Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code);
     Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code);

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1176,20 +1176,6 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// ConvertScoreDefMarkupParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: a flag indicating whereas the conversion is permanent of not
- **/
-
-class ConvertScoreDefMarkupParams : public FunctorParams {
-public:
-    ConvertScoreDefMarkupParams(bool permanent) { m_permanent = permanent; }
-    bool m_permanent;
-};
-
-//----------------------------------------------------------------------------
 // ConvertToCastOffMensuralParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -76,7 +76,7 @@ public:
      */
     std::wstring GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname);
 
-    int GetFifthsInt();
+    int GetFifthsInt() const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -108,7 +108,7 @@ public:
     /** Return true if the element is a grace note */
     bool IsGraceNote();
     /** Return true if the element is has to be rederred as cue sized */
-    bool GetDrawingCueSize();
+    bool GetDrawingCueSize() const;
     /** Return true if the element is a note within a ligature */
     bool IsInLigature() const;
     /** Return the FTrem parten if the element is a note or a chord within a fTrem */
@@ -212,10 +212,10 @@ public:
      * Used only on beam, tuplet or ftrem have.
      */
     double GetSameAsContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
 
     double GetContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
 
     /**
      * Get zone bounds using child elements with facsimile information.

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -189,7 +189,7 @@ public:
     /**
      * Return the SMuFL code for a mensural note looking at the staff notation type, the coloration and the duration
      */
-    wchar_t GetMensuralNoteheadGlyph();
+    wchar_t GetMensuralNoteheadGlyph() const;
 
     /**
      * Return a SMuFL code for the notehead

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -146,7 +146,7 @@ public:
      * @name Return the smufl string to use for a note give the notation type
      */
     ///@{
-    std::wstring GetTabFretString(data_NOTATIONTYPE notationType);
+    std::wstring GetTabFretString(data_NOTATIONTYPE notationType) const;
     ///@}
 
     /**
@@ -199,7 +199,7 @@ public:
     /**
      * Check if a note or its parent chord are visible
      */
-    bool IsVisible();
+    bool IsVisible() const;
 
     /**
      * Correct dots placement depending on other dots present in the current alignment
@@ -216,13 +216,13 @@ public:
     void SetRealTimeOffsetSeconds(double timeInSeconds);
     void SetScoreTimeTiedDuration(double timeInSeconds);
     void CalcMIDIPitch(int shift);
-    double GetScoreTimeOnset();
-    double GetRealTimeOnsetMilliseconds();
-    double GetScoreTimeOffset();
-    double GetScoreTimeTiedDuration();
-    double GetRealTimeOffsetMilliseconds();
-    double GetScoreTimeDuration();
-    char GetMIDIPitch();
+    double GetScoreTimeOnset() const;
+    double GetRealTimeOnsetMilliseconds() const;
+    double GetScoreTimeOffset() const;
+    double GetScoreTimeTiedDuration() const;
+    double GetRealTimeOffsetMilliseconds() const;
+    double GetScoreTimeDuration() const;
+    char GetMIDIPitch() const;
     ///@}
 
 public:

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -660,14 +660,6 @@ public:
     ///@}
 
     /**
-     * Convert scoreDef / staffDef markup (@clef.*, @key.*) to elements.
-     * See Doc::ConvertScoreDefMarkupDoc
-     */
-    ///@{
-    virtual int ConvertScoreDefMarkup(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    ///@}
-
-    /**
      * Save the content of any object by calling the appropriate FileOutputStream method.
      */
     ///@{

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -151,7 +151,7 @@ private:
     /**
      * Get location of the object on the layer if it's note, chord or ftrem
      */
-    std::pair<int, RestAccidental> GetElementLocation(Object *object, Layer *layer, bool isTopLayer);
+    std::pair<int, RestAccidental> GetElementLocation(Object *object, Layer *layer, bool isTopLayer) const;
 
     /**
      * Get correct offset for the rest from the options based on layer and location

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -82,7 +82,7 @@ public:
      * Return the maximum and minimum X positions of the notes in the tuplets.
      * Look at flipped noteheads in chords.
      */
-    void GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc);
+    void GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc) const;
 
     //----------//
     // Functors //

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -165,7 +165,7 @@ void Artic::AddSlurPositioner(FloatingCurvePositioner *positioner, bool start)
     }
 }
 
-wchar_t Artic::GetArticGlyph(data_ARTICULATION artic, const data_STAFFREL &place)
+wchar_t Artic::GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const
 {
     // If there is glyph.num, prioritize it
     if (HasGlyphNum()) {

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -59,14 +59,14 @@ void Artic::Reset()
     m_drawingPlace = STAFFREL_NONE;
 }
 
-bool Artic::IsInsideArtic()
+bool Artic::IsInsideArtic() const
 {
     auto end = Artic::s_outStaffArtic.end();
     auto i = std::find(Artic::s_outStaffArtic.begin(), end, this->GetArticFirst());
     return (i == end);
 }
 
-data_ARTICULATION Artic::GetArticFirst()
+data_ARTICULATION Artic::GetArticFirst() const
 {
     std::vector<data_ARTICULATION> articList = this->GetArtic();
     if (articList.empty()) return ARTICULATION_NONE;

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -337,22 +337,22 @@ int Artic::CalcArtic(FunctorParams *functorParams)
 
     // Exception for artic because they are relative to the staff - we set m_crossStaff and m_crossLayer
     if (this->GetDrawingPlace() == STAFFREL_above && params->m_crossStaffAbove) {
-        this->m_crossStaff = params->m_staffAbove;
-        this->m_crossLayer = params->m_layerAbove;
+        m_crossStaff = params->m_staffAbove;
+        m_crossLayer = params->m_layerAbove;
         // Exception - the artic is above in a cross-staff note / chord going down - the positioning is relative to the
         // parent where the beam is
         if (beam && beam->m_crossStaffContent && !beam->m_crossStaff && beam->m_crossStaffRel == STAFFREL_basic_below) {
-            this->m_crossStaff = NULL;
-            this->m_crossLayer = NULL;
+            m_crossStaff = NULL;
+            m_crossLayer = NULL;
         }
     }
     else if (this->GetDrawingPlace() == STAFFREL_below && params->m_crossStaffBelow) {
-        this->m_crossStaff = params->m_staffBelow;
-        this->m_crossLayer = params->m_layerBelow;
+        m_crossStaff = params->m_staffBelow;
+        m_crossLayer = params->m_layerBelow;
         // Exception - opposite as above
         if (beam && beam->m_crossStaffContent && !beam->m_crossStaff && beam->m_crossStaffRel == STAFFREL_basic_above) {
-            this->m_crossStaff = NULL;
-            this->m_crossLayer = NULL;
+            m_crossStaff = NULL;
+            m_crossLayer = NULL;
         }
     }
 
@@ -373,8 +373,8 @@ int Artic::AdjustArtic(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff);
 
-    if (this->m_crossStaff) {
-        staff = this->m_crossStaff;
+    if (m_crossStaff) {
+        staff = m_crossStaff;
     }
 
     int staffYBottom = -params->m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);

--- a/src/att.cpp
+++ b/src/att.cpp
@@ -52,17 +52,17 @@ std::string Att::VUToStr(data_VU data) const
 
 // Basic converters for reading
 
-double Att::StrToDbl(std::string value) const
+double Att::StrToDbl(const std::string &value) const
 {
     return atof(value.c_str());
 }
 
-int Att::StrToInt(std::string value) const
+int Att::StrToInt(const std::string &value) const
 {
     return atoi(value.c_str());
 }
 
-data_VU Att::StrToVU(std::string value, bool logWarning) const
+data_VU Att::StrToVU(const std::string &value, bool logWarning) const
 {
     std::regex test("[0-9]*(\\.[0-9]+)?(vu)?");
     if (!std::regex_match(value, test)) {
@@ -84,7 +84,7 @@ std::string Att::ArticulationListToStr(data_ARTICULATION_List data) const
     return ss.str();
 }
 
-data_ARTICULATION_List Att::StrToArticulationList(std::string value, bool logWarning) const
+data_ARTICULATION_List Att::StrToArticulationList(const std::string &value, bool logWarning) const
 {
     data_ARTICULATION_List list;
     std::istringstream iss(value);
@@ -113,7 +113,7 @@ std::string Att::BeatrptRendToStr(data_BEATRPT_REND data) const
     return value;
 }
 
-data_BEATRPT_REND Att::StrToBeatrptRend(std::string value, bool logWarning) const
+data_BEATRPT_REND Att::StrToBeatrptRend(const std::string &value, bool logWarning) const
 {
     if (value == "1") return BEATRPT_REND_1;
     if (value == "2") return BEATRPT_REND_2;
@@ -158,7 +158,7 @@ std::string Att::DurationToStr(data_DURATION data) const
     return value;
 }
 
-data_DURATION Att::StrToDuration(std::string value, bool logWarning) const
+data_DURATION Att::StrToDuration(const std::string &value, bool logWarning) const
 {
     if (value == "maxima") return DURATION_maxima;
     if (value == "longa") return DURATION_longa;
@@ -236,7 +236,7 @@ std::string Att::FontsizeToStr(data_FONTSIZE data) const
     return value;
 }
 
-data_FONTSIZE Att::StrToFontsize(std::string value, bool logWarning) const
+data_FONTSIZE Att::StrToFontsize(const std::string &value, bool logWarning) const
 {
     data_FONTSIZE data;
     data.SetFontSizeNumeric(StrToFontsizenumeric(value, false));
@@ -262,7 +262,7 @@ std::string Att::LinewidthToStr(data_LINEWIDTH data) const
     return value;
 }
 
-data_LINEWIDTH Att::StrToLinewidth(std::string value, bool logWarning) const
+data_LINEWIDTH Att::StrToLinewidth(const std::string &value, bool logWarning) const
 {
     data_LINEWIDTH data;
     data.SetLineWidthTerm(StrToLinewidthterm(value, false));
@@ -280,7 +280,7 @@ std::string Att::FontsizenumericToStr(data_FONTSIZENUMERIC data) const
     return StringFormat("%.2fpt", data);
 }
 
-data_FONTSIZENUMERIC Att::StrToFontsizenumeric(std::string value, bool logWarning) const
+data_FONTSIZENUMERIC Att::StrToFontsizenumeric(const std::string &value, bool logWarning) const
 {
     std::regex test("[0-9]*(\\.[0-9]+)?(pt)");
     if (!std::regex_match(value, test)) {
@@ -307,7 +307,7 @@ std::string Att::KeysignatureToStr(data_KEYSIGNATURE data) const
     return value;
 }
 
-data_KEYSIGNATURE Att::StrToKeysignature(std::string value, bool logWarning) const
+data_KEYSIGNATURE Att::StrToKeysignature(const std::string &value, bool logWarning) const
 {
     int alterationNumber = 0;
     data_ACCIDENTAL_WRITTEN alterationType = ACCIDENTAL_WRITTEN_NONE;
@@ -370,7 +370,7 @@ std::string Att::MidivalueNameToStr(data_MIDIVALUE_NAME data) const
     return value;
 }
 
-data_MIDIVALUE_NAME Att::StrToMidivalueName(std::string value, bool logWarning) const
+data_MIDIVALUE_NAME Att::StrToMidivalueName(const std::string &value, bool logWarning) const
 {
     data_MIDIVALUE_NAME data;
     data.SetMidivalue(StrToMidivalue(value));
@@ -394,7 +394,7 @@ std::string Att::MidivaluePanToStr(data_MIDIVALUE_PAN data) const
     return value;
 }
 
-data_MIDIVALUE_PAN Att::StrToMidivaluePan(std::string value, bool logWarning) const
+data_MIDIVALUE_PAN Att::StrToMidivaluePan(const std::string &value, bool logWarning) const
 {
     data_MIDIVALUE_PAN data;
     data.SetMidivalue(StrToMidivalue(value));
@@ -421,7 +421,7 @@ std::string Att::ModusmaiorToStr(data_MODUSMAIOR data) const
     return value;
 }
 
-data_MODUSMAIOR Att::StrToModusmaior(std::string value, bool logWarning) const
+data_MODUSMAIOR Att::StrToModusmaior(const std::string &value, bool logWarning) const
 {
     if (value == "2") return MODUSMAIOR_2;
     if (value == "3") return MODUSMAIOR_3;
@@ -443,7 +443,7 @@ std::string Att::ModusminorToStr(data_MODUSMINOR data) const
     return value;
 }
 
-data_MODUSMINOR Att::StrToModusminor(std::string value, bool logWarning) const
+data_MODUSMINOR Att::StrToModusminor(const std::string &value, bool logWarning) const
 {
     if (value == "2") return MODUSMINOR_2;
     if (value == "3") return MODUSMINOR_3;
@@ -466,7 +466,7 @@ std::string Att::OctaveDisToStr(data_OCTAVE_DIS data) const
     return value;
 }
 
-data_OCTAVE_DIS Att::StrToOctaveDis(std::string value, bool logWarning) const
+data_OCTAVE_DIS Att::StrToOctaveDis(const std::string &value, bool logWarning) const
 {
     if (value == "8") return OCTAVE_DIS_8;
     if (value == "15") return OCTAVE_DIS_15;
@@ -490,7 +490,7 @@ std::string Att::OrientationToStr(data_ORIENTATION data) const
     return value;
 }
 
-data_ORIENTATION Att::StrToOrientation(std::string value, bool logWarning) const
+data_ORIENTATION Att::StrToOrientation(const std::string &value, bool logWarning) const
 {
     if (value == "reversed") return ORIENTATION_reversed;
     if (value == "90CW") return ORIENTATION_90CW;
@@ -504,7 +504,7 @@ std::string Att::PercentToStr(data_PERCENT data) const
     return StringFormat("%.2f%%", data);
 }
 
-data_PERCENT Att::StrToPercent(std::string value, bool logWarning) const
+data_PERCENT Att::StrToPercent(const std::string &value, bool logWarning) const
 {
     std::regex test("[0-9]+(\\.?[0-9]*)?%");
     if (!std::regex_match(value, test)) {
@@ -519,7 +519,7 @@ std::string Att::PercentLimitedToStr(data_PERCENT_LIMITED data) const
     return StringFormat("%.2f%%", data);
 }
 
-data_PERCENT_LIMITED Att::StrToPercentLimited(std::string value, bool logWarning) const
+data_PERCENT_LIMITED Att::StrToPercentLimited(const std::string &value, bool logWarning) const
 {
     std::regex test("[0-9]+(\\.?[0-9]*)?%");
     if (!std::regex_match(value, test)) {
@@ -534,7 +534,7 @@ std::string Att::PercentLimitedSignedToStr(data_PERCENT_LIMITED_SIGNED data) con
     return StringFormat("%.2f%%", data);
 }
 
-data_PERCENT_LIMITED_SIGNED Att::StrToPercentLimitedSigned(std::string value, bool logWarning) const
+data_PERCENT_LIMITED_SIGNED Att::StrToPercentLimitedSigned(const std::string &value, bool logWarning) const
 {
     std::regex test("(+|-)?[0-9]+(\\.?[0-9]*)?%");
     if (!std::regex_match(value, test)) {
@@ -563,7 +563,7 @@ std::string Att::PitchnameToStr(data_PITCHNAME data) const
     return value;
 }
 
-data_PITCHNAME Att::StrToPitchname(std::string value, bool logWarning) const
+data_PITCHNAME Att::StrToPitchname(const std::string &value, bool logWarning) const
 {
     if (value == "c") return PITCHNAME_c;
     if (value == "d") return PITCHNAME_d;
@@ -589,7 +589,7 @@ std::string Att::PlacementToStr(data_PLACEMENT data) const
     return value;
 }
 
-data_PLACEMENT Att::StrToPlacement(std::string value, bool logWarning) const
+data_PLACEMENT Att::StrToPlacement(const std::string &value, bool logWarning) const
 {
     data_PLACEMENT data;
     data.SetStaffRel(StrToStaffrel(value, false));
@@ -619,7 +619,7 @@ std::string Att::ProlatioToStr(data_PROLATIO data) const
     return value;
 }
 
-data_PROLATIO Att::StrToProlatio(std::string value, bool logWarning) const
+data_PROLATIO Att::StrToProlatio(const std::string &value, bool logWarning) const
 {
     if (value == "2") return PROLATIO_2;
     if (value == "3") return PROLATIO_3;
@@ -641,7 +641,7 @@ std::string Att::TempusToStr(data_TEMPUS data) const
     return value;
 }
 
-data_TEMPUS Att::StrToTempus(std::string value, bool logWarning) const
+data_TEMPUS Att::StrToTempus(const std::string &value, bool logWarning) const
 {
     if (value == "2") return TEMPUS_2;
     if (value == "3") return TEMPUS_3;
@@ -664,7 +664,7 @@ std::string Att::TieToStr(data_TIE data) const
     return value;
 }
 
-data_TIE Att::StrToTie(std::string value, bool logWarning) const
+data_TIE Att::StrToTie(const std::string &value, bool logWarning) const
 {
     if (value == "i") return TIE_i;
     if (value == "m") return TIE_m;
@@ -683,7 +683,7 @@ std::string Att::XsdAnyURIListToStr(xsdAnyURI_List data) const
     return ss.str();
 }
 
-xsdAnyURI_List Att::StrToXsdAnyURIList(std::string value) const
+xsdAnyURI_List Att::StrToXsdAnyURIList(const std::string &value) const
 {
     xsdAnyURI_List list;
     std::istringstream iss(value);
@@ -704,7 +704,7 @@ std::string Att::XsdPositiveIntegerListToStr(xsdPositiveInteger_List data) const
     return ss.str();
 }
 
-xsdPositiveInteger_List Att::StrToXsdPositiveIntegerList(std::string value) const
+xsdPositiveInteger_List Att::StrToXsdPositiveIntegerList(const std::string &value) const
 {
     xsdPositiveInteger_List list;
     std::istringstream iss(value);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -311,7 +311,7 @@ void BeamSegment::CalcBeamInit(
         coord->m_x = coord->m_element->GetDrawingX();
     }
 
-    this->m_verticalCenter = staff->GetDrawingY()
+    m_verticalCenter = staff->GetDrawingY()
         - (doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2); // center point of the staff
 
     beamInterface->m_beamWidthBlack = doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, beamInterface->m_cueSize);
@@ -363,7 +363,7 @@ void BeamSegment::CalcBeamInit(
             assert(chord);
             chord->GetYExtremes(yMax, yMin);
 
-            this->m_avgY += ((yMax + yMin) / 2);
+            m_avgY += ((yMax + yMin) / 2);
 
             int linesAbove = 0;
             int linesBelow = 0;
@@ -381,7 +381,7 @@ void BeamSegment::CalcBeamInit(
         else if (coord->m_element->Is(NOTE)) {
             Note *note = vrv_cast<Note *>(coord->m_element);
             assert(note);
-            this->m_avgY += note->GetDrawingY();
+            m_avgY += note->GetDrawingY();
 
             int linesAbove = 0;
             int linesBelow = 0;
@@ -397,7 +397,7 @@ void BeamSegment::CalcBeamInit(
 
     // Only if not only rests. (Will produce non-sense output anyway)
     if (elementCount != nbRests) {
-        this->m_avgY /= (elementCount - nbRests);
+        m_avgY /= (elementCount - nbRests);
     }
 }
 
@@ -530,7 +530,7 @@ bool BeamSegment::CalcBeamSlope(
             // For 8th note groups, reduce the length of the last note if possible - disabled because not working well
             /*
             if ((beamInterface->m_shortestDur == DUR_8) && !m_lastNoteOrChord->m_shortened
-                && !this->m_extendedToCenter) {
+                && !m_extendedToCenter) {
                 shorten = true;
             }
             */
@@ -548,7 +548,7 @@ bool BeamSegment::CalcBeamSlope(
             // For 8th note groups, reduce the length of the first note if possible - disabled because not working well
             /*
             if ((beamInterface->m_shortestDur == DUR_8) && !m_firstNoteOrChord->m_shortened
-                && !this->m_extendedToCenter) {
+                && !m_extendedToCenter) {
                 //shorten = true;
             }
             */
@@ -568,7 +568,7 @@ bool BeamSegment::CalcBeamSlope(
             // For 8th note groups, reduce the length of the last note if possible - disabled because not working well
             /*
             if ((beamInterface->m_shortestDur == DUR_8) && !m_lastNoteOrChord->m_shortened
-                && !this->m_extendedToCenter) {
+                && !m_extendedToCenter) {
                 //shorten = true;
             }
             */
@@ -586,7 +586,7 @@ bool BeamSegment::CalcBeamSlope(
             // For 8th note groups, reduce the length of the first note if possible - disabled because not working well
             /*
             if ((beamInterface->m_shortestDur == DUR_8) && !m_firstNoteOrChord->m_shortened
-                && !this->m_extendedToCenter) {
+                && !m_extendedToCenter) {
                 //shorten = true;
             }
             */
@@ -615,7 +615,7 @@ bool BeamSegment::CalcBeamSlope(
         }
     }
 
-    this->m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
+    m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
         Point(m_lastNoteOrChord->m_x, m_lastNoteOrChord->m_yBeam));
     // LogDebug("Slope (adjusted) %f", m_beamSlope);
 
@@ -770,7 +770,7 @@ void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *
             }
 
             // Reset the slop and the value
-            this->m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
+            m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
                 Point(m_lastNoteOrChord->m_x, m_lastNoteOrChord->m_yBeam));
 
             this->CalcSetValues();
@@ -815,7 +815,7 @@ void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *
             }
 
             // Reset the slop and the value
-            this->m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
+            m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
                 Point(m_lastNoteOrChord->m_x, m_lastNoteOrChord->m_yBeam));
 
             this->CalcSetValues();
@@ -894,13 +894,12 @@ void BeamSegment::CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterfac
         data_STEMDIRECTION layerStemDir = layer->GetDrawingStemDir(&m_beamElementCoordRefs);
         // Layer direction ?
         if (layerStemDir == STEMDIRECTION_NONE) {
-            if (this->m_ledgerLinesBelow != this->m_ledgerLinesAbove) {
+            if (m_ledgerLinesBelow != m_ledgerLinesAbove) {
                 beamInterface->m_drawingPlace
-                    = (this->m_ledgerLinesBelow > this->m_ledgerLinesAbove) ? BEAMPLACE_above : BEAMPLACE_below;
+                    = (m_ledgerLinesBelow > m_ledgerLinesAbove) ? BEAMPLACE_above : BEAMPLACE_below;
             }
             else {
-                beamInterface->m_drawingPlace
-                    = (this->m_avgY < this->m_verticalCenter) ? BEAMPLACE_above : BEAMPLACE_below;
+                beamInterface->m_drawingPlace = (m_avgY < m_verticalCenter) ? BEAMPLACE_above : BEAMPLACE_below;
             }
         }
         // Look at the note position
@@ -1012,11 +1011,11 @@ void BeamSegment::CalcPartialFlagPlace()
 
 void BeamSegment::CalcSetValues()
 {
-    this->m_startingX = m_beamElementCoordRefs.at(0)->m_x;
-    this->m_startingY = m_beamElementCoordRefs.at(0)->m_yBeam;
+    m_startingX = m_beamElementCoordRefs.at(0)->m_x;
+    m_startingY = m_beamElementCoordRefs.at(0)->m_yBeam;
 
     for (auto coord : m_beamElementCoordRefs) {
-        coord->m_yBeam = this->m_startingY + this->m_beamSlope * (coord->m_x - this->m_startingX);
+        coord->m_yBeam = m_startingY + m_beamSlope * (coord->m_x - m_startingX);
     }
 }
 
@@ -1207,35 +1206,35 @@ void BeamElementCoord::SetDrawingStemDir(
             stemLen *= -1;
         }
     }
-    this->m_centered = segment->m_uniformStemLength % 2;
+    m_centered = segment->m_uniformStemLength % 2;
 
     if (m_element->Is({ REST, SPACE })) {
-        this->m_x += m_element->GetDrawingRadius(doc);
-        this->m_yBeam = this->m_element->GetDrawingY();
-        this->m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
+        m_x += m_element->GetDrawingRadius(doc);
+        m_yBeam = m_element->GetDrawingY();
+        m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
         return;
     }
 
-    if (!this->m_element->Is({ CHORD, NOTE })) return;
+    if (!m_element->Is({ CHORD, NOTE })) return;
 
-    StemmedDrawingInterface *stemInterface = this->m_element->GetStemmedDrawingInterface();
+    StemmedDrawingInterface *stemInterface = m_element->GetStemmedDrawingInterface();
     assert(stemInterface);
     m_stem = stemInterface->GetDrawingStem();
     assert(m_stem);
 
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
-    this->m_stem->SetDrawingStemDir(stemDir);
+    m_stem->SetDrawingStemDir(stemDir);
     int ledgerLines = 0;
     int ledgerLinesOpposite = 0;
-    this->m_shortened = false;
+    m_shortened = false;
 
-    this->m_yBeam = this->m_element->GetDrawingY();
-    this->m_x += (STEMDIRECTION_up == stemDir) ? interface->m_stemXAbove[interface->m_cueSize]
-                                               : interface->m_stemXBelow[interface->m_cueSize];
+    m_yBeam = m_element->GetDrawingY();
+    m_x += (STEMDIRECTION_up == stemDir) ? interface->m_stemXAbove[interface->m_cueSize]
+                                         : interface->m_stemXBelow[interface->m_cueSize];
     if (!m_closestNote) return;
 
-    this->m_yBeam = m_closestNote->GetDrawingY();
+    m_yBeam = m_closestNote->GetDrawingY();
     if (stemDir == STEMDIRECTION_up) {
         m_closestNote->HasLedgerLines(ledgerLinesOpposite, ledgerLines);
     }
@@ -1243,7 +1242,7 @@ void BeamElementCoord::SetDrawingStemDir(
         m_closestNote->HasLedgerLines(ledgerLines, ledgerLinesOpposite);
     }
 
-    this->m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
+    m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
 
     const bool isInGraceGroup = m_element->GetFirstAncestor(GRACEGRP);
     if (m_element->IsGraceNote() || isInGraceGroup) return;
@@ -1253,11 +1252,11 @@ void BeamElementCoord::SetDrawingStemDir(
     if (interface->m_crossStaffContent || (BEAMPLACE_mixed == interface->m_drawingPlace)) {
         segment->m_extendedToCenter = false;
     }
-    else if (((stemDir == STEMDIRECTION_up) && (this->m_yBeam <= segment->m_verticalCenter))
-        || ((stemDir == STEMDIRECTION_down) && (segment->m_verticalCenter <= this->m_yBeam))) {
-        this->m_yBeam = segment->m_verticalCenter;
+    else if (((stemDir == STEMDIRECTION_up) && (m_yBeam <= segment->m_verticalCenter))
+        || ((stemDir == STEMDIRECTION_down) && (segment->m_verticalCenter <= m_yBeam))) {
+        m_yBeam = segment->m_verticalCenter;
         segment->m_extendedToCenter = true;
-        this->m_centered = false;
+        m_centered = false;
     }
     else {
         segment->m_extendedToCenter = false;
@@ -1265,13 +1264,13 @@ void BeamElementCoord::SetDrawingStemDir(
 
     // Make sure there is a at least one staff space before the ledger lines
     if ((ledgerLines > 2) && (interface->m_shortestDur > DUR_32)) {
-        this->m_yBeam += (stemDir == STEMDIRECTION_up) ? 4 * unit : -4 * unit;
+        m_yBeam += (stemDir == STEMDIRECTION_up) ? 4 * unit : -4 * unit;
     }
     else if ((ledgerLines > 1) && (interface->m_shortestDur > DUR_16)) {
-        this->m_yBeam += (stemDir == STEMDIRECTION_up) ? 2 * unit : -2 * unit;
+        m_yBeam += (stemDir == STEMDIRECTION_up) ? 2 * unit : -2 * unit;
     }
 
-    this->m_yBeam += m_overlapMargin;
+    m_yBeam += m_overlapMargin;
 }
 
 int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemDir)
@@ -1290,14 +1289,14 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
         if ((m_maxShortening > 0) && ((stemLenInHalfUnits - standardStemLen) > m_maxShortening)) {
             stemLenInHalfUnits = standardStemLen - m_maxShortening;
         }
-        this->m_shortened = true;
+        m_shortened = true;
         extend = false;
     }
 
     const int directionBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
     int stemLen = directionBias;
     // For 8th notes, use the shortened stem (if shortened)
-    if (this->m_dur == DUR_8) {
+    if (m_dur == DUR_8) {
         if (stemLenInHalfUnits != standardStemLen) {
             stemLen *= stemLenInHalfUnits;
         }
@@ -1306,7 +1305,7 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
         }
     }
     else {
-        switch (this->m_dur) {
+        switch (m_dur) {
             case (DUR_16): stemLen *= (extend) ? 14 : 13; break;
             case (DUR_32): stemLen *= (extend) ? 18 : 16; break;
             case (DUR_64): stemLen *= (extend) ? 22 : 20; break;
@@ -1492,14 +1491,14 @@ int Beam::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    this->m_beamSegment.InitCoordRefs(this->GetElementCoords());
+    m_beamSegment.InitCoordRefs(this->GetElementCoords());
 
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
 
-    this->m_beamSegment.CalcBeam(layer, staff, params->m_doc, this, this->GetPlace());
+    m_beamSegment.CalcBeam(layer, staff, params->m_doc, this, this->GetPlace());
 
     return FUNCTOR_CONTINUE;
 }
@@ -1509,7 +1508,7 @@ int Beam::ResetDrawing(FunctorParams *functorParams)
     // Call parent one too
     LayerElement::ResetDrawing(functorParams);
 
-    this->m_beamSegment.Reset();
+    m_beamSegment.Reset();
 
     // We want the list of the ObjectListInterface to be re-generated
     this->Modify();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -66,7 +66,7 @@ void BeamSegment::Reset()
     m_lastNoteOrChord = NULL;
 }
 
-const ArrayOfBeamElementCoords *BeamSegment::GetElementCoordRefs()
+const ArrayOfBeamElementCoords *BeamSegment::GetElementCoordRefs() const
 {
     // this->GetList(this);
     return &m_beamElementCoordRefs;
@@ -1170,7 +1170,7 @@ const ArrayOfBeamElementCoords *Beam::GetElementCoords()
 
 BeamElementCoord::~BeamElementCoord() {}
 
-data_STEMDIRECTION BeamElementCoord::GetStemDir()
+data_STEMDIRECTION BeamElementCoord::GetStemDir() const
 {
     // m_stem is not necssary set, so we need to look at the Note / Chord original value
     // Example: IsInBeam called in Note::PrepareLayerElementParts when reaching the first note of the beam

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -62,7 +62,7 @@ void BeatRpt::SetScoreTimeOnset(double scoreTime)
     m_scoreTimeOnset = scoreTime;
 }
 
-double BeatRpt::GetScoreTimeOnset()
+double BeatRpt::GetScoreTimeOnset() const
 {
     return m_scoreTimeOnset;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -546,11 +546,11 @@ int Chord::CalcArtic(FunctorParams *functorParams)
     params->m_crossStaffAbove = false;
     params->m_crossStaffBelow = false;
 
-    if (this->m_crossStaff) {
-        params->m_staffAbove = this->m_crossStaff;
-        params->m_staffBelow = this->m_crossStaff;
-        params->m_layerAbove = this->m_crossLayer;
-        params->m_layerBelow = this->m_crossLayer;
+    if (m_crossStaff) {
+        params->m_staffAbove = m_crossStaff;
+        params->m_staffBelow = m_crossStaff;
+        params->m_layerAbove = m_crossLayer;
+        params->m_layerBelow = m_crossLayer;
         params->m_crossStaffAbove = true;
         params->m_crossStaffBelow = true;
     }
@@ -610,9 +610,9 @@ int Chord::CalcStem(FunctorParams *functorParams)
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
-    if (this->m_crossStaff) {
-        staff = this->m_crossStaff;
-        layer = this->m_crossLayer;
+    if (m_crossStaff) {
+        staff = m_crossStaff;
+        layer = m_crossLayer;
     }
 
     // Cache the in params to avoid further lookup

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -333,7 +333,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
          staves != prepareProcessingListsParams.m_layerTree.child.end(); ++staves) {
 
         int transSemi = 0;
-        if (StaffDef *staffDef = this->m_mdivScoreDef.GetStaffDef(staves->first)) {
+        if (StaffDef *staffDef = m_mdivScoreDef.GetStaffDef(staves->first)) {
             // get the transposition (semi-tone) value for the staff
             if (staffDef->HasTransSemi()) transSemi = staffDef->GetTransSemi();
             midiTrack = staffDef->GetN();
@@ -366,7 +366,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
                 if (!trackName.empty()) midiFile->addTrackName(midiTrack, 0, trackName);
             }
             // set MIDI time signature
-            MeterSig *meterSig = dynamic_cast<MeterSig *>(this->m_mdivScoreDef.FindDescendantByType(METERSIG));
+            MeterSig *meterSig = dynamic_cast<MeterSig *>(m_mdivScoreDef.FindDescendantByType(METERSIG));
             if (meterSig && meterSig->HasCount()) {
                 midiFile->addTimeSignature(midiTrack, 0, meterSig->GetCount(), meterSig->GetUnit());
             }
@@ -876,7 +876,7 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     else {
         CastOffSystemsParams castOffSystemsParams(contentSystem, contentPage, currentSystem, this, smart);
         castOffSystemsParams.m_systemWidth
-            = this->m_drawingPageContentWidth - currentSystem->m_systemLeftMar - currentSystem->m_systemRightMar;
+            = m_drawingPageContentWidth - currentSystem->m_systemLeftMar - currentSystem->m_systemRightMar;
         castOffSystemsParams.m_shift = -contentSystem->GetDrawingLabelsWidth();
         castOffSystemsParams.m_currentScoreDefWidth
             = contentPage->m_drawingScoreDef.GetDrawingWidth() + contentSystem->GetDrawingAbbrLabelsWidth();
@@ -909,7 +909,7 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     Page *currentPage = new Page();
     CastOffPagesParams castOffPagesParams(contentPage, this, currentPage);
     CastOffRunningElements(&castOffPagesParams);
-    castOffPagesParams.m_pageHeight = this->m_drawingPageContentHeight;
+    castOffPagesParams.m_pageHeight = m_drawingPageContentHeight;
     Functor castOffPages(&Object::CastOffPages);
     pages->AddChild(currentPage);
     contentPage->Process(&castOffPages, &castOffPagesParams);
@@ -1256,7 +1256,7 @@ void Doc::TransposeDoc()
 {
     Transposer transposer;
     transposer.SetBase600(); // Set extended chromatic alteration mode (allowing more than double sharps/flats)
-    std::string transpositionOption = this->m_options->m_transpose.GetValue();
+    std::string transpositionOption = m_options->m_transpose.GetValue();
     if (transposer.IsValidIntervalName(transpositionOption)) {
         transposer.SetTransposition(transpositionOption);
     }
@@ -1265,7 +1265,7 @@ void Doc::TransposeDoc()
         // Find the starting key tonic of the data to use in calculating the tranposition interval:
         // Set transposition by key tonic.
         // Detect the current key from the keysignature.
-        KeySig *keysig = dynamic_cast<KeySig *>(this->m_mdivScoreDef.FindDescendantByType(KEYSIG));
+        KeySig *keysig = dynamic_cast<KeySig *>(m_mdivScoreDef.FindDescendantByType(KEYSIG));
         // If there is no keysignature, assume it is C.
         TransPitch currentKey = TransPitch(0, 0, 0);
         if (keysig && keysig->HasPname()) {
@@ -1282,7 +1282,7 @@ void Doc::TransposeDoc()
     }
 
     else if (transposer.IsValidSemitones(transpositionOption)) {
-        KeySig *keysig = dynamic_cast<KeySig *>(this->m_mdivScoreDef.FindDescendantByType(KEYSIG, 3));
+        KeySig *keysig = dynamic_cast<KeySig *>(m_mdivScoreDef.FindDescendantByType(KEYSIG, 3));
         int fifths = 0;
         if (keysig) {
             fifths = keysig->GetFifthsInt();
@@ -1305,7 +1305,7 @@ void Doc::TransposeDoc()
     Functor transpose(&Object::Transpose);
     TransposeParams transposeParams(this, &transposer);
 
-    if (this->m_options->m_transposeSelectedOnly.GetValue() == false) {
+    if (m_options->m_transposeSelectedOnly.GetValue() == false) {
         transpose.m_visibleOnly = false;
     }
 
@@ -1327,7 +1327,7 @@ void Doc::ExpandExpansions()
 
     xsdAnyURI_List expansionList = start->GetPlist();
     xsdAnyURI_List existingList;
-    this->m_expansionMap.Expand(expansionList, existingList, start);
+    m_expansionMap.Expand(expansionList, existingList, start);
 
     // save original/notated expansion as element in expanded MEI
     // Expansion *originalExpansion = new Expansion();
@@ -1382,7 +1382,7 @@ int Doc::GetGlyphHeight(wchar_t code, int staffSize, bool graceSize) const
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     h = h * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
-    if (graceSize) h = h * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) h = h * m_options->m_graceFactor.GetValue();
     h = h * staffSize / 100;
     return h;
 }
@@ -1394,7 +1394,7 @@ int Doc::GetGlyphWidth(wchar_t code, int staffSize, bool graceSize) const
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     w = w * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
-    if (graceSize) w = w * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) w = w * m_options->m_graceFactor.GetValue();
     w = w * staffSize / 100;
     return w;
 }
@@ -1405,7 +1405,7 @@ int Doc::GetGlyphAdvX(wchar_t code, int staffSize, bool graceSize) const
     assert(glyph);
     int advX = glyph->GetHorizAdvX();
     advX = advX * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
-    if (graceSize) advX = advX * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) advX = advX * m_options->m_graceFactor.GetValue();
     advX = advX * staffSize / 100;
     return advX;
 }
@@ -1418,8 +1418,8 @@ Point Doc::ConvertFontPoint(const Glyph *glyph, const Point &fontPoint, int staf
     point.x = fontPoint.x * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
     point.y = fontPoint.y * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
     if (graceSize) {
-        point.x = point.x * this->m_options->m_graceFactor.GetValue();
-        point.y = point.y * this->m_options->m_graceFactor.GetValue();
+        point.x = point.x * m_options->m_graceFactor.GetValue();
+        point.y = point.y * m_options->m_graceFactor.GetValue();
     }
     if (staffSize != 100) {
         point.x = point.x * staffSize / 100;
@@ -1435,7 +1435,7 @@ int Doc::GetGlyphDescender(wchar_t code, int staffSize, bool graceSize) const
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     y = y * m_drawingSmuflFontSize / glyph->GetUnitsPerEm();
-    if (graceSize) y = y * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) y = y * m_options->m_graceFactor.GetValue();
     y = y * staffSize / 100;
     return y;
 }
@@ -1449,7 +1449,7 @@ int Doc::GetTextGlyphHeight(wchar_t code, FontInfo *font, bool graceSize) const
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     h = h * font->GetPointSize() / glyph->GetUnitsPerEm();
-    if (graceSize) h = h * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) h = h * m_options->m_graceFactor.GetValue();
     return h;
 }
 
@@ -1462,7 +1462,7 @@ int Doc::GetTextGlyphWidth(wchar_t code, FontInfo *font, bool graceSize) const
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     w = w * font->GetPointSize() / glyph->GetUnitsPerEm();
-    if (graceSize) w = w * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) w = w * m_options->m_graceFactor.GetValue();
     return w;
 }
 
@@ -1474,7 +1474,7 @@ int Doc::GetTextGlyphAdvX(wchar_t code, FontInfo *font, bool graceSize) const
     assert(glyph);
     int advX = glyph->GetHorizAdvX();
     advX = advX * font->GetPointSize() / glyph->GetUnitsPerEm();
-    if (graceSize) advX = advX * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) advX = advX * m_options->m_graceFactor.GetValue();
     return advX;
 }
 
@@ -1487,7 +1487,7 @@ int Doc::GetTextGlyphDescender(wchar_t code, FontInfo *font, bool graceSize) con
     assert(glyph);
     glyph->GetBoundingBox(x, y, w, h);
     y = y * font->GetPointSize() / glyph->GetUnitsPerEm();
-    if (graceSize) y = y * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) y = y * m_options->m_graceFactor.GetValue();
     return y;
 }
 
@@ -1566,21 +1566,21 @@ int Doc::GetDrawingHairpinSize(int staffSize, bool withMargin) const
 int Doc::GetDrawingBeamWidth(int staffSize, bool graceSize) const
 {
     int value = m_drawingBeamWidth * staffSize / 100;
-    if (graceSize) value = value * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) value = value * m_options->m_graceFactor.GetValue();
     return value;
 }
 
 int Doc::GetDrawingBeamWhiteWidth(int staffSize, bool graceSize) const
 {
     int value = m_drawingBeamWhiteWidth * staffSize / 100;
-    if (graceSize) value = value * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) value = value * m_options->m_graceFactor.GetValue();
     return value;
 }
 
 int Doc::GetDrawingLedgerLineLength(int staffSize, bool graceSize) const
 {
     int value = m_drawingLedgerLine * staffSize / 100;
-    if (graceSize) value = value * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) value = value * m_options->m_graceFactor.GetValue();
     return value;
 }
 
@@ -1598,7 +1598,7 @@ FontInfo *Doc::GetDrawingSmuflFont(int staffSize, bool graceSize)
 {
     m_drawingSmuflFont.SetFaceName(m_options->m_font.GetValue().c_str());
     int value = m_drawingSmuflFontSize * staffSize / 100;
-    if (graceSize) value = value * this->m_options->m_graceFactor.GetValue();
+    if (graceSize) value = value * m_options->m_graceFactor.GetValue();
     m_drawingSmuflFont.SetPointSize(value);
     return &m_drawingSmuflFont;
 }
@@ -1739,13 +1739,13 @@ Page *Doc::SetDrawingPage(int pageIdx)
         m_drawingPageMarginRight = m_drawingPage->m_pageMarginRight;
         m_drawingPageMarginTop = m_drawingPage->m_pageMarginTop;
     }
-    else if (this->m_pageHeight != -1) {
-        m_drawingPageHeight = this->m_pageHeight;
-        m_drawingPageWidth = this->m_pageWidth;
-        m_drawingPageMarginBottom = this->m_pageMarginBottom;
-        m_drawingPageMarginLeft = this->m_pageMarginLeft;
-        m_drawingPageMarginRight = this->m_pageMarginRight;
-        m_drawingPageMarginTop = this->m_pageMarginTop;
+    else if (m_pageHeight != -1) {
+        m_drawingPageHeight = m_pageHeight;
+        m_drawingPageWidth = m_pageWidth;
+        m_drawingPageMarginBottom = m_pageMarginBottom;
+        m_drawingPageMarginLeft = m_pageMarginLeft;
+        m_drawingPageMarginRight = m_pageMarginRight;
+        m_drawingPageMarginTop = m_pageMarginTop;
     }
     else {
         m_drawingPageHeight = m_options->m_pageHeight.GetValue();
@@ -1756,7 +1756,7 @@ Page *Doc::SetDrawingPage(int pageIdx)
         m_drawingPageMarginTop = m_options->m_pageMarginTop.GetValue();
     }
 
-    if (this->m_options->m_landscape.GetValue()) {
+    if (m_options->m_landscape.GetValue()) {
         int pageHeight = m_drawingPageWidth;
         m_drawingPageWidth = m_drawingPageHeight;
         m_drawingPageHeight = pageHeight;
@@ -1772,14 +1772,14 @@ Page *Doc::SetDrawingPage(int pageIdx)
     // Since m_options->m_interlDefin stays the same, it's useless to do it
     // every time for now.
 
-    m_drawingBeamMaxSlope = this->m_options->m_beamMaxSlope.GetValue();
-    m_drawingBeamMinSlope = this->m_options->m_beamMinSlope.GetValue();
+    m_drawingBeamMaxSlope = m_options->m_beamMaxSlope.GetValue();
+    m_drawingBeamMinSlope = m_options->m_beamMinSlope.GetValue();
     m_drawingBeamMaxSlope /= 100;
     m_drawingBeamMinSlope /= 100;
 
     // values for beams
-    m_drawingBeamWidth = this->m_options->m_unit.GetValue();
-    m_drawingBeamWhiteWidth = this->m_options->m_unit.GetValue() / 2;
+    m_drawingBeamWidth = m_options->m_unit.GetValue();
+    m_drawingBeamWhiteWidth = m_options->m_unit.GetValue() / 2;
 
     // values for fonts
     m_drawingSmuflFontSize = CalcMusicFontSize();

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1176,15 +1176,6 @@ void Doc::ConvertToUnCastOffMensuralDoc()
     this->ScoreDefSetCurrentDoc(true);
 }
 
-void Doc::ConvertScoreDefMarkupDoc(bool permanent)
-{
-    ConvertScoreDefMarkupParams convertScoreDefMarkupParams(permanent);
-    Functor convertScoreDefMarkup(&Object::ConvertScoreDefMarkup);
-
-    m_mdivScoreDef.Process(&convertScoreDefMarkup, &convertScoreDefMarkupParams);
-    this->Process(&convertScoreDefMarkup, &convertScoreDefMarkupParams);
-}
-
 void Doc::ConvertMarkupDoc(bool permanent)
 {
     if (m_markup == MARKUP_DEFAULT) return;

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -67,8 +67,8 @@ int Dot::ResetDrawing(FunctorParams *functorParams)
     LayerElement::ResetDrawing(functorParams);
     PositionInterface::InterfaceResetDrawing(functorParams, this);
 
-    this->m_drawingPreviousElement = NULL;
-    this->m_drawingNextElement = NULL;
+    m_drawingPreviousElement = NULL;
+    m_drawingNextElement = NULL;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -148,7 +148,7 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
         currentDur = (current->GetDurationInterface())->GetActualDur();
 
         if (current->Is(CHORD)) {
-            this->m_beamHasChord = true;
+            m_beamHasChord = true;
         }
 
         m_beamElementCoords.at(elementCount)->m_element = current;
@@ -158,39 +158,39 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
         m_beamElementCoords.at(elementCount)->m_breaksec = 0;
         AttBeamSecondary *beamsecondary = dynamic_cast<AttBeamSecondary *>(current);
         if (beamsecondary && beamsecondary->HasBreaksec()) {
-            if (!this->m_changingDur) this->m_changingDur = true;
+            if (!m_changingDur) m_changingDur = true;
             m_beamElementCoords.at(elementCount)->m_breaksec = beamsecondary->GetBreaksec();
         }
 
         Staff *staff = current->GetCrossStaff(layer);
         if (staff && (staff != m_beamStaff)) {
-            this->m_crossStaffContent = staff;
-            this->m_crossStaffRel = current->GetCrossStaffRel();
+            m_crossStaffContent = staff;
+            m_crossStaffRel = current->GetCrossStaffRel();
         }
 
         // Skip rests
         if (current->Is({ NOTE, CHORD })) {
             // Look at the stemDir to see if we have multiple stem Dir
-            if (!this->m_hasMultipleStemDir) {
+            if (!m_hasMultipleStemDir) {
                 // At this stage, BeamCoord::m_stem is not necessary set, so we need to look at the Note / Chord
                 // original value Example: IsInBeam called in Note::PrepareLayerElementParts when reaching the first
                 // note of the beam
                 currentStemDir = m_beamElementCoords.at(elementCount)->GetStemDir();
                 if (currentStemDir != STEMDIRECTION_NONE) {
-                    if ((this->m_notesStemDir != STEMDIRECTION_NONE) && (this->m_notesStemDir != currentStemDir)) {
-                        this->m_hasMultipleStemDir = true;
-                        this->m_notesStemDir = STEMDIRECTION_NONE;
+                    if ((m_notesStemDir != STEMDIRECTION_NONE) && (m_notesStemDir != currentStemDir)) {
+                        m_hasMultipleStemDir = true;
+                        m_notesStemDir = STEMDIRECTION_NONE;
                     }
                     else {
-                        this->m_notesStemDir = currentStemDir;
+                        m_notesStemDir = currentStemDir;
                     }
                 }
             }
             // keep the shortest dur in the beam
-            this->m_shortestDur = std::max(currentDur, this->m_shortestDur);
+            m_shortestDur = std::max(currentDur, m_shortestDur);
         }
         // check if we have more than duration in the beam
-        if (!this->m_changingDur && currentDur != lastDur) this->m_changingDur = true;
+        if (!m_changingDur && currentDur != lastDur) m_changingDur = true;
         lastDur = currentDur;
 
         elementCount++;
@@ -216,11 +216,11 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
     int last = elementCount - 1;
 
     // We look only at the last note for checking if cue-sized. Somehow arbitrarily
-    this->m_cueSize = m_beamElementCoords.at(last)->m_element->GetDrawingCueSize();
+    m_cueSize = m_beamElementCoords.at(last)->m_element->GetDrawingCueSize();
 
     // Always set stem direction to up for grace note beam unless stem direction is provided
-    if (this->m_cueSize && (this->m_notesStemDir == STEMDIRECTION_NONE)) {
-        this->m_notesStemDir = STEMDIRECTION_up;
+    if (m_cueSize && (m_notesStemDir == STEMDIRECTION_NONE)) {
+        m_notesStemDir = STEMDIRECTION_up;
     }
 }
 

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -205,7 +205,7 @@ int DurationInterface::GetNoteOrChordDur(LayerElement *element)
     return this->GetActualDur();
 }
 
-bool DurationInterface::IsMensuralDur()
+bool DurationInterface::IsMensuralDur() const
 {
     // maxima (-1) is a mensural only value
     if (this->GetDur() == DURATION_maxima) return true;

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -122,7 +122,7 @@ int EditorialElement::ConvertToPageBasedEnd(FunctorParams *functorParams)
     ConvertToPageBasedParams *params = vrv_params_cast<ConvertToPageBasedParams *>(functorParams);
     assert(params);
 
-    if (this->m_visibility == Visible) ConvertToPageBasedBoundary(this, params->m_pageBasedSystem);
+    if (m_visibility == Visible) ConvertToPageBasedBoundary(this, params->m_pageBasedSystem);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -311,7 +311,7 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     interface->SetStartid("#" + startid);
     interface->SetEndid("#" + endid);
 
-    this->m_chainedId = element->GetUuid();
+    m_chainedId = element->GetUuid();
     m_editInfo.import("uuid", element->GetUuid());
 
     return true;
@@ -357,7 +357,7 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     measure->AddChild(element);
     interface->SetStartid("#" + startid);
 
-    this->m_chainedId = element->GetUuid();
+    m_chainedId = element->GetUuid();
     m_editInfo.import("uuid", element->GetUuid());
 
     return true;
@@ -406,10 +406,10 @@ bool EditorToolkitCMN::Set(std::string &elementId, std::string const &attribute,
 Object *EditorToolkitCMN::GetElement(std::string &elementId)
 {
     if (elementId == CHAINED_ID) {
-        elementId = this->m_chainedId;
+        elementId = m_chainedId;
     }
     else {
-        this->m_chainedId = elementId;
+        m_chainedId = elementId;
     }
 
     Object *element = NULL;
@@ -440,7 +440,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         assert(currentChord);
         Note *note = new Note();
         currentChord->AddChild(note);
-        this->m_chainedId = note->GetUuid();
+        m_chainedId = note->GetUuid();
         return true;
     }
     else if (object->Is(NOTE)) {
@@ -451,7 +451,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         if (currentChord) {
             Note *note = new Note();
             currentChord->AddChild(note);
-            this->m_chainedId = note->GetUuid();
+            m_chainedId = note->GetUuid();
             return true;
         }
 
@@ -494,7 +494,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         }
         currentNote->ClearRelinquishedChildren();
 
-        this->m_chainedId = note->GetUuid();
+        m_chainedId = note->GetUuid();
         return true;
     }
     else if (object->Is(REST)) {
@@ -506,7 +506,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         assert(parent);
         parent->ReplaceChild(rest, note);
         delete rest;
-        this->m_chainedId = note->GetUuid();
+        m_chainedId = note->GetUuid();
         return true;
     }
     return false;
@@ -547,13 +547,13 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             for (auto &artic : artics) {
                 artic->MoveItselfTo(otherNote);
             }
-            this->m_chainedId = chord->GetUuid();
+            m_chainedId = chord->GetUuid();
             delete chord;
             return true;
         }
         else if (count > 2) {
             chord->DeleteChild(note);
-            this->m_chainedId = chord->GetUuid();
+            m_chainedId = chord->GetUuid();
             return true;
         }
         // Handle cases of chords with one single note
@@ -589,7 +589,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             beam->DetachChild(otherElement->GetIdx());
             parent->ReplaceChild(beam, otherElement);
             delete beam;
-            this->m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetUuid();
             return true;
         }
         if (beam->IsFirstIn(beam, note)) {
@@ -599,7 +599,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             assert(parent);
             parent->InsertBefore(beam, rest);
             beam->DeleteChild(note);
-            this->m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetUuid();
             return true;
         }
         else if (beam->IsLastIn(beam, note)) {
@@ -609,7 +609,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             assert(parent);
             parent->InsertAfter(beam, rest);
             beam->DeleteChild(note);
-            this->m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetUuid();
             return true;
         }
         else {
@@ -617,7 +617,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             rest->DurationInterface::operator=(*note);
             beam->ReplaceChild(note, rest);
             delete note;
-            this->m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetUuid();
             return true;
         }
     }
@@ -628,7 +628,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
         assert(parent);
         parent->ReplaceChild(note, rest);
         delete note;
-        this->m_chainedId = rest->GetUuid();
+        m_chainedId = rest->GetUuid();
         return true;
     }
 }

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -71,7 +71,7 @@ void Flag::Reset()
     m_drawingNbFlags = 0;
 }
 
-wchar_t Flag::GetFlagGlyph(data_STEMDIRECTION stemDir)
+wchar_t Flag::GetFlagGlyph(data_STEMDIRECTION stemDir) const
 {
     if (stemDir == STEMDIRECTION_up) {
         switch (m_drawingNbFlags) {

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -101,7 +101,7 @@ wchar_t Flag::GetFlagGlyph(data_STEMDIRECTION stemDir) const
     }
 }
 
-Point Flag::GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code)
+Point Flag::GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const
 {
     code = this->GetFlagGlyph(STEMDIRECTION_up);
 
@@ -109,7 +109,7 @@ Point Flag::GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code)
     return Point(0, h + doc->GetGlyphDescender(code, staffSize, graceSize));
 }
 
-Point Flag::GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code)
+Point Flag::GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const
 {
     code = this->GetFlagGlyph(STEMDIRECTION_down);
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -330,17 +330,17 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
     if (horizOverlapingBBox == NULL) {
         // Apply element margin and enforce minimal staff distance
         int staffIndex = staffAlignment->GetStaff()->GetN();
-        int minStaffDistance = doc->GetStaffDistance(this->m_object->GetClassId(), staffIndex, this->m_place)
-            * doc->GetDrawingUnit(staffSize);
-        if (this->m_place == STAFFREL_above) {
+        int minStaffDistance
+            = doc->GetStaffDistance(m_object->GetClassId(), staffIndex, m_place) * doc->GetDrawingUnit(staffSize);
+        if (m_place == STAFFREL_above) {
             yRel = GetContentY1();
-            yRel -= doc->GetBottomMargin(this->m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+            yRel -= doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
             this->SetDrawingYRel(yRel);
             this->SetDrawingYRel(-minStaffDistance);
         }
         else {
             yRel = staffAlignment->GetStaffHeight() + GetContentY2();
-            yRel += doc->GetTopMargin(this->m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+            yRel += doc->GetTopMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
             this->SetDrawingYRel(yRel);
             this->SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
         }
@@ -350,9 +350,9 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         if (curve) {
             assert(curve->m_object);
         }
-        int margin = doc->GetBottomMargin(this->m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+        int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
 
-        if (this->m_place == STAFFREL_above) {
+        if (m_place == STAFFREL_above) {
             if (curve && curve->m_object->Is({ PHRASE, SLUR, TIE })) {
                 int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
@@ -399,7 +399,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
 
 int FloatingPositioner::GetSpaceBelow(Doc *doc, StaffAlignment *staffAlignment, BoundingBox *horizOverlapingBBox)
 {
-    if (this->m_place != STAFFREL_between) return VRV_UNSET;
+    if (m_place != STAFFREL_between) return VRV_UNSET;
 
     int staffSize = staffAlignment->GetStaffSize();
 
@@ -407,7 +407,7 @@ int FloatingPositioner::GetSpaceBelow(Doc *doc, StaffAlignment *staffAlignment, 
     if (curve) {
         assert(curve->m_object);
     }
-    int margin = doc->GetBottomMargin(this->m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+    int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
 
     if (curve && curve->m_object->Is({ PHRASE, SLUR, TIE })) {
         // For now ignore curves

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -135,27 +135,27 @@ void FTrem::InitCoords(ArrayOfObjects *childList)
         return;
     }
 
-    this->m_changingDur = false;
-    this->m_beamHasChord = false;
-    this->m_hasMultipleStemDir = false;
-    this->m_cueSize = false;
+    m_changingDur = false;
+    m_beamHasChord = false;
+    m_hasMultipleStemDir = false;
+    m_cueSize = false;
     // adjust beam->m_drawingParams.m_shortestDur depending on the number of slashes
-    this->m_shortestDur = std::max(DUR_8, DUR_1 + this->GetBeams());
-    this->m_stemDir = STEMDIRECTION_NONE;
+    m_shortestDur = std::max(DUR_8, DUR_1 + this->GetBeams());
+    m_stemDir = STEMDIRECTION_NONE;
 
     if (firstElement->m_element->Is(CHORD)) {
-        this->m_beamHasChord = true;
+        m_beamHasChord = true;
     }
     if (secondElement->m_element->Is(CHORD)) {
-        this->m_beamHasChord = true;
+        m_beamHasChord = true;
     }
 
     // For now look at the stemDir only on the first note
     assert(dynamic_cast<AttStems *>(firstElement->m_element));
-    this->m_stemDir = (dynamic_cast<AttStems *>(firstElement->m_element))->GetStemDir();
+    m_stemDir = (dynamic_cast<AttStems *>(firstElement->m_element))->GetStemDir();
 
     // We look only at the first note for checking if cue-sized. Somehow arbitrarily
-    this->m_cueSize = firstElement->m_element->GetDrawingCueSize();
+    m_cueSize = firstElement->m_element->GetDrawingCueSize();
  }
  */
 
@@ -180,14 +180,14 @@ int FTrem::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    this->m_beamSegment.InitCoordRefs(this->GetElementCoords());
+    m_beamSegment.InitCoordRefs(this->GetElementCoords());
 
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
 
-    this->m_beamSegment.CalcBeam(layer, staff, params->m_doc, this);
+    m_beamSegment.CalcBeam(layer, staff, params->m_doc, this);
 
     return FUNCTOR_CONTINUE;
 }
@@ -197,7 +197,7 @@ int FTrem::ResetDrawing(FunctorParams *functorParams)
     // Call parent one too
     LayerElement::ResetDrawing(functorParams);
 
-    this->m_beamSegment.Reset();
+    m_beamSegment.Reset();
 
     // We want the list of the ObjectListInterface to be re-generated
     this->Modify();

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -226,21 +226,21 @@ int Hairpin::PrepareFloatingGrps(FunctorParams *functorParams)
 
     for (auto &dynam : params->m_dynams) {
         if ((dynam->GetStart() == this->GetStart()) && (dynam->GetStaff() == this->GetStaff())) {
-            if (!this->m_leftLink) this->SetLeftLink(dynam);
+            if (!m_leftLink) this->SetLeftLink(dynam);
         }
         else if ((dynam->GetStart() == this->GetEnd()) && (dynam->GetStaff() == this->GetStaff())) {
-            if (!this->m_rightLink) this->SetRightLink(dynam);
+            if (!m_rightLink) this->SetRightLink(dynam);
         }
     }
 
     for (auto &hairpin : params->m_hairpins) {
         if ((hairpin->GetEnd() == this->GetStart()) && (hairpin->GetStaff() == this->GetStaff())) {
-            if (!this->m_leftLink) this->SetLeftLink(hairpin);
+            if (!m_leftLink) this->SetLeftLink(hairpin);
             if (!hairpin->GetRightLink()) hairpin->SetRightLink(this);
         }
         if ((hairpin->GetStart() == this->GetEnd()) && (hairpin->GetStaff() == this->GetStaff())) {
             if (!hairpin->GetLeftLink()) hairpin->SetLeftLink(this);
-            if (!this->m_rightLink) this->SetRightLink(hairpin);
+            if (!m_rightLink) this->SetRightLink(hairpin);
         }
     }
 

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1169,12 +1169,12 @@ int Alignment::SetAlignmentXPos(FunctorParams *functorParams)
     assert(params);
 
     // Do not set an x pos for anything before the barline (including it)
-    if (this->m_type <= ALIGNMENT_MEASURE_LEFT_BARLINE) return FUNCTOR_CONTINUE;
+    if (m_type <= ALIGNMENT_MEASURE_LEFT_BARLINE) return FUNCTOR_CONTINUE;
 
     int intervalXRel = 0;
     double intervalTime = (m_time - params->m_previousTime);
 
-    if (this->m_type > ALIGNMENT_MEASURE_RIGHT_BARLINE) {
+    if (m_type > ALIGNMENT_MEASURE_RIGHT_BARLINE) {
         intervalTime = 0.0;
     }
 
@@ -1240,20 +1240,19 @@ int Alignment::JustifyX(FunctorParams *functorParams)
     }
     else if (m_type < ALIGNMENT_MEASURE_RIGHT_BARLINE) {
         // All elements up to the next barline, move them but also take into account the leftBarlineX
-        SetXRel(ceil((((double)this->m_xRel - (double)params->m_leftBarLineX) * params->m_justifiableRatio)
-            + params->m_leftBarLineX));
+        SetXRel(ceil(
+            (((double)m_xRel - (double)params->m_leftBarLineX) * params->m_justifiableRatio) + params->m_leftBarLineX));
     }
     else {
         //  Now more the right barline and all right scoreDef elements
-        int shift = this->m_xRel - params->m_rightBarLineX;
-        this->m_xRel
-            = ceil(((double)params->m_rightBarLineX - (double)params->m_leftBarLineX) * params->m_justifiableRatio)
+        int shift = m_xRel - params->m_rightBarLineX;
+        m_xRel = ceil(((double)params->m_rightBarLineX - (double)params->m_leftBarLineX) * params->m_justifiableRatio)
             + params->m_leftBarLineX + shift;
     }
 
     // Finally, when reaching the end of the measure, update the measureXRel for the next measure
     if (m_type == ALIGNMENT_MEASURE_END) {
-        params->m_measureXRel += this->m_xRel;
+        params->m_measureXRel += m_xRel;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -868,7 +868,7 @@ void HumdrumInput::checkForBreak(hum::HumdrumFile &infile, int line)
     if (linebreaki > 0) {
         hum::HTp token = infile[linebreaki].token(0);
         Sb *sb = new Sb;
-        this->m_hasLayoutInformation = true;
+        m_hasLayoutInformation = true;
         setLocationId(sb, token);
         m_sections.back()->AddChild(sb);
         // Maybe allow other types of line breaks here, but
@@ -880,7 +880,7 @@ void HumdrumInput::checkForBreak(hum::HumdrumFile &infile, int line)
     else if (pagebreaki > 0) {
         hum::HTp token = infile[pagebreaki].token(0);
         Pb *pb = new Pb;
-        this->m_hasLayoutInformation = true;
+        m_hasLayoutInformation = true;
         setLocationId(pb, token);
         m_sections.back()->AddChild(pb);
         // Maybe allow other types of line breaks here, but
@@ -5973,7 +5973,7 @@ void HumdrumInput::checkForLayoutBreak(int line)
     if (!group.empty()) {
         std::string tstring = removeCommas(group);
         Sb *sb = new Sb;
-        this->m_hasLayoutInformation = true;
+        m_hasLayoutInformation = true;
         if (m_currentending) {
             m_currentending->AddChild(sb);
         }
@@ -5990,7 +5990,7 @@ void HumdrumInput::checkForLayoutBreak(int line)
         std::string tstring = removeCommas(group);
         // Pb *pb = new Pb;
         Sb *pb = new Sb;
-        this->m_hasLayoutInformation = true;
+        m_hasLayoutInformation = true;
         if (m_currentending) {
             m_currentending->AddChild(pb);
         }
@@ -22478,7 +22478,7 @@ void HumdrumInput::setupMeiDocument()
         // breaks encoded in the file to be activated, so adding a
         // dummy page break here:
         Pb *pb = new Pb;
-        this->m_hasLayoutInformation = true;
+        m_hasLayoutInformation = true;
         section->AddChild(pb);
     }
 }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -24155,8 +24155,6 @@ void HumdrumInput::importVerovioOptions(Doc *doc)
 
 void HumdrumInput::finalizeDocument(Doc *doc)
 {
-
-    doc->ConvertScoreDefMarkupDoc();
     doc->ExpandExpansions();
     doc->ConvertToPageBasedDoc();
     doc->ConvertMarkupDoc();

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3007,10 +3007,6 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     success = ReadMdivChildren(m_doc, body, false);
 
     if (success) {
-        m_doc->ConvertScoreDefMarkupDoc();
-    }
-
-    if (success) {
         m_doc->ExpandExpansions();
     }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3104,7 +3104,7 @@ bool MEIInput::ReadPages(Object *parent, pugi::xml_node pages)
     }
 
     // This is a page-based MEI file
-    this->m_hasLayoutInformation = true;
+    m_hasLayoutInformation = true;
 
     bool success = true;
     // We require to have s <scoreDef> as first child of <score>
@@ -3155,7 +3155,7 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
     parent->AddChild(vrvScore);
 
     // This is a score-based MEI file
-    this->m_readingScoreBased = true;
+    m_readingScoreBased = true;
 
     // We require to have s <scoreDef> as first child of <score>
     pugi::xml_node scoreDef = score.first_child();
@@ -3324,7 +3324,7 @@ bool MEIInput::ReadExpansion(Object *parent, pugi::xml_node expansion)
 
 bool MEIInput::ReadPb(Object *parent, pugi::xml_node pb)
 {
-    this->m_hasLayoutInformation = true;
+    m_hasLayoutInformation = true;
 
     Pb *vrvPb = new Pb();
     ReadSystemElement(pb, vrvPb);
@@ -3454,7 +3454,7 @@ bool MEIInput::ReadSystem(Object *parent, pugi::xml_node system)
         vrvSystem->m_systemRightMar = atoi(system.attribute("system.rightmar").value());
         system.remove_attribute("system.rightmar");
     }
-    if (system.attribute("uly") && (this->m_doc->GetType() == Transcription)) {
+    if (system.attribute("uly") && (m_doc->GetType() == Transcription)) {
         vrvSystem->m_yAbs = atoi(system.attribute("uly").value()) * DEFINITION_FACTOR;
         system.remove_attribute("uly");
     }
@@ -4102,7 +4102,7 @@ bool MEIInput::ReadMeasure(Object *parent, pugi::xml_node measure)
     vrvMeasure->ReadPointing(measure);
     vrvMeasure->ReadTyped(measure);
 
-    if (measure.attribute("ulx") && measure.attribute("lrx") && (this->m_doc->GetType() == Transcription)) {
+    if (measure.attribute("ulx") && measure.attribute("lrx") && (m_doc->GetType() == Transcription)) {
         vrvMeasure->m_xAbs = atoi(measure.attribute("ulx").value()) * DEFINITION_FACTOR;
         vrvMeasure->m_xAbs2 = atoi(measure.attribute("lrx").value()) * DEFINITION_FACTOR;
         measure.remove_attribute("ulx");
@@ -4649,7 +4649,7 @@ bool MEIInput::ReadStaff(Object *parent, pugi::xml_node staff)
     vrvStaff->ReadTyped(staff);
     vrvStaff->ReadVisibility(staff);
 
-    if (staff.attribute("uly") && (this->m_doc->GetType() == Transcription)) {
+    if (staff.attribute("uly") && (m_doc->GetType() == Transcription)) {
         vrvStaff->m_yAbs = atoi(staff.attribute("uly").value()) * DEFINITION_FACTOR;
         staff.remove_attribute("uly");
     }
@@ -4865,7 +4865,7 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
 
 bool MEIInput::ReadLayerElement(pugi::xml_node element, LayerElement *object)
 {
-    if (element.attribute("ulx") && (this->m_doc->GetType() == Transcription)) {
+    if (element.attribute("ulx") && (m_doc->GetType() == Transcription)) {
         object->m_xAbs = atoi(element.attribute("ulx").value()) * DEFINITION_FACTOR;
         element.remove_attribute("ulx");
     }

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -220,7 +220,7 @@ std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, d
     return symbolStr;
 }
 
-int KeySig::GetFifthsInt()
+int KeySig::GetFifthsInt() const
 {
     if (this->GetSig().second == ACCIDENTAL_WRITTEN_f) {
         return -1 * this->GetSig().first;

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -239,10 +239,10 @@ data_STEMDIRECTION Layer::GetDrawingStemDir(LayerElement *element)
         return STEMDIRECTION_NONE;
     }
     else {
-        if (this->m_crossStaffFromBelow) {
+        if (m_crossStaffFromBelow) {
             return (element->m_crossStaff) ? STEMDIRECTION_down : STEMDIRECTION_up;
         }
-        else if (this->m_crossStaffFromAbove) {
+        else if (m_crossStaffFromAbove) {
             return (element->m_crossStaff) ? STEMDIRECTION_up : STEMDIRECTION_down;
         }
         else {
@@ -431,20 +431,20 @@ void Layer::SetDrawingStaffDefValues(StaffDef *currentStaffDef)
     this->ResetStaffDefObjects();
 
     if (currentStaffDef->DrawClef()) {
-        this->m_staffDefClef = new Clef(*currentStaffDef->GetCurrentClef());
-        this->m_staffDefClef->SetParent(this);
+        m_staffDefClef = new Clef(*currentStaffDef->GetCurrentClef());
+        m_staffDefClef->SetParent(this);
     }
     if (currentStaffDef->DrawKeySig()) {
-        this->m_staffDefKeySig = new KeySig(*currentStaffDef->GetCurrentKeySig());
-        this->m_staffDefKeySig->SetParent(this);
+        m_staffDefKeySig = new KeySig(*currentStaffDef->GetCurrentKeySig());
+        m_staffDefKeySig->SetParent(this);
     }
     if (currentStaffDef->DrawMensur()) {
-        this->m_staffDefMensur = new Mensur(*currentStaffDef->GetCurrentMensur());
-        this->m_staffDefMensur->SetParent(this);
+        m_staffDefMensur = new Mensur(*currentStaffDef->GetCurrentMensur());
+        m_staffDefMensur->SetParent(this);
     }
     if (currentStaffDef->DrawMeterSig()) {
-        this->m_staffDefMeterSig = new MeterSig(*currentStaffDef->GetCurrentMeterSig());
-        this->m_staffDefMeterSig->SetParent(this);
+        m_staffDefMeterSig = new MeterSig(*currentStaffDef->GetCurrentMeterSig());
+        m_staffDefMeterSig->SetParent(this);
     }
 
     // Don't draw on the next one
@@ -462,21 +462,21 @@ void Layer::SetDrawingCautionValues(StaffDef *currentStaffDef)
     }
 
     if (currentStaffDef->DrawClef()) {
-        this->m_cautionStaffDefClef = new Clef(*currentStaffDef->GetCurrentClef());
-        this->m_cautionStaffDefClef->SetParent(this);
+        m_cautionStaffDefClef = new Clef(*currentStaffDef->GetCurrentClef());
+        m_cautionStaffDefClef->SetParent(this);
     }
     // special case - see above
     if (currentStaffDef->DrawKeySig()) {
-        this->m_cautionStaffDefKeySig = new KeySig(*currentStaffDef->GetCurrentKeySig());
-        this->m_cautionStaffDefKeySig->SetParent(this);
+        m_cautionStaffDefKeySig = new KeySig(*currentStaffDef->GetCurrentKeySig());
+        m_cautionStaffDefKeySig->SetParent(this);
     }
     if (currentStaffDef->DrawMensur()) {
-        this->m_cautionStaffDefMensur = new Mensur(*currentStaffDef->GetCurrentMensur());
-        this->m_cautionStaffDefMensur->SetParent(this);
+        m_cautionStaffDefMensur = new Mensur(*currentStaffDef->GetCurrentMensur());
+        m_cautionStaffDefMensur->SetParent(this);
     }
     if (currentStaffDef->DrawMeterSig()) {
-        this->m_cautionStaffDefMeterSig = new MeterSig(*currentStaffDef->GetCurrentMeterSig());
-        this->m_cautionStaffDefMeterSig->SetParent(this);
+        m_cautionStaffDefMeterSig = new MeterSig(*currentStaffDef->GetCurrentMeterSig());
+        m_cautionStaffDefMeterSig->SetParent(this);
     }
 
     // Don't draw on the next one
@@ -700,8 +700,8 @@ int Layer::CalcOnsetOffset(FunctorParams *functorParams)
 
 int Layer::ResetDrawing(FunctorParams *functorParams)
 {
-    this->m_crossStaffFromBelow = false;
-    this->m_crossStaffFromAbove = false;
+    m_crossStaffFromBelow = false;
+    m_crossStaffFromAbove = false;
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -395,7 +395,7 @@ int LayerElement::GetDrawingY() const
     if (m_cachedDrawingY != VRV_UNSET) return m_cachedDrawingY;
 
     // Look if we have a crossStaff situation
-    Object *object = this->m_crossStaff; // GetCrossStaff();
+    Object *object = m_crossStaff; // GetCrossStaff();
     // First get the first layerElement parent (if any) but only if the element is not directly relative to staff
     // (e.g. artic, syl)
     if (!object && !this->IsRelativeToStaff()) object = this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max);
@@ -451,7 +451,7 @@ void LayerElement::SetDrawingYRel(int drawingYRel)
 
 void LayerElement::CenterDrawingX()
 {
-    if (this->m_xAbs != VRV_UNSET) return;
+    if (m_xAbs != VRV_UNSET) return;
 
     SetDrawingXRel(0);
 
@@ -1708,7 +1708,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
 
 int LayerElement::AdjustXRelForTranscription(FunctorParams *)
 {
-    if (this->m_xAbs == VRV_UNSET) return FUNCTOR_CONTINUE;
+    if (m_xAbs == VRV_UNSET) return FUNCTOR_CONTINUE;
 
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
@@ -1887,8 +1887,8 @@ int LayerElement::PrepareCrossStaffEnd(FunctorParams *functorParams)
             }
         }
         if (crossStaff) {
-            this->m_crossStaff = crossStaff;
-            this->m_crossLayer = crossLayer;
+            m_crossStaff = crossStaff;
+            m_crossLayer = crossLayer;
         }
     }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -170,7 +170,7 @@ bool LayerElement::IsGraceNote()
     return false;
 }
 
-bool LayerElement::GetDrawingCueSize()
+bool LayerElement::GetDrawingCueSize() const
 {
     return m_drawingCueSize;
 }
@@ -464,7 +464,7 @@ void LayerElement::CenterDrawingX()
 int LayerElement::GetDrawingTop(Doc *doc, int staffSize, bool withArtic, ArticType type)
 {
     if (this->Is({ NOTE, CHORD }) && withArtic) {
-        int articY = GetDrawingArticulationTopOrBottom(STAFFREL_above, type);
+        int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_above, type);
         if (articY != VRV_UNSET) return articY;
     }
 
@@ -502,7 +502,7 @@ int LayerElement::GetDrawingTop(Doc *doc, int staffSize, bool withArtic, ArticTy
 int LayerElement::GetDrawingBottom(Doc *doc, int staffSize, bool withArtic, ArticType type)
 {
     if (this->Is({ NOTE, CHORD }) && withArtic) {
-        int articY = GetDrawingArticulationTopOrBottom(STAFFREL_below, type);
+        int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_below, type);
         if (articY != -VRV_UNSET) return articY;
     }
 
@@ -670,7 +670,7 @@ double LayerElement::GetAlignmentDuration(
 }
 
 double LayerElement::GetSameAsContentAlignmentDuration(
-    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType)
+    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
     if (!this->HasSameasLink() || !this->GetSameasLink()->Is({ BEAM, FTREM, TUPLET })) {
         return 0.0;
@@ -683,7 +683,7 @@ double LayerElement::GetSameAsContentAlignmentDuration(
 }
 
 double LayerElement::GetContentAlignmentDuration(
-    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType)
+    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
     if (!this->Is({ BEAM, FTREM, TUPLET })) {
         return 0.0;

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -67,7 +67,7 @@ void LinkingInterface::SetUuidStr()
 Measure *LinkingInterface::GetNextMeasure()
 {
     if (!m_next) return NULL;
-    return dynamic_cast<Measure *>(this->m_next->GetFirstAncestor(MEASURE));
+    return dynamic_cast<Measure *>(m_next->GetFirstAncestor(MEASURE));
 }
 
 //----------------------------------------------------------------------------

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -317,7 +317,7 @@ int Measure::GetWidth() const
         }
     }
 
-    if (this->m_xAbs2 != VRV_UNSET) return (m_xAbs2 - m_xAbs);
+    if (m_xAbs2 != VRV_UNSET) return (m_xAbs2 - m_xAbs);
 
     assert(m_measureAligner.GetRightAlignment());
     return m_measureAligner.GetRightAlignment()->GetXRel();
@@ -1102,7 +1102,7 @@ int Measure::AlignMeasures(FunctorParams *functorParams)
 
 int Measure::ResetDrawing(FunctorParams *functorParams)
 {
-    this->m_timestampAligner.Reset();
+    m_timestampAligner.Reset();
     m_drawingEnding = NULL;
     return FUNCTOR_CONTINUE;
 }
@@ -1126,11 +1126,11 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
         // Break it if necessary
-        else if (this->m_drawingXRel + this->GetWidth() + params->m_currentScoreDefWidth - params->m_shift
+        else if (m_drawingXRel + this->GetWidth() + params->m_currentScoreDefWidth - params->m_shift
             > params->m_systemWidth) {
             params->m_currentSystem = new System();
             params->m_page->AddChild(params->m_currentSystem);
-            params->m_shift = this->m_drawingXRel;
+            params->m_shift = m_drawingXRel;
             for (Object *oneOfPendingObjects : params->m_pendingObjects) {
                 if (oneOfPendingObjects->Is(MEASURE)) {
                     Measure *firstPendingMesure = vrv_cast<Measure *>(oneOfPendingObjects);
@@ -1218,7 +1218,7 @@ int Measure::PrepareBoundaries(FunctorParams *functorParams)
 
     if (params->m_currentEnding) {
         // Set the ending to each measure in between
-        this->m_drawingEnding = params->m_currentEnding;
+        m_drawingEnding = params->m_currentEnding;
     }
 
     // Keep a pointer to the measure for when we are reaching the end (see BoundaryEnd::PrepareBoundaries)

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -73,11 +73,11 @@ int MRpt::PrepareRpt(FunctorParams *functorParams)
 
     // If this is the first one, number has to be 2
     if (params->m_currentMRpt == NULL) {
-        this->m_drawingMeasureCount = 2;
+        m_drawingMeasureCount = 2;
     }
     // Otherwise increment it
     else {
-        this->m_drawingMeasureCount = params->m_currentMRpt->m_drawingMeasureCount + 1;
+        m_drawingMeasureCount = params->m_currentMRpt->m_drawingMeasureCount + 1;
     }
     params->m_currentMRpt = this;
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -434,7 +434,7 @@ int Note::CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir)
     return baseStem;
 }
 
-wchar_t Note::GetMensuralNoteheadGlyph()
+wchar_t Note::GetMensuralNoteheadGlyph() const
 {
     assert(this->IsMensuralDur());
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -231,7 +231,7 @@ int Note::GetDrawingDur() const
 
 bool Note::IsClusterExtreme() const
 {
-    ChordCluster *cluster = this->m_cluster;
+    ChordCluster *cluster = m_cluster;
     if (this == cluster->at(0)) return true;
     if (this == cluster->at(cluster->size() - 1))
         return true;
@@ -785,11 +785,11 @@ int Note::CalcArtic(FunctorParams *functorParams)
     params->m_crossStaffAbove = false;
     params->m_crossStaffBelow = false;
 
-    if (this->m_crossStaff) {
-        params->m_staffAbove = this->m_crossStaff;
-        params->m_staffBelow = this->m_crossStaff;
-        params->m_layerAbove = this->m_crossLayer;
-        params->m_layerBelow = this->m_crossLayer;
+    if (m_crossStaff) {
+        params->m_staffAbove = m_crossStaff;
+        params->m_staffBelow = m_crossStaff;
+        params->m_layerAbove = m_crossLayer;
+        params->m_layerBelow = m_crossLayer;
         params->m_crossStaffAbove = true;
         params->m_crossStaffBelow = true;
     }
@@ -847,9 +847,9 @@ int Note::CalcStem(FunctorParams *functorParams)
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
-    if (this->m_crossStaff) {
-        staff = this->m_crossStaff;
-        layer = this->m_crossLayer;
+    if (m_crossStaff) {
+        staff = m_crossStaff;
+        layer = m_crossLayer;
     }
 
     // Cache the in params to avoid further lookup
@@ -982,7 +982,7 @@ int Note::CalcDots(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff);
 
-    if (this->m_crossStaff) staff = this->m_crossStaff;
+    if (m_crossStaff) staff = m_crossStaff;
 
     bool drawingCueSize = this->GetDrawingCueSize();
     int staffSize = staff->m_drawingStaffSize;
@@ -1109,7 +1109,7 @@ int Note::CalcLedgerLines(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    if (this->m_crossStaff) staff = this->m_crossStaff;
+    if (m_crossStaff) staff = m_crossStaff;
 
     bool drawingCueSize = this->GetDrawingCueSize();
     int staffSize = staff->m_drawingStaffSize;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -244,7 +244,7 @@ TabGrp *Note::IsTabGrpNote() const
     return dynamic_cast<TabGrp *>(this->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
 }
 
-std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType)
+std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const
 {
     if (notationType == NOTATIONTYPE_tab_lute_italian) {
         std::wstring fretStr;
@@ -521,14 +521,14 @@ wchar_t Note::GetNoteheadGlyph(const int duration) const
     return SMUFL_E0A4_noteheadBlack;
 }
 
-bool Note::IsVisible()
+bool Note::IsVisible() const
 {
     if (this->HasVisible()) {
         return this->GetVisible() == BOOLEAN_true;
     }
     // if the chord doens't have it, see if all the children are invisible
-    else if (GetParent() && GetParent()->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(GetParent());
+    else if (this->GetParent() && this->GetParent()->Is(CHORD)) {
+        Chord *chord = vrv_cast<Chord *>(this->GetParent());
         assert(chord);
         return chord->IsVisible();
     }
@@ -595,37 +595,37 @@ void Note::CalcMIDIPitch(int shift)
     }
 }
 
-double Note::GetScoreTimeOnset()
+double Note::GetScoreTimeOnset() const
 {
     return m_scoreTimeOnset;
 }
 
-double Note::GetRealTimeOnsetMilliseconds()
+double Note::GetRealTimeOnsetMilliseconds() const
 {
     return m_realTimeOnsetMilliseconds;
 }
 
-double Note::GetScoreTimeOffset()
+double Note::GetScoreTimeOffset() const
 {
     return m_scoreTimeOffset;
 }
 
-double Note::GetRealTimeOffsetMilliseconds()
+double Note::GetRealTimeOffsetMilliseconds() const
 {
     return m_realTimeOffsetMilliseconds;
 }
 
-double Note::GetScoreTimeTiedDuration()
+double Note::GetScoreTimeTiedDuration() const
 {
     return m_scoreTimeTiedDuration;
 }
 
-double Note::GetScoreTimeDuration()
+double Note::GetScoreTimeDuration() const
 {
-    return GetScoreTimeOffset() - GetScoreTimeOnset();
+    return this->GetScoreTimeOffset() - this->GetScoreTimeOnset();
 }
 
-char Note::GetMIDIPitch()
+char Note::GetMIDIPitch() const
 {
     return m_MIDIPitch;
 }
@@ -685,7 +685,7 @@ void Note::UpdateFromTransPitch(const TransPitch &tp)
 
 bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShifted)
 {
-    Object *stem = GetFirst(STEM);
+    Object *stem = this->GetFirst(STEM);
     if (!stem) return false;
 
     Flag *flag = dynamic_cast<Flag *>(stem->GetFirst(FLAG));
@@ -694,10 +694,10 @@ bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShi
     // for the purposes of vertical spacing we care only up to 16th flags - shorter ones grow upwards
     wchar_t flagGlyph = SMUFL_E242_flag16thUp;
     data_DURATION dur = this->GetDur();
-    if (dur < DURATION_16) flagGlyph = flag->GetFlagGlyph(GetDrawingStemDir());
-    const int flagHeight = doc->GetGlyphHeight(flagGlyph, staffSize, GetDrawingCueSize());
+    if (dur < DURATION_16) flagGlyph = flag->GetFlagGlyph(this->GetDrawingStemDir());
+    const int flagHeight = doc->GetGlyphHeight(flagGlyph, staffSize, this->GetDrawingCueSize());
 
-    const int dotMargin = flag->GetDrawingY() - GetDrawingY() - flagHeight - GetDrawingRadius(doc) / 2
+    const int dotMargin = flag->GetDrawingY() - this->GetDrawingY() - flagHeight - this->GetDrawingRadius(doc) / 2
         - (isDotShifted ? doc->GetDrawingUnit(staffSize) : 0);
 
     return dotMargin < 0;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -238,7 +238,7 @@ void Object::MoveChildrenFrom(Object *sourceParent, int idx, bool allowTypeChang
             idx++;
         }
         else {
-            this->m_children.push_back(child);
+            m_children.push_back(child);
         }
     }
 }
@@ -840,7 +840,7 @@ void Object::Process(Functor *functor, FunctorParams *functorParams, Functor *en
         };
 
         // We need a pointer to the array for the option to work on a reversed copy
-        ArrayOfObjects *children = &this->m_children;
+        ArrayOfObjects *children = &m_children;
         if (direction == BACKWARD) {
             for (ArrayOfObjects::reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
                 // we will end here if there is no filter at all or for the current child type
@@ -1001,7 +1001,7 @@ ObjectListInterface &ObjectListInterface::operator=(const ObjectListInterface &i
 {
     // actually nothing to do, we just don't want the list to be copied
     if (this != &interface) {
-        this->m_list.clear();
+        m_list.clear();
     }
     return *this;
 }
@@ -1364,7 +1364,7 @@ int Object::ConvertToCastOffMensural(FunctorParams *functorParams)
 
     assert(m_parent);
     // We want to move only the children of the layer of any type (notes, editorial elements, etc)
-    if (this->m_parent->Is(LAYER)) {
+    if (m_parent->Is(LAYER)) {
         assert(params->m_targetLayer);
         this->MoveItselfTo(params->m_targetLayer);
         // Do not precess children because we move the full sub-tree
@@ -1826,7 +1826,7 @@ int Object::ReorderByXPos(FunctorParams *functorParams)
         }
     }
 
-    std::stable_sort(this->m_children.begin(), this->m_children.end(), sortByUlx);
+    std::stable_sort(m_children.begin(), m_children.end(), sortByUlx);
     this->Modify();
     return FUNCTOR_CONTINUE;
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -581,8 +581,8 @@ void Page::JustifyVertically()
             Page *penultimatePage = dynamic_cast<Page *>(pages->GetPrevious(this));
             assert(penultimatePage);
 
-            if (penultimatePage->m_drawingJustifiableHeight < this->m_drawingJustifiableHeight) {
-                this->m_drawingJustifiableHeight = penultimatePage->m_drawingJustifiableHeight;
+            if (penultimatePage->m_drawingJustifiableHeight < m_drawingJustifiableHeight) {
+                m_drawingJustifiableHeight = penultimatePage->m_drawingJustifiableHeight;
             }
 
             const int maxSystemsPerPage = doc->GetOptions()->m_systemMaxPerPage.GetValue();
@@ -599,8 +599,8 @@ void Page::JustifyVertically()
     // Justify Y position
     Functor justifyY(&Object::JustifyY);
     JustifyYParams justifyYParams(&justifyY, doc);
-    justifyYParams.m_justificationSum = this->m_justificationSum;
-    justifyYParams.m_spaceToDistribute = this->m_drawingJustifiableHeight;
+    justifyYParams.m_justificationSum = m_justificationSum;
+    justifyYParams.m_spaceToDistribute = m_drawingJustifiableHeight;
     this->Process(&justifyY, &justifyYParams);
 }
 
@@ -714,12 +714,12 @@ int Page::ApplyPPUFactor(FunctorParams *functorParams)
     assert(params);
 
     params->m_page = this;
-    this->m_pageWidth /= params->m_page->GetPPUFactor();
-    this->m_pageHeight /= params->m_page->GetPPUFactor();
-    this->m_pageMarginBottom /= params->m_page->GetPPUFactor();
-    this->m_pageMarginLeft /= params->m_page->GetPPUFactor();
-    this->m_pageMarginRight /= params->m_page->GetPPUFactor();
-    this->m_pageMarginTop /= params->m_page->GetPPUFactor();
+    m_pageWidth /= params->m_page->GetPPUFactor();
+    m_pageHeight /= params->m_page->GetPPUFactor();
+    m_pageMarginBottom /= params->m_page->GetPPUFactor();
+    m_pageMarginLeft /= params->m_page->GetPPUFactor();
+    m_pageMarginRight /= params->m_page->GetPPUFactor();
+    m_pageMarginTop /= params->m_page->GetPPUFactor();
 
     return FUNCTOR_CONTINUE;
 }
@@ -793,12 +793,12 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
     AlignSystemsParams *params = vrv_params_cast<AlignSystemsParams *>(functorParams);
     assert(params);
 
-    this->m_drawingJustifiableHeight = params->m_shift;
-    this->m_justificationSum = params->m_justificationSum;
+    m_drawingJustifiableHeight = params->m_shift;
+    m_justificationSum = params->m_justificationSum;
 
     RunningElement *footer = this->GetFooter();
     if (footer) {
-        this->m_drawingJustifiableHeight -= footer->GetTotalHeight();
+        m_drawingJustifiableHeight -= footer->GetTotalHeight();
 
         // Move it up below the last system
         if (params->m_doc->GetOptions()->m_adjustPageHeight.GetValue()) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -435,7 +435,7 @@ int Rest::GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLay
     return VRV_UNSET;
 }
 
-std::pair<int, RestAccidental> Rest::GetElementLocation(Object *object, Layer *layer, bool isTopLayer)
+std::pair<int, RestAccidental> Rest::GetElementLocation(Object *object, Layer *layer, bool isTopLayer) const
 {
     if (object->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(object);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -578,7 +578,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff);
 
-    if (this->m_crossStaff) staff = this->m_crossStaff;
+    if (m_crossStaff) staff = m_crossStaff;
 
     bool drawingCueSize = this->GetDrawingCueSize();
     int staffSize = staff->m_drawingStaffSize;

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -204,7 +204,7 @@ void Staff::AdjustDrawingStaffSize()
             assert(zone);
             int yDiff
                 = zone->GetLry() - zone->GetUly() - (zone->GetLrx() - zone->GetUlx()) * tan(abs(rotate) * M_PI / 180.0);
-            this->m_drawingStaffSize = 100 * yDiff / (doc->GetOptions()->m_unit.GetValue() * 2 * (m_drawingLines - 1));
+            m_drawingStaffSize = 100 * yDiff / (doc->GetOptions()->m_unit.GetValue() * 2 * (m_drawingLines - 1));
         }
     }
 }
@@ -222,25 +222,24 @@ bool Staff::DrawingIsVisible()
 
 bool Staff::IsMensural()
 {
-    bool isMensural = (this->m_drawingNotationType == NOTATIONTYPE_mensural
-        || this->m_drawingNotationType == NOTATIONTYPE_mensural_white
-        || this->m_drawingNotationType == NOTATIONTYPE_mensural_black);
+    bool isMensural
+        = (m_drawingNotationType == NOTATIONTYPE_mensural || m_drawingNotationType == NOTATIONTYPE_mensural_white
+            || m_drawingNotationType == NOTATIONTYPE_mensural_black);
     return isMensural;
 }
 
 bool Staff::IsNeume()
 {
-    bool isNeume = (this->m_drawingNotationType == NOTATIONTYPE_neume);
+    bool isNeume = (m_drawingNotationType == NOTATIONTYPE_neume);
     return isNeume;
 }
 
 bool Staff::IsTablature()
 {
-    bool isTablature
-        = (this->m_drawingNotationType == NOTATIONTYPE_tab || this->m_drawingNotationType == NOTATIONTYPE_tab_guitar
-            || this->m_drawingNotationType == NOTATIONTYPE_tab_lute_italian
-            || this->m_drawingNotationType == NOTATIONTYPE_tab_lute_french
-            || this->m_drawingNotationType == NOTATIONTYPE_tab_lute_german);
+    bool isTablature = (m_drawingNotationType == NOTATIONTYPE_tab || m_drawingNotationType == NOTATIONTYPE_tab_guitar
+        || m_drawingNotationType == NOTATIONTYPE_tab_lute_italian
+        || m_drawingNotationType == NOTATIONTYPE_tab_lute_french
+        || m_drawingNotationType == NOTATIONTYPE_tab_lute_german);
     return isTablature;
 }
 
@@ -249,8 +248,8 @@ int Staff::CalcPitchPosYRel(Doc *doc, int loc)
     assert(doc);
 
     // the staff loc offset is based on the number of lines: 0 with 1 line, 2 with 2, etc
-    int staffLocOffset = (this->m_drawingLines - 1) * 2;
-    return (loc - staffLocOffset) * doc->GetDrawingUnit(this->m_drawingStaffSize);
+    int staffLocOffset = (m_drawingLines - 1) * 2;
+    return (loc - staffLocOffset) * doc->GetDrawingUnit(m_drawingStaffSize);
 }
 
 void Staff::AddLedgerLineAbove(int count, int left, int right, bool cueSize)
@@ -304,7 +303,7 @@ bool Staff::IsOnStaffLine(int y, Doc *doc)
 {
     assert(doc);
 
-    return ((y - this->GetDrawingY()) % (2 * doc->GetDrawingUnit(this->m_drawingStaffSize)) == 0);
+    return ((y - this->GetDrawingY()) % (2 * doc->GetDrawingUnit(m_drawingStaffSize)) == 0);
 }
 
 int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
@@ -312,14 +311,14 @@ int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
     assert(doc);
 
     int yPos = y - this->GetDrawingY();
-    int distance = yPos % doc->GetDrawingUnit(this->m_drawingStaffSize);
+    int distance = yPos % doc->GetDrawingUnit(m_drawingStaffSize);
     if (place == STAFFREL_above) {
-        if (distance > 0) distance = doc->GetDrawingUnit(this->m_drawingStaffSize) - distance;
-        return y - distance + doc->GetDrawingUnit(this->m_drawingStaffSize);
+        if (distance > 0) distance = doc->GetDrawingUnit(m_drawingStaffSize) - distance;
+        return y - distance + doc->GetDrawingUnit(m_drawingStaffSize);
     }
     else {
-        if (distance < 0) distance = doc->GetDrawingUnit(this->m_drawingStaffSize) + distance;
-        return y - distance - doc->GetDrawingUnit(this->m_drawingStaffSize);
+        if (distance < 0) distance = doc->GetDrawingUnit(m_drawingStaffSize) + distance;
+        return y - distance - doc->GetDrawingUnit(m_drawingStaffSize);
     }
 }
 
@@ -463,10 +462,10 @@ int Staff::AlignHorizontally(FunctorParams *functorParams)
     AlignHorizontallyParams *params = vrv_params_cast<AlignHorizontallyParams *>(functorParams);
     assert(params);
 
-    assert(this->m_drawingStaffDef);
+    assert(m_drawingStaffDef);
 
-    if (this->m_drawingStaffDef->HasNotationtype()) {
-        params->m_notationType = this->m_drawingStaffDef->GetNotationtype();
+    if (m_drawingStaffDef->HasNotationtype()) {
+        params->m_notationType = m_drawingStaffDef->GetNotationtype();
     }
     else {
         params->m_notationType = NOTATIONTYPE_cmn;
@@ -531,7 +530,7 @@ int Staff::FillStaffCurrentTimeSpanning(FunctorParams *functorParams)
 
 int Staff::ResetDrawing(FunctorParams *functorParams)
 {
-    this->m_timeSpanningElements.clear();
+    m_timeSpanningElements.clear();
     ClearLedgerLines();
     return FUNCTOR_CONTINUE;
 }
@@ -564,10 +563,10 @@ int Staff::CalcOnsetOffset(FunctorParams *functorParams)
     CalcOnsetOffsetParams *params = vrv_params_cast<CalcOnsetOffsetParams *>(functorParams);
     assert(params);
 
-    assert(this->m_drawingStaffDef);
+    assert(m_drawingStaffDef);
 
-    if (this->m_drawingStaffDef->HasNotationtype()) {
-        params->m_notationType = this->m_drawingStaffDef->GetNotationtype();
+    if (m_drawingStaffDef->HasNotationtype()) {
+        params->m_notationType = m_drawingStaffDef->GetNotationtype();
     }
     else {
         params->m_notationType = NOTATIONTYPE_cmn;
@@ -632,7 +631,7 @@ int Staff::AdjustSylSpacing(FunctorParams *functorParams)
     assert(params);
 
     // Set the staff size for this pass
-    params->m_staffSize = this->m_drawingStaffSize;
+    params->m_staffSize = m_drawingStaffSize;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -600,7 +600,7 @@ int System::AlignMeasures(FunctorParams *functorParams)
     AlignMeasuresParams *params = vrv_params_cast<AlignMeasuresParams *>(functorParams);
     assert(params);
 
-    SetDrawingXRel(this->m_systemLeftMar + this->GetDrawingLabelsWidth());
+    SetDrawingXRel(m_systemLeftMar + this->GetDrawingLabelsWidth());
     params->m_shift = 0;
     params->m_justifiableWidth = 0;
 
@@ -657,7 +657,7 @@ int System::JustifyX(FunctorParams *functorParams)
     Object *parent = GetParent();
 
     params->m_measureXRel = 0;
-    int margins = this->m_systemLeftMar + this->m_systemRightMar;
+    int margins = m_systemLeftMar + m_systemRightMar;
     int nonJustifiableWidth
         = margins + (m_drawingTotalWidth - m_drawingJustifiableWidth); // m_drawingTotalWidth includes the labels
     params->m_justifiableRatio
@@ -879,13 +879,13 @@ int System::CastOffPages(FunctorParams *functorParams)
     const int systemMaxPerPage = params->m_doc->GetOptions()->m_systemMaxPerPage.GetValue();
     const int childCount = params->m_currentPage->GetChildCount();
     if ((systemMaxPerPage && systemMaxPerPage == childCount)
-        || (childCount > 0 && (this->m_drawingYRel - this->GetHeight() - currentShift < 0))) {
+        || (childCount > 0 && (m_drawingYRel - this->GetHeight() - currentShift < 0))) {
         params->m_currentPage = new Page();
         // Use VRV_UNSET value as a flag
         params->m_pgHeadHeight = VRV_UNSET;
         assert(params->m_doc->GetPages());
         params->m_doc->GetPages()->AddChild(params->m_currentPage);
-        params->m_shift = this->m_drawingYRel - params->m_pageHeight;
+        params->m_shift = m_drawingYRel - params->m_pageHeight;
     }
 
     // Special case where we use the Relinquish method.

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -83,7 +83,7 @@ void TimePointInterface::SetUuidStr()
 Measure *TimePointInterface::GetStartMeasure()
 {
     if (!m_start) return NULL;
-    return dynamic_cast<Measure *>(this->m_start->GetFirstAncestor(MEASURE));
+    return dynamic_cast<Measure *>(m_start->GetFirstAncestor(MEASURE));
 }
 
 bool TimePointInterface::IsOnStaff(int n)
@@ -204,7 +204,7 @@ bool TimeSpanningInterface::SetStartAndEnd(LayerElement *element)
 Measure *TimeSpanningInterface::GetEndMeasure()
 {
     if (!m_end) return NULL;
-    return dynamic_cast<Measure *>(this->m_end->GetFirstAncestor(MEASURE));
+    return dynamic_cast<Measure *>(m_end->GetFirstAncestor(MEASURE));
 }
 
 bool TimeSpanningInterface::IsSpanningMeasures()

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -220,7 +220,7 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
     return;
 }
 
-void Tuplet::GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc)
+void Tuplet::GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc) const
 {
     assert(m_drawingLeft);
     assert(m_drawingRight);

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -135,7 +135,7 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
     }
 
     bool newLabelAbbr = false;
-    this->m_drawingLabelAbbr = NULL;
+    m_drawingLabelAbbr = NULL;
     // Find the labelAbbr (if none previously given)
     if (params->m_currentLabelAbbr == NULL) {
         params->m_currentLabelAbbr = dynamic_cast<LabelAbbr *>(this->FindDescendantByType(LABELABBR));
@@ -187,7 +187,7 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
         params->m_lastSyl = lastSyl;
 
         if (!newLabelAbbr && params->m_currentLabelAbbr) {
-            this->m_drawingLabelAbbr = params->m_currentLabelAbbr;
+            m_drawingLabelAbbr = params->m_currentLabelAbbr;
         }
 
         // No free space because we never move the first one back

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -638,7 +638,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             if (overflowAbove > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
                 // LogMessage("%sparams->m_doc top overflow: %d", this->GetUuid().c_str(), overflowAbove);
                 this->SetOverflowAbove(overflowAbove);
-                this->m_overflowAboveBBoxes.push_back((*iter));
+                m_overflowAboveBBoxes.push_back((*iter));
             }
 
             int overflowBelow = 0;
@@ -646,7 +646,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             if (overflowBelow > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
                 // LogMessage("%s bottom overflow: %d", this->GetUuid().c_str(), overflowBelow);
                 this->SetOverflowBelow(overflowBelow);
-                this->m_overflowBelowBBoxes.push_back((*iter));
+                m_overflowBelowBBoxes.push_back((*iter));
             }
             continue;
         }
@@ -893,7 +893,7 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
     assert(params);
 
     // This is the bottom alignment (or something is wrong)
-    if (!this->m_staff) return FUNCTOR_STOP;
+    if (!m_staff) return FUNCTOR_STOP;
 
     if (params->m_previous == NULL) {
         params->m_previous = this;
@@ -913,7 +913,7 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
                 // calculate the vertical overlap and see if this is more than the expected space
                 int overflowBelow = params->m_previous->CalcOverflowBelow(*iter);
                 int overflowAbove = this->CalcOverflowAbove(*i);
-                int spacing = std::max(params->m_previous->m_overflowBelow, this->m_overflowAbove);
+                int spacing = std::max(params->m_previous->m_overflowBelow, m_overflowAbove);
                 if (spacing < (overflowBelow + overflowAbove)) {
                     // LogDebug("Overlap %d", (overflowBelow + overflowAbove) - spacing);
                     this->SetOverlap((overflowBelow + overflowAbove) - spacing);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1896,7 +1896,7 @@ void View::DrawMordent(DeviceContext *dc, Mordent *mordent, Measure *measure, Sy
         }
         else if (mordent->HasAccidupper()) {
             double mordentHeight = m_doc->GetGlyphHeight(code, (*staffIter)->m_drawingStaffSize, false);
-            int accid = Accid::GetAccidGlyph(mordent->GetAccidupper());
+            wchar_t accid = Accid::GetAccidGlyph(mordent->GetAccidupper());
             std::wstring accidStr;
             accidStr.push_back(accid);
             dc->SetFont(m_doc->GetDrawingSmuflFont((*staffIter)->m_drawingStaffSize, false));


### PR DESCRIPTION
This PR does code cleanup such as:

- Add `const` to member functions
- Remove `this` when accessing member variables
- Pass string arguments by const reference instead of value
- Remove the functor `ConvertScoreDefMarkup` which does nothing except traversing the tree