### PR TITLE
Better support for engravingDefaults

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -85,7 +85,7 @@ public:
         m_isCmdOnly = false;
     }
     virtual ~Option() {}
-    virtual void CopyTo(Option *option);
+    virtual void CopyTo(Option *option) = 0;
 
     void SetKey(const std::string &key) { m_key = key; }
     std::string GetKey() const { return m_key; }
@@ -94,8 +94,10 @@ public:
     virtual bool SetValueDbl(double value);
     virtual bool SetValueArray(const std::vector<std::string> &values);
     virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    virtual std::string GetStrValue() const = 0;
+    virtual std::string GetDefaultStrValue() const = 0;
+
+    virtual void Reset() = 0;
 
     void SetInfo(const std::string &title, const std::string &description);
     std::string GetTitle() const { return m_title; }
@@ -161,6 +163,8 @@ public:
     virtual std::string GetStrValue() const;
     virtual std::string GetDefaultStrValue() const;
 
+    virtual void Reset();
+
     bool GetValue() const { return m_value; }
     bool GetDefault() const { return m_defaultValue; }
     bool SetValue(bool value);
@@ -198,6 +202,8 @@ public:
     virtual bool SetValue(const std::string &value);
     virtual std::string GetStrValue() const;
     virtual std::string GetDefaultStrValue() const;
+
+    virtual void Reset();
 
     double GetValue() const { return m_value; }
     double GetDefault() const { return m_defaultValue; }
@@ -241,6 +247,8 @@ public:
     virtual std::string GetStrValue() const;
     virtual std::string GetDefaultStrValue() const;
 
+    virtual void Reset();
+
     int GetValue() const;
     int GetUnfactoredValue() const;
     int GetDefault() const { return m_defaultValue; }
@@ -282,6 +290,8 @@ public:
     std::string GetValue() const { return m_value; }
     std::string GetDefault() const { return m_defaultValue; }
 
+    virtual void Reset();
+
 private:
     //
 public:
@@ -314,6 +324,8 @@ public:
     std::vector<std::string> GetValue() const { return m_values; }
     std::vector<std::string> GetDefault() const { return m_defaultValues; }
     bool SetValue(std::vector<std::string> const &values);
+
+    virtual void Reset();
 
 private:
     //
@@ -350,6 +362,8 @@ public:
     std::vector<std::string> GetStrValues(bool withoutDefault) const;
     std::string GetStrValuesAsStr(bool withoutDefault) const;
 
+    virtual void Reset();
+
 private:
     //
 public:
@@ -380,7 +394,9 @@ public:
     virtual std::string GetStrValue() const;
     virtual std::string GetDefaultStrValue() const;
 
-    // For altenate types return a reference to the value
+    virtual void Reset();
+
+    // For alternate types return a reference to the value
     // Alternatively we can have a values vector for each sub-type
     const data_STAFFREL *GetValueAlternate() const { return &m_value; }
     const data_STAFFREL *GetDefaultAlernate() const { return &m_defaultValue; }
@@ -392,38 +408,6 @@ public:
 private:
     data_STAFFREL m_value;
     data_STAFFREL m_defaultValue;
-};
-
-//----------------------------------------------------------------------------
-// OptionStaffrelBasic
-//----------------------------------------------------------------------------
-
-/**
- * This class is for map styling params
- */
-class OptionStaffrelBasic : public Option {
-public:
-    // constructors and destructors
-    OptionStaffrelBasic(){};
-    virtual ~OptionStaffrelBasic(){};
-    virtual void CopyTo(Option *option);
-    void Init(data_STAFFREL_basic defaultValue, const std::vector<data_STAFFREL_basic> &values);
-
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
-
-    data_STAFFREL_basic GetValue() const { return m_value; }
-    data_STAFFREL_basic GetDefault() const { return m_defaultValue; }
-
-private:
-    //
-public:
-    //
-private:
-    std::vector<data_STAFFREL_basic> m_values;
-    data_STAFFREL_basic m_value;
-    data_STAFFREL_basic m_defaultValue;
 };
 
 //----------------------------------------------------------------------------
@@ -464,6 +448,8 @@ public:
     bool SetValue(const std::string &value) override;
     std::string GetStrValue() const override;
     std::string GetDefaultStrValue() const override;
+
+    void Reset() override;
     ///@}
 
     /**
@@ -567,7 +553,7 @@ public:
     // They are ordered by short option alphabetical order
     OptionBool m_standardOutput;
     OptionBool m_help;
-    OptionBool m_allPpages;
+    OptionBool m_allPages;
     OptionString m_inputFrom;
     OptionString m_outfile;
     OptionInt m_page;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -667,6 +667,7 @@ public:
     OptionIntMap m_multiRestStyle;
     OptionBool m_octaveAlternativeSymbols;
     OptionDbl m_octaveLineThickness;
+    OptionDbl m_pedalLineThickness;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionInt m_slurControlPoints;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -475,6 +475,12 @@ public:
     double GetDoubleValue(const std::vector<std::string> &jsonNodePath, bool getDefault = false) const;
     bool UpdateNodeValue(const std::vector<std::string> &jsonNodePath, const std::string &value);
     ///@}
+
+    /**
+     * Accessing all keys
+     */
+    std::set<std::string> GetKeys() const;
+
 protected:
     JsonPath StringPath2NodePath(const jsonxx::Object &obj, const std::vector<std::string> &jsonNodePath) const;
 

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -217,6 +217,11 @@ public:
     bool SetOption(const std::string &option, const std::string &value);
 
     /**
+     * Reset all options to default values
+     */
+    void ResetOptions();
+
+    /**
      * Set the scale option
      *
      * @param scale the scale value as integer

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -39,12 +39,6 @@ const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_a
 const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
     { SYSTEMDIVIDER_auto, "auto" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
-constexpr const char *engravingDefaults
-    = "{'thinBarlineThickness':0.15,'lyricLineThickness':0.125,"
-      "'slurMidpointThickness':0.3,'staffLineThickness':0.075,'stemThickness':0.1,'tieMidpointThickness':0.25,"
-      "'hairpinThickness':0.1,'thickBarlineThickness':0.5,'tupletBracketThickness':0.1,'subBracketThickness':0.1,"
-      "'bracketThickness':0.5,'repeatEndingLineThickness':0.075,'textEnclosureThickness':0.1}";
-
 //----------------------------------------------------------------------------
 // Option
 //----------------------------------------------------------------------------
@@ -1059,7 +1053,7 @@ Options::Options()
     this->Register(&m_dynamDist, "dynamDist", &m_generalLayout);
 
     m_engravingDefaults.SetInfo("Engraving defaults", "Json describing defaults for engraving SMuFL elements");
-    m_engravingDefaults.Init(JsonSource::String, engravingDefaults);
+    m_engravingDefaults.Init(JsonSource::String, "{}");
     this->Register(&m_engravingDefaults, "engravingDefaults", &m_generalLayout);
 
     m_engravingDefaultsFile.SetInfo(
@@ -1182,7 +1176,7 @@ Options::Options()
     m_pedalLineThickness.SetInfo("Pedal line thickness", "The thickness of the line used for piano pedaling");
     m_pedalLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_pedalLineThickness, "pedalLineThickness", &m_generalLayout);
-    
+
     m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation",
         "The default horizontal distance between the dots and the inner barline of a repeat barline");
     m_repeatBarLineDotSeparation.Init(0.30, 0.10, 1.00);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -43,12 +43,6 @@ const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_non
 // Option
 //----------------------------------------------------------------------------
 
-void Option::CopyTo(Option *option)
-{
-    // Make sure it is overriden
-    assert(false);
-}
-
 void Option::SetInfo(const std::string &title, const std::string &description)
 {
     m_title = title;
@@ -87,20 +81,6 @@ bool Option::SetValue(const std::string &value)
     // If not overriden
     LogError("Unsupported type string for %s", m_key.c_str());
     return false;
-}
-
-std::string Option::GetStrValue() const
-{
-    // If not overriden
-    assert(false);
-    return "[unspecified]";
-}
-
-std::string Option::GetDefaultStrValue() const
-{
-    // If not overriden
-    assert(false);
-    return "[unspecified]";
 }
 
 jsonxx::Object Option::ToJson() const
@@ -223,6 +203,12 @@ std::string OptionBool::GetDefaultStrValue() const
     return (m_defaultValue) ? "true" : "false";
 }
 
+void OptionBool::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
+}
+
 bool OptionBool::SetValue(bool value)
 {
     m_value = value;
@@ -279,6 +265,12 @@ bool OptionDbl::SetValue(double value)
     m_value = value;
     m_isSet = true;
     return true;
+}
+
+void OptionDbl::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
 }
 
 //----------------------------------------------------------------------------
@@ -343,6 +335,12 @@ bool OptionInt::SetValue(int value)
     return true;
 }
 
+void OptionInt::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
+}
+
 //----------------------------------------------------------------------------
 // OptionString
 //----------------------------------------------------------------------------
@@ -365,6 +363,12 @@ bool OptionString::SetValue(const std::string &value)
     m_value = value;
     m_isSet = true;
     return true;
+}
+
+void OptionString::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
 }
 
 //----------------------------------------------------------------------------
@@ -437,6 +441,12 @@ bool OptionArray::SetValue(std::vector<std::string> const &values)
     m_values.erase(std::remove_if(m_values.begin(), m_values.end(), [](const std::string &s) { return s.empty(); }),
         m_values.end());
     return true;
+}
+
+void OptionArray::Reset()
+{
+    m_values.clear();
+    m_isSet = false;
 }
 
 //----------------------------------------------------------------------------
@@ -539,6 +549,12 @@ std::string OptionIntMap::GetStrValuesAsStr(bool withoutDefault) const
     return ss.str();
 }
 
+void OptionIntMap::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
+}
+
 //----------------------------------------------------------------------------
 // OptionStaffrel
 //----------------------------------------------------------------------------
@@ -579,6 +595,12 @@ std::string OptionStaffrel::GetDefaultStrValue() const
 {
     Att converter;
     return converter.StaffrelToStr(m_defaultValue);
+}
+
+void OptionStaffrel::Reset()
+{
+    m_value = m_defaultValue;
+    m_isSet = false;
 }
 
 //----------------------------------------------------------------------------
@@ -640,6 +662,12 @@ std::string OptionJson::GetStrValue() const
 std::string OptionJson::GetDefaultStrValue() const
 {
     return m_defaultValues.json();
+}
+
+void OptionJson::Reset()
+{
+    m_values.reset();
+    m_isSet = false;
 }
 
 bool OptionJson::ReadJson(jsonxx::Object &output, const std::string &input) const
@@ -777,11 +805,11 @@ Options::Options()
     m_help.SetShortOption('h', true);
     m_baseOptions.AddOption(&m_help);
 
-    m_allPpages.SetInfo("All pages", "Output all pages");
-    m_allPpages.Init(false);
-    m_allPpages.SetKey("allPages");
-    m_allPpages.SetShortOption('a', true);
-    m_baseOptions.AddOption(&m_allPpages);
+    m_allPages.SetInfo("All pages", "Output all pages");
+    m_allPages.Init(false);
+    m_allPages.SetKey("allPages");
+    m_allPages.SetShortOption('a', true);
+    m_baseOptions.AddOption(&m_allPages);
 
     m_inputFrom.SetInfo("Input from",
         "Select input format from: \"abc\", \"darms\", \"humdrum\", \"mei\", \"pae\", \"xml\" (musicxml)");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1171,11 +1171,6 @@ Options::Options()
     m_multiRestStyle.Init(MULTIRESTSTYLE_auto, &Option::s_multiRestStyle);
     this->Register(&m_multiRestStyle, "multiRestStyle", &m_generalLayout);
 
-    m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation",
-        "The default horizontal distance between the dots and the inner barline of a repeat barline");
-    m_repeatBarLineDotSeparation.Init(0.30, 0.10, 1.00);
-    this->Register(&m_repeatBarLineDotSeparation, "repeatBarLineDotSeparation", &m_generalLayout);
-
     m_octaveAlternativeSymbols.SetInfo("Alternative octave symbols", "Use alternative symbols for displaying octaves");
     m_octaveAlternativeSymbols.Init(false);
     this->Register(&m_octaveAlternativeSymbols, "octaveAlternativeSymbols", &m_generalLayout);
@@ -1183,6 +1178,15 @@ Options::Options()
     m_octaveLineThickness.SetInfo("Octave line thickness", "The thickness of the line used for an octave line");
     m_octaveLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_octaveLineThickness, "octaveLineThickness", &m_generalLayout);
+
+    m_pedalLineThickness.SetInfo("Pedal line thickness", "The thickness of the line used for piano pedaling");
+    m_pedalLineThickness.Init(0.20, 0.10, 1.00);
+    this->Register(&m_pedalLineThickness, "pedalLineThickness", &m_generalLayout);
+    
+    m_repeatBarLineDotSeparation.SetInfo("Repeat barline dot separation",
+        "The default horizontal distance between the dots and the inner barline of a repeat barline");
+    m_repeatBarLineDotSeparation.Init(0.30, 0.10, 1.00);
+    this->Register(&m_repeatBarLineDotSeparation, "repeatBarLineDotSeparation", &m_generalLayout);
 
     m_repeatEndingLineThickness.SetInfo("Repeat ending line thickness", "Repeat and ending line thickness");
     m_repeatEndingLineThickness.Init(0.15, 0.10, 2.0);
@@ -1596,6 +1600,7 @@ void Options::Sync()
         { "subBracketThickness", &m_subBracketThickness }, //
         { "hairpinThickness", &m_hairpinThickness }, //
         { "octaveLineThickness", &m_octaveLineThickness }, //
+        { "pedalLineThickness", &m_pedalLineThickness }, //
         { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, //
         { "lyricLineThickness", &m_lyricLineThickness }, //
         { "tupletBracketThickness", &m_tupletBracketThickness }, //

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1000,6 +1000,15 @@ bool Toolkit::SetOption(const std::string &option, const std::string &value)
     return opt->SetValue(value);
 }
 
+void Toolkit::ResetOptions()
+{
+    std::for_each(m_options->GetItems()->begin(), m_options->GetItems()->end(),
+        [](const MapOfStrOptions::value_type &opt) { opt.second->Reset(); });
+
+    // Set the (default) font
+    Resources::SetFont(m_options->m_font.GetValue());
+}
+
 std::string Toolkit::GetElementAttr(const std::string &xmlId)
 {
     jsonxx::Object o;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -957,7 +957,7 @@ void View::DrawPedalLine(
     }
 
     const int bracketSize = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-    const int lineWidth = m_options->m_pedalLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);;
+    const int lineWidth = m_options->m_pedalLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     // Opening bracket
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -956,8 +956,8 @@ void View::DrawPedalLine(
         dc->StartGraphic(pedal, "", pedal->GetUuid(), false);
     }
 
-    int bracketSize = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-    int lineWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+    const int bracketSize = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int lineWidth = m_options->m_pedalLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);;
 
     // Opening bracket
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {


### PR DESCRIPTION
This PR cleans up around the implementation of `engravingDefaults`. It removes the hard-coded default values here and adds the possibility to `ResetOptions` to the toolkit. This is useful for iterative rendering of files with different styles or different options. 
Also it adds support for SMuFL's `pedalLineThickness`.