### PR TITLE
Fix for rare beam crash

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1421,7 +1421,7 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
     AdjustBeamParams *params = vrv_params_cast<AdjustBeamParams *>(functorParams);
     assert(params);
 
-    if (this->HasSameas() || !this->GetChildCount()) {
+    if (this->HasSameas() || !this->GetChildCount() || m_beamSegment.m_beamElementCoordRefs.empty()) {
         return FUNCTOR_CONTINUE;
     }
 


### PR DESCRIPTION
- changed code to adjust beams only if there are element coord references present. In rare cases with beams this could lead to a crash