### PR TITLE
Implement support for <lv> element

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -1228,6 +1228,12 @@
 		BDEF9ECA26725234008A3A47 /* caesura.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDEF9EC626725234008A3A47 /* caesura.cpp */; };
 		BDEF9ECC26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
 		BDEF9ECD26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
+		E79C87C3269440570098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
+		E79C87C4269440790098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
+		E79C87C52694407A0098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
+		E79C87C62694407B0098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
+		E79C87C7269440800098FE85 /* lv.h in Headers */ = {isa = PBXBuildFile; fileRef = E79C87C1269440420098FE85 /* lv.h */; };
+		E79C87C8269440810098FE85 /* lv.h in Headers */ = {isa = PBXBuildFile; fileRef = E79C87C1269440420098FE85 /* lv.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1683,6 +1689,8 @@
 		BDC366C62576AF9300E4D826 /* grpsym.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = grpsym.h; path = include/vrv/grpsym.h; sourceTree = "<group>"; };
 		BDEF9EC626725234008A3A47 /* caesura.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = caesura.cpp; path = src/caesura.cpp; sourceTree = "<group>"; };
 		BDEF9ECB26725248008A3A47 /* caesura.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = caesura.h; path = include/vrv/caesura.h; sourceTree = "<group>"; };
+		E79C87C1269440420098FE85 /* lv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lv.h; path = include/vrv/lv.h; sourceTree = "<group>"; };
+		E79C87C2269440570098FE85 /* lv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lv.cpp; path = src/lv.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2267,8 +2275,6 @@
 				8F59291218854BF800FE51AD /* clef.h */,
 				4DC34BA619BC4A83006175CD /* custos.cpp */,
 				4DC34BA019BC4A70006175CD /* custos.h */,
-				4D674B45255F40B7008AEF4C /* plica.cpp */,
-				4D674B3E255F40AC008AEF4C /* plica.h */,
 				4DC34BA719BC4A83006175CD /* dot.cpp */,
 				4DC34BA119BC4A70006175CD /* dot.h */,
 				4DEEDE631E617C930087E8BC /* elementpart.cpp */,
@@ -2287,6 +2293,8 @@
 				8F59291E18854BF800FE51AD /* layerelement.h */,
 				152886C41C9CA86100B515BB /* ligature.cpp */,
 				152886C11C9CA2E000B515BB /* ligature.h */,
+				E79C87C2269440570098FE85 /* lv.cpp */,
+				E79C87C1269440420098FE85 /* lv.h */,
 				8F086ECA188539540037FD8E /* mensur.cpp */,
 				8F59292118854BF800FE51AD /* mensur.h */,
 				4D763EC51987D04D003FCAB5 /* metersig.cpp */,
@@ -2311,6 +2319,8 @@
 				4D766EF420ACAD41006875D8 /* neume.h */,
 				8F086ECC188539540037FD8E /* note.cpp */,
 				8F59292318854BF800FE51AD /* note.h */,
+				4D674B45255F40B7008AEF4C /* plica.cpp */,
+				4D674B3E255F40AC008AEF4C /* plica.h */,
 				1579B3421B15033100B16F5C /* proport.cpp */,
 				1579B3411B15031D00B16F5C /* proport.h */,
 				8F086ED1188539540037FD8E /* rest.cpp */,
@@ -2443,6 +2453,7 @@
 				4DB3D8AF1F83D05100B5FC2B /* atts_midi.h in Headers */,
 				4DA1448D1C2AB29400CB7CEE /* textelement.h in Headers */,
 				4DB787662022F0BF00394520 /* jsonxx.h in Headers */,
+				E79C87C7269440800098FE85 /* lv.h in Headers */,
 				8F59294918854BF800FE51AD /* multirest.h in Headers */,
 				8F59294A18854BF800FE51AD /* note.h in Headers */,
 				8F59294B18854BF800FE51AD /* object.h in Headers */,
@@ -2771,6 +2782,7 @@
 				BB4C4A6322A9321F001F6AF0 /* atts_cmn.h in Headers */,
 				BBC19FBF22B37CA000100F42 /* all.h in Headers */,
 				4DA0EAE222BB77AF00A7EBEB /* editortoolkit_mensural.h in Headers */,
+				E79C87C8269440810098FE85 /* lv.h in Headers */,
 				BB4C4B5822A932D7001F6AF0 /* layerelement.h in Headers */,
 				BB4C4A7722A9321F001F6AF0 /* atts_gestural.h in Headers */,
 				BB4C4B9422A932E5001F6AF0 /* areaposinterface.h in Headers */,
@@ -3012,6 +3024,7 @@
 				4D94722020CA702C00C780C8 /* linkinginterface.cpp in Sources */,
 				4DEC4DAB21C81EEC00D1D273 /* restore.cpp in Sources */,
 				4D766EFE20ACAD6D006875D8 /* nc.cpp in Sources */,
+				E79C87C4269440790098FE85 /* lv.cpp in Sources */,
 				4D72A5DE208A37D5009DEC1E /* mrpt2.cpp in Sources */,
 				4DA0EAF722BB78E100A7EBEB /* atts_facsimile.cpp in Sources */,
 				4DEC4D9321C81E0B00D1D273 /* del.cpp in Sources */,
@@ -3278,6 +3291,7 @@
 				8F086F09188539540037FD8E /* view_graph.cpp in Sources */,
 				4DA0EAF622BB78E100A7EBEB /* atts_facsimile.cpp in Sources */,
 				8F086F0A188539540037FD8E /* view_page.cpp in Sources */,
+				E79C87C3269440570098FE85 /* lv.cpp in Sources */,
 				4DEC4DA621C81ED400D1D273 /* reg.cpp in Sources */,
 				8F086F0B188539540037FD8E /* view_tuplet.cpp in Sources */,
 				4D4C26ED1EF7E75400681770 /* label.cpp in Sources */,
@@ -3429,6 +3443,7 @@
 				8F3DD34C18854B2E0051330C /* note.cpp in Sources */,
 				4D20740C22A4FDFA00E0765F /* course.cpp in Sources */,
 				4DB3D8A91F828EA900B5FC2B /* areaposinterface.cpp in Sources */,
+				E79C87C52694407A0098FE85 /* lv.cpp in Sources */,
 				4DB3D8FD1F83D1FD00B5FC2B /* horizontalaligner.cpp in Sources */,
 				4D8CD8A71B4E927300F0756F /* atts_critapp.cpp in Sources */,
 				403BEFF2206C00D700D022D5 /* mrpt2.cpp in Sources */,
@@ -3638,6 +3653,7 @@
 				BB4C4BAB22A932EB001F6AF0 /* view_beam.cpp in Sources */,
 				BB4C4B0322A932C3001F6AF0 /* runningelement.cpp in Sources */,
 				BB4C4A9022A9328F001F6AF0 /* boundingbox.cpp in Sources */,
+				E79C87C62694407B0098FE85 /* lv.cpp in Sources */,
 				BB4C4AD322A932B6001F6AF0 /* staffdef.cpp in Sources */,
 				BB4C4B6722A932D7001F6AF0 /* multirpt.cpp in Sources */,
 				4DA0EAF922BB78E200A7EBEB /* atts_facsimile.cpp in Sources */,

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -78,6 +78,7 @@ class LayerElement;
 class Lb;
 class Lem;
 class Ligature;
+class Lv;
 class Mdiv;
 class Measure;
 class Mensur;
@@ -320,6 +321,7 @@ private:
     void WriteGliss(pugi::xml_node currentNode, Gliss *gliss);
     void WriteHairpin(pugi::xml_node currentNode, Hairpin *hairpin);
     void WriteHarm(pugi::xml_node currentNode, Harm *harm);
+    void WriteLv(pugi::xml_node currentNode, Lv *lv);
     void WriteMNum(pugi::xml_node currentNode, MNum *mnum);
     void WriteMordent(pugi::xml_node currentNode, Mordent *mordent);
     void WriteOctave(pugi::xml_node currentNode, Octave *octave);
@@ -586,6 +588,7 @@ private:
     bool ReadGliss(Object *parent, pugi::xml_node gliss);
     bool ReadHairpin(Object *parent, pugi::xml_node hairpin);
     bool ReadHarm(Object *parent, pugi::xml_node harm);
+    bool ReadLv(Object *parent, pugi::xml_node lv);
     bool ReadMNum(Object *parent, pugi::xml_node mnum);
     bool ReadMordent(Object *parent, pugi::xml_node mordent);
     bool ReadOctave(Object *parent, pugi::xml_node octave);

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -417,7 +417,7 @@ private:
     /* measure repeats */
     bool m_slash = false;
     /* MIDI ticks */
-    int m_ppq;
+    int m_ppq = 1;
     /* measure time */
     int m_durTotal = 0;
     /* measure time */

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -215,6 +215,7 @@ private:
     void ReadMusicXmlTupletStart(const pugi::xml_node &node, const pugi::xml_node &tupletStart, Layer *layer);
     void ReadMusicXmlBeamStart(const pugi::xml_node &node, const pugi::xml_node &beamStart, Layer *layer);
     void ReadMusicXMLMeterSig(const pugi::xml_node &node, Object *parent);
+    void ReadMusicXmlTies(const pugi::xml_node &node, Layer *layer, Note *note, const std::string &measureNum);
     ///@}
 
     /**

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -8,8 +8,7 @@
 #ifndef __VRV_LV_H__
 #define __VRV_LV_H__
 
-#include "controlelement.h"
-#include "timeinterface.h"
+#include "tie.h"
 
 namespace vrv {
 
@@ -20,11 +19,7 @@ namespace vrv {
 /**
  * This class models the MEI <lv> element.
  */
-class Lv : public ControlElement,
-           public TimeSpanningInterface,
-           public AttColor,
-           public AttCurvature,
-           public AttCurveRend {
+class Lv : public Tie {
 public:
     /**
      * @name Constructors, destructors, and other standard methods
@@ -39,13 +34,7 @@ public:
     virtual ClassId GetClassId() const { return LV; }
     ///@}
 
-    /**
-     * @name Getter to interfaces
-     */
-    ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return this; }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return this; }
-    ///@}
+    virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
 
     //----------//
     // Functors //

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -1,0 +1,63 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        lv.h
+// Author:      Andriy Makarchuk
+// Created:     1/07/2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_LV_H__
+#define __VRV_LV_H__
+
+#include "controlelement.h"
+#include "timeinterface.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Lv
+//----------------------------------------------------------------------------
+
+/**
+ * This class models the MEI <lv> element.
+ */
+class Lv : public ControlElement,
+           public TimeSpanningInterface,
+           public AttColor,
+           public AttCurvature,
+           public AttCurveRend {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method resets all attribute classes
+     */
+    ///@{
+    Lv();
+    virtual ~Lv();
+    virtual Object *Clone() const { return new Lv(*this); }
+    virtual void Reset();
+    virtual std::string GetClassName() const { return "Lv"; }
+    virtual ClassId GetClassId() const { return LV; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    virtual TimePointInterface *GetTimePointInterface() { return this; }
+    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return this; }
+    ///@}
+
+    //----------//
+    // Functors //
+    //----------//
+
+private:
+    //
+public:
+    //
+private:
+}; // lv
+
+} // namespace vrv
+
+#endif // __VRV_LV_H__

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -36,6 +36,7 @@ public:
      */
     ///@{
     Tie();
