### PR TITLE
Rests and cross staff content

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1661,7 +1661,7 @@ public:
     }
     double m_time;
     double m_duration;
-    std::vector<int> m_layers;
+    std::set<int> m_layers;
     MeterSig *m_meterSig;
     Mensur *m_mensur;
     Functor *m_functor;

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -104,16 +104,22 @@ public:
     ///@}
 
     /**
-     * Get the number of layer used for the duration of an element.
-     * Takes into account cross-staff situations.
+     * @name Get the layers used for the duration of an element.
+     * Takes into account cross-staff situations: cross staff layers have negative N.
      */
+    ///@{
+    std::set<int> GetLayersNForTimeSpanOf(LayerElement *element);
     int GetLayerCountForTimeSpanOf(LayerElement *element);
+    ///@}
 
     /**
-     * Get the number of layer used within a time span.
-     * Takes into account cross-staff situations.
+     * @name Get the layers used within a time span.
+     * Takes into account cross-staff situations: cross staff layers have negative N.
      */
+    ///@{
+    std::set<int> GetLayersNInTimeSpan(double time, double duration, Measure *measure, int staff);
     int GetLayerCountInTimeSpan(double time, double duration, Measure *measure, int staff);
+    ///@}
 
     /**
      * Get the list of the layer elements for the duration of an element

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <set>
 #include <vector>
 
 //----------------------------------------------------------------------------

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -287,7 +287,7 @@ data_STEMDIRECTION Layer::GetDrawingStemDir(const ArrayOfBeamElementCoords *coor
     }
 }
 
-int Layer::GetLayerCountForTimeSpanOf(LayerElement *element)
+std::set<int> Layer::GetLayersNForTimeSpanOf(LayerElement *element)
 {
     assert(element);
 
@@ -305,10 +305,15 @@ int Layer::GetLayerCountForTimeSpanOf(LayerElement *element)
     // At this stage we have the parent or the cross-staff
     assert(staff);
 
-    return this->GetLayerCountInTimeSpan(alignment->GetTime(), element->GetAlignmentDuration(), measure, staff->GetN());
+    return this->GetLayersNInTimeSpan(alignment->GetTime(), element->GetAlignmentDuration(), measure, staff->GetN());
 }
 
-int Layer::GetLayerCountInTimeSpan(double time, double duration, Measure *measure, int staff)
+int Layer::GetLayerCountForTimeSpanOf(LayerElement *element)
+{
+    return static_cast<int>(this->GetLayersNForTimeSpanOf(element).size());
+}
+
+std::set<int> Layer::GetLayersNInTimeSpan(double time, double duration, Measure *measure, int staff)
 {
     assert(measure);
 
@@ -324,7 +329,12 @@ int Layer::GetLayerCountInTimeSpan(double time, double duration, Measure *measur
 
     measure->m_measureAligner.Process(&layerCountInTimeSpan, &layerCountInTimeSpanParams, NULL, &filters);
 
-    return (int)layerCountInTimeSpanParams.m_layers.size();
+    return layerCountInTimeSpanParams.m_layers;
+}
+
+int Layer::GetLayerCountInTimeSpan(double time, double duration, Measure *measure, int staff)
+{
+    return static_cast<int>(this->GetLayersNInTimeSpan(time, duration, measure, staff).size());
 }
 
 ListOfObjects Layer::GetLayerElementsForTimeSpanOf(LayerElement *element, bool excludeCurrent)

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1170,13 +1170,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             if ((rest->GetDur() == DUR_1) && (staff->m_drawingLines > 1)) loc += 2;
             if ((rest->GetDur() == DUR_BR) && (staff->m_drawingLines < 2)) loc -= 2;
 
-            Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, 1));
-            // Limitation: GetLayerCount does not take into account editorial markup
-            // should be refined later
-            bool hasMultipleLayer = (staffY->GetChildCount(LAYER) > 1);
-
             // If within a beam, calculate the rest's height based on it's relationship to the notes that surround it
-            if (beam) {
+            if (Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, 1)); beam) {
                 beam->ResetList(beam);
 
                 const ArrayOfObjects *beamList = beam->GetList(beam);
@@ -1282,11 +1277,9 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                         loc++;
                 }
             }
-            if (hasMultipleLayer || m_crossStaff) {
-                Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
-                assert(staff);
-                loc = rest->GetOptimalLayerLocation(staff, layer, loc);
-            }
+
+            Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+            loc = rest->GetOptimalLayerLocation(staff, layer, loc);
         }
         rest->SetDrawingLoc(loc);
         this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, loc));
@@ -1975,11 +1968,9 @@ int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams)
 
     // For mRest we do not look at the time span
     if (this->Is(MREST)) {
-        // Add the layerN to the list of layer element occuring in this time frame
-        if (std::find(params->m_layers.begin(), params->m_layers.end(), this->GetAlignmentLayerN())
-            == params->m_layers.end()) {
-            params->m_layers.push_back(this->GetAlignmentLayerN());
-        }
+        // Add the layerN to the list of layer elements occuring in this time frame
+        params->m_layers.insert(this->GetAlignmentLayerN());
+
         return FUNCTOR_SIBLINGS;
     }
 
@@ -1998,11 +1989,8 @@ int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams)
         return FUNCTOR_STOP;
     }
 
-    // Add the layerN to the list of layer element occuring in this time frame
-    if (std::find(params->m_layers.begin(), params->m_layers.end(), this->GetAlignmentLayerN())
-        == params->m_layers.end()) {
-        params->m_layers.push_back(this->GetAlignmentLayerN());
-    }
+    // Add the layerN to the list of layer elements occuring in this time frame
+    params->m_layers.insert(this->GetAlignmentLayerN());
 
     // Not need to recurse for chords? Not quite sure about it.
     return (this->Is(CHORD)) ? FUNCTOR_SIBLINGS : FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1171,7 +1171,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             if ((rest->GetDur() == DUR_BR) && (staff->m_drawingLines < 2)) loc -= 2;
 
             // If within a beam, calculate the rest's height based on it's relationship to the notes that surround it
-            if (Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, 1)); beam) {
+            Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, 1));
+            if (beam) {
                 beam->ResetList(beam);
 
                 const ArrayOfObjects *beamList = beam->GetList(beam);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -264,19 +264,18 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
 {
     Layer *parentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     if (!layer) return defaultLocation;
-    const int layerCount = parentLayer->GetLayerCountForTimeSpanOf(this);
+    const std::set<int> layersN = parentLayer->GetLayersNForTimeSpanOf(this);
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
-    if (layerCount != 2) return defaultLocation;
+    if (layersN.size() != 2) return defaultLocation;
 
+    const bool isTopLayer
+        = m_crossStaff ? (staff->GetN() < m_crossStaff->GetN()) : (layer->GetN() == *layersN.cbegin());
+
+    // find best rest location relative to elements on other layers
     Staff *realStaff = m_crossStaff ? m_crossStaff : staff;
-
     ListOfObjects layers;
     ClassIdComparison matchType(LAYER);
     realStaff->FindAllDescendantByComparison(&layers, &matchType);
-    const bool isTopLayer((m_crossStaff && (staff->GetN() < m_crossStaff->GetN()))
-        || (!m_crossStaff && vrv_cast<Layer *>(*layers.begin())->GetN() == layer->GetN()));
-
-    // find best rest location relative to elements on other layers
     const auto otherLayerRelativeLocationInfo = GetLocationRelativeToOtherLayers(layers, layer, isTopLayer);
     int currentLayerRelativeLocation = GetLocationRelativeToCurrentLayer(staff, layer, isTopLayer);
     int otherLayerRelativeLocation = otherLayerRelativeLocationInfo.first


### PR DESCRIPTION
This PR fixes rest collisions with cross staff voices. Such situations are treated the same as if there were two voices in one staff.

| Before  | After |
| ------------- | ------------- |
| <img width="491" alt="Before" src="https://user-images.githubusercontent.com/63608463/120808998-ef1ef500-c549-11eb-84ea-b8c9570df252.png"> | <img width="477" alt="After" src="https://user-images.githubusercontent.com/63608463/120809075-0362f200-c54a-11eb-96f3-9072e780db88.png"> |

**MEI example**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2021-04-19" type="encoding-date">2021-04-19</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000001579468208">
         <appInfo xml:id="appinfo-0000001076811289">
            <application xml:id="application-0000001122640954" isodate="2021-05-31T09:21:13" version="3.5.0-dev-c917581">
               <name xml:id="name-0000000435191336">Verovio</name>
               <p xml:id="p-0000002078966117">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000001624591729">
            <score xml:id="score-0000001406101345">
               <scoreDef xml:id="scoredef-0000001844543345">
                  <staffGrp xml:id="staffgrp-0000001774747285">
                     <staffGrp xml:id="S1-Piano" bar.thru="true">
                        <staffDef xml:id="staffdef-0000000820316161" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <meterSig xml:id="msig-0000002080451258" count="3" unit="4" />
                        </staffDef>
                        <staffDef xml:id="staffdef-0000000815552752" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <meterSig xml:id="msig-0000000473537286" count="3" unit="4" />
                        </staffDef>
                        <grpSym xml:id="grpsym-0000000166770020" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000001435253827">
                  <pb xml:id="pb-0000001628007834" />
                  <measure xml:id="measure-82-mdiv-1" n="1">
                     <staff xml:id="staff-0000002022716527" n="1">
                        <layer xml:id="layer-0000000004739497" n="1">
                           <rest xml:id="rest-0062-10490-12010" dur.ppq="4" dur="4" />
                           <rest xml:id="rest-0062-10560-12000" dur.ppq="2" dur="8" />
                           <beam xml:id="beam-0000000338716998">
                              <note xml:id="note-0062-10590-12160-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="f" stem.dir="up" />
                              <note xml:id="note-0062-10620-12150-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="f" />
                              <note xml:id="note-0062-10660-12170-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="f" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001130537279" n="2">
                        <layer xml:id="layer-0000000378457195" n="5">
                           <note xml:id="note-0062-10490-12200-2" dur.ppq="2" dur="8" oct="2" pname="b" stem.dir="down" accid.ges="f" />
                           <rest xml:id="rest-0062-10530-12240" dur.ppq="2" dur="8" />
                           <rest xml:id="rest-0062-10560-12250" dur.ppq="4" dur="4" />
                           <rest xml:id="rest-0062-10630-12250" dur.ppq="4" dur="4" />
                        </layer>
                     </staff>
                     <slur xml:id="bow-0062-10680-12140" startid="#note-0062-10590-12160-1" endid="#note-0062-10750-12250-2" curvedir="above" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```