### PR TITLE
Update att.relativesize

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4989,6 +4989,13 @@ bool MEIInput::ReadChord(Object *parent, pugi::xml_node chord)
     Chord *vrvChord = new Chord();
     ReadLayerElement(chord, vrvChord);
 
+    if (m_version < MEI_4_0_0) {
+        if (chord.attribute("size")) {
+            chord.remove_attribute("size");
+            chord.append_attribute("cue").set_value("true");
+        }
+    }
+
     ReadDurationInterface(chord, vrvChord);
     vrvChord->ReadColor(chord);
     vrvChord->ReadCue(chord);
@@ -5172,6 +5179,13 @@ bool MEIInput::ReadMensur(Object *parent, pugi::xml_node mensur)
     Mensur *vrvMensur = new Mensur();
     ReadLayerElement(mensur, vrvMensur);
 
+    if (m_version < MEI_4_0_0) {
+        if (mensur.attribute("size")) {
+            mensur.remove_attribute("size");
+            mensur.append_attribute("cue").set_value("true");
+        }
+    }
+
     vrvMensur->ReadColor(mensur);
     vrvMensur->ReadCue(mensur);
     vrvMensur->ReadDurationRatio(mensur);
@@ -5207,6 +5221,13 @@ bool MEIInput::ReadMRest(Object *parent, pugi::xml_node mRest)
     MRest *vrvMRest = new MRest();
     ReadLayerElement(mRest, vrvMRest);
     ReadPositionInterface(mRest, vrvMRest);
+
+    if (m_version < MEI_4_0_0) {
+        if (mRest.attribute("size")) {
+            mRest.remove_attribute("size");
+            mRest.append_attribute("cue").set_value("true");
+        }
+    }
 
     vrvMRest->ReadColor(mRest);
     vrvMRest->ReadCue(mRest);
@@ -5323,6 +5344,13 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
     Note *vrvNote = new Note();
     ReadLayerElement(note, vrvNote);
 
+    if (m_version < MEI_4_0_0) {
+        if (note.attribute("size")) {
+            note.remove_attribute("size");
+            note.append_attribute("cue").set_value("true");
+        }
+    }
+
     ReadDurationInterface(note, vrvNote);
     ReadPitchInterface(note, vrvNote);
     ReadPositionInterface(note, vrvNote);
@@ -5367,6 +5395,13 @@ bool MEIInput::ReadRest(Object *parent, pugi::xml_node rest)
 {
     Rest *vrvRest = new Rest();
     ReadLayerElement(rest, vrvRest);
+
+    if (m_version < MEI_4_0_0) {
+        if (rest.attribute("size")) {
+            rest.remove_attribute("size");
+            rest.append_attribute("cue").set_value("true");
+        }
+    }
 
     ReadDurationInterface(rest, vrvRest);
     ReadPositionInterface(rest, vrvRest);


### PR DESCRIPTION
To get valid MEI4 out of MEI3 (and for correct rendering) this updates `size="cue"` to `cue="true"`.