### PR TITLE
Change default staccato placement + add option for it

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -140,6 +140,8 @@ public:
 
 private:
     bool IsInsideArtic(data_ARTICULATION artic) const;
+    // Calculate shift for the articulation based on its type and presence of other articulations
+    int CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const;
 
 public:
     std::vector<FloatingCurvePositioner *> m_startSlurPositioners;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -602,7 +602,7 @@ public:
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
     OptionBool m_shrinkToFit;
-    OptionBool m_centerStaccato;
+    OptionBool m_staccatoCenter;
     OptionBool m_svgBoundingBoxes;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -602,7 +602,7 @@ public:
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
     OptionBool m_shrinkToFit;
-    OptionBool m_stemSideStaccato;
+    OptionBool m_centerStaccato;
     OptionBool m_svgBoundingBoxes;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -602,6 +602,7 @@ public:
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
     OptionBool m_shrinkToFit;
+    OptionBool m_stemSideStaccato;
     OptionBool m_svgBoundingBoxes;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -361,8 +361,7 @@ int Artic::CalcArtic(FunctorParams *functorParams)
 
     /************** adjust the xRel position **************/
 
-    int xShift = params->m_parent->GetDrawingRadius(params->m_doc);
-    this->SetDrawingXRel(xShift);
+    this->SetDrawingXRel(CalculateHorizontalShift(params->m_doc, params->m_parent, params->m_stemDir));
 
     /************** set cross-staff / layer **************/
 
@@ -527,6 +526,34 @@ int Artic::ResetDrawing(FunctorParams *functorParams)
     m_drawingPlace = STAFFREL_NONE;
 
     return FUNCTOR_CONTINUE;
