### PR TITLE
Thread safety

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -141,11 +141,11 @@ public:
     /**
      * A static array for storing the articulation that have to be placed outside the staff
      */
-    static std::vector<data_ARTICULATION> s_outStaffArtic;
+    static const std::vector<data_ARTICULATION> s_outStaffArtic;
     /**
      * A static array for storing the articulation that have to be place above the staff is possible
      */
-    static std::vector<data_ARTICULATION> s_aboveStaffArtic;
+    static const std::vector<data_ARTICULATION> s_aboveStaffArtic;
 
 private:
     //

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -135,7 +135,7 @@ private:
      * The ids of the group is then the position in the vector + GRPS_BASE_ID.
      * Groups coded in MEI have negative ids (-@vgrp value)
      */
-    static std::vector<void *> s_drawingObjectIds;
+    static thread_local std::vector<void *> s_drawingObjectIds;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/iodarms.h
+++ b/include/vrv/iodarms.h
@@ -65,7 +65,7 @@ private:
     // Static members //
     //----------------//
 
-    static pitchmap PitchMap[];
+    static const pitchmap PitchMap[];
 };
 
 #endif /* NO_DARMS_SUPPORT */

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -781,7 +781,7 @@ private:
     /**
      * A static array for storing the implemented editorial elements
      */
-    static std::vector<std::string> s_editorialElementNames;
+    static const std::vector<std::string> s_editorialElementNames;
 };
 
 } // namespace vrv

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -118,8 +118,8 @@ public:
     // Static members //
     //----------------//
 
-    static thread_local data_PITCHNAME s_pnameForFlats[];
-    static thread_local data_PITCHNAME s_pnameForSharps[];
+    static const data_PITCHNAME s_pnameForFlats[];
+    static const data_PITCHNAME s_pnameForSharps[];
 
 private:
     static const int octave_map[2][9][7];

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -118,11 +118,11 @@ public:
     // Static members //
     //----------------//
 
-    static data_PITCHNAME s_pnameForFlats[];
-    static data_PITCHNAME s_pnameForSharps[];
+    static thread_local data_PITCHNAME s_pnameForFlats[];
+    static thread_local data_PITCHNAME s_pnameForSharps[];
 
 private:
-    static int octave_map[2][9][7];
+    static const int octave_map[2][9][7];
 };
 
 } // namespace vrv

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -72,12 +72,12 @@ public:
      * Static member for setting a value from a controller.
      * Used for example in SetValue
      */
-    static int s_num;
+    static const int s_num;
     /**
      * Static member for setting a value from a controller.
      * Used for examle in SetValue.
      */
-    static int s_numBase;
+    static const int s_numBase;
 
 private:
 };

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -100,7 +100,7 @@ public:
     /**
      * String keys come from the contours of neume groupings as defined in MEI4
      */
-    static std::map<std::string, NeumeGroup> s_neumes;
+    static thread_local std::map<std::string, NeumeGroup> s_neumes;
 
     static std::string NeumeGroupToString(NeumeGroup group);
 

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -100,7 +100,7 @@ public:
     /**
      * String keys come from the contours of neume groupings as defined in MEI4
      */
-    static thread_local std::map<std::string, NeumeGroup> s_neumes;
+    static const std::map<std::string, NeumeGroup> s_neumes;
 
     static std::string NeumeGroupToString(NeumeGroup group);
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1349,7 +1349,7 @@ private:
     /**
      * A static counter for uuid generation.
      */
-    static unsigned long s_objectCounter;
+    static thread_local unsigned long s_objectCounter;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -120,12 +120,12 @@ public:
     /**
      * Static maps used my OptionIntMap objects. Set in OptIntMap::Init
      */
-    static thread_local std::map<int, std::string> s_breaks;
-    static thread_local std::map<int, std::string> s_condense;
-    static thread_local std::map<int, std::string> s_footer;
-    static thread_local std::map<int, std::string> s_header;
-    static thread_local std::map<int, std::string> s_multiRestStyle;
-    static thread_local std::map<int, std::string> s_systemDivider;
+    static const std::map<int, std::string> s_breaks;
+    static const std::map<int, std::string> s_condense;
+    static const std::map<int, std::string> s_footer;
+    static const std::map<int, std::string> s_header;
+    static const std::map<int, std::string> s_multiRestStyle;
+    static const std::map<int, std::string> s_systemDivider;
 
 protected:
     std::string m_title;
@@ -337,7 +337,7 @@ public:
     OptionIntMap();
     virtual ~OptionIntMap() {}
     virtual void CopyTo(Option *option);
-    void Init(int defaultValue, std::map<int, std::string> *values);
+    void Init(int defaultValue, const std::map<int, std::string> *values);
 
     virtual bool SetValue(const std::string &value);
     virtual std::string GetStrValue() const;
@@ -355,7 +355,7 @@ private:
 public:
     //
 private:
-    std::map<int, std::string> *m_values;
+    const std::map<int, std::string> *m_values;
     int m_value;
     int m_defaultValue;
 };

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -120,12 +120,12 @@ public:
     /**
      * Static maps used my OptionIntMap objects. Set in OptIntMap::Init
      */
-    static std::map<int, std::string> s_breaks;
-    static std::map<int, std::string> s_condense;
-    static std::map<int, std::string> s_footer;
-    static std::map<int, std::string> s_header;
-    static std::map<int, std::string> s_multiRestStyle;
-    static std::map<int, std::string> s_systemDivider;
+    static thread_local std::map<int, std::string> s_breaks;
+    static thread_local std::map<int, std::string> s_condense;
+    static thread_local std::map<int, std::string> s_footer;
+    static thread_local std::map<int, std::string> s_header;
+    static thread_local std::map<int, std::string> s_multiRestStyle;
+    static thread_local std::map<int, std::string> s_systemDivider;
 
 protected:
     std::string m_title;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -629,8 +629,8 @@ private:
 
     /** @name Internal values for storing temporary values for ligatures */
     ///@{
-    static int s_drawingLigX[2], s_drawingLigY[2];
-    static bool s_drawingLigObliqua;
+    static thread_local int s_drawingLigX[2], s_drawingLigY[2];
+    static thread_local bool s_drawingLigObliqua;
     ///@}
 };
 

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -170,12 +170,12 @@ private:
     //----------------//
 
     /** The path to the resources directory (e.g., for the svg/ subdirectory with fonts as XML */
-    static std::string s_path;
+    static thread_local std::string s_path;
     /** The loaded SMuFL font */
-    static GlyphMap s_font;
+    static thread_local GlyphMap s_font;
     /** A text font used for bounding box calculations */
