### PR TITLE
Fix for layer overlapping beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -186,7 +186,7 @@ protected:
      * Helper function to calculate overlap with layer elements that
      * are placed within the duration of the beam
      */
-    int CalcLayerOverlap(Doc *doc, int directionBias, int y1, int y2);
+    int CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, int y2);
 
 private:
     //


### PR DESCRIPTION
- changed code for beams to be influenced only by those elements, that have horizontal overlap with them (closes #2196)

This fixes problem with over-avoidance for the beams mentioned in #2196. Problem with cross-staff beam overlap from the same issue seems to be fixed already.

![image](https://user-images.githubusercontent.com/1819669/121665060-ce5a2080-cab0-11eb-98d1-276f0038a519.png)
![image](https://user-images.githubusercontent.com/1819669/121665081-d6b25b80-cab0-11eb-8069-37abeeb2c9d0.png)

