### PR TITLE
Option to prevent widow measure from happening

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1069,7 +1069,8 @@ public:
  * member 1: a pointer the document we are adding pages to
  * member 2: a pointer to the current page
  * member 3: the cummulated shift (m_drawingYRel of the first system of the current page)
- * member 4: the page height
+ * members 4-8: the page heights
+ * member 9: a pointer to the leftover system (last system with only one measure)
  **/
 
 class CastOffPagesParams : public FunctorParams {
@@ -1085,6 +1086,7 @@ public:
         m_pgFootHeight = 0;
         m_pgHead2Height = 0;
         m_pgFoot2Height = 0;
+        m_leftoverSystem = NULL;
     }
     Page *m_contentPage;
     Doc *m_doc;
@@ -1095,6 +1097,7 @@ public:
     int m_pgFootHeight;
     int m_pgHead2Height;
     int m_pgFoot2Height;
+    System *m_leftoverSystem;
 };
 
 //----------------------------------------------------------------------------
@@ -1111,6 +1114,7 @@ public:
  * member 6: the current pending objects (ScoreDef, Endings, etc.) to be place at the beginning of a system
  * member 7: the doc
  * member 8: whether to smartly use encoded system breaks
+ * member 9: a pointer to the leftover system (last system with only one measure)
  **/
 
 class CastOffSystemsParams : public FunctorParams {
@@ -1125,6 +1129,7 @@ public:
         m_currentScoreDefWidth = 0;
         m_doc = doc;
         m_smart = smart;
+        m_leftoverSystem = NULL;
     }
     System *m_contentSystem;
     Page *m_page;
@@ -1135,6 +1140,7 @@ public:
     ArrayOfObjects m_pendingObjects;
     Doc *m_doc;
     bool m_smart;
+    System *m_leftoverSystem;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -634,7 +634,7 @@ public:
     OptionDbl m_clefChangeFactor;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;
-    OptionBool m_fitLastMeasure;
+    OptionBool m_breaksNoWidow;
     OptionString m_font;
     OptionDbl m_graceFactor;
     OptionBool m_graceRhythmAlign;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -634,6 +634,7 @@ public:
     OptionDbl m_clefChangeFactor;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;
+    OptionBool m_fitLastMeasure;
     OptionString m_font;
     OptionDbl m_graceFactor;
     OptionBool m_graceRhythmAlign;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -867,6 +867,7 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     System *currentSystem = new System();
     contentPage->AddChild(currentSystem);
 
+    System *leftoverSystem = NULL;
     if (useSb && !usePb && !smart) {
         CastOffEncodingParams castOffEncodingParams(this, contentPage, currentSystem, contentSystem, false);
 
@@ -884,6 +885,7 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
         Functor castOffSystems(&Object::CastOffSystems);
         Functor castOffSystemsEnd(&Object::CastOffSystemsEnd);
         contentSystem->Process(&castOffSystems, &castOffSystemsParams, &castOffSystemsEnd);
+        leftoverSystem = castOffSystemsParams.m_leftoverSystem;
     }
     delete contentSystem;
 
@@ -909,7 +911,8 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     Page *currentPage = new Page();
     CastOffPagesParams castOffPagesParams(contentPage, this, currentPage);
     CastOffRunningElements(&castOffPagesParams);
-    castOffPagesParams.m_pageHeight = m_drawingPageContentHeight;
+    castOffPagesParams.m_pageHeight = this->m_drawingPageContentHeight;
+    castOffPagesParams.m_leftoverSystem = leftoverSystem;
     Functor castOffPages(&Object::CastOffPages);
     pages->AddChild(currentPage);
     contentPage->Process(&castOffPages, &castOffPagesParams);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1129,8 +1129,8 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
         // Break it if necessary
