### PR TITLE
Avoid overlapping dots

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -205,9 +205,16 @@ public:
 
 protected:
     /**
-     * Helper function for calculation of optimal locations for dots
+     * The note locations w.r.t. each staff
      */
-    void CaltOptimalDots(Dots *dots, Staff *staff, const std::set<int> &noteLocations);
+    virtual MapOfNoteLocs CalcNoteLocations();
+
+    /**
+     * The dot locations w.r.t. each staff
+     * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
+     * secondary
+     */
+    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary);
 
     /**
      * Clear the m_clusters vector and delete all the objects.

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -147,9 +147,10 @@ public:
     bool HasNoteWithDots();
 
     /**
-     * Helper to adjust overlaping layers for chords
+     * Helper to adjust overlapping layers for chords
      */
-    virtual void AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements, bool &isUnison);
+    virtual void AdjustOverlappingLayers(
+        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
 
     //----------//
     // Functors //

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -41,9 +41,10 @@ public:
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }
 
-    std::list<int> *GetDotLocsForStaff(Staff *staff);
+    std::set<int> GetDotLocsForStaff(Staff *staff) const;
+    std::set<int> &ModifyDotLocsForStaff(Staff *staff);
 
-    const MapOfDotLocs *GetMapOfDotLocs() const { return &m_dotLocsByStaff; }
+    const MapOfDotLocs &GetMapOfDotLocs() const { return m_dotLocsByStaff; }
 
     void IsAdjusted(bool isAdjusted) { m_isAdjusted = isAdjusted; }
     bool IsAdjusted() const { return m_isAdjusted; }

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -45,6 +45,7 @@ public:
     std::set<int> &ModifyDotLocsForStaff(Staff *staff);
 
     const MapOfDotLocs &GetMapOfDotLocs() const { return m_dotLocsByStaff; }
+    void SetMapOfDotLocs(const MapOfDotLocs &dotLocs) { m_dotLocsByStaff = dotLocs; };
 
     void IsAdjusted(bool isAdjusted) { m_isAdjusted = isAdjusted; }
     bool IsAdjusted() const { return m_isAdjusted; }

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -427,6 +427,30 @@ protected:
     virtual int CountElementsInUnison(
         const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
 
+    /**
+     * The note locations w.r.t. each staff, implemented for note and chord
+     */
+    virtual MapOfNoteLocs CalcNoteLocations() { return {}; };
+
+    /**
+     * The dot locations w.r.t. each staff, implemented for note and chord
+     * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
+     * secondary
+     */
+    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) { return {}; };
+
+    /**
+     * Calculate the optimal dot location for a note or chord
+     * Takes two layers into account in order to avoid collisions of dots between corresponding notes/chords
+     */
+    MapOfDotLocs CalcOptimalDotLocations();
+
+    /**
+     * Helper to calculate the total displacement of a set of dots generated from a set of notes
+     * This can be used as an indicator to choose between different sets of dots
+     */
+    static int GetDotDisplacement(const MapOfNoteLocs &noteLocations, const MapOfDotLocs &dotLocations);
+
 private:
     /**
      * Indicates whether it is a ScoreDef or StaffDef attribute

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -381,6 +381,49 @@ public:
      */
     virtual int GetRelativeLayerElement(FunctorParams *functorParams);
 
+protected:
+    /**
+     * Helper to figure whether two chords are in fully in unison based on the locations of the notes.
+     * This function assumes that two chords are already in unison and checks whether chords can overlap with
+     * their unison notes or if they should be placed separately.
+     * Returns true if all elements can safely overlap.
+     */
+    virtual int CountElementsInUnison(
+        const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
+
+    /**
+     * The note locations w.r.t. each staff, implemented for note and chord
+     */
+    virtual MapOfNoteLocs CalcNoteLocations() { return {}; };
+
+    /**
+     * The dot locations w.r.t. each staff, implemented for note and chord
+     * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
+     * secondary
+     */
+    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) { return {}; };
+
+    /**
+     * Calculate the optimal dot location for a note or chord
+     * Takes two layers into account in order to avoid collisions of dots between corresponding notes/chords
+     */
+    MapOfDotLocs CalcOptimalDotLocations();
+
+    //----------------//
+    // Static methods //
+    //----------------//
+
+    /**
+     * Helper to count the number of dots
+     * This can be used as an indicator to choose between different sets of dots
+     */
+    static int GetDotCount(const MapOfDotLocs &dotLocations);
+
+    /**
+     * Helper to count the collisions between two sets of dots
+     */
+    static int GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDotLocs &dotLocs2);
+
 private:
     int GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type);
 
