### PR TITLE
Improve handling of polyphonic clef changes in the MusicXML

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_IOMUSXML_H__
 #define __VRV_IOMUSXML_H__
 
+#include <deque>
 #include <map>
 #include <string>
 #include <vector>
@@ -117,10 +118,11 @@ namespace musicxml {
 
     class ClefChange {
     public:
-        ClefChange(const std::string &measureNum, Staff *staff, Clef *clef, const int &scoreOnset, bool afterBarline)
+        ClefChange(const std::string &measureNum, Staff *staff, Layer *layer, Clef *clef, const int &scoreOnset, bool afterBarline)
         {
             m_measureNum = measureNum;
             m_staff = staff;
+            m_layer = layer;
             m_clef = clef;
             m_scoreOnset = scoreOnset;
             m_afterBarline = afterBarline;
@@ -128,9 +130,9 @@ namespace musicxml {
 
         std::string m_measureNum;
         Staff *m_staff;
+        Layer *m_layer;
         Clef *m_clef;
         int m_scoreOnset; // the score position of clef change
-        bool isFirst = true; // insert clef change at first layer, others use @sameas
         bool m_afterBarline = false; // musicXML attribute
     };
 
@@ -208,14 +210,19 @@ private:
     ///@}
 
     /**
+     * Process all clef change queue and add clefs to corresponding places in the score
+     */
+    void ProcessClefChangeQueue(Section *section);
+
+    /**
      * Add clef changes to all layers of a given measure, staff, and time stamp
      */
-    void AddClef(Section *section, Measure *measure, Staff *staff, const std::string &measureNum);
+    void AddClefs(Measure *measure, const musicxml::ClefChange &clefChange);
     
     /**
      * Add clef as layer element to specified layer and #sameas clefs to previous layers, if needed
      */
-    void InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef);
+    void InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, int scoreOnSet);
 
     /*
      * Add a Measure to the section.
@@ -450,7 +457,7 @@ private:
      */
     std::vector<std::pair<std::string, ControlElement *>> m_controlElements;
     /* stack of clef changes to be inserted to all layers of a given staff */
-    std::vector<musicxml::ClefChange> m_clefChangeStack;
+    std::deque<musicxml::ClefChange> m_clefChangeQueue;
     /* stack of new arpeggios that get more notes added. */
     std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio>> m_ArpeggioStack;
     /* a map for the measure counts storing the index of each measure created */

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -9,9 +9,9 @@
 #define __VRV_IOMUSXML_H__
 
 #include <map>
+#include <queue>
 #include <string>
 #include <vector>
-#include <queue>
 
 //----------------------------------------------------------------------------
 

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_IOMUSXML_H__
 #define __VRV_IOMUSXML_H__
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -206,10 +207,15 @@ private:
     void ReadMusicXmlBeamStart(const pugi::xml_node &node, const pugi::xml_node &beamStart, Layer *layer);
     ///@}
 
-    /*
+    /**
      * Add clef changes to all layers of a given measure, staff, and time stamp
      */
     void AddClef(Section *section, Measure *measure, Staff *staff, const std::string &measureNum);
+    
+    /**
+     * Add clef as layer element to specified layer and #sameas clefs to previous layers, if needed
+     */
+    void InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef);
 
     /*
      * Add a Measure to the section.
@@ -405,6 +411,7 @@ private:
     std::map<Layer *, std::vector<LayerElement *>> m_elementStackMap;
     /* A maps of time stamps (score time) to indicate write pointer of a given layer */
     std::map<Layer *, int> m_layerEndTimes;
+    std::map<Layer *, std::multimap<int, LayerElement *>> m_layerTimes;
     /* To remember layer of last element (note) to handle chords */
     Layer *m_prevLayer = NULL;
     /* To remember current layer to properly handle layers/staves/cross-staff elements */

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -8,10 +8,10 @@
 #ifndef __VRV_IOMUSXML_H__
 #define __VRV_IOMUSXML_H__
 
-#include <deque>
 #include <map>
 #include <string>
 #include <vector>
