### PR TITLE
Fix LayerCountInTimeSpan handling of chords and drawingCurvedir selection for slurs

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2141,6 +2141,7 @@ int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams)
 
     if (!this->GetDurationInterface() || this->Is(MSPACE) || this->Is(SPACE) || this->HasSameasLink())
         return FUNCTOR_CONTINUE;
+    if (this->Is(NOTE) && this->GetParent()->Is(CHORD)) return FUNCTOR_CONTINUE;
 
     double duration = this->GetAlignmentDuration(params->m_mensur, params->m_meterSig);
     double time = m_alignment->GetTime();

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -173,17 +173,6 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     if (layerElement->m_crossStaff) layer = layerElement->m_crossLayer;
     assert(layer);
 
-    if (!start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && (spanningType == SPANNING_START_END)) {
-        System *system = vrv_cast<System *>(staff->GetFirstAncestor(SYSTEM));
-        assert(system);
-        // If we have a start to end situation, then store the curvedir in the slur for mixed drawing stem dir
-        // situations
-        if (system->HasMixedDrawingStemDir(start, end)) {
-            auto curveDir = system->GetPreferredCurveDirection(start, end, slur);
-            slur->SetDrawingCurvedir(curveDir != curvature_CURVEDIR_NONE ? curveDir : curvature_CURVEDIR_above);
-        }
-    }
-
     if (start->m_crossStaff != end->m_crossStaff) {
         curve->SetCrossStaff(end->m_crossStaff);
     }
@@ -192,6 +181,22 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
         Staff *startStaff = vrv_cast<Staff *>(start->GetFirstAncestor(STAFF));
         Staff *endStaff = vrv_cast<Staff *>(end->GetFirstAncestor(STAFF));
         if (startStaff && endStaff && (startStaff->GetN() != endStaff->GetN())) curve->SetCrossStaff(endStaff);
+    }
+
+    if (!start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && (spanningType == SPANNING_START_END)) {
+        System *system = vrv_cast<System *>(staff->GetFirstAncestor(SYSTEM));
+        assert(system);
+        // If we have a start to end situation, then store the curvedir in the slur for mixed drawing stem dir
+        // situations
+        if (system->HasMixedDrawingStemDir(start, end)) {
+            if (!curve->IsCrossStaff()) {
+                slur->SetDrawingCurvedir(curvature_CURVEDIR_above);
+            }
+            else {
+                curvature_CURVEDIR curveDir = system->GetPreferredCurveDirection(start, end, slur);
+                slur->SetDrawingCurvedir(curveDir != curvature_CURVEDIR_NONE ? curveDir : curvature_CURVEDIR_above);
+            }
+        }
     }
 
     /************** calculate the radius for adjusting the x position **************/


### PR DESCRIPTION
closes #2273
closes #2259
closes #2274
closes #2270
- fixed LayerCountInTimeSpan not to process notes that belong to chords, so that invalid time/duration are not used for counting
- changed code for slurs with mixed drawing stem direction to use GetPreferredCurveDirection only for cross-staff slurs - otherwise slurs should always be above

![image](https://user-images.githubusercontent.com/1819669/128201806-8d3df556-0125-4cff-aa7c-3d46bf6626f5.png)
![image](https://user-images.githubusercontent.com/1819669/128201851-1d507cc4-f67d-4f31-a8e4-e139b79f6bc5.png)
![image](https://user-images.githubusercontent.com/1819669/128201938-f83beb15-949e-4d74-8ba4-f77935711ca6.png)
