### PR TITLE
Support android ndk logging

### DIFF
--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -52,6 +52,11 @@
 #include <emscripten.h>
 #endif
 
+#ifdef ANDROID
+#include <android/log.h>
+#define android_log_puts(prio, msg) __android_log_print(prio, "Verovio", "%s", msg)
+#endif
+
 #define STRING_FORMAT_MAX_LEN 2048
 
 namespace vrv {
@@ -401,6 +406,14 @@ void LogString(std::string message, consoleLogLevel level)
             case CONSOLE_WARN: EM_ASM_ARGS({ console.warn(UTF8ToString($0)); }, message.c_str()); break;
             case CONSOLE_INFO: EM_ASM_ARGS({ console.info(UTF8ToString($0)); }, message.c_str()); break;
             default: EM_ASM_ARGS({ console.log(UTF8ToString($0)); }, message.c_str()); break;
+        }
+#elif defined ANDROID
+        switch (level) {
+            case CONSOLE_DEBUG: android_log_puts(ANDROID_LOG_DEBUG, message.c_str()); break;
+            case CONSOLE_ERROR: android_log_puts(ANDROID_LOG_ERROR, message.c_str()); break;
+            case CONSOLE_WARN: android_log_puts(ANDROID_LOG_WARN, message.c_str()); break;
+            case CONSOLE_INFO:
+            default: android_log_puts(ANDROID_LOG_INFO, message.c_str()); break;
         }
 #else
         fputs(message.c_str(), stderr);


### PR DESCRIPTION
When built for android, send messages to the native logcat.