### PR TITLE
Spaces under beams

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1401,7 +1401,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
         || (!params->m_isOtherLayer && Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam)
             && !IsGraceNote()))
         return FUNCTOR_SIBLINGS;
-    if (Is({ GRACEGRP, TUPLET, TUPLET_NUM, TUPLET_BRACKET, BTREM })) return FUNCTOR_CONTINUE;
+    if (Is({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
     assert(staff);


### PR DESCRIPTION
This PR fixes an issue where beams were adjusted due to spaces.

| Before  | After |
| ------------- | ------------- |
| <img width="1178" alt="Before" src="https://user-images.githubusercontent.com/63608463/123415565-c1135a80-d5b5-11eb-9ad8-cb8d5a09a043.png"> | <img width="1197" alt="After" src="https://user-images.githubusercontent.com/63608463/123415617-d5575780-d5b5-11eb-8f73-5082ddd11887.png"> | 

**MEI example**
```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Beams and spaces</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2021-06-16">2021-06-16</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="5" pname="e" stem.dir="down" />
                              <space dots="1" dur="16" />
                              <note dur="32" oct="5" pname="g" stem.dir="down" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="f" stem.dir="down" />
                              <space dur="16" />
                              <space dur="32" />
                              <note dur="32" oct="5" pname="a" stem.dir="down" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="b" stem.dir="down" />
                              <space dots="2" dur="16" />
                              <note dur="64" oct="6" pname="d" stem.dir="down" />
                           </beam>
                           <beam>
                              <note dur="8" oct="6" pname="c" stem.dir="down" />
                              <space dur="16" />
                              <space dur="32" />
                              <space dur="64" />
                              <note dur="64" oct="6" pname="e" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="3" pname="e" stem.dir="up" />
                              <space dots="1" dur="16" />
                              <note dur="32" oct="3" pname="g" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur="8" oct="3" pname="f" stem.dir="up" />
                              <space dots="1" dur="16" />
                              <note dur="32" oct="3" pname="a" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur="8" oct="3" pname="b" stem.dir="up" />
                              <space dots="2" dur="16" />
                              <note dur="64" oct="4" pname="d" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="c" stem.dir="up" />
                              <space dur="16" />
                              <space dur="32" />
                              <space dur="64" />
                              <note dur="64" oct="4" pname="e" stem.dir="up" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