+#include <queue>
 
 //----------------------------------------------------------------------------
 
@@ -457,7 +457,7 @@ private:
      */
     std::vector<std::pair<std::string, ControlElement *>> m_controlElements;
     /* stack of clef changes to be inserted to all layers of a given staff */
-    std::deque<musicxml::ClefChange> m_clefChangeQueue;
+    std::queue<musicxml::ClefChange> m_clefChangeQueue;
     /* stack of new arpeggios that get more notes added. */
     std::vector<std::pair<Arpeg *, musicxml::OpenArpeggio>> m_ArpeggioStack;
     /* a map for the measure counts storing the index of each measure created */

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -267,7 +267,7 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
         Layer *otherLayer = vrv_cast<Layer *>(listLayer);
         if (m_layerTimes.find(otherLayer) == m_layerTimes.end()) continue;
         // Get first element for the same (or higher if same is not present) duration
-        const auto start = m_layerTimes[otherLayer].lower_bound(scoreOnset);
+        const auto start = m_layerTimes.at(otherLayer).lower_bound(scoreOnset);
         // Add either clef or #sameas, depending on the layer we're adding to
         Clef *clefToAdd = NULL;
         if (listLayer == layer) {
@@ -280,24 +280,24 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
 
         // In case scoreOnset is 0 - add clef before the first element
         if (!scoreOnset) {
-             otherLayer->InsertBefore(start->second, clefToAdd);
-            m_layerTimes[otherLayer].emplace(scoreOnset, clefToAdd);
+            otherLayer->InsertBefore(start->second, clefToAdd);
+            m_layerTimes.at(otherLayer).emplace(scoreOnset, clefToAdd);
         }
         else {
             // If corresponding time couldn't be found (i.e. it's higher than any other duration in the layer) - add
             // clef to the end of the layer
-            if (start == m_layerTimes[otherLayer].end()) {
+            if (start == m_layerTimes.at(otherLayer).end()) {
                 otherLayer->AddChild(clefToAdd);
-                m_layerTimes[otherLayer].emplace(std::prev(m_layerTimes[otherLayer].end())->first, clefToAdd);
+                m_layerTimes.at(otherLayer).emplace(std::prev(m_layerTimes.at(otherLayer).end())->first, clefToAdd);
             }
             else {
                 // Always try to add clefs at the end of current duration, to honor their order in the musicxml
                 const int actualScoreOnSet = start->first;
-                auto end = m_layerTimes[otherLayer].upper_bound(actualScoreOnSet);
+                auto end = m_layerTimes.at(otherLayer).upper_bound(actualScoreOnSet);
                 LayerElement *layerElement = (--end)->second;
                 if (layerElement->GetParent()->Is(LAYER)) {
                     otherLayer->InsertAfter(layerElement, clefToAdd);
-                    m_layerTimes[otherLayer].emplace(actualScoreOnSet, clefToAdd);
+                    m_layerTimes.at(otherLayer).emplace(actualScoreOnSet, clefToAdd);
                 }
                 else if (layerElement->GetParent()->Is(BEAM)) {
                     layerElement->GetParent()->InsertAfter(layerElement, clefToAdd);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -240,7 +240,7 @@ void MusicXmlInput::AddClefs(Measure *measure, const musicxml::ClefChange &clefC
                 Layer *parentLayer = dynamic_cast<Layer *>(mSpace->GetParent());
                 if (mSpace && parentLayer) {
                     int index = mSpace->GetIdx();
-                    parentLayer->DetachChild(index);
+                    parentLayer->DeleteChild(mSpace);
                     m_elementStackMap[parentLayer] = {};
                     FillSpace(parentLayer, clefChange.m_scoreOnset);
                     parentLayer->AddChild(clefChange.m_clef);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -295,8 +295,16 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
                 const int actualScoreOnSet = start->first;
                 auto end = m_layerTimes[otherLayer].upper_bound(actualScoreOnSet);
                 LayerElement *layerElement = (--end)->second;
-                otherLayer->InsertAfter(layerElement, clefToAdd);
-                m_layerTimes[otherLayer].emplace(actualScoreOnSet, clefToAdd);
+                if (layerElement->GetParent()->Is(LAYER)) {
+                    otherLayer->InsertAfter(layerElement, clefToAdd);
+                    m_layerTimes[otherLayer].emplace(actualScoreOnSet, clefToAdd);
+                }
+                else if (layerElement->GetParent()->Is(BEAM)) {
+                    layerElement->GetParent()->InsertAfter(layerElement, clefToAdd);
+                }
+                else if (layerElement->GetParent()->Is({ CHORD, FTREM })) {
+                    otherLayer->InsertAfter(layerElement->GetParent(), clefToAdd);
+                }
             }
         }
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -175,7 +175,7 @@ void MusicXmlInput::ProcessClefChangeQueue(Section *section)
 {
     while (!m_clefChangeQueue.empty()) {
         musicxml::ClefChange clefChange = m_clefChangeQueue.front();
-        m_clefChangeQueue.pop_front();
+        m_clefChangeQueue.pop();
         AttNNumberLikeComparison comparisonMeasure(MEASURE, clefChange.m_measureNum);
         Measure *currentMeasure = vrv_cast<Measure *>(section->FindDescendantByComparison(&comparisonMeasure));
         if (!currentMeasure) {
@@ -237,11 +237,10 @@ void MusicXmlInput::AddClefs(Measure *measure, const musicxml::ClefChange &clefC
             // cross-staff clef. Remove mSpace in this case and add clef to it instead, filling space if required
             Object *mSpace = clefChange.m_staff->FindDescendantByType(MSPACE);
             if (mSpace) {
-                Layer *parentLayer = vrv_cast<Layer *>(mSpace->GetParent());
+                Layer *parentLayer = dynamic_cast<Layer *>(mSpace->GetParent());
                 if (mSpace && parentLayer) {
                     int index = mSpace->GetIdx();
-                    Object *mSpace = parentLayer->Relinquish(index);
-                    parentLayer->ClearRelinquishedChildren();
+                    parentLayer->DetachChild(index);
                     m_elementStackMap[parentLayer] = {};
                     FillSpace(parentLayer, clefChange.m_scoreOnset);
                     parentLayer->AddChild(clefChange.m_clef);
@@ -1578,7 +1577,7 @@ void MusicXmlInput::ReadMusicXmlAttributes(
         Clef *meiClef = ConvertClef(clef);
         if (meiClef) {
             const bool afterBarline = clef.attribute("after-barline").as_bool();
-            m_clefChangeQueue.push_back(
+            m_clefChangeQueue.push(
                 musicxml::ClefChange(measureNum, staff, m_currentLayer, meiClef, m_durTotal, afterBarline));
         }
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -201,6 +201,8 @@ void MusicXmlInput::AddClef(Section *section, Measure *measure, Staff *staff, co
                     Object *previousStaff = previousMeasure->FindDescendantByComparison(&comparisonStaff);
                     if (previousStaff == NULL) {
                         InsertClefToLayer(staff, layer, iter->m_clef);
+                        iter->isFirst = false;
+                        continue;
                     }
                     // adding the clef to the last layer is sufficient
                     Object *prevLayer = previousStaff->FindDescendantByType(LAYER, UNLIMITED_DEPTH, BACKWARD);


### PR DESCRIPTION
With how handling of MusicXML  is implemented currently, clef changes that happened in the later layers (e.g. third layer, fourth layer, etc.) would never be added to previous layers as @sameas clefs. Clefs currently are processed sequentially, and @sameas clefs are added only to the future layers. This leads to cases like following:
![image](https://user-images.githubusercontent.com/1819669/122820928-dd2ca880-d2e4-11eb-8d1f-9273bf707a54.png)
<details><summary>MusicXML example</summary>

```XML
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <identification>
    <encoding>
      <supports attribute="new-system" element="print" type="yes" value="yes"/>
      <supports attribute="new-page" element="print" type="yes" value="yes"/>
      <encoding-date>2021-04-27</encoding-date>
    </encoding>
  </identification>
  <part-list>
    <score-part id="P1-NULL">
      <part-name></part-name>
    </score-part>
  </part-list>
  <!--...Part 1...-->
  <part id="P1-NULL">
    <!--...Measure 1...-->
    <measure number="1" id="measure-1-mdiv-1">
      <print new-page="yes"/>
      <attributes>
        <divisions>2</divisions>
        <key number="1" id="key-1">
          <fifths>0</fifths>
        </key>
        <key number="2" id="key-2">
          <fifths>0</fifths>
        </key>
        <time number="1" id="time-1">
          <beats>4</beats>
          <beat-type>4</beat-type>
        </time>
        <time number="2" id="time-2">
          <beats>4</beats>
          <beat-type>4</beat-type>
        </time>
        <staves>2</staves>
        <clef number="1" id="clef-1">
          <sign>G</sign>
          <line>2</line>
        </clef>
        <clef number="2" id="clef-2">
          <sign>F</sign>
          <line>4</line>
        </clef>
      </attributes>
      <note id="note-Clef_change_three_voices-8340-10080-1">
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>1</staff>
      </note>
      <note id="note-Clef_change_three_voices-8740-10080-1">
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>1</staff>
      </note>
      <note id="note-Clef_change_three_voices-9130-10080-1">
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <staff>1</staff>
        <beam number="1">begin</beam>
      </note>
      <note id="note-Clef_change_three_voices-9380-10070-1">
        <pitch>
          <step>G</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <staff>1</staff>
        <beam number="1">end</beam>
      </note>
      <attributes>
        <clef number="2" id="clef-4">
          <sign>F</sign>
          <line>4</line>
        </clef>
      </attributes>
      <note id="note-Clef_change_three_voices-9620-10250-1">
        <pitch>
          <step>B</step>
          <octave>3</octave>
        </pitch>
        <duration>2</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>2</staff>
      </note>
      <backup>
        <duration>8</duration>
      </backup>
      <note id="note-Clef_change_three_voices-8340-10280-1">
        <pitch>
          <step>F</step>
          <octave>3</octave>
        </pitch>
        <duration>4</duration>
        <voice>5</voice>
        <type>half</type>
        <stem>up</stem>
        <staff>2</staff>
      </note>
      <note id="note-Clef_change_three_voices-9130-10280-1">
        <pitch>
          <step>D</step>
          <octave>5</octave>
        </pitch>
        <duration>2</duration>
        <voice>5</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>2</staff>
      </note>
      <note id="note-Clef_change_three_voices-9630-10270-1">
        <pitch>
          <step>G</step>
          <octave>3</octave>
        </pitch>
        <duration>2</duration>
        <voice>5</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>2</staff>
      </note>
      <backup>
        <duration>8</duration>
      </backup>
      <note id="note-Clef_change_three_voices-8340-10330-2">
        <pitch>
          <step>A</step>
          <octave>2</octave>
        </pitch>
        <duration>2</duration>
        <voice>6</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>2</staff>
      </note>
      <attributes>
        <clef number="2" id="clef-3">
          <sign>G</sign>
          <line>2</line>
        </clef>
      </attributes>
      <note id="note-Clef_change_three_voices-8740-10330-2">
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>6</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>2</staff>
      </note>
      <note id="note-Clef_change_three_voices-9130-10330-2">
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>2</duration>
        <voice>6</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>2</staff>
      </note>
      <note id="note-Clef_change_three_voices-9620-10330-2">
        <pitch>
          <step>A</step>
          <octave>2</octave>
        </pitch>
        <duration>2</duration>
        <voice>6</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>2</staff>
      </note>
      <barline location="right" id="barline-1">
        <bar-style>light-heavy</bar-style>
      </barline>
    </measure>
  </part>
</score-partwise>

```

</details>

This change should be addressing this issue, handling clef changes after all information about document and all layers/measures is present. This also should clean up code around clef handling in MusicXML, moving logic to one place.
![image](https://user-images.githubusercontent.com/1819669/122821233-3eed1280-d2e5-11eb-8df3-5af1a9f3530d.png)
