### PR TITLE
Fix type cast

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -691,8 +691,8 @@ void Chord::CaltOptimalDots(Dots *dots, Staff *staff, const std::set<int> &noteL
     std::transform(secondElem.begin(), secondElem.end(), noteLocations.begin(), secondElem.begin(), std::minus<int>());
     // apply std::abs to elements in the vectors and then calculate sum of the elements. Can be achieved with
     // std::transform_reduce, but gcc needs to support it
-    std::transform(firstElem.begin(), firstElem.end(), firstElem.begin(), static_cast<float (*)(float)>(&std::abs));
-    std::transform(secondElem.begin(), secondElem.end(), secondElem.begin(), static_cast<float (*)(float)>(&std::abs));
+    std::transform(firstElem.begin(), firstElem.end(), firstElem.begin(), static_cast<int (*)(int)>(&std::abs));
+    std::transform(secondElem.begin(), secondElem.end(), secondElem.begin(), static_cast<int (*)(int)>(&std::abs));
     const int firstDiff = std::accumulate(firstElem.begin(), firstElem.end(), 0);
     const int secondDiff = std::accumulate(secondElem.begin(), secondElem.end(), 0);
     std::set<int> dotLocations = (secondDiff < firstDiff) ? *secondRef : *firstRef;


### PR DESCRIPTION
Under strict compiler rules, `std::abs` supports only integral types, unless `#include`-ing `cmath`. This yields:
```
verovio/src/chord.cpp:694:75: error: address of overloaded function 'abs' cannot be static_cast to type 'float (*)(float)'
    std::transform(firstElem.begin(), firstElem.end(), firstElem.begin(), static_cast<float (*)(float)>(&std::abs));
                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

However, the target of this transform is `int`s, so floating point overload should not be used.  This fixes both issues.