### PR TITLE
Give warning instead of crashing when staff number is not matching

### DIFF
--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -190,7 +190,10 @@ SystemAligner::SpacingType SystemAligner::GetAboveSpacingType(Staff *staff)
     }
 
     auto iter = m_spacingTypes.find(staff->GetN());
-    assert(iter != m_spacingTypes.end());
+    if (iter == m_spacingTypes.end()) {
+        LogWarning("No spacing type found matching @n=%d for '<%s>'", staff->GetN(), staff->GetUuid().c_str());
+        return SpacingType::None;
+    }
 
     return iter->second;
 }


### PR DESCRIPTION
Closes #1702 

New behavior is similar to the existing (when staff doesn't have `@n` provided at all) - there will be incorrect rendering, but Verovio is not going to crash and warning will be printed with staff and staff number that could not be found.