### PR TITLE
Improve performance

### DIFF
--- a/include/vrv/abbr.h
+++ b/include/vrv/abbr.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Abbr(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Abbr"; }
-    virtual ClassId GetClassId() const { return ABBR; }
     ///@}
 
 private:

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -43,7 +43,6 @@ public:
     virtual Object *Clone() const { return new Accid(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Accid"; }
-    virtual ClassId GetClassId() const { return ACCID; }
     ///@}
 
     virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }

--- a/include/vrv/add.h
+++ b/include/vrv/add.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Add(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Add"; }
-    virtual ClassId GetClassId() const { return ADD; }
     ///@}
 
 private:

--- a/include/vrv/anchoredtext.h
+++ b/include/vrv/anchoredtext.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new AnchoredText(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "AnchoredText"; }
-    virtual ClassId GetClassId() const { return ANCHOREDTEXT; }
     ///@}
 
     /**

--- a/include/vrv/annot.h
+++ b/include/vrv/annot.h
@@ -33,7 +33,6 @@ public:
     // virtual Object *Clone() const { return new Annot(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Annot"; }
-    virtual ClassId GetClassId() const { return ANNOT; }
     ///@}
 
     /**

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new App(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "App"; }
-    virtual ClassId GetClassId() const { return APP; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -40,7 +40,6 @@ public:
     virtual Object *Clone() const { return new Arpeg(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Arpeg"; }
-    virtual ClassId GetClassId() const { return ARPEG; }
     ///@}
 
     /**

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new Artic(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Artic"; }
-    virtual ClassId GetClassId() const { return ARTIC; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -13,6 +13,8 @@
 
 namespace vrv {
 
+enum class BarLinePosition { None, Left, Right };
+
 //----------------------------------------------------------------------------
 // BarLine
 //----------------------------------------------------------------------------
@@ -53,6 +55,12 @@ public:
      */
     bool HasRepetitionDots() const;
 
+    /**
+     * @name Get and set the position
+     */
+    BarLinePosition GetPosition() const { return m_position; }
+    void SetPosition(BarLinePosition position) { m_position = position; }
+
     //----------//
     // Functors //
     //----------//
@@ -67,41 +75,8 @@ private:
 public:
     //
 private:
-};
-
-//----------------------------------------------------------------------------
-// BarLineAttr
-//----------------------------------------------------------------------------
-
-/**
- * This class models the barLine related attributes of a MEI measure.
- */
-class BarLineAttr : public BarLine {
-public:
-    /**
-     * @name Constructors, destructors, and other standard methods
-     * No Reset() method is required.
-     */
-    ///@{
-    BarLineAttr();
-    virtual ~BarLineAttr();
-    virtual Object *Clone() const { return new BarLineAttr(*this); }
-    virtual std::string GetClassName() const { return "BarLineAttr"; }
-    ///@}
-
-    void SetLeft();
-    void SetNoAttr();
-
-private:
-    /** The class id here depends on the value of the class members */
-    void UpdateClassId();
-
-public:
-    //
-private:
-    /** A flag for left barlines (right if false) */
-    bool m_isLeft;
-    bool m_noAttr;
+    /** The barline position (left/right) */
+    BarLinePosition m_position;
 };
 
 } // namespace vrv

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -32,11 +32,11 @@ public:
      */
     ///@{
     BarLine();
+    BarLine(ClassId classId);
     virtual ~BarLine();
     virtual Object *Clone() const { return new BarLine(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "BarLine"; }
-    virtual ClassId GetClassId() const { return BARLINE; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -87,18 +87,15 @@ public:
     virtual ~BarLineAttr();
     virtual Object *Clone() const { return new BarLineAttr(*this); }
     virtual std::string GetClassName() const { return "BarLineAttr"; }
-    virtual ClassId GetClassId() const
-    {
-        if (m_noAttr) return BARLINE;
-        return m_isLeft ? BARLINE_ATTR_LEFT : BARLINE_ATTR_RIGHT;
-    }
     ///@}
 
-    void SetLeft() { m_isLeft = true; }
-    void SetNoAttr() { m_noAttr = true; }
+    void SetLeft();
+    void SetNoAttr();
 
 private:
-    //
+    /** The class id here depends on the value of the class members */
+    void UpdateClassId();
+
 public:
     //
 private:

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -43,7 +43,6 @@ public:
     ///@{
     BBoxDeviceContext(View *view, int width, int height, unsigned char update = BBOX_BOTH);
     virtual ~BBoxDeviceContext();
-    virtual ClassId GetClassId() const { return BBOX_DEVICE_CONTEXT; }
     ///@}
 
     /**

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -135,7 +135,6 @@ public:
     virtual Object *Clone() const { return new Beam(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Beam"; }
-    virtual ClassId GetClassId() const { return BEAM; }
     ///@}
 
     int GetNoteCount() const { return this->GetChildCount(NOTE); }

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new BeatRpt(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "BeatRpt"; }
-    virtual ClassId GetClassId() const { return BEATRPT; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -36,7 +36,7 @@ public:
     ///@{
     BoundingBox();
     virtual ~BoundingBox(){};
-    virtual ClassId GetClassId() const;
+    virtual ClassId GetClassId() const = 0;
     bool Is(ClassId classId) const { return (this->GetClassId() == classId); }
     bool Is(const std::vector<ClassId> &classIds) const;
     ///@}

--- a/include/vrv/bracketspan.h
+++ b/include/vrv/bracketspan.h
@@ -38,7 +38,6 @@ public:
     virtual Object *Clone() const { return new BracketSpan(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "BracketSpan"; }
-    virtual ClassId GetClassId() const { return BRACKETSPAN; }
     ///@}
 
     /**

--- a/include/vrv/breath.h
+++ b/include/vrv/breath.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Breath(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Breath"; }
-    virtual ClassId GetClassId() const { return BREATH; }
     ///@}
 
     /**

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new BTrem(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "BTrem"; }
-    virtual ClassId GetClassId() const { return BTREM; }
     ///@}
 
     /**

--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Caesura(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Caesura"; }
-    virtual ClassId GetClassId() const { return CAESURA; }
     ///@}
 
     /**

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -30,7 +30,6 @@ public:
     virtual ~Choice();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Choice"; }
-    virtual ClassId GetClassId() const { return CHOICE; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -52,7 +52,6 @@ public:
     virtual Object *Clone() const { return new Chord(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Chord"; }
-    virtual ClassId GetClassId() const { return CHORD; }
     ///@}
 
     /**

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Clef(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Clef"; }
-    virtual ClassId GetClassId() const { return CLEF; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -31,10 +31,10 @@ public:
      */
     ///@{
     ControlElement();
-    ControlElement(const std::string &classid);
+    ControlElement(ClassId classId);
+    ControlElement(ClassId classId, const std::string &classIdStr);
     virtual ~ControlElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return CONTROL_ELEMENT; }
     ///@}
 
     /**

--- a/include/vrv/corr.h
+++ b/include/vrv/corr.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Corr(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Corr"; }
-    virtual ClassId GetClassId() const { return CORR; }
     ///@}
 
 private:

--- a/include/vrv/course.h
+++ b/include/vrv/course.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Course(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Course"; };
-    virtual ClassId GetClassId() const { return COURSE; };
     ///@}
 
     /**

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Custos(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Custos"; }
-    virtual ClassId GetClassId() const { return CUSTOS; }
     ///@}
 
     /**

--- a/include/vrv/damage.h
+++ b/include/vrv/damage.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Damage(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Damage"; }
-    virtual ClassId GetClassId() const { return DAMAGE; }
     ///@}
 
 private:

--- a/include/vrv/del.h
+++ b/include/vrv/del.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Del(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Del"; }
-    virtual ClassId GetClassId() const { return DEL; }
     ///@}
 
 private:

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -61,6 +61,18 @@ public:
     ///@{
     DeviceContext()
     {
+        m_classId = DEVICE_CONTEXT;
+        m_isDeactivatedX = false;
+        m_isDeactivatedY = false;
+        m_width = 0;
+        m_height = 0;
+        m_contentHeight = 0;
+        m_userScaleX = 1.0;
+        m_userScaleY = 1.0;
+    }
+    DeviceContext(ClassId classId)
+    {
+        m_classId = classId;
         m_isDeactivatedX = false;
         m_isDeactivatedY = false;
         m_width = 0;
@@ -70,8 +82,8 @@ public:
         m_userScaleY = 1.0;
     }
     virtual ~DeviceContext(){};
-    virtual ClassId GetClassId() const;
-    bool Is(ClassId classId) const { return (this->GetClassId() == classId); }
+    ClassId GetClassId() const { return m_classId; }
+    bool Is(ClassId classId) const { return (m_classId == classId); }
     ///@}
 
     /**
@@ -294,6 +306,9 @@ protected:
     Zone *m_facsimile = NULL;
 
 private:
+    /** The class id representing the actual (derived) class */
+    ClassId m_classId;
+
     /** stores the width and height of the device context */
     int m_width;
     int m_height;

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -42,7 +42,6 @@ public:
     virtual Object *Clone() const { return new Dir(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Dir"; }
-    virtual ClassId GetClassId() const { return DIR; }
     ///@}
 
     /**

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -46,7 +46,6 @@ public:
     ///@{
     Doc();
     virtual ~Doc();
-    virtual ClassId GetClassId() const { return DOC; }
     ///@}
 
     /**

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -181,7 +181,9 @@ public:
      */
     ///@{
     double GetLeftMargin(const ClassId classId) const;
+    double GetLeftMargin(Object *object) const;
     double GetRightMargin(const ClassId classId) const;
+    double GetRightMargin(Object *object) const;
     double GetLeftPosition() const;
     double GetBottomMargin(const ClassId classId) const;
     double GetTopMargin(const ClassId classId) const;

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -31,7 +31,6 @@ public:
     virtual Object *Clone() const { return new Dot(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Dot"; }
-    virtual ClassId GetClassId() const { return DOT; }
     ///@}
 
     /**

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Dynam(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Dynam"; }
-    virtual ClassId GetClassId() const { return DYNAM; }
     ///@}
 
     /**

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -43,10 +43,10 @@ public:
      */
     ///@{
     EditorialElement();
-    EditorialElement(const std::string &classid);
+    EditorialElement(ClassId classId);
+    EditorialElement(ClassId classId, const std::string &classIdStr);
     virtual ~EditorialElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return EDITORIAL_ELEMENT; }
     ///@}
 
     /**

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -35,7 +35,6 @@ public:
     virtual ~Dots();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Dots"; }
-    virtual ClassId GetClassId() const { return DOTS; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -117,7 +116,6 @@ public:
     virtual ~Flag();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Flag"; }
-    virtual ClassId GetClassId() const { return FLAG; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -173,7 +171,6 @@ public:
     virtual ~TupletBracket();
     virtual void Reset();
     virtual std::string GetClassName() const { return "TupletBracket"; }
-    virtual ClassId GetClassId() const { return TUPLET_BRACKET; }
     ///@}
 
     /**
@@ -267,7 +264,6 @@ public:
     virtual ~TupletNum();
     virtual void Reset();
     virtual std::string GetClassName() const { return "TupletNum"; }
-    virtual ClassId GetClassId() const { return TUPLET_NUM; }
     ///@}
 
     /**
@@ -339,7 +335,6 @@ public:
     virtual ~Stem();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Stem"; }
-    virtual ClassId GetClassId() const { return STEM; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -37,7 +37,6 @@ public:
     virtual Object *Clone() const { return new Ending(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Ending"; }
-    virtual ClassId GetClassId() const { return ENDING; }
     ///@}
 
     /**

--- a/include/vrv/expan.h
+++ b/include/vrv/expan.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Expan(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Expan"; }
-    virtual ClassId GetClassId() const { return EXPAN; }
     ///@}
 
 private:

--- a/include/vrv/expansion.h
+++ b/include/vrv/expansion.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new Expansion(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Expansion"; }
-    virtual ClassId GetClassId() const { return EXPANSION; }
     ///@}
 
     /**

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new F(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "F"; }
-    virtual ClassId GetClassId() const { return FIGURE; }
     ///@}
 
     /**

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -39,7 +39,6 @@ public:
     virtual ~Facsimile();
     virtual Object *Clone() const { return new Facsimile(*this); }
     virtual void Reset();
-    virtual ClassId GetClassId() const { return FACSIMILE; }
     virtual std::string GetClassName() const { return "facsimile"; }
     ///@}
     virtual bool IsSupportedChild(Object *object);

--- a/include/vrv/fb.h
+++ b/include/vrv/fb.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Fb(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Fb"; }
-    virtual ClassId GetClassId() const { return FB; }
     ///@}
 
     /**

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -43,7 +43,6 @@ public:
     virtual Object *Clone() const { return new Fermata(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Fermata"; }
-    virtual ClassId GetClassId() const { return FERMATA; }
     ///@}
 
     /**

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Fig(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Fig"; }
-    virtual ClassId GetClassId() const { return FIG; }
     ///@}
 
     /**

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new Fing(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Fing"; }
-    virtual ClassId GetClassId() const { return FING; }
     ///@}
 
     /**

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -33,10 +33,10 @@ public:
      */
     ///@{
     FloatingObject();
-    FloatingObject(const std::string &classid);
+    FloatingObject(ClassId classId);
+    FloatingObject(ClassId classId, const std::string &classIdStr);
     virtual ~FloatingObject();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return FLOATING_OBJECT; }
     ///@}
 
     virtual void UpdateContentBBoxX(int x1, int x2);

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new FTrem(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "FTrem"; }
-    virtual ClassId GetClassId() const { return FTREM; }
     ///@}
 
     /**

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -679,12 +679,13 @@ public:
  * member 7: the upcoming bounding boxes (to be used in the next aligner)
  * member 8: list of types to include
  * member 9: list of types to exclude
- * member 10: list of tie endpoints for the current measure
- * member 11: the Doc
- * member 12: the Functor for redirection to the MeasureAligner
- * member 13: the end Functor for redirection
- * member 14: current aligner that is being processed
- * member 15: preceeding aligner that was handled before
+ * member 10: flag to indicate whether only right bar line positions should be considered
+ * member 11: list of tie endpoints for the current measure
+ * member 12: the Doc
+ * member 13: the Functor for redirection to the MeasureAligner
+ * member 14: the end Functor for redirection
+ * member 15: current aligner that is being processed
+ * member 16: preceeding aligner that was handled before
  **/
 
 class AdjustXPosParams : public FunctorParams {
@@ -697,6 +698,7 @@ public:
         m_staffN = 0;
         m_staffNs = staffNs;
         m_staffSize = 100;
+        m_rightBarLinesOnly = false;
         m_doc = doc;
         m_functor = functor;
         m_functorEnd = functorEnd;
@@ -714,6 +716,7 @@ public:
     std::vector<BoundingBox *> m_upcomingBoundingBoxes;
     std::vector<ClassId> m_includes;
     std::vector<ClassId> m_excludes;
+    bool m_rightBarLinesOnly;
     std::vector<std::pair<LayerElement *, LayerElement *>> m_measureTieEndpoints;
     Doc *m_doc;
     Functor *m_functor;

--- a/include/vrv/gliss.h
+++ b/include/vrv/gliss.h
@@ -38,7 +38,6 @@ public:
     virtual Object *Clone() const { return new Gliss(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Gliss"; }
-    virtual ClassId GetClassId() const { return GLISS; }
     ///@}
 
     /**

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new GraceGrp(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "GraceGrp"; };
-    virtual ClassId GetClassId() const { return GRACEGRP; };
     ///@}
 
     /**

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -39,7 +39,6 @@ public:
     virtual Object *Clone() const { return new GrpSym(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "GrpSym"; }
-    virtual ClassId GetClassId() const { return GRPSYM; }
     ///@}
 
     /**

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -40,7 +40,6 @@ public:
     virtual Object *Clone() const { return new Hairpin(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Hairpin"; }
-    virtual ClassId GetClassId() const { return HAIRPIN; }
     ///@}
 
     /**

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new HalfmRpt(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "HalfmRpt"; }
-    virtual ClassId GetClassId() const { return HALFMRPT; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Harm(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Harm"; }
-    virtual ClassId GetClassId() const { return HARM; }
     ///@}
 
     /**

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -76,7 +76,6 @@ public:
     Alignment(double time, AlignmentType type = ALIGNMENT_DEFAULT);
     virtual ~Alignment();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return ALIGNMENT; }
     ///@}
 
     /**
@@ -300,7 +299,6 @@ public:
     AlignmentReference(int staffN);
     virtual ~AlignmentReference();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return ALIGNMENT_REFERENCE; }
     ///@}
 
     /**
@@ -390,7 +388,7 @@ public:
      * Reset method resets all attribute classes
      */
     ///@(
-    HorizontalAligner();
+    HorizontalAligner(ClassId classId);
     virtual ~HorizontalAligner();
     virtual void Reset();
     ///@}
@@ -442,7 +440,6 @@ public:
     ///@(
     MeasureAligner();
     virtual ~MeasureAligner();
-    virtual ClassId GetClassId() const { return MEASURE_ALIGNER; }
     virtual void Reset();
     ///@}
 
@@ -579,7 +576,6 @@ public:
     ///@(
     GraceAligner();
     virtual ~GraceAligner();
-    virtual ClassId GetClassId() const { return GRACE_ALIGNER; }
     virtual void Reset();
     ///@}
 
@@ -660,7 +656,6 @@ public:
     // constructors and destructors
     TimestampAligner();
     virtual ~TimestampAligner();
-    virtual ClassId GetClassId() const { return TIMESTAMP_ALIGNER; }
 
     /**
      * Reset the aligner (clear the content)

--- a/include/vrv/instrdef.h
+++ b/include/vrv/instrdef.h
@@ -38,7 +38,6 @@ public:
     virtual Object *Clone() const { return new InstrDef(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "InstrDef"; }
-    virtual ClassId GetClassId() const { return INSTRDEF; }
     ///@}
 
     //----------//

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -37,7 +37,6 @@ public:
     virtual Object *Clone() const { return new KeyAccid(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "KeyAccid"; }
-    virtual ClassId GetClassId() const { return KEYACCID; }
     ///@}
 
     virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -45,7 +45,6 @@ public:
     virtual Object *Clone() const { return new KeySig(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "KeySig"; }
-    virtual ClassId GetClassId() const { return KEYSIG; }
 
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }

--- a/include/vrv/label.h
+++ b/include/vrv/label.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Label(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Label"; }
-    virtual ClassId GetClassId() const { return LABEL; }
     ///@}
 
     /**

--- a/include/vrv/labelabbr.h
+++ b/include/vrv/labelabbr.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new LabelAbbr(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "LabelAbbr"; }
-    virtual ClassId GetClassId() const { return LABELABBR; }
     ///@}
 
     /**

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -47,7 +47,6 @@ public:
     virtual Object *Clone() const { return new Layer(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Layer"; }
-    virtual ClassId GetClassId() const { return LAYER; }
     ///@}
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -49,10 +49,10 @@ public:
      */
     ///@{
     LayerElement();
-    LayerElement(const std::string &classid);
+    LayerElement(ClassId classId);
+    LayerElement(ClassId classId, const std::string &classIdStr);
     virtual ~LayerElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return LAYER_ELEMENT; }
     ///@}
 
     /**

--- a/include/vrv/lb.h
+++ b/include/vrv/lb.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Lb(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Lb"; }
-    virtual ClassId GetClassId() const { return LB; }
     ///@}
 
     /**

--- a/include/vrv/lem.h
+++ b/include/vrv/lem.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Lem(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Lem"; }
-    virtual ClassId GetClassId() const { return LEM; }
     ///@}
 
 private:

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -37,7 +37,6 @@ public:
     virtual Object *Clone() const { return new Ligature(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Ligature"; }
-    virtual ClassId GetClassId() const { return LIGATURE; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -31,7 +31,6 @@ public:
     virtual Object *Clone() const { return new Lv(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Lv"; }
-    virtual ClassId GetClassId() const { return LV; }
     ///@}
 
     virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new Mdiv(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Mdiv"; }
-    virtual ClassId GetClassId() const { return MDIV; }
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -495,8 +495,8 @@ private:
      * @name The measure barlines (left and right) used when drawing
      */
     ///@{
-    BarLineAttr m_leftBarLine;
-    BarLineAttr m_rightBarLine;
+    BarLine m_leftBarLine;
+    BarLine m_rightBarLine;
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -54,7 +54,6 @@ public:
     virtual Object *Clone() const { return new Measure(*this); };
     virtual void Reset();
     virtual std::string GetClassName() const { return "Measure"; }
-    virtual ClassId GetClassId() const { return MEASURE; }
     ///@}
 
     /**

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -43,7 +43,6 @@ public:
     virtual Object *Clone() const { return new Mensur(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Mensur"; }
-    virtual ClassId GetClassId() const { return MENSUR; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new MeterSig(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MeterSig"; }
-    virtual ClassId GetClassId() const { return METERSIG; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -45,7 +45,6 @@ public:
     virtual Object *Clone() const { return new MeterSigGrp(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MeterSigGrp"; }
-    virtual ClassId GetClassId() const { return METERSIGGRP; }
     ///@}
 
     /**

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new MNum(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MNum"; }
-    virtual ClassId GetClassId() const { return MNUM; }
     ///@}
 
     /**

--- a/include/vrv/mordent.h
+++ b/include/vrv/mordent.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Mordent(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Mordent"; }
-    virtual ClassId GetClassId() const { return MORDENT; }
     ///@}
 
     /**

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new MRest(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MRest"; }
-    virtual ClassId GetClassId() const { return MREST; }
     ///@}
 
     /**

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new MRpt(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MRpt"; }
-    virtual ClassId GetClassId() const { return MRPT; }
     ///@}
 
     //----------//

--- a/include/vrv/mrpt2.h
+++ b/include/vrv/mrpt2.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new MRpt2(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MRpt2"; }
-    virtual ClassId GetClassId() const { return MRPT2; }
     ///@}
 
 private:

--- a/include/vrv/mspace.h
+++ b/include/vrv/mspace.h
@@ -31,7 +31,6 @@ public:
     virtual Object *Clone() const { return new MSpace(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MSpace"; }
-    virtual ClassId GetClassId() const { return MSPACE; }
     ///@}
 
     //----------//

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -40,7 +40,6 @@ public:
     virtual Object *Clone() const { return new MultiRest(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MultiRest"; }
-    virtual ClassId GetClassId() const { return MULTIREST; }
     ///@}
 
     /**

--- a/include/vrv/multirpt.h
+++ b/include/vrv/multirpt.h
@@ -34,7 +34,6 @@ public:
     virtual Object *Clone() const { return new MultiRpt(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "MultiRpt"; }
-    virtual ClassId GetClassId() const { return MULTIRPT; }
     ///@}
 
 private:

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -48,7 +48,6 @@ public:
     virtual Object *Clone() const { return new Nc(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Nc"; }
-    virtual ClassId GetClassId() const { return NC; }
     ///@}
 
     /**

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -69,7 +69,6 @@ public:
     virtual void Reset();
     virtual Object *Clone() const { return new Neume(*this); }
     virtual std::string GetClassName() const { return "Neume"; }
-    virtual ClassId GetClassId() const { return NEUME; }
     ///@}
 
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -72,7 +72,6 @@ public:
     virtual Object *Clone() const { return new Note(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Note"; }
-    virtual ClassId GetClassId() const { return NOTE; }
     ///@}
 
     /**

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Num(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Num"; }
-    virtual ClassId GetClassId() const { return NUM; }
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1257,12 +1257,6 @@ public:
      */
     virtual int Transpose(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
-protected:
-    /**
-     * Change the class id
-     */
-    void SetClassId(ClassId classId) { m_classId = classId; }
-
 private:
     /**
      * Method for generating the uuid.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -59,9 +59,10 @@ public:
      */
     ///@{
     Object();
-    Object(const std::string &classid);
+    Object(ClassId classId);
+    Object(ClassId classId, const std::string &classIdStr);
     virtual ~Object();
-    virtual ClassId GetClassId() const;
+    ClassId GetClassId() const final { return m_classId; }
     virtual std::string GetClassName() const { return "[MISSING]"; }
     ///@}
 
@@ -90,32 +91,14 @@ public:
      * See classId enum.
      */
     ///@{
-    bool IsControlElement() const
-    {
-        return (this->GetClassId() > CONTROL_ELEMENT && this->GetClassId() < CONTROL_ELEMENT_max);
-    }
-    bool IsEditorialElement() const
-    {
-        return (this->GetClassId() > EDITORIAL_ELEMENT && this->GetClassId() < EDITORIAL_ELEMENT_max);
-    }
-    bool IsLayerElement() const
-    {
-        return (this->GetClassId() > LAYER_ELEMENT && this->GetClassId() < LAYER_ELEMENT_max);
-    }
-    bool IsPageElement() const { return (this->GetClassId() > PAGE_ELEMENT && this->GetClassId() < PAGE_ELEMENT_max); }
-    bool IsRunningElement() const
-    {
-        return (this->GetClassId() > RUNNING_ELEMENT && this->GetClassId() < RUNNING_ELEMENT_max);
-    }
-    bool IsScoreDefElement() const
-    {
-        return (this->GetClassId() > SCOREDEF_ELEMENT && this->GetClassId() < SCOREDEF_ELEMENT_max);
-    }
-    bool IsSystemElement() const
-    {
-        return (this->GetClassId() > SYSTEM_ELEMENT && this->GetClassId() < SYSTEM_ELEMENT_max);
-    }
-    bool IsTextElement() const { return (this->GetClassId() > TEXT_ELEMENT && this->GetClassId() < TEXT_ELEMENT_max); }
+    bool IsControlElement() const { return ((m_classId > CONTROL_ELEMENT) && (m_classId < CONTROL_ELEMENT_max)); }
+    bool IsEditorialElement() const { return ((m_classId > EDITORIAL_ELEMENT) && (m_classId < EDITORIAL_ELEMENT_max)); }
+    bool IsLayerElement() const { return ((m_classId > LAYER_ELEMENT) && (m_classId < LAYER_ELEMENT_max)); }
+    bool IsPageElement() const { return ((m_classId > PAGE_ELEMENT) && (m_classId < PAGE_ELEMENT_max)); }
+    bool IsRunningElement() const { return ((m_classId > RUNNING_ELEMENT) && (m_classId < RUNNING_ELEMENT_max)); }
+    bool IsScoreDefElement() const { return ((m_classId > SCOREDEF_ELEMENT) && (m_classId < SCOREDEF_ELEMENT_max)); }
+    bool IsSystemElement() const { return ((m_classId > SYSTEM_ELEMENT) && (m_classId < SYSTEM_ELEMENT_max)); }
+    bool IsTextElement() const { return ((m_classId > TEXT_ELEMENT) && (m_classId < TEXT_ELEMENT_max)); }
     ///@}
 
     /**
@@ -540,7 +523,7 @@ public:
      * limit (EditorialElement objects do not count).
      * skipFirst does not call the functor or endFunctor on the first (calling) level
      */
-    virtual void Process(Functor *functor, FunctorParams *functorParams, Functor *endFunctor = NULL,
+    void Process(Functor *functor, FunctorParams *functorParams, Functor *endFunctor = NULL,
         ArrayOfComparisons *filters = NULL, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD,
         bool skipFirst = false);
 
@@ -1275,7 +1258,11 @@ public:
     virtual int Transpose(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
 protected:
-    //
+    /**
+     * Change the class id
+     */
+    void SetClassId(ClassId classId) { m_classId = classId; }
+
 private:
     /**
      * Method for generating the uuid.
@@ -1283,9 +1270,9 @@ private:
     void GenerateUuid();
 
     /**
-     * Initialisation method taking a uuid prefix argument.
+     * Initialisation method taking the class id and a uuid prefix argument.
      */
-    void Init(const std::string &);
+    void Init(ClassId classId, const std::string &classIdStr);
 
 public:
     /**
@@ -1309,11 +1296,16 @@ private:
     Object *m_parent;
 
     /**
+     * The class id representing the actual (derived) class
+     */
+    ClassId m_classId;
+
+    /**
      * Members for storing / generating uuids
      */
     ///@{
     std::string m_uuid;
-    std::string m_classid;
+    std::string m_classIdStr;
     ///@}
 
     /**

--- a/include/vrv/octave.h
+++ b/include/vrv/octave.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Octave(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Octave"; }
-    virtual ClassId GetClassId() const { return OCTAVE; }
     ///@}
 
     /**

--- a/include/vrv/orig.h
+++ b/include/vrv/orig.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Orig(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Orig"; }
-    virtual ClassId GetClassId() const { return ORIG; }
     ///@}
 
 private:

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -40,7 +40,6 @@ public:
     virtual ~Page();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Page"; }
-    virtual ClassId GetClassId() const { return PAGE; }
     ///@}
 
     /**

--- a/include/vrv/pageboundary.h
+++ b/include/vrv/pageboundary.h
@@ -34,7 +34,6 @@ public:
     virtual ~PageElementEnd();
     virtual void Reset();
     virtual std::string GetClassName() const { return "PageElementEnd"; }
-    virtual ClassId GetClassId() const { return PAGE_ELEMENT_END; }
     ///@}
 
     // void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/pageelement.h
+++ b/include/vrv/pageelement.h
@@ -30,10 +30,10 @@ public:
      */
     ///@{
     PageElement();
-    PageElement(const std::string &classid);
+    PageElement(ClassId classId);
+    PageElement(ClassId classId, const std::string &classIdStr);
     virtual ~PageElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return PAGE_ELEMENT; }
     ///@}
 
     //----------//

--- a/include/vrv/pages.h
+++ b/include/vrv/pages.h
@@ -34,7 +34,6 @@ public:
     virtual ~Pages();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Pages"; }
-    virtual ClassId GetClassId() const { return PAGES; }
     ///@}
 
     /**

--- a/include/vrv/pb.h
+++ b/include/vrv/pb.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Pb(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Pb"; }
-    virtual ClassId GetClassId() const { return PB; }
     ///@}
 
     //----------//

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -42,7 +42,6 @@ public:
     virtual Object *Clone() const { return new Pedal(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Pedal"; }
-    virtual ClassId GetClassId() const { return PEDAL; }
     ///@}
 
     /**

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -30,7 +30,6 @@ public:
     virtual ~PgFoot();
     virtual void Reset();
     virtual std::string GetClassName() const { return "PgFoot"; }
-    virtual ClassId GetClassId() const { return PGFOOT; }
     ///@}
 
     //----------//

--- a/include/vrv/pgfoot2.h
+++ b/include/vrv/pgfoot2.h
@@ -30,7 +30,6 @@ public:
     virtual ~PgFoot2();
     virtual void Reset();
     virtual std::string GetClassName() const { return "PgFoot2"; }
-    virtual ClassId GetClassId() const { return PGFOOT2; }
     ///@}
 
     //----------//

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -30,7 +30,6 @@ public:
     virtual ~PgHead();
     virtual void Reset();
     virtual std::string GetClassName() const { return "PgHead"; }
-    virtual ClassId GetClassId() const { return PGHEAD; }
     ///@}
 
     bool GenerateFromMEIHeader(pugi::xml_document &header);

--- a/include/vrv/pghead2.h
+++ b/include/vrv/pghead2.h
@@ -30,7 +30,6 @@ public:
     virtual ~PgHead2();
     virtual void Reset();
     virtual std::string GetClassName() const { return "PgHead2"; }
-    virtual ClassId GetClassId() const { return PGHEAD2; }
     ///@}
 
     //----------//

--- a/include/vrv/phrase.h
+++ b/include/vrv/phrase.h
@@ -28,7 +28,6 @@ public:
     virtual Object *Clone() const { return new Phrase(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Phrase"; }
-    virtual ClassId GetClassId() const { return PHRASE; }
     ///@}
 
     //----------//

--- a/include/vrv/pitchinflection.h
+++ b/include/vrv/pitchinflection.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new PitchInflection(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "PitchInflection"; }
-    virtual ClassId GetClassId() const { return PITCHINFLECTION; }
     ///@}
 
     /**

--- a/include/vrv/plica.h
+++ b/include/vrv/plica.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Plica(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Plica"; }
-    virtual ClassId GetClassId() const { return PLICA; }
 
     //----------//
     // Functors //

--- a/include/vrv/proport.h
+++ b/include/vrv/proport.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Proport(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Proport"; }
-    virtual ClassId GetClassId() const { return PROPORT; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/rdg.h
+++ b/include/vrv/rdg.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Rdg(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Rdg"; }
-    virtual ClassId GetClassId() const { return RDG; }
     ///@}
 
 private:

--- a/include/vrv/ref.h
+++ b/include/vrv/ref.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Ref(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Ref"; }
-    virtual ClassId GetClassId() const { return REF; }
     ///@}
 
     //----------//

--- a/include/vrv/reg.h
+++ b/include/vrv/reg.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Reg(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Reg"; }
-    virtual ClassId GetClassId() const { return REG; }
     ///@}
 
 private:

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -40,7 +40,6 @@ public:
     virtual Object *Clone() const { return new Reh(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Reh"; }
-    virtual ClassId GetClassId() const { return REH; }
     ///@}
 
     /**

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -39,7 +39,6 @@ public:
     virtual Object *Clone() const { return new Rend(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Rend"; }
-    virtual ClassId GetClassId() const { return REND; }
     ///@}
 
     /**

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -51,7 +51,6 @@ public:
     virtual Object *Clone() const { return new Rest(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Rest"; }
-    virtual ClassId GetClassId() const { return REST; }
     ///@}
 
     /**

--- a/include/vrv/restore.h
+++ b/include/vrv/restore.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Restore(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Restore"; }
-    virtual ClassId GetClassId() const { return RESTORE; }
     ///@}
 
 private:

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -33,10 +33,10 @@ public:
      */
     ///@{
     RunningElement();
-    RunningElement(const std::string &classid);
+    RunningElement(ClassId classId);
+    RunningElement(ClassId classId, const std::string &classIdStr);
     virtual ~RunningElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return RUNNING_ELEMENT; }
     ///@}
 
     /**

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -33,7 +33,6 @@ public:
     virtual Object *Clone() const { return new Sb(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Sb"; }
-    virtual ClassId GetClassId() const { return SB; }
     ///@}
 
     //----------//

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -37,7 +37,6 @@ public:
     virtual ~Score();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Score"; }
-    virtual ClassId GetClassId() const { return SCORE; }
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -46,10 +46,11 @@ public:
      * @name Constructors, destructors, and other standard methods.
      */
     ///@{
-    ScoreDefElement(const std::string &classid);
+    ScoreDefElement();
+    ScoreDefElement(ClassId classId);
+    ScoreDefElement(ClassId classId, const std::string &classIdStr);
     virtual ~ScoreDefElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return SCOREDEF_ELEMENT; }
     ///@}
 
     /**
@@ -128,7 +129,6 @@ public:
     virtual Object *Clone() const { return new ScoreDef(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "ScoreDef"; }
-    virtual ClassId GetClassId() const { return SCOREDEF; }
     ///@}
 
     virtual bool IsSupportedChild(Object *object);

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -37,7 +37,6 @@ public:
     virtual Object *Clone() const { return new Section(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Section"; }
-    virtual ClassId GetClassId() const { return SECTION; }
     ///@}
 
     /**

--- a/include/vrv/sic.h
+++ b/include/vrv/sic.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Sic(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Sic"; }
-    virtual ClassId GetClassId() const { return SIC; }
     ///@}
 
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -29,12 +29,12 @@ public:
      */
     ///@{
     Slur();
-    Slur(const std::string &classid);
+    Slur(ClassId classId);
+    Slur(ClassId classId, const std::string &classIdStr);
     virtual ~Slur();
     virtual Object *Clone() const { return new Slur(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Slur"; }
-    virtual ClassId GetClassId() const { return SLUR; }
     ///@}
 
     /**

--- a/include/vrv/space.h
+++ b/include/vrv/space.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Space(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Space"; }
-    virtual ClassId GetClassId() const { return SPACE; }
     ///@}
 
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -46,7 +46,6 @@ public:
     virtual Object *Clone() const { return new Staff(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Staff"; }
-    virtual ClassId GetClassId() const { return STAFF; }
     ///@}
 
     /**

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -44,7 +44,6 @@ public:
     virtual Object *Clone() const { return new StaffDef(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "StaffDef"; }
-    virtual ClassId GetClassId() const { return STAFFDEF; }
     ///@}
 
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -47,7 +47,6 @@ public:
     virtual Object *Clone() const { return new StaffGrp(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "StaffGrp"; }
-    virtual ClassId GetClassId() const { return STAFFGRP; }
     ///@}
 
     /**

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Subst(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Subst"; }
-    virtual ClassId GetClassId() const { return SUBST; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/supplied.h
+++ b/include/vrv/supplied.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Supplied(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Supplied"; }
-    virtual ClassId GetClassId() const { return SUPPLIED; }
     ///@}
 
 private:

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -37,7 +37,6 @@ public:
     virtual ~Surface();
     virtual Object *Clone() const { return new Surface(*this); }
     virtual void Reset();
-    ClassId GetClassId() const { return SURFACE; }
     ///@}
     virtual bool IsSupportedChild(Object *object);
 

--- a/include/vrv/svg.h
+++ b/include/vrv/svg.h
@@ -28,7 +28,6 @@ public:
     virtual ~Svg();
     virtual void Reset();
     virtual std::string GetClassName() const { return "Svg"; }
-    virtual ClassId GetClassId() const { return SVG; }
     ///@}
 
     /**

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -41,7 +41,6 @@ public:
     ///@{
     SvgDeviceContext();
     virtual ~SvgDeviceContext();
-    virtual ClassId GetClassId() const { return SVG_DEVICE_CONTEXT; }
     ///@}
 
     /**

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -46,7 +46,6 @@ public:
     virtual Object *Clone() const { return new Syl(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Syl"; }
-    virtual ClassId GetClassId() const { return SYL; }
     ///@}
 
     /** Override the method since it is align to the staff */

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -35,7 +35,6 @@ public:
     virtual Object *Clone() const { return new Syllable(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Syllable"; }
-    virtual ClassId GetClassId() const { return SYLLABLE; }
     ///@}
 
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -44,7 +44,6 @@ public:
     virtual ~System();
     virtual void Reset();
     virtual std::string GetClassName() const { return "System"; }
-    virtual ClassId GetClassId() const { return SYSTEM; }
     ///@}
 
     /**

--- a/include/vrv/systemboundary.h
+++ b/include/vrv/systemboundary.h
@@ -34,7 +34,6 @@ public:
     virtual ~SystemElementEnd();
     virtual void Reset();
     virtual std::string GetClassName() const { return "systemElementEnd"; }
-    virtual ClassId GetClassId() const { return SYSTEM_ELEMENT_END; }
     ///@}
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -30,10 +30,10 @@ public:
      */
     ///@{
     SystemElement();
-    SystemElement(const std::string &classid);
+    SystemElement(ClassId classId);
+    SystemElement(ClassId classId, const std::string &classIdStr);
     virtual ~SystemElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return SYSTEM_ELEMENT; }
     ///@}
 
     //----------//

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -31,7 +31,6 @@ public:
     virtual ~TabDurSym();
     virtual void Reset();
     virtual std::string GetClassName() const { return "TabDurSym"; };
-    virtual ClassId GetClassId() const { return TABDURSYM; };
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -31,7 +31,6 @@ public:
     virtual ~TabGrp();
     virtual void Reset();
     virtual std::string GetClassName() const { return "TabGrp"; };
-    virtual ClassId GetClassId() const { return TABGRP; };
     ///@}
 
     /**

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Tempo(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Tempo"; }
-    virtual ClassId GetClassId() const { return TEMPO; }
     ///@}
 
     /**

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Text(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Text"; }
-    virtual ClassId GetClassId() const { return TEXT; }
     ///@}
 
     /**

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -27,10 +27,10 @@ public:
      */
     ///@{
     TextElement();
-    TextElement(const std::string &classid);
+    TextElement(ClassId classId);
+    TextElement(ClassId classId, const std::string &classIdStr);
     virtual ~TextElement();
     virtual void Reset();
-    virtual ClassId GetClassId() const { return TEXT_ELEMENT; }
     ///@}
 
     /**

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -36,12 +36,12 @@ public:
      */
     ///@{
     Tie();
-    Tie(const std::string &classid);
+    Tie(ClassId classId);
+    Tie(ClassId classId, const std::string &classIdStr);
     virtual ~Tie();
     virtual Object *Clone() const { return new Tie(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Tie"; }
-    virtual ClassId GetClassId() const { return TIE; }
     ///@}
 
     /**

--- a/include/vrv/timestamp.h
+++ b/include/vrv/timestamp.h
@@ -27,7 +27,6 @@ public:
     virtual ~TimestampAttr();
     virtual void Reset();
     virtual std::string GetClassName() const { return "TimestampAttr"; }
-    virtual ClassId GetClassId() const { return TIMESTAMP_ATTR; }
     ///@}
 
     /**

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -43,7 +43,6 @@ public:
     virtual Object *Clone() const { return new Trill(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Trill"; }
-    virtual ClassId GetClassId() const { return TRILL; }
     ///@}
 
     /**

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Tuning(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Tuning"; };
-    virtual ClassId GetClassId() const { return TUNING; };
     ///@}
 
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -38,7 +38,6 @@ public:
     virtual Object *Clone() const { return new Tuplet(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Tuplet"; }
-    virtual ClassId GetClassId() const { return TUPLET; }
     ///@}
 
     /**

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -41,7 +41,6 @@ public:
     virtual Object *Clone() const { return new Turn(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Turn"; }
-    virtual ClassId GetClassId() const { return TURN; }
     ///@}
 
     /**

--- a/include/vrv/unclear.h
+++ b/include/vrv/unclear.h
@@ -29,7 +29,6 @@ public:
     virtual Object *Clone() const { return new Unclear(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Unclear"; }
-    virtual ClassId GetClassId() const { return UNCLEAR; }
     ///@}
 
 private:

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -32,7 +32,6 @@ public:
     virtual Object *Clone() const { return new Verse(*this); }
     virtual void Reset();
     virtual std::string GetClassName() const { return "Verse"; }
-    virtual ClassId GetClassId() const { return VERSE; }
     ///@}
 
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -39,7 +39,6 @@ public:
     // constructors and destructors
     SystemAligner();
     virtual ~SystemAligner();
-    virtual ClassId GetClassId() const { return SYSTEM_ALIGNER; }
 
     /**
      * Do not copy children for HorizontalAligner
@@ -148,7 +147,6 @@ public:
     ///@{
     StaffAlignment();
     virtual ~StaffAlignment();
-    virtual ClassId GetClassId() const { return STAFF_ALIGNMENT; }
     ///@}
 
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -193,8 +193,6 @@ enum ClassId : uint16_t {
     ACCID,
     ARTIC,
     BARLINE,
-    BARLINE_ATTR_LEFT,
-    BARLINE_ATTR_RIGHT,
     BEAM,
     BEATRPT,
     BTREM,

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -71,12 +71,12 @@ enum MEIVersion { MEI_UNDEFINED = 0, MEI_2013, MEI_3_0_0, MEI_4_0_0, MEI_4_0_1, 
 
 /**
  * The ClassIds are used to identify Object child classes through the Object::Is virtual method.
- * Each Object child class has to have its own id and has to override the GetClassId() method.
+ * Each Object child class has to have its own id which is stored in the member variable m_classId.
  * Base classes (e.g., LayerElement) that are never instanciated have boundary ids
  * used for checking if an Object is child of a base class. See for example
  * Object::IsLayerElement.
  */
-enum ClassId {
+enum ClassId : uint16_t {
     BOUNDING_BOX = 0, // Should not be instanciated as is
     OBJECT, // Should not be instanciated as is
     DEVICE_CONTEXT, // Should not be instanciated as is,

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -37,7 +37,6 @@ public:
     virtual ~Zone();
     virtual Object *Clone() const { return new Zone(*this); }
     virtual void Reset();
-    ClassId GetClassId() const { return ZONE; }
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
     int GetLogicalUly();

--- a/src/abbr.cpp
+++ b/src/abbr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Abbr> s_factory("abbr", ABBR);
 
-Abbr::Abbr() : EditorialElement("abbr-"), AttSource()
+Abbr::Abbr() : EditorialElement(ABBR, "abbr-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 static const ClassRegistrar<Accid> s_factory("accid", ACCID);
 
 Accid::Accid()
-    : LayerElement("accid-")
+    : LayerElement(ACCID, "accid-")
     , PositionInterface()
     , AttAccidental()
     , AttAccidentalGestural()

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Add> s_factory("add", ADD);
 
-Add::Add() : EditorialElement("add-"), AttSource()
+Add::Add() : EditorialElement(ADD, "add-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/anchoredtext.cpp
+++ b/src/anchoredtext.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
 
-AnchoredText::AnchoredText() : ControlElement("anchtxt-"), TextDirInterface()
+AnchoredText::AnchoredText() : ControlElement(ANCHOREDTEXT, "anchtxt-"), TextDirInterface()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
 

--- a/src/annot.cpp
+++ b/src/annot.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Annot> s_factory("annot", ANNOT);
 
-Annot::Annot() : EditorialElement("annot-"), TextListInterface(), AttPlist(), AttSource()
+Annot::Annot() : EditorialElement(ANNOT, "annot-"), TextListInterface(), AttPlist(), AttSource()
 {
     RegisterAttClass(ATT_PLIST);
     RegisterAttClass(ATT_SOURCE);

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -25,14 +25,14 @@ namespace vrv {
 
 static const ClassRegistrar<App> s_factory("app", APP);
 
-App::App() : EditorialElement("app-")
+App::App() : EditorialElement(APP, "app-")
 {
     m_level = EDITORIAL_UNDEFINED;
 
     Reset();
 }
 
-App::App(EditorialLevel level) : EditorialElement("app-")
+App::App(EditorialLevel level) : EditorialElement(APP, "app-")
 {
     m_level = level;
 

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
 
 Arpeg::Arpeg()
-    : ControlElement("arpeg-"), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis(), AttColor()
+    : ControlElement(ARPEG, "arpeg-"), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis(), AttColor()
 {
     RegisterInterface(PlistInterface::GetAttClasses(), PlistInterface::IsInterface());
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -37,7 +37,12 @@ const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_d
 static const ClassRegistrar<Artic> s_factory("artic", ARTIC);
 
 Artic::Artic()
-    : LayerElement("artic-"), AttArticulation(), AttColor(), AttEnclosingChars(), AttExtSym(), AttPlacementRelEvent()
+    : LayerElement(ARTIC, "artic-")
+    , AttArticulation()
+    , AttColor()
+    , AttEnclosingChars()
+    , AttExtSym()
+    , AttPlacementRelEvent()
 {
     RegisterAttClass(ATT_ARTICULATION);
     RegisterAttClass(ATT_COLOR);

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -59,6 +59,8 @@ void BarLine::Reset()
     ResetBarLineLog();
     ResetColor();
     ResetVisibility();
+
+    m_position = BarLinePosition::None;
 }
 
 bool BarLine::SetAlignment(Alignment *alignment)
@@ -73,43 +75,6 @@ bool BarLine::HasRepetitionDots() const
         return true;
     }
     return false;
-}
-
-//----------------------------------------------------------------------------
-// BarLineAttr
-//----------------------------------------------------------------------------
-
-BarLineAttr::BarLineAttr() : BarLine(BARLINE_ATTR_RIGHT)
-{
-    m_isLeft = false;
-    m_noAttr = false;
-}
-
-BarLineAttr::~BarLineAttr() {}
-
-void BarLineAttr::SetLeft()
-{
-    m_isLeft = true;
-    this->UpdateClassId();
-}
-
-void BarLineAttr::SetNoAttr()
-{
-    m_noAttr = true;
-    this->UpdateClassId();
-}
-
-void BarLineAttr::UpdateClassId()
-{
-    if (m_noAttr) {
-        this->SetClassId(BARLINE);
-    }
-    else if (m_isLeft) {
-        this->SetClassId(BARLINE_ATTR_LEFT);
-    }
-    else {
-        this->SetClassId(BARLINE_ATTR_RIGHT);
-    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -31,7 +31,17 @@ namespace vrv {
 
 static const ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
-BarLine::BarLine() : LayerElement("bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
+BarLine::BarLine() : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
+{
+    RegisterAttClass(ATT_BARLINELOG);
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_VISIBILITY);
+
+    Reset();
+}
+
+BarLine::BarLine(ClassId classId)
+    : LayerElement(classId, "bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     RegisterAttClass(ATT_BARLINELOG);
     RegisterAttClass(ATT_COLOR);
@@ -69,13 +79,38 @@ bool BarLine::HasRepetitionDots() const
 // BarLineAttr
 //----------------------------------------------------------------------------
 
-BarLineAttr::BarLineAttr() : BarLine()
+BarLineAttr::BarLineAttr() : BarLine(BARLINE_ATTR_RIGHT)
 {
     m_isLeft = false;
     m_noAttr = false;
 }
 
 BarLineAttr::~BarLineAttr() {}
+
+void BarLineAttr::SetLeft()
+{
+    m_isLeft = true;
+    this->UpdateClassId();
+}
+
+void BarLineAttr::SetNoAttr()
+{
+    m_noAttr = true;
+    this->UpdateClassId();
+}
+
+void BarLineAttr::UpdateClassId()
+{
+    if (m_noAttr) {
+        this->SetClassId(BARLINE);
+    }
+    else if (m_isLeft) {
+        this->SetClassId(BARLINE_ATTR_LEFT);
+    }
+    else {
+        this->SetClassId(BARLINE_ATTR_RIGHT);
+    }
+}
 
 //----------------------------------------------------------------------------
 // Functors methods

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -24,7 +24,8 @@ namespace vrv {
 // BBoxDeviceContext
 //----------------------------------------------------------------------------
 
-BBoxDeviceContext::BBoxDeviceContext(View *view, int width, int height, unsigned char update) : DeviceContext()
+BBoxDeviceContext::BBoxDeviceContext(View *view, int width, int height, unsigned char update)
+    : DeviceContext(BBOX_DEVICE_CONTEXT)
 {
     m_view = view;
     m_width = width;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1025,7 +1025,7 @@ void BeamSegment::CalcSetValues()
 
 static const ClassRegistrar<Beam> s_factory("beam", BEAM);
 
-Beam::Beam() : LayerElement("beam-"), BeamDrawingInterface(), AttColor(), AttBeamedWith(), AttBeamRend()
+Beam::Beam() : LayerElement(BEAM, "beam-"), BeamDrawingInterface(), AttColor(), AttBeamedWith(), AttBeamRend()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_BEAMEDWITH);

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
 
-BeatRpt::BeatRpt() : LayerElement("beatrpt-"), AttColor(), AttBeatRptVis()
+BeatRpt::BeatRpt() : LayerElement(BEATRPT, "beatrpt-"), AttColor(), AttBeatRptVis()
 {
     RegisterAttClass(ATT_BEATRPTVIS);
     RegisterAttClass(ATT_COLOR);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -40,13 +40,6 @@ BoundingBox::BoundingBox()
     ResetBoundingBox();
 }
 
-ClassId BoundingBox::GetClassId() const
-{
-    // we should always have the method overridden
-    assert(false);
-    return BOUNDING_BOX;
-}
-
 bool BoundingBox::Is(const std::vector<ClassId> &classIds) const
 {
     return (std::find(classIds.begin(), classIds.end(), this->GetClassId()) != classIds.end());

--- a/src/bracketspan.cpp
+++ b/src/bracketspan.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 static const ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
 
 BracketSpan::BracketSpan()
-    : ControlElement("bspan-")
+    : ControlElement(BRACKETSPAN, "bspan-")
     , TimeSpanningInterface()
     , AttBracketSpanLog()
     , AttColor()

--- a/src/breath.cpp
+++ b/src/breath.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Breath> s_factory("breath", BREATH);
 
-Breath::Breath() : ControlElement("breath-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
+Breath::Breath() : ControlElement(BREATH, "breath-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<BTrem> s_factory("btrem", BTREM);
 
-BTrem::BTrem() : LayerElement("btrem-"), AttBTremLog(), AttTremMeasured()
+BTrem::BTrem() : LayerElement(BTREM, "btrem-"), AttBTremLog(), AttTremMeasured()
 {
     RegisterAttClass(ATT_BTREMLOG);
     RegisterAttClass(ATT_TREMMEASURED);

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
 
-Caesura::Caesura() : ControlElement("caesura-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
+Caesura::Caesura() : ControlElement(CAESURA, "caesura-"), TimePointInterface(), AttColor(), AttPlacementRelStaff()
 {
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -30,14 +30,14 @@ namespace vrv {
 
 static const ClassRegistrar<Choice> s_factory("choice", CHOICE);
 
-Choice::Choice() : EditorialElement("choice-")
+Choice::Choice() : EditorialElement(CHOICE, "choice-")
 {
     m_level = EDITORIAL_UNDEFINED;
 
     Reset();
 }
 
-Choice::Choice(EditorialLevel level) : EditorialElement("choice-")
+Choice::Choice(EditorialLevel level) : EditorialElement(CHOICE, "choice-")
 {
     m_level = level;
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -64,7 +64,7 @@ template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin,
 static const ClassRegistrar<Chord> s_factory("chord", CHORD);
 
 Chord::Chord()
-    : LayerElement("chord-")
+    : LayerElement(CHORD, "chord-")
     , ObjectListInterface()
     , DrawingListInterface()
     , StemmedDrawingInterface()

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -27,7 +27,8 @@ namespace vrv {
 
 static const ClassRegistrar<Clef> s_factory("clef", CLEF);
 
-Clef::Clef() : LayerElement("clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement(), AttVisibility()
+Clef::Clef()
+    : LayerElement(CLEF, "clef-"), AttClefShape(), AttColor(), AttLineLoc(), AttOctaveDisplacement(), AttVisibility()
 {
     RegisterAttClass(ATT_CLEFSHAPE);
     RegisterAttClass(ATT_COLOR);

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // ControlElement
 //----------------------------------------------------------------------------
 
-ControlElement::ControlElement() : FloatingObject("ce"), LinkingInterface(), AttLabelled(), AttTyped()
+ControlElement::ControlElement() : FloatingObject(CONTROL_ELEMENT, "ce"), LinkingInterface(), AttLabelled(), AttTyped()
 {
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
     RegisterAttClass(ATT_LABELLED);
@@ -36,8 +36,18 @@ ControlElement::ControlElement() : FloatingObject("ce"), LinkingInterface(), Att
     Reset();
 }
 
-ControlElement::ControlElement(const std::string &classid)
-    : FloatingObject(classid), LinkingInterface(), AttLabelled(), AttTyped()
+ControlElement::ControlElement(ClassId classId)
+    : FloatingObject(classId, "ce"), LinkingInterface(), AttLabelled(), AttTyped()
+{
+    RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
+    RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+ControlElement::ControlElement(ClassId classId, const std::string &classIdStr)
+    : FloatingObject(classId, classIdStr), LinkingInterface(), AttLabelled(), AttTyped()
 {
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
     RegisterAttClass(ATT_LABELLED);

--- a/src/corr.cpp
+++ b/src/corr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Corr> s_factory("corr", CORR);
 
-Corr::Corr() : EditorialElement("corr-"), AttSource()
+Corr::Corr() : EditorialElement(CORR, "corr-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/course.cpp
+++ b/src/course.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 
 static const ClassRegistrar<Course> s_factory("course", COURSE);
 
-Course::Course() : Object("course-"), AttNNumberLike()
+Course::Course() : Object(COURSE, "course-"), AttNNumberLike()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
 

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Custos> s_factory("custos", CUSTOS);
 
-Custos::Custos() : LayerElement("custos-"), PitchInterface(), PositionInterface(), AttColor()
+Custos::Custos() : LayerElement(CUSTOS, "custos-"), PitchInterface(), PositionInterface(), AttColor()
 {
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Damage> s_factory("damage", DAMAGE);
 
-Damage::Damage() : EditorialElement("lem-"), AttSource()
+Damage::Damage() : EditorialElement(DAMAGE, "damage-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/del.cpp
+++ b/src/del.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Del> s_factory("del", DEL);
 
-Del::Del() : EditorialElement("del-"), AttSource()
+Del::Del() : EditorialElement(DEL, "del-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -41,13 +41,6 @@ void BezierCurve::CalculateControlPointOffset(Doc *doc, int staffSize)
 // DeviceContext
 //----------------------------------------------------------------------------
 
-ClassId DeviceContext::GetClassId() const
-{
-    // we should always have the method overridden
-    assert(false);
-    return DEVICE_CONTEXT;
-}
-
 void DeviceContext::SetPen(int colour, int width, int opacity, int dashLength, int lineCap)
 {
     float opacityValue;

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 static const ClassRegistrar<Dir> s_factory("dir", DIR);
 
 Dir::Dir()
-    : ControlElement("dir-")
+    : ControlElement(DIR, "dir-")
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1535,8 +1535,6 @@ double Doc::GetLeftMargin(const ClassId classId) const
 {
     if (classId == ACCID) return m_options->m_leftMarginAccid.GetValue();
     if (classId == BARLINE) return m_options->m_leftMarginBarLine.GetValue();
-    if (classId == BARLINE_ATTR_LEFT) return m_options->m_leftMarginLeftBarLine.GetValue();
-    if (classId == BARLINE_ATTR_RIGHT) return m_options->m_leftMarginRightBarLine.GetValue();
     if (classId == BEATRPT) return m_options->m_leftMarginBeatRpt.GetValue();
     if (classId == CHORD) return m_options->m_leftMarginChord.GetValue();
     if (classId == CLEF) return m_options->m_leftMarginClef.GetValue();
@@ -1554,12 +1552,26 @@ double Doc::GetLeftMargin(const ClassId classId) const
     return m_options->m_defaultLeftMargin.GetValue();
 }
 
+double Doc::GetLeftMargin(Object *object) const
+{
+    assert(object);
+    const ClassId id = object->GetClassId();
+    if (id == BARLINE) {
+        BarLine *barLine = vrv_cast<BarLine *>(object);
+        switch (barLine->GetPosition()) {
+            case BarLinePosition::None: return m_options->m_leftMarginBarLine.GetValue();
+            case BarLinePosition::Left: return m_options->m_leftMarginLeftBarLine.GetValue();
+            case BarLinePosition::Right: return m_options->m_leftMarginRightBarLine.GetValue();
+            default: break;
+        }
+    }
+    return this->GetLeftMargin(id);
+}
+
 double Doc::GetRightMargin(const ClassId classId) const
 {
     if (classId == ACCID) return m_options->m_rightMarginAccid.GetValue();
     if (classId == BARLINE) return m_options->m_rightMarginBarLine.GetValue();
-    if (classId == BARLINE_ATTR_LEFT) return m_options->m_rightMarginLeftBarLine.GetValue();
-    if (classId == BARLINE_ATTR_RIGHT) return m_options->m_rightMarginRightBarLine.GetValue();
     if (classId == BEATRPT) return m_options->m_rightMarginBeatRpt.GetValue();
     if (classId == CHORD) return m_options->m_rightMarginChord.GetValue();
     if (classId == CLEF) return m_options->m_rightMarginClef.GetValue();
@@ -1575,6 +1587,22 @@ double Doc::GetRightMargin(const ClassId classId) const
     if (classId == REST) return m_options->m_rightMarginRest.GetValue();
     if (classId == TABDURSYM) return m_options->m_rightMarginTabDurSym.GetValue();
     return m_options->m_defaultRightMargin.GetValue();
+}
+
+double Doc::GetRightMargin(Object *object) const
+{
+    assert(object);
+    const ClassId id = object->GetClassId();
+    if (id == BARLINE) {
+        BarLine *barLine = vrv_cast<BarLine *>(object);
+        switch (barLine->GetPosition()) {
+            case BarLinePosition::None: return m_options->m_rightMarginBarLine.GetValue();
+            case BarLinePosition::Left: return m_options->m_rightMarginLeftBarLine.GetValue();
+            case BarLinePosition::Right: return m_options->m_rightMarginRightBarLine.GetValue();
+            default: break;
+        }
+    }
+    return this->GetRightMargin(id);
 }
 
 double Doc::GetBottomMargin(const ClassId classId) const

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -70,7 +70,7 @@ namespace vrv {
 // Doc
 //----------------------------------------------------------------------------
 
-Doc::Doc() : Object("doc-")
+Doc::Doc() : Object(DOC, "doc-")
 {
     m_options = new Options();
 

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Dot> s_factory("dot", DOT);
 
-Dot::Dot() : LayerElement("dot-"), PositionInterface(), AttColor(), AttDotLog()
+Dot::Dot() : LayerElement(DOT, "dot-"), PositionInterface(), AttColor(), AttDotLog()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -35,7 +35,7 @@ std::wstring dynamSmufl[] = { L"\uE520", L"\uE521", L"\uE522", L"\uE523", L"\uE5
 static const ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
 
 Dynam::Dynam()
-    : ControlElement("dynam-")
+    : ControlElement(DYNAM, "dynam-")
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -33,7 +33,8 @@ namespace vrv {
 // EditorialElement
 //----------------------------------------------------------------------------
 
-EditorialElement::EditorialElement() : Object("ee-"), SystemElementStartInterface(), AttLabelled(), AttTyped()
+EditorialElement::EditorialElement()
+    : Object(EDITORIAL_ELEMENT, "ee-"), SystemElementStartInterface(), AttLabelled(), AttTyped()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);
@@ -41,8 +42,17 @@ EditorialElement::EditorialElement() : Object("ee-"), SystemElementStartInterfac
     Reset();
 }
 
-EditorialElement::EditorialElement(const std::string &classid)
-    : Object(classid), SystemElementStartInterface(), AttLabelled(), AttTyped()
+EditorialElement::EditorialElement(ClassId classId)
+    : Object(classId, "ee-"), SystemElementStartInterface(), AttLabelled(), AttTyped()
+{
+    RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+EditorialElement::EditorialElement(ClassId classId, const std::string &classIdStr)
+    : Object(classId, classIdStr), SystemElementStartInterface(), AttLabelled(), AttTyped()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 // Dots
 //----------------------------------------------------------------------------
 
-Dots::Dots() : LayerElement("dots-"), AttAugmentDots()
+Dots::Dots() : LayerElement(DOTS, "dots-"), AttAugmentDots()
 {
     RegisterAttClass(ATT_AUGMENTDOTS);
 
@@ -65,7 +65,7 @@ std::set<int> &Dots::ModifyDotLocsForStaff(Staff *staff)
 // Flag
 //----------------------------------------------------------------------------
 
-Flag::Flag() : LayerElement("flag-")
+Flag::Flag() : LayerElement(FLAG, "flag-")
 {
 
     Reset();
@@ -129,7 +129,7 @@ Point Flag::GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code
 // TupletBracket
 //----------------------------------------------------------------------------
 
-TupletBracket::TupletBracket() : LayerElement("bracket-"), AttTupletVis()
+TupletBracket::TupletBracket() : LayerElement(TUPLET_BRACKET, "bracket-"), AttTupletVis()
 {
     RegisterAttClass(ATT_TUPLETVIS);
 
@@ -202,7 +202,7 @@ int TupletBracket::GetDrawingYRight()
 // TupletNum
 //----------------------------------------------------------------------------
 
-TupletNum::TupletNum() : LayerElement("num-"), AttNumberPlacement(), AttTupletVis()
+TupletNum::TupletNum() : LayerElement(TUPLET_NUM, "num-"), AttNumberPlacement(), AttTupletVis()
 {
     RegisterAttClass(ATT_NUMBERPLACEMENT);
     RegisterAttClass(ATT_TUPLETVIS);
@@ -271,7 +271,7 @@ void TupletNum::SetAlignedBracket(TupletBracket *alignedBracket)
 // Stem
 //----------------------------------------------------------------------------
 
-Stem::Stem() : LayerElement("stem-"), AttGraced(), AttStems(), AttStemsCmn()
+Stem::Stem() : LayerElement(STEM, "stem-"), AttGraced(), AttStems(), AttStemsCmn()
 {
     RegisterAttClass(ATT_GRACED);
     RegisterAttClass(ATT_STEMS);

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Ending> s_factory("ending", ENDING);
 
-Ending::Ending() : SystemElement("ending-"), SystemElementStartInterface(), AttLineRend(), AttNNumberLike()
+Ending::Ending() : SystemElement(ENDING, "ending-"), SystemElementStartInterface(), AttLineRend(), AttNNumberLike()
 {
     RegisterAttClass(ATT_LINEREND);
     RegisterAttClass(ATT_NINTEGER);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Expan> s_factory("expan", EXPAN);
 
-Expan::Expan() : EditorialElement("expan-"), AttSource()
+Expan::Expan() : EditorialElement(EXPAN, "expan-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 
 static const ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
 
-Expansion::Expansion() : SystemElement("expansion-"), PlistInterface()
+Expansion::Expansion() : SystemElement(EXPANSION, "expansion-"), PlistInterface()
 {
     RegisterInterface(PlistInterface::GetAttClasses(), PlistInterface::IsInterface());
 

--- a/src/f.cpp
+++ b/src/f.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<F> s_factory("f", FIGURE);
 
-F::F() : TextElement("f-"), TimeSpanningInterface(), AttExtender()
+F::F() : TextElement(FIGURE, "f-"), TimeSpanningInterface(), AttExtender()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_EXTENDER);

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
 
-Facsimile::Facsimile() : Object("facsimile-") {}
+Facsimile::Facsimile() : Object(FACSIMILE, "facsimile-") {}
 
 Facsimile::~Facsimile() {}
 

--- a/src/fb.cpp
+++ b/src/fb.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fb> s_factory("fb", FB);
 
-Fb::Fb() : Object("fb-")
+Fb::Fb() : Object(FB, "fb-")
 {
 
     Reset();

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -26,7 +26,12 @@ namespace vrv {
 static const ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
 
 Fermata::Fermata()
-    : ControlElement("fermata-"), TimePointInterface(), AttColor(), AttExtSym(), AttFermataVis(), AttPlacementRelStaff()
+    : ControlElement(FERMATA, "fermata-")
+    , TimePointInterface()
+    , AttColor()
+    , AttExtSym()
+    , AttFermataVis()
+    , AttPlacementRelStaff()
 {
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/fig.cpp
+++ b/src/fig.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fig> s_factory("fig", FIG);
 
-Fig::Fig() : TextElement("fig-"), AreaPosInterface()
+Fig::Fig() : TextElement(FIG, "fig-"), AreaPosInterface()
 {
     RegisterInterface(AreaPosInterface::GetAttClasses(), AreaPosInterface::IsInterface());
 

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fing> s_factory("fing", FING);
 
-Fing::Fing() : ControlElement("fing-"), TimePointInterface(), TextDirInterface(), AttNNumberLike()
+Fing::Fing() : ControlElement(FING, "fing-"), TimePointInterface(), TextDirInterface(), AttNNumberLike()
 {
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -50,12 +50,17 @@ thread_local std::vector<void *> FloatingObject::s_drawingObjectIds;
 // FloatingObject
 //----------------------------------------------------------------------------
 
-FloatingObject::FloatingObject() : Object("fe")
+FloatingObject::FloatingObject() : Object(FLOATING_OBJECT, "fe")
 {
     Reset();
 }
 
-FloatingObject::FloatingObject(const std::string &classid) : Object(classid)
+FloatingObject::FloatingObject(ClassId classId) : Object(classId, "fe")
+{
+    Reset();
+}
+
+FloatingObject::FloatingObject(ClassId classId, const std::string &classIdStr) : Object(classId, classIdStr)
 {
     Reset();
 

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
 
-FTrem::FTrem() : LayerElement("ftrem-"), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
+FTrem::FTrem() : LayerElement(FTREM, "ftrem-"), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
 {
     RegisterAttClass(ATT_FTREMVIS);
     RegisterAttClass(ATT_TREMMEASURED);

--- a/src/gliss.cpp
+++ b/src/gliss.cpp
@@ -27,7 +27,12 @@ namespace vrv {
 static const ClassRegistrar<Gliss> s_factory("gliss", GLISS);
 
 Gliss::Gliss()
-    : ControlElement("gliss-"), TimeSpanningInterface(), AttColor(), AttLineRend(), AttLineRendBase(), AttNNumberLike()
+    : ControlElement(GLISS, "gliss-")
+    , TimeSpanningInterface()
+    , AttColor()
+    , AttLineRend()
+    , AttLineRendBase()
+    , AttNNumberLike()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
 
-GraceGrp::GraceGrp() : LayerElement("gracegrp-"), AttColor(), AttGraced(), AttGraceGrpLog()
+GraceGrp::GraceGrp() : LayerElement(GRACEGRP, "gracegrp-"), AttColor(), AttGraced(), AttGraceGrpLog()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_GRACED);

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -27,7 +27,8 @@ namespace vrv {
 
 static const ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
 
-GrpSym::GrpSym() : Object("grpsym-"), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
+GrpSym::GrpSym()
+    : Object(GRPSYM, "grpsym-"), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_GRPSYMLOG);

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
 
 Hairpin::Hairpin()
-    : ControlElement("hairpin-")
+    : ControlElement(HAIRPIN, "hairpin-")
     , TimeSpanningInterface()
     , AttColor()
     , AttHairpinLog()

--- a/src/halfmrpt.cpp
+++ b/src/halfmrpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
 
-HalfmRpt::HalfmRpt() : LayerElement("mrpt-")
+HalfmRpt::HalfmRpt() : LayerElement(HALFMRPT, "mrpt-")
 {
     RegisterAttClass(ATT_COLOR);
 

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 static const ClassRegistrar<Harm> s_factory("harm", HARM);
 
 Harm::Harm()
-    : ControlElement("harm-")
+    : ControlElement(HARM, "harm-")
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -36,7 +36,7 @@ namespace vrv {
 // HorizontalAligner
 //----------------------------------------------------------------------------
 
-HorizontalAligner::HorizontalAligner() : Object()
+HorizontalAligner::HorizontalAligner(ClassId classId) : Object(classId)
 {
     Reset();
 }
@@ -93,7 +93,7 @@ void HorizontalAligner::AddAlignment(Alignment *alignment, int idx)
 // MeasureAligner
 //----------------------------------------------------------------------------
 
-MeasureAligner::MeasureAligner() : HorizontalAligner()
+MeasureAligner::MeasureAligner() : HorizontalAligner(MEASURE_ALIGNER)
 {
     m_leftAlignment = NULL;
     m_leftBarLineAlignment = NULL;
@@ -299,7 +299,7 @@ void MeasureAligner::AdjustGraceNoteSpacing(Doc *doc, Alignment *alignment, int 
 // GraceAligner
 //----------------------------------------------------------------------------
 
-GraceAligner::GraceAligner() : HorizontalAligner()
+GraceAligner::GraceAligner() : HorizontalAligner(GRACE_ALIGNER)
 {
     Reset();
 }
@@ -434,12 +434,12 @@ void GraceAligner::SetGraceAligmentXPos(Doc *doc)
 // Alignment
 //----------------------------------------------------------------------------
 
-Alignment::Alignment() : Object()
+Alignment::Alignment() : Object(ALIGNMENT)
 {
     Reset();
 }
 
-Alignment::Alignment(double time, AlignmentType type) : Object()
+Alignment::Alignment(double time, AlignmentType type) : Object(ALIGNMENT)
 {
     Reset();
     m_time = time;
@@ -668,7 +668,7 @@ void Alignment::AddToAccidSpace(Accid *accid)
 // AlignmentReference
 //----------------------------------------------------------------------------
 
-AlignmentReference::AlignmentReference() : Object(), AttNInteger()
+AlignmentReference::AlignmentReference() : Object(ALIGNMENT_REFERENCE), AttNInteger()
 {
     RegisterAttClass(ATT_NINTEGER);
 
@@ -677,7 +677,7 @@ AlignmentReference::AlignmentReference() : Object(), AttNInteger()
     this->SetAsReferenceObject();
 }
 
-AlignmentReference::AlignmentReference(int staffN) : Object(), AttNInteger()
+AlignmentReference::AlignmentReference(int staffN) : Object(ALIGNMENT_REFERENCE), AttNInteger()
 {
     RegisterAttClass(ATT_NINTEGER);
 
@@ -768,7 +768,7 @@ bool AlignmentReference::HasCrossStaffElements()
 // TimestampAligner
 //----------------------------------------------------------------------------
 
-TimestampAligner::TimestampAligner() : Object()
+TimestampAligner::TimestampAligner() : Object(TIMESTAMP_ALIGNER)
 {
     Reset();
 }

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -544,7 +544,7 @@ bool Alignment::AddLayerElementRef(LayerElement *element)
             }
             // staffN and layerN remain unused for barLine attributes and timestamps
             else {
-                assert(element->Is({ BARLINE, BARLINE_ATTR_LEFT, BARLINE_ATTR_RIGHT, TIMESTAMP_ATTR }));
+                assert(element->Is({ BARLINE, TIMESTAMP_ATTR }));
             }
         }
     }

--- a/src/instrdef.cpp
+++ b/src/instrdef.cpp
@@ -24,7 +24,8 @@ namespace vrv {
 
 static const ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
 
-InstrDef::InstrDef() : Object("instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
+InstrDef::InstrDef()
+    : Object(INSTRDEF, "instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
 {
     RegisterAttClass(ATT_CHANNELIZED);
     RegisterAttClass(ATT_LABELLED);

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -30,7 +30,8 @@ namespace vrv {
 
 static const ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
 
-KeyAccid::KeyAccid() : LayerElement("keyaccid-"), PitchInterface(), AttAccidental(), AttColor(), AttEnclosingChars()
+KeyAccid::KeyAccid()
+    : LayerElement(KEYACCID, "keyaccid-"), PitchInterface(), AttAccidental(), AttColor(), AttEnclosingChars()
 {
 
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -69,7 +69,7 @@ const int KeySig::octave_map[2][9][7] = {
 static const ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
 
 KeySig::KeySig()
-    : LayerElement("keysig-")
+    : LayerElement(KEYSIG, "keysig-")
     , ObjectListInterface()
     , AttAccidental()
     , AttPitch()

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Label> s_factory("label", LABEL);
 
-Label::Label() : Object("label-"), TextListInterface()
+Label::Label() : Object(LABEL, "label-"), TextListInterface()
 {
     Reset();
 }

--- a/src/labelabbr.cpp
+++ b/src/labelabbr.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
 
-LabelAbbr::LabelAbbr() : Object("labelAbbr-"), TextListInterface()
+LabelAbbr::LabelAbbr() : Object(LABELABBR, "labelAbbr-"), TextListInterface()
 {
     Reset();
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -42,7 +42,7 @@ namespace vrv {
 static const ClassRegistrar<Layer> s_factory("layer", LAYER);
 
 Layer::Layer()
-    : Object("layer-"), DrawingListInterface(), ObjectListInterface(), AttNInteger(), AttTyped(), AttVisibility()
+    : Object(LAYER, "layer-"), DrawingListInterface(), ObjectListInterface(), AttNInteger(), AttTyped(), AttVisibility()
 {
     RegisterAttClass(ATT_NINTEGER);
     RegisterAttClass(ATT_TYPED);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -69,7 +69,8 @@ namespace vrv {
 // LayerElement
 //----------------------------------------------------------------------------
 
-LayerElement::LayerElement() : Object("le-"), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+LayerElement::LayerElement()
+    : Object(LAYER_ELEMENT, "le-"), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
 {
     RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
@@ -79,8 +80,19 @@ LayerElement::LayerElement() : Object("le-"), FacsimileInterface(), LinkingInter
     Reset();
 }
 
-LayerElement::LayerElement(const std::string &classid)
-    : Object(classid), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+LayerElement::LayerElement(ClassId classId)
+    : Object(classId, "le-"), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+{
+    RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
+    RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
+    RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+LayerElement::LayerElement(ClassId classId, const std::string &classIdStr)
+    : Object(classId, classIdStr), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
 {
     RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lb> s_factory("lb", LB);
 
-Lb::Lb() : TextElement("lb-")
+Lb::Lb() : TextElement(LB, "lb-")
 {
     Reset();
 }

--- a/src/lem.cpp
+++ b/src/lem.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lem> s_factory("lem", LEM);
 
-Lem::Lem() : EditorialElement("lem-"), AttSource()
+Lem::Lem() : EditorialElement(LEM, "lem-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
 
-Ligature::Ligature() : LayerElement("ligature-"), ObjectListInterface(), AttLigatureVis()
+Ligature::Ligature() : LayerElement(LIGATURE, "ligature-"), ObjectListInterface(), AttLigatureVis()
 {
     RegisterAttClass(ATT_LIGATUREVIS);
 

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lv> s_factory("lv", LV);
 
-Lv::Lv() : Tie("lv-")
+Lv::Lv() : Tie(LV, "lv-")
 {
     Reset();
 }

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
 
-Mdiv::Mdiv() : PageElement("mdiv-"), PageElementStartInterface(), AttLabelled(), AttNNumberLike()
+Mdiv::Mdiv() : PageElement(MDIV, "mdiv-"), PageElementStartInterface(), AttLabelled(), AttNNumberLike()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -74,8 +74,9 @@ Measure::Measure(bool measureMusic, int logMeasureNb)
     // owned pointers need to be set to NULL;
     m_drawingScoreDef = NULL;
 
-    // Make the left barLine a left one...
-    m_leftBarLine.SetLeft();
+    // Set the barline positions
+    m_leftBarLine.SetPosition(BarLinePosition::Left);
+    m_rightBarLine.SetPosition(BarLinePosition::Right);
 
     Reset();
 
@@ -574,7 +575,7 @@ void Measure::SetDrawingBarLines(Measure *previous, int barlineDrawingFlags)
             if (right != left) {
                 previous->SetDrawingRightBarLine(right);
                 this->SetDrawingLeftBarLine(left);
-                if (this->HasInvisibleStaffBarlines()) vrv_cast<BarLineAttr *>(this->GetLeftBarLine())->SetNoAttr();
+                if (this->HasInvisibleStaffBarlines()) this->GetLeftBarLine()->SetPosition(BarLinePosition::None);
             }
         }
     }
@@ -585,7 +586,7 @@ void Measure::SetDrawingBarLines(Measure *previous, int barlineDrawingFlags)
             if (this->GetLeft() == BARRENDITION_NONE) {
                 this->SetLeft(BARRENDITION_single);
             }
-            vrv_cast<BarLineAttr *>(this->GetLeftBarLine())->SetNoAttr();
+            this->GetLeftBarLine()->SetPosition(BarLinePosition::None);
         }
         // with a scoredef inbetween always set it to what we have in the encoding
         this->SetDrawingLeftBarLine(this->GetLeft());

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -47,7 +47,7 @@ namespace vrv {
 static const ClassRegistrar<Measure> s_factory("measure", MEASURE);
 
 Measure::Measure(bool measureMusic, int logMeasureNb)
-    : Object("measure-")
+    : Object(MEASURE, "measure-")
     , AttBarring()
     , AttMeasureLog()
     , AttMeterConformanceBar()

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -30,7 +30,7 @@ const int Mensur::s_numBase = 2;
 static const ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
 
 Mensur::Mensur()
-    : LayerElement("mensur-")
+    : LayerElement(MENSUR, "mensur-")
     , AttColor()
     , AttCue()
     , AttDurationRatio()

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
 
-MeterSig::MeterSig() : LayerElement("msig-"), AttMeterSigLog(), AttMeterSigVis()
+MeterSig::MeterSig() : LayerElement(METERSIG, "msig-"), AttMeterSigLog(), AttMeterSigVis()
 {
     RegisterAttClass(ATT_METERSIGLOG);
     RegisterAttClass(ATT_METERSIGVIS);

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 static const ClassRegistrar<MeterSigGrp> s_factory("meterSigGrp", METERSIGGRP);
 
 MeterSigGrp::MeterSigGrp()
-    : Object("metersiggrp-")
+    : Object(METERSIGGRP, "metersiggrp-")
     , ObjectListInterface()
     , LinkingInterface()
     , AttBasic()

--- a/src/mnum.cpp
+++ b/src/mnum.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 MNum::MNum()
-    : ControlElement("mnum-")
+    : ControlElement(MNUM, "mnum-")
     , TextListInterface()
     , TextDirInterface()
     , TimePointInterface()

--- a/src/mordent.cpp
+++ b/src/mordent.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 static const ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
 
 Mordent::Mordent()
-    : ControlElement("mordent-")
+    : ControlElement(MORDENT, "mordent-")
     , TimePointInterface()
     , AttColor()
     , AttExtSym()

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -29,7 +29,8 @@ namespace vrv {
 
 static const ClassRegistrar<MRest> s_factory("mRest", MREST);
 
-MRest::MRest() : LayerElement("mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
+MRest::MRest()
+    : LayerElement(MREST, "mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
 
-MRpt::MRpt() : LayerElement("mrpt-"), AttColor()
+MRpt::MRpt() : LayerElement(MRPT, "mrpt-"), AttColor()
 {
     RegisterAttClass(ATT_COLOR);
 

--- a/src/mrpt2.cpp
+++ b/src/mrpt2.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
 
-MRpt2::MRpt2() : LayerElement("mrpt2-"), AttColor()
+MRpt2::MRpt2() : LayerElement(MRPT2, "mrpt2-"), AttColor()
 {
     RegisterAttClass(ATT_COLOR);
 

--- a/src/mspace.cpp
+++ b/src/mspace.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 
 static const ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
 
-MSpace::MSpace() : LayerElement("mSpace-")
+MSpace::MSpace() : LayerElement(MSPACE, "mSpace-")
 {
     Reset();
 }

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -20,7 +20,12 @@ namespace vrv {
 static const ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
 
 MultiRest::MultiRest()
-    : LayerElement("multirest-"), PositionInterface(), AttColor(), AttMultiRestVis(), AttNumbered(), AttWidth()
+    : LayerElement(MULTIREST, "multirest-")
+    , PositionInterface()
+    , AttColor()
+    , AttMultiRestVis()
+    , AttNumbered()
+    , AttWidth()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/multirpt.cpp
+++ b/src/multirpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
 
-MultiRpt::MultiRpt() : LayerElement("multirpt-"), AttNumbered()
+MultiRpt::MultiRpt() : LayerElement(MULTIRPT, "multirpt-"), AttNumbered()
 {
     RegisterAttClass(ATT_NUMBERED);
     Reset();

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 static const ClassRegistrar<Nc> s_factory("nc", NC);
 
 Nc::Nc()
-    : LayerElement("nc-")
+    : LayerElement(NC, "nc-")
     , DurationInterface()
     , PitchInterface()
     , PositionInterface()

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -44,7 +44,7 @@ const std::map<std::string, NeumeGroup> Neume::s_neumes
 
 static const ClassRegistrar<Neume> s_factory("neume", NEUME);
 
-Neume::Neume() : LayerElement("neume-"), ObjectListInterface(), AttColor()
+Neume::Neume() : LayerElement(NEUME, "neume-"), ObjectListInterface(), AttColor()
 {
     RegisterAttClass(ATT_COLOR);
     Reset();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -48,7 +48,7 @@ namespace vrv {
 static const ClassRegistrar<Note> s_factory("note", NOTE);
 
 Note::Note()
-    : LayerElement("note-")
+    : LayerElement(NOTE, "note-")
     , StemmedDrawingInterface()
     , DurationInterface()
     , PitchInterface()

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Num> s_factory("num", NUM);
 
-Num::Num() : TextElement("num-")
+Num::Num() : TextElement(NUM, "num-")
 {
     Reset();
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -62,15 +62,23 @@ thread_local unsigned long Object::s_objectCounter = 0;
 
 Object::Object() : BoundingBox()
 {
-    Init("m-");
+    Init(OBJECT, "m-");
     if (s_objectCounter++ == 0) {
         SeedUuid();
     }
 }
 
-Object::Object(const std::string &classid) : BoundingBox()
+Object::Object(ClassId classId) : BoundingBox()
 {
-    Init(classid);
+    Init(classId, "m-");
+    if (s_objectCounter++ == 0) {
+        SeedUuid();
+    }
+}
+
+Object::Object(ClassId classId, const std::string &classIdStr) : BoundingBox()
+{
+    Init(classId, classIdStr);
     if (s_objectCounter++ == 0) {
         SeedUuid();
     }
@@ -88,7 +96,8 @@ Object::Object(const Object &object) : BoundingBox(object)
     ClearChildren();
     ResetBoundingBox(); // It does not make sense to keep the values of the BBox
 
-    m_classid = object.m_classid;
+    m_classId = object.m_classId;
+    m_classIdStr = object.m_classIdStr;
     m_parent = NULL;
 
     // Flags
@@ -134,7 +143,8 @@ Object &Object::operator=(const Object &object)
         ClearChildren();
         ResetBoundingBox(); // It does not make sense to keep the values of the BBox
 
-        m_classid = object.m_classid;
+        m_classId = object.m_classId;
+        m_classIdStr = object.m_classIdStr;
         m_parent = NULL;
         // Flags
         m_isAttribute = object.m_isAttribute;
@@ -170,9 +180,10 @@ Object::~Object()
     ClearChildren();
 }
 
-void Object::Init(const std::string &classid)
+void Object::Init(ClassId classId, const std::string &classIdStr)
 {
-    m_classid = classid;
+    m_classId = classId;
+    m_classIdStr = classIdStr;
     m_parent = NULL;
     // Flags
     m_isAttribute = false;
@@ -185,13 +196,6 @@ void Object::Init(const std::string &classid)
     this->GenerateUuid();
 
     Reset();
-}
-
-ClassId Object::GetClassId() const
-{
-    // we should always have the method overridden
-    assert(false);
-    return OBJECT;
 }
 
 void Object::SetAsReferenceObject()
@@ -233,7 +237,7 @@ void Object::MoveChildrenFrom(Object *sourceParent, int idx, bool allowTypeChang
     if (this == sourceParent) {
         assert("Object cannot be copied to itself");
     }
-    if (!allowTypeChange && (this->GetClassId() != sourceParent->GetClassId())) {
+    if (!allowTypeChange && (m_classId != sourceParent->m_classId)) {
         assert("Object must be of the same type");
     }
 
@@ -594,7 +598,7 @@ bool Object::DeleteChild(Object *child)
 
 void Object::GenerateUuid()
 {
-    m_uuid = m_classid + Object::GenerateRandUuid();
+    m_uuid = m_classIdStr + Object::GenerateRandUuid();
 }
 
 void Object::ResetUuid()
@@ -710,7 +714,7 @@ Object *Object::GetFirstAncestor(const ClassId classId, int maxDepth) const
         return NULL;
     }
 
-    if (m_parent->GetClassId() == classId) {
+    if (m_parent->m_classId == classId) {
         return m_parent;
     }
     else {
@@ -724,7 +728,7 @@ Object *Object::GetFirstAncestorInRange(const ClassId classIdMin, const ClassId 
         return NULL;
     }
 
-    if ((m_parent->GetClassId() > classIdMin) && (m_parent->GetClassId() < classIdMax)) {
+    if ((m_parent->m_classId > classIdMin) && (m_parent->m_classId < classIdMax)) {
         return m_parent;
     }
     else {
@@ -738,7 +742,7 @@ Object *Object::GetLastAncestorNot(const ClassId classId, int maxDepth)
         return NULL;
     }
 
-    if (m_parent->GetClassId() == classId) {
+    if (m_parent->m_classId == classId) {
         return this;
     }
     else {
@@ -846,7 +850,7 @@ void Object::Process(Functor *functor, FunctorParams *functorParams, Functor *en
         auto filterPredicate = [filters](Object *iter) -> bool {
             if (filters && !filters->empty()) {
                 // first we look if there is a comparison object for the object type (e.g., a Staff)
-                ClassId classId = iter->GetClassId();
+                ClassId classId = iter->m_classId;
                 ArrayOfComparisons::iterator comparisonIter
                     = std::find_if(filters->begin(), filters->end(), [classId](Comparison *iter) -> bool {
                           ClassIdComparison *attComparison = vrv_cast<ClassIdComparison *>(iter);

--- a/src/octave.cpp
+++ b/src/octave.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 static const ClassRegistrar<Octave> s_factory("octave", OCTAVE);
 
 Octave::Octave()
-    : ControlElement("octave-")
+    : ControlElement(OCTAVE, "octave-")
     , TimeSpanningInterface()
     , AttColor()
     , AttExtender()

--- a/src/orig.cpp
+++ b/src/orig.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Orig> s_factory("orig", ORIG);
 
-Orig::Orig() : EditorialElement("orig-"), AttSource()
+Orig::Orig() : EditorialElement(ORIG, "orig-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -358,9 +358,10 @@ void Page::LayOutHorizontally()
     // Adjust tabRhyhtm separately
     adjustXPosParams.m_excludes.clear();
     adjustXPosParams.m_includes.push_back(TABDURSYM);
-    adjustXPosParams.m_includes.push_back(BARLINE_ATTR_RIGHT);
+    adjustXPosParams.m_includes.push_back(BARLINE);
     adjustXPosParams.m_includes.push_back(METERSIG);
     adjustXPosParams.m_includes.push_back(KEYSIG);
+    adjustXPosParams.m_rightBarLinesOnly = true;
     this->Process(&adjustXPos, &adjustXPosParams, &adjustXPosEnd);
 
     // Adjust the X shift of the Alignment looking at the bounding boxes

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -35,7 +35,7 @@ namespace vrv {
 // Page
 //----------------------------------------------------------------------------
 
-Page::Page() : Object("page-")
+Page::Page() : Object(PAGE, "page-")
 {
     Reset();
 }

--- a/src/pageboundary.cpp
+++ b/src/pageboundary.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // PageElementEnd
 //----------------------------------------------------------------------------
 
-PageElementEnd::PageElementEnd(Object *start) : PageElement("page-element-end-")
+PageElementEnd::PageElementEnd(Object *start) : PageElement(PAGE_ELEMENT_END, "page-element-end-")
 {
     Reset();
     m_start = start;

--- a/src/pageelement.cpp
+++ b/src/pageelement.cpp
@@ -22,14 +22,21 @@ namespace vrv {
 // PageElement
 //----------------------------------------------------------------------------
 
-PageElement::PageElement() : Object("se"), AttTyped()
+PageElement::PageElement() : Object(PAGE_ELEMENT, "pe"), AttTyped()
 {
     RegisterAttClass(ATT_TYPED);
 
     Reset();
 }
 
-PageElement::PageElement(const std::string &classid) : Object(classid), AttTyped()
+PageElement::PageElement(ClassId classId) : Object(classId, "pe"), AttTyped()
+{
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+PageElement::PageElement(ClassId classId, const std::string &classIdStr) : Object(classId, classIdStr), AttTyped()
 {
     RegisterAttClass(ATT_TYPED);
 

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Pages
 //----------------------------------------------------------------------------
 
-Pages::Pages() : Object("pages-"), AttLabelled(), AttNNumberLike()
+Pages::Pages() : Object(PAGES, "pages-"), AttLabelled(), AttNNumberLike()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/pb.cpp
+++ b/src/pb.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Pb> s_factory("pb", PB);
 
-Pb::Pb() : SystemElement("pb-"), AttNNumberLike()
+Pb::Pb() : SystemElement(PB, "pb-"), AttNNumberLike()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
 

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
 
 Pedal::Pedal()
-    : ControlElement("pedal-")
+    : ControlElement(PEDAL, "pedal-")
     , TimeSpanningInterface()
     , AttColor()
     , AttExtSym()

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
 
-PgFoot::PgFoot() : RunningElement("pgfoot-")
+PgFoot::PgFoot() : RunningElement(PGFOOT, "pgfoot-")
 {
     Reset();
 }

--- a/src/pgfoot2.cpp
+++ b/src/pgfoot2.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgFoot2> s_factory("pgFoot2", PGFOOT2);
 
-PgFoot2::PgFoot2() : RunningElement("pgfoot2-")
+PgFoot2::PgFoot2() : RunningElement(PGFOOT2, "pgfoot2-")
 {
     Reset();
 }

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
 
-PgHead::PgHead() : RunningElement("pghead-")
+PgHead::PgHead() : RunningElement(PGHEAD, "pghead-")
 {
     Reset();
 }

--- a/src/pghead2.cpp
+++ b/src/pghead2.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgHead2> s_factory("pgHead2", PGHEAD2);
 
-PgHead2::PgHead2() : RunningElement("pghead2-")
+PgHead2::PgHead2() : RunningElement(PGHEAD2, "pghead2-")
 {
     Reset();
 }

--- a/src/phrase.cpp
+++ b/src/phrase.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
 
-Phrase::Phrase() : Slur("phrase-")
+Phrase::Phrase() : Slur(PHRASE, "phrase-")
 {
     Reset();
 }

--- a/src/pitchinflection.cpp
+++ b/src/pitchinflection.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
 
-PitchInflection::PitchInflection() : ControlElement("pinflexion-"), TimeSpanningInterface()
+PitchInflection::PitchInflection() : ControlElement(PITCHINFLECTION, "pinflexion-"), TimeSpanningInterface()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
 

--- a/src/plica.cpp
+++ b/src/plica.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Plica> s_factory("plica", PLICA);
 
-Plica::Plica() : LayerElement("plica-"), AttPlicaVis()
+Plica::Plica() : LayerElement(PLICA, "plica-"), AttPlicaVis()
 {
     RegisterAttClass(ATT_PLICAVIS);
 

--- a/src/proport.cpp
+++ b/src/proport.cpp
@@ -15,7 +15,7 @@ namespace vrv {
 
 static const ClassRegistrar<Proport> s_factory("proport", PROPORT);
 
-Proport::Proport() : LayerElement("prop-"), AttDurationRatio()
+Proport::Proport() : LayerElement(PROPORT, "prop-"), AttDurationRatio()
 {
     RegisterAttClass(ATT_DURATIONRATIO);
 

--- a/src/rdg.cpp
+++ b/src/rdg.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Rdg> s_factory("rdg", RDG);
 
-Rdg::Rdg() : EditorialElement("rdg-"), AttSource()
+Rdg::Rdg() : EditorialElement(RDG, "rdg-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Ref> s_factory("ref", REF);
 
-Ref::Ref() : EditorialElement("ref-")
+Ref::Ref() : EditorialElement(REF, "ref-")
 {
     Reset();
 }

--- a/src/reg.cpp
+++ b/src/reg.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Reg> s_factory("reg", REG);
 
-Reg::Reg() : EditorialElement("reg-"), AttSource()
+Reg::Reg() : EditorialElement(REG, "reg-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -26,7 +26,8 @@ namespace vrv {
 
 static const ClassRegistrar<Reh> s_factory("reh", REH);
 
-Reh::Reh() : ControlElement("reh-"), TextDirInterface(), TimePointInterface(), AttColor(), AttLang(), AttVerticalGroup()
+Reh::Reh()
+    : ControlElement(REH, "reh-"), TextDirInterface(), TimePointInterface(), AttColor(), AttLang(), AttVerticalGroup()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/rend.cpp
+++ b/src/rend.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 static const ClassRegistrar<Rend> s_factory("rend", REND);
 
 Rend::Rend()
-    : TextElement("rend-")
+    : TextElement(REND, "rend-")
     , AreaPosInterface()
     , AttColor()
     , AttLang()

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -152,7 +152,7 @@ RestAccidental MeiAccidentalToRestAccidental(data_ACCIDENTAL_WRITTEN accidental)
 static const ClassRegistrar<Rest> s_factory("rest", REST);
 
 Rest::Rest()
-    : LayerElement("rest-")
+    : LayerElement(REST, "rest-")
     , DurationInterface()
     , PositionInterface()
     , AttColor()

--- a/src/restore.cpp
+++ b/src/restore.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Restore> s_factory("restore", RESTORE);
 
-Restore::Restore() : EditorialElement("restore-"), AttSource()
+Restore::Restore() : EditorialElement(RESTORE, "restore-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -31,7 +31,8 @@ namespace vrv {
 // RunningElement
 //----------------------------------------------------------------------------
 
-RunningElement::RunningElement() : Object("re"), ObjectListInterface(), AttHorizontalAlign(), AttTyped()
+RunningElement::RunningElement()
+    : Object(RUNNING_ELEMENT, "re"), ObjectListInterface(), AttHorizontalAlign(), AttTyped()
 {
     RegisterAttClass(ATT_HORIZONTALALIGN);
     RegisterAttClass(ATT_TYPED);
@@ -39,7 +40,17 @@ RunningElement::RunningElement() : Object("re"), ObjectListInterface(), AttHoriz
     Reset();
 }
 
-RunningElement::RunningElement(const std::string &classid) : Object(classid), AttHorizontalAlign(), AttTyped()
+RunningElement::RunningElement(ClassId classId)
+    : Object(classId, "re"), ObjectListInterface(), AttHorizontalAlign(), AttTyped()
+{
+    RegisterAttClass(ATT_HORIZONTALALIGN);
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+RunningElement::RunningElement(ClassId classId, const std::string &classIdStr)
+    : Object(classId, classIdStr), AttHorizontalAlign(), AttTyped()
 {
     RegisterAttClass(ATT_HORIZONTALALIGN);
     RegisterAttClass(ATT_TYPED);

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Sb> s_factory("sb", SB);
 
-Sb::Sb() : SystemElement("sb-"), AttNNumberLike()
+Sb::Sb() : SystemElement(SB, "sb-"), AttNNumberLike()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
 

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -36,7 +36,7 @@ namespace vrv {
 
 static const ClassRegistrar<Score> s_factory("score", SCORE);
 
-Score::Score() : PageElement("score-"), PageElementStartInterface(), AttLabelled(), AttNNumberLike()
+Score::Score() : PageElement(SCORE, "score-"), PageElementStartInterface(), AttLabelled(), AttNNumberLike()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -40,7 +40,24 @@ namespace vrv {
 // ScoreDefElement
 //----------------------------------------------------------------------------
 
-ScoreDefElement::ScoreDefElement(const std::string &classid) : Object(classid), ScoreDefInterface(), AttTyped()
+ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT, "scoredefelement-"), ScoreDefInterface(), AttTyped()
+{
+    RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+ScoreDefElement::ScoreDefElement(ClassId classId) : Object(classId, "scoredefelement-"), ScoreDefInterface(), AttTyped()
+{
+    RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+ScoreDefElement::ScoreDefElement(ClassId classId, const std::string &classIdStr)
+    : Object(classId, classIdStr), ScoreDefInterface(), AttTyped()
 {
     RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
     RegisterAttClass(ATT_TYPED);
@@ -174,7 +191,7 @@ MeterSigGrp *ScoreDefElement::GetMeterSigGrpCopy()
 static const ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
 
 ScoreDef::ScoreDef()
-    : ScoreDefElement("scoredef-")
+    : ScoreDefElement(SCOREDEF, "scoredef-")
     , ObjectListInterface()
     , AttDistances()
     , AttEndings()

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -32,7 +32,8 @@ namespace vrv {
 
 static const ClassRegistrar<Section> s_factory("section", SECTION);
 
-Section::Section() : SystemElement("section-"), SystemElementStartInterface(), AttNNumberLike(), AttSectionVis()
+Section::Section()
+    : SystemElement(SECTION, "section-"), SystemElementStartInterface(), AttNNumberLike(), AttSectionVis()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
     RegisterAttClass(ATT_SECTIONVIS);

--- a/src/sic.cpp
+++ b/src/sic.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Sic> s_factory("sic", SIC);
 
-Sic::Sic() : EditorialElement("sic-"), AttSource()
+Sic::Sic() : EditorialElement(SIC, "sic-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 
 static const ClassRegistrar<Slur> s_factory("slur", SLUR);
 
-Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Slur::Slur() : ControlElement(SLUR, "slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
@@ -41,8 +41,19 @@ Slur::Slur() : ControlElement("slur-"), TimeSpanningInterface(), AttColor(), Att
     Reset();
 }
 
-Slur::Slur(const std::string &classid)
-    : ControlElement(classid), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Slur::Slur(ClassId classId)
+    : ControlElement(classId, "slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+{
+    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
+
+    Reset();
+}
+
+Slur::Slur(ClassId classId, const std::string &classIdStr)
+    : ControlElement(classId, classIdStr), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Space> s_factory("space", SPACE);
 
-Space::Space() : LayerElement("space-"), DurationInterface()
+Space::Space() : LayerElement(SPACE, "space-"), DurationInterface()
 {
     RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
 

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -41,7 +41,7 @@ namespace vrv {
 
 static const ClassRegistrar<Staff> s_factory("staff", STAFF);
 
-Staff::Staff(int n) : Object("staff-"), FacsimileInterface(), AttNInteger(), AttTyped(), AttVisibility()
+Staff::Staff(int n) : Object(STAFF, "staff-"), FacsimileInterface(), AttNInteger(), AttTyped(), AttVisibility()
 {
     RegisterAttClass(ATT_NINTEGER);
     RegisterAttClass(ATT_TYPED);

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 static const ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
 
 StaffDef::StaffDef()
-    : ScoreDefElement("staffdef-")
+    : ScoreDefElement(STAFFDEF, "staffdef-")
     , AttDistances()
     , AttLabelled()
     , AttNInteger()

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
 
 StaffGrp::StaffGrp()
-    : Object("staffgrp-")
+    : Object(STAFFGRP, "staffgrp-")
     , ObjectListInterface()
     , AttBasic()
     , AttLabelled()

--- a/src/subst.cpp
+++ b/src/subst.cpp
@@ -25,14 +25,14 @@ namespace vrv {
 
 static const ClassRegistrar<Subst> s_factory("subst", SUBST);
 
-Subst::Subst() : EditorialElement("subst-")
+Subst::Subst() : EditorialElement(SUBST, "subst-")
 {
     m_level = EDITORIAL_UNDEFINED;
 
     Reset();
 }
 
-Subst::Subst(EditorialLevel level) : EditorialElement("subst-")
+Subst::Subst(EditorialLevel level) : EditorialElement(SUBST, "subst-")
 {
     m_level = level;
 

--- a/src/supplied.cpp
+++ b/src/supplied.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
 
-Supplied::Supplied() : EditorialElement("supplied-"), AttSource()
+Supplied::Supplied() : EditorialElement(SUPPLIED, "supplied-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<Surface> s_factory("surface", SURFACE);
 
-Surface::Surface() : Object("surface-"), AttTyped(), AttCoordinated()
+Surface::Surface() : Object(SURFACE, "surface-"), AttTyped(), AttCoordinated()
 {
     RegisterAttClass(ATT_TYPED);
     RegisterAttClass(ATT_COORDINATED);

--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Svg> s_factory("svg", SVG);
 
-Svg::Svg() : Object("fig-")
+Svg::Svg() : Object(SVG, "svg-")
 {
     Reset();
 }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -33,7 +33,7 @@ namespace vrv {
 // SvgDeviceContext
 //----------------------------------------------------------------------------
 
-SvgDeviceContext::SvgDeviceContext() : DeviceContext()
+SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
 {
     m_originX = 0;
     m_originY = 0;

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -32,7 +32,8 @@ namespace vrv {
 
 static const ClassRegistrar<Syl> s_factory("syl", SYL);
 
-Syl::Syl() : LayerElement("syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
+Syl::Syl()
+    : LayerElement(SYL, "syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_LANG);

--- a/src/syllable.cpp
+++ b/src/syllable.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
 
-Syllable::Syllable() : LayerElement("syllable-"), ObjectListInterface(), AttColor(), AttSlashCount()
+Syllable::Syllable() : LayerElement(SYLLABLE, "syllable-"), ObjectListInterface(), AttColor(), AttSlashCount()
 {
     Init();
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -40,7 +40,7 @@ namespace vrv {
 // System
 //----------------------------------------------------------------------------
 
-System::System() : Object("system-"), DrawingListInterface(), AttTyped()
+System::System() : Object(SYSTEM, "system-"), DrawingListInterface(), AttTyped()
 {
     RegisterAttClass(ATT_TYPED);
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -483,7 +483,7 @@ int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
 
     if (m_drawingScoreDef) m_drawingScoreDef->Process(params->m_functor, functorParams);
 
-    return FUNCTOR_CONTINUE;
+    return FUNCTOR_SIBLINGS;
 }
 
 int System::ResetHorizontalAlignment(FunctorParams *functorParams)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -483,7 +483,7 @@ int System::ScoreDefSetGrpSym(FunctorParams *functorParams)
 
     if (m_drawingScoreDef) m_drawingScoreDef->Process(params->m_functor, functorParams);
 
-    return FUNCTOR_SIBLINGS;
+    return FUNCTOR_CONTINUE;
 }
 
 int System::ResetHorizontalAlignment(FunctorParams *functorParams)

--- a/src/systemboundary.cpp
+++ b/src/systemboundary.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // SystemElementEnd
 //----------------------------------------------------------------------------
 
-SystemElementEnd::SystemElementEnd(Object *start) : SystemElement("system-element-end-")
+SystemElementEnd::SystemElementEnd(Object *start) : SystemElement(SYSTEM_ELEMENT_END, "system-element-end-")
 {
     Reset();
     m_start = start;

--- a/src/systemelement.cpp
+++ b/src/systemelement.cpp
@@ -22,14 +22,22 @@ namespace vrv {
 // SystemElement
 //----------------------------------------------------------------------------
 
-SystemElement::SystemElement() : FloatingObject("se"), AttTyped()
+SystemElement::SystemElement() : FloatingObject(SYSTEM_ELEMENT, "se"), AttTyped()
 {
     RegisterAttClass(ATT_TYPED);
 
     Reset();
 }
 
-SystemElement::SystemElement(const std::string &classid) : FloatingObject(classid), AttTyped()
+SystemElement::SystemElement(ClassId classId) : FloatingObject(classId, "se"), AttTyped()
+{
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+SystemElement::SystemElement(ClassId classId, const std::string &classIdStr)
+    : FloatingObject(classId, classIdStr), AttTyped()
 {
     RegisterAttClass(ATT_TYPED);
 

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
 
-TabDurSym::TabDurSym() : LayerElement("tabdursym-"), AttNNumberLike()
+TabDurSym::TabDurSym() : LayerElement(TABDURSYM, "tabdursym-"), AttNNumberLike()
 {
     RegisterAttClass(ATT_NNUMBERLIKE);
 

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
 
-TabGrp::TabGrp() : LayerElement("tabgrp-"), DurationInterface()
+TabGrp::TabGrp() : LayerElement(TABGRP, "tabgrp-"), DurationInterface()
 {
     RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
 

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
 
 Tempo::Tempo()
-    : ControlElement("tempo-"), TextDirInterface(), TimePointInterface(), AttLang(), AttMidiTempo(), AttMmTempo()
+    : ControlElement(TEMPO, "tempo-"), TextDirInterface(), TimePointInterface(), AttLang(), AttMidiTempo(), AttMmTempo()
 {
     RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 // Text
 //----------------------------------------------------------------------------
 
-Text::Text() : TextElement("text-")
+Text::Text() : TextElement(TEXT, "text-")
 {
     Reset();
 }

--- a/src/textelement.cpp
+++ b/src/textelement.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // TextElement
 //----------------------------------------------------------------------------
 
-TextElement::TextElement() : Object("te-"), AttLabelled(), AttTyped()
+TextElement::TextElement() : Object(TEXT_ELEMENT, "te-"), AttLabelled(), AttTyped()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);
@@ -27,7 +27,16 @@ TextElement::TextElement() : Object("te-"), AttLabelled(), AttTyped()
     Reset();
 }
 
-TextElement::TextElement(const std::string &classid) : Object(classid), AttLabelled(), AttTyped()
+TextElement::TextElement(ClassId classId) : Object(classId, "te-"), AttLabelled(), AttTyped()
+{
+    RegisterAttClass(ATT_LABELLED);
+    RegisterAttClass(ATT_TYPED);
+
+    Reset();
+}
+
+TextElement::TextElement(ClassId classId, const std::string &classIdStr)
+    : Object(classId, classIdStr), AttLabelled(), AttTyped()
 {
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 
 static const ClassRegistrar<Tie> s_factory("tie", TIE);
 
-Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Tie::Tie() : ControlElement(TIE, "tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
@@ -42,8 +42,19 @@ Tie::Tie() : ControlElement("tie-"), TimeSpanningInterface(), AttColor(), AttCur
     Reset();
 }
 
-Tie::Tie(const std::string &classid)
-    : ControlElement(classid), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Tie::Tie(ClassId classId)
+    : ControlElement(classId, "tie-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+{
+    RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_CURVATURE);
+    RegisterAttClass(ATT_CURVEREND);
+
+    Reset();
+}
+
+Tie::Tie(ClassId classId, const std::string &classIdStr)
+    : ControlElement(classId, classIdStr), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);

--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 // TimestampAttr
 //----------------------------------------------------------------------------
 
-TimestampAttr::TimestampAttr() : LayerElement("tstp-")
+TimestampAttr::TimestampAttr() : LayerElement(TIMESTAMP_ATTR, "tstp-")
 {
     Reset();
 }

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 static const ClassRegistrar<Trill> s_factory("trill", TRILL);
 
 Trill::Trill()
-    : ControlElement("trill-")
+    : ControlElement(TRILL, "trill-")
     , TimeSpanningInterface()
     , AttColor()
     , AttExtender()

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Tuning> s_factory("tuning", TUNING);
 
-Tuning::Tuning() : Object("tuning-"), AttCourseLog()
+Tuning::Tuning() : Object(TUNING, "tuning-"), AttCourseLog()
 {
     RegisterAttClass(ATT_COURSELOG);
 

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -37,7 +37,7 @@ namespace vrv {
 static const ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
 
 Tuplet::Tuplet()
-    : LayerElement("tuplet-")
+    : LayerElement(TUPLET, "tuplet-")
     , ObjectListInterface()
     , AttColor()
     , AttDurationRatio()

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Turn> s_factory("turn", TURN);
 
 Turn::Turn()
-    : ControlElement("turn-")
+    : ControlElement(TURN, "turn-")
     , TimePointInterface()
     , AttColor()
     , AttExtSym()

--- a/src/unclear.cpp
+++ b/src/unclear.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
 
-Unclear::Unclear() : EditorialElement("unclear-"), AttSource()
+Unclear::Unclear() : EditorialElement(UNCLEAR, "unclear-"), AttSource()
 {
     RegisterAttClass(ATT_SOURCE);
 

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -33,7 +33,7 @@ namespace vrv {
 
 static const ClassRegistrar<Verse> s_factory("verse", VERSE);
 
-Verse::Verse() : LayerElement("verse-"), AttColor(), AttLang(), AttNInteger(), AttTypography()
+Verse::Verse() : LayerElement(VERSE, "verse-"), AttColor(), AttLang(), AttNInteger(), AttTypography()
 {
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_LANG);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 // SystemAligner
 //----------------------------------------------------------------------------
 
-SystemAligner::SystemAligner() : Object(), m_bottomAlignment(NULL), m_system(NULL)
+SystemAligner::SystemAligner() : Object(SYSTEM_ALIGNER), m_bottomAlignment(NULL), m_system(NULL)
 {
     Reset();
 }
@@ -246,7 +246,7 @@ SystemAligner::SpacingType SystemAligner::CalculateSpacingAbove(StaffDef *staffD
 // StaffAlignment
 //----------------------------------------------------------------------------
 
-StaffAlignment::StaffAlignment() : Object()
+StaffAlignment::StaffAlignment() : Object(STAFF_ALIGNMENT)
 {
     m_yRel = 0;
     m_verseNs.clear();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -245,9 +245,11 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     }
 
     // Overwrite the spanningType for open ended control events
-    // We can identify them because they end on a right barline attribute
-    if ((spanningType == SPANNING_START_END) && end->Is(BARLINE_ATTR_RIGHT)) {
-        spanningType = SPANNING_START;
+    // We can identify them because they end on a right barline
+    if ((spanningType == SPANNING_START_END) && end->Is(BARLINE)) {
+        if (vrv_cast<BarLine *>(end)->GetPosition() == BarLinePosition::Right) {
+            spanningType = SPANNING_START;
+        }
     }
 
     int startRadius = 0;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -720,7 +720,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                 // drawn
                 data_BARRENDITION form = barLine->GetForm();
                 if (measure->HasInvisibleStaffBarlines()) {
-                    data_BARRENDITION barlineRend = barLine->Is(BARLINE_ATTR_RIGHT)
+                    data_BARRENDITION barlineRend = (barLine->GetPosition() == BarLinePosition::Right)
                         ? measure->GetDrawingRightBarLineByStaffN(childStaffDef->GetN())
                         : measure->GetDrawingLeftBarLineByStaffN(childStaffDef->GetN());
                     if (barlineRend != BARRENDITION_NONE) form = barlineRend;
@@ -804,7 +804,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // erase intersections only if we have more than one staff
         bool eraseIntersections = (first != last) ? true : false;
         // do not erase intersections with right barline of the last measure of the system
-        if (isLastMeasure && barLine->Is(BARLINE_ATTR_RIGHT)) {
+        if (isLastMeasure && (barLine->GetPosition() == BarLinePosition::Right)) {
             eraseIntersections = false;
         }
         DrawBarLine(dc, yTop, yBottom, barLine, barLine->GetForm(), eraseIntersections);

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Zone> s_factory("zone", ZONE);
 
-Zone::Zone() : Object("zone-"), AttTyped(), AttCoordinated()
+Zone::Zone() : Object(ZONE, "zone-"), AttTyped(), AttCoordinated()
 {
     RegisterAttClass(ATT_TYPED);
     RegisterAttClass(ATT_COORDINATED);


### PR DESCRIPTION
This PR should improve total runtime by ~10%. The idea is not to retrieve class IDs via virtual functions, but to store them at construction in the Object base class.

Some examples that I have tested:

| Piece | Size | Runtime before | Runtime after |
| ----- | ---- | ---------------- | ------------- |
| Beethoven - Presto | 1.1 MB / 10 pages | 530ms | 475ms |
| Hummel - Trumpet Concerto | 5.7 MB / 128 pages | 4.52s | 3.94s |
| Holst - The Planets | 50.1 MB / 403 pages | 2min 8s | 1min 56s | 