### PR TITLE
Rewrite code for inserting clefs into the layer/other parent

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -234,6 +234,15 @@ private:
     void InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, int scoreOnSet);
 
     /*
+     * @name Helper function to insert clef into correct position in layer/other parent based on the insertAfter
+     * variable.
+     */
+    ///@{
+    void InsertClefIntoObject(Object *layerElement, Clef *clef, Layer *layer, int scoreOnset, bool insertAfter);
+    void InsertClefIntoObject(Object *parent, Clef *clef, Object *relevantChild, bool insertAfter);
+    ///@}
+
+    /*
      * Add a Measure to the section.
      * If the measure already exists it will move all its content.
      * The measure can contain only staves. Other elements must be stacked on m_floatingElements.

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -283,8 +283,7 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
 
         // In case scoreOnset is 0 - add clef before the first element
         if (!scoreOnset) {
-            otherLayer->InsertBefore(start->second, clefToAdd);
-            m_layerTimes.at(otherLayer).emplace(scoreOnset, clefToAdd);
+            InsertClefIntoObject(start->second, clefToAdd, otherLayer, scoreOnset, false);
         }
         else {
             // If corresponding time couldn't be found (i.e. it's higher than any other duration in the layer) - add
@@ -298,21 +297,38 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
                 const int actualScoreOnSet = start->first;
                 auto end = m_layerTimes.at(otherLayer).upper_bound(actualScoreOnSet);
                 LayerElement *layerElement = (--end)->second;
-                if (layerElement->GetParent()->Is(LAYER)) {
-                    otherLayer->InsertAfter(layerElement, clefToAdd);
-                    m_layerTimes.at(otherLayer).emplace(actualScoreOnSet, clefToAdd);
-                }
-                else {
-                    Object *parent = layerElement->GetParent();
-                    if (parent->Is({ CHORD, FTREM })) {
-                        parent->GetParent()->InsertAfter(parent, clefToAdd);
-                    }
-                    else {
-                        parent->InsertAfter(layerElement, clefToAdd);
-                    }
-                }
+                InsertClefIntoObject(layerElement, clefToAdd, otherLayer, scoreOnset, true);
             }
         }
+    }
+}
+
+void MusicXmlInput::InsertClefIntoObject(
+    Object *layerElement, Clef *clef, Layer *layer, int scoreOnset, bool insertAfter)
+{
+    if (layerElement->GetParent()->Is(LAYER)) {
+        InsertClefIntoObject(layer, clef, layerElement, insertAfter);
+        m_layerTimes.at(layer).emplace(scoreOnset, clef);
+    }
+    else {
+        Object *parent = layerElement->GetParent();
+        if (parent->Is({ CHORD, FTREM })) {
+            InsertClefIntoObject(parent->GetParent(), clef, parent, insertAfter);
+        }
+        else {
+            InsertClefIntoObject(parent, clef, layerElement, insertAfter);
+        }
+    }
+}
+
+void MusicXmlInput::InsertClefIntoObject(Object *parent, Clef *clef, Object *layerElement, bool insertAfter)
+{
+    if (parent->GetChildIndex(layerElement) == -1) return;
+    if (insertAfter) {
+        parent->InsertAfter(layerElement, clef);
+    }
+    else {
+        parent->InsertBefore(layerElement, clef);
     }
 }
 


### PR DESCRIPTION
Follow up for #2291
- created generic function for inserting clefs into layer/other parent
- replaced code for inserting before/after elements with calls to new generic function
Even after previous fix there was the same problem present - in this case when clef was being added before the elements, instead of after. Should not be happening anymore after this fix.