### PR TITLE
Improve extender lines positioning over system break

### DIFF
--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -63,7 +63,7 @@ public:
     /**
      * See FloatingObject::IsExtenderElement
      */
-    virtual bool IsExtenderElement() const { return GetCurrentSize() == 0; }
+    virtual bool IsExtenderElement() const { return GetExtender() == BOOLEAN_true; }
 
     //----------//
     // Functors //

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -60,6 +60,11 @@ public:
      */
     virtual bool IsSupportedChild(Object *object);
 
+    /**
+     * See FloatingObject::IsExtenderElement
+     */
+    virtual bool IsExtenderElement() const { return GetCurrentSize() == 0; }
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -70,6 +70,11 @@ public:
      */
     std::wstring GetSymbolStr() const;
 
+    /**
+     * See FloatingObject::IsExtenderElement
+     */
+    virtual bool IsExtenderElement() const { return GetSymbolStr().empty(); }
+
     //----------------//
     // Static methods //
     //----------------//

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -73,7 +73,7 @@ public:
     /**
      * See FloatingObject::IsExtenderElement
      */
-    virtual bool IsExtenderElement() const { return GetSymbolStr().empty(); }
+    virtual bool IsExtenderElement() const { return GetExtender() == BOOLEAN_true; }
 
     //----------------//
     // Static methods //

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -80,6 +80,11 @@ public:
     int GetMaxDrawingYRel() const { return m_maxDrawingYRel; };
     ///@}
 
+    /**
+     * Check whether current object represents initial element or extender lines
+     */
+    virtual bool IsExtenderElement() const { return false; }
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -70,6 +70,9 @@ public:
     void SetDrawingGrpId(int drawingGrpId) { m_drawingGrpId = drawingGrpId; }
     int SetDrawingGrpObject(void *drawingGrpObject);
     ///@}
+    
+    void SetMaxDrawingYRel(int maxDrawingYRel) { m_maxDrawingYRel = maxDrawingYRel; };
+    int GetMaxDrawingYRel() const { return m_maxDrawingYRel; };
 
     //----------//
     // Functors //
@@ -124,6 +127,8 @@ private:
 
     /* Drawing Id to group floating elements horizontally */
     int m_drawingGrpId;
+    
+    int m_maxDrawingYRel;
 
     //----------------//
     // Static members //

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -70,7 +70,7 @@ public:
     void SetDrawingGrpId(int drawingGrpId) { m_drawingGrpId = drawingGrpId; }
     int SetDrawingGrpObject(void *drawingGrpObject);
     ///@}
-    
+
     /**
      * @name Get and set maximum drawing yRel that is persistent for the floating object across all its floating
      * positioners, which allows for persisten vertical positioning for some elements
@@ -138,7 +138,7 @@ private:
 
     /* Drawing Id to group floating elements horizontally */
     int m_drawingGrpId;
-    
+
     int m_maxDrawingYRel;
 
     //----------------//

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -71,8 +71,14 @@ public:
     int SetDrawingGrpObject(void *drawingGrpObject);
     ///@}
     
-    void SetMaxDrawingYRel(int maxDrawingYRel) { m_maxDrawingYRel = maxDrawingYRel; };
+    /**
+     * @name Get and set maximum drawing yRel that is persistent for the floating object across all its floating
+     * positioners, which allows for persisten vertical positioning for some elements
+     */
+    ///@{
+    void SetMaxDrawingYRel(int maxDrawingYRel);
     int GetMaxDrawingYRel() const { return m_maxDrawingYRel; };
