### PR TITLE
Fix widow measure detection

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1172,6 +1172,7 @@ int Measure::CastOffSystems(FunctorParams *functorParams)
                 if (oneOfPendingObjects->Is(MEASURE)) {
                     Measure *firstPendingMesure = vrv_cast<Measure *>(oneOfPendingObjects);
                     assert(firstPendingMesure);
+                    params->m_leftoverSystem = NULL;
                     params->m_shift = firstPendingMesure->m_drawingXRel;
                     // it has to be first measure
                     break;


### PR DESCRIPTION
This PR fixes a bug in the widow measure detection: Verovio sometimes assumed there is a widow measure even though the last system contained more than one measure. It then moved the first measure of the last system into the previous system and deleted the remaining measures of the last system after `CastOffPages`. We actually observed a crash due to this in an example with a sameas pointing to a clef in the last measure.