### PR TITLE
WIP: MusicXML: Convert line-through attribute in lyrics into rend 

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2721,6 +2721,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     // std::string textColor = textNode.attribute("color").as_string();
                     std::string textStyle = textNode.attribute("font-style").as_string();
                     std::string textWeight = textNode.attribute("font-weight").as_string();
+                    int lineThrough = textNode.attribute("line-through").as_int();
                     std::string lang = textNode.attribute("xml:lang").as_string();
                     std::string textStr = textNode.text().as_string();
                     Syl *syl = new Syl();

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2757,7 +2757,14 @@ void MusicXmlInput::ReadMusicXmlNote(
 
                     Text *text = new Text();
                     text->SetText(UTF8to16(textStr));
-                    syl->AddChild(text);
+                    if (lineThrough){
+                        Rend *rend = new Rend();
+                        rend->AddChild(text);
+                        rend->SetRend(TEXTRENDITION_line_through);
+                        syl->AddChild(rend);
+                    } else {
+                        syl->AddChild(text);
+                    }
                     verse->AddChild(syl);
                 }
             }


### PR DESCRIPTION
> line-through: Number of lines to use when striking through text. [0,3]

[musicxml spec for text](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/text/)

We will also want to use this for other places where `<text>` is used, so I have made this a method.

> The “combining long stroke overlay” (U+0336) results in an unbroken stroke across the text: 

[Wikipedia article for strikethrough](https://en.wikipedia.org/wiki/Strikethrough)