+    Tie(const std::string &classid);
     virtual ~Tie();
     virtual Object *Clone() const { return new Tie(*this); }
     virtual void Reset();
@@ -51,7 +52,7 @@ public:
     virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
-    bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
+    virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
 
     //----------//
     // Functors //
@@ -71,7 +72,7 @@ public:
 
 private:
     // Calculate initial position X position and return stem direction of the startNote
-    void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
+    virtual void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
         bool isOuterChordNote, Point &startPoint, Point &endPoint);
 
     // Helper function to get preferred curve direction based on the number of conditions (like note direction, position

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -72,7 +72,7 @@ public:
 
 private:
     // Calculate initial position X position and return stem direction of the startNote
-    virtual void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
+    void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
         bool isOuterChordNote, Point &startPoint, Point &endPoint);
 
     // Helper function to get preferred curve direction based on the number of conditions (like note direction, position

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -170,6 +170,7 @@ enum ClassId {
     GLISS,
     HAIRPIN,
     HARM,
+    LV,
     MORDENT,
     MNUM,
     OCTAVE,

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -513,7 +513,7 @@ int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int m
 {
     assert(curve);
     assert(curve->GetObject());
-    assert(curve->GetObject()->Is({ PHRASE, SLUR, TIE }));
+    assert(curve->GetObject()->Is({ LV, PHRASE, SLUR, TIE }));
 
     // for lisability
     Point points[4];

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -353,7 +353,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
 
         if (m_place == STAFFREL_above) {
-            if (curve && curve->m_object->Is({ PHRASE, SLUR, TIE })) {
+            if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
                 int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
@@ -373,7 +373,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             }
         }
         else {
-            if (curve && curve->m_object->Is({ PHRASE, SLUR, TIE })) {
+            if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
                 int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
@@ -409,7 +409,7 @@ int FloatingPositioner::GetSpaceBelow(Doc *doc, StaffAlignment *staffAlignment, 
     }
     int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
 
-    if (curve && curve->m_object->Is({ PHRASE, SLUR, TIE })) {
+    if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
         // For now ignore curves
         return 0;
     }
@@ -494,7 +494,7 @@ void FloatingCurvePositioner::MoveBackVertical(int distance)
 int FloatingCurvePositioner::CalcMinMaxY(const Point points[4])
 {
     assert(this->GetObject());
-    assert(this->GetObject()->Is({ PHRASE, SLUR, TIE }));
+    assert(this->GetObject()->Is({ LV, PHRASE, SLUR, TIE }));
     assert(m_dir != curvature_CURVEDIR_NONE);
 
     if (m_cachedMinMaxY != VRV_UNSET) return m_cachedMinMaxY;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -67,6 +67,7 @@
 #include "lb.h"
 #include "lem.h"
 #include "ligature.h"
+#include "lv.h"
 #include "mdiv.h"
 #include "measure.h"
 #include "mensur.h"
@@ -443,6 +444,10 @@ bool MEIOutput::WriteObject(Object *object)
     else if (object->Is(HARM)) {
         m_currentNode = m_currentNode.append_child("harm");
         WriteHarm(m_currentNode, dynamic_cast<Harm *>(object));
+    }
+    else if (object->Is(LV)) {
+        m_currentNode = m_currentNode.append_child("lv");
+        WriteLv(m_currentNode, dynamic_cast<Lv *>(object));
     }
     else if (object->Is(MNUM)) {
         m_currentNode = m_currentNode.append_child("mNum");
@@ -1375,6 +1380,17 @@ void MEIOutput::WriteHarm(pugi::xml_node currentNode, Harm *harm)
     WriteTimeSpanningInterface(currentNode, harm);
     harm->WriteLang(currentNode);
     harm->WriteNNumberLike(currentNode);
+}
+
+void MEIOutput::WriteLv(pugi::xml_node currentNode, Lv *lv)
+{
+    assert(lv);
+
+    WriteControlElement(currentNode, lv);
+    WriteTimeSpanningInterface(currentNode, lv);
+    lv->WriteColor(currentNode);
+    lv->WriteCurvature(currentNode);
+    lv->WriteCurveRend(currentNode);
 }
 
 void MEIOutput::WriteMNum(pugi::xml_node currentNode, MNum *mNum)
@@ -4216,6 +4232,9 @@ bool MEIInput::ReadMeasureChildren(Object *parent, pugi::xml_node parentNode)
         else if (std::string(current.name()) == "harm") {
             success = ReadHarm(parent, current);
         }
+        else if (std::string(current.name()) == "lv") {
+            success = ReadLv(parent, current);
+        }
         else if (std::string(current.name()) == "mNum") {
             success = ReadMNum(parent, current);
         }
@@ -4504,6 +4523,21 @@ bool MEIInput::ReadHarm(Object *parent, pugi::xml_node harm)
     parent->AddChild(vrvHarm);
     ReadUnsupportedAttr(harm, vrvHarm);
     return ReadTextChildren(vrvHarm, harm, vrvHarm);
+}
+
+bool MEIInput::ReadLv(Object* parent, pugi::xml_node lv) 
+{
+    Lv *vrvLv = new Lv();
+    ReadControlElement(lv, vrvLv);
+
+    ReadTimeSpanningInterface(lv, vrvLv);
+    vrvLv->ReadColor(lv);
+    vrvLv->ReadCurvature(lv);
+    vrvLv->ReadCurveRend(lv);
+
+    parent->AddChild(vrvLv);
+    ReadUnsupportedAttr(lv, vrvLv);
+    return true;
 }
 
 bool MEIInput::ReadMNum(Object *parent, pugi::xml_node mNum)

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -13,6 +13,8 @@
 
 //----------------------------------------------------------------------------
 
+#include "layerelement.h"
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
@@ -21,13 +23,8 @@ namespace vrv {
 
 static const ClassRegistrar<Lv> s_factory("lv", LV);
 
-Lv::Lv() : ControlElement("lv-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Lv::Lv() : Tie("lv-")
 {
-    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
-    RegisterAttClass(ATT_COLOR);
-    RegisterAttClass(ATT_CURVATURE);
-    RegisterAttClass(ATT_CURVEREND);
-
     Reset();
 }
 
@@ -35,16 +32,30 @@ Lv::~Lv() {}
 
 void Lv::Reset()
 {
-    ControlElement::Reset();
-    TimeSpanningInterface::Reset();
-    ResetColor();
-    ResetCurvature();
-    ResetCurveRend();
+    Tie::Reset();
+}
+
+bool Lv::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
+{
+    if (spanningType != SPANNING_START_END) {
+        //  this makes no sense
+        LogWarning("Lv across systems is not supported. Use <tie> iinstead.");
+        return false;
+    }
+
+    LayerElement *start = GetStart();
+    LayerElement *end = GetEnd();
+    if (start->GetFirstAncestor(MEASURE) != end->GetFirstAncestor(MEASURE)) {
+        //  this makes no sense
+        LogWarning("Lv across measures is not supported. Use <tie> instead.");
+        return false;
+    }
+
+    return Tie::CalculatePosition(doc, staff, x1, x2, spanningType, bezier);
 }
 
 //----------------------------------------------------------------------------
 // Lv functor methods
 //----------------------------------------------------------------------------
-
 
 } // namespace vrv

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -39,7 +39,7 @@ bool Lv::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningT
 {
     if (spanningType != SPANNING_START_END) {
         //  this makes no sense
-        LogWarning("Lv across systems is not supported. Use <tie> iinstead.");
+        LogWarning("Lv across systems is not supported. Use <tie> instead.");
         return false;
     }
 

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        lv.cpp
+// Author:      Andriy Makarchuk
+// Created:     01/07/2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "lv.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Lv
+//----------------------------------------------------------------------------
+
+static const ClassRegistrar<Lv> s_factory("lv", LV);
+
+Lv::Lv() : ControlElement("lv-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+{
+    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
+
+    Reset();
+}
+
+Lv::~Lv() {}
+
+void Lv::Reset()
+{
+    ControlElement::Reset();
+    TimeSpanningInterface::Reset();
+    ResetColor();
+    ResetCurvature();
+    ResetCurveRend();
+}
+
+//----------------------------------------------------------------------------
+// Lv functor methods
+//----------------------------------------------------------------------------
+
+
+} // namespace vrv

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -306,7 +306,7 @@ void System::AddToDrawingListIfNeccessary(Object *object)
 
     if (!object->HasInterface(INTERFACE_TIME_SPANNING)) return;
 
-    if (object->Is({ BRACKETSPAN, FIGURE, GLISS, HAIRPIN, OCTAVE, PHRASE, PITCHINFLECTION, SLUR, SYL, TIE })) {
+    if (object->Is({ BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION, SLUR, SYL, TIE })) {
         this->AddToDrawingList(object);
     }
     else if (object->Is(DIR)) {
@@ -768,6 +768,9 @@ int System::AdjustFloatingPositioners(FunctorParams *functorParams)
     Functor adjustFloatingPositionerGrps(&Object::AdjustFloatingPositionerGrps);
 
     params->m_classId = GLISS;
+    m_systemAligner.Process(params->m_functor, params);
+
+    params->m_classId = LV;
     m_systemAligner.Process(params->m_functor, params);
 
     params->m_classId = TIE;

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -42,6 +42,17 @@ Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCur
     Reset();
 }
 
+Tie::Tie(const std::string &classid)
+    : ControlElement(classid), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+{
+    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
+
+    Reset();
+}
+
 Tie::~Tie() {}
 
 void Tie::Reset()

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -469,7 +469,7 @@ void StaffAlignment::SetCurrentFloatingPositioner(
 {
     FloatingPositioner *positioner = this->GetCorrespFloatingPositioner(object);
     if (positioner == NULL) {
-        if (object->Is({ PHRASE, SLUR, TIE })) {
+        if (object->Is({ LV, PHRASE, SLUR, TIE })) {
             positioner = new FloatingCurvePositioner(object, this, spanningType);
             m_floatingPositioners.push_back(positioner);
         }
@@ -613,7 +613,8 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         if (!(*iter)->HasContentBB()) continue;
 
         // for slurs and ties we do not need to adjust them, only add them to the overflow boxes if required
-        if ((params->m_classId == PHRASE) || (params->m_classId == SLUR) || (params->m_classId == TIE)) {
+        if ((params->m_classId == LV) || (params->m_classId == PHRASE) || (params->m_classId == SLUR)
+            || (params->m_classId == TIE)) {
 
             assert((*iter)->Is(FLOATING_CURVE_POSITIONER));
             FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(*iter);
@@ -627,7 +628,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
                 assert(slur);
                 slur->GetCrossStaffOverflows(this, curve->GetDir(), skipAbove, skipBelow);
             }
-            else if ((*iter)->GetObject()->Is(TIE)) {
+            else if ((*iter)->GetObject()->Is({ LV, TIE })) {
                 Tie *tie = vrv_cast<Tie *>((*iter)->GetObject());
                 assert(tie);
                 tie->GetCrossStaffOverflows(this, curve->GetDir(), skipAbove, skipBelow);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -73,7 +73,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
     assert(element);
 
     // For dir, dynam, fermata, and harm, we do not consider the @tstamp2 for rendering
-    if (element->Is({ BRACKETSPAN, FIGURE, GLISS, HAIRPIN, OCTAVE, PHRASE, PITCHINFLECTION, SLUR, TIE })) {
+    if (element->Is({ BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION, SLUR, TIE })) {
         // create placeholder
         dc->StartGraphic(element, "", element->GetUuid());
         dc->EndGraphic(element, this);
@@ -311,13 +311,18 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
             // cast to Hairpin check in DrawHairpin
             DrawHairpin(dc, dynamic_cast<Hairpin *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
+        else if (element->Is(LV)) {
+            // For ties we limit support to one value in @staff
+            if (staffIter != staffList.begin()) continue;
+            // cast to Tie check in DrawTie
+            DrawTie(dc, dynamic_cast<Tie *>(element), x1, x2, *staffIter, spanningType, graphic);
+        }
         else if (element->Is(PHRASE)) {
             // For phrases (slurs) we limit support to one value in @staff
             if (staffIter != staffList.begin()) continue;
             // cast to Slur check in DrawSlur
             DrawSlur(dc, dynamic_cast<Slur *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
-
         else if (element->Is(OCTAVE)) {
             // cast to Slur check in DrawOctave
             DrawOctave(dc, dynamic_cast<Octave *>(element), x1, x2, *staffIter, spanningType, graphic);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -176,6 +176,7 @@ void View::DrawSystem(DeviceContext *dc, System *system)
     DrawSystemList(dc, system, HAIRPIN);
     DrawSystemList(dc, system, TRILL);
     DrawSystemList(dc, system, FIGURE);
+    DrawSystemList(dc, system, LV);
     DrawSystemList(dc, system, PHRASE);
     DrawSystemList(dc, system, OCTAVE);
     DrawSystemList(dc, system, PEDAL);
@@ -212,6 +213,9 @@ void View::DrawSystemList(DeviceContext *dc, System *system, const ClassId class
             DrawTimeSpanningElement(dc, *iter, system);
         }
         if ((*iter)->Is(classId) && (classId == HAIRPIN)) {
+            DrawTimeSpanningElement(dc, *iter, system);
+        }
+        if ((*iter)->Is(classId) && (classId == LV)) {
             DrawTimeSpanningElement(dc, *iter, system);
         }
         if ((*iter)->Is(classId) && (classId == PHRASE)) {


### PR DESCRIPTION
Added support for the MEI `<lv>` element, based on the `<tie>` rendering.
![image](https://user-images.githubusercontent.com/1819669/124911698-badd9f00-dff5-11eb-8614-6ee73601b3d9.png)
