### PR TITLE
Fix problematic assertion in JustifyY

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -827,7 +827,8 @@ int Chord::JustifyY(FunctorParams *functorParams)
 {
     JustifyYParams *params = vrv_params_cast<JustifyYParams *>(functorParams);
     assert(params);
-    assert(params->m_justificationSum > 0);
+    if (params->m_justificationSum <= 0.0) return FUNCTOR_STOP;
+    if (params->m_spaceToDistribute <= 0) return FUNCTOR_STOP;
 
     // Check if chord spreads across several staves
     std::list<Staff *> extremalStaves;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -729,6 +729,8 @@ int System::JustifyY(FunctorParams *functorParams)
 {
     JustifyYParams *params = vrv_params_cast<JustifyYParams *>(functorParams);
     assert(params);
+    if (params->m_justificationSum <= 0.0) return FUNCTOR_STOP;
+    if (params->m_spaceToDistribute <= 0) return FUNCTOR_STOP;
 
     const double systemJustificationFactor = params->m_doc->GetOptions()->m_justificationSystem.GetValue();
     const double shift = systemJustificationFactor / params->m_justificationSum * params->m_spaceToDistribute;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1031,6 +1031,8 @@ int StaffAlignment::JustifyY(FunctorParams *functorParams)
 {
     JustifyYParams *params = vrv_params_cast<JustifyYParams *>(functorParams);
     assert(params);
+    if (params->m_justificationSum <= 0.0) return FUNCTOR_STOP;
+    if (params->m_spaceToDistribute <= 0) return FUNCTOR_STOP;
 
     // Skip bottom aligner and first staff
     if (!m_staff || SystemAligner::SpacingType::System == m_spacingType) {


### PR DESCRIPTION
This PR removes an assertion which is not waterproof. Instead param state is checked.