@@ -415,47 +458,9 @@ protected:
     int m_drawingXRel;
 
     /**
-     * The cached drawing cue size set by PrepareDarwingCueSize
+     * The cached drawing cue size set by PrepareDrawingCueSize
      */
     bool m_drawingCueSize;
-
-    /**
-     * Helper to figure whether two chords are in fully in unison based on the locations of the notes.
-     * This function assumes that two chords are already in unison and checks whether chords can overlap with
-     * their unison notes or if they should be placed separately.
-     * Returns true if all elements can safely overlap.
-     */
-    virtual int CountElementsInUnison(
-        const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
-
-    /**
-     * The note locations w.r.t. each staff, implemented for note and chord
-     */
-    virtual MapOfNoteLocs CalcNoteLocations() { return {}; };
-
-    /**
-     * The dot locations w.r.t. each staff, implemented for note and chord
-     * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
-     * secondary
-     */
-    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) { return {}; };
-
-    /**
-     * Calculate the optimal dot location for a note or chord
-     * Takes two layers into account in order to avoid collisions of dots between corresponding notes/chords
-     */
-    MapOfDotLocs CalcOptimalDotLocations();
-
-    /**
-     * Helper to count the number of dots
-     * This can be used as an indicator to choose between different sets of dots
-     */
-    static int GetDotCount(const MapOfDotLocs &dotLocations);
-
-    /**
-     * Helper to count the collisions between two sets of dots
-     */
-    static int GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDotLocs &dotLocs2);
 
 private:
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -446,10 +446,10 @@ protected:
     MapOfDotLocs CalcOptimalDotLocations();
 
     /**
-     * Helper to calculate the total displacement of a set of dots generated from a set of notes
+     * Helper to count the number of dots
      * This can be used as an indicator to choose between different sets of dots
      */
-    static int GetDotDisplacement(const MapOfNoteLocs &noteLocations, const MapOfDotLocs &dotLocations);
+    static int GetDotCount(const MapOfDotLocs &dotLocations);
 
 private:
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -453,7 +453,7 @@ protected:
     static int GetDotCount(const MapOfDotLocs &dotLocations);
 
     /**
-     * Helper to count the collisions between to sets of dots
+     * Helper to count the collisions between two sets of dots
      */
     static int GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDotLocs &dotLocs2);
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -224,16 +224,17 @@ public:
     bool GenerateZoneBounds(int *ulx, int *uly, int *lrx, int *lry);
 
     /**
-     * Helper to adjust overlaping layers for notes, chords, stems, etc.
+     * Helper to adjust overlapping layers for notes, chords, stems, etc.
      */
-    virtual void AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements, bool &isUnison);
+    virtual void AdjustOverlappingLayers(
+        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
 
     /**
      * Calculate note horizontal overlap with elemenents from another layers. Returns overlapMargin and index of other
      * element if it's in unison with it
      */
     std::pair<int, bool> CalcElementHorizontalOverlap(Doc *doc, const std::vector<LayerElement *> &otherElements,
-        bool isChordElement, bool isLowerElement = false, bool unison = true);
+        bool areDotsAdjusted, bool isChordElement, bool isLowerElement = false, bool unison = true);
 
     //----------//
     // Functors //

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -451,6 +451,11 @@ protected:
      */
     static int GetDotCount(const MapOfDotLocs &dotLocations);
 
+    /**
+     * Helper to count the collisions between to sets of dots
+     */
+    static int GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDotLocs &dotLocs2);
+
 private:
     /**
      * Indicates whether it is a ScoreDef or StaffDef attribute

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -202,11 +202,6 @@ public:
     bool IsVisible() const;
 
     /**
-     * Correct dots placement depending on other dots present in the current alignment
-     */
-    int CorrectDotsPlacement(Staff *staff, int NoteLoc, int dotLoc, bool isDotShifted);
-
-    /**
      * MIDI timing information
      */
     ///@{
@@ -299,6 +294,19 @@ public:
      * See Object::Transpose
      */
     virtual int Transpose(FunctorParams *);
+
+protected:
+    /**
+     * The note locations w.r.t. each staff
+     */
+    virtual MapOfNoteLocs CalcNoteLocations();
+
+    /**
+     * The dot locations w.r.t. each staff
+     * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
+     * secondary
+     */
+    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary);
 
 private:
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -150,10 +150,10 @@ public:
     ///@}
 
     /**
-     * Return true if the note is a unisson.
+     * Return true if the note is a unison.
      * If ignoreAccid is set to true then only @pname and @oct are compared.
      */
