### PR TITLE
Enclose for articulations and fermata

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -139,7 +139,8 @@ public:
     virtual int ResetDrawing(FunctorParams *functorParams);
 
 private:
-    //
+    bool IsInsideArtic(data_ARTICULATION artic) const;
+
 public:
     std::vector<FloatingCurvePositioner *> m_startSlurPositioners;
     std::vector<FloatingCurvePositioner *> m_endSlurPositioners;

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -93,11 +93,11 @@ public:
     //----------------//
 
     /**
-     * Static method that retrieves the vertical correctoin for a SMuFL code for with data_STAFFREL.
+     * Static method that retrieves the vertical correction for a SMuFL code with data_STAFFREL.
      * The reason for this is that SMuFL sometimes has the glyph below the line, sometimes above.
      * See bow indications for an example where is is always above
      */
-    static bool VerticalCorr(wchar_t code, const data_STAFFREL &place);
+    static bool VerticalCorr(wchar_t code, data_STAFFREL place);
 
     /**
      * Static method that returns true if the data_ARTICULATION has to be centered between staff lines

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -21,6 +21,7 @@ namespace vrv {
 class Artic : public LayerElement,
               public AttArticulation,
               public AttColor,
+              public AttEnclosingChars,
               public AttExtSym,
               public AttPlacementRelEvent {
 public:
@@ -81,6 +82,11 @@ public:
      * Retrieves the appropriate SMuFL code for a data_ARTICULATION with data_STAFFREL
      */
     wchar_t GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const;
+
+    /**
+     * Retrieves parentheses / brackets from the enclose attribute
+     */
+    wchar_t GetEnclosingGlyph(bool beforeArtic) const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -28,6 +28,7 @@ class ConvertMarkupAnalyticalParams;
 class Fermata : public ControlElement,
                 public TimePointInterface,
                 public AttColor,
