### PR TITLE
Sligtly increase offset for the mNum

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -963,7 +963,8 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
                 ScoreDef *scoreDef = system->GetDrawingScoreDef();
                 GrpSym *groupSymbol = vrv_cast<GrpSym *>(scoreDef->FindDescendantByType(GRPSYM));
                 if (groupSymbol && (groupSymbol->GetSymbol() == staffGroupingSym_SYMBOL_bracket)) {
-                    symbolOffset += m_doc->GetGlyphHeight(SMUFL_E003_bracketTop, 100, false);
+                    symbolOffset
+                        += m_doc->GetGlyphHeight(SMUFL_E003_bracketTop, 100, false) + m_doc->GetDrawingUnit(100) / 6;
                 }
                 // hardcoded offset for the mNum based on the lyric font size
                 const int yOffset = m_doc->GetDrawingLyricFont(60)->GetPointSize();


### PR DESCRIPTION
Follow-up for #2281.
Just slight increase for the `mNum` positioning - while they are positioned above, in some cases (e.g. zooming out document) margin is barely distinguishable. It might look like `mNum` is sitting on the bracket, so this change should increase this gap slightly, while not being large enough to overlap with other elements or stand out too much.