### PR TITLE
Implementation of section@restart

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2111,7 +2111,9 @@ public:
  * member 3: the previous measure (for setting cautionary scoreDef)
  * member 4: the current system (for setting the system scoreDef)
  * member 5: the flag indicating whereas full labels have to be drawn
- * member 6: the doc
+ * member 6: the flag indicating that the scoreDef restarts (draw brace and label)
+ * member 7: the flag indicating is we already have a measure in the system
+ * member 8: the doc
  **/
 
 class ScoreDefSetCurrentParams : public FunctorParams {
@@ -2124,6 +2126,8 @@ public:
         m_previousMeasure = NULL;
         m_currentSystem = NULL;
         m_drawLabels = false;
+        m_restart = false;
+        m_hasMeasure = false;
         m_doc = doc;
     }
     ScoreDef *m_currentScoreDef;
@@ -2132,6 +2136,8 @@ public:
     Measure *m_previousMeasure;
     System *m_currentSystem;
     bool m_drawLabels;
+    bool m_restart;
+    bool m_hasMeasure;
     Doc *m_doc;
 };
 

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -178,6 +178,9 @@ public:
     void SetDrawingWidth(int drawingWidth);
     ///@}
 
+    int GetDrawingLabelsWidth() const { return m_drawingLabelsWidth; }
+    void SetDrawingLabelsWidth(int width);
+
     /**
      * @name Getters for running elements
      */
@@ -196,6 +199,11 @@ public:
     //----------//
     // Functors //
     //----------//
+
+    /**
+     * See Object::ResetHorizontalAlignment
+     */
+    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
 
     /**
      * See Object::ConvertToPageBased
@@ -230,6 +238,8 @@ private:
     bool m_drawLabels;
     /** Store the drawing width (clef and key sig) of the scoreDef */
     int m_drawingWidth;
+    /** Store the label drawing width of the scoreDef */
+    int m_drawingLabelsWidth;
 };
 
 } // namespace vrv

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -68,6 +68,7 @@ public:
     bool HasMensurInfo(int depth = 1);
     bool HasMeterSigInfo(int depth = 1);
     bool HasMeterSigGrpInfo(int depth = 1);
+    bool HasLabelInfo(int depth = 1);
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -197,6 +197,8 @@ public:
      */
     int GetMaxStaffSize();
 
+    bool DrawWithinStaff();
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -146,9 +146,20 @@ public:
     void ReplaceDrawingValues(StaffDef *newStaffDef);
 
     /**
+     * Replace the corresponding staffGrp with the labels of the newStaffGrp.
+     * Looks for the staffGrp with the same m_n (@n) and replaces label child
+     */
+    void ReplaceDrawingLabels(StaffGrp *newStaffGrp);
+
+    /**
      * Get the staffDef with number n (NULL if not found).
      */
     StaffDef *GetStaffDef(int n);
+
+    /**
+     * Get the staffGrp with number n (NULL if not found).
+     */
+    StaffGrp *GetStaffGrp(const std::string &n);
 
     /**
      * Return all the @n values of the staffDef in a scoreDef

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -222,6 +222,16 @@ public:
      */
     virtual int CastOffEncoding(FunctorParams *functorParams);
 
+    /**
+     * See Object::AlignMeasures
+     */
+    virtual int AlignMeasures(FunctorParams *functorParams);
+
+    /**
+     * See Object::JustifyX
+     */
+    virtual int JustifyX(FunctorParams *functorParams);
+
 protected:
     /**
      * Filter the flat list and keep only StaffDef elements.

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -68,7 +68,6 @@ public:
     bool HasMensurInfo(int depth = 1);
     bool HasMeterSigInfo(int depth = 1);
     bool HasMeterSigGrpInfo(int depth = 1);
-    bool HasLabelInfo(int depth = 1);
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -197,7 +197,7 @@ public:
      */
     int GetMaxStaffSize();
 
-    bool DrawWithinStaff();
+    bool IsSectionRestart();
 
     //----------//
     // Functors //

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -9,6 +9,7 @@
 #define __VRV_SECTION_H__
 
 #include "atts_shared.h"
+#include "atts_visual.h"
 #include "boundary.h"
 #include "systemelement.h"
 
@@ -24,7 +25,7 @@ class Section;
  * This class represents a MEI section.
  * It can be both a container (in score-based MEI) and a boundary (in page-based MEI)
  */
