### PR TITLE
Adjust mNum position for bracket group symbol

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -207,7 +207,7 @@ protected:
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, ArrayOfLedgerLines *lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);
     void DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff);
-    void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure);
+    void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset);
     void DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
     void DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
     void DrawLayer(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -955,7 +955,15 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
             if ((mnumInterval == 0 && measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1")
                 || !mnum->IsGenerated()
                 || (mnumInterval >= 1 && (std::atoi(measure->GetN().c_str()) % mnumInterval == 0))) {
-                DrawMNum(dc, mnum, measure);
+                int symbolOffset = m_doc->GetDrawingUnit(100);
+                ScoreDef *scoreDef = system->GetDrawingScoreDef();
+                GrpSym *groupSymbol = vrv_cast<GrpSym *>(scoreDef->FindDescendantByType(GRPSYM));
+                if (groupSymbol && (groupSymbol->GetSymbol() == staffGroupingSym_SYMBOL_bracket)) {
+                    symbolOffset += m_doc->GetGlyphHeight(SMUFL_E003_bracketTop, 100, false);                  
+                }
+                // hardcoded offset for the mNum based on the lyric font size
+                const int yOffset = m_doc->GetDrawingLyricFont(60)->GetPointSize();
+                DrawMNum(dc, mnum, measure, std::max(symbolOffset, yOffset));
             }
         }
     }
@@ -1027,7 +1035,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     dc->EndGraphic(meterSigGrp, this);
 }
 
-void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure)
+void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset)
 {
     assert(dc);
     assert(measure);
@@ -1053,7 +1061,7 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure)
         // HARDCODED
         // we set mNum to a fixed height above the system and make it a bit smaller than other text
         params.m_x = staff->GetDrawingX();
-        params.m_y = staff->GetDrawingY() + m_doc->GetDrawingLyricFont(60)->GetPointSize();
+        params.m_y = staff->GetDrawingY() + yOffset;
         if (mnum->HasFontsize()) {
             data_FONTSIZE *fs = mnum->GetFontsizeAlternate();
             if (fs->GetType() == FONTSIZE_fontSizeNumeric) {


### PR DESCRIPTION
- added code to adjust position of the mNum so that it doesn't overlap with bracket group symbol for 2+ figure numbers

Before:
![image](https://user-images.githubusercontent.com/1819669/124881097-a2f72280-dfd7-11eb-9232-741809741ff2.png)

After:
![image](https://user-images.githubusercontent.com/1819669/124881357-e94c8180-dfd7-11eb-921e-a161f8e552e0.png)