### PR TITLE
Ledger lines and stems

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -148,8 +148,9 @@ public:
 
     /**
      * Helper to adjust overlapping layers for chords
+     * Returns the shift of the adjustment
      */
-    virtual void AdjustOverlappingLayers(
+    virtual int AdjustOverlappingLayers(
         Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
 
     //----------//

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -428,36 +428,36 @@ public:
  * member 1: the current layerN set in the AlignmentRef (negative values for cross-staff)
  * member 2: the elements for the previous layer(s)
  * member 3: the elements of the current layer
- * member 4: the current note
- * member 5: the current chord (if any)
- * member 6: the doc
- * member 7: a pointer to the functor for passing it to the system aligner
- * member 8: flag whether element is in unison
+ * member 4: the doc
+ * member 5: a pointer to the functor for passing it to the system aligner
+ * member 6: a pointer to the end functor for passing it to the system aligner
+ * member 7: flag whether element is in unison
+ * member 8: the total shift of the current note or chord
  **/
 
 class AdjustLayersParams : public FunctorParams {
 public:
-    AdjustLayersParams(Doc *doc, Functor *functor, const std::vector<int> &staffNs)
+    AdjustLayersParams(Doc *doc, Functor *functor, Functor *functorEnd, const std::vector<int> &staffNs)
     {
         m_currentLayerN = VRV_UNSET;
-        m_currentNote = NULL;
-        m_currentChord = NULL;
         m_doc = doc;
         m_functor = functor;
+        m_functorEnd = functorEnd;
         m_staffNs = staffNs;
         m_unison = false;
         m_ignoreDots = true;
+        m_accumulatedShift = 0;
     }
     std::vector<int> m_staffNs;
     int m_currentLayerN;
     std::vector<LayerElement *> m_previous;
     std::vector<LayerElement *> m_current;
-    Note *m_currentNote;
-    Chord *m_currentChord;
     Doc *m_doc;
     Functor *m_functor;
+    Functor *m_functorEnd;
     bool m_unison;
     bool m_ignoreDots;
+    int m_accumulatedShift;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -341,6 +341,7 @@ public:
      * See Object::AdjustLayers
      */
     virtual int AdjustLayers(FunctorParams *functorParams);
+    virtual int AdjustLayersEnd(FunctorParams *functorParams);
 
     /**
      * See Object::AdjustGraceXPos

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -225,8 +225,9 @@ public:
 
     /**
      * Helper to adjust overlapping layers for notes, chords, stems, etc.
+     * Returns the shift of the adjustment
      */
-    virtual void AdjustOverlappingLayers(
+    virtual int AdjustOverlappingLayers(
         Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
 
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -226,6 +226,16 @@ public:
     ///@}
 
 public:
+    //----------------//
+    // Static methods //
+    //----------------//
+
+    /**
+     * Assume that two notes from different layers are given occuring at the same time
+     * Returns true if one note has a ledger line that collides (or is quite close) to the other note's stem
+     */
+    static bool HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, Note *note2);
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -746,9 +746,12 @@ public:
     ///@}
 
     /**
-     * Adjust the position the outside articulations.
+     * Adjust the position of notes and chords for multiple layers
      */
+    ///@{
     virtual int AdjustLayers(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustLayersEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    ///@}
 
     /**
      * @name Lay out the X positions of the grace notes looking at the bounding boxes.

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -425,7 +425,7 @@ bool Chord::HasNoteWithDots()
     return false;
 }
 
-void Chord::AdjustOverlappingLayers(
+int Chord::AdjustOverlappingLayers(
     Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison)
 {
     int margin = 0;
@@ -469,7 +469,9 @@ void Chord::AdjustOverlappingLayers(
     }
     else if (margin) {
         SetDrawingXRel(GetDrawingXRel() + margin);
+        return margin;
     }
+    return 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1293,7 +1293,7 @@ int AlignmentReference::AdjustLayersEnd(FunctorParams *functorParams)
 
     // Determine staff
     if (params->m_current.empty()) return FUNCTOR_CONTINUE;
-    LayerElement *firstElem = params->m_current[0];
+    LayerElement *firstElem = params->m_current.at(0);
     Layer *layer = NULL;
     Staff *staff = firstElem->GetCrossStaff(layer);
     if (!staff) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1490,25 +1490,27 @@ int LayerElement::AdjustLayers(FunctorParams *functorParams)
     // We are processing the first layer, nothing to do yet
     if (params->m_previous.empty()) return FUNCTOR_SIBLINGS;
 
-    AdjustOverlappingLayers(params->m_doc, params->m_previous, !params->m_ignoreDots, params->m_unison);
+    const int shift
+        = AdjustOverlappingLayers(params->m_doc, params->m_previous, !params->m_ignoreDots, params->m_unison);
+    params->m_accumulatedShift += shift;
 
     return FUNCTOR_SIBLINGS;
 }
 
-void LayerElement::AdjustOverlappingLayers(
+int LayerElement::AdjustOverlappingLayers(
     Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison)
 {
     if (Is(NOTE) && GetParent()->Is(CHORD))
-        return;
+        return 0;
     else if (Is(STEM) && isUnison) {
         isUnison = false;
-        return;
+        return 0;
     }
 
     auto [margin, isInUnison] = CalcElementHorizontalOverlap(doc, otherElements, areDotsAdjusted, false);
     if (Is(NOTE)) {
         isUnison = isInUnison;
-        if (isUnison) return;
+        if (isUnison) return 0;
     }
 
     if (Is({ DOTS, STEM })) {
@@ -1519,6 +1521,7 @@ void LayerElement::AdjustOverlappingLayers(
     else {
         SetDrawingXRel(GetDrawingXRel() + margin);
     }
+    return margin;
 }
 
 std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -908,7 +908,7 @@ int Measure::AdjustLayers(FunctorParams *functorParams)
         AttNIntegerAnyComparison matchStaff(ALIGNMENT_REFERENCE, ns);
         filters.push_back(&matchStaff);
 
-        m_measureAligner.Process(params->m_functor, params, NULL, &filters);
+        m_measureAligner.Process(params->m_functor, params, params->m_functorEnd, &filters);
     }
 
     return FUNCTOR_SIBLINGS;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -313,8 +313,9 @@ void Page::LayOutHorizontally()
     // Look at each LayerElement and change the m_xShift if the bounding box is overlapping
     // For the first iteration align elements without taking dots into consideration
     Functor adjustLayers(&Object::AdjustLayers);
-    AdjustLayersParams adjustLayersParams(doc, &adjustLayers, doc->m_mdivScoreDef.GetStaffNs());
-    this->Process(&adjustLayers, &adjustLayersParams);
+    Functor adjustLayersEnd(&Object::AdjustLayersEnd);
+    AdjustLayersParams adjustLayersParams(doc, &adjustLayers, &adjustLayersEnd, doc->m_mdivScoreDef.GetStaffNs());
+    this->Process(&adjustLayers, &adjustLayersParams, &adjustLayersEnd);
 
     // Adjust dots for the multiple layers. Try to align dots that can be grouped together when layers collide,
     // otherwise keep their relative positioning
@@ -324,9 +325,9 @@ void Page::LayOutHorizontally()
     this->Process(&adjustDots, &adjustDotsParams, &adjustDotsEnd);
 
     // adjust Layers again, this time including dots positioning
-    AdjustLayersParams newAdjustLayersParams(doc, &adjustLayers, doc->m_mdivScoreDef.GetStaffNs());
+    AdjustLayersParams newAdjustLayersParams(doc, &adjustLayers, &adjustLayersEnd, doc->m_mdivScoreDef.GetStaffNs());
     newAdjustLayersParams.m_ignoreDots = false;
-    this->Process(&adjustLayers, &newAdjustLayersParams);
+    this->Process(&adjustLayers, &newAdjustLayersParams, &adjustLayersEnd);
 
     // Adjust the X position of the accidentals, including in chords
     Functor adjustAccidX(&Object::AdjustAccidX);


### PR DESCRIPTION
This PR fixes collisions of ledger lines with note stems of the other layer.

**Before**
![Before1](https://user-images.githubusercontent.com/63608463/128328200-ef6564ff-b3ca-42f7-9324-c993ef56432d.png)

**After**
![After1](https://user-images.githubusercontent.com/63608463/128328270-0b0cfc19-c65d-48e6-a1d5-8af2b3ee81a3.png)

<details>
  <summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Double-stemmed adjacent notes and overlapping parts</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2021-06-18">2021-06-18</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>The two parts may share ledger lines, which should extend either side of all noteheads between the stave and the displaced part.</annot>
            <annot>When parts overlap, ledger lines that are not shared by the part whose pitch is closest to the stave should not cut through its stem.</annot>
         </notesStmt>
         <sourceDesc>
            <source>
               <bibl>Behind Bars, p. 27, example 3</bibl>
            </source>
         </sourceDesc>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffGrp>
                        <staffDef n="1" lines="5">
                           <clef shape="G" line="2" visible="false" />
                           <keySig sig="0" visible="false" />
                        </staffDef>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                 <measure>
                    <staff n="1">
                       <layer n="1">
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                       </layer>
                       <layer n="2">
                          <note dur="4" oct="3" pname="a" />
                          <note dur="4" oct="4" pname="c" />
                          <note dur="4" oct="4" pname="e" />
                          <note dur="4" oct="4" pname="g" />
                       </layer>
                    </staff>
                 </measure>
                 <measure>
                    <staff n="1">
                       <layer n="1">
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                       </layer>
                       <layer n="2">
                          <note dur="4" oct="4" pname="b" />
                          <note dur="4" oct="5" pname="d" />
                          <note dur="4" oct="5" pname="f" />
                          <note dur="4" oct="5" pname="a" />
                       </layer>
                    </staff>
                 </measure>
                 <measure>
                    <staff n="1">
                       <layer n="1">
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="3" pname="f" />
                           <note oct="3" pname="d" />
                         </chord>
                       </layer>
                       <layer n="2">
                         <chord dur="4">
                           <note oct="4" pname="a" />
                           <note oct="5" pname="c" />
                         </chord>
                         <chord dur="4">
                           <note oct="4" pname="b" />
                           <note oct="5" pname="d" />
                         </chord>
                         <chord dur="4">
                           <note oct="5" pname="c" />
                           <note oct="5" pname="e" />
                         </chord>
                         <chord dur="4">
                           <note oct="5" pname="d" />
                           <note oct="5" pname="f" />
                         </chord>
                       </layer>
                    </staff>
                 </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

This is also works for cross staff content.
| Before | After |
| ------ | ----- |
| ![Before2](https://user-images.githubusercontent.com/63608463/128328810-d1a104aa-e8c0-4a8d-b75e-f488335f632c.png) | ![After2](https://user-images.githubusercontent.com/63608463/128328837-1cc68b26-e9e7-4df3-9504-d0f3fe3e4160.png) |

<details>
  <summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Double-stemmed adjacent notes and overlapping parts</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2021-06-18">2021-06-18</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>The two parts may share ledger lines, which should extend either side of all noteheads between the stave and the displaced part.</annot>
            <annot>When parts overlap, ledger lines that are not shared by the part whose pitch is closest to the stave should not cut through its stem.</annot>
         </notesStmt>
         <sourceDesc>
            <source>
               <bibl>Behind Bars, p. 27, example 3</bibl>
            </source>
         </sourceDesc>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffGrp>
                       <staffDef xml:id="staffdef-0000001789269193" n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="4s" meter.count="3" meter.unit="4" />
                       <staffDef xml:id="staffdef-0000000374059713" n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="4s" meter.count="3" meter.unit="4" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                 <measure left="invis" right="invis" label="overlapping parts">
                    <staff n="1">
                       <layer n="1">
                         <chord dur="4">
                           <note oct="4" pname="g" />
                           <note oct="3" pname="g" staff="2"/>
                         </chord>
                         <chord dur="4">
                           <note oct="4" pname="g" />
                           <note oct="4" pname="c" staff="2"/>
                         </chord>
                         <chord dur="4">
                           <note oct="4" pname="g" />
                           <note oct="4" pname="e" staff="2"/>
                         </chord>
                       </layer>
                    </staff>
                    <staff n="2">
                      <layer n="2">
                        <chord dur="4">
                          <note oct="4" pname="c" />
                          <note oct="3" pname="e" />
                        </chord>
                        <chord dur="4">
                          <note oct="4" pname="e" />
                          <note oct="3" pname="e" />
                        </chord>
                        <chord dur="4">
                          <note oct="4" pname="c" />
                          <note oct="3" pname="e" />
                        </chord>
                      </layer>
                    </staff>
                 </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

