### PR TITLE
Implement delayed turns

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -57,6 +57,7 @@ class System;
 class SystemAligner;
 class Transposer;
 class TupletNum;
+class Turn;
 class Verse;
 
 //----------------------------------------------------------------------------
@@ -1762,6 +1763,31 @@ public:
     Measure *m_lastMeasure;
     Ending *m_currentEnding;
     std::vector<SystemElementStartInterface *> m_startBoundaries;
+};
+
+//----------------------------------------------------------------------------
+// PrepareDelayedTurnsParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a flag indicating that we are running a first pass to fill the map
+ * member 1: a pointer to the element to which a turn is pointing to
+ * member 2: a pointer to the turn to which we want to set a m_drawingEndElement
+ * member 3: a map of the delayed turns and the layer element they point to
+ **/
+
+class PrepareDelayedTurnsParams : public FunctorParams {
+public:
+    PrepareDelayedTurnsParams()
+    {
+        m_initMap = true;
+        m_previousElement = NULL;
+        m_currentTurn = NULL;
+    }
+    bool m_initMap;
+    LayerElement *m_previousElement;
+    Turn *m_currentTurn;
+    std::map<LayerElement *, Turn *> m_delayedTurns;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -317,6 +317,11 @@ public:
     virtual int PreparePointersByLayer(FunctorParams *functorParams);
 
     /**
+     * See Object::PrepareDelayedTurns
+     */
+    virtual int PrepareDelayedTurns(FunctorParams *functorParams);
+
+    /**
      * See Object::PrepareTimePointing
      */
     virtual int PrepareTimePointing(FunctorParams *functorParams);

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1111,6 +1111,13 @@ public:
     virtual int PrepareRpt(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Functor for setting Turn::m_drawingEndNote for delayed turns
+     * Need a first pass to fill the map with m_initMap to true
+     * Processed by staff/layer after that
+     */
+    virtual int PrepareDelayedTurns(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Functor for setting Measure of Ending
      */
     virtual int PrepareBoundaries(FunctorParams *) { return FUNCTOR_CONTINUE; }

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -60,12 +60,26 @@ public:
     // Functors //
     //----------//
 
+    /**
+     * See Object::PrepareDelayedTurns
+     */
+    virtual int PrepareDelayedTurns(FunctorParams *functorParams);
+
+    /**
+     * See Object::ResetDrawing
+     */
+    virtual int ResetDrawing(FunctorParams *functorParams);
+
 protected:
     //
 private:
     //
 public:
-    //
+    /**
+     * The end point of a delayed turn when @startid is used
+     */
+    LayerElement *m_drawingEndElement;
+
 private:
     //
 };

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -623,6 +623,32 @@ void Doc::PrepareDrawing()
         }
     }
 
+    /************ Resolve delayed turns ************/
+
+    PrepareDelayedTurnsParams prepareDelayedTurnsParams;
+    Functor prepareDelayedTurns(&Object::PrepareDelayedTurns);
+    this->Process(&prepareDelayedTurns, &prepareDelayedTurnsParams);
+
+    if (!prepareDelayedTurnsParams.m_delayedTurns.empty()) {
+        prepareDelayedTurnsParams.m_initMap = false;
+        for (staves = prepareProcessingListsParams.m_layerTree.child.begin();
+             staves != prepareProcessingListsParams.m_layerTree.child.end(); ++staves) {
+            for (layers = staves->second.child.begin(); layers != staves->second.child.end(); ++layers) {
+                filters.clear();
+                // Create ad comparison object for each type / @n
+                AttNIntegerComparison matchStaff(STAFF, staves->first);
+                AttNIntegerComparison matchLayer(LAYER, layers->first);
+                filters.push_back(&matchStaff);
+                filters.push_back(&matchLayer);
+
+                prepareDelayedTurnsParams.m_currentTurn = NULL;
+                prepareDelayedTurnsParams.m_previousElement = NULL;
+
+                this->Process(&prepareDelayedTurns, &prepareDelayedTurnsParams, NULL, &filters);
+            }
+        }
+    }
+
     /************ Resolve lyric connectors ************/
 
     // Same for the lyrics, but Verse by Verse since Syl are TimeSpanningInterface elements for handling connectors

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -57,6 +57,7 @@
 #include "timestamp.h"
 #include "tuning.h"
 #include "tuplet.h"
