### PR TITLE
Add MusicXML conversion of caesuras

### DIFF
--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -1,0 +1,62 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        caesura.h
+// Author:      Klaus Rettinghaus, Thomas Weber
+// Created:     2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_CAESURA_H__
+#define __VRV_CAESURA_H__
+
+#include "atts_cmn.h"
+#include "controlelement.h"
+#include "timeinterface.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Caesura
+//----------------------------------------------------------------------------
+
+/**
+ * This class models the MEI <caesura> element.
+ */
+class Caesura : public ControlElement, public TimePointInterface, public AttColor, public AttPlacementRelStaff {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method reset all attribute classes
+     */
+    ///@{
+    Caesura();
+    virtual ~Caesura();
+    virtual Object *Clone() const { return new Caesura(*this); }
+    virtual void Reset();
+    virtual std::string GetClassName() const { return "Caesura"; }
+    virtual ClassId GetClassId() const { return CAESURA; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    ///@}
+
+    //----------//
+    // Functors //
+    //----------//
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    //
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -37,6 +37,7 @@ class BoundaryEnd;
 class BracketSpan;
 class Breath;
 class BTrem;
+class Caesura;
 class Choice;
 class Chord;
 class Clef;
@@ -309,6 +310,7 @@ private:
     void WriteArpeg(pugi::xml_node currentNode, Arpeg *arpeg);
     void WriteBracketSpan(pugi::xml_node currentNode, BracketSpan *bracketSpan);
     void WriteBreath(pugi::xml_node currentNode, Breath *breath);
+    void WriteCaesura(pugi::xml_node currentNode, Caesura *caesura);
     void WriteDir(pugi::xml_node currentNode, Dir *dir);
     void WriteDynam(pugi::xml_node currentNode, Dynam *dynam);
     void WriteFermata(pugi::xml_node currentNode, Fermata *fermata);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -574,6 +574,7 @@ private:
     bool ReadArpeg(Object *parent, pugi::xml_node arpeg);
     bool ReadBracketSpan(Object *parent, pugi::xml_node bracketSpan);
     bool ReadBreath(Object *parent, pugi::xml_node breath);
+    bool ReadCaesura(Object *parent, pugi::xml_node caesura);
     bool ReadDir(Object *parent, pugi::xml_node dir);
     bool ReadDynam(Object *parent, pugi::xml_node dynam);
     bool ReadFermata(Object *parent, pugi::xml_node fermata);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -160,6 +160,7 @@ enum ClassId {
     ARPEG,
     BRACKETSPAN,
     BREATH,
+    CAESURA,
     DIR,
     DYNAM,
     FERMATA,

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -1,0 +1,45 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        caesura.cpp
+// Author:      Klaus Rettinghaus, Thomas Weber
+// Created:     2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "caesura.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+#include "verticalaligner.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Caesura
+//----------------------------------------------------------------------------
+
+static ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
+
+Caesura::Caesura() : ControlElement("caesura-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
+{
+    RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_PLACEMENTRELSTAFF);
+
+    Reset();
+}
+
+Caesura::~Caesura() {}
+
+void Caesura::Reset()
+{
+    ControlElement::Reset();
+    TimePointInterface::Reset();
+    ResetColor();
+    ResetPlacementRelStaff();
+}
+
+} // namespace vrv

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -28,6 +28,7 @@
 #include "bracketspan.h"
 #include "breath.h"
 #include "btrem.h"
+#include "caesura.h"
 #include "choice.h"
 #include "chord.h"
 #include "clef.h"
@@ -407,6 +408,10 @@ bool MEIOutput::WriteObject(Object *object)
     else if (object->Is(BREATH)) {
         m_currentNode = m_currentNode.append_child("breath");
         WriteBreath(m_currentNode, dynamic_cast<Breath *>(object));
+    }
+    else if (object->Is(CAESURA)) {
+        m_currentNode = m_currentNode.append_child("caesura");
+        WriteCaesura(m_currentNode, dynamic_cast<Caesura *>(object));
     }
     else if (object->Is(DIR)) {
         m_currentNode = m_currentNode.append_child("dir");
@@ -1258,6 +1263,16 @@ void MEIOutput::WriteBreath(pugi::xml_node currentNode, Breath *breath)
     WriteTimePointInterface(currentNode, breath);
     breath->WriteColor(currentNode);
     breath->WritePlacementRelStaff(currentNode);
+}
+
+void MEIOutput::WriteCaesura(pugi::xml_node currentNode, Caesura *caesura)
+{
+    assert(caesura);
+
+    WriteControlElement(currentNode, caesura);
+    WriteTimePointInterface(currentNode, caesura);
+    caesura->WriteColor(currentNode);
+    caesura->WritePlacementRelStaff(currentNode);
 }
 
 void MEIOutput::WriteDir(pugi::xml_node currentNode, Dir *dir)
@@ -4154,6 +4169,9 @@ bool MEIInput::ReadMeasureChildren(Object *parent, pugi::xml_node parentNode)
         else if (std::string(current.name()) == "breath") {
             success = ReadBreath(parent, current);
         }
+        else if (std::string(current.name()) == "caesura") {
+            success = ReadCaesura(parent, current);
+        }
         else if (std::string(current.name()) == "dir") {
             success = ReadDir(parent, current);
         }
@@ -4295,6 +4313,20 @@ bool MEIInput::ReadBreath(Object *parent, pugi::xml_node breath)
 
     parent->AddChild(vrvBreath);
     ReadUnsupportedAttr(breath, vrvBreath);
+    return true;
+}
+
+bool MEIInput::ReadCaesura(Object *parent, pugi::xml_node caesura)
+{
+    Caesura *vrvCaesura = new Caesura();
+    ReadControlElement(caesura, vrvCaesura);
+
+    ReadTimePointInterface(caesura, vrvCaesura);
+    vrvCaesura->ReadColor(caesura);
+    vrvCaesura->ReadPlacementRelStaff(caesura);
+
+    parent->AddChild(vrvCaesura);
+    ReadUnsupportedAttr(caesura, vrvCaesura);
     return true;
 }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -21,6 +21,7 @@
 #include "bracketspan.h"
 #include "breath.h"
 #include "btrem.h"
+#include "caesura.h"
 #include "chord.h"
 #include "clef.h"
 #include "comparison.h"
@@ -2910,6 +2911,18 @@ void MusicXmlInput::ReadMusicXmlNote(
             breath->AttPlacementRelStaff::StrToStaffrel(xmlBreath.node().attribute("placement").as_string()));
         breath->SetColor(xmlBreath.node().attribute("color").as_string());
         breath->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 1.0);