-    static GlyphTextMap s_textFont;
-    static StyleAttributes s_currentStyle;
+    static thread_local GlyphTextMap s_textFont;
+    static thread_local StyleAttributes s_currentStyle;
     static const StyleAttributes k_defaultStyle;
     /**
      * A map of glyph name / code

--- a/src/abbr.cpp
+++ b/src/abbr.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Abbr
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Abbr> s_factory("abbr", ABBR);
+// static ClassRegistrar<Abbr> s_factory("abbr", ABBR);
 
 Abbr::Abbr() : EditorialElement("abbr-"), AttSource()
 {

--- a/src/abbr.cpp
+++ b/src/abbr.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Abbr
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Abbr> s_factory("abbr", ABBR);
+static const ClassRegistrar<Abbr> s_factory("abbr", ABBR);
 
 Abbr::Abbr() : EditorialElement("abbr-"), AttSource()
 {

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Accid
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Accid> s_factory("accid", ACCID);
+static const ClassRegistrar<Accid> s_factory("accid", ACCID);
 
 Accid::Accid()
     : LayerElement("accid-")

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Accid
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Accid> s_factory("accid", ACCID);
+// static ClassRegistrar<Accid> s_factory("accid", ACCID);
 
 Accid::Accid()
     : LayerElement("accid-")

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Add
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Add> s_factory("add", ADD);
+// static ClassRegistrar<Add> s_factory("add", ADD);
 
 Add::Add() : EditorialElement("add-"), AttSource()
 {

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Add
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Add> s_factory("add", ADD);
+static const ClassRegistrar<Add> s_factory("add", ADD);
 
 Add::Add() : EditorialElement("add-"), AttSource()
 {

--- a/src/anchoredtext.cpp
+++ b/src/anchoredtext.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // AnchoredText
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
+// static ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
 
 AnchoredText::AnchoredText() : ControlElement("anchtxt-"), TextDirInterface()
 {

--- a/src/anchoredtext.cpp
+++ b/src/anchoredtext.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // AnchoredText
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
+static const ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
 
 AnchoredText::AnchoredText() : ControlElement("anchtxt-"), TextDirInterface()
 {

--- a/src/annot.cpp
+++ b/src/annot.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Annot
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Annot> s_factory("annot", ANNOT);
+// static ClassRegistrar<Annot> s_factory("annot", ANNOT);
 
 Annot::Annot() : EditorialElement("annot-"), TextListInterface(), AttPlist(), AttSource()
 {

--- a/src/annot.cpp
+++ b/src/annot.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Annot
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Annot> s_factory("annot", ANNOT);
+static const ClassRegistrar<Annot> s_factory("annot", ANNOT);
 
 Annot::Annot() : EditorialElement("annot-"), TextListInterface(), AttPlist(), AttSource()
 {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // App
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<App> s_factory("app", APP);
+static const ClassRegistrar<App> s_factory("app", APP);
 
 App::App() : EditorialElement("app-")
 {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // App
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<App> s_factory("app", APP);
+// static ClassRegistrar<App> s_factory("app", APP);
 
 App::App() : EditorialElement("app-")
 {

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Arpeg
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
+// static ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
 
 Arpeg::Arpeg()
     : ControlElement("arpeg-"), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis(), AttColor()

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Arpeg
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
+static const ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
 
 Arpeg::Arpeg()
     : ControlElement("arpeg-"), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis(), AttColor()

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -34,7 +34,7 @@ const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_d
 // Artic
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Artic> s_factory("artic", ARTIC);
+static const ClassRegistrar<Artic> s_factory("artic", ARTIC);
 
 Artic::Artic() : LayerElement("artic-"), AttArticulation(), AttColor(), AttPlacementRelEvent()
 {

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -24,11 +24,11 @@
 
 namespace vrv {
 
-std::vector<data_ARTICULATION> Artic::s_outStaffArtic = { ARTICULATION_acc, ARTICULATION_dnbow, ARTICULATION_marc,
+const std::vector<data_ARTICULATION> Artic::s_outStaffArtic = { ARTICULATION_acc, ARTICULATION_dnbow, ARTICULATION_marc,
     ARTICULATION_upbow, ARTICULATION_harm, ARTICULATION_snap, ARTICULATION_damp };
 
-std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_dnbow, ARTICULATION_marc, ARTICULATION_upbow,
-    ARTICULATION_harm, ARTICULATION_snap, ARTICULATION_damp };
+const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_dnbow, ARTICULATION_marc,
+    ARTICULATION_upbow, ARTICULATION_harm, ARTICULATION_snap, ARTICULATION_damp };
 
 //----------------------------------------------------------------------------
 // Artic

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -34,7 +34,7 @@ const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_d
 // Artic
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Artic> s_factory("artic", ARTIC);
+// static ClassRegistrar<Artic> s_factory("artic", ARTIC);
 
 Artic::Artic() : LayerElement("artic-"), AttArticulation(), AttColor(), AttPlacementRelEvent()
 {

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // BarLine
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
+static const ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
 BarLine::BarLine() : LayerElement("bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
 {

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // BarLine
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
+// static ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
 BarLine::BarLine() : LayerElement("bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
 {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1023,7 +1023,7 @@ void BeamSegment::CalcSetValues()
 // Beam
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Beam> s_factory("beam", BEAM);
+static const ClassRegistrar<Beam> s_factory("beam", BEAM);
 
 Beam::Beam() : LayerElement("beam-"), BeamDrawingInterface(), AttColor(), AttBeamedWith(), AttBeamRend()
 {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1023,7 +1023,7 @@ void BeamSegment::CalcSetValues()
 // Beam
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Beam> s_factory("beam", BEAM);
+// static ClassRegistrar<Beam> s_factory("beam", BEAM);
 
 Beam::Beam() : LayerElement("beam-"), BeamDrawingInterface(), AttColor(), AttBeamedWith(), AttBeamRend()
 {

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 // BeatRpt
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
+// static ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
 
 BeatRpt::BeatRpt() : LayerElement("beatrpt-"), AttColor(), AttBeatRptVis()
 {

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 // BeatRpt
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
+static const ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
 
 BeatRpt::BeatRpt() : LayerElement("beatrpt-"), AttColor(), AttBeatRptVis()
 {

--- a/src/bracketspan.cpp
+++ b/src/bracketspan.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // BracketSpan
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
+// static ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
 
 BracketSpan::BracketSpan()
     : ControlElement("bspan-")

--- a/src/bracketspan.cpp
+++ b/src/bracketspan.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // BracketSpan
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
+static const ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
 
 BracketSpan::BracketSpan()
     : ControlElement("bspan-")

--- a/src/breath.cpp
+++ b/src/breath.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Breath
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Breath> s_factory("breath", BREATH);
+static const ClassRegistrar<Breath> s_factory("breath", BREATH);
 
 Breath::Breath() : ControlElement("breath-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {

--- a/src/breath.cpp
+++ b/src/breath.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Breath
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Breath> s_factory("breath", BREATH);
+// static ClassRegistrar<Breath> s_factory("breath", BREATH);
 
 Breath::Breath() : ControlElement("breath-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // BTrem
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<BTrem> s_factory("btrem", BTREM);
+static const ClassRegistrar<BTrem> s_factory("btrem", BTREM);
 
 BTrem::BTrem() : LayerElement("btrem-"), AttBTremLog(), AttTremMeasured()
 {

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // BTrem
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<BTrem> s_factory("btrem", BTREM);
+// static ClassRegistrar<BTrem> s_factory("btrem", BTREM);
 
 BTrem::BTrem() : LayerElement("btrem-"), AttBTremLog(), AttTremMeasured()
 {

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Caesura
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
+static const ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
 
 Caesura::Caesura() : ControlElement("caesura-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Caesura
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
+// static ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
 
 Caesura::Caesura() : ControlElement("caesura-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // Choice
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Choice> s_factory("choice", CHOICE);
+// static ClassRegistrar<Choice> s_factory("choice", CHOICE);
 
 Choice::Choice() : EditorialElement("choice-")
 {

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // Choice
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Choice> s_factory("choice", CHOICE);
+static const ClassRegistrar<Choice> s_factory("choice", CHOICE);
 
 Choice::Choice() : EditorialElement("choice-")
 {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -60,7 +60,7 @@ template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin,
 // Chord
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Chord> s_factory("chord", CHORD);
+static const ClassRegistrar<Chord> s_factory("chord", CHORD);
 
 Chord::Chord()
     : LayerElement("chord-")

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -60,7 +60,7 @@ template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin,
 // Chord
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Chord> s_factory("chord", CHORD);
+// static ClassRegistrar<Chord> s_factory("chord", CHORD);
 
 Chord::Chord()
     : LayerElement("chord-")

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Clef
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Clef> s_factory("clef", CLEF);
+// static ClassRegistrar<Clef> s_factory("clef", CLEF);
 
 Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement(), AttVisibility()
 {

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Clef
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Clef> s_factory("clef", CLEF);
+static const ClassRegistrar<Clef> s_factory("clef", CLEF);
 
 Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement(), AttVisibility()
 {

--- a/src/corr.cpp
+++ b/src/corr.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Corr
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Corr> s_factory("corr", CORR);
+static const ClassRegistrar<Corr> s_factory("corr", CORR);
 
 Corr::Corr() : EditorialElement("corr-"), AttSource()
 {

--- a/src/corr.cpp
+++ b/src/corr.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Corr
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Corr> s_factory("corr", CORR);
+// static ClassRegistrar<Corr> s_factory("corr", CORR);
 
 Corr::Corr() : EditorialElement("corr-"), AttSource()
 {

--- a/src/course.cpp
+++ b/src/course.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // Course
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Course> s_factory("course", COURSE);
+static const ClassRegistrar<Course> s_factory("course", COURSE);
 
 Course::Course() : Object("course-"), AttNNumberLike()
 {

--- a/src/course.cpp
+++ b/src/course.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // Course
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Course> s_factory("course", COURSE);
+// static ClassRegistrar<Course> s_factory("course", COURSE);
 
 Course::Course() : Object("course-"), AttNNumberLike()
 {

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Custos
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Custos> s_factory("custos", CUSTOS);
+// static ClassRegistrar<Custos> s_factory("custos", CUSTOS);
 
 Custos::Custos() : LayerElement("custos-"), PitchInterface(), PositionInterface(), AttColor()
 {

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Custos
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Custos> s_factory("custos", CUSTOS);
+static const ClassRegistrar<Custos> s_factory("custos", CUSTOS);
 
 Custos::Custos() : LayerElement("custos-"), PitchInterface(), PositionInterface(), AttColor()
 {

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Damage
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Damage> s_factory("damage", DAMAGE);
+static const ClassRegistrar<Damage> s_factory("damage", DAMAGE);
 
 Damage::Damage() : EditorialElement("lem-"), AttSource()
 {

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Damage
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Damage> s_factory("damage", DAMAGE);
+// static ClassRegistrar<Damage> s_factory("damage", DAMAGE);
 
 Damage::Damage() : EditorialElement("lem-"), AttSource()
 {

--- a/src/del.cpp
+++ b/src/del.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Del
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Del> s_factory("del", DEL);
+// static ClassRegistrar<Del> s_factory("del", DEL);
 
 Del::Del() : EditorialElement("del-"), AttSource()
 {

--- a/src/del.cpp
+++ b/src/del.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Del
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Del> s_factory("del", DEL);
+static const ClassRegistrar<Del> s_factory("del", DEL);
 
 Del::Del() : EditorialElement("del-"), AttSource()
 {

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Dir
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Dir> s_factory("dir", DIR);
+static const ClassRegistrar<Dir> s_factory("dir", DIR);
 
 Dir::Dir()
     : ControlElement("dir-")

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Dir
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Dir> s_factory("dir", DIR);
+// static ClassRegistrar<Dir> s_factory("dir", DIR);
 
 Dir::Dir()
     : ControlElement("dir-")

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Dot
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Dot> s_factory("dot", DOT);
+static const ClassRegistrar<Dot> s_factory("dot", DOT);
 
 Dot::Dot() : LayerElement("dot-"), PositionInterface(), AttColor(), AttDotLog()
 {

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Dot
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Dot> s_factory("dot", DOT);
+// static ClassRegistrar<Dot> s_factory("dot", DOT);
 
 Dot::Dot() : LayerElement("dot-"), PositionInterface(), AttColor(), AttDotLog()
 {

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -32,7 +32,7 @@ std::wstring dynamSmufl[] = { L"\uE520", L"\uE521", L"\uE522", L"\uE523", L"\uE5
 // Dynam
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
+static const ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
 
 Dynam::Dynam()
     : ControlElement("dynam-")

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -32,7 +32,7 @@ std::wstring dynamSmufl[] = { L"\uE520", L"\uE521", L"\uE522", L"\uE523", L"\uE5
 // Dynam
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
+// static ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
 
 Dynam::Dynam()
     : ControlElement("dynam-")

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Ending
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Ending> s_factory("ending", ENDING);
+static const ClassRegistrar<Ending> s_factory("ending", ENDING);
 
 Ending::Ending() : SystemElement("ending-"), BoundaryStartInterface(), AttLineRend(), AttNNumberLike()
 {

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Ending
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Ending> s_factory("ending", ENDING);
+// static ClassRegistrar<Ending> s_factory("ending", ENDING);
 
 Ending::Ending() : SystemElement("ending-"), BoundaryStartInterface(), AttLineRend(), AttNNumberLike()
 {

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Expan
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Expan> s_factory("expan", EXPAN);
+static const ClassRegistrar<Expan> s_factory("expan", EXPAN);
 
 Expan::Expan() : EditorialElement("expan-"), AttSource()
 {

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Expan
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Expan> s_factory("expan", EXPAN);
+// static ClassRegistrar<Expan> s_factory("expan", EXPAN);
 
 Expan::Expan() : EditorialElement("expan-"), AttSource()
 {

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // Expansion
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
+static const ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
 
 Expansion::Expansion() : SystemElement("expansion-"), PlistInterface()
 {

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // Expansion
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
+// static ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
 
 Expansion::Expansion() : SystemElement("expansion-"), PlistInterface()
 {

--- a/src/f.cpp
+++ b/src/f.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // F (Figure)
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<F> s_factory("f", FIGURE);
+static const ClassRegistrar<F> s_factory("f", FIGURE);
 
 F::F() : TextElement("f-"), TimeSpanningInterface(), AttExtender()
 {

--- a/src/f.cpp
+++ b/src/f.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // F (Figure)
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<F> s_factory("f", FIGURE);
+// static ClassRegistrar<F> s_factory("f", FIGURE);
 
 F::F() : TextElement("f-"), TimeSpanningInterface(), AttExtender()
 {

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Facsimile
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
+// static ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
 
 Facsimile::Facsimile() : Object("facsimile-") {}
 

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Facsimile
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
+static const ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
 
 Facsimile::Facsimile() : Object("facsimile-") {}
 

--- a/src/fb.cpp
+++ b/src/fb.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fb
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Fb> s_factory("fb", FB);
+// static ClassRegistrar<Fb> s_factory("fb", FB);
 
 Fb::Fb() : Object("fb-")
 {

--- a/src/fb.cpp
+++ b/src/fb.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fb
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Fb> s_factory("fb", FB);
+static const ClassRegistrar<Fb> s_factory("fb", FB);
 
 Fb::Fb() : Object("fb-")
 {

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fermata
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
+// static ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
 
 Fermata::Fermata()
     : ControlElement("fermata-"), TimePointInterface(), AttColor(), AttExtSym(), AttFermataVis(), AttPlacementRelStaff()

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fermata
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
+static const ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
 
 Fermata::Fermata()
     : ControlElement("fermata-"), TimePointInterface(), AttColor(), AttExtSym(), AttFermataVis(), AttPlacementRelStaff()

--- a/src/fig.cpp
+++ b/src/fig.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fig
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Fig> s_factory("fig", FIG);
+// static ClassRegistrar<Fig> s_factory("fig", FIG);
 
 Fig::Fig() : TextElement("fig-"), AreaPosInterface()
 {

--- a/src/fig.cpp
+++ b/src/fig.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Fig
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Fig> s_factory("fig", FIG);
+static const ClassRegistrar<Fig> s_factory("fig", FIG);
 
 Fig::Fig() : TextElement("fig-"), AreaPosInterface()
 {

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -20,7 +20,7 @@ namespace vrv {
 // Fing
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Fing> s_factory("fing", FING);
+// static ClassRegistrar<Fing> s_factory("fing", FING);
 
 Fing::Fing() : ControlElement("fing-"), TimePointInterface(), TextDirInterface(), AttNNumberLike()
 {

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -20,7 +20,7 @@ namespace vrv {
 // Fing
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Fing> s_factory("fing", FING);
+static const ClassRegistrar<Fing> s_factory("fing", FING);
 
 Fing::Fing() : ControlElement("fing-"), TimePointInterface(), TextDirInterface(), AttNNumberLike()
 {

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -44,7 +44,7 @@ namespace vrv {
 // Static members
 //----------------------------------------------------------------------------
 
-std::vector<void *> FloatingObject::s_drawingObjectIds;
+thread_local std::vector<void *> FloatingObject::s_drawingObjectIds;
 
 //----------------------------------------------------------------------------
 // FloatingObject

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 // FTrem
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
+// static ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
 
 FTrem::FTrem() : LayerElement("ftrem-"), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
 {

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 // FTrem
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
+static const ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
 
 FTrem::FTrem() : LayerElement("ftrem-"), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
 {

--- a/src/gliss.cpp
+++ b/src/gliss.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Gliss
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Gliss> s_factory("gliss", GLISS);
+static const ClassRegistrar<Gliss> s_factory("gliss", GLISS);
 
 Gliss::Gliss()
     : ControlElement("gliss-"), TimeSpanningInterface(), AttColor(), AttLineRend(), AttLineRendBase(), AttNNumberLike()

--- a/src/gliss.cpp
+++ b/src/gliss.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Gliss
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Gliss> s_factory("gliss", GLISS);
+// static ClassRegistrar<Gliss> s_factory("gliss", GLISS);
 
 Gliss::Gliss()
     : ControlElement("gliss-"), TimeSpanningInterface(), AttColor(), AttLineRend(), AttLineRendBase(), AttNNumberLike()

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // GraceGrp
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
+static const ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
 
 GraceGrp::GraceGrp() : LayerElement("gracegrp-"), AttColor(), AttGraced(), AttGraceGrpLog()
 {

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // GraceGrp
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
+// static ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
 
 GraceGrp::GraceGrp() : LayerElement("gracegrp-"), AttColor(), AttGraced(), AttGraceGrpLog()
 {

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // GrpSym
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
+// static ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
 
 GrpSym::GrpSym() : Object("grpsym-"), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
 {

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // GrpSym
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
+static const ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
 
 GrpSym::GrpSym() : Object("grpsym-"), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
 {

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Hairpin
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
+static const ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
 
 Hairpin::Hairpin()
     : ControlElement("hairpin-")

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Hairpin
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
+// static ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
 
 Hairpin::Hairpin()
     : ControlElement("hairpin-")

--- a/src/halfmrpt.cpp
+++ b/src/halfmrpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // HalfmRpt
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
+// static ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
 
 HalfmRpt::HalfmRpt() : LayerElement("mrpt-")
 {

--- a/src/halfmrpt.cpp
+++ b/src/halfmrpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // HalfmRpt
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
+static const ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
 
 HalfmRpt::HalfmRpt() : LayerElement("mrpt-")
 {

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 // Harm
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Harm> s_factory("harm", HARM);
+static const ClassRegistrar<Harm> s_factory("harm", HARM);
 
 Harm::Harm()
     : ControlElement("harm-")

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 // Harm
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Harm> s_factory("harm", HARM);
+// static ClassRegistrar<Harm> s_factory("harm", HARM);
 
 Harm::Harm()
     : ControlElement("harm-")

--- a/src/instrdef.cpp
+++ b/src/instrdef.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // InstrDef
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
+// static ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
 
 InstrDef::InstrDef() : Object("instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
 {

--- a/src/instrdef.cpp
+++ b/src/instrdef.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // InstrDef
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
+static const ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
 
 InstrDef::InstrDef() : Object("instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
 {

--- a/src/iodarms.cpp
+++ b/src/iodarms.cpp
@@ -41,7 +41,7 @@ namespace vrv {
 #ifndef NO_DARMS_SUPPORT
 
 // Ok, this is ugly, but since this is static data, why not?
-pitchmap DarmsInput::PitchMap[] = {
+const pitchmap DarmsInput::PitchMap[] = {
     /* 00 */ { 1, PITCHNAME_c },
     { 1, PITCHNAME_d },
     { 1, PITCHNAME_e },

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -136,7 +136,7 @@
 
 namespace vrv {
 
-std::vector<std::string> MEIInput::s_editorialElementNames = { "abbr", "add", "app", "annot", "choice", "corr",
+const std::vector<std::string> MEIInput::s_editorialElementNames = { "abbr", "add", "app", "annot", "choice", "corr",
     "damage", "del", "expan", "orig", "ref", "reg", "restore", "sic", "subst", "supplied", "unclear" };
 
 //----------------------------------------------------------------------------

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // KeyAccid
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
+static const ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
 
 KeyAccid::KeyAccid() : LayerElement("keyaccid-"), PitchInterface(), AttAccidental(), AttColor(), AttEnclosingChars()
 {

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // KeyAccid
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
+// static ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
 
 KeyAccid::KeyAccid() : LayerElement("keyaccid-"), PitchInterface(), AttAccidental(), AttColor(), AttEnclosingChars()
 {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -66,7 +66,7 @@ const int KeySig::octave_map[2][9][7] = {
 // KeySig
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
+// static ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
 
 KeySig::KeySig()
     : LayerElement("keysig-")

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -66,7 +66,7 @@ const int KeySig::octave_map[2][9][7] = {
 // KeySig
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
+static const ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
 
 KeySig::KeySig()
     : LayerElement("keysig-")

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -28,12 +28,12 @@ namespace vrv {
 // Static members with some default values
 //----------------------------------------------------------------------------
 
-data_PITCHNAME KeySig::s_pnameForFlats[]
+thread_local data_PITCHNAME KeySig::s_pnameForFlats[]
     = { PITCHNAME_b, PITCHNAME_e, PITCHNAME_a, PITCHNAME_d, PITCHNAME_g, PITCHNAME_c, PITCHNAME_f };
-data_PITCHNAME KeySig::s_pnameForSharps[]
+thread_local data_PITCHNAME KeySig::s_pnameForSharps[]
     = { PITCHNAME_f, PITCHNAME_c, PITCHNAME_g, PITCHNAME_d, PITCHNAME_a, PITCHNAME_e, PITCHNAME_b };
 
-int KeySig::octave_map[2][9][7] = {
+const int KeySig::octave_map[2][9][7] = {
     {
         // flats
         // C,  D,  E,  F,  G,  A,  B

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -28,9 +28,9 @@ namespace vrv {
 // Static members with some default values
 //----------------------------------------------------------------------------
 
-thread_local data_PITCHNAME KeySig::s_pnameForFlats[]
+const data_PITCHNAME KeySig::s_pnameForFlats[]
     = { PITCHNAME_b, PITCHNAME_e, PITCHNAME_a, PITCHNAME_d, PITCHNAME_g, PITCHNAME_c, PITCHNAME_f };
-thread_local data_PITCHNAME KeySig::s_pnameForSharps[]
+const data_PITCHNAME KeySig::s_pnameForSharps[]
     = { PITCHNAME_f, PITCHNAME_c, PITCHNAME_g, PITCHNAME_d, PITCHNAME_a, PITCHNAME_e, PITCHNAME_b };
 
 const int KeySig::octave_map[2][9][7] = {
@@ -200,22 +200,19 @@ std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, d
         return keyAccid->GetSymbolStr();
     }
 
-    data_PITCHNAME *accidSet;
-
     if (pos > 6) return symbolStr;
 
     int symb;
     accid = this->GetAccidType();
     if (accid == ACCIDENTAL_WRITTEN_f) {
         symb = SMUFL_E260_accidentalFlat;
-        accidSet = s_pnameForFlats;
+        pname = s_pnameForFlats[pos];
     }
     else {
         symb = SMUFL_E262_accidentalSharp;
-        accidSet = s_pnameForSharps;
+        pname = s_pnameForSharps[pos];
     }
 
-    pname = accidSet[pos];
     symbolStr.push_back(symb);
     return symbolStr;
 }
@@ -237,18 +234,14 @@ int KeySig::GetFifthsInt() const
 
 data_PITCHNAME KeySig::GetAccidPnameAt(data_ACCIDENTAL_WRITTEN accidType, int pos)
 {
-    data_PITCHNAME *accidSet;
-
     if (pos > 6) return PITCHNAME_c;
 
     if (accidType == ACCIDENTAL_WRITTEN_f) {
-        accidSet = s_pnameForFlats;
+        return s_pnameForFlats[pos];
     }
     else {
-        accidSet = s_pnameForSharps;
+        return s_pnameForSharps[pos];
     }
-
-    return accidSet[pos];
 }
 
 int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, Clef *clef)

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Label
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Label> s_factory("label", LABEL);
+// static ClassRegistrar<Label> s_factory("label", LABEL);
 
 Label::Label() : Object("label-"), TextListInterface()
 {

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Label
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Label> s_factory("label", LABEL);
+static const ClassRegistrar<Label> s_factory("label", LABEL);
 
 Label::Label() : Object("label-"), TextListInterface()
 {

--- a/src/labelabbr.cpp
+++ b/src/labelabbr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // LabelAbbr
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
+static const ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
 
 LabelAbbr::LabelAbbr() : Object("labelAbbr-"), TextListInterface()
 {

--- a/src/labelabbr.cpp
+++ b/src/labelabbr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // LabelAbbr
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
+// static ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
 
 LabelAbbr::LabelAbbr() : Object("labelAbbr-"), TextListInterface()
 {

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -38,7 +38,7 @@ namespace vrv {
 // Layer
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Layer> s_factory("layer", LAYER);
+static const ClassRegistrar<Layer> s_factory("layer", LAYER);
 
 Layer::Layer()
     : Object("layer-"), DrawingListInterface(), ObjectListInterface(), AttNInteger(), AttTyped(), AttVisibility()

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -38,7 +38,7 @@ namespace vrv {
 // Layer
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Layer> s_factory("layer", LAYER);
+// static ClassRegistrar<Layer> s_factory("layer", LAYER);
 
 Layer::Layer()
     : Object("layer-"), DrawingListInterface(), ObjectListInterface(), AttNInteger(), AttTyped(), AttVisibility()

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Lb
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Lb> s_factory("lb", LB);
+static const ClassRegistrar<Lb> s_factory("lb", LB);
 
 Lb::Lb() : TextElement("lb-")
 {

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Lb
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Lb> s_factory("lb", LB);
+// static ClassRegistrar<Lb> s_factory("lb", LB);
 
 Lb::Lb() : TextElement("lb-")
 {

--- a/src/lem.cpp
+++ b/src/lem.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Lem
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Lem> s_factory("lem", LEM);
+static const ClassRegistrar<Lem> s_factory("lem", LEM);
 
 Lem::Lem() : EditorialElement("lem-"), AttSource()
 {

--- a/src/lem.cpp
+++ b/src/lem.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Lem
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Lem> s_factory("lem", LEM);
+// static ClassRegistrar<Lem> s_factory("lem", LEM);
 
 Lem::Lem() : EditorialElement("lem-"), AttSource()
 {

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // Ligature
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
+static const ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
 
 Ligature::Ligature() : LayerElement("ligature-"), ObjectListInterface(), AttLigatureVis()
 {

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // Ligature
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
+// static ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
 
 Ligature::Ligature() : LayerElement("ligature-"), ObjectListInterface(), AttLigatureVis()
 {

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Mdiv
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
+static const ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
 
 Mdiv::Mdiv() : Object("mdiv-"), AttLabelled(), AttNNumberLike()
 {

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Mdiv
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
+// static ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
 
 Mdiv::Mdiv() : Object("mdiv-"), AttLabelled(), AttNNumberLike()
 {

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -43,7 +43,7 @@ namespace vrv {
 // Measure
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Measure> s_factory("measure", MEASURE);
+static const ClassRegistrar<Measure> s_factory("measure", MEASURE);
 
 Measure::Measure(bool measureMusic, int logMeasureNb)
     : Object("measure-")

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -43,7 +43,7 @@ namespace vrv {
 // Measure
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Measure> s_factory("measure", MEASURE);
+// static ClassRegistrar<Measure> s_factory("measure", MEASURE);
 
 Measure::Measure(bool measureMusic, int logMeasureNb)
     : Object("measure-")

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -27,7 +27,7 @@ const int Mensur::s_numBase = 2;
 // Mensur
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
+// static ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
 
 Mensur::Mensur()
     : LayerElement("mensur-")

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -27,7 +27,7 @@ const int Mensur::s_numBase = 2;
 // Mensur
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
+static const ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
 
 Mensur::Mensur()
     : LayerElement("mensur-")

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -20,8 +20,8 @@
 
 namespace vrv {
 
-int Mensur::s_num = 3;
-int Mensur::s_numBase = 2;
+const int Mensur::s_num = 3;
+const int Mensur::s_numBase = 2;
 
 //----------------------------------------------------------------------------
 // Mensur

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // MeterSig
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
+static const ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
 
 MeterSig::MeterSig() : LayerElement("msig-"), AttMeterSigLog(), AttMeterSigVis()
 {

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // MeterSig
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
+// static ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
 
 MeterSig::MeterSig() : LayerElement("msig-"), AttMeterSigLog(), AttMeterSigVis()
 {

--- a/src/mnum.cpp
+++ b/src/mnum.cpp
@@ -74,7 +74,7 @@ bool MNum::IsSupportedChild(Object *child)
 // MNum functor methods
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MNum> s_factory("mNum", MNUM);
+static const ClassRegistrar<MNum> s_factory("mNum", MNUM);
 
 int MNum::Save(FunctorParams *functorParams)
 {

--- a/src/mnum.cpp
+++ b/src/mnum.cpp
@@ -74,7 +74,7 @@ bool MNum::IsSupportedChild(Object *child)
 // MNum functor methods
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MNum> s_factory("mNum", MNUM);
+// static ClassRegistrar<MNum> s_factory("mNum", MNUM);
 
 int MNum::Save(FunctorParams *functorParams)
 {

--- a/src/mordent.cpp
+++ b/src/mordent.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Mordent
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
+static const ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
 
 Mordent::Mordent()
     : ControlElement("mordent-")

--- a/src/mordent.cpp
+++ b/src/mordent.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Mordent
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
+// static ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
 
 Mordent::Mordent()
     : ControlElement("mordent-")

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // MRest
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MRest> s_factory("mRest", MREST);
+// static ClassRegistrar<MRest> s_factory("mRest", MREST);
 
 MRest::MRest() : LayerElement("mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
 {

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // MRest
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MRest> s_factory("mRest", MREST);
+static const ClassRegistrar<MRest> s_factory("mRest", MREST);
 
 MRest::MRest() : LayerElement("mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
 {

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MRpt
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
+static const ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
 
 MRpt::MRpt() : LayerElement("mrpt-"), AttColor()
 {

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MRpt
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
+// static ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
 
 MRpt::MRpt() : LayerElement("mrpt-"), AttColor()
 {

--- a/src/mrpt2.cpp
+++ b/src/mrpt2.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MRpt2
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
+static const ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
 
 MRpt2::MRpt2() : LayerElement("mrpt2-"), AttColor()
 {

--- a/src/mrpt2.cpp
+++ b/src/mrpt2.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MRpt2
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
+// static ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
 
 MRpt2::MRpt2() : LayerElement("mrpt2-"), AttColor()
 {

--- a/src/mspace.cpp
+++ b/src/mspace.cpp
@@ -20,7 +20,7 @@ namespace vrv {
 // MSpace
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
+static const ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
 
 MSpace::MSpace() : LayerElement("mSpace-")
 {

--- a/src/mspace.cpp
+++ b/src/mspace.cpp
@@ -20,7 +20,7 @@ namespace vrv {
 // MSpace
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
+// static ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
 
 MSpace::MSpace() : LayerElement("mSpace-")
 {

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -17,7 +17,7 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
+// static ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
 
 MultiRest::MultiRest()
     : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -17,7 +17,7 @@ namespace vrv {
 // MultiRest
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
+static const ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
 
 MultiRest::MultiRest()
     : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()

--- a/src/multirpt.cpp
+++ b/src/multirpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MultiRpt
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
+static const ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
 
 MultiRpt::MultiRpt() : LayerElement("multirpt-"), AttNumbered()
 {

--- a/src/multirpt.cpp
+++ b/src/multirpt.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 // MultiRpt
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
+// static ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
 
 MultiRpt::MultiRpt() : LayerElement("multirpt-"), AttNumbered()
 {

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Nc
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Nc> s_factory("nc", NC);
+static const ClassRegistrar<Nc> s_factory("nc", NC);
 
 Nc::Nc()
     : LayerElement("nc-")

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Nc
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Nc> s_factory("nc", NC);
+// static ClassRegistrar<Nc> s_factory("nc", NC);
 
 Nc::Nc()
     : LayerElement("nc-")

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -42,7 +42,7 @@ thread_local std::map<std::string, NeumeGroup> Neume::s_neumes
 // Neume
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Neume> s_factory("neume", NEUME);
+static const ClassRegistrar<Neume> s_factory("neume", NEUME);
 
 Neume::Neume() : LayerElement("neume-"), ObjectListInterface(), AttColor()
 {

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -32,7 +32,7 @@
 
 namespace vrv {
 
-thread_local std::map<std::string, NeumeGroup> Neume::s_neumes
+const std::map<std::string, NeumeGroup> Neume::s_neumes
     = { { "", PUNCTUM }, { "u", PES }, { "d", CLIVIS }, { "uu", SCANDICUS }, { "dd", CLIMACUS }, { "ud", TORCULUS },
           { "du", PORRECTUS }, { "ddd", CLIMACUS }, { "ddu", CLIMACUS_RESUPINUS }, { "udu", TORCULUS_RESUPINUS },
           { "dud", PORRECTUS_FLEXUS }, { "udd", PES_SUBPUNCTIS }, { "uud", SCANDICUS_FLEXUS },
@@ -117,7 +117,13 @@ NeumeGroup Neume::GetNeumeGroup()
         }
         previous = current;
     }
-    return s_neumes[key];
+
+    try {
+        return s_neumes.at(key);
+    }
+    catch (std::out_of_range &e) {
+        return NEUME_ERROR;
+    }
 }
 
 std::vector<int> Neume::GetPitchDifferences()

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -42,7 +42,7 @@ thread_local std::map<std::string, NeumeGroup> Neume::s_neumes
 // Neume
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Neume> s_factory("neume", NEUME);
+// static ClassRegistrar<Neume> s_factory("neume", NEUME);
 
 Neume::Neume() : LayerElement("neume-"), ObjectListInterface(), AttColor()
 {

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -118,10 +118,10 @@ NeumeGroup Neume::GetNeumeGroup()
         previous = current;
     }
 
-    try {
+    if (s_neumes.count(key) > 0) {
         return s_neumes.at(key);
     }
-    catch (std::out_of_range &e) {
+    else {
         return NEUME_ERROR;
     }
 }

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -32,7 +32,7 @@
 
 namespace vrv {
 
-std::map<std::string, NeumeGroup> Neume::s_neumes
+thread_local std::map<std::string, NeumeGroup> Neume::s_neumes
     = { { "", PUNCTUM }, { "u", PES }, { "d", CLIVIS }, { "uu", SCANDICUS }, { "dd", CLIMACUS }, { "ud", TORCULUS },
           { "du", PORRECTUS }, { "ddd", CLIMACUS }, { "ddu", CLIMACUS_RESUPINUS }, { "udu", TORCULUS_RESUPINUS },
           { "dud", PORRECTUS_FLEXUS }, { "udd", PES_SUBPUNCTIS }, { "uud", SCANDICUS_FLEXUS },

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -45,7 +45,7 @@ namespace vrv {
 // Note
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Note> s_factory("note", NOTE);
+static const ClassRegistrar<Note> s_factory("note", NOTE);
 
 Note::Note()
     : LayerElement("note-")

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -45,7 +45,7 @@ namespace vrv {
 // Note
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Note> s_factory("note", NOTE);
+// static ClassRegistrar<Note> s_factory("note", NOTE);
 
 Note::Note()
     : LayerElement("note-")

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Num
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Num> s_factory("num", NUM);
+static const ClassRegistrar<Num> s_factory("num", NUM);
 
 Num::Num() : TextElement("num-")
 {

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Num
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Num> s_factory("num", NUM);
+// static ClassRegistrar<Num> s_factory("num", NUM);
 
 Num::Num() : TextElement("num-")
 {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1175,7 +1175,7 @@ void Functor::Call(Object *ptr, FunctorParams *functorParams)
 
 ObjectFactory *ObjectFactory::GetInstance()
 {
-    static ObjectFactory factory;
+    static thread_local ObjectFactory factory;
     return &factory;
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -57,7 +57,7 @@ namespace vrv {
 // Object
 //----------------------------------------------------------------------------
 
-unsigned long Object::s_objectCounter = 0;
+thread_local unsigned long Object::s_objectCounter = 0;
 
 Object::Object() : BoundingBox()
 {

--- a/src/octave.cpp
+++ b/src/octave.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Octave
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Octave> s_factory("octave", OCTAVE);
+// static ClassRegistrar<Octave> s_factory("octave", OCTAVE);
 
 Octave::Octave()
     : ControlElement("octave-")

--- a/src/octave.cpp
+++ b/src/octave.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Octave
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Octave> s_factory("octave", OCTAVE);
+static const ClassRegistrar<Octave> s_factory("octave", OCTAVE);
 
 Octave::Octave()
     : ControlElement("octave-")

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -21,23 +21,23 @@
 
 namespace vrv {
 
-std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
+thread_local std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
     { BREAKS_line, "line" }, { BREAKS_smart, "smart" }, { BREAKS_encoded, "encoded" } };
 
-std::map<int, std::string> Option::s_condense
+thread_local std::map<int, std::string> Option::s_condense
     = { { CONDENSE_none, "none" }, { CONDENSE_auto, "auto" }, { CONDENSE_encoded, "encoded" } };
 
-std::map<int, std::string> Option::s_footer
+thread_local std::map<int, std::string> Option::s_footer
     = { { FOOTER_none, "none" }, { FOOTER_auto, "auto" }, { FOOTER_encoded, "encoded" }, { FOOTER_always, "always" } };
 
-std::map<int, std::string> Option::s_header
+thread_local std::map<int, std::string> Option::s_header
     = { { HEADER_none, "none" }, { HEADER_auto, "auto" }, { HEADER_encoded, "encoded" } };
 
-std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
+thread_local std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
-std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" }, { SYSTEMDIVIDER_auto, "auto" },
-    { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
+thread_local std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
+    { SYSTEMDIVIDER_auto, "auto" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
 constexpr const char *engravingDefaults
     = "{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -21,22 +21,22 @@
 
 namespace vrv {
 
-thread_local std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
+const std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
     { BREAKS_line, "line" }, { BREAKS_smart, "smart" }, { BREAKS_encoded, "encoded" } };
 
-thread_local std::map<int, std::string> Option::s_condense
+const std::map<int, std::string> Option::s_condense
     = { { CONDENSE_none, "none" }, { CONDENSE_auto, "auto" }, { CONDENSE_encoded, "encoded" } };
 
-thread_local std::map<int, std::string> Option::s_footer
+const std::map<int, std::string> Option::s_footer
     = { { FOOTER_none, "none" }, { FOOTER_auto, "auto" }, { FOOTER_encoded, "encoded" }, { FOOTER_always, "always" } };
 
-thread_local std::map<int, std::string> Option::s_header
+const std::map<int, std::string> Option::s_header
     = { { HEADER_none, "none" }, { HEADER_auto, "auto" }, { HEADER_encoded, "encoded" } };
 
-thread_local std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
+const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
-thread_local std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
+const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
     { SYSTEMDIVIDER_auto, "auto" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
 constexpr const char *engravingDefaults
@@ -464,7 +464,7 @@ void OptionIntMap::CopyTo(Option *option)
     *child = *this;
 }
 
-void OptionIntMap::Init(int defaultValue, std::map<int, std::string> *values)
+void OptionIntMap::Init(int defaultValue, const std::map<int, std::string> *values)
 {
     m_value = defaultValue;
     m_defaultValue = defaultValue;
@@ -476,8 +476,8 @@ bool OptionIntMap::SetValue(const std::string &value)
 {
     assert(m_values);
 
-    std::map<int, std::string>::iterator it;
-    for (it = m_values->begin(); it != m_values->end(); ++it)
+    std::map<int, std::string>::const_iterator it;
+    for (it = m_values->cbegin(); it != m_values->cend(); ++it)
         if (it->second == value) {
             m_value = it->first;
             m_isSet = true;
@@ -520,8 +520,8 @@ std::vector<std::string> OptionIntMap::GetStrValues(bool withoutDefault) const
 
     std::vector<std::string> strValues;
     strValues.reserve(m_values->size());
-    std::map<int, std::string>::iterator it;
-    for (it = m_values->begin(); it != m_values->end(); ++it) {
+    std::map<int, std::string>::const_iterator it;
+    for (it = m_values->cbegin(); it != m_values->cend(); ++it) {
         if (withoutDefault && (it->first == m_defaultValue)) {
             continue;
         }

--- a/src/orig.cpp
+++ b/src/orig.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Orig
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Orig> s_factory("orig", ORIG);
+// static ClassRegistrar<Orig> s_factory("orig", ORIG);
 
 Orig::Orig() : EditorialElement("orig-"), AttSource()
 {

--- a/src/orig.cpp
+++ b/src/orig.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Orig
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Orig> s_factory("orig", ORIG);
+static const ClassRegistrar<Orig> s_factory("orig", ORIG);
 
 Orig::Orig() : EditorialElement("orig-"), AttSource()
 {

--- a/src/pb.cpp
+++ b/src/pb.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Pb
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Pb> s_factory("pb", PB);
+static const ClassRegistrar<Pb> s_factory("pb", PB);
 
 Pb::Pb() : SystemElement("pb-"), AttNNumberLike()
 {

--- a/src/pb.cpp
+++ b/src/pb.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Pb
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Pb> s_factory("pb", PB);
+// static ClassRegistrar<Pb> s_factory("pb", PB);
 
 Pb::Pb() : SystemElement("pb-"), AttNNumberLike()
 {

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Pedal
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
+// static ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
 
 Pedal::Pedal()
     : ControlElement("pedal-")

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Pedal
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
+static const ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
 
 Pedal::Pedal()
     : ControlElement("pedal-")

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // PgFoot
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
+// static ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
 
 PgFoot::PgFoot() : RunningElement("pgfoot-")
 {

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // PgFoot
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
+static const ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
 
 PgFoot::PgFoot() : RunningElement("pgfoot-")
 {

--- a/src/pgfoot2.cpp
+++ b/src/pgfoot2.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // PgFoot2
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<PgFoot2> s_factory("pgFoot2", PGFOOT2);
+// static ClassRegistrar<PgFoot2> s_factory("pgFoot2", PGFOOT2);
 
 PgFoot2::PgFoot2() : RunningElement("pgfoot2-")
 {

--- a/src/pgfoot2.cpp
+++ b/src/pgfoot2.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // PgFoot2
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<PgFoot2> s_factory("pgFoot2", PGFOOT2);
+static const ClassRegistrar<PgFoot2> s_factory("pgFoot2", PGFOOT2);
 
 PgFoot2::PgFoot2() : RunningElement("pgfoot2-")
 {

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // PgHead
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
+// static ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
 
 PgHead::PgHead() : RunningElement("pghead-")
 {

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // PgHead
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
+static const ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
 
 PgHead::PgHead() : RunningElement("pghead-")
 {

--- a/src/pghead2.cpp
+++ b/src/pghead2.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // PgHead2
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<PgHead2> s_factory("pgHead2", PGHEAD2);
+static const ClassRegistrar<PgHead2> s_factory("pgHead2", PGHEAD2);
 
 PgHead2::PgHead2() : RunningElement("pghead2-")
 {

--- a/src/pghead2.cpp
+++ b/src/pghead2.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // PgHead2
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<PgHead2> s_factory("pgHead2", PGHEAD2);
+// static ClassRegistrar<PgHead2> s_factory("pgHead2", PGHEAD2);
 
 PgHead2::PgHead2() : RunningElement("pghead2-")
 {

--- a/src/phrase.cpp
+++ b/src/phrase.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Phrase
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
+static const ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
 
 Phrase::Phrase() : Slur("phrase-")
 {

--- a/src/phrase.cpp
+++ b/src/phrase.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Phrase
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
+// static ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
 
 Phrase::Phrase() : Slur("phrase-")
 {

--- a/src/pitchinflection.cpp
+++ b/src/pitchinflection.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // PitchInflection
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
+static const ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
 
 PitchInflection::PitchInflection() : ControlElement("pinflexion-"), TimeSpanningInterface()
 {

--- a/src/pitchinflection.cpp
+++ b/src/pitchinflection.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // PitchInflection
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
+// static ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
 
 PitchInflection::PitchInflection() : ControlElement("pinflexion-"), TimeSpanningInterface()
 {

--- a/src/plica.cpp
+++ b/src/plica.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Plica
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Plica> s_factory("plica", PLICA);
+static const ClassRegistrar<Plica> s_factory("plica", PLICA);
 
 Plica::Plica() : LayerElement("plica-"), AttPlicaVis()
 {

--- a/src/plica.cpp
+++ b/src/plica.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Plica
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Plica> s_factory("plica", PLICA);
+// static ClassRegistrar<Plica> s_factory("plica", PLICA);
 
 Plica::Plica() : LayerElement("plica-"), AttPlicaVis()
 {

--- a/src/proport.cpp
+++ b/src/proport.cpp
@@ -13,7 +13,7 @@ namespace vrv {
 // Proport
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Proport> s_factory("proport", PROPORT);
+static const ClassRegistrar<Proport> s_factory("proport", PROPORT);
 
 Proport::Proport() : LayerElement("prop-"), AttDurationRatio()
 {

--- a/src/proport.cpp
+++ b/src/proport.cpp
@@ -13,7 +13,7 @@ namespace vrv {
 // Proport
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Proport> s_factory("proport", PROPORT);
+// static ClassRegistrar<Proport> s_factory("proport", PROPORT);
 
 Proport::Proport() : LayerElement("prop-"), AttDurationRatio()
 {

--- a/src/rdg.cpp
+++ b/src/rdg.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Rdg
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Rdg> s_factory("rdg", RDG);
+static const ClassRegistrar<Rdg> s_factory("rdg", RDG);
 
 Rdg::Rdg() : EditorialElement("rdg-"), AttSource()
 {

--- a/src/rdg.cpp
+++ b/src/rdg.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Rdg
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Rdg> s_factory("rdg", RDG);
+// static ClassRegistrar<Rdg> s_factory("rdg", RDG);
 
 Rdg::Rdg() : EditorialElement("rdg-"), AttSource()
 {

--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Ref
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Ref> s_factory("ref", REF);
+// static ClassRegistrar<Ref> s_factory("ref", REF);
 
 Ref::Ref() : EditorialElement("ref-")
 {

--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Ref
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Ref> s_factory("ref", REF);
+static const ClassRegistrar<Ref> s_factory("ref", REF);
 
 Ref::Ref() : EditorialElement("ref-")
 {

--- a/src/reg.cpp
+++ b/src/reg.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Reg
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Reg> s_factory("reg", REG);
+static const ClassRegistrar<Reg> s_factory("reg", REG);
 
 Reg::Reg() : EditorialElement("reg-"), AttSource()
 {

--- a/src/reg.cpp
+++ b/src/reg.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Reg
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Reg> s_factory("reg", REG);
+// static ClassRegistrar<Reg> s_factory("reg", REG);
 
 Reg::Reg() : EditorialElement("reg-"), AttSource()
 {

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Reh
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Reh> s_factory("reh", REH);
+// static ClassRegistrar<Reh> s_factory("reh", REH);
 
 Reh::Reh() : ControlElement("reh-"), TextDirInterface(), TimePointInterface(), AttColor(), AttLang(), AttVerticalGroup()
 {

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Reh
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Reh> s_factory("reh", REH);
+static const ClassRegistrar<Reh> s_factory("reh", REH);
 
 Reh::Reh() : ControlElement("reh-"), TextDirInterface(), TimePointInterface(), AttColor(), AttLang(), AttVerticalGroup()
 {

--- a/src/rend.cpp
+++ b/src/rend.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 // Rend
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Rend> s_factory("rend", REND);
+// static ClassRegistrar<Rend> s_factory("rend", REND);
 
 Rend::Rend()
     : TextElement("rend-")

--- a/src/rend.cpp
+++ b/src/rend.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 // Rend
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Rend> s_factory("rend", REND);
+static const ClassRegistrar<Rend> s_factory("rend", REND);
 
 Rend::Rend()
     : TextElement("rend-")

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -149,7 +149,7 @@ RestAccidental MeiAccidentalToRestAccidental(data_ACCIDENTAL_WRITTEN accidental)
 // Rest
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Rest> s_factory("rest", REST);
+static const ClassRegistrar<Rest> s_factory("rest", REST);
 
 Rest::Rest()
     : LayerElement("rest-")

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -149,7 +149,7 @@ RestAccidental MeiAccidentalToRestAccidental(data_ACCIDENTAL_WRITTEN accidental)
 // Rest
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Rest> s_factory("rest", REST);
+// static ClassRegistrar<Rest> s_factory("rest", REST);
 
 Rest::Rest()
     : LayerElement("rest-")

--- a/src/restore.cpp
+++ b/src/restore.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Restore
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Restore> s_factory("restore", RESTORE);
+// static ClassRegistrar<Restore> s_factory("restore", RESTORE);
 
 Restore::Restore() : EditorialElement("restore-"), AttSource()
 {

--- a/src/restore.cpp
+++ b/src/restore.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Restore
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Restore> s_factory("restore", RESTORE);
+static const ClassRegistrar<Restore> s_factory("restore", RESTORE);
 
 Restore::Restore() : EditorialElement("restore-"), AttSource()
 {

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Sb
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Sb> s_factory("sb", SB);
+// static ClassRegistrar<Sb> s_factory("sb", SB);
 
 Sb::Sb() : SystemElement("sb-"), AttNNumberLike()
 {

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Sb
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Sb> s_factory("sb", SB);
+static const ClassRegistrar<Sb> s_factory("sb", SB);
 
 Sb::Sb() : SystemElement("sb-"), AttNNumberLike()
 {

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Score
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Score> s_factory("score", SCORE);
+// static ClassRegistrar<Score> s_factory("score", SCORE);
 
 Score::Score() : Object("score-"), AttLabelled(), AttNNumberLike()
 {

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Score
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Score> s_factory("score", SCORE);
+static const ClassRegistrar<Score> s_factory("score", SCORE);
 
 Score::Score() : Object("score-"), AttLabelled(), AttNNumberLike()
 {

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -145,7 +145,7 @@ MeterSig *ScoreDefElement::GetMeterSigCopy()
 // ScoreDef
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
+// static ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
 
 ScoreDef::ScoreDef()
     : ScoreDefElement("scoredef-")

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -145,7 +145,7 @@ MeterSig *ScoreDefElement::GetMeterSigCopy()
 // ScoreDef
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
+static const ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
 
 ScoreDef::ScoreDef()
     : ScoreDefElement("scoredef-")

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Section
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Section> s_factory("section", SECTION);
+static const ClassRegistrar<Section> s_factory("section", SECTION);
 
 Section::Section() : SystemElement("section-"), BoundaryStartInterface(), AttNNumberLike()
 {

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Section
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Section> s_factory("section", SECTION);
+// static ClassRegistrar<Section> s_factory("section", SECTION);
 
 Section::Section() : SystemElement("section-"), BoundaryStartInterface(), AttNNumberLike()
 {

--- a/src/sic.cpp
+++ b/src/sic.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Sic
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Sic> s_factory("sic", SIC);
+static const ClassRegistrar<Sic> s_factory("sic", SIC);
 
 Sic::Sic() : EditorialElement("sic-"), AttSource()
 {

--- a/src/sic.cpp
+++ b/src/sic.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Sic
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Sic> s_factory("sic", SIC);
+// static ClassRegistrar<Sic> s_factory("sic", SIC);
 
 Sic::Sic() : EditorialElement("sic-"), AttSource()
 {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Slur> s_factory("slur", SLUR);
+// static ClassRegistrar<Slur> s_factory("slur", SLUR);
 
 Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Slur
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Slur> s_factory("slur", SLUR);
+static const ClassRegistrar<Slur> s_factory("slur", SLUR);
 
 Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Space
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Space> s_factory("space", SPACE);
+// static ClassRegistrar<Space> s_factory("space", SPACE);
 
 Space::Space() : LayerElement("space-"), DurationInterface()
 {

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Space
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Space> s_factory("space", SPACE);
+static const ClassRegistrar<Space> s_factory("space", SPACE);
 
 Space::Space() : LayerElement("space-"), DurationInterface()
 {

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -39,7 +39,7 @@ namespace vrv {
 // Staff
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Staff> s_factory("staff", STAFF);
+static const ClassRegistrar<Staff> s_factory("staff", STAFF);
 
 Staff::Staff(int n) : Object("staff-"), FacsimileInterface(), AttNInteger(), AttTyped(), AttVisibility()
 {

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -39,7 +39,7 @@ namespace vrv {
 // Staff
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Staff> s_factory("staff", STAFF);
+// static ClassRegistrar<Staff> s_factory("staff", STAFF);
 
 Staff::Staff(int n) : Object("staff-"), FacsimileInterface(), AttNInteger(), AttTyped(), AttVisibility()
 {

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // StaffDef
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
+// static ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
 
 StaffDef::StaffDef()
     : ScoreDefElement("staffdef-")

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // StaffDef
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
+static const ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
 
 StaffDef::StaffDef()
     : ScoreDefElement("staffdef-")

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // StaffGrp
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
+static const ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
 
 StaffGrp::StaffGrp()
     : Object("staffgrp-")

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // StaffGrp
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
+// static ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
 
 StaffGrp::StaffGrp()
     : Object("staffgrp-")

--- a/src/subst.cpp
+++ b/src/subst.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Subst
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Subst> s_factory("subst", SUBST);
+// static ClassRegistrar<Subst> s_factory("subst", SUBST);
 
 Subst::Subst() : EditorialElement("subst-")
 {

--- a/src/subst.cpp
+++ b/src/subst.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Subst
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Subst> s_factory("subst", SUBST);
+static const ClassRegistrar<Subst> s_factory("subst", SUBST);
 
 Subst::Subst() : EditorialElement("subst-")
 {

--- a/src/supplied.cpp
+++ b/src/supplied.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Supplied
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
+static const ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
 
 Supplied::Supplied() : EditorialElement("supplied-"), AttSource()
 {

--- a/src/supplied.cpp
+++ b/src/supplied.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Supplied
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
+// static ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
 
 Supplied::Supplied() : EditorialElement("supplied-"), AttSource()
 {

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Surface
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Surface> s_factory("surface", SURFACE);
+// static ClassRegistrar<Surface> s_factory("surface", SURFACE);
 
 Surface::Surface() : Object("surface-"), AttTyped(), AttCoordinated()
 {

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // Surface
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Surface> s_factory("surface", SURFACE);
+static const ClassRegistrar<Surface> s_factory("surface", SURFACE);
 
 Surface::Surface() : Object("surface-"), AttTyped(), AttCoordinated()
 {

--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Svg
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Svg> s_factory("svg", SVG);
+// static ClassRegistrar<Svg> s_factory("svg", SVG);
 
 Svg::Svg() : Object("fig-")
 {

--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Svg
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Svg> s_factory("svg", SVG);
+static const ClassRegistrar<Svg> s_factory("svg", SVG);
 
 Svg::Svg() : Object("fig-")
 {

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Syl
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Syl> s_factory("syl", SYL);
+// static ClassRegistrar<Syl> s_factory("syl", SYL);
 
 Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Syl
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Syl> s_factory("syl", SYL);
+static const ClassRegistrar<Syl> s_factory("syl", SYL);
 
 Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {

--- a/src/syllable.cpp
+++ b/src/syllable.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Syllable
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
+static const ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
 
 Syllable::Syllable() : LayerElement("syllable-"), ObjectListInterface(), AttColor(), AttSlashCount()
 {

--- a/src/syllable.cpp
+++ b/src/syllable.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Syllable
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
+// static ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
 
 Syllable::Syllable() : LayerElement("syllable-"), ObjectListInterface(), AttColor(), AttSlashCount()
 {

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // TabDurSym
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
+// static ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
 
 TabDurSym::TabDurSym() : LayerElement("tabdursym-"), AttNNumberLike()
 {

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // TabDurSym
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
+static const ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
 
 TabDurSym::TabDurSym() : LayerElement("tabdursym-"), AttNNumberLike()
 {

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // TabGrp
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
+static const ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
 
 TabGrp::TabGrp() : LayerElement("tabgrp-"), DurationInterface()
 {

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // TabGrp
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
+// static ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
 
 TabGrp::TabGrp() : LayerElement("tabgrp-"), DurationInterface()
 {

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Tempo
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
+static const ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
 
 Tempo::Tempo()
     : ControlElement("tempo-"), TextDirInterface(), TimePointInterface(), AttLang(), AttMidiTempo(), AttMmTempo()

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Tempo
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
+// static ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
 
 Tempo::Tempo()
     : ControlElement("tempo-"), TextDirInterface(), TimePointInterface(), AttLang(), AttMidiTempo(), AttMmTempo()

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Tie
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Tie> s_factory("tie", TIE);
+static const ClassRegistrar<Tie> s_factory("tie", TIE);
 
 Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Tie
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Tie> s_factory("tie", TIE);
+// static ClassRegistrar<Tie> s_factory("tie", TIE);
 
 Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Trill
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Trill> s_factory("trill", TRILL);
+// static ClassRegistrar<Trill> s_factory("trill", TRILL);
 
 Trill::Trill()
     : ControlElement("trill-")

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Trill
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Trill> s_factory("trill", TRILL);
+static const ClassRegistrar<Trill> s_factory("trill", TRILL);
 
 Trill::Trill()
     : ControlElement("trill-")

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Tuning
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Tuning> s_factory("tuning", TUNING);
+// static ClassRegistrar<Tuning> s_factory("tuning", TUNING);
 
 Tuning::Tuning() : Object("tuning-"), AttCourseLog()
 {

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Tuning
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Tuning> s_factory("tuning", TUNING);
+static const ClassRegistrar<Tuning> s_factory("tuning", TUNING);
 
 Tuning::Tuning() : Object("tuning-"), AttCourseLog()
 {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 // Tuplet
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
+static const ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
 
 Tuplet::Tuplet()
     : LayerElement("tuplet-")

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 // Tuplet
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
+// static ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
 
 Tuplet::Tuplet()
     : LayerElement("tuplet-")

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Turn
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Turn> s_factory("turn", TURN);
+// static ClassRegistrar<Turn> s_factory("turn", TURN);
 
 Turn::Turn()
     : ControlElement("turn-")

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Turn
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Turn> s_factory("turn", TURN);
+static const ClassRegistrar<Turn> s_factory("turn", TURN);
 
 Turn::Turn()
     : ControlElement("turn-")

--- a/src/unclear.cpp
+++ b/src/unclear.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Unclear
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
+static const ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
 
 Unclear::Unclear() : EditorialElement("unclear-"), AttSource()
 {

--- a/src/unclear.cpp
+++ b/src/unclear.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // Unclear
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
+// static ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
 
 Unclear::Unclear() : EditorialElement("unclear-"), AttSource()
 {

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 // Verse
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Verse> s_factory("verse", VERSE);
+static const ClassRegistrar<Verse> s_factory("verse", VERSE);
 
 Verse::Verse() : LayerElement("verse-"), AttColor(), AttLang(), AttNInteger(), AttTypography()
 {

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 // Verse
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Verse> s_factory("verse", VERSE);
+// static ClassRegistrar<Verse> s_factory("verse", VERSE);
 
 Verse::Verse() : LayerElement("verse-"), AttColor(), AttLang(), AttNInteger(), AttTypography()
 {

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -31,8 +31,8 @@
 
 namespace vrv {
 
-int View::s_drawingLigX[2], View::s_drawingLigY[2]; // to keep coords. of ligatures
-bool View::s_drawingLigObliqua = false; // mark the first pass for an oblique
+thread_local int View::s_drawingLigX[2], View::s_drawingLigY[2]; // to keep coords. of ligatures
+thread_local bool View::s_drawingLigObliqua = false; // mark the first pass for an oblique
 
 //----------------------------------------------------------------------------
 // View - Mensural

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -60,10 +60,10 @@ namespace vrv {
 // Static members with some default values
 //----------------------------------------------------------------------------
 
-std::string Resources::s_path = "/usr/local/share/verovio";
-Resources::GlyphTextMap Resources::s_textFont;
-Resources::GlyphMap Resources::s_font;
-Resources::StyleAttributes Resources::s_currentStyle;
+thread_local std::string Resources::s_path = "/usr/local/share/verovio";
+thread_local Resources::GlyphTextMap Resources::s_textFont;
+thread_local Resources::GlyphMap Resources::s_font;
+thread_local Resources::StyleAttributes Resources::s_currentStyle;
 const Resources::StyleAttributes Resources::k_defaultStyle{ data_FONTWEIGHT::FONTWEIGHT_normal,
     data_FONTSTYLE::FONTSTYLE_normal };
 

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Zone
 //----------------------------------------------------------------------------
 
-static ClassRegistrar<Zone> s_factory("zone", ZONE);
+// static ClassRegistrar<Zone> s_factory("zone", ZONE);
 
 Zone::Zone() : Object("zone-"), AttTyped(), AttCoordinated()
 {

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Zone
 //----------------------------------------------------------------------------
 
-// static ClassRegistrar<Zone> s_factory("zone", ZONE);
+static const ClassRegistrar<Zone> s_factory("zone", ZONE);
 
 Zone::Zone() : Object("zone-"), AttTyped(), AttCoordinated()
 {


### PR DESCRIPTION
This PR improves thread safety by declaring static member variables either as const or thread_local. This should allow running several instances of Verovio concurrently.

One issue is the singleton object factory where element classes are registered. This is not used anywhere (!) for object construction. For now, we have commented out all declarations of factory variables. Other options would be to remove this code completely or to declare the singleton instance itself as thread_local. 