### PR TITLE
Fix for whole note collision on multi-layers

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1552,10 +1552,10 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             Note *previousNote = vrv_cast<Note *>(otherElements.at(i));
             assert(previousNote);
             isUnisonElement = currentNote->IsUnisonWith(previousNote, true);
+            const bool isPreviousCoord = previousNote->GetParent()->Is(CHORD);
             // Unisson, look at the duration for the note heads
             if (unison && currentNote->IsUnisonWith(previousNote, false)) {
                 int previousDuration = previousNote->GetDrawingDur();
-                const bool isPreviousCoord = previousNote->GetParent()->Is(CHORD);
                 bool isEdgeElement = false;
                 if (isPreviousCoord) {
                     Chord *parentChord = vrv_cast<Chord *>(previousNote->GetParent());
@@ -1640,6 +1640,18 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
                 // Otherwise move the appropriate parent to the right
                 shift -= horizontalMargin
                     - HorizontalRightOverlap(otherElements.at(i), doc, horizontalMargin - shift, verticalMargin);
+            }
+        }
+        else if (Note *currentNote = vrv_cast<Note *>(this);
+                 Is(NOTE) && (currentNote->GetDrawingDur() == DUR_1) && otherElements.at(i)->Is(STEM)) {
+            const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+            Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
+            data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
+            if (this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0) != 0) {
+                shift = 3 * horizontalMargin;
+                if (stemDir == STEMDIRECTION_up) {
+                    shift *= -1;
+                }
             }
         }
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1642,15 +1642,18 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
                     - HorizontalRightOverlap(otherElements.at(i), doc, horizontalMargin - shift, verticalMargin);
             }
         }
-        else if (Note *currentNote = vrv_cast<Note *>(this);
-                 Is(NOTE) && (currentNote->GetDrawingDur() == DUR_1) && otherElements.at(i)->Is(STEM)) {
-            const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-            Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
-            data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
-            if (this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0) != 0) {
-                shift = 3 * horizontalMargin;
-                if (stemDir == STEMDIRECTION_up) {
-                    shift *= -1;
+        else if (this->Is(NOTE)) {
+            Note *currentNote = vrv_cast<Note *>(this);
+            assert(currentNote);
+            if ((currentNote->GetDrawingDur() == DUR_1) && otherElements.at(i)->Is(STEM)) {
+                const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
+                data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
+                if (this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0) != 0) {
+                    shift = 3 * horizontalMargin;
+                    if (stemDir == STEMDIRECTION_up) {
+                        shift *= -1;
+                    }
                 }
             }
         }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1552,10 +1552,10 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             Note *previousNote = vrv_cast<Note *>(otherElements.at(i));
             assert(previousNote);
             isUnisonElement = currentNote->IsUnisonWith(previousNote, true);
-            const bool isPreviousCoord = previousNote->GetParent()->Is(CHORD);
             // Unisson, look at the duration for the note heads
             if (unison && currentNote->IsUnisonWith(previousNote, false)) {
                 int previousDuration = previousNote->GetDrawingDur();
+                const bool isPreviousCoord = previousNote->GetParent()->Is(CHORD);
                 bool isEdgeElement = false;
                 if (isPreviousCoord) {
                     Chord *parentChord = vrv_cast<Chord *>(previousNote->GetParent());


### PR DESCRIPTION
Fix for an issue where whole noteheads on second layers are not accounted for and end up overlapping with elements from other layers.

Before:
![image](https://user-images.githubusercontent.com/1819669/127671909-5b15c2d1-7b38-4f96-9b2f-fdd814901d87.png)

After:
![image](https://user-images.githubusercontent.com/1819669/127671937-c0c450ed-b5ce-49a2-b61d-0a7fbd6385e2.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Title</title>
            <respStmt>
               <persName role="composer">Composer</persName>
            </respStmt>
         </titleStmt>
         <pubStmt><date isodate="2021-07-27" type="encoding-date">2021-07-27</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2021-07-29T13:07:10" version="3.6.0-dev-[undefined]">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="1">
                        <label>Piano</label>
                        <labelAbbr>Pno.</labelAbbr>
                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <chord xml:id="chord-m1l1" dur.ppq="2" dur="2" stem.dir="up">
                              <note oct="4" pname="g" />
                              <note oct="5" pname="g" />
                           </chord>
                           <rest dur.ppq="2" dur="2" />
                        </layer>
                        <layer n="2">
                           <note xml:id="note-m1l2" dur.ppq="4" dur="1" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <chord xml:id="chord-m2l1" dur.ppq="2" dur="2" stem.dir="down">
                              <note oct="4" pname="g" />
                              <note oct="5" pname="g" />
                           </chord>
                           <rest dur.ppq="2" dur="2" />
                        </layer>
                        <layer n="2">
                           <note xml:id="note-m2l2" dur.ppq="4" dur="1" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="note-m3l1" dur.ppq="4" dur="1" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <chord xml:id="chord-m3l2" dur.ppq="2" dur="2" stem.dir="down">
                              <note oct="4" pname="g" />
                              <note oct="5" pname="g" />
                           </chord>
                           <rest dur.ppq="2" dur="2" />
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end" n="4">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="note-m4l1" dur.ppq="4" dur="1" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <chord xml:id="chord-m4l2" dur.ppq="2" dur="2" stem.dir="up">
                              <note oct="4" pname="g" />
                              <note oct="5" pname="g" />
                           </chord>
                           <rest dur.ppq="2" dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>