+    }
+
+    // caesura
+    pugi::xpath_node xmlCaesura = notations.node().select_node("articulations/caesura");
+    if (xmlCaesura) {
+        Caesura *caesura = new Caesura();
+        m_controlElements.push_back(std::make_pair(measureNum, caesura));
+        caesura->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        caesura->SetPlace(
+            caesura->AttPlacementRelStaff::StrToStaffrel(xmlCaesura.node().attribute("placement").as_string()));
+        caesura->SetColor(xmlCaesura.node().attribute("color").as_string());
+        caesura->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 1.0);
     }
 
     // dynamics


### PR DESCRIPTION
This is a dreadful copy&paste orgy. I'd love to share the code between breath and caesura because they can be handled almost identically.  With my lacking C++ skills however, I don't know how to do that, especially given there is multiple inheritance involved.

If I should rework this with an approach more like [like this](https://github.com/notengrafik/verovio/commit/7e59001b3634969af6e530936f058968c5c90d26#diff-2b9be0b2a2f7c7e36c0baaf88f4961c4f10211eafc67e82c7ee950711aff74f1L2903) please advise how to do that. Also, the [drawing code](https://github.com/rism-digital/verovio/blob/93849afbb80d59fc346614e64ce75703ca1f556c/src/view_control.cpp#L1352) could be re-used, just changing the glyph. I didn't do the copy&paste orgy for the drawing code (yet).