### PR TITLE
Add spacing between tied notes in chords

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -689,7 +689,7 @@ public:
     std::vector<BoundingBox *> m_upcomingBoundingBoxes;
     std::vector<ClassId> m_includes;
     std::vector<ClassId> m_excludes;
-    std::vector<LayerElement *> m_measureTieEndpoints;
+    std::vector<std::pair<LayerElement *, LayerElement *>> m_measureTieEndpoints;
     Doc *m_doc;
     Functor *m_functor;
     Functor *m_functorEnd;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -652,11 +652,14 @@ public:
  * member 5: the list of staffN in the top-level scoreDef
  * member 6: the bounding box in the previous aligner
  * member 7: the upcoming bounding boxes (to be used in the next aligner)
- * member 8: the Doc
- * member 9: the Functor for redirection to the MeasureAligner
- * member 10: the end Functor for redirection
- * member 11: current aligner that is being processed
- * member 12: preceeding aligner that was handled before
+ * member 8: list of types to include
+ * member 9: list of types to exclude
+ * member 10: list of tie endpoints for the current measure
+ * member 11: the Doc
+ * member 12: the Functor for redirection to the MeasureAligner
+ * member 13: the end Functor for redirection
+ * member 14: current aligner that is being processed
+ * member 15: preceeding aligner that was handled before
  **/
 
 class AdjustXPosParams : public FunctorParams {

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -674,6 +674,7 @@ public:
         m_functorEnd = functorEnd;
         m_currentAlignment.Reset();
         m_previousAlignment.Reset();
+        m_measureTieEndpoints.clear();
     }
     int m_minPos;
     int m_upcomingMinPos;
@@ -685,6 +686,7 @@ public:
     std::vector<BoundingBox *> m_upcomingBoundingBoxes;
     std::vector<ClassId> m_includes;
     std::vector<ClassId> m_excludes;
+    std::vector<LayerElement *> m_measureTieEndpoints;
     Doc *m_doc;
     Functor *m_functor;
     Functor *m_functorEnd;

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -249,7 +249,7 @@ public:
     /**
      * Return vector with tie endpoints for ties that start and end in current measure
      */
