### PR TITLE
Decimal Midi.BPM

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -220,7 +220,7 @@ public:
     bool ExportTimemap(std::string &output);
     void PrepareJsonTimemap(std::string &output, std::map<double, double> &realTimeToScoreTime,
         std::map<double, std::vector<std::string>> &realTimeToOnElements,
-        std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, int> &realTimeToTempo);
+        std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, double> &realTimeToTempo);
 
     /**
      * Set the initial scoreDef of each page.

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -987,14 +987,14 @@ public:
         m_currentMensur = NULL;
         m_currentMeterSig = NULL;
         m_notationType = NOTATIONTYPE_cmn;
-        m_currentTempo = 120;
+        m_currentTempo = 120.0;
     }
     double m_currentScoreTime;
     double m_currentRealTimeSeconds;
     Mensur *m_currentMensur;
     MeterSig *m_currentMeterSig;
     data_NOTATIONTYPE m_notationType;
-    int m_currentTempo;
+    double m_currentTempo;
 };
 
 //----------------------------------------------------------------------------
@@ -1475,7 +1475,7 @@ using MIDINoteSequence = std::list<MIDINote>;
  * member 1: int: the midi track number
  * member 3: double: the score time from the start of the music to the start of the current measure
  * member 4: int: the semi tone transposition for the current track
- * member 5: int with the current tempo
+ * member 5: double with the current tempo
  * member 6: expanded notes due to ornaments and tremolandi
  **/
 
@@ -1488,7 +1488,7 @@ public:
         m_midiTrack = 1;
         m_totalTime = 0.0;
         m_transSemi = 0;
-        m_currentTempo = 120;
+        m_currentTempo = 120.0;
         m_functor = functor;
     }
     smf::MidiFile *m_midiFile;
@@ -1496,7 +1496,7 @@ public:
     int m_midiTrack;
     double m_totalTime;
     int m_transSemi;
-    int m_currentTempo;
+    double m_currentTempo;
     std::map<Note *, MIDINoteSequence> m_expandedNotes;
     Functor *m_functor;
 };
@@ -1521,16 +1521,16 @@ public:
     {
         m_scoreTimeOffset = 0.0;
         m_realTimeOffsetMilliseconds = 0;
-        m_currentTempo = 120;
+        m_currentTempo = 120.0;
         m_functor = functor;
     }
     std::map<double, double> realTimeToScoreTime;
     std::map<double, std::vector<std::string>> realTimeToOnElements;
     std::map<double, std::vector<std::string>> realTimeToOffElements;
-    std::map<double, int> realTimeToTempo;
+    std::map<double, double> realTimeToTempo;
     double m_scoreTimeOffset;
     double m_realTimeOffsetMilliseconds;
-    int m_currentTempo;
+    double m_currentTempo;
     Functor *m_functor;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -954,14 +954,14 @@ public:
         m_currentRealTimeSeconds = 0.0;
         m_maxCurrentScoreTime = 0.0;
         m_maxCurrentRealTimeSeconds = 0.0;
-        m_currentTempo = 120;
+        m_currentTempo = 120.0;
         m_tempoAdjustment = 1.0;
     }
     double m_currentScoreTime;
     double m_currentRealTimeSeconds;
     double m_maxCurrentScoreTime;
     double m_maxCurrentRealTimeSeconds;
-    int m_currentTempo;
+    double m_currentTempo;
     double m_tempoAdjustment;
 };
 

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -518,7 +518,7 @@ private:
      */
     std::vector<double> m_scoreTimeOffset;
     std::vector<double> m_realTimeOffsetMilliseconds;