-    bool IsUnissonWith(Note *note, bool ignoreAccid = false);
+    bool IsUnisonWith(Note *note, bool ignoreAccid = false);
 
     /**
      * @name Setter and getter for the chord cluster and the position of the note

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -336,6 +336,8 @@ typedef std::vector<LedgerLine> ArrayOfLedgerLines;
 
 typedef std::vector<TextElement *> ArrayOfTextElements;
 
+typedef std::map<Staff *, std::set<int>> MapOfNoteLocs;
+
 typedef std::map<Staff *, std::set<int>> MapOfDotLocs;
 
 typedef std::map<std::string, Option *> MapOfStrOptions;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <set>
 #include <vector>
 
 //----------------------------------------------------------------------------
@@ -335,7 +336,7 @@ typedef std::vector<LedgerLine> ArrayOfLedgerLines;
 
 typedef std::vector<TextElement *> ArrayOfTextElements;
 
-typedef std::map<Staff *, std::list<int>> MapOfDotLocs;
+typedef std::map<Staff *, std::set<int>> MapOfDotLocs;
 
 typedef std::map<std::string, Option *> MapOfStrOptions;
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -421,7 +421,8 @@ bool Chord::HasNoteWithDots()
     return false;
 }
 
-void Chord::AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements, bool &isUnison)
+void Chord::AdjustOverlappingLayers(
+    Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison)
 {
     int margin = 0;
     // get positions of other elements
@@ -452,7 +453,7 @@ void Chord::AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> 
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
         auto [overlap, isInUnison] = note->CalcElementHorizontalOverlap(
-            doc, otherElements, true, isLowerPosition, expectedElementsInUnison > 0);
+            doc, otherElements, areDotsAdjusted, true, isLowerPosition, expectedElementsInUnison > 0);
         if (((margin >= 0) && (overlap > margin)) || ((margin <= 0) && (overlap < margin))) {
             margin = overlap;
         }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -657,47 +657,39 @@ int Chord::CalcStem(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-void Chord::CaltOptimalDots(Dots *dots, Staff *staff, const std::set<int> &noteLocations)
+MapOfNoteLocs Chord::CalcNoteLocations()
 {
-    // calculate optimal dot locations both in normal and reverse orders
-    std::set<int> forwardLocations = CalculateDotLocations(noteLocations.begin(), noteLocations.end(), false);
-    std::set<int> backwardLocations = CalculateDotLocations(noteLocations.rbegin(), noteLocations.rend(), true);
-    //
-    std::vector<int> firstElem, secondElem;
-    const std::set<int> *firstRef, *secondRef;
-    Staff *currentStaff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    const bool isUpwardDirection
-        = (GetDrawingStemDir() == STEMDIRECTION_up) || (currentStaff->GetChildCount(LAYER) == 1);
-    // On upper layer normal order positioning is prioritized, hence assign positions in the same order as they were
-    // calculated. This way, if differences in positioning are the same for both normal/reverse orders, normal is going
-    // to be selected
-    if (isUpwardDirection) {
-        firstElem.assign(forwardLocations.begin(), forwardLocations.end());
-        secondElem.assign(backwardLocations.begin(), backwardLocations.end());
-        firstRef = &forwardLocations;
-        secondRef = &backwardLocations;
-    }
-    // ... and vice versa for the bottom layer, where reverse ordering is in priority
-    else {
-        firstElem.assign(backwardLocations.begin(), backwardLocations.end());
-        secondElem.assign(forwardLocations.begin(), forwardLocations.end());
-        firstRef = &backwardLocations;
-        secondRef = &forwardLocations;
-    }
+    const ArrayOfObjects *notes = this->GetList(this);
+    assert(notes);
 
-    // substract note and dot positions and calculate difference between all locations. This way, better positioning can
-    // be determined by taking order, where difference between dot and note positions is the smallest
-    std::transform(firstElem.begin(), firstElem.end(), noteLocations.begin(), firstElem.begin(), std::minus<int>());
-    std::transform(secondElem.begin(), secondElem.end(), noteLocations.begin(), secondElem.begin(), std::minus<int>());
-    // apply std::abs to elements in the vectors and then calculate sum of the elements. Can be achieved with
-    // std::transform_reduce, but gcc needs to support it
-    std::transform(firstElem.begin(), firstElem.end(), firstElem.begin(), static_cast<float (*)(float)>(&std::abs));
-    std::transform(secondElem.begin(), secondElem.end(), secondElem.begin(), static_cast<float (*)(float)>(&std::abs));
-    const int firstDiff = std::accumulate(firstElem.begin(), firstElem.end(), 0);
-    const int secondDiff = std::accumulate(secondElem.begin(), secondElem.end(), 0);
-    std::set<int> dotLocations = (secondDiff < firstDiff) ? *secondRef : *firstRef;
+    MapOfNoteLocs noteLocations;
+    for (Object *obj : *notes) {
+        Note *note = vrv_cast<Note *>(obj);
+        assert(note);
 
-    dots->ModifyDotLocsForStaff(staff) = dotLocations;
+        Layer *layer = NULL;
+        Staff *staff = note->GetCrossStaff(layer);
+        if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+        assert(staff);
+
+        noteLocations[staff].insert(note->GetDrawingLoc());
+    }
+    return noteLocations;
+}
+
+MapOfDotLocs Chord::CalcDotLocations(int layerCount, bool primary)
+{
+    const bool isUpwardDirection = (this->GetDrawingStemDir() == STEMDIRECTION_up) || (layerCount == 1);
+    const bool useReverseOrder = (isUpwardDirection && !primary) || (!isUpwardDirection && primary);
+    MapOfNoteLocs noteLocs = this->CalcNoteLocations();
+    MapOfDotLocs dotLocs;
+    for (const auto &mapEntry : noteLocs) {
+        if (useReverseOrder)
+            dotLocs[mapEntry.first] = CalculateDotLocations(mapEntry.second.rbegin(), mapEntry.second.rend(), true);
+        else
+            dotLocs[mapEntry.first] = CalculateDotLocations(mapEntry.second.begin(), mapEntry.second.end(), false);
+    }
+    return dotLocs;
 }
 
 int Chord::CalcDots(FunctorParams *functorParams)
@@ -726,33 +718,7 @@ int Chord::CalcDots(FunctorParams *functorParams)
     params->m_chordDrawingX = this->GetDrawingX();
     params->m_chordStemDir = this->GetDrawingStemDir();
 
-    ArrayOfObjects::const_reverse_iterator rit;
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
-
-    assert(this->GetTopNote());
-    assert(this->GetBottomNote());
-
-    // Get note locations first
-    std::map<Staff *, std::set<int>> noteLocations;
-    for (rit = notes->rbegin(); rit != notes->rend(); ++rit) {
-        Note *note = vrv_cast<Note *>(*rit);
-        assert(note);
-        if (note->GetDots() == 0) {
-            continue;
-        }
-
-        Layer *layer = NULL;
-        Staff *staff = note->GetCrossStaff(layer);
-        if (noteLocations.end() == noteLocations.find(staff)) {
-            noteLocations[staff] = {};
-        }
-        noteLocations[staff].insert(note->GetDrawingLoc());
-    }
-
-    for (const auto &loc : noteLocations) {
-        CaltOptimalDots(dots, loc.first, loc.second);
-    }
+    dots->SetMapOfDotLocs(this->CalcOptimalDotLocations());
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -697,8 +697,7 @@ void Chord::CaltOptimalDots(Dots *dots, Staff *staff, const std::set<int> &noteL
     const int secondDiff = std::accumulate(secondElem.begin(), secondElem.end(), 0);
     std::set<int> dotLocations = (secondDiff < firstDiff) ? *secondRef : *firstRef;
 
-    std::list<int> *dotLocs = dots->GetDotLocsForStaff(staff);
-    dotLocs->insert(dotLocs->end(), dotLocations.begin(), dotLocations.end());
+    dots->ModifyDotLocsForStaff(staff) = dotLocations;
 }
 
 int Chord::CalcDots(FunctorParams *functorParams)

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -39,18 +39,15 @@ namespace vrv {
 template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin, Iterator end, bool isReverseOrder)
 {
     // location adjustment that should be applied when looking for optimal position
-    std::vector<int> locAdjust{ 1, 2, -3 };
+    std::vector<int> locAdjust{ 0, 1, -2, 2 };
     if (isReverseOrder) std::transform(locAdjust.begin(), locAdjust.end(), locAdjust.begin(), std::negate<int>());
     std::set<int> dotLocations;
     for (auto iter = begin; iter != end; ++iter) {
         bool result = false;
-        if (*iter % 2 != 0) std::tie(std::ignore, result) = dotLocations.insert(*iter);
-        if (!result) {
-            for (auto adjust : locAdjust) {
-                if ((*iter + adjust) % 2 == 0) continue;
-                std::tie(std::ignore, result) = dotLocations.insert(*iter + adjust);
-                if (result) break;
-            }
+        for (int adjust : locAdjust) {
+            if ((*iter + adjust) % 2 == 0) continue;
+            std::tie(std::ignore, result) = dotLocations.insert(*iter + adjust);
+            if (result) break;
         }
     }
     return dotLocations;

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -47,9 +47,17 @@ void Dots::Reset()
     m_dotLocsByStaff.clear();
 }
 
-std::list<int> *Dots::GetDotLocsForStaff(Staff *staff)
+std::set<int> Dots::GetDotLocsForStaff(Staff *staff) const
 {
-    return &m_dotLocsByStaff[staff];
+    if (m_dotLocsByStaff.find(staff) != m_dotLocsByStaff.end()) {
+        return m_dotLocsByStaff.at(staff);
+    }
+    return {};
+}
+
+std::set<int> &Dots::ModifyDotLocsForStaff(Staff *staff)
+{
+    return m_dotLocsByStaff[staff];
 }
 
 //----------------------------------------------------------------------------

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1108,12 +1108,20 @@ int Alignment::AdjustDotsEnd(FunctorParams *functorParams)
         // multimap of overlapping dots with other elements
         std::multimap<LayerElement *, LayerElement *> overlapElements;
 
-        // Try to find which dots can be groupped together. To achieve this, find layer elements that collide with these
+        // Try to find which dots can be grouped together. To achieve this, find layer elements that collide with these
         // dots. Then find if their parents (note/chord) have dots - if they do then we can group these dots together,
         // otherwise they should be kept separate
         for (auto dot : params->m_dots) {
+            // A third staff size will be used as required margin
+            const Staff *staff
+                = vrv_cast<Staff *>(dot->m_crossStaff ? dot->m_crossStaff : dot->GetFirstAncestor(STAFF));
+            assert(staff);
+            const int staffSize = staff->m_drawingStaffSize;
+            const int thirdUnit = params->m_doc->GetDrawingUnit(staffSize) / 3;
+
             for (LayerElement *element : params->m_elements) {
-                if (dot->HorizontalSelfOverlap(element, 30) && dot->VerticalSelfOverlap(element, 60)) {
+                if (dot->HorizontalSelfOverlap(element, thirdUnit)
+                    && dot->VerticalSelfOverlap(element, 2 * thirdUnit)) {
                     if (element->Is({ CHORD, NOTE })) {
                         if (dynamic_cast<AttAugmentDots *>(element)->GetDots() <= 0) continue;
                         overlapElements.emplace(dot, element);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -866,6 +866,10 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
     return usePrimary ? dotLocs1 : dotLocs2;
 }
 
+//----------------------------------------------------------------------------
+// Static methods for LayerElement
+//----------------------------------------------------------------------------
+
 int LayerElement::GetDotCount(const MapOfDotLocs &dotLocations)
 {
     return std::accumulate(dotLocations.cbegin(), dotLocations.cend(), 0,
@@ -888,7 +892,7 @@ int LayerElement::GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDot
 }
 
 //----------------------------------------------------------------------------
-// LayerElement functors methods
+// LayerElement functor methods
 //----------------------------------------------------------------------------
 
 int LayerElement::ResetHorizontalAlignment(FunctorParams *functorParams)

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -830,6 +830,15 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
             const MapOfDotLocs otherDotLocs1 = other->CalcDotLocations(layerCount, true);
             const MapOfDotLocs otherDotLocs2 = other->CalcDotLocations(layerCount, false);
 
+            // Handling of unisons
+            if (this->Is(NOTE) && other->Is(NOTE)) {
+                Note *note = vrv_cast<Note *>(this);
+                Note *otherNote = vrv_cast<Note *>(other);
+                if (note->IsUnisonWith(otherNote)) {
+                    return (currentLayer < otherLayer) ? dotLocs1 : dotLocs2;
+                }
+            }
+
             // Count collisions between each pair of dot choices
             const int collisions11 = GetCollisionCount(dotLocs1, otherDotLocs1);
             const int collisions12 = GetCollisionCount(dotLocs1, otherDotLocs2);
@@ -843,8 +852,8 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
                 if (collisions11 == minCollisions) return dotLocs1;
                 if (collisions12 == minCollisions) {
                     if (collisions21 == minCollisions) {
-                        // Symmetric case: choose primary dot location on lower layer
-                        return (currentLayer > otherLayer) ? dotLocs1 : dotLocs2;
+                        // Symmetric case: choose primary dot location on upper layer
+                        return (currentLayer < otherLayer) ? dotLocs1 : dotLocs2;
                     }
                     return dotLocs1;
                 }
@@ -1535,9 +1544,9 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             Note *currentNote = vrv_cast<Note *>(this);
             Note *previousNote = vrv_cast<Note *>(otherElements.at(i));
             assert(previousNote);
-            isUnisonElement = currentNote->IsUnissonWith(previousNote, true);
+            isUnisonElement = currentNote->IsUnisonWith(previousNote, true);
             // Unisson, look at the duration for the note heads
-            if (unison && currentNote->IsUnissonWith(previousNote, false)) {
+            if (unison && currentNote->IsUnisonWith(previousNote, false)) {
                 int previousDuration = previousNote->GetDrawingDur();
                 const bool isPreviousCoord = previousNote->GetParent()->Is(CHORD);
                 bool isEdgeElement = false;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <climits>
 #include <math.h>
+#include <numeric>
 
 //----------------------------------------------------------------------------
 
@@ -803,26 +804,15 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
     MapOfDotLocs dotLocs1 = this->CalcDotLocations(layerCount, true);
     MapOfDotLocs dotLocs2 = this->CalcDotLocations(layerCount, false);
 
-    // Use total displacement to decide which set of dots is used
-    const bool usePrimary = (GetDotDisplacement(noteLocs, dotLocs1) <= GetDotDisplacement(noteLocs, dotLocs2));
+    // Count dots to decide which set is used
+    const bool usePrimary = (GetDotCount(dotLocs1) >= GetDotCount(dotLocs2));
     return usePrimary ? dotLocs1 : dotLocs2;
 }
 
-int LayerElement::GetDotDisplacement(const MapOfNoteLocs &noteLocations, const MapOfDotLocs &dotLocations)
+int LayerElement::GetDotCount(const MapOfDotLocs &dotLocations)
 {
-    int displacement = 0;
-    for (const auto &mapEntry : noteLocations) {
-        assert(dotLocations.find(mapEntry.first) != dotLocations.end());
-        for (int noteLoc : mapEntry.second) {
-            // For each note find the closest dot and add the distance
-            int distance = 100;
-            for (int dotLoc : dotLocations.at(mapEntry.first)) {
-                distance = std::min(distance, abs(noteLoc - dotLoc));
-            }
-            displacement += distance;
-        }
-    }
-    return displacement;
+    return std::accumulate(dotLocations.cbegin(), dotLocations.cend(), 0,
+        [](int sum, const MapOfDotLocs::value_type &mapEntry) { return sum + mapEntry.second.size(); });
 }
 
 //----------------------------------------------------------------------------

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -806,25 +806,24 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
     // Special treatment for two layers
     if (layerCount == 2) {
         // Find the first note on the other layer
-        LayerElement *other = NULL;
         Alignment *alignment = this->GetAlignment();
-        const int currentLayer = abs(this->GetAlignmentLayerN());
+        const int currentLayerN = abs(this->GetAlignmentLayerN());
         ListOfObjects notes;
         ClassIdComparison noteCmp(NOTE);
         alignment->FindAllDescendantByComparison(&notes, &noteCmp, 2);
-        auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayer](Object *obj) {
-            const int otherLayer = abs(vrv_cast<Note *>(obj)->GetAlignmentLayerN());
-            return (currentLayer != otherLayer);
+        auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayerN](Object *obj) {
+            const int otherLayerN = abs(vrv_cast<Note *>(obj)->GetAlignmentLayerN());
+            return (currentLayerN != otherLayerN);
         });
 
         if (noteIt != notes.cend()) {
             // Prefer the note's chord if it has one
-            other = vrv_cast<Note *>(*noteIt);
+            LayerElement *other = vrv_cast<Note *>(*noteIt);
             if (Chord *chord = vrv_cast<Note *>(*noteIt)->IsChordTone(); chord) {
                 other = chord;
             }
             assert(other);
-            const int otherLayer = abs(other->GetAlignmentLayerN());
+            const int otherLayerN = abs(other->GetAlignmentLayerN());
 
             // Calculate the primary/secondary dot locations
             const MapOfDotLocs otherDotLocs1 = other->CalcDotLocations(layerCount, true);
@@ -835,7 +834,7 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
                 Note *note = vrv_cast<Note *>(this);
                 Note *otherNote = vrv_cast<Note *>(other);
                 if (note->IsUnisonWith(otherNote)) {
-                    return (currentLayer < otherLayer) ? dotLocs1 : dotLocs2;
+                    return (currentLayerN < otherLayerN) ? dotLocs1 : dotLocs2;
                 }
             }
 
@@ -853,7 +852,7 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
                 if (collisions12 == minCollisions) {
                     if (collisions21 == minCollisions) {
                         // Symmetric case: choose primary dot location on upper layer
-                        return (currentLayer < otherLayer) ? dotLocs1 : dotLocs2;
+                        return (currentLayerN < otherLayerN) ? dotLocs1 : dotLocs2;
                     }
                     return dotLocs1;
                 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -312,7 +312,7 @@ std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const
     }
 }
 
-bool Note::IsUnissonWith(Note *note, bool ignoreAccid)
+bool Note::IsUnisonWith(Note *note, bool ignoreAccid)
 {
     if (!ignoreAccid) {
         Accid *accid = this->GetDrawingAccid();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1016,7 +1016,7 @@ int Note::CalcDots(FunctorParams *functorParams)
         dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
         assert(dots);
 
-        std::list<int> *dotLocs = dots->GetDotLocsForStaff(staff);
+        std::set<int> &dotLocs = dots->ModifyDotLocsForStaff(staff);
         int loc = this->GetDrawingLoc();
 
         // if it's on a staff line to start with, we need to compensate here and add a full unit like DrawDots would
@@ -1030,7 +1030,7 @@ int Note::CalcDots(FunctorParams *functorParams)
         }
 
         loc = CorrectDotsPlacement(staff, GetDrawingLoc(), loc, isDotShifted);
-        dotLocs->push_back(loc);
+        dotLocs.insert(loc);
 
         // Stem up, shorter than 4th and not in beam
         if ((GetDrawingStemDir() == STEMDIRECTION_up) && (!this->IsInBeam()) && (GetDrawingStemLen() < 3)
@@ -1060,9 +1060,9 @@ int Note::CorrectDotsPlacement(Staff *staff, int noteLoc, int dotLoc, bool isDot
     std::vector<Note *> otherNotes;
     for (const auto element : objects) {
         if (element->Is(DOTS)) {
-            std::list<int> *dotLocs = vrv_cast<Dots *>(element)->GetDotLocsForStaff(staff);
-            if (dotLocs->empty()) continue;
-            std::copy(dotLocs->begin(), dotLocs->end(), std::inserter(dotLocations, dotLocations.begin()));
+            const std::set<int> dotLocs = vrv_cast<Dots *>(element)->GetDotLocsForStaff(staff);
+            if (dotLocs.empty()) continue;
+            std::copy(dotLocs.cbegin(), dotLocs.cend(), std::inserter(dotLocations, dotLocations.begin()));
         }
         else {
             if (this == element) continue;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -522,7 +522,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
                 Dots *dots = vrv_cast<Dots *>(FindDescendantByType(DOTS, 1));
                 if (dots) {
                     std::set<int> &dotLocs = dots->ModifyDotLocsForStaff(staff);
-                    const int dotLoc = (oldLoc % 2)? oldLoc : oldLoc + 1;
+                    const int dotLoc = (oldLoc % 2) ? oldLoc : oldLoc + 1;
                     if (std::find(dotLocs.cbegin(), dotLocs.cend(), dotLoc) != dotLocs.cend()) {
                         dotLocs.erase(dotLoc);
                         dotLocs.insert(newLoc);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -521,9 +521,11 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
         if (GetDots() > 0) {
             Dots *dots = vrv_cast<Dots *>(FindDescendantByType(DOTS, 1));
             if (dots) {
-                std::list<int> *dotLocs = dots->GetDotLocsForStaff(staff);
-                const auto iter = std::find(dotLocs->begin(), dotLocs->end(), oldLoc);
-                if (iter != dotLocs->end()) *iter = newLoc;
+                std::set<int> &dotLocs = dots->ModifyDotLocsForStaff(staff);
+                if (std::find(dotLocs.cbegin(), dotLocs.cend(), oldLoc) != dotLocs.cend()) {
+                    dotLocs.erase(oldLoc);
+                    dotLocs.insert(newLoc);
+                }
             }
         }
     }
@@ -597,7 +599,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
     Dots *dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
     assert(dots);
 
-    std::list<int> *dotLocs = dots->GetDotLocsForStaff(staff);
+    std::set<int> &dotLocs = dots->ModifyDotLocsForStaff(staff);
     int loc = this->GetDrawingLoc();
 
     // if it's on a staff line to start with, we need to compensate here and add a full unit like DrawDots would
@@ -618,7 +620,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
         default: break;
     }
 
-    dotLocs->push_back(loc);
+    dotLocs.insert(loc);
 
     // HARDCODED
     int xRel = params->m_doc->GetDrawingUnit(staffSize) * 2.5;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -776,18 +776,13 @@ void View::DrawDots(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    MapOfDotLocs::const_iterator iter;
-    const MapOfDotLocs *map = dots->GetMapOfDotLocs();
-    for (iter = map->begin(); iter != map->end(); ++iter) {
-        Staff *dotStaff = (iter->first) ? iter->first : staff;
+    for (const auto &mapEntry : dots->GetMapOfDotLocs()) {
+        Staff *dotStaff = (mapEntry.first) ? mapEntry.first : staff;
         int y = dotStaff->GetDrawingY()
             - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (dotStaff->m_drawingLines - 1);
         int x = dots->GetDrawingX() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        const std::list<int> *dotLocs = &iter->second;
-        std::list<int>::const_iterator intIter;
-        for (intIter = dotLocs->begin(); intIter != dotLocs->end(); ++intIter) {
-            DrawDotsPart(
-                dc, x, y + (*intIter) * m_doc->GetDrawingUnit(staff->m_drawingStaffSize), dots->GetDots(), dotStaff);
+        for (int loc : mapEntry.second) {
+            DrawDotsPart(dc, x, y + loc * m_doc->GetDrawingUnit(staff->m_drawingStaffSize), dots->GetDots(), dotStaff);
         }
     }
 


### PR DESCRIPTION
This PR improves the positioning of dots for two layers such that overlaps are avoided.

| Before  | After |
| ------------- | ------------- |
| ![Before](https://user-images.githubusercontent.com/63608463/121841794-5a518f80-ccdf-11eb-9b0a-6ef39bf7eaea.png) | ![After](https://user-images.githubusercontent.com/63608463/121841822-689fab80-ccdf-11eb-85fe-91d58c406c02.png) |

Collisions between dots and noteheads are now resolved. (In measure 4 and 5 only one of the two chords is dotted.)

| Before  | After |
| ------------- | ------------- |
| ![Before](https://user-images.githubusercontent.com/63608463/121842180-393d6e80-cce0-11eb-90bd-0c7e2adaf7a0.png) | ![After](https://user-images.githubusercontent.com/63608463/121842205-46f2f400-cce0-11eb-9df5-8ef45205af9c.png) |

Finally, the position of dots in (clustered) chords is slightly improved with an edge towards more dots.

| Before  | After |
| ------------- | ------------- |
| ![Before](https://user-images.githubusercontent.com/63608463/121842574-ea440900-cce0-11eb-8d9d-f8c39e417145.png) | ![After](https://user-images.githubusercontent.com/63608463/121842610-f8922500-cce0-11eb-90f6-747f0c49ccfe.png) |

**MEI (1st example)**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-04-14" type="encoding-date">2021-04-14</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000001660925475">
         <appInfo xml:id="appinfo-0000000034530972">
            <application xml:id="application-0000000541461714" isodate="2021-06-08T08:19:55" version="3.5.0-dev-a51627c">
               <name xml:id="name-0000001458814859">Verovio</name>
               <p xml:id="p-0000000480537414">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000001853804378">
            <score xml:id="score-0000001197430370">
               <scoreDef xml:id="scoredef-0000000514840524">
                  <staffGrp xml:id="staffgrp-0000001138097290">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="4">
                        <label xml:id="label-0000000364309201">Piano</label>
                        <labelAbbr xml:id="labelAbbr-0000001073192427">Pno.</labelAbbr>
                        <instrDef xml:id="instrdef-0000000213838697" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="clef-0000000928079695" shape="G" line="2" />
                        <keySig xml:id="keysig-0000001061705704" sig="0" />
                        <meterSig xml:id="msig-0000000646144205" count="7" unit="16" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000001142972553">
                  <pb xml:id="pb-0000000698475856" />
                  <measure xml:id="measure-0000002068334203" n="1">
                     <staff xml:id="staff-0000000358272839" n="1">
                        <layer xml:id="layer-0000002094942532" n="1">
                           <chord xml:id="chord-0000002032215886" dots="2" dur.ppq="7" dur="4" stem.dir="up">
                              <note xml:id="note-0000001704742759" oct="4" pname="e" />
                              <note xml:id="note-0000001872474114" oct="4" pname="b" />
                           </chord>
                        </layer>
                        <layer xml:id="layer-0000001447070860" n="2">
                           <note xml:id="note-0000000667641745" dots="2" dur.ppq="7" dur="4" oct="5" pname="c" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-0000000452752640" n="2">
                     <staff xml:id="staff-0000000182616793" n="1">
                        <layer xml:id="layer-0000000486308388" n="1">
                           <chord xml:id="chord-0000001531131549" dots="2" dur.ppq="7" dur="4" stem.dir="up">
                              <note xml:id="note-0000000062316634" oct="4" pname="e" />
                              <note xml:id="note-0000000431402042" oct="4" pname="b" />
                           </chord>
                        </layer>
                        <layer xml:id="layer-0000000669327622" n="2">
                           <note xml:id="note-0000000869999968" dots="2" dur.ppq="7" dur="4" oct="4" pname="f" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-0000002020793400" right="end" n="3">
                     <staff xml:id="staff-0000001199041829" n="1">
                        <layer xml:id="layer-0000000309476555" n="1">
                           <note xml:id="note-0000000167066851" dots="2" dur.ppq="7" dur="4" oct="4" pname="c" stem.dir="up" />
                        </layer>
                        <layer xml:id="layer-0000001131438128" n="2">
                           <chord xml:id="chord-0000001670666276" dots="2" dur.ppq="7" dur="4" stem.dir="down">
                              <note xml:id="note-0000000112923111" oct="4" pname="e" />
                              <note xml:id="note-0000000539416207" oct="4" pname="b" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```