### PR TITLE
Align dot positioning for the unison notes

### DIFF
--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -66,7 +66,7 @@ public:
     virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
     virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
     ///@}
-    
+
     /**
      * Set/get methods for the flagShift
      */

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -66,6 +66,14 @@ public:
     virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
     virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
     ///@}
+    
+    /**
+     * Set/get methods for the flagShift
+     */
+    ///@{
+    int GetFlagShift() const { return m_flagShift; }
+    void SetFlagShift(int shiftVal) { m_flagShift = shiftVal; }
+    ///@}
 
     /**
      * See Object::ResetDrawing
@@ -88,6 +96,7 @@ private:
     MapOfDotLocs m_dotLocsByStaff;
 
     bool m_isAdjusted;
+    int m_flagShift;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -105,6 +105,11 @@ public:
     virtual void AddChild(Object *object);
 
     /**
+     * Align dots shift for two notes. Should be used for unison notes to align dots positioning
+     */
+    void AlignDotsShift(Note *otherNote);
+
+    /**
      * @name Setter and getter for accid attribute and other pointers
      */
     ///@{

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -44,6 +44,7 @@ void Dots::Reset()
     ResetAugmentDots();
 
     m_isAdjusted = false;
+    m_flagShift = 0;
     m_dotLocsByStaff.clear();
 }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -835,6 +835,12 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
                 Note *note = vrv_cast<Note *>(this);
                 Note *otherNote = vrv_cast<Note *>(other);
                 if (note->IsUnisonWith(otherNote)) {
+                    if (note->GetDrawingStemDir() == STEMDIRECTION_up) {
+                        otherNote->AlignDotsShift(note);
+                    }
+                    else if (otherNote->GetDrawingStemDir() == STEMDIRECTION_up) {
+                        note->AlignDotsShift(otherNote);
+                    }
                     return (currentLayerN < otherLayerN) ? dotLocs1 : dotLocs2;
                 }
             }
@@ -1789,7 +1795,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
                 if (hasOverlap) {
                     // For note to note alignment, make sure there is a standard spacing even if they to not overlap
                     // vertically
-                    if (this->Is(NOTE) and element->Is(NOTE)) {
+                    if (this->Is(NOTE) && element->Is(NOTE)) {
                         overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
                     }
                     else {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -191,7 +191,7 @@ void Note::AddChild(Object *child)
     Modify();
 }
 
-void Note::AlignDotsShift(Note* otherNote) 
+void Note::AlignDotsShift(Note *otherNote)
 {
     Dots *dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
     Dots *otherDots = vrv_cast<Dots *>(otherNote->FindDescendantByType(DOTS, 1));

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -191,6 +191,16 @@ void Note::AddChild(Object *child)
     Modify();
 }
 
+void Note::AlignDotsShift(Note* otherNote) 
+{
+    Dots *dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
+    Dots *otherDots = vrv_cast<Dots *>(otherNote->FindDescendantByType(DOTS, 1));
+    if (!dots || !otherDots) return;
+    if (otherDots->GetFlagShift()) {
+        dots->SetFlagShift(otherDots->GetFlagShift());
+    }
+}
+
 Accid *Note::GetDrawingAccid()
 {
     Accid *accid = dynamic_cast<Accid *>(this->FindDescendantByType(ACCID));
@@ -1047,10 +1057,15 @@ int Note::CalcDots(FunctorParams *functorParams)
         const bool isDotShifted = (this->GetDrawingLoc() % 2 == 0);
 
         // Stem up, shorter than 4th and not in beam
-        if ((GetDrawingStemDir() == STEMDIRECTION_up) && (!this->IsInBeam()) && (GetDrawingStemLen() < 3)
+        if (const int shift = dots->GetFlagShift(); shift) {
+            flagShift += shift;
+        }
+        else if ((GetDrawingStemDir() == STEMDIRECTION_up) && (!this->IsInBeam()) && (GetDrawingStemLen() < 3)
             && (IsDotOverlappingWithFlag(params->m_doc, staffSize, isDotShifted))) {
             // HARDCODED
-            flagShift += params->m_doc->GetGlyphWidth(SMUFL_E240_flag8thUp, staffSize, drawingCueSize) * 0.8;
+            const int shift = params->m_doc->GetGlyphWidth(SMUFL_E240_flag8thUp, staffSize, drawingCueSize) * 0.8;
+            flagShift += shift;
+            dots->SetFlagShift(shift);
         }
 
         int xRel = 2 * radius + flagShift;


### PR DESCRIPTION
- added code to align shift for dots from other layers if they are in unison and there is offset due to flag

For scores with two layers and notes in unison, if note with flag on the upper layer had a dot, it would be shifted to the right to avoid collision, but note on the lower would keep its dot position. This led to weird rendering, which looked as if notes had two dots (+ dot collided with flag).
![image](https://user-images.githubusercontent.com/1819669/126310513-a0240a50-f975-4391-a07a-942d3a82e87d.png)

After the fix:
![image](https://user-images.githubusercontent.com/1819669/126310586-d5e0782a-d431-4ad8-88ac-8b880fc7bb26.png)
