### PR TITLE
Fix for the dotted rests

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -513,9 +513,19 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
         assert(staff);
         const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         const int locAdjust = (params->m_directionBias * (overlapMargin - 2 * unit + 1) / unit);
-        const int newLoc = GetDrawingLoc() + locAdjust - locAdjust % 2;
+        const int oldLoc = GetDrawingLoc();
+        const int newLoc = oldLoc + locAdjust - locAdjust % 2;
         SetDrawingLoc(newLoc);
         SetDrawingYRel(staff->CalcPitchPosYRel(params->m_doc, newLoc));
+        // If there are dots, adjust their location as well
+        if (GetDots() > 0) {
+            Dots *dots = vrv_cast<Dots *>(FindDescendantByType(DOTS, 1));
+            if (dots) {
+                std::list<int> *dotLocs = dots->GetDotLocsForStaff(staff);
+                const auto iter = std::find(dotLocs->begin(), dotLocs->end(), oldLoc);
+                if (iter != dotLocs->end()) *iter = newLoc;
+            }
+        }
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- fixed code so that dots are adjusted alongside with rests when they overlap with beams (closes #2212)

![image](https://user-images.githubusercontent.com/1819669/119999486-79aba580-bfda-11eb-938f-bb3549de0122.png)