-    int m_currentTempo;
+    double m_currentTempo;
 
     std::map<int, BarlineRenditionPair> m_invisibleStaffBarlines;
 };

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -1243,6 +1243,8 @@ std::string AttConverter::EnclosureToStr(data_ENCLOSURE data) const
     switch (data) {
         case ENCLOSURE_paren: value = "paren"; break;
         case ENCLOSURE_brack: value = "brack"; break;
+        case ENCLOSURE_box: value = "box"; break;
+        case ENCLOSURE_none: value = "none"; break;
         default:
             LogWarning("Unknown value '%d' for data.ENCLOSURE", data);
             value = "";
@@ -1255,6 +1257,8 @@ data_ENCLOSURE AttConverter::StrToEnclosure(const std::string &value, bool logWa
 {
     if (value == "paren") return ENCLOSURE_paren;
     if (value == "brack") return ENCLOSURE_brack;
+    if (value == "box") return ENCLOSURE_box;
+    if (value == "none") return ENCLOSURE_none;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for data.ENCLOSURE", value.c_str());
     return ENCLOSURE_NONE;

--- a/libmei/atts_midi.cpp
+++ b/libmei/atts_midi.cpp
@@ -345,7 +345,7 @@ AttMidiTempo::~AttMidiTempo()
 
 void AttMidiTempo::ResetMidiTempo()
 {
-    m_midiBpm = -1;
+    m_midiBpm = 0.0;
     m_midiMspb = -1;
 }
 
@@ -353,7 +353,7 @@ bool AttMidiTempo::ReadMidiTempo(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("midi.bpm")) {
-        this->SetMidiBpm(StrToMidibpm(element.attribute("midi.bpm").value()));
+        this->SetMidiBpm(StrToDbl(element.attribute("midi.bpm").value()));
         element.remove_attribute("midi.bpm");
         hasAttribute = true;
     }
@@ -369,7 +369,7 @@ bool AttMidiTempo::WriteMidiTempo(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasMidiBpm()) {
-        element.append_attribute("midi.bpm") = MidibpmToStr(this->GetMidiBpm()).c_str();
+        element.append_attribute("midi.bpm") = DblToStr(this->GetMidiBpm()).c_str();
         wroteAttribute = true;
     }
     if (this->HasMidiMspb()) {
@@ -381,7 +381,7 @@ bool AttMidiTempo::WriteMidiTempo(pugi::xml_node element)
 
 bool AttMidiTempo::HasMidiBpm() const
 {
-    return (m_midiBpm != -1);
+    return (m_midiBpm != 0.0);
 }
 
 bool AttMidiTempo::HasMidiMspb() const
@@ -645,7 +645,7 @@ bool Att::SetMidi(Object *element, const std::string &attrType, const std::strin
         AttMidiTempo *att = dynamic_cast<AttMidiTempo *>(element);
         assert(att);
         if (attrType == "midi.bpm") {
-            att->SetMidiBpm(att->StrToMidibpm(attrValue));
+            att->SetMidiBpm(att->StrToDbl(attrValue));
             return true;
         }
         if (attrType == "midi.mspb") {
@@ -747,7 +747,7 @@ void Att::GetMidi(const Object *element, ArrayOfStrAttr *attributes)
         const AttMidiTempo *att = dynamic_cast<const AttMidiTempo *>(element);
         assert(att);
         if (att->HasMidiBpm()) {
-            attributes->push_back(std::make_pair("midi.bpm", att->MidibpmToStr(att->GetMidiBpm())));
+            attributes->push_back(std::make_pair("midi.bpm", att->DblToStr(att->GetMidiBpm())));
         }
         if (att->HasMidiMspb()) {
             attributes->push_back(std::make_pair("midi.mspb", att->MidimspbToStr(att->GetMidiMspb())));

--- a/libmei/atts_midi.h
+++ b/libmei/atts_midi.h
@@ -253,8 +253,8 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetMidiBpm(data_MIDIBPM midiBpm_) { m_midiBpm = midiBpm_; }
-    data_MIDIBPM GetMidiBpm() const { return m_midiBpm; }
+    void SetMidiBpm(double midiBpm_) { m_midiBpm = midiBpm_; }
+    double GetMidiBpm() const { return m_midiBpm; }
     bool HasMidiBpm() const;
     //
     void SetMidiMspb(data_MIDIMSPB midiMspb_) { m_midiMspb = midiMspb_; }
@@ -268,7 +268,7 @@ private:
      * In MIDI, a beat is always defined as a quarter note, *not the numerator of the
      * time signature or the metronomic indication*.
      **/
-    data_MIDIBPM m_midiBpm;
+    double m_midiBpm;
     /**
      * Records the number of microseconds per *quarter note*.
      * In MIDI, a beat is always defined as a quarter note, *not the numerator of the

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -593,6 +593,8 @@ enum data_ENCLOSURE {
     ENCLOSURE_NONE = 0,
     ENCLOSURE_paren,
     ENCLOSURE_brack,
+    ENCLOSURE_box,
+    ENCLOSURE_none,
     ENCLOSURE_MAX
 };
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -261,7 +261,7 @@ void Doc::CalculateMidiTimemap()
         page->LayOutHorizontally();
     }
 
-    int tempo = MIDI_TEMPO;
+    double tempo = MIDI_TEMPO;
 
     // Set tempo
     if (m_mdivScoreDef.HasMidiBpm()) {

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -299,7 +299,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
         LogWarning("Calculation of MIDI timemap failed, not exporting MidiFile.");
     }
 
-    int tempo = MIDI_TEMPO;
+    double tempo = MIDI_TEMPO;
 
     // set MIDI tempo
     if (m_mdivScoreDef.HasMidiBpm()) {
@@ -416,11 +416,11 @@ bool Doc::ExportTimemap(std::string &output)
 
 void Doc::PrepareJsonTimemap(std::string &output, std::map<double, double> &realTimeToScoreTime,
     std::map<double, std::vector<std::string>> &realTimeToOnElements,
-    std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, int> &realTimeToTempo)
+    std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, double> &realTimeToTempo)
 {
 
-    int currentTempo = -1000;
-    int newTempo;
+    double currentTempo = -1000.0;
+    double newTempo;
     int mapsize = (int)realTimeToScoreTime.size();
     output = "";
     output.reserve(mapsize * 100); // Estimate 100 characters for each entry.

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -778,7 +778,7 @@ void ABCInput::parseTempo(const std::string &tempoString)
     Tempo *tempo = new Tempo();
     if (tempoString.find('=') != std::string::npos) {
         const int numStart = int(tempoString.find('=') + 1);
-        tempo->SetMm(std::atoi(tempoString.substr(numStart).c_str()));
+        tempo->SetMm(std::atof(tempoString.substr(numStart).c_str()));
     }
     if (tempoString.find('\"') != std::string::npos) {
         std::string tempoWord = tempoString.substr(tempoString.find('\"') + 1);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -136,7 +136,7 @@ void Measure::Reset()
 
     m_scoreTimeOffset.clear();
     m_realTimeOffsetMilliseconds.clear();
-    m_currentTempo = 120;
+    m_currentTempo = 120.0;
 }
 
 bool Measure::IsSupportedChild(Object *child)
@@ -1433,7 +1433,7 @@ int Measure::CalcMaxMeasureDuration(FunctorParams *functorParams)
         params->m_currentTempo = tempo->GetMidiBpm();
     }
     else if (tempo && tempo->HasMm()) {
-        int mm = tempo->GetMm();
+        double mm = tempo->GetMm();
         int mmUnit = 4;
         if (tempo->HasMmUnit() && (tempo->GetMmUnit() > DURATION_breve)) {
             mmUnit = pow(2, (int)tempo->GetMmUnit() - 2);
@@ -1441,7 +1441,7 @@ int Measure::CalcMaxMeasureDuration(FunctorParams *functorParams)
         if (tempo->HasMmDots()) {
             mmUnit = 2 * mmUnit - (mmUnit / pow(2, tempo->GetMmDots()));
         }
-        params->m_currentTempo = int(mm * 4.0 / mmUnit + 0.5);
+        params->m_currentTempo = mm * 4.0 / mmUnit + 0.5;
     }
     m_currentTempo = params->m_currentTempo * params->m_tempoAdjustment;
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -427,8 +427,8 @@ Staff *Measure::GetBottomVisibleStaff()
 int Measure::EnclosesTime(int time) const
 {
     int repeat = 1;
-    int timeDuration = int(
-        m_measureAligner.GetRightAlignment()->GetTime() * DURATION_4 / DUR_MAX * 60.0 / m_currentTempo * 1000.0 + 0.5);
+    double timeDuration
+        = m_measureAligner.GetRightAlignment()->GetTime() * DURATION_4 / DUR_MAX * 60.0 / m_currentTempo * 1000.0 + 0.5;
     std::vector<double>::const_iterator iter;
     for (iter = m_realTimeOffsetMilliseconds.begin(); iter != m_realTimeOffsetMilliseconds.end(); ++iter) {
         if ((time >= *iter) && (time <= *iter + timeDuration)) return repeat;


### PR DESCRIPTION
This PR
- regenerates LibMEI from [the changes here](https://github.com/rism-digital/libmei/pull/5)
- changes `midi.bpm` from int to double and fixes #1953
- passes the decimal tempo into the MIDI-functor