-class Section : public SystemElement, public BoundaryStartInterface, public AttNNumberLike {
+class Section : public SystemElement, public BoundaryStartInterface, public AttNNumberLike, public AttSectionVis {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -17,6 +17,9 @@
 
 namespace vrv {
 
+class Label;
+class LabelAbbr;
+
 //----------------------------------------------------------------------------
 // StaffGrp
 //----------------------------------------------------------------------------
@@ -29,6 +32,7 @@ class StaffGrp : public Object,
                  public ObjectListInterface,
                  public AttBasic,
                  public AttLabelled,
+                 public AttNNumberLike,
                  public AttStaffGroupingSym,
                  public AttStaffGrpVis,
                  public AttTyped {
@@ -77,6 +81,26 @@ public:
     ///@{
     void SetGroupSymbol(GrpSym *grpSym);
     GrpSym *GetGroupSymbol() const { return m_groupSymbol; }
+    ///@}
+
+    /**
+     * @name Methods for checking the presence of label and labelAbbr information and getting them.
+     */
+    ///@{
+    bool HasLabelInfo();
+    bool HasLabelAbbrInfo();
+
+    ///@}
+
+    /**
+     * @name Get a copy of the label and labelAbbr.
+     * These methods create new objects (heap) that will need to be deleted.
+     */
+    ///@{
+    Label *GetLabel();
+    Label *GetLabelCopy();
+    LabelAbbr *GetLabelAbbr();
+    LabelAbbr *GetLabelAbbrCopy();
     ///@}
 
     //----------//

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -76,7 +76,7 @@ public:
      * @name Set and get the labels drawing width (normal and abbreviated)
      */
     ///@{
-    int GetDrawingLabelsWidth() const { return m_drawingLabelsWidth; }
+    int GetDrawingLabelsWidth() const;
     void SetDrawingLabelsWidth(int width);
     int GetDrawingAbbrLabelsWidth() const { return m_drawingAbbrLabelsWidth; }
     void SetDrawingAbbrLabelsWidth(int width);
@@ -292,11 +292,9 @@ public:
      */
     int m_xAbs;
     /**
-     * The width used by the labels at the left of the system.
+     * The width used by the abbreviated labels at the left of the system.
      * It is used internally when calculating the layout and it is not stored in the file.
      */
-    int m_drawingLabelsWidth;
-    /** The width used by the abbreviated labels */
     int m_drawingAbbrLabelsWidth;
     /**
      * @name The total width of the system.

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -195,8 +195,8 @@ protected:
     void DrawStaffDefCautionary(DeviceContext *dc, Staff *staff, Measure *measure);
     void DrawStaffDefLabels(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, int x, bool abbreviations = false);
     void DrawGrpSym(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, int &x);
-    void DrawLabels(
-        DeviceContext *dc, System *system, Object *object, int x, int y, bool abbreviations, int staffSize, int space);
+    void DrawLabels(DeviceContext *dc, ScoreDef *scoreDef, Object *object, int x, int y, bool abbreviations,
+        int staffSize, int space);
     void DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBracketsq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1137,6 +1137,7 @@ void MEIOutput::WriteStaffGrp(pugi::xml_node currentNode, StaffGrp *staffGrp)
     WriteXmlId(currentNode, staffGrp);
     staffGrp->WriteBasic(currentNode);
     staffGrp->WriteLabelled(currentNode);
+    staffGrp->WriteNNumberLike(currentNode);
     staffGrp->WriteStaffGroupingSym(currentNode);
     staffGrp->WriteStaffGrpVis(currentNode);
     staffGrp->WriteTyped(currentNode);
@@ -3809,6 +3810,7 @@ bool MEIInput::ReadStaffGrp(Object *parent, pugi::xml_node staffGrp)
 
     vrvStaffGrp->ReadBasic(staffGrp);
     vrvStaffGrp->ReadLabelled(staffGrp);
+    vrvStaffGrp->ReadNNumberLike(staffGrp);
     AttStaffGroupingSym groupingSym;
     groupingSym.ReadStaffGroupingSym(staffGrp);
     if (groupingSym.HasSymbol()) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1016,6 +1016,7 @@ void MEIOutput::WriteSection(pugi::xml_node currentNode, Section *section)
 
     WriteSystemElement(currentNode, section);
     section->WriteNNumberLike(currentNode);
+    section->WriteSectionVis(currentNode);
 }
 
 void MEIOutput::WriteEnding(pugi::xml_node currentNode, Ending *ending)
@@ -3263,6 +3264,7 @@ bool MEIInput::ReadSection(Object *parent, pugi::xml_node section)
     SetMeiUuid(section, vrvSection);
 
     vrvSection->ReadNNumberLike(section);
+    vrvSection->ReadSectionVis(section);
 
     parent->AddChild(vrvSection);
     ReadUnsupportedAttr(section, vrvSection);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1612,6 +1612,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
     if (this->Is(STAFFGRP)) {
         StaffGrp *staffGrp = vrv_cast<StaffGrp *>(this);
         assert(staffGrp);
+        // For now replace labels only if we have a section@restart
         if (params->m_restart) {
             params->m_upcomingScoreDef->ReplaceDrawingLabels(staffGrp);
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1504,11 +1504,17 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
         assert(system);
         // This is the only thing we do for now - we need to wait until we reach the first measure
         params->m_currentSystem = system;
+        params->m_hasMeasure = false;
         return FUNCTOR_CONTINUE;
     }
 
     // starting a new measure
     if (this->Is(MEASURE)) {
+        // If we have a restart scoreDef before, for redrawing of everything on the measure
+        if (params->m_restart) {
+            params->m_upcomingScoreDef->SetRedrawFlags(StaffDefRedrawFlags::REDRAW_ALL);
+        }
+
         Measure *measure = vrv_cast<Measure *>(this);
         assert(measure);
         int drawingFlags = 0;
@@ -1518,7 +1524,8 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
             // We had a scoreDef so we need to put cautionnary values
             // This will also happend with clef in the last measure - however, the cautionnary functor will not do
             // anything then
-            if (params->m_upcomingScoreDef->m_setAsDrawing && params->m_previousMeasure) {
+            // The cautionary scoreDef for restart is already done when hitting the scoreDef
+            if (params->m_upcomingScoreDef->m_setAsDrawing && params->m_previousMeasure && !params->m_restart) {
                 ScoreDef cautionaryScoreDef = *params->m_upcomingScoreDef;
                 SetCautionaryScoreDefParams setCautionaryScoreDefParams(&cautionaryScoreDef);
                 Functor setCautionaryScoreDef(&Object::SetCautionaryScoreDef);
@@ -1539,6 +1546,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
             params->m_upcomingScoreDef->SetRedrawFlags(StaffDefRedrawFlags::FORCE_REDRAW);
             params->m_upcomingScoreDef->m_setAsDrawing = false;
         }
+        params->m_drawLabels = false;
 
         // set other flags based on score def change
         if (params->m_upcomingScoreDef->m_insertScoreDef) {
@@ -1564,6 +1572,9 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
         measure->SetDrawingBarLines(params->m_previousMeasure, drawingFlags);
 
         params->m_previousMeasure = measure;
+        params->m_restart = false;
+        params->m_hasMeasure = true;
+
         return FUNCTOR_CONTINUE;
     }
 
@@ -1579,7 +1590,22 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
             params->m_upcomingScoreDef->ReplaceDrawingValues(scoreDef);
             params->m_upcomingScoreDef->m_insertScoreDef = true;
         }
-        return FUNCTOR_CONTINUE;
+        if (scoreDef->GetType() == "restart") {
+            // Trigger the redrawing of the labels - including for the system scoreDef if at the beginning
+            params->m_drawLabels = true;
+            params->m_restart = true;
+            // Redraw the labels only if we already have a mesure in the system. Otherwise this will be
+            // done through the system scoreDef
+            scoreDef->SetDrawLabels(params->m_hasMeasure);
+            // If we have a previous measure, we need to set the cautionary scoreDef indenpendently from the
+            // presence of a system break
+            if (params->m_previousMeasure) {
+                ScoreDef cautionaryScoreDef = *params->m_upcomingScoreDef;
+                SetCautionaryScoreDefParams setCautionaryScoreDefParams(&cautionaryScoreDef);
+                Functor setCautionaryScoreDef(&Object::SetCautionaryScoreDef);
+                params->m_previousMeasure->Process(&setCautionaryScoreDef, &setCautionaryScoreDefParams);
+            }
+        }
     }
 
     // starting a new staffDef

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1608,7 +1608,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
         }
     }
 
-    // starting a new staffDef
+    // starting a new staffGrp
     if (this->Is(STAFFGRP)) {
         StaffGrp *staffGrp = vrv_cast<StaffGrp *>(this);
         assert(staffGrp);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1590,7 +1590,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
             params->m_upcomingScoreDef->ReplaceDrawingValues(scoreDef);
             params->m_upcomingScoreDef->m_insertScoreDef = true;
         }
-        if (scoreDef->GetType() == "restart") {
+        if (scoreDef->IsSectionRestart()) {
             // Trigger the redrawing of the labels - including for the system scoreDef if at the beginning
             params->m_drawLabels = true;
             params->m_restart = true;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1609,6 +1609,15 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
     }
 
     // starting a new staffDef
+    if (this->Is(STAFFGRP)) {
+        StaffGrp *staffGrp = vrv_cast<StaffGrp *>(this);
+        assert(staffGrp);
+        if (params->m_restart) {
+            params->m_upcomingScoreDef->ReplaceDrawingLabels(staffGrp);
+        }
+    }
+
+    // starting a new staffDef
     if (this->Is(STAFFDEF)) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(this);
         assert(staffDef);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -20,6 +20,7 @@
 #include "grpsym.h"
 #include "keysig.h"
 #include "label.h"
+#include "labelabbr.h"
 #include "mensur.h"
 #include "metersig.h"
 #include "metersiggrp.h"
@@ -347,15 +348,31 @@ void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
     // first find the staffGrp with the same @n
     StaffGrp *staffGrp = this->GetStaffGrp(newStaffGrp->GetN());
     if (staffGrp) {
+        // Replace with thew new label only if we have one
         if (newStaffGrp->HasLabelInfo()) {
             Label *label = newStaffGrp->GetLabelCopy();
+            // Check if we previoulsy had one, and replace it if yes
             if (staffGrp->HasLabelInfo()) {
                 Label *oldLabel = staffGrp->GetLabel();
                 staffGrp->ReplaceChild(oldLabel, label);
                 delete oldLabel;
             }
+            // Otherwise simply add it
             else {
                 staffGrp->AddChild(label);
+            }
+        }
+        if (newStaffGrp->HasLabelAbbrInfo()) {
+            LabelAbbr *labelAbbr = newStaffGrp->GetLabelAbbrCopy();
+            // Check if we previoulsy had one, and replace it if yes
+            if (staffGrp->HasLabelAbbrInfo()) {
+                LabelAbbr *oldLabelAbbr = staffGrp->GetLabelAbbr();
+                staffGrp->ReplaceChild(oldLabelAbbr, labelAbbr);
+                delete oldLabelAbbr;
+            }
+            // Otherwise simply add it
+            else {
+                staffGrp->AddChild(labelAbbr);
             }
         }
     }

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -79,6 +79,11 @@ bool ScoreDefElement::HasMeterSigGrpInfo(int depth)
     return (this->FindDescendantByType(METERSIGGRP, depth));
 }
 
+bool ScoreDefElement::HasLabelInfo(int depth)
+{
+    return (this->FindDescendantByType(LABEL, depth));
+}
+
 Clef *ScoreDefElement::GetClef()
 {
     // Always check if HasClefInfo() is true before asking for it

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -26,6 +26,7 @@
 #include "pgfoot2.h"
 #include "pghead.h"
 #include "pghead2.h"
+#include "section.h"
 #include "staffdef.h"
 #include "staffgrp.h"
 #include "system.h"
@@ -440,6 +441,14 @@ int ScoreDef::GetMaxStaffSize()
 {
     StaffGrp *staffGrp = dynamic_cast<StaffGrp *>(this->FindDescendantByType(STAFFGRP));
     return (staffGrp) ? staffGrp->GetMaxStaffSize() : 100;
+}
+
+bool ScoreDef::DrawWithinStaff()
+{
+    if (!this->GetParent() || !this->GetParent()->Is(SECTION)) return false;
+    Section *section = vrv_cast<Section *>(this->GetParent());
+    assert(section);
+    return (section->GetRestart() == BOOLEAN_true);
 }
 
 //----------------------------------------------------------------------------

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "clef.h"
+#include "comparison.h"
 #include "editorial.h"
 #include "functorparams.h"
 #include "grpsym.h"
@@ -339,6 +340,27 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
     }
 }
 
+void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
+{
+    assert(newStaffGrp);
+
+    // first find the staffGrp with the same @n
+    StaffGrp *staffGrp = this->GetStaffGrp(newStaffGrp->GetN());
+    if (staffGrp) {
+        if (newStaffGrp->HasLabelInfo()) {
+            Label *label = newStaffGrp->GetLabelCopy();
+            if (staffGrp->HasLabelInfo()) {
+                Label *oldLabel = staffGrp->GetLabel();
+                staffGrp->ReplaceChild(oldLabel, label);
+                delete oldLabel;
+            }
+            else {
+                staffGrp->AddChild(label);
+            }
+        }
+    }
+}
+
 void ScoreDef::FilterList(ArrayOfObjects *childList)
 {
     // We want to keep only staffDef
@@ -371,6 +393,22 @@ StaffDef *ScoreDef::GetStaffDef(int n)
     }
 
     return staffDef;
+}
+
+StaffGrp *ScoreDef::GetStaffGrp(const std::string &n)
+{
+    // First get all the staffGrps
+    ClassIdComparison matchType(STAFFGRP);
+    ListOfObjects staffGrps;
+    this->FindAllDescendantByComparison(&staffGrps, &matchType);
+
+    // Then the @n of each first staffDef
+    for (auto &item : staffGrps) {
+        StaffGrp *staffGrp = vrv_cast<StaffGrp *>(item);
+        assert(staffGrp);
+        if (staffGrp->GetN() == n) return staffGrp;
+    }
+    return NULL;
 }
 
 std::vector<int> ScoreDef::GetStaffNs()

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -197,6 +197,7 @@ void ScoreDef::Reset()
 
     m_drawLabels = false;
     m_drawingWidth = 0;
+    m_drawingLabelsWidth = 0;
     m_setAsDrawing = false;
 }
 
@@ -403,6 +404,13 @@ void ScoreDef::SetDrawingWidth(int drawingWidth)
     m_drawingWidth = drawingWidth;
 }
 
+void ScoreDef::SetDrawingLabelsWidth(int width)
+{
+    if (m_drawingLabelsWidth < width) {
+        m_drawingLabelsWidth = width;
+    }
+}
+
 PgFoot *ScoreDef::GetPgFoot()
 {
     return dynamic_cast<PgFoot *>(this->FindDescendantByType(PGFOOT));
@@ -432,6 +440,13 @@ int ScoreDef::GetMaxStaffSize()
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------
+
+int ScoreDef::ResetHorizontalAlignment(FunctorParams *functorParams)
+{
+    m_drawingLabelsWidth = 0;
+
+    return FUNCTOR_CONTINUE;
+}
 
 int ScoreDef::ConvertToPageBased(FunctorParams *functorParams)
 {

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -80,11 +80,6 @@ bool ScoreDefElement::HasMeterSigGrpInfo(int depth)
     return (this->FindDescendantByType(METERSIGGRP, depth));
 }
 
-bool ScoreDefElement::HasLabelInfo(int depth)
-{
-    return (this->FindDescendantByType(LABEL, depth));
-}
-
 Clef *ScoreDefElement::GetClef()
 {
     // Always check if HasClefInfo() is true before asking for it

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -443,12 +443,14 @@ int ScoreDef::GetMaxStaffSize()
     return (staffGrp) ? staffGrp->GetMaxStaffSize() : 100;
 }
 
-bool ScoreDef::DrawWithinStaff()
+bool ScoreDef::IsSectionRestart()
 {
-    if (!this->GetParent() || !this->GetParent()->Is(SECTION)) return false;
-    Section *section = vrv_cast<Section *>(this->GetParent());
-    assert(section);
-    return (section->GetRestart() == BOOLEAN_true);
+    if (!this->GetParent()) return false;
+    // In page-based structure, Section is a sibling to scoreDef
+    // This has limitations: will not work with editorial markup, additional nested sections, and
+    // if the section milestone is in the previous system.
+    Section *section = dynamic_cast<Section *>(this->GetParent()->GetPrevious(this, SECTION));
+    return (section && (section->GetRestart() == BOOLEAN_true));
 }
 
 //----------------------------------------------------------------------------

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -498,4 +498,25 @@ int ScoreDef::CastOffEncoding(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int ScoreDef::AlignMeasures(FunctorParams *functorParams)
+{
+    AlignMeasuresParams *params = vrv_params_cast<AlignMeasuresParams *>(functorParams);
+    assert(params);
+
+    // SetDrawingXRel(m_systemLeftMar + this->GetDrawingWidth());
+    params->m_shift += m_drawingLabelsWidth;
+
+    return FUNCTOR_CONTINUE;
+}
+
+int ScoreDef::JustifyX(FunctorParams *functorParams)
+{
+    JustifyXParams *params = vrv_params_cast<JustifyXParams *>(functorParams);
+    assert(params);
+
+    params->m_measureXRel += m_drawingLabelsWidth;
+
+    return FUNCTOR_SIBLINGS;
+}
+
 } // namespace vrv

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -32,9 +32,10 @@ namespace vrv {
 
 static const ClassRegistrar<Section> s_factory("section", SECTION);
 
-Section::Section() : SystemElement("section-"), BoundaryStartInterface(), AttNNumberLike()
+Section::Section() : SystemElement("section-"), BoundaryStartInterface(), AttNNumberLike(), AttSectionVis()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
+    RegisterAttClass(ATT_SECTIONVIS);
 
     Reset();
 }
@@ -46,6 +47,7 @@ void Section::Reset()
     SystemElement::Reset();
     BoundaryStartInterface::Reset();
     ResetNNumberLike();
+    ResetSectionVis();
 }
 
 bool Section::IsSupportedChild(Object *child)

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -34,12 +34,14 @@ StaffGrp::StaffGrp()
     , ObjectListInterface()
     , AttBasic()
     , AttLabelled()
+    , AttNNumberLike()
     , AttStaffGroupingSym()
     , AttStaffGrpVis()
     , AttTyped()
 {
     RegisterAttClass(ATT_BASIC);
     RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_NNUMBERLIKE);
     RegisterAttClass(ATT_STAFFGROUPINGSYM);
     RegisterAttClass(ATT_STAFFGRPVIS);
     RegisterAttClass(ATT_TYPED);
@@ -54,6 +56,7 @@ void StaffGrp::Reset()
     Object::Reset();
     ResetBasic();
     ResetLabelled();
+    ResetNNumberLike();
     ResetStaffGroupingSym();
     ResetStaffGrpVis();
     ResetTyped();
@@ -167,6 +170,50 @@ void StaffGrp::SetGroupSymbol(GrpSym *grpSym)
     if (grpSym) {
         m_groupSymbol = grpSym;
     }
+}
+
+bool StaffGrp::HasLabelInfo()
+{
+    return (this->FindDescendantByType(LABEL, 1));
+}
+
+bool StaffGrp::HasLabelAbbrInfo()
+{
+    return (this->FindDescendantByType(LABELABBR, 1));
+}
+
+Label *StaffGrp::GetLabel()
+{
+    // Always check if HasLabelInfo() is true before asking for it
+    Label *label = vrv_cast<Label *>(this->FindDescendantByType(LABEL, 1));
+    assert(label);
+    return label;
+}
+
+Label *StaffGrp::GetLabelCopy()
+{
+    // Always check if HasClefInfo() is true before asking for a clone
+    Label *clone = dynamic_cast<Label *>(this->GetLabel()->Clone());
+    clone->CloneReset();
+    assert(clone);
+    return clone;
+}
+
+LabelAbbr *StaffGrp::GetLabelAbbr()
+{
+    // Always check if HasLabelAbbrInfo() is true before asking for it
+    LabelAbbr *labelAbbr = vrv_cast<LabelAbbr *>(this->FindDescendantByType(LABELABBR, 1));
+    assert(labelAbbr);
+    return labelAbbr;
+}
+
+LabelAbbr *StaffGrp::GetLabelAbbrCopy()
+{
+    // Always check if HasClefInfo() is true before asking for a clone
+    LabelAbbr *clone = dynamic_cast<LabelAbbr *>(this->GetLabelAbbr()->Clone());
+    clone->CloneReset();
+    assert(clone);
+    return clone;
 }
 
 //----------------------------------------------------------------------------

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -153,8 +153,7 @@ int System::GetMinimumSystemSpacing(const Doc *doc) const
 
 int System::GetDrawingLabelsWidth() const
 {
-    assert(m_drawingScoreDef);
-    return m_drawingScoreDef->GetDrawingLabelsWidth();
+    return (m_drawingScoreDef) ? m_drawingScoreDef->GetDrawingLabelsWidth() : 0;
 }
 
 void System::SetDrawingLabelsWidth(int width)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -78,7 +78,6 @@ void System::Reset()
     m_drawingYRel = 0;
     m_drawingTotalWidth = 0;
     m_drawingJustifiableWidth = 0;
-    m_drawingLabelsWidth = 0;
     m_drawingAbbrLabelsWidth = 0;
     m_drawingIsOptimized = false;
 }
@@ -152,11 +151,16 @@ int System::GetMinimumSystemSpacing(const Doc *doc) const
     return spacingSystem.GetValue() * doc->GetDrawingUnit(100);
 }
 
+int System::GetDrawingLabelsWidth() const
+{
+    assert(m_drawingScoreDef);
+    return m_drawingScoreDef->GetDrawingLabelsWidth();
+}
+
 void System::SetDrawingLabelsWidth(int width)
 {
-    if (m_drawingLabelsWidth < width) {
-        m_drawingLabelsWidth = width;
-    }
+    assert(m_drawingScoreDef);
+    m_drawingScoreDef->SetDrawingLabelsWidth(width);
 }
 
 void System::SetDrawingAbbrLabelsWidth(int width)
@@ -399,7 +403,6 @@ int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
 int System::ResetHorizontalAlignment(FunctorParams *functorParams)
 {
     SetDrawingXRel(0);
-    m_drawingLabelsWidth = 0;
     m_drawingAbbrLabelsWidth = 0;
 
     return FUNCTOR_CONTINUE;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -397,7 +397,7 @@ int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
 
     if (m_drawingScoreDef) m_drawingScoreDef->Process(params->m_functor, functorParams);
 
-    return FUNCTOR_SIBLINGS;
+    return FUNCTOR_CONTINUE;
 }
 
 int System::ResetHorizontalAlignment(FunctorParams *functorParams)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -73,6 +73,7 @@ void View::SetPage(int pageIdx, bool doLayout)
 
     if (doLayout) {
         m_doc->ScoreDefSetCurrentDoc();
+        m_doc->ScoreDefSetGrpSymDoc();
         // if we once deal with multiple views, it would be better
         // to redo the layout only when necessary?
         if (m_doc->GetType() == Transcription || m_doc->GetType() == Facs)

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -339,7 +339,7 @@ void View::DrawStaffGrp(
     }
 
     // DrawStaffGrpLabel
-    System *system = dynamic_cast<System *>(measure->GetFirstAncestor(SYSTEM));
+    ScoreDef *scoreDef = dynamic_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
     const int space = m_doc->GetDrawingDoubleUnit(staffGrp->GetMaxStaffSize());
     int xLabel = x - space;
     int yLabel = yBottom - (yBottom - yTop) / 2 - m_doc->GetDrawingUnit(100);
@@ -364,10 +364,10 @@ void View::DrawStaffDefLabels(DeviceContext *dc, Measure *measure, StaffGrp *sta
 
         AttNIntegerComparison comparison(STAFF, staffDef->GetN());
         Staff *staff = dynamic_cast<Staff *>(measure->FindDescendantByComparison(&comparison, 1));
-        System *system = dynamic_cast<System *>(measure->GetFirstAncestor(SYSTEM));
+        ScoreDef *scoreDef = dynamic_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
 
-        if (!staff || !system) {
-            LogDebug("Staff or System missing in View::DrawStaffDefLabels");
+        if (!staff || !scoreDef) {
+            LogDebug("Staff or ScoreDef missing in View::DrawStaffDefLabels");
             continue;
         }
 
@@ -380,7 +380,7 @@ void View::DrawStaffDefLabels(DeviceContext *dc, Measure *measure, StaffGrp *sta
         int y = staff->GetDrawingY()
             - (staffDef->GetLines() * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);
 
-        this->DrawLabels(dc, system, staffDef, x - space, y, abbreviations, staff->m_drawingStaffSize, 2 * space);
+        this->DrawLabels(dc, scoreDef, staffDef, x - space, y, abbreviations, staff->m_drawingStaffSize, 2 * space);
     }
 }
 
@@ -444,7 +444,7 @@ void View::DrawGrpSym(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, i
 }
 
 void View::DrawLabels(
-    DeviceContext *dc, System *system, Object *object, int x, int y, bool abbreviations, int staffSize, int space)
+    DeviceContext *dc, ScoreDef *scoreDef, Object *object, int x, int y, bool abbreviations, int staffSize, int space)
 {
     assert(dc);
     assert(system);
@@ -494,7 +494,7 @@ void View::DrawLabels(
     dc->EndGraphic(graphic, this);
 
     // keep the widest width for the system - careful: this can be the label OR labelAbbr
-    system->SetDrawingLabelsWidth(graphic->GetContentX2() - graphic->GetContentX1() + space);
+    scoreDef->SetDrawingLabelsWidth(graphic->GetContentX2() - graphic->GetContentX1() + space);
     // also store in the system the maximum width with abbreviations for justification
     if (labelAbbr && !abbreviations && (labelAbbrStr.length() > 0)) {
         TextExtend extend;
@@ -505,7 +505,7 @@ void View::DrawLabels(
             dc->GetTextExtent(line, &extend, true);
             maxLength = (extend.m_width > maxLength) ? extend.m_width : maxLength;
         }
-        system->SetDrawingAbbrLabelsWidth(maxLength + space);
+        /// system->SetDrawingAbbrLabelsWidth(maxLength + space);
     }
 
     dc->ResetFont();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -505,7 +505,9 @@ void View::DrawLabels(
             dc->GetTextExtent(line, &extend, true);
             maxLength = (extend.m_width > maxLength) ? extend.m_width : maxLength;
         }
-        /// system->SetDrawingAbbrLabelsWidth(maxLength + space);
+        System *system = vrv_cast<System *>(scoreDef->GetFirstAncestor(SYSTEM));
+        assert(system);
+        system->SetDrawingAbbrLabelsWidth(maxLength + space);
     }
 
     dc->ResetFont();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1503,6 +1503,11 @@ void View::DrawSystemChildren(DeviceContext *dc, Object *parent, System *system)
             // nothing to do, then
             ScoreDef *scoreDef = vrv_cast<ScoreDef *>(current);
             assert(scoreDef);
+
+            Measure *nextMeasure = dynamic_cast<Measure *>(system->GetNext(scoreDef, MEASURE));
+            if (nextMeasure && scoreDef->DrawLabels())
+                DrawScoreDef(dc, scoreDef, nextMeasure, nextMeasure->GetDrawingX());
+
             SetScoreDefDrawingWidth(dc, scoreDef);
         }
         else if (current->IsSystemElement()) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1507,8 +1507,9 @@ void View::DrawSystemChildren(DeviceContext *dc, Object *parent, System *system)
             assert(scoreDef);
 
             Measure *nextMeasure = dynamic_cast<Measure *>(system->GetNext(scoreDef, MEASURE));
-            if (nextMeasure && scoreDef->DrawLabels())
+            if (nextMeasure && scoreDef->DrawLabels()) {
                 DrawScoreDef(dc, scoreDef, nextMeasure, nextMeasure->GetDrawingX());
+            }
 
             SetScoreDefDrawingWidth(dc, scoreDef);
         }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -325,7 +325,9 @@ void View::DrawStaffGrp(
         DrawVerticalLine(dc, yTop, yBottom, x + barLineWidth / 2, barLineWidth);
     }
     // draw the group symbol
+    int staffGrpX = x;
     DrawGrpSym(dc, measure, staffGrp, x);
+    int grpSymSpace = staffGrpX - x;
 
     // recursively draw the children
     StaffGrp *childStaffGrp = NULL;
@@ -341,7 +343,7 @@ void View::DrawStaffGrp(
     const int space = m_doc->GetDrawingDoubleUnit(staffGrp->GetMaxStaffSize());
     int xLabel = x - space;
     int yLabel = yBottom - (yBottom - yTop) / 2 - m_doc->GetDrawingUnit(100);
-    this->DrawLabels(dc, system, staffGrp, xLabel, yLabel, abbreviations, 100, 2 * space);
+    this->DrawLabels(dc, scoreDef, staffGrp, xLabel, yLabel, abbreviations, 100, 2 * space + grpSymSpace);
 
     DrawStaffDefLabels(dc, measure, staffGrp, x, abbreviations);
 }


### PR DESCRIPTION
The implementation of section@restart allows for scoreDef changes to be displayed within a staff. This somehow addresses the case raised raised by @wergo [here](https://github.com/rism-digital/verovio/issues/1262#issue-550300604). However, it works only when all sections are in the same `<mdiv>`, so the rendering of multiple `<mdiv>` will have to be treated separately.

The current implementation expects the `staffGrp` with the label change to carry a `@n`. See the [test suite example](https://github.com/rism-digital/verovio.org/blob/gh-pages/_tests/section/section_001.mei) Cautionary scoreDef values (keySig, meterSig) should be properly handled.

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/689412/127732900-56bc61bb-6d58-4621-b4d3-f1972ee0f229.png">
