### PR TITLE
Fix grouped tremolo tuplets

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -210,7 +210,7 @@ bool Slur::AdjustSlurPosition(
             int yPos = 0;
             std::tie(time, yPos)
                 = BoundingBox::ApproximateBezierExtrema(points, (curve->GetDir() == curvature_CURVEDIR_above));
-                        
+
             const double extremaShift = time - 0.5;
             const int relevantPoint = extremaShift < 0 ? bezierCurve.p1.y : bezierCurve.p2.y;
             Object *startMeasure
@@ -238,7 +238,7 @@ bool Slur::AdjustSlurPosition(
                 bezierCurve.p1.y += (curve->GetDir() == curvature_CURVEDIR_above) ? maxShiftLeft : -maxShiftLeft;
                 bezierCurve.p2.y += (curve->GetDir() == curvature_CURVEDIR_above) ? maxShiftRight : -maxShiftRight;
                 return false;
-            }            
+            }
         }
     }
     // otherwise it is normal slur - just move position of the start/end points up or down and recalculate angle
@@ -264,9 +264,8 @@ bool Slur::AdjustSlurPosition(
     }
 }
 
-
-std::pair<int, int> Slur::CalculateAdjustedSlurShift(
-    FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin, bool forceBothSides, bool &isNotAdjustable)
+std::pair<int, int> Slur::CalculateAdjustedSlurShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
+    int margin, bool forceBothSides, bool &isNotAdjustable)
 {
     int maxShiftLeft = 0;
     int maxShiftRight = 0;
@@ -284,7 +283,7 @@ std::pair<int, int> Slur::CalculateAdjustedSlurShift(
         [dir = curve->GetDir(), &extremeY](CurveSpannedElement *element) {
             if (dir == curvature_CURVEDIR_above) {
                 const int y = element->m_boundingBox->GetSelfTop();
-                extremeY = (extremeY == VRV_UNSET)? y : std::max(y, extremeY);
+                extremeY = (extremeY == VRV_UNSET) ? y : std::max(y, extremeY);
             }
             else {
                 const int y = element->m_boundingBox->GetSelfBottom();
@@ -333,7 +332,7 @@ std::pair<int, int> Slur::CalculateAdjustedSlurShift(
             maxShiftLeft = leftShift > maxShiftLeft ? leftShift : maxShiftLeft;
             maxShiftRight = rightShift > maxShiftRight ? rightShift : maxShiftRight;
         }
-        
+
         // if intersection happens on the start/end of the slur, make sure that there is enough place for proper slur to
         // be drawn. If intersection is too large, cross-staff slurs should not be drawn with adjusted angles to avoid
         // extreme cases

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -262,7 +262,7 @@ bool System::HasMixedDrawingStemDir(LayerElement *start, LayerElement *end)
     return false;
 }
 
-curvature_CURVEDIR System::GetPreferredCurveDirection(LayerElement *start, LayerElement *end, Slur* slur) 
+curvature_CURVEDIR System::GetPreferredCurveDirection(LayerElement *start, LayerElement *end, Slur *slur)
 {
     FindSpannedLayerElementsParams findSpannedLayerElementsParams(slur, slur);
     findSpannedLayerElementsParams.m_minPos = start->GetDrawingX();

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -272,8 +272,10 @@ int Tuplet::PrepareLayerElementParts(FunctorParams *functorParams)
             beamed = true;
         }
     }
-    // Is a beam the only child? (will not work with editorial elements)
-    if ((this->GetChildCount() == 1) && (this->GetChildCount(BEAM) == 1)) beamed = true;
+    // Is a beam or bTrem the only child? (will not work with editorial elements)
+    if (this->GetChildCount() == 1) {
+        if ((this->GetChildCount(BEAM) == 1) || (this->GetChildCount(BTREM) == 1)) beamed = true;
+    }
 
     if ((!this->HasBracketVisible() && !beamed) || (this->GetBracketVisible() == BOOLEAN_true)) {
         if (!currentBracket) {

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -180,7 +180,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
         // situations
         if (system->HasMixedDrawingStemDir(start, end)) {
             auto curveDir = system->GetPreferredCurveDirection(start, end, slur);
-            slur->SetDrawingCurvedir(curveDir != curvature_CURVEDIR_NONE? curveDir : curvature_CURVEDIR_above);
+            slur->SetDrawingCurvedir(curveDir != curvature_CURVEDIR_NONE ? curveDir : curvature_CURVEDIR_above);
         }
     }
 
@@ -562,7 +562,7 @@ float View::CalcInitialSlur(
     Staff *startStaff = slur->GetStart()->m_crossStaff ? slur->GetStart()->m_crossStaff
                                                        : vrv_cast<Staff *>(slur->GetStart()->GetFirstAncestor(STAFF));
     Staff *endStaff = slur->GetEnd()->m_crossStaff ? slur->GetEnd()->m_crossStaff
-                                                     : vrv_cast<Staff *>(slur->GetEnd()->GetFirstAncestor(STAFF));
+                                                   : vrv_cast<Staff *>(slur->GetEnd()->GetFirstAncestor(STAFF));
     if (startStaff && (startStaff != staff)) {
         staffNumbers.emplace(startStaff->GetN());
     }

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -97,9 +97,6 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
         return;
     }
 
-    // do not draw brackets on tremolos
-    if (tuplet->GetChildCount(BTREM)) return;
-
     data_STAFFREL_basic position = tuplet->GetDrawingBracketPos();
     const int lineWidth
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();


### PR DESCRIPTION
Previous solution didn't take groups of `bTrem` into account. Now everything is handled in one place.