### PR TITLE
Allow for accidentals to have @edit and @enclose attributes at the same time

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1923,7 +1923,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
     else if (this->Is(ACCID)) {
         Accid const *accid = vrv_cast<Accid *>(this);
         assert(accid);
-        if ((accid->GetFunc() == accidLog_FUNC_edit) && !accid->HasEnclose())
+        if (accid->GetFunc() == accidLog_FUNC_edit)
             m_drawingCueSize = true;
         else {
             Note *note = dynamic_cast<Note *>(this->GetFirstAncestor(NOTE, MAX_ACCID_DEPTH));

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -256,7 +256,7 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int x = accid->GetDrawingX();
     int y = accid->GetDrawingY();
 
-    if ((accid->GetFunc() == accidLog_FUNC_edit) && (!accid->HasEnclose())) {
+    if (accid->GetFunc() == accidLog_FUNC_edit) {
         y = staff->GetDrawingY();
         // look at the note position and adjust it if necessary
         Note *note = dynamic_cast<Note *>(accid->GetFirstAncestor(NOTE, MAX_ACCID_DEPTH));


### PR DESCRIPTION
closes #2322
![image](https://user-images.githubusercontent.com/1819669/128376921-7f53c777-ae2f-487f-9d2d-922ab59b8cfc.png)
