### PR TITLE
Fix incorrect positioning for the spanning slurs

### DIFF
--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -624,7 +624,9 @@ float View::CalcInitialSlur(
     }
     for (FloatingPositioner *positioner : tiePositioners) {
         if (positioner->HasContentBB() && (positioner->GetContentRight() > bezier.p1.x)
-            && (positioner->GetContentLeft() < bezier.p2.x)) {
+            && (positioner->GetContentLeft() < bezier.p2.x)
+            && (vrv_cast<System *>(positioner->GetObject()->GetFirstAncestor(SYSTEM))
+                == curve->GetAlignment()->GetParentSystem())) {
             CurveSpannedElement *spannedElement = new CurveSpannedElement();
             spannedElement->m_boundingBox = positioner;
             curve->AddSpannedElement(spannedElement);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -623,10 +623,10 @@ float View::CalcInitialSlur(
         std::copy(endTiePositioners.begin(), endTiePositioners.end(), std::back_inserter(tiePositioners));
     }
     for (FloatingPositioner *positioner : tiePositioners) {
+        System *positionerSystem = vrv_cast<System *>(positioner->GetObject()->GetFirstAncestor(SYSTEM));
         if (positioner->HasContentBB() && (positioner->GetContentRight() > bezier.p1.x)
             && (positioner->GetContentLeft() < bezier.p2.x)
-            && (vrv_cast<System *>(positioner->GetObject()->GetFirstAncestor(SYSTEM))
-                == curve->GetAlignment()->GetParentSystem())) {
+            && (positionerSystem == curve->GetAlignment()->GetParentSystem())) {
             CurveSpannedElement *spannedElement = new CurveSpannedElement();
             spannedElement->m_boundingBox = positioner;
             curve->AddSpannedElement(spannedElement);


### PR DESCRIPTION
There was an issue where slur, spanning over the system would consider positions of the spanned elements from previous system. That led to slur having extreme offset, placing it way above the staff:
![image](https://user-images.githubusercontent.com/1819669/128145667-5597e791-f68f-4e42-9a74-31cd315f9008.png)

This change should fix the issue, adding only relevant spanned elements to the list (i.e. elements from the same system, as the curve):
![image](https://user-images.githubusercontent.com/1819669/128145596-0b17c9b9-7ba4-4e4a-a212-8103dd4a4364.png)

