### PR TITLE
prevent slurs from touching bar lines 

### DIFF
--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -212,12 +212,12 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     if (spanningType == SPANNING_START_END) {
         stemDir = startStemDir;
     }
-    // This is the case when the tie is split over two system of two pages.
+    // This is the case when the slur is split over two system of two pages.
     // In this case, we are now drawing its beginning to the end of the measure (i.e., the last aligner)
     else if (spanningType == SPANNING_START) {
         stemDir = startStemDir;
     }
-    // Now this is the case when the tie is split but we are drawing the end of it
+    // Now this is the case when the slur is split but we are drawing the end of it
     else if (spanningType == SPANNING_END) {
         stemDir = endStemDir;
     }
@@ -420,6 +420,10 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
         else {
             y2 = staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
         }
+        // At the end of a system, the slur finishes just short of the last barline
+        x2 -= (m_doc->GetDrawingBarLineWidth(staff->m_drawingStaffSize)
+                  + m_doc->GetDrawingUnit(staff->m_drawingStaffSize))
+            / 2;
     }
     if (end->Is(TIMESTAMP_ATTR)) {
         if (drawingCurveDir == curvature_CURVEDIR_above) {


### PR DESCRIPTION
_At the end of a system, the slur finishes just short of the last barline, and not beyond it._ (Gould p. 112)

### before
![slur_before](https://user-images.githubusercontent.com/7693447/120796189-ce9b6e80-c53a-11eb-916c-a36e977a08e5.png)

### after
![slurs_after](https://user-images.githubusercontent.com/7693447/120796168-c80cf700-c53a-11eb-8b7b-2a0ed7cd4d94.png)
