### PR TITLE
Improve tuplet number positioning with angled beams

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -575,6 +575,7 @@ public:
     {
         m_tupletNum = tupletNum;
         m_drawingNumPos = STAFFREL_basic_NONE;
+        m_horizontalMargin = 0;
         m_verticalMargin = 0;
         m_ignoreCrossStaff = false;
         m_yRel = 0;
@@ -582,6 +583,7 @@ public:
 
     TupletNum *m_tupletNum;
     data_STAFFREL_basic m_drawingNumPos;
+    int m_horizontalMargin;
     int m_verticalMargin;
     bool m_ignoreCrossStaff;
     int m_yRel;

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -55,7 +55,7 @@ public:
     /**
      * Adjust tuplet relative positioning based on possible overlaps
      */
-    void AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int staffHeight);
+    void AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int staffSize);
 
     /**
      * @name Setter and getter for darwing elements and position

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -53,6 +53,11 @@ public:
     virtual void AddChild(Object *object);
 
     /**
+     * Adjust tuplet relative positioning based on possible overlaps
+     */
+    void AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int staffHeight);
+
+    /**
      * @name Setter and getter for darwing elements and position
      */
     ///@{

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -361,6 +361,11 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 }
                 return true;
             }
+            else if (m_object->Is(DYNAM) && horizOverlapingBBox->Is(BEAM)) {
+                // Try to avoid comparing with BEAM BB since it might be much larger overlap while having a lot of
+                // whitespace. For such cases, DYNAM should be compared to individual elements of BEAM instead
+                return true;
+            }
             yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + GetContentY1() - margin;
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
             // With LayerElement always move them up

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1692,7 +1692,7 @@ int LayerElement::AdjustTupletNumOverlap(FunctorParams *functorParams)
 
     if (params->m_ignoreCrossStaff && Is({ CHORD, NOTE, REST }) && m_crossStaff) return FUNCTOR_SIBLINGS;
 
