### PR TITLE
Single stemmed dotted unisons

### DIFF
--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -339,7 +339,7 @@ typedef std::vector<LedgerLine> ArrayOfLedgerLines;
 
 typedef std::vector<TextElement *> ArrayOfTextElements;
 
-typedef std::map<Staff *, std::set<int>> MapOfNoteLocs;
+typedef std::map<Staff *, std::multiset<int>> MapOfNoteLocs;
 
 typedef std::map<Staff *, std::set<int>> MapOfDotLocs;
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -39,16 +39,19 @@ namespace vrv {
 template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin, Iterator end, bool isReverseOrder)
 {
     // location adjustment that should be applied when looking for optimal position
-    std::vector<int> locAdjust{ 0, 1, -1, 2, -2 };
+    std::vector<int> locAdjust{ 0, 1, -1, -2, 2 };
     if (isReverseOrder) std::transform(locAdjust.begin(), locAdjust.end(), locAdjust.begin(), std::negate<int>());
     std::set<int> dotLocations;
+    Iterator prev = begin;
     for (auto iter = begin; iter != end; ++iter) {
         bool result = false;
         for (int adjust : locAdjust) {
             if ((*iter + adjust) % 2 == 0) continue;
+            if ((prev != iter) && (*prev == *iter) && (adjust == -2)) continue;
             std::tie(std::ignore, result) = dotLocations.insert(*iter + adjust);
             if (result) break;
         }
+        prev = iter;
     }
     return dotLocations;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -39,7 +39,7 @@ namespace vrv {
 template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin, Iterator end, bool isReverseOrder)
 {
     // location adjustment that should be applied when looking for optimal position
-    std::vector<int> locAdjust{ 0, 1, -2, 2 };
+    std::vector<int> locAdjust{ 0, 1, -1, 2, -2 };
     if (isReverseOrder) std::transform(locAdjust.begin(), locAdjust.end(), locAdjust.begin(), std::negate<int>());
     std::set<int> dotLocations;
     for (auto iter = begin; iter != end; ++iter) {


### PR DESCRIPTION
This PR fixes dot positioning on single stemmed unisons.

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/125895186-dc869a42-3593-47a8-a187-73e8938626b4.png) | ![After](https://user-images.githubusercontent.com/63608463/125895204-8df436e2-e756-453d-b69a-e9af611b07cd.png) |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Single stemmed dotted unisons</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2021-07-09">2021-07-09</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
             <annot n="1">
                 <p>Each notehead requires a dot. Each dot must have a separate stave-space, even though the noteheads are in the same space or on the same line; they will otherwise appear to be double-dotted</p>
             </annot>
         </notesStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                         <clef  shape="G" line="2" visible="false"/>
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure left="invis" right="invis">
                     <staff n="1">
                        <layer n="1">
                           <chord dots="1" dur="4" n="1">
                              <note oct="4" pname="b" />
                              <note oct="4" pname="b" />
                           </chord>
                           <chord dots="1" dur="2" n="2">
                              <note oct="5" pname="c" />
                              <note oct="5" pname="c" />
                           </chord>
                           <chord dots="1" dur="1" n="3">
                              <note oct="5" pname="d" />
                              <note oct="5" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