+#include "turn.h"
 #include "verse.h"
 #include "view.h"
 #include "vrv.h"
@@ -2089,6 +2090,31 @@ int LayerElement::PreparePointersByLayer(FunctorParams *functorParams)
     }
     else if (this->Is({ NOTE, REST })) {
         params->m_currentElement = this;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+int LayerElement::PrepareDelayedTurns(FunctorParams *functorParams)
+{
+    PrepareDelayedTurnsParams *params = vrv_params_cast<PrepareDelayedTurnsParams *>(functorParams);
+    assert(params);
+
+    // We are initializing the params->m_delayedTurns map
+    if (params->m_initMap) return FUNCTOR_CONTINUE;
+
+    if (!this->HasInterface(INTERFACE_DURATION)) return FUNCTOR_CONTINUE;
+
+    if (params->m_previousElement) {
+        assert(params->m_currentTurn);
+        params->m_currentTurn->m_drawingEndElement = this;
+        params->m_currentTurn = NULL;
+        params->m_previousElement = NULL;
+    }
+
+    if (params->m_delayedTurns.count(this)) {
+        params->m_previousElement = this;
+        params->m_currentTurn = params->m_delayedTurns.at(this);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -13,6 +13,8 @@
 
 //----------------------------------------------------------------------------
 
+#include "functorparams.h"
+#include "layerelement.h"
 #include "smufl.h"
 #include "verticalaligner.h"
 
@@ -54,6 +56,8 @@ void Turn::Reset()
     ResetOrnamentAccid();
     ResetPlacementRelStaff();
     ResetTurnLog();
+
+    m_drawingEndElement = NULL;
 }
 
 wchar_t Turn::GetTurnGlyph() const
@@ -75,5 +79,34 @@ wchar_t Turn::GetTurnGlyph() const
 //----------------------------------------------------------------------------
 // Turn functor methods
 //----------------------------------------------------------------------------
+
+int Turn::PrepareDelayedTurns(FunctorParams *functorParams)
+{
+    PrepareDelayedTurnsParams *params = vrv_params_cast<PrepareDelayedTurnsParams *>(functorParams);
+    assert(params);
+
+    // We already initialized the params->m_delayedTurns map
+    if (!params->m_initMap) return FUNCTOR_CONTINUE;
+
+    // Map only delayed turns
+    if (this->GetDelayed() != BOOLEAN_true) return FUNCTOR_CONTINUE;
+
+    // Map only delayed turn pointing to a LayerElement (i.e., not using @tstamp)
+    if (this->GetStart() && !this->GetStart()->Is(TIMESTAMP_ATTR)) {
+        params->m_delayedTurns[this->GetStart()] = this;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+int Turn::ResetDrawing(FunctorParams *functorParams)
+{
+    // Call parent one too
+    ControlElement::ResetDrawing(functorParams);
+
+    m_drawingEndElement = NULL;
+
+    return FUNCTOR_CONTINUE;
+}
 
 } // namespace vrv

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2234,7 +2234,16 @@ void View::DrawTurn(DeviceContext *dc, Turn *turn, Measure *measure, System *sys
     dc->StartGraphic(turn, "", turn->GetUuid());
 
     int x = turn->GetStart()->GetDrawingX() + turn->GetStart()->GetDrawingRadius(m_doc);
-    if (turn->GetDelayed() == BOOLEAN_true && !turn->HasTstamp()) LogWarning("delayed turns not supported");
+
+    if (turn->m_drawingEndElement) {
+        // Get the parent system of the start and end element
+        LayerElement *end = turn->m_drawingEndElement;
+        Object *parentSystem1 = turn->GetStart()->GetFirstAncestor(SYSTEM);
+        Object *parentSystem2 = end->GetFirstAncestor(SYSTEM);
+        // We have a system break, use the measure right bar line instead
+        if (parentSystem1 != parentSystem2) end = measure->GetRightBarLine();
+        x += ((end->GetDrawingX() - x) / 2);
+    }
 
     // set norm as default
     int code = turn->GetTurnGlyph();


### PR DESCRIPTION
This PR add support for delayed turns that have a `@startid`. The turn is placed between the start note and the next note (or the right bar line at the end of a system)

<img width="459" alt="image" src="https://user-images.githubusercontent.com/689412/129872449-c754f57e-78eb-4e92-991d-8deea8414e7b.png">
