### PR TITLE
Fix bbox conditional check

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -856,7 +856,7 @@ void SvgDeviceContext::DrawText(const std::string &text, const std::wstring wtex
     textChild.append_child(pugi::node_pcdata).set_value(svgText.c_str());
 
     if ((x != 0) && (y != 0) && (x != VRV_UNSET) && (y != VRV_UNSET)
-        && (((width != 0) && (height != 0)) || ((width != VRV_UNSET) && (height != VRV_UNSET)))) {
+        && (width != 0) && (height != 0) && (width != VRV_UNSET) && (height != VRV_UNSET)) {
         pugi::xml_node g = m_currentNode.parent().parent();
         pugi::xml_node rectChild = g.append_child("rect");
         rectChild.append_attribute("class") = "sylTextRect";


### PR DESCRIPTION
The conditional could never become false.  As such, svg could generate elements such as:
```xml
<rect class="sylTextRect" x="1847" y="2237" width="-2147483647" height="-2147483647" opacity="0.0" />
```