### PR TITLE
Handle lyric verse number when converting from MusicXML

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2728,42 +2728,40 @@ void MusicXmlInput::ReadMusicXmlNote(
                     std::string textWeight = textNode.attribute("font-weight").as_string();
                     std::string lang = textNode.attribute("xml:lang").as_string();
                     std::string textStr = textNode.text().as_string();
-                    
+
                     // convert verse numbers to labels
-                    std::regex labelSearch ("^([^[:alpha:]]*\\d[^[:alpha:]]*)$");
+                    std::regex labelSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)$");
                     std::smatch labelSearchMatches;
-                    std::regex labelPrefixSearch ("^([^[:alpha:]]*\\d[^[:alpha:]]*)[\\s\\u00A0]+");
+                    std::regex labelPrefixSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)[\\s\\u00A0]+");
                     std::smatch labelPrefixSearchMatches;
-                    if (!textStr.empty()
-                        && std::regex_search(textStr, labelSearchMatches, labelSearch)
-                        && labelSearchMatches.ready()
-                        && textNode.next_sibling("elision")) {
+                    if (!textStr.empty() && std::regex_search(textStr, labelSearchMatches, labelSearch)
+                        && labelSearchMatches.ready() && textNode.next_sibling("elision")) {
                         // entire textStr is a label (MusicXML from Finale)
-                        
+
                         Label *label = new Label();
-                        
+
                         Text *text = new Text();
                         text->SetText(UTF8to16(labelSearchMatches[0]));
                         label->AddChild(text);
                         verse->AddChild(label);
-                        
+
                         continue;
                     }
-                    else if (!textStr.empty()
-                        && std::regex_search(textStr, labelPrefixSearchMatches, labelPrefixSearch)
+                    else if (!textStr.empty() && std::regex_search(textStr, labelPrefixSearchMatches, labelPrefixSearch)
                         && labelPrefixSearchMatches.ready()) {
                         // first part of textStr is a label (MusicXML from Sibelius, MuseScore)
-                        
+
                         Label *label = new Label();
-                        
+
                         Text *text = new Text();
-                        text->SetText(UTF8to16(labelPrefixSearchMatches[0].str().erase(labelPrefixSearchMatches[0].str().find_last_not_of(" \f\n\r\t\v\u00A0") + 1)));
+                        text->SetText(UTF8to16(labelPrefixSearchMatches[0].str().erase(
+                            labelPrefixSearchMatches[0].str().find_last_not_of(" \f\n\r\t\v\u00A0") + 1)));
                         label->AddChild(text);
                         verse->AddChild(label);
-                        
+
                         textStr = textStr.erase(0, labelPrefixSearchMatches[0].length());
                     }
-                    
+
                     Syl *syl = new Syl();
                     syl->SetLang(lang.c_str());
                     if (GetContentOfChild(lyric, "syllabic") == "single") {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2730,7 +2730,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     const std::string textWeight = textNode.attribute("font-weight").as_string();
                     int lineThrough = textNode.attribute("line-through").as_int();
                     const std::string lang = textNode.attribute("xml:lang").as_string();
-                    const std::string textStr = textNode.text().as_string();
+                    std::string textStr = textNode.text().as_string();
 
                     // convert verse numbers to labels
                     std::regex labelSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)$");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2727,6 +2727,18 @@ void MusicXmlInput::ReadMusicXmlNote(
                     std::string textWeight = textNode.attribute("font-weight").as_string();
                     std::string lang = textNode.attribute("xml:lang").as_string();
                     std::string textStr = textNode.text().as_string();
+                    
+                    // convert verse numbers to labels
+                    if (!textStr.empty() && textStr.find_first_not_of("0123456789.") == std::string::npos && textNode.next_sibling("elision")) {
+                        Label *label = new Label();
+                        
+                        Text *text = new Text();
+                        text->SetText(UTF8to16(textStr));
+                        label->AddChild(text);
+                        verse->AddChild(label);
+                        continue;
+                    }
+                    
                     Syl *syl = new Syl();
                     syl->SetLang(lang.c_str());
                     if (GetContentOfChild(lyric, "syllabic") == "single") {


### PR DESCRIPTION
This pull request improves MusicXML import by converting MusicXML verse numbers into MEI labels (see issue #2235).

The `<text>` element in a `<lyric>` will be converted into `<label>` if:
1. The text content is not empty.
2. The text content contains nothing other than digits and/or periods.
3. The next sibling is an elision.

Example input (MusicXML):
```
	<lyric default-y="-120" number="2">
		<syllabic>single</syllabic>
		<text>2.</text>
		<elision> </elision>
		<syllabic>single</syllabic>
		<text>“Come,</text>
	</lyric>
```

Output (MEI):
```
	<verse xml:id="verse-0000002112875384" n="2">
		<label xml:id="label-0000000306992096">2.</label>
		<syl xml:id="syl-0000000612622437" con="s" wordpos="s">“Come,</syl>
	</verse>
```