### PR TITLE
Disconnected chord notes

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -204,6 +204,11 @@ public:
      */
     virtual int ResetDrawing(FunctorParams *functorParams);
 
+    /**
+     * See Object::JustifyY
+     */
+    virtual int JustifyY(FunctorParams *functorParams);
+
 protected:
     /**
      * The note locations w.r.t. each staff


### PR DESCRIPTION
This PR fixes disconnected chord notes appearing after vertical justification.

| Before | After |
| ------ | ----- |
| <img width="345" alt="Before" src="https://user-images.githubusercontent.com/63608463/125093274-6e1bc600-e0d2-11eb-8a4d-912e0304ea49.png"> | <img width="348" alt="After" src="https://user-images.githubusercontent.com/63608463/125093331-78d65b00-e0d2-11eb-9687-fc2bd72655d3.png"> |

Since this affects global page layout, I do not have a small example. The following text file contains musicxml, to reproduce the issue vertical justification must be enabled.

[Grieg.txt](https://github.com/rism-digital/verovio/files/6792029/Grieg.txt)