+                public AttEnclosingChars,
                 public AttExtSym,
                 public AttFermataVis,
                 public AttPlacementRelStaff {
@@ -62,6 +63,20 @@ public:
      * Get the SMuFL glyph for the fermata based on type, shape or glyph.num
      */
     wchar_t GetFermataGlyph() const;
+
+    /**
+     * Retrieves parentheses / brackets from the enclose attribute
+     */
+    wchar_t GetEnclosingGlyph(bool beforeFermata) const;
+
+    //----------------//
+    // Static methods //
+    //----------------//
+
+    /**
+     * Retrieves the vertical alignment for the fermata SMuFL code
+     */
+    static data_VERTICALALIGNMENT GetVerticalAlignment(wchar_t code);
 
     //----------//
     // Functors //

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -36,7 +36,8 @@ const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_d
 
 static const ClassRegistrar<Artic> s_factory("artic", ARTIC);
 
-Artic::Artic() : LayerElement("artic-"), AttArticulation(), AttColor(), AttPlacementRelEvent()
+Artic::Artic()
+    : LayerElement("artic-"), AttArticulation(), AttColor(), AttEnclosingChars(), AttExtSym(), AttPlacementRelEvent()
 {
     RegisterAttClass(ATT_ARTICULATION);
     RegisterAttClass(ATT_COLOR);
@@ -99,6 +100,8 @@ void Artic::SplitMultival(Object *parent)
         Artic *artic = new Artic();
         artic->SetArtic({ *iter });
         artic->AttColor::operator=(*this);
+        artic->AttEnclosingChars::operator=(*this);
+        artic->AttExtSym::operator=(*this);
         artic->AttPlacementRelEvent::operator=(*this);
         artic->SetParent(parent);
         parent->InsertChild(artic, idx);

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -61,11 +61,21 @@ void Artic::Reset()
     m_drawingPlace = STAFFREL_NONE;
 }
 
+bool Artic::IsInsideArtic(data_ARTICULATION artic) const
+{
+    // Always outside if enclosing brackets are used
+    if ((this->GetEnclose() == ENCLOSURE_brack) || (this->GetEnclose() == ENCLOSURE_paren)) {
+        return false;
+    }
+
+    const auto end = Artic::s_outStaffArtic.end();
+    const auto it = std::find(Artic::s_outStaffArtic.begin(), end, artic);
+    return (it == end);
+}
+
 bool Artic::IsInsideArtic() const
 {
-    auto end = Artic::s_outStaffArtic.end();
-    auto i = std::find(Artic::s_outStaffArtic.begin(), end, this->GetArticFirst());
-    return (i == end);
+    return IsInsideArtic(this->GetArticFirst());
 }
 
 data_ARTICULATION Artic::GetArticFirst() const
@@ -132,17 +142,12 @@ void Artic::SplitArtic(std::vector<data_ARTICULATION> *insideSlur, std::vector<d
     assert(insideSlur);
     assert(outsideSlur);
 
-    std::vector<data_ARTICULATION>::iterator iter;
-    auto end = Artic::s_outStaffArtic.end();
     std::vector<data_ARTICULATION> articList = this->GetArtic();
-
-    for (iter = articList.begin(); iter != articList.end(); ++iter) {
-        // return false if one cannot be rendered on the staff
-        auto i = std::find(Artic::s_outStaffArtic.begin(), end, *iter);
-        if (i != end)
-            outsideSlur->push_back(*iter);
+    for (data_ARTICULATION artic : articList) {
+        if (IsInsideArtic(artic))
+            insideSlur->push_back(artic);
         else
-            insideSlur->push_back(*iter);
+            outsideSlur->push_back(artic);
     }
 }
 

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -40,6 +40,7 @@ Artic::Artic() : LayerElement("artic-"), AttArticulation(), AttColor(), AttPlace
 {
     RegisterAttClass(ATT_ARTICULATION);
     RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_ENCLOSINGCHARS);
     RegisterAttClass(ATT_EXTSYM);
     RegisterAttClass(ATT_PLACEMENTRELEVENT);
 
@@ -53,6 +54,7 @@ void Artic::Reset()
     LayerElement::Reset();
     ResetArticulation();
     ResetColor();
+    ResetEnclosingChars();
     ResetExtSym();
     ResetPlacementRelEvent();
 
@@ -246,6 +248,23 @@ wchar_t Artic::GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const
         return 0;
 }
 
+wchar_t Artic::GetEnclosingGlyph(bool beforeArtic) const
+{
+    wchar_t glyph = 0;
+    if (this->HasEnclose()) {
+        switch (this->GetEnclose()) {
+            case ENCLOSURE_brack:
+                glyph = beforeArtic ? SMUFL_E26C_accidentalBracketLeft : SMUFL_E26D_accidentalBracketRight;
+                break;
+            case ENCLOSURE_paren:
+                glyph = beforeArtic ? SMUFL_E26A_accidentalParensLeft : SMUFL_E26B_accidentalParensRight;
+                break;
+            default: break;
+        }
+    }
+    return glyph;
+}
+
 //----------------------------------------------------------------------------
 // Static methods for Artic
 //----------------------------------------------------------------------------
@@ -257,6 +276,8 @@ bool Artic::VerticalCorr(wchar_t code, const data_STAFFREL &place)
     else if (code == SMUFL_E611_stringsDownBowTurned)
         return true;
     else if (code == SMUFL_E613_stringsUpBowTurned)
+        return true;
+    else if (code == SMUFL_E630_pluckedSnapPizzicatoBelow)
         return true;
     else
         return false;

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -147,10 +147,12 @@ void Artic::SplitArtic(std::vector<data_ARTICULATION> *insideSlur, std::vector<d
 
     std::vector<data_ARTICULATION> articList = this->GetArtic();
     for (data_ARTICULATION artic : articList) {
-        if (IsInsideArtic(artic))
+        if (IsInsideArtic(artic)) {
             insideSlur->push_back(artic);
-        else
+        }
+        else {
             outsideSlur->push_back(artic);
+        }
     }
 }
 

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -269,7 +269,7 @@ wchar_t Artic::GetEnclosingGlyph(bool beforeArtic) const
 // Static methods for Artic
 //----------------------------------------------------------------------------
 
-bool Artic::VerticalCorr(wchar_t code, const data_STAFFREL &place)
+bool Artic::VerticalCorr(wchar_t code, data_STAFFREL place)
 {
     if (place == STAFFREL_above)
         return false;

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -30,6 +30,7 @@ Fermata::Fermata()
 {
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_ENCLOSINGCHARS);
     RegisterAttClass(ATT_EXTSYM);
     RegisterAttClass(ATT_FERMATAVIS);
     RegisterAttClass(ATT_PLACEMENTRELSTAFF);
@@ -44,6 +45,7 @@ void Fermata::Reset()
     ControlElement::Reset();
     TimePointInterface::Reset();
     ResetColor();
+    ResetEnclosingChars();
     ResetExtSym();
     ResetFermataVis();
     ResetPlacementRelStaff();
@@ -92,6 +94,46 @@ wchar_t Fermata::GetFermataGlyph() const
 
     // If no other attributes match, return default one (fermataAbove)
     return SMUFL_E4C0_fermataAbove;
+}
+
+wchar_t Fermata::GetEnclosingGlyph(bool beforeFermata) const
+{
+    wchar_t glyph = 0;
+    if (this->HasEnclose()) {
+        switch (this->GetEnclose()) {
+            case ENCLOSURE_brack:
+                glyph = beforeFermata ? SMUFL_E26C_accidentalBracketLeft : SMUFL_E26D_accidentalBracketRight;
+                break;
+            case ENCLOSURE_paren:
+                glyph = beforeFermata ? SMUFL_E26A_accidentalParensLeft : SMUFL_E26B_accidentalParensRight;
+                break;
+            default: break;
+        }
+    }
+    return glyph;
+}
+
+//----------------------------------------------------------------------------
+// Static methods
+//----------------------------------------------------------------------------
+
+data_VERTICALALIGNMENT Fermata::GetVerticalAlignment(wchar_t code)
+{
+    switch (code) {
+        case SMUFL_E4C0_fermataAbove:
+        case SMUFL_E4C2_fermataVeryShortAbove:
+        case SMUFL_E4C4_fermataShortAbove:
+        case SMUFL_E4C6_fermataLongAbove:
+        case SMUFL_E4C8_fermataVeryLongAbove: return VERTICALALIGNMENT_top;
+
+        case SMUFL_E4C1_fermataBelow:
+        case SMUFL_E4C3_fermataVeryShortBelow:
+        case SMUFL_E4C5_fermataShortBelow:
+        case SMUFL_E4C7_fermataLongBelow:
+        case SMUFL_E4C9_fermataVeryLongBelow: return VERTICALALIGNMENT_bottom;
+
+        default: return VERTICALALIGNMENT_middle;
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1326,6 +1326,7 @@ void MEIOutput::WriteFermata(pugi::xml_node currentNode, Fermata *fermata)
     WriteControlElement(currentNode, fermata);
     WriteTimePointInterface(currentNode, fermata);
     fermata->WriteColor(currentNode);
+    fermata->WriteEnclosingChars(currentNode);
     fermata->WriteExtSym(currentNode);
     fermata->WriteFermataVis(currentNode);
     fermata->WritePlacementRelStaff(currentNode);
@@ -4436,6 +4437,7 @@ bool MEIInput::ReadFermata(Object *parent, pugi::xml_node fermata)
 
     ReadTimePointInterface(fermata, vrvFermata);
     vrvFermata->ReadColor(fermata);
+    vrvFermata->ReadEnclosingChars(fermata);
     vrvFermata->ReadExtSym(fermata);
     vrvFermata->ReadFermataVis(fermata);
     vrvFermata->ReadPlacementRelStaff(fermata);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1592,6 +1592,7 @@ void MEIOutput::WriteArtic(pugi::xml_node currentNode, Artic *artic)
     WriteLayerElement(currentNode, artic);
     artic->WriteArticulation(currentNode);
     artic->WriteColor(currentNode);
+    artic->WriteEnclosingChars(currentNode);
     artic->WriteExtSym(currentNode);
     artic->WritePlacementRelEvent(currentNode);
 }
@@ -5011,6 +5012,7 @@ bool MEIInput::ReadArtic(Object *parent, pugi::xml_node artic)
 
     vrvArtic->ReadArticulation(artic);
     vrvArtic->ReadColor(artic);
+    vrvArtic->ReadEnclosingChars(artic);
     vrvArtic->ReadExtSym(artic);
     vrvArtic->ReadPlacementRelEvent(artic);
 

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -78,15 +78,18 @@ std::wstring KeyAccid::GetSymbolStr() const
     std::wstring symbolStr;
 
     if (this->HasEnclose()) {
-        if (this->GetEnclose() == ENCLOSURE_brack) {
-            symbolStr.push_back(SMUFL_E26C_accidentalBracketLeft);
-            symbolStr.push_back(symc);
-            symbolStr.push_back(SMUFL_E26D_accidentalBracketRight);
-        }
-        else {
-            symbolStr.push_back(SMUFL_E26A_accidentalParensLeft);
-            symbolStr.push_back(symc);
-            symbolStr.push_back(SMUFL_E26B_accidentalParensRight);
+        switch (this->GetEnclose()) {
+            case ENCLOSURE_brack:
+                symbolStr.push_back(SMUFL_E26C_accidentalBracketLeft);
+                symbolStr.push_back(symc);
+                symbolStr.push_back(SMUFL_E26D_accidentalBracketRight);
+                break;
+            case ENCLOSURE_paren:
+                symbolStr.push_back(SMUFL_E26A_accidentalParensLeft);
+                symbolStr.push_back(symc);
+                symbolStr.push_back(SMUFL_E26B_accidentalParensRight);
+                break;
+            default: symbolStr.push_back(symc);
         }
     }
     else {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1598,13 +1598,14 @@ void View::DrawFermata(DeviceContext *dc, Fermata *fermata, Measure *measure, Sy
     const wchar_t enclosingBack = fermata->GetEnclosingGlyph(false);
 
     const int x = fermata->GetStart()->GetDrawingX() + fermata->GetStart()->GetDrawingRadius(m_doc);
-    const int y = fermata->GetDrawingY();
 
     std::vector<Staff *> staffList = fermata->GetTstampStaves(measure, fermata);
     for (Staff *staff : staffList) {
         if (!system->SetCurrentFloatingPositioner(staff->GetN(), fermata, fermata->GetStart(), staff)) {
             continue;
         }
+
+        const int y = fermata->GetDrawingY();
 
         // The correction for centering the glyph
         const int xCorr = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, drawingCueSize) / 2;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1589,26 +1589,51 @@ void View::DrawFermata(DeviceContext *dc, Fermata *fermata, Measure *measure, Sy
     // Cannot draw a fermata that has no start position
     if (!fermata->GetStart()) return;
 
+    const bool drawingCueSize = false;
+
     dc->StartGraphic(fermata, "", fermata->GetUuid());
 
-    int x = fermata->GetStart()->GetDrawingX() + fermata->GetStart()->GetDrawingRadius(m_doc);
+    const wchar_t code = fermata->GetFermataGlyph();
+    const wchar_t enclosingFront = fermata->GetEnclosingGlyph(true);
+    const wchar_t enclosingBack = fermata->GetEnclosingGlyph(false);
 
-    // for a start always put fermatas up
-    int code = fermata->GetFermataGlyph();
+    const int x = fermata->GetStart()->GetDrawingX() + fermata->GetStart()->GetDrawingRadius(m_doc);
+    const int y = fermata->GetDrawingY();
 
-    std::wstring str;
-    str.push_back(code);
-
-    std::vector<Staff *>::iterator staffIter;
     std::vector<Staff *> staffList = fermata->GetTstampStaves(measure, fermata);
-    for (staffIter = staffList.begin(); staffIter != staffList.end(); ++staffIter) {
-        if (!system->SetCurrentFloatingPositioner((*staffIter)->GetN(), fermata, fermata->GetStart(), *staffIter)) {
+    for (Staff *staff : staffList) {
+        if (!system->SetCurrentFloatingPositioner(staff->GetN(), fermata, fermata->GetStart(), staff)) {
             continue;
         }
-        int y = fermata->GetDrawingY();
 
-        dc->SetFont(m_doc->GetDrawingSmuflFont((*staffIter)->m_drawingStaffSize, false));
-        DrawSmuflString(dc, x, y, str, HORIZONTALALIGNMENT_center, (*staffIter)->m_drawingStaffSize);
+        // The correction for centering the glyph
+        const int xCorr = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, drawingCueSize) / 2;
+        int yCorr = 0;
+        const int height = m_doc->GetGlyphHeight(code, staff->m_drawingStaffSize, drawingCueSize);
+        const data_VERTICALALIGNMENT yAlignment = Fermata::GetVerticalAlignment(code);
+        if (yAlignment == VERTICALALIGNMENT_top) {
+            yCorr = height / 2;
+        }
+        else if (yAlignment == VERTICALALIGNMENT_bottom) {
+            yCorr = -height / 2;
+        }
+
+        // Draw glyph including possible enclosing brackets
+        dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, drawingCueSize));
+
+        if (enclosingFront) {
+            const int xCorrEncl = xCorr + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 3
+                + m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+            DrawSmuflCode(dc, x - xCorrEncl, y, enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+        }
+
+        DrawSmuflCode(dc, x - xCorr, y - yCorr, code, staff->m_drawingStaffSize, drawingCueSize);
+
+        if (enclosingBack) {
+            const int xCorrEncl = xCorr + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 3;
+            DrawSmuflCode(dc, x + xCorrEncl, y, enclosingBack, staff->m_drawingStaffSize, drawingCueSize);
+        }
+
         dc->ResetFont();
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -312,6 +312,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     // Skip it if we do not have it in the font (for now - we should log / document this somewhere)
     if (code == 0) {
         artic->SetEmptyBB();
+        dc->ResetFont();
         return;
     }
 
@@ -367,6 +368,8 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     }
 
     dc->EndGraphic(element, this);
+
+    dc->ResetFont();
 }
 
 void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -298,16 +298,16 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int x = artic->GetDrawingX();
     int y = artic->GetDrawingY();
 
-    int xCorr;
-    int baselineCorr;
-
-    bool drawingCueSize = true;
+    const bool drawingCueSize = true;
 
     dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, drawingCueSize));
 
-    data_ARTICULATION articValue = artic->GetArticFirst();
+    const data_ARTICULATION articValue = artic->GetArticFirst();
+    const data_STAFFREL place = artic->GetDrawingPlace();
 
-    wchar_t code = artic->GetArticGlyph(articValue, artic->GetDrawingPlace());
+    const wchar_t code = artic->GetArticGlyph(articValue, place);
+    const wchar_t enclosingFront = artic->GetEnclosingGlyph(true);
+    const wchar_t enclosingBack = artic->GetEnclosingGlyph(false);
 
     // Skip it if we do not have it in the font (for now - we should log / document this somewhere)
     if (code == 0) {
@@ -315,27 +315,54 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         return;
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
-
     // The correction for centering the glyph
-    xCorr = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, drawingCueSize) / 2;
-    // The position of the next glyph (and for correcting the baseline if necessary
-    int glyphHeight = m_doc->GetGlyphHeight(code, staff->m_drawingStaffSize, drawingCueSize);
+    const int xCorr = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, drawingCueSize) / 2;
 
-    // Center the glyh if necessary
+    const int glyphHeight = m_doc->GetGlyphHeight(code, staff->m_drawingStaffSize, drawingCueSize);
+
+    // The height by which enclosing brackets exceed the artic symbol
+    int exceedingHeight = 0;
+    for (const wchar_t symbol : { enclosingFront, enclosingBack }) {
+        if (symbol == 0) continue;
+        const int symbolHeight = m_doc->GetGlyphHeight(symbol, staff->m_drawingStaffSize, drawingCueSize);
+        exceedingHeight = std::max(exceedingHeight, symbolHeight - glyphHeight);
+    }
+
+    // Center the glyph if necessary
     if (Artic::IsCentered(articValue)) {
-        y += (artic->GetDrawingPlace() == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
+        y += (place == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
     }
-    // @glyph.num/name are (usually?) aligned for placement above and needs to be shifted when below
-    else if ((artic->HasGlyphNum() || artic->HasGlyphName()) && artic->GetDrawingPlace() == STAFFREL_below) {
-        y -= glyphHeight;
+    else {
+        y += (place == STAFFREL_above) ? (exceedingHeight / 2) : -(exceedingHeight / 2);
+        // @glyph.num/name are (usually?) aligned for placement above and needs to be shifted when below
+        if ((artic->HasGlyphNum() || artic->HasGlyphName()) && (place == STAFFREL_below)) {
+            y -= glyphHeight;
+        }
     }
+
+    // The relative vertical displacement of enclosing brackets
+    int yCorrEncl = (place == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
 
     // Adjust the baseline for glyph above the baseline in SMuFL
-    baselineCorr = 0;
-    if (Artic::VerticalCorr(code, artic->GetDrawingPlace())) baselineCorr = glyphHeight;
+    if (Artic::VerticalCorr(code, place)) {
+        y -= glyphHeight;
+        yCorrEncl = -glyphHeight / 2;
+    }
 
-    DrawSmuflCode(dc, x - xCorr, y - baselineCorr, code, staff->m_drawingStaffSize, drawingCueSize);
+    // Draw glyph including possible enclosing brackets
+    dc->StartGraphic(element, "", element->GetUuid());
+
+    if (enclosingFront) {
+        const int xCorrEncl = m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+        DrawSmuflCode(
+            dc, x - xCorr - xCorrEncl, y - yCorrEncl, enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+    }
+
+    DrawSmuflCode(dc, x - xCorr, y, code, staff->m_drawingStaffSize, drawingCueSize);
+
+    if (enclosingBack) {
+        DrawSmuflCode(dc, x + xCorr, y - yCorrEncl, enclosingBack, staff->m_drawingStaffSize, drawingCueSize);
+    }
 
     dc->EndGraphic(element, this);
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -329,6 +329,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     }
 
     // Center the glyph if necessary
+    int yCorr = 0;
     if (Artic::IsCentered(articValue)) {
         y += (place == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
     }
@@ -336,7 +337,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         y += (place == STAFFREL_above) ? (exceedingHeight / 2) : -(exceedingHeight / 2);
         // @glyph.num/name are (usually?) aligned for placement above and needs to be shifted when below
         if ((artic->HasGlyphNum() || artic->HasGlyphName()) && (place == STAFFREL_below)) {
-            y -= glyphHeight;
+            yCorr += glyphHeight;
         }
     }
 
@@ -353,15 +354,16 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     dc->StartGraphic(element, "", element->GetUuid());
 
     if (enclosingFront) {
-        const int xCorrEncl = m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
-        DrawSmuflCode(
-            dc, x - xCorr - xCorrEncl, y - yCorrEncl, enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+        int xCorrEncl = std::max(xCorr, m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 / 3);
+        xCorrEncl += m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
+        DrawSmuflCode(dc, x - xCorrEncl, y - yCorrEncl, enclosingFront, staff->m_drawingStaffSize, drawingCueSize);
     }
 
-    DrawSmuflCode(dc, x - xCorr, y, code, staff->m_drawingStaffSize, drawingCueSize);
+    DrawSmuflCode(dc, x - xCorr, y - yCorr, code, staff->m_drawingStaffSize, drawingCueSize);
 
     if (enclosingBack) {
-        DrawSmuflCode(dc, x + xCorr, y - yCorrEncl, enclosingBack, staff->m_drawingStaffSize, drawingCueSize);
+        const int xCorrEncl = std::max(xCorr, m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 / 3);
+        DrawSmuflCode(dc, x + xCorrEncl, y - yCorrEncl, enclosingBack, staff->m_drawingStaffSize, drawingCueSize);
     }
 
     dc->EndGraphic(element, this);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -331,7 +331,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     // Center the glyph if necessary
     int yCorr = 0;
-    if (Artic::IsCentered(articValue)) {
+    if (Artic::IsCentered(articValue) && !enclosingFront && !enclosingBack) {
         y += (place == STAFFREL_above) ? -(glyphHeight / 2) : (glyphHeight / 2);
     }
     else {


### PR DESCRIPTION
This PR implements the drawing of enclosing brackets and parenthesis for articulations and fermata.
- We use SMuFL glyphs for brackets and parenthesis.
- Articulations with enclosing are always positioned outside the staff.

![Artic1](https://user-images.githubusercontent.com/63608463/125936299-c8e7ca1c-25f7-40c5-a9d3-dd951e4f31ea.png)

![Artic2](https://user-images.githubusercontent.com/63608463/125936304-0e4b1870-d710-43a4-b0c8-010cbe3f2b3c.png)

![Fermata](https://user-images.githubusercontent.com/63608463/125935796-a028c128-d4e9-493d-b690-994c6326b0bb.png)

<details>
<summary> Show MEI for articulations </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Articulation example</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-03</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio supports both "artic" attribute on notes and "artic" element for encoding articulations. Currently, the articulation
					values supported are: acc, stacc, ten, stacciss, marc, spicc, ten, dnbow, upbow, harm, snap.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1" label="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="acc" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="stacc" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="stacc" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="stacc" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="marc" place="below" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" artic="stacc" stem.dir="up" />
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="spicc" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="ten" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="dnbow" place="below" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="upbow" place="below" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="upbow" place="below" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" stem.dir="up">
                             <artic artic="snap" place="below" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="4" label="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b">
                             <artic artic="acc" place="above" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b">
                             <artic artic="stacc" place="above" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b">
                             <artic artic="stacc" place="above" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b">
                             <artic artic="stacc" place="above" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="5">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="marc" place="above" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" artic="stacc" />
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="spicc" place="above" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="ten" place="above" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="6">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="dnbow" place="above" enclose="paren"/>
                           </note>
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="upbow" place="above" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="upbow" place="above" enclose="brack"/>
                           </note>
                           <note dur="4" oct="4" pname="b" >
                             <artic artic="snap" place="above" enclose="paren"/>
                           </note>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
<summary> Show MEI for fermata </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Fermata element example</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-04</date>
         </pubStmt>
         <notesStmt>
            <annot>For more control over fermatas the fermata element may be used. Verovio takes the attributes form, place, and shape into
					account.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef key.sig="1f" meter.count="4" meter.unit="4" meter.sym="common">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="F" clef.line="4" />
                  </staffGrp>
               </scoreDef>
               <section label="feature-example">
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="note-000000191714646" dur="4" oct="3" pname="f" stem.dir="down" />
                           <chord xml:id="chord-000000067789064" dur="4" stem.dir="up">
                              <note oct="2" pname="e" />
                              <note oct="3" pname="c" />
                              <note oct="3" pname="f" />
                              <note oct="3" pname="a" />
                              <note oct="4" pname="d" />
                           </chord>
                           <rest xml:id="rest-000000131319457" dur="4" />
                           <rest xml:id="rest-000000070546468" dur="4" />
                        </layer>
                     </staff>
                     <fermata staff="1" startid="#note-000000191714646" enclose="paren" />
                     <fermata staff="1" startid="#chord-000000067789064" form="inv" shape="angular" place="below" enclose="brack" />
                     <fermata staff="1" startid="#rest-000000131319457" form="norm" shape="square" place="above" enclose="brack" />
                     <fermata staff="1" startid="#rest-000000070546468" form="inv" shape="square" place="above" enclose="paren" />
                     <fermata staff="1" tstamp="5.000000" place="above" enclose="brack" />
                     <fermata staff="1" tstamp="5.000000" place="below" enclose="brack" />
                  </measure>
                  <measure right="end" n="2">
                     <staff n="1">
                        <layer n="1">
                           <mRest xml:id="mrest-000000001988686" />
                        </layer>
                     </staff>
                     <fermata staff="1" startid="#mrest-000000001988686" place="above" enclose="paren" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

