### PR TITLE
Fix layout detection in MusicXML

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -767,7 +767,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     Section *section = new Section();
     score->AddChild(section);
     // initialize layout
-    if (root.select_node("/score-partwise/part/measure/print")) {
+    if (root.select_node("/score-partwise/part/measure/print[@new-system or @new-page]")) {
         m_hasLayoutInformation = true;
         if (!root.select_node("/score-partwise/part[1]/measure[1]/print[@new-system or @new-page]")) {
             // always start with a new page


### PR DESCRIPTION
Minor fix to correctly handle MusicXML files without breaks but other layout information.