-    std::vector<LayerElement *> GetInternalTieEndpoints();
+    std::vector<std::pair<LayerElement *, LayerElement *>> GetInternalTieEndpoints();
 
     //----------//
     // Functors //

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -16,8 +16,9 @@
 
 namespace vrv {
 
-class Ending;
 class ControlElement;
+class Ending;
+class LayerElement;
 class ScoreDef;
 class System;
 class TimestampAttr;
@@ -244,6 +245,11 @@ public:
      * Return the real time offset in millisecond for the repeat (1-based).
      */
     double GetRealTimeOffsetMilliseconds(int repeat) const;
+
+    /**
+     * Return vector with tie endpoints for ties that start and end in current measure
+     */
+    std::vector<LayerElement *> GetInternalTieEndpoints();
 
     //----------//
     // Functors //

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1848,10 +1848,11 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
 
     auto it = std::find_if(params->m_measureTieEndpoints.begin(), params->m_measureTieEndpoints.end(),
         [this](const std::pair<LayerElement *, LayerElement *> &pair) { return pair.second == this; });
-    if ((it != params->m_measureTieEndpoints.end()) && (GetFirstAncestor(CHORD) != NULL)) {
+    if (it != params->m_measureTieEndpoints.end()) {
         const int minTiedDistance = 7 * drawingUnit;
         const int alignmentDistance = it->second->GetAlignment()->GetXRel() - it->first->GetAlignment()->GetXRel();
-        if (alignmentDistance < minTiedDistance) {
+        if ((alignmentDistance < minTiedDistance)
+            && ((this->GetFirstAncestor(CHORD) != NULL) || (it->first->FindDescendantByType(FLAG) != NULL))) {
             const int adjust = minTiedDistance - alignmentDistance;
             this->GetAlignment()->SetXRel(this->GetAlignment()->GetXRel() + adjust);
             // Also move the accumulated x shift and the minimum position for the next alignment accordingly

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1814,6 +1814,11 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     }
 
     offset = std::min(offset, selfLeft - params->m_minPos);
+    if ((std::find(params->m_measureTieEndpoints.begin(), params->m_measureTieEndpoints.end(), this)
+            != params->m_measureTieEndpoints.end())
+        && (GetFirstAncestor(CHORD) != NULL) && (offset >= 0)) {
+        offset = -drawingUnit;
+    }
     if (offset < 0) {
         this->GetAlignment()->SetXRel(this->GetAlignment()->GetXRel() - offset);
         // Also move the accumulated x shift and the minimum position for the next alignment accordingly

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -619,13 +619,13 @@ void Measure::SetInvisibleStaffBarlines(
     }
 }
 
-std::vector<LayerElement *> Measure::GetInternalTieEndpoints()
+std::vector<std::pair<LayerElement *, LayerElement *>> Measure::GetInternalTieEndpoints()
 {
     ListOfObjects children;
     ClassIdComparison comp(TIE);
     this->FindAllDescendantByComparison(&children, &comp);
 
-    std::vector<LayerElement *> endpoints;
+    std::vector<std::pair<LayerElement *, LayerElement *>> endpoints;
     for (Object *object : children) {
         Tie *tie = vrv_cast<Tie *>(object);
         // If both start and end points of the tie are not within current measure - skip it
@@ -633,7 +633,7 @@ std::vector<LayerElement *> Measure::GetInternalTieEndpoints()
         if (!start || (start->GetFirstAncestor(MEASURE) != this)) continue;
         LayerElement *end = tie->GetEnd();
         if (!end || (end->GetFirstAncestor(MEASURE) != this)) continue;
-        endpoints.push_back(end);
+        endpoints.emplace_back(start, end);
     }
 
     return endpoints;


### PR DESCRIPTION
- added code to increase offset between tied notes in chords to avoid ties being rendered in unrecognizable ways

Previous rendering:
![image](https://user-images.githubusercontent.com/1819669/127185002-0cc8aff6-e492-4f7c-958b-f99174cc3dff.png)

New rendering:
![image](https://user-images.githubusercontent.com/1819669/127184275-d2b3ea36-ffa7-496a-ac11-640544d26aec.png)


<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-07-09" type="encoding-date">2021-07-09</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000000000005091">
         <appInfo xml:id="appinfo-0000000000002777">
            <application xml:id="application-0000000000012924" isodate="2021-07-26T13:24:40" version="3.5.0-dev-[undefined]">
               <name xml:id="name-0000000000025138">Verovio</name>
               <p xml:id="p-0000000000015009">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000000010324">
            <score xml:id="score-0000000000012585">
               <scoreDef xml:id="scoredef-0000000000008943">
                  <staffGrp xml:id="staffgrp-0000000000031535">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <label xml:id="label-0000000000018949">Piano</label>
                        <labelAbbr xml:id="labelAbbr-0000000000022999">Pno.</labelAbbr>
                        <instrDef xml:id="instrdef-0000000000017035" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef xml:id="staffdef-0000000000021611" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-0000000000004386" shape="G" line="2" />
                           <keySig xml:id="keysig-0000000000006115" sig="0" />
                           <meterSig xml:id="msig-0000000000021477" count="2" unit="4" />
                        </staffDef>
                        <staffDef xml:id="staffdef-0000000000008128" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-0000000000000530" shape="F" line="4" />
                           <keySig xml:id="keysig-0000000000008467" sig="0" />
                           <meterSig xml:id="msig-0000000000019333" count="2" unit="4" />
                        </staffDef>
                        <grpSym xml:id="grpsym-0000000000018880" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000000015378">
                  <pb xml:id="pb-0000000000006540" />
                  <measure xml:id="measure-0000000000023174" n="1">
                     <staff xml:id="staff-0000000000013382" n="1">
                        <layer xml:id="layer-0000000000000952" n="1">
                           <beam xml:id="beam-0000000000030081">
                              <note xml:id="note-0000000000021610" dur.ppq="1" dur="16" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0000000000009621" dur.ppq="1" dur="16" oct="5" pname="d" stem.dir="down">
                                 <accid xml:id="accid-0000000000002127" accid="s" accid.ges="s" />
                              </note>
                              <note xml:id="note-0000000000015778" dur.ppq="1" dur="16" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0000000000009364" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000000000010397">
                              <note xml:id="note-0000000000014169" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="up" />
                              <note xml:id="note-0000000000001481" dur.ppq="1" dur="16" oct="4" pname="e" stem.dir="up" />
                              <note xml:id="note-0000000000004930" dur.ppq="1" dur="16" oct="4" pname="f" stem.dir="up" />
                              <note xml:id="note-0000000000001644" dur.ppq="1" dur="16" oct="4" pname="f" stem.dir="up">
                                 <accid xml:id="accid-0000000000002142" accid="s" accid.ges="s" />
                              </note>
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000000006788" n="2">
                        <layer xml:id="layer-0000000000009643" n="5">
                           <beam xml:id="beam-0000000000001031">
                              <note xml:id="note-0000000000010010" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                              <chord xml:id="chord-test" dur.ppq="2" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000000008351" oct="3" pname="g" />
                                 <note xml:id="note-0000000000016241" oct="4" pname="c" />
                                 <note xml:id="note-0000000000014215" oct="4" pname="e" />
                              </chord>
                           </beam>
                           <beam xml:id="beam-0000000000032402">
                              <note xml:id="note-0000000000009981" dur.ppq="2" dur="8" oct="2" pname="g" stem.dir="down" />
                              <chord xml:id="chord-0000000000018226" dur.ppq="2" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000000021192" oct="3" pname="g" />
                                 <note xml:id="note-0000000000003529" oct="4" pname="c" />
                                 <note xml:id="note-0000000000027892" oct="4" pname="e" />
                              </chord>
                           </beam>
                        </layer>
                     </staff>
                     <tie xml:id="tie-0000000000015529" startid="#note-0000000000009364" endid="#note-0000000000014169" />
                  </measure>
                  <measure xml:id="measure-0000000000006990" right="end" n="2">
                     <staff xml:id="staff-0000000000002306" n="1">
                        <layer xml:id="layer-0000000000009951" n="1">
                           <beam xml:id="beam-0000000000025294">
                              <note xml:id="note-0000000000024865" dur.ppq="1" dur="16" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="note-0000000000030456" dur.ppq="1" dur="16" oct="5" pname="c" stem.dir="down" />
                              <note xml:id="note-0000000000019826" dur.ppq="1" dur="16" oct="5" pname="e" stem.dir="down" />
                              <chord xml:id="chord-0000000000030424" dur.ppq="1" dur="16" stem.dir="down">
                                 <note xml:id="note-a" oct="4" pname="g" />
                                 <note xml:id="note-b" oct="5" pname="e" />
                                 <note xml:id="note-c" oct="5" pname="g" />
                              </chord>
                           </beam>
                           <beam xml:id="beam-0000000000018683">
                              <chord xml:id="chord-0000000000021401" dur.ppq="1" dur="16" stem.dir="down">
                                 <note xml:id="note-d" oct="4" pname="g" />
                                 <note xml:id="note-e" oct="5" pname="e" />
                                 <note xml:id="note-f" oct="5" pname="g" />
                              </chord>
                              <chord xml:id="chord-0000000000030443" breaksec="1" dur.ppq="1" dur="16" stem.dir="down">
                                 <note xml:id="note-0000000000004056" oct="4" pname="f">
                                    <accid xml:id="accid-0000000000016660" accid="s" accid.ges="s" />
                                 </note>
                                 <note xml:id="note-0000000000028468" oct="5" pname="d">
                                    <accid xml:id="accid-0000000000005531" accid="s" accid.ges="s" />
                                 </note>
                                 <note xml:id="note-0000000000007826" oct="5" pname="f">
                                    <accid xml:id="accid-0000000000020828" accid="s" accid.ges="s" />
                                 </note>
                              </chord>
                              <chord xml:id="chord-0000000000000997" dur.ppq="2" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000000018782" oct="4" pname="g" />
                                 <note xml:id="note-0000000000012699" oct="5" pname="e" />
                                 <note xml:id="note-0000000000000457" oct="5" pname="g" />
                              </chord>
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000000011401" n="2">
                        <layer xml:id="layer-0000000000029117" n="5">
                           <beam xml:id="beam-0000000000031509">
                              <note xml:id="note-0000000000009060" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                              <chord xml:id="chord-0000000000021710" dur.ppq="2" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000000011683" oct="3" pname="g" />
                                 <note xml:id="note-0000000000024387" oct="4" pname="c" />
                                 <note xml:id="note-0000000000002804" oct="4" pname="e" />
                              </chord>
                           </beam>
                           <beam xml:id="beam-0000000000001511">
                              <note xml:id="note-0000000000015722" dur.ppq="2" dur="8" oct="2" pname="g" stem.dir="down" />
                              <chord xml:id="chord-0000000000025221" dur.ppq="2" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000000030326" oct="3" pname="g" />
                                 <note xml:id="note-0000000000030451" oct="4" pname="c" />
                                 <note xml:id="note-0000000000005449" oct="4" pname="e" />
                              </chord>
                           </beam>
                        </layer>
                     </staff>
                     <tie xml:id="tie-1" startid="#note-a" endid="#note-d" />
                     <tie xml:id="tie-2" startid="#note-b" endid="#note-e" />
                     <tie xml:id="tie-3" startid="#note-c" endid="#note-f" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>