+}
+
+int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const
+{
+    int shift = parent->GetDrawingRadius(doc);
+    if ((parent->GetChildCount(ARTIC) > 1) || (!doc->GetOptions()->m_stemSideStaccato.GetValue())) {
+        return shift;
+    }
+    data_ARTICULATION artic = GetArticFirst();
+    switch (artic) {
+        case ARTICULATION_stacc:
+        case ARTICULATION_stacciss: 
+        {
+            const int stemWidth = doc->GetDrawingStemWidth(100);
+            if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
+                shift += shift - stemWidth;
+            }
+            else if ((stemDir == STEMDIRECTION_down) && (m_drawingPlace == STAFFREL_below)) {
+                shift = stemWidth;
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+    
+    return shift;
 }
 
 } // namespace vrv

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -539,7 +539,10 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
         case ARTICULATION_stacc:
         case ARTICULATION_stacciss: 
         {
-            const int stemWidth = doc->GetDrawingStemWidth(100);
+            Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+            assert(staff);
+            const int staffSize = doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
+            const int stemWidth = doc->GetDrawingStemWidth(staffSize);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
                 shift += shift - stemWidth / 2;
             }

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -541,10 +541,10 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
         {
             const int stemWidth = doc->GetDrawingStemWidth(100);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
-                shift += shift - stemWidth;
+                shift += shift - stemWidth / 2;
             }
             else if ((stemDir == STEMDIRECTION_down) && (m_drawingPlace == STAFFREL_below)) {
-                shift = stemWidth;
+                shift = stemWidth / 2;
             }
             break;
         }

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -537,8 +537,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
     data_ARTICULATION artic = GetArticFirst();
     switch (artic) {
         case ARTICULATION_stacc:
-        case ARTICULATION_stacciss: 
-        {
+        case ARTICULATION_stacciss: {
             Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
             assert(staff);
             const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
@@ -554,7 +553,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
             break;
         }
     }
-    
+
     return shift;
 }
 

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -531,7 +531,7 @@ int Artic::ResetDrawing(FunctorParams *functorParams)
 int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const
 {
     int shift = parent->GetDrawingRadius(doc);
-    if ((parent->GetChildCount(ARTIC) > 1) || (doc->GetOptions()->m_centerStaccato.GetValue())) {
+    if ((parent->GetChildCount(ARTIC) > 1) || (doc->GetOptions()->m_staccatoCenter.GetValue())) {
         return shift;
     }
     data_ARTICULATION artic = GetArticFirst();

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -531,7 +531,7 @@ int Artic::ResetDrawing(FunctorParams *functorParams)
 int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const
 {
     int shift = parent->GetDrawingRadius(doc);
-    if ((parent->GetChildCount(ARTIC) > 1) || (!doc->GetOptions()->m_stemSideStaccato.GetValue())) {
+    if ((parent->GetChildCount(ARTIC) > 1) || (doc->GetOptions()->m_centerStaccato.GetValue())) {
         return shift;
     }
     data_ARTICULATION artic = GetArticFirst();
@@ -541,8 +541,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
         {
             Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
             assert(staff);
-            const int staffSize = doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
-            const int stemWidth = doc->GetDrawingStemWidth(staffSize);
+            const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
                 shift += shift - stemWidth / 2;
             }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1006,6 +1006,10 @@ Options::Options()
     m_shrinkToFit.Init(false);
     this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);
 
+    m_stemSideStaccato.SetInfo("Stem side staccato", "Align staccato and staccatissimo articulations with stem");
+    m_stemSideStaccato.Init(false);
+    this->Register(&m_stemSideStaccato, "stemSideStaccato", &m_general);
+
     m_svgBoundingBoxes.SetInfo("Svg bounding boxes viewbox on svg root", "Include bounding boxes in SVG output");
     m_svgBoundingBoxes.Init(false);
     this->Register(&m_svgBoundingBoxes, "svgBoundingBoxes", &m_general);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1006,7 +1006,8 @@ Options::Options()
     m_shrinkToFit.Init(false);
     this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);
 
-    m_centerStaccato.SetInfo("Center staccato", "Align staccato and staccatissimo articulations with center of the note");
+    m_centerStaccato.SetInfo(
+        "Center staccato", "Align staccato and staccatissimo articulations with center of the note");
     m_centerStaccato.Init(false);
     this->Register(&m_centerStaccato, "centerStaccato", &m_general);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1006,10 +1006,10 @@ Options::Options()
     m_shrinkToFit.Init(false);
     this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);
 
-    m_centerStaccato.SetInfo(
+    m_staccatoCenter.SetInfo(
         "Center staccato", "Align staccato and staccatissimo articulations with center of the note");
-    m_centerStaccato.Init(false);
-    this->Register(&m_centerStaccato, "centerStaccato", &m_general);
+    m_staccatoCenter.Init(false);
+    this->Register(&m_staccatoCenter, "staccatoCenter", &m_general);
 
     m_svgBoundingBoxes.SetInfo("Svg bounding boxes viewbox on svg root", "Include bounding boxes in SVG output");
     m_svgBoundingBoxes.Init(false);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1006,9 +1006,9 @@ Options::Options()
     m_shrinkToFit.Init(false);
     this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);
 
-    m_stemSideStaccato.SetInfo("Stem side staccato", "Align staccato and staccatissimo articulations with stem");
-    m_stemSideStaccato.Init(false);
-    this->Register(&m_stemSideStaccato, "stemSideStaccato", &m_general);
+    m_centerStaccato.SetInfo("Center staccato", "Align staccato and staccatissimo articulations with center of the note");
+    m_centerStaccato.Init(false);
+    this->Register(&m_centerStaccato, "centerStaccato", &m_general);
 
     m_svgBoundingBoxes.SetInfo("Svg bounding boxes viewbox on svg root", "Include bounding boxes in SVG output");
     m_svgBoundingBoxes.Init(false);


### PR DESCRIPTION
closes #398
Changed default staccato/staccatisimo position to be at the stem side, with the possibility to use previous position by option `--center-staccato`.
When paired with other articulations, centered positioning will be used instead.
![image](https://user-images.githubusercontent.com/1819669/128491138-bf4b6467-dc85-425b-a561-98497cb80ea3.png)