-        else if ((m_drawingXRel + GetWidth() + params->m_currentScoreDefWidth - params->m_shift
-                     > params->m_systemWidth)) {
+        else if (m_drawingXRel + GetWidth() + params->m_currentScoreDefWidth - params->m_shift
+            > params->m_systemWidth) {
             params->m_currentSystem = new System();
             params->m_page->AddChild(params->m_currentSystem);
             params->m_shift = this->m_drawingXRel;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1116,7 +1116,7 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
     int overflow = this->GetDrawingOverflow();
 
     Object *nextMeasure = params->m_contentSystem->GetNext(this, MEASURE);
-    const bool isLeftoverMeasure = ((NULL == nextMeasure) && params->m_doc->GetOptions()->m_fitLastMeasure.GetValue()
+    const bool isLeftoverMeasure = ((NULL == nextMeasure) && params->m_doc->GetOptions()->m_breaksNoWidow.GetValue()
         && (params->m_doc->GetOptions()->m_breaks.GetValue() != BREAKS_encoded));
     if (params->m_currentSystem->GetChildCount() > 0) {
         // We have overflowing content (dir, dynam, tempo) larger than 5 units, keep it as pending

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1115,6 +1115,9 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
     // Check if the measure has some overflowing control elements
     int overflow = this->GetDrawingOverflow();
 
+    Object *nextMeasure = params->m_contentSystem->GetNext(this, MEASURE);
+    const bool fitLastMeasure = ((NULL == nextMeasure) && params->m_doc->GetOptions()->m_fitLastMeasure.GetValue()
+        && (params->m_doc->GetOptions()->m_breaks.GetValue() != BREAKS_encoded));
     if (params->m_currentSystem->GetChildCount() > 0) {
         // We have overflowing content (dir, dynam, tempo) larger than 5 units, keep it as pending
         if (overflow > (params->m_doc->GetDrawingUnit(100) * 5)) {
@@ -1126,8 +1129,8 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
         // Break it if necessary
-        else if (m_drawingXRel + this->GetWidth() + params->m_currentScoreDefWidth - params->m_shift
-            > params->m_systemWidth) {
+        else if ((m_drawingXRel + GetWidth() + params->m_currentScoreDefWidth - params->m_shift > params->m_systemWidth)
+            && !fitLastMeasure) {
             params->m_currentSystem = new System();
             params->m_page->AddChild(params->m_currentSystem);
             params->m_shift = m_drawingXRel;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1116,7 +1116,7 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
     int overflow = this->GetDrawingOverflow();
 
     Object *nextMeasure = params->m_contentSystem->GetNext(this, MEASURE);
-    const bool fitLastMeasure = ((NULL == nextMeasure) && params->m_doc->GetOptions()->m_fitLastMeasure.GetValue()
+    const bool isLeftoverMeasure = ((NULL == nextMeasure) && params->m_doc->GetOptions()->m_fitLastMeasure.GetValue()
         && (params->m_doc->GetOptions()->m_breaks.GetValue() != BREAKS_encoded));
     if (params->m_currentSystem->GetChildCount() > 0) {
         // We have overflowing content (dir, dynam, tempo) larger than 5 units, keep it as pending
@@ -1129,11 +1129,15 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
         // Break it if necessary
-        else if ((m_drawingXRel + GetWidth() + params->m_currentScoreDefWidth - params->m_shift > params->m_systemWidth)
-            && !fitLastMeasure) {
+        else if ((m_drawingXRel + GetWidth() + params->m_currentScoreDefWidth - params->m_shift
+                     > params->m_systemWidth)) {
             params->m_currentSystem = new System();
             params->m_page->AddChild(params->m_currentSystem);
-            params->m_shift = m_drawingXRel;
+            params->m_shift = this->m_drawingXRel;
+            // If last measure requires separate system - mark that system as leftover for the future CastOffPages call
+            if (isLeftoverMeasure) {
+                params->m_leftoverSystem = params->m_currentSystem;
+            }
             for (Object *oneOfPendingObjects : params->m_pendingObjects) {
                 if (oneOfPendingObjects->Is(MEASURE)) {
                     Measure *firstPendingMesure = vrv_cast<Measure *>(oneOfPendingObjects);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1054,6 +1054,10 @@ Options::Options()
     m_engravingDefaultsFile.Init(JsonSource::FilePath, "");
     this->Register(&m_engravingDefaultsFile, "engravingDefaultsFile", &m_generalLayout);
 
+    m_fitLastMeasure.SetInfo("Fit last measure", "Prevent single measures on the last page by fitting it into previous system");
+    m_fitLastMeasure.Init(false);
+    this->Register(&m_fitLastMeasure, "fitLastMeasure", &m_generalLayout);
+
     m_font.SetInfo("Font", "Set the music font");
     m_font.Init("Leipzig");
     this->Register(&m_font, "font", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1054,9 +1054,10 @@ Options::Options()
     m_engravingDefaultsFile.Init(JsonSource::FilePath, "");
     this->Register(&m_engravingDefaultsFile, "engravingDefaultsFile", &m_generalLayout);
 
-    m_fitLastMeasure.SetInfo("Fit last measure", "Prevent single measures on the last page by fitting it into previous system");
-    m_fitLastMeasure.Init(false);
-    this->Register(&m_fitLastMeasure, "fitLastMeasure", &m_generalLayout);
+    m_breaksNoWidow.SetInfo(
+        "Breaks no widow", "Prevent single measures on the last page by fitting it into previous system");
+    m_breaksNoWidow.Init(false);
+    this->Register(&m_breaksNoWidow, "breaksNoWidow", &m_generalLayout);
 
     m_font.SetInfo("Font", "Set the music font");
     m_font.Init("Leipzig");


### PR DESCRIPTION
Added a new option `--fit-last-measure` to prevent pages with single measure. If such option is provided, whenever there is one measure left on the the last page, we would try to fit it to the previous page/system. In some cases that might lead to too tight placement in the system, hence by default this option is off.
Additionally, it honors `--breaks encoded` option, so in cases where there is single page after the page break, even if option is specified it would not try to move that measure.
I'm not quite sure if the name for the option is the best, so if there are any suggestions for the name - please let me know.