+    ///@}
 
     //----------//
     // Functors //

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -492,17 +492,20 @@ public:
 
 /**
  * member 0: a pointer to the previous staff alignment
- * member 1: a pointer to the functor for passing it to the system aligner
+ * member 1: the doc
+ * member 2: a pointer to the functor for passing it to the system aligner
  **/
 
 class AdjustStaffOverlapParams : public FunctorParams {
 public:
-    AdjustStaffOverlapParams(Functor *functor)
+    AdjustStaffOverlapParams(Doc *doc, Functor *functor)
     {
         m_previous = NULL;
+        m_doc = doc;
         m_functor = functor;
     }
     StaffAlignment *m_previous;
+    Doc *m_doc;
     Functor *m_functor;
 };
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1395,6 +1395,11 @@ public:
     Object *GetListNext(Object *listElement);
 
     /**
+     * Returns current size of the m_list
+     */
+    int GetCurrentSize() const { return static_cast<int>(m_list.size()); }
+
+    /**
      * Return the list.
      * Before returning the list, it checks that the list is up-to-date with Object::IsModified
      * If not, it updates the list and also calls FilterList.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1395,11 +1395,6 @@ public:
     Object *GetListNext(Object *listElement);
 
     /**
-     * Returns current size of the m_list
-     */
-    int GetCurrentSize() const { return static_cast<int>(m_list.size()); }
-
-    /**
      * Return the list.
      * Before returning the list, it checks that the list is up-to-date with Object::IsModified
      * If not, it updates the list and also calls FilterList.

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -383,7 +383,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
             // For elements, that can have extender lines, we need to make sure that they continue in next system on the
             // same height, as they were before (even if there are no overlapping elements in subsequent measures)
-            if (m_object->Is({ DIR, DYNAM })) {
+            if (m_object->Is({ DIR, DYNAM }) && m_object->IsExtenderElement()) {
                 m_object->SetMaxDrawingYRel(yRel);
                 this->SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
             }
@@ -410,7 +410,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
             // For elements, that can have extender lines, we need to make sure that they continue in next system on the
             // same height, as they were before (even if there are no overlapping elements in subsequent measures)
-            if (m_object->Is({ DIR, DYNAM })) {
+            if (m_object->Is({ DIR, DYNAM }) && m_object->IsExtenderElement()) {
                 m_object->SetMaxDrawingYRel(yRel);
                 this->SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
             }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -379,7 +379,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + this->GetContentY1() - margin;
-            
+
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
             // For elements, that can have extender lines, we need to make sure that they continue in next system on the
             // same height, as they were before (even if there are no overlapping elements in subsequent measures)

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -60,6 +60,7 @@ FloatingObject::FloatingObject(const std::string &classid) : Object(classid)
     Reset();
 
     m_currentPositioner = NULL;
+    m_maxDrawingYRel = 0;
 }
 
 FloatingObject::~FloatingObject() {}
@@ -367,9 +368,14 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + GetContentY1() - margin;
+            
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            if (m_object->Is({ DIR, DYNAM })) {
+                if (m_object->GetMaxDrawingYRel() > yRel) m_object->SetMaxDrawingYRel(yRel);
+                SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
+            }
             // With LayerElement always move them up
-            if (object && object->IsLayerElement()) {
+            else if (object && object->IsLayerElement()) {
                 if (yRel < 0) this->SetDrawingYRel(yRel);
             }
             // Otherwise only if the is a vertical overlap
@@ -388,9 +394,14 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             }
             yRel = staffAlignment->CalcOverflowBelow(horizOverlapingBBox) + staffAlignment->GetStaffHeight()
                 + GetContentY2() + margin;
+            
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            if (m_object->Is({ DIR, DYNAM })) {
+                if (m_object->GetMaxDrawingYRel() < yRel) m_object->SetMaxDrawingYRel(yRel);
+                SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
+            }
             // With LayerElement always move them down
-            if (object && object->IsLayerElement()) {
+            else if (object && object->IsLayerElement()) {
                 if (yRel > 0) this->SetDrawingYRel(yRel);
             }
             // Otherwise only if the is a vertical overlap

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -334,26 +334,18 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         int minStaffDistance
             = doc->GetStaffDistance(m_object->GetClassId(), staffIndex, m_place) * doc->GetDrawingUnit(staffSize);
         if (m_place == STAFFREL_above) {
-            yRel = GetContentY1();
+            yRel = this->GetContentY1();
             yRel -= doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
-            if (m_object->Is({ DIR, DYNAM })) {
-                SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
-            }
-            else {
-                SetDrawingYRel(yRel);
-                SetDrawingYRel(-minStaffDistance);
-            }
+            this->SetDrawingYRel(yRel);
+            this->SetDrawingYRel(m_object->GetMaxDrawingYRel());
+            this->SetDrawingYRel(-minStaffDistance);
         }
         else {
-            yRel = staffAlignment->GetStaffHeight() + GetContentY2();
+            yRel = staffAlignment->GetStaffHeight() + this->GetContentY2();
             yRel += doc->GetTopMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
-            if (m_object->Is({ DIR, DYNAM })) {
-                SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
-            }
-            else {
-                SetDrawingYRel(yRel);
-                SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
-            }
+            this->SetDrawingYRel(yRel);
+            this->SetDrawingYRel(m_object->GetMaxDrawingYRel());
+            this->SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
         }
     }
     else {
@@ -365,9 +357,9 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
 
         if (m_place == STAFFREL_above) {
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
-                int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
+                const int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
-                    SetDrawingYRel(GetDrawingYRel() - shift);
+                    this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
                 return true;
             }
@@ -376,46 +368,49 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 // whitespace. For such cases, DYNAM should be compared to individual elements of BEAM instead
                 return true;
             }
-            yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + GetContentY1() - margin;
+            yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + this->GetContentY1() - margin;
             
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            // For elements, that can have extender lines, we need to make sure that they continue in next system on the
+            // same height, as they were before (even if there are no overlapping elements in subsequent measures)
             if (m_object->Is({ DIR, DYNAM })) {
                 if (m_object->GetMaxDrawingYRel() > yRel) m_object->SetMaxDrawingYRel(yRel);
-                SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
+                this->SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
             }
             // With LayerElement always move them up
             else if (object && object->IsLayerElement()) {
-                if (yRel < 0) SetDrawingYRel(yRel);
+                if (yRel < 0) this->SetDrawingYRel(yRel);
             }
-            // Otherwise only if the is a vertical overlap
-            else if (VerticalContentOverlap(horizOverlapingBBox, margin)) {
-                SetDrawingYRel(yRel);
+            // Otherwise only if there is a vertical overlap
+            else if (this->VerticalContentOverlap(horizOverlapingBBox, margin)) {
+                this->SetDrawingYRel(yRel);
             }
         }
         else {
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
-                int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
+                const int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
-                    SetDrawingYRel(GetDrawingYRel() - shift);
-                    // LogDebug("Shift %d", shift);
+                    this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
                 return true;
             }
             yRel = staffAlignment->CalcOverflowBelow(horizOverlapingBBox) + staffAlignment->GetStaffHeight()
-                + GetContentY2() + margin;
-            
+                + this->GetContentY2() + margin;
+
             Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            // For elements, that can have extender lines, we need to make sure that they continue in next system on the
+            // same height, as they were before (even if there are no overlapping elements in subsequent measures)
             if (m_object->Is({ DIR, DYNAM })) {
                 if (m_object->GetMaxDrawingYRel() < yRel) m_object->SetMaxDrawingYRel(yRel);
-                SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
+                this->SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
             }
             // With LayerElement always move them down
             else if (object && object->IsLayerElement()) {
-                if (yRel > 0) SetDrawingYRel(yRel);
+                if (yRel > 0) this->SetDrawingYRel(yRel);
             }
-            // Otherwise only if the is a vertical overlap
-            else if (VerticalContentOverlap(horizOverlapingBBox, margin)) {
-                SetDrawingYRel(yRel);
+            // Otherwise only if there is a vertical overlap
+            else if (this->VerticalContentOverlap(horizOverlapingBBox, margin)) {
+                this->SetDrawingYRel(yRel);
             }
         }
     }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -336,14 +336,24 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         if (m_place == STAFFREL_above) {
             yRel = GetContentY1();
             yRel -= doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
-            this->SetDrawingYRel(yRel);
-            this->SetDrawingYRel(-minStaffDistance);
+            if (m_object->Is({ DIR, DYNAM })) {
+                SetDrawingYRel(std::min(yRel, m_object->GetMaxDrawingYRel()));
+            }
+            else {
+                SetDrawingYRel(yRel);
+                SetDrawingYRel(-minStaffDistance);
+            }
         }
         else {
             yRel = staffAlignment->GetStaffHeight() + GetContentY2();
             yRel += doc->GetTopMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
-            this->SetDrawingYRel(yRel);
-            this->SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
+            if (m_object->Is({ DIR, DYNAM })) {
+                SetDrawingYRel(std::max(yRel, m_object->GetMaxDrawingYRel()));
+            }
+            else {
+                SetDrawingYRel(yRel);
+                SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
+            }
         }
     }
     else {
@@ -357,8 +367,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
                 int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
-                    this->SetDrawingYRel(this->GetDrawingYRel() - shift);
-                    // LogDebug("Shift %d", shift);
+                    SetDrawingYRel(GetDrawingYRel() - shift);
                 }
                 return true;
             }
@@ -376,18 +385,18 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             }
             // With LayerElement always move them up
             else if (object && object->IsLayerElement()) {
-                if (yRel < 0) this->SetDrawingYRel(yRel);
+                if (yRel < 0) SetDrawingYRel(yRel);
             }
             // Otherwise only if the is a vertical overlap
-            else if (this->VerticalContentOverlap(horizOverlapingBBox, margin)) {
-                this->SetDrawingYRel(yRel);
+            else if (VerticalContentOverlap(horizOverlapingBBox, margin)) {
+                SetDrawingYRel(yRel);
             }
         }
         else {
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
                 int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
                 if (shift != 0) {
-                    this->SetDrawingYRel(this->GetDrawingYRel() - shift);
+                    SetDrawingYRel(GetDrawingYRel() - shift);
                     // LogDebug("Shift %d", shift);
                 }
                 return true;
@@ -402,11 +411,11 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             }
             // With LayerElement always move them down
             else if (object && object->IsLayerElement()) {
-                if (yRel > 0) this->SetDrawingYRel(yRel);
+                if (yRel > 0) SetDrawingYRel(yRel);
             }
             // Otherwise only if the is a vertical overlap
-            else if (this->VerticalContentOverlap(horizOverlapingBBox, margin)) {
-                this->SetDrawingYRel(yRel);
+            else if (VerticalContentOverlap(horizOverlapingBBox, margin)) {
+                SetDrawingYRel(yRel);
             }
         }
     }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -483,7 +483,7 @@ void Page::LayOutVertically()
 
     // Adjust the overlap of the staff aligments by looking at the overflow bounding boxes params.clear();
     Functor adjustStaffOverlap(&Object::AdjustStaffOverlap);
-    AdjustStaffOverlapParams adjustStaffOverlapParams(&adjustStaffOverlap);
+    AdjustStaffOverlapParams adjustStaffOverlapParams(doc, &adjustStaffOverlap);
     this->Process(&adjustStaffOverlap, &adjustStaffOverlapParams);
 
     // Set the Y position of each StaffAlignment

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -616,7 +616,8 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
     AdjustFloatingPositionersParams *params = vrv_params_cast<AdjustFloatingPositionersParams *>(functorParams);
     assert(params);
 
-    int staffSize = this->GetStaffSize();
+    const int staffSize = this->GetStaffSize();
+    const int drawingUnit = params->m_doc->GetDrawingUnit(staffSize);
 
     const bool verseCollapse = params->m_doc->GetOptions()->m_lyricVerseCollapse.GetValue();
     if (params->m_classId == SYL) {
@@ -624,9 +625,8 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             FontInfo *lyricFont = params->m_doc->GetDrawingLyricFont(m_staff->m_drawingStaffSize);
             int descender = params->m_doc->GetTextGlyphDescender(L'q', lyricFont, false);
             int height = params->m_doc->GetTextGlyphHeight(L'I', lyricFont, false);
-            int margin = params->m_doc->GetBottomMargin(SYL) * params->m_doc->GetDrawingUnit(staffSize);
-            int minMargin = std::max((int)(params->m_doc->GetOptions()->m_lyricTopMinMargin.GetValue()
-                                         * params->m_doc->GetDrawingUnit(staffSize)),
+            int margin = params->m_doc->GetBottomMargin(SYL) * drawingUnit;
+            int minMargin = std::max((int)(params->m_doc->GetOptions()->m_lyricTopMinMargin.GetValue() * drawingUnit),
                 this->GetOverflowBelow());
             this->SetOverflowBelow(minMargin + this->GetVerseCount(verseCollapse) * (height - descender + margin));
             // For now just clear the overflowBelow, which avoids the overlap to be calculated. We could also keep them
@@ -703,12 +703,18 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         auto i = overflowBoxes->begin();
         auto end = overflowBoxes->end();
         while (i != end) {
-            // find all the overflowing elements from the staff that overlap horizontally
-            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
+            // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
+            // elements - vertically)
+			const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
                 ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
                 : 0;
-            i = std::find_if(
-                i, end, [iter, margin](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem, margin); });
+            i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
+                if ((*iter)->GetObject()->IsExtenderElement()) {
+                    return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)
+                        || (*iter)->VerticalContentOverlap(elem);                
+                }
+                return (*iter)->HorizontalContentOverlap(elem, margin);
+            });
             if (i != end) {
                 // update the yRel accordingly
                 (*iter)->CalcDrawingYRel(params->m_doc, this, *i);
@@ -952,7 +958,6 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
         auto end = m_overflowAboveBBoxes.end();
         while (i != end) {
             // find all the elements from the bottom staff that have an overflow at the top with an horizontal overlap
-            i = std::find_if(i, end, [iter](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem); });
             i = std::find_if(i, end, [iter](BoundingBox *elem) {
                 if ((*iter)->Is(FLOATING_POSITIONER)) {
                     FloatingPositioner *fp = vrv_cast<FloatingPositioner *>(*iter);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -711,7 +711,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
                 if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)
-                        || (*iter)->VerticalContentOverlap(elem);                
+                        || (*iter)->VerticalContentOverlap(elem);
                 }
                 return (*iter)->HorizontalContentOverlap(elem, margin);
             });
@@ -950,6 +950,9 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
+    const int staffSize = this->GetStaffSize();
+    const int drawingUnit = params->m_doc->GetDrawingUnit(staffSize);
+
     ArrayOfBoundingBoxes::iterator iter;
     // go through all the elements of the top staff that have an overflow below
     for (iter = params->m_previous->m_overflowBelowBBoxes.begin();
@@ -958,11 +961,12 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
         auto end = m_overflowAboveBBoxes.end();
         while (i != end) {
             // find all the elements from the bottom staff that have an overflow at the top with an horizontal overlap
-            i = std::find_if(i, end, [iter](BoundingBox *elem) {
+            i = std::find_if(i, end, [iter, drawingUnit](BoundingBox *elem) {
                 if ((*iter)->Is(FLOATING_POSITIONER)) {
                     FloatingPositioner *fp = vrv_cast<FloatingPositioner *>(*iter);
-                    if (fp->GetObject()->Is({ DIR, DYNAM })) {
-                        return (*iter)->HorizontalContentOverlap(elem) || (*iter)->VerticalContentOverlap(elem);
+                    if (fp->GetObject()->Is({ DIR, DYNAM }) && fp->GetObject()->IsExtenderElement()) {
+                        return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 4)
+                            || (*iter)->VerticalContentOverlap(elem);
                     }
                 }
                 return (*iter)->HorizontalContentOverlap(elem);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -953,6 +953,15 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
         while (i != end) {
             // find all the elements from the bottom staff that have an overflow at the top with an horizontal overlap
             i = std::find_if(i, end, [iter](BoundingBox *elem) { return (*iter)->HorizontalContentOverlap(elem); });
+            i = std::find_if(i, end, [iter](BoundingBox *elem) {
+                if ((*iter)->Is(FLOATING_POSITIONER)) {
+                    FloatingPositioner *fp = vrv_cast<FloatingPositioner *>(*iter);
+                    if (fp->GetObject()->Is({ DIR, DYNAM })) {
+                        return (*iter)->HorizontalContentOverlap(elem) || (*iter)->VerticalContentOverlap(elem);
+                    }
+                }
+                return (*iter)->HorizontalContentOverlap(elem);
+            });
             if (i != end) {
                 // calculate the vertical overlap and see if this is more than the expected space
                 int overflowBelow = params->m_previous->CalcOverflowBelow(*iter);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -705,7 +705,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
-			const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
+            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
                 ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
                 : 0;
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -709,7 +709,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
                 ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
                 : 0;
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
-                if ((*iter)->GetObject()->IsExtenderElement()) {
+                if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)
                         || (*iter)->VerticalContentOverlap(elem);                
                 }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1033,8 +1033,6 @@ void View::DrawControlElementConnector(
     assert(element->GetNextLink() || interface->GetEnd());
     if (!element->GetNextLink() && !interface->GetEnd()) return;
 
-    int y = element->GetDrawingY() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
-
     // Adjust the x1
     if ((spanningType == SPANNING_START) || (spanningType == SPANNING_START_END)) {
         if (element->GetCurrentFloatingPositioner() && element->GetCurrentFloatingPositioner()->HasContentBB()) {
@@ -1054,6 +1052,7 @@ void View::DrawControlElementConnector(
     }
 
     const int width = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int y = element->GetDrawingY() + width / 2;
 
     // the length of the dash and the space between them - can be made a parameter
     const int dashLength = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 4 / 3;


### PR DESCRIPTION
There are two main changes to the behavior of the extender lines:
1. Extender lines now should keep their vertical position when spanning over the systems, making rendering more clear.
2. Extender lines now should avoid overlaps with other elemens (e.g. stems) that are in their way , even if there is no physical overlap of the elements (which will allow to distinguish which staff/system it belongs to in some cases)

Previous rendering:
![image](https://user-images.githubusercontent.com/1819669/127499279-1849523b-ea78-4975-9246-0d0b1a7cb03c.png)

New rendering:
![image](https://user-images.githubusercontent.com/1819669/127499324-ba83b6af-ebb5-43a1-a214-b8908db5e39f.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-05-03" type="encoding-date">2021-05-03</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffGrp bar.thru="true">
                        <label>Piano</label>
                        <labelAbbr>Pno.</labelAbbr>
                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef n="1" lines="5" ppq="1">
                           <clef shape="G" line="2" />
                           <keySig sig="0" />
                           <meterSig count="2" unit="2" />
                        </staffDef>
                        <staffDef n="2" lines="5" ppq="1">
                           <clef shape="F" line="4" />
                           <keySig sig="0" />
                           <meterSig count="2" unit="2" />
                        </staffDef>
                        <grpSym symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                  <pb />
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="2" dur="2" oct="5" pname="c" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="5" pname="c" stem.dir="up">
                              <accid accid="s" accid.ges="s" />
                           </note>
                        </layer>
                        <layer n="2">
                           <note dur.ppq="2" dur="2" oct="4" pname="e" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="4" pname="e" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="5">
                           <note dur.ppq="2" dur="2" oct="3" pname="g" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="3" pname="g" stem.dir="up" />
                        </layer>
                        <layer n="6">
                           <note dur.ppq="2" dur="2" oct="3" pname="c" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="2" pname="b" stem.dir="down">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                     </staff>
                     <dynam place="below" staff="1" tstamp="1.000000" tstamp2="4m+1.0000" extender="true" lform="dashed" vgrp="90">
                        <rend fontfam="FreeSerif" fontstyle="italic">dim.</rend>
                     </dynam>
                     <dynam place="below" staff="2" tstamp="1.000000" tstamp2="4m+1.0000" extender="true" lform="dashed" vgrp="90">
                        <rend fontfam="FreeSerif" fontstyle="italic">cresc.</rend>
                     </dynam>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="2" dur="2" oct="5" pname="d" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="5" pname="d" stem.dir="up">
                              <accid accid="s" accid.ges="s" />
                           </note>
                        </layer>
                        <layer n="2">
                           <note dur.ppq="2" dur="2" oct="4" pname="d" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="4" pname="b" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="5">
                           <note dur.ppq="2" dur="2" oct="3" pname="f" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="3" pname="f" stem.dir="up">
                              <accid accid="s" accid.ges="s" />
                           </note>
                        </layer>
                        <layer n="6">
                           <note dur.ppq="2" dur="2" oct="2" pname="a" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="2" pname="a" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="2" dur="2" oct="5" pname="e" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="5" pname="f" stem.dir="up" />
                        </layer>
                        <layer n="2">
                           <note dur.ppq="2" dur="2" oct="4" pname="b" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="5" pname="c" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="5">
                           <note dur.ppq="2" dur="2" oct="3" pname="g" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="3" pname="e" stem.dir="up">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                        <layer n="6">
                           <note dur.ppq="2" dur="2" oct="2" pname="g" stem.dir="down">
                              <accid accid="n" />
                           </note>
                           <note dur.ppq="2" dur="2" oct="2" pname="a" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <sb />
                  <measure n="4">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="2" dur="2" oct="5" pname="a" stem.dir="up">
                              <accid accid="f" accid.ges="f" />
                           </note>
                           <note dur.ppq="2" dur="2" oct="5" pname="g" stem.dir="up" />
                        </layer>
                        <layer n="2">
                           <note dur.ppq="2" dur="2" oct="4" pname="b" stem.dir="down">
                              <accid accid="f" accid.ges="f" />
                           </note>
                           <note dur.ppq="2" dur="2" oct="4" pname="b" stem.dir="down" accid.ges="f" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="5">
                           <note dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                           <note dur.ppq="2" dur="2" oct="3" pname="e" stem.dir="up">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                        <layer n="6">
                           <note dur.ppq="2" dur="2" oct="1" pname="g" stem.dir="down" />
                           <note dur.ppq="2" dur="2" oct="2" pname="e" stem.dir="down">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end" n="5">
                     <staff n="1">
                        <layer n="1">
                           <note dur.ppq="4" dur="1" oct="5" pname="a">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                        <layer n="2">
                           <note dur.ppq="4" dur="1" oct="5" pname="c" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="5">
                           <note dur.ppq="4" dur="1" oct="3" pname="e">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                        <layer n="6">
                           <note dur.ppq="4" dur="1" oct="2" pname="a">
                              <accid accid="f" accid.ges="f" />
                           </note>
                        </layer>
                     </staff>
                     <dynam place="below" staff="1" tstamp="1.000000" val="64" vgrp="45">fff</dynam>
                     <dynam place="below" staff="1" tstamp="1.000000" val="64" vgrp="90">mp</dynam>
                     <dynam place="below" staff="2" tstamp="1.000000" val="96" vgrp="90">f</dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>


```

</details>
