### PR TITLE
fix offset on timeSigPlus

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1017,7 +1017,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
             // draw plus sign here
             const int plusX = x + width;
             DrawSmuflCode(dc, plusX, y, SMUFL_E08C_timeSigPlus, staff->m_drawingStaffSize, false);
-            offset += width + 2 * m_doc->GetGlyphWidth(SMUFL_E262_accidentalSharp, staff->m_drawingStaffSize, false);
+            offset += width + m_doc->GetGlyphWidth(SMUFL_E08C_timeSigPlus, staff->m_drawingStaffSize, false);
         }
         else {
             offset += width + margin * 2;


### PR DESCRIPTION
This fixes a minor offset issue in `meterSigGrp` that happens with some fonts (e.g. Leland):

### before
![Leland](https://user-images.githubusercontent.com/7693447/124585781-f0e41d00-de55-11eb-9ded-77d2a05e05f9.png)
### after
![Leland-after](https://user-images.githubusercontent.com/7693447/124585780-efb2f000-de55-11eb-8578-a8c1c49b8627.png)