-    if (!params->m_tupletNum->HorizontalSelfOverlap(this)
+    if (!params->m_tupletNum->HorizontalSelfOverlap(this, params->m_horizontalMargin)
         && !params->m_tupletNum->VerticalSelfOverlap(this, params->m_verticalMargin)) {
         return FUNCTOR_CONTINUE;
     }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -169,6 +169,18 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
     this->Process(&adjustTupletNumOverlap, &adjustTupletNumOverlapParams);
     int yRel = adjustTupletNumOverlapParams.m_yRel - yReference + numVerticalMargin;
 
+    // If yRel turns out to be too far from the tuplet - try to adjust it accordingly, aligning with the staff
+    // top/bottom sides, unless doing so will make tuplet number overlap
+    const int relevenatPosition = (m_drawingNumPos == STAFFREL_basic_above) ? GetContentTop() : GetContentBottom();
+    const int adjustedPosition
+        = (m_drawingNumPos == STAFFREL_basic_above) ? yReference : yReference - staffHeight;
+    if (((m_drawingNumPos == STAFFREL_basic_above) && (yRel > relevenatPosition)
+            && (adjustedPosition > relevenatPosition))
+        || ((m_drawingNumPos == STAFFREL_basic_below) && (yRel < relevenatPosition)
+            && (adjustedPosition < relevenatPosition))) {
+        yRel = adjustedPosition;
+    }
+
     // If we have a beam, see if we can move it to more appropriate postion
     Beam *beam = this->GetNumAlignedBeam();
     if (beam && !m_crossStaff) {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -177,7 +177,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
     this->Process(&adjustTupletNumOverlap, &adjustTupletNumOverlapParams);
     int yRel = adjustTupletNumOverlapParams.m_yRel - yReference;
 
-    // If we have a beam, see if we can move it to more appropriate postion
+    // If we have a beam, see if we can move it to more appropriate position
     if (beam && !m_crossStaff) {
         const int xMid = tupletNum->GetDrawingXMid(doc);
         const int yMid = beam->m_beamSegment.m_startingY

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -169,7 +169,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
 
     // Calculate relative Y for the tupletNum
     AdjustTupletNumOverlapParams adjustTupletNumOverlapParams(tupletNum);
-    adjustTupletNumOverlapParams.m_horizontalMargin = doc->GetDrawingUnit(staffSize);
+    adjustTupletNumOverlapParams.m_horizontalMargin = 2 * doc->GetDrawingUnit(staffSize);
     adjustTupletNumOverlapParams.m_drawingNumPos = m_drawingNumPos;
     adjustTupletNumOverlapParams.m_yRel = tupletNum->GetDrawingY();
     adjustTupletNumOverlapParams.m_ignoreCrossStaff = (descendants.end() != it);
@@ -178,7 +178,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
     int yRel = adjustTupletNumOverlapParams.m_yRel - yReference;
 
     // If we have a beam, see if we can move it to more appropriate position
-    if (beam && !m_crossStaff) {
+    if (beam && !m_crossStaff && !FindDescendantByType(ARTIC)) {
         const int xMid = tupletNum->GetDrawingXMid(doc);
         const int yMid = beam->m_beamSegment.m_startingY
             + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -136,6 +136,55 @@ void Tuplet::AddChild(Object *child)
     Modify();
 }
 
+void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int staffHeight)
+{
+    TupletNum *tupletNum = dynamic_cast<TupletNum *>(FindDescendantByType(TUPLET_NUM));
+    if (!tupletNum || (GetNumVisible() == BOOLEAN_false)) return;
+    // The num is within a bracket
+    if (tupletNum->GetAlignedBracket()) {
+        // yRel is not used for drawing but we need to adjust it for the bounding box to follow the changes
+        tupletNum->SetDrawingYRel(tupletNum->GetAlignedBracket()->GetDrawingYRel());
+        return;
+    }
+
+    // The num is on its own
+    const int numVerticalMargin = (m_drawingNumPos == STAFFREL_basic_above) ? verticalMargin : -verticalMargin;
+    // Find if there is a mix of cross-staff and non-cross-staff elements in the tuplet
+    ListOfObjects descendants;
+    ClassIdsComparison comparison({ CHORD, NOTE, REST });
+    this->FindAllDescendantByComparison(&descendants, &comparison);
+
+    auto it = std::find_if(descendants.begin(), descendants.end(), [](Object *object) {
+        LayerElement *element = vrv_cast<LayerElement *>(object);
+        if (!element) return false;
+        return !element->m_crossStaff;
+    });
+
+    // Calculate relative Y for the tupletNum
+    AdjustTupletNumOverlapParams adjustTupletNumOverlapParams(tupletNum);
+    adjustTupletNumOverlapParams.m_drawingNumPos = m_drawingNumPos;
+    adjustTupletNumOverlapParams.m_yRel = tupletNum->GetDrawingY();
+    adjustTupletNumOverlapParams.m_ignoreCrossStaff = (descendants.end() != it);
+    Functor adjustTupletNumOverlap(&Object::AdjustTupletNumOverlap);
+    this->Process(&adjustTupletNumOverlap, &adjustTupletNumOverlapParams);
+    int yRel = adjustTupletNumOverlapParams.m_yRel - yReference + numVerticalMargin;
+
+    // If we have a beam, see if we can move it to more appropriate postion
+    Beam *beam = this->GetNumAlignedBeam();
+    if (beam && !m_crossStaff) {
+        const int xMid = tupletNum->GetDrawingXMid(doc);
+        const int yMid = beam->m_beamSegment.m_startingY
+            + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);
+        int beamYRel = yMid - yReference + numVerticalMargin;
+        if (((m_drawingNumPos == STAFFREL_basic_above) && (beamYRel > yReference))
+            || ((m_drawingNumPos == STAFFREL_basic_below) && (beamYRel < yReference - staffHeight))) {
+            yRel = beamYRel;
+        }
+    }
+
+    tupletNum->SetDrawingYRel(yRel);
+}
+
 void Tuplet::FilterList(ArrayOfObjects *childList)
 {
     // We want to keep only notes and rests
@@ -427,8 +476,7 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
 
     assert(m_drawingBracketPos != STAFFREL_basic_NONE);
 
-    int verticalLine = params->m_doc->GetDrawingUnit(staffSize);
-    int verticalMargin = 2 * verticalLine;
+    const int verticalMargin = params->m_doc->GetDrawingDoubleUnit(staffSize);
     const int yReference = m_crossStaff ? m_crossStaff->GetDrawingY() : staff->GetDrawingY();
 
     TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
@@ -504,60 +552,7 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
         }
     }
 
-    TupletNum *tupletNum = dynamic_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM));
-    if (tupletNum && (this->GetNumVisible() != BOOLEAN_false)) {
-        // The num is within a bracket
-        if (tupletNum->GetAlignedBracket()) {
-            // yRel is not used for drawing but we need to adjust it for the bounding box to follow the changes
-            tupletNum->SetDrawingYRel(tupletNum->GetAlignedBracket()->GetDrawingYRel());
-        }
-        // The num is on its own
-        else {
-            int numVerticalMargin = verticalMargin;
-            numVerticalMargin *= (m_drawingNumPos == STAFFREL_basic_above) ? 1 : -1;
-
-            Beam *beam = this->GetNumAlignedBeam();
-            // If we have a beam first move it to the appropriate postion
-            if (beam) {
-
-                int xMid = tupletNum->GetDrawingXMid(params->m_doc);
-                int yMid = beam->m_beamSegment.m_startingY
-                    + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);
-                int yMidRel = yMid - yReference;
-
-                tupletNum->SetDrawingYRel(tupletNum->GetDrawingYRel() + yMidRel);
-            }
-            else {
-                int yRel = (m_drawingBracketPos == STAFFREL_basic_above)
-                    ? 0
-                    : -params->m_doc->GetDrawingStaffSize(staffSize);
-                tupletNum->SetDrawingYRel(yRel);
-            }
-
-            // Find if there is a mix of cross-staff and non-cross-staff elements in the tuplet
-            ListOfObjects descendants;
-            ClassIdsComparison comparison({ CHORD, NOTE, REST });
-            this->FindAllDescendantByComparison(&descendants, &comparison);
-
-            auto it = std::find_if(descendants.begin(), descendants.end(), [](Object *object) {
-                LayerElement *element = vrv_cast<LayerElement *>(object);
-                if (!element) return false;
-                return !element->m_crossStaff;
-            });
-
-            // Calculate relative Y for the tupletNum
-            AdjustTupletNumOverlapParams adjustTupletNumOverlapParams(tupletNum);
-            adjustTupletNumOverlapParams.m_drawingNumPos = m_drawingNumPos;
-            adjustTupletNumOverlapParams.m_ignoreCrossStaff = false;
-            adjustTupletNumOverlapParams.m_yRel = tupletNum->GetDrawingY();
-            adjustTupletNumOverlapParams.m_ignoreCrossStaff = (descendants.end() != it);
-            Functor adjustTupletNumOverlap(&Object::AdjustTupletNumOverlap);
-            this->Process(&adjustTupletNumOverlap, &adjustTupletNumOverlapParams);
-
-            const int yRel = adjustTupletNumOverlapParams.m_yRel - yReference;
-            tupletNum->SetDrawingYRel(yRel + numVerticalMargin);
-        }
-    }
+    AdjustTupletNumY(params->m_doc, verticalMargin, yReference, params->m_doc->GetDrawingStaffSize(staffSize));
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -172,8 +172,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
     // If yRel turns out to be too far from the tuplet - try to adjust it accordingly, aligning with the staff
     // top/bottom sides, unless doing so will make tuplet number overlap
     const int relevenatPosition = (m_drawingNumPos == STAFFREL_basic_above) ? GetContentTop() : GetContentBottom();
-    const int adjustedPosition
-        = (m_drawingNumPos == STAFFREL_basic_above) ? yReference : yReference - staffHeight;
+    const int adjustedPosition = (m_drawingNumPos == STAFFREL_basic_above) ? 0 : -staffHeight;
     if (((m_drawingNumPos == STAFFREL_basic_above) && (yRel > relevenatPosition)
             && (adjustedPosition > relevenatPosition))
         || ((m_drawingNumPos == STAFFREL_basic_below) && (yRel < relevenatPosition)
@@ -187,9 +186,9 @@ void Tuplet::AdjustTupletNumY(Doc *doc, int verticalMargin, int yReference, int 
         const int xMid = tupletNum->GetDrawingXMid(doc);
         const int yMid = beam->m_beamSegment.m_startingY
             + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.m_startingX);
-        int beamYRel = yMid - yReference + numVerticalMargin;
-        if (((m_drawingNumPos == STAFFREL_basic_above) && (beamYRel > yReference))
-            || ((m_drawingNumPos == STAFFREL_basic_below) && (beamYRel < yReference - staffHeight))) {
+        const int beamYRel = yMid - yReference + numVerticalMargin;
+        if (((m_drawingNumPos == STAFFREL_basic_above) && (beamYRel > 0))
+            || ((m_drawingNumPos == STAFFREL_basic_below) && (beamYRel < -staffHeight))) {
             yRel = beamYRel;
         }
     }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -664,8 +664,9 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         auto end = overflowBoxes->end();
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally
-            const int margin
-                = (*iter)->GetObject()->Is(DYNAM) ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
+            const int margin = (*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM)
+                ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
+                : 0;
             i = std::find_if(
                 i, end, [iter, margin](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem, margin); });
             if (i != end) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -664,7 +664,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         auto end = overflowBoxes->end();
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally
-            const int margin = (*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM)
+            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
                 ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
                 : 0;
             i = std::find_if(

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -664,7 +664,10 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         auto end = overflowBoxes->end();
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally
-            i = std::find_if(i, end, [iter](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem); });
+            const int margin
+                = (*iter)->GetObject()->Is(DYNAM) ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
+            i = std::find_if(
+                i, end, [iter, margin](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem, margin); });
             if (i != end) {
                 // update the yRel accordingly
                 (*iter)->CalcDrawingYRel(params->m_doc, this, *i);


### PR DESCRIPTION
Adjusted positioning for the tuplet numbers, so that they are placed closer to the beams, instead of putting them at the highest position of the beam. Adjusted positioning for the dynamics in the similar fashion.

Previous rendering:
![image](https://user-images.githubusercontent.com/1819669/124565994-4c5cdd80-de4b-11eb-815a-b9d5828d3486.png)

New rendering:
![image](https://user-images.githubusercontent.com/1819669/124566026-554daf00-de4b-11eb-87fe-727d369db6ed.png)

<details><summary>MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2021-05-04" type="encoding-date">2021-05-04</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000000000012087">
         <appInfo xml:id="appinfo-0000000000027307">
            <application xml:id="application-0000000000005034" isodate="2021-06-09T17:58:28" version="3.5.0-dev-[undefined]">
               <name xml:id="name-0000000000014984">Verovio</name>
               <p xml:id="p-0000000000001165">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000000015890">
            <score xml:id="score-0000000000004211">
               <scoreDef xml:id="scoredef-0000000000007233">
                  <staffGrp xml:id="staffgrp-0000000000017405">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="24">
                        <label xml:id="label-0000000000031254">Piano</label>
                        <labelAbbr xml:id="labelAbbr-0000000000006313">Pno.</labelAbbr>
                        <instrDef xml:id="instrdef-0000000000019550" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="clef-0000000000015451" shape="F" line="4" />
                        <keySig xml:id="keysig-0000000000023074" sig="5f" />
                        <meterSig xml:id="msig-0000000000022983" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000000002931">
                  <pb xml:id="pb-0000000000014139" />
                  <measure xml:id="measure-64-mdiv-1" n="3">
                     <staff xml:id="staff-0000000000021565" n="1">
                        <layer xml:id="layer-0000000000004401" n="1">
                           <beam xml:id="beam-0000000000005294">
                              <tuplet xml:id="tuplet-0000000000025435" num="6" numbase="4" num.format="count">
                                 <note xml:id="note-0101-10110-12720-1" dur.ppq="4" dur="16" oct="2" pname="e" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10160-12680-1" dur.ppq="4" dur="16" oct="2" pname="b" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10200-12650-1" dur.ppq="4" dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10250-12630-1" dur.ppq="4" dur="16" oct="3" pname="b" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10290-12610-1" dur.ppq="4" dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10340-12580-1" dur.ppq="4" dur="16" oct="4" pname="a" stem.dir="up" accid.ges="f" />
                              </tuplet>
                           </beam>
                           <note xml:id="note-0101-10380-12560-1" dur.ppq="24" dur="4" oct="4" pname="g" stem.dir="up" accid.ges="f">
                              <artic xml:id="artic-0000000000007299" artic="ten" place="above" />
                           </note>
                           <beam xml:id="beam-0000000000020044">
                              <tuplet xml:id="tuplet-0000000000024937" num="6" numbase="4" num.format="count">
                                 <note xml:id="note-0101-10560-12760-1" dur.ppq="4" dur="16" oct="1" pname="a" stem.dir="up" accid.ges="f">
                                    <artic xml:id="artic-0000000000007005" artic="acc" place="below" />
                                 </note>
                                 <note xml:id="note-0101-10610-12690-1" dur.ppq="4" dur="16" oct="2" pname="a" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10650-12650-1" dur.ppq="4" dur="16" oct="3" pname="e" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10700-12620-1" dur.ppq="4" dur="16" oct="3" pname="a" stem.dir="up" accid.ges="f" />
                                 <note xml:id="note-0101-10740-12600-1" dur.ppq="4" dur="16" oct="4" pname="c" stem.dir="up" />
                                 <note xml:id="note-0101-10780-12580-1" dur.ppq="4" dur="16" oct="4" pname="e" stem.dir="up" accid.ges="f" />
                              </tuplet>
                           </beam>
                           <clef xml:id="clef-49" shape="F" line="4" />
                           <beam xml:id="beam-0000000000021707">
                              <note xml:id="note-0101-10850-12680-1" dur.ppq="12" dur="8" oct="4" pname="g" stem.dir="up" accid.ges="f" />
                              <note xml:id="note-0101-10940-12670-1" dur.ppq="12" dur="8" oct="4" pname="a" stem.dir="up" accid.ges="f" />
                           </beam>
                        </layer>
                     </staff>
                     <dynam place="above" staff="1" tstamp="1.25000">f</dynam>
                     <dynam place="above" staff="1" tstamp="1.75000">f</dynam>
                  </measure>
                  <measure xml:id="measure-11-mdiv-1" n="4">
                     <staff xml:id="staff-0000000000018732" n="1">
                        <layer xml:id="layer-0000000000005998" n="1">
                           <beam xml:id="beam-0000000000031164">
                              <tuplet xml:id="tuplet-0000000000027153" num="6" numbase="4" num.format="count" num.place="below">
                                 <note xml:id="note-0097-10670-11870-2" dur.ppq="4" dur="16" oct="2" pname="a" stem.dir="up">
                                    <accid xml:id="accid-0000000000015420" accid="n" accid.ges="n" />
                                 </note>
                                 <note xml:id="note-0097-10730-11860-2" dur.ppq="4" dur="16" oct="2" pname="b" stem.dir="up">
                                    <accid xml:id="accid-0000000000002730" accid="n" accid.ges="n" />
                                 </note>
                                 <note xml:id="note-0097-10780-11840-2" dur.ppq="4" dur="16" oct="3" pname="c" stem.dir="up">
                                    <accid xml:id="accid-0000000000001257" accid="n" accid.ges="n" />
                                 </note>
                                 <note xml:id="note-0097-10490-11960-2" dur.ppq="4" dur="16" oct="3" pname="d" stem.dir="up">
                                    <accid xml:id="accid-0000000000024876" accid="n" accid.ges="n" />
                                 </note>
                                 <note xml:id="note-0097-10550-11920-2" dur.ppq="4" dur="16" oct="3" pname="e" stem.dir="up">
                                    <accid xml:id="accid-0000000000021813" accid="n" accid.ges="n" />
                                 </note>
                                 <note xml:id="note-0097-10610-11890-2" dur.ppq="4" dur="16" oct="3" pname="f" stem.dir="up">
                                    <accid xml:id="accid-0000000000021375" accid="n" accid.ges="n" />
                                 </note>
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000000000014726">
                              <note xml:id="note-0097-10830-11840-2" dots="1" dur.ppq="9" dur="16" oct="4" pname="f" stem.dir="down" />
                              <note xml:id="note-0097-10910-11820-2" dur.ppq="3" dur="32" oct="4" pname="g" stem.dir="down">
                                 <accid xml:id="accid-0000000000017230" accid="n" accid.ges="n" />
                              </note>
                              <note xml:id="note-0097-10940-11840-2" dur.ppq="12" dur="8" oct="4" pname="f" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000000000004557">
                              <tuplet xml:id="tuplet-0000000000019387" num="6" numbase="4" num.format="count">
                                 <note xml:id="note-0097-11010-11960-2" dur.ppq="4" dur="16" oct="2" pname="g" stem.dir="down" accid.ges="n" />
                                 <note xml:id="note-0097-11050-11920-2" dur.ppq="4" dur="16" oct="3" pname="d" stem.dir="down" accid.ges="n" />
                                 <note xml:id="note-0097-11090-11890-2" dur.ppq="4" dur="16" oct="3" pname="g" stem.dir="down" accid.ges="n" />
                                 <note xml:id="note-0097-11130-11870-2" dur.ppq="4" dur="16" oct="3" pname="b" stem.dir="down" accid.ges="n" />
                                 <note xml:id="note-0097-11170-11860-2" dur.ppq="4" dur="16" oct="4" pname="d" stem.dir="down" accid.ges="n" />
                                 <note xml:id="note-0097-11210-11850-2" dur.ppq="4" dur="16" oct="4" pname="e" stem.dir="down" accid.ges="n" />
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000000000000995">
                              <note xml:id="note-0097-11250-11840-2" dur.ppq="6" dur="16" oct="4" pname="f" stem.dir="down" />
                              <note xml:id="note-0097-11330-11830-2" dur.ppq="6" dur="16" oct="4" pname="g" stem.dir="down" accid.ges="n" />
                              <note xml:id="note-0097-11390-11840-2" dur.ppq="12" dur="8" oct="4" pname="f" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <dynam xml:id="dynam-L21F3" place="below" staff="1" tstamp="3.750000">f</dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>