### PR TITLE
Add line break for each instance of <words> after the first

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -578,6 +578,9 @@ void MusicXmlInput::TextRendition(const pugi::xpath_node_set words, ControlEleme
         std::string textStr = GetWordsOrDynamicsText(textNode);
         std::string textColor = textNode.attribute("color").as_string();
         Object *textParent = element;
+        if (it != words.begin()) {
+            textParent->AddChild(new Lb());
+        }
         if (textNode.attribute("xml:lang") || textNode.attribute("xml:space") || textNode.attribute("color")
             || textNode.attribute("halign") || textNode.attribute("font-family") || textNode.attribute("font-style")
             || textNode.attribute("font-weight") || textNode.attribute("enclosure")) {


### PR DESCRIPTION
Closes #2045
Just a small fix to add line breaks after each instance of `<words>` in the MusicXML:
![image](https://user-images.githubusercontent.com/1819669/126283819-215fb722-c917-46dc-b625-38ce18b9b5ac.png)
