### PR TITLE
Improve beam overlaps

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -62,7 +62,7 @@ public:
     void ClearCoordRefs();
 
     /**
-     * Get longest duration of the elements that are adjustent to the X coordinate passed
+     * Get longest duration of the elements that are adjacent to the X coordinate passed
      */
     int GetAdjacentElementsDuration(int elementX) const;
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -61,6 +61,11 @@ public:
      */
     void ClearCoordRefs();
 
+    /**
+     * Get longest duration of the elements that are adjustent to the X coordinate passed
+     */
+    int GetAdjacentElementsDuration(int elementX) const;
+
 private:
     void CalcBeamInit(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -171,6 +171,8 @@ public:
         m_beam = NULL;
         m_y1 = 0;
         m_y2 = 0;
+        m_x1 = 0;
+        m_beamSlope = 0.0;
         m_directionBias = 0;
         m_overlapMargin = 0;
         m_doc = doc;
@@ -180,6 +182,8 @@ public:
     Object *m_beam;
     int m_y1;
     int m_y2;
+    int m_x1;
+    double m_beamSlope;
     int m_directionBias;
     int m_overlapMargin;
     Doc *m_doc;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -160,8 +160,11 @@ public:
  * member 0: the beam that should be adjusted
  * member 1: y coordinate of the beam left side
  * member 2: y coordinate of the beam right side
- * member 3: overlap margin that beam needs to be displaced by
- * member 4: the Doc
+ * member 3: x coordinate of the beam left side (starting point)
+ * member 4: slope of the beam
+ * member 5: overlap margin that beam needs to be displaced by
+ * member 6: the Doc
+ * member 7: the flag indicating whether element from different layer is being processed
  **/
 
 class AdjustBeamParams : public FunctorParams {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1444,7 +1444,7 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
             params->m_beam = this;
             params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
             params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
-            params->m_x1 = m_beamSegment.m_beamElementCoordRefs.back()->m_x;
+            params->m_x1 = m_beamSegment.m_beamElementCoordRefs.front()->m_x;
             params->m_beamSlope = m_beamSegment.m_beamSlope;
             params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
             params->m_overlapMargin

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1024,7 +1024,7 @@ int BeamSegment::GetAdjacentElementsDuration(int elementX) const
     if ((elementX < m_beamElementCoordRefs.front()->m_x) || (elementX > m_beamElementCoordRefs.back()->m_x)) {
         return DUR_8;
     }
-    for (int i = 0; i < m_beamElementCoordRefs.size() - 1; ++i) {
+    for (int i = 0; i < int(m_beamElementCoordRefs.size()) - 1; ++i) {
         if ((m_beamElementCoordRefs.at(i)->m_x < elementX) && (m_beamElementCoordRefs.at(i + 1)->m_x > elementX)) {
             return std::min(m_beamElementCoordRefs.at(i)->m_dur, m_beamElementCoordRefs.at(i + 1)->m_dur);
         }
@@ -1444,6 +1444,8 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
             params->m_beam = this;
             params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
             params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
+            params->m_x1 = m_beamSegment.m_beamElementCoordRefs.back()->m_x;
+            params->m_beamSlope = m_beamSegment.m_beamSlope;
             params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
             params->m_overlapMargin
                 = CalcLayerOverlap(params->m_doc, params->m_beam, params->m_directionBias, params->m_y1, params->m_y2);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1019,6 +1019,19 @@ void BeamSegment::CalcSetValues()
     }
 }
 
+int BeamSegment::GetAdjacentElementsDuration(int elementX) const
+{
+    if ((elementX < m_beamElementCoordRefs.front()->m_x) || (elementX > m_beamElementCoordRefs.back()->m_x)) {
+        return DUR_8;
+    }
+    for (int i = 0; i < m_beamElementCoordRefs.size() - 1; ++i) {
+        if ((m_beamElementCoordRefs.at(i)->m_x < elementX) && (m_beamElementCoordRefs.at(i + 1)->m_x > elementX)) {
+            return std::min(m_beamElementCoordRefs.at(i)->m_dur, m_beamElementCoordRefs.at(i + 1)->m_dur);
+        }
+    }
+    return DUR_8;
+}
+
 //----------------------------------------------------------------------------
 // Beam
 //----------------------------------------------------------------------------

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1408,12 +1408,12 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
 
     // ignore elements that are not in the beam or are direct children of the beam
     if (!params->m_beam) return FUNCTOR_CONTINUE;
-    if (!params->m_isOtherLayer && (Is({ NOTE, CHORD }) || !Is(ACCID)) && (GetFirstAncestor(BEAM) == params->m_beam)
+    if (!params->m_isOtherLayer && !Is(ACCID) && (GetFirstAncestor(BEAM) == params->m_beam)
         && !IsGraceNote())
         return FUNCTOR_CONTINUE;
     // ignore elements that are both on other layer and cross-staff
     if (params->m_isOtherLayer && m_crossStaff) return FUNCTOR_CONTINUE;
-    // ignore specific elemtns, since they should not be influencing beam positiong
+    // ignore specific elements, since they should not be influencing beam positioning
     if (Is({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
     // ignore elements that start before the beam
     if (this->GetDrawingX() < params->m_x1) return FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1425,7 +1425,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     int margin = 0;
     Beam *beam = vrv_cast<Beam *>(params->m_beam);
     const int beamCount = beam->m_beamSegment.GetAdjacentElementsDuration(GetDrawingX()) - DUR_8;
-    const int currentBeamY = params->m_y1 + params->m_beamSlope * (params->m_x1 - this->GetDrawingX());
+    const int currentBeamY = params->m_y1 + params->m_beamSlope * (this->GetDrawingX() - params->m_x1);
     if (params->m_directionBias > 0) {
         margin = GetContentTop() - currentBeamY + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1408,8 +1408,7 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
 
     // ignore elements that are not in the beam or are direct children of the beam
     if (!params->m_beam) return FUNCTOR_CONTINUE;
-    if (!params->m_isOtherLayer && !Is(ACCID) && (GetFirstAncestor(BEAM) == params->m_beam)
-        && !IsGraceNote())
+    if (!params->m_isOtherLayer && !Is(ACCID) && (GetFirstAncestor(BEAM) == params->m_beam) && !IsGraceNote())
         return FUNCTOR_CONTINUE;
     // ignore elements that are both on other layer and cross-staff
     if (params->m_isOtherLayer && m_crossStaff) return FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1418,21 +1418,18 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     assert(staff);
 
     // check if top/bottom of the element overlaps with beam coordinates
-    // const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
-    int leftMargin = 0, rightMargin = 0;
-
+    int margin = 0;
     Beam *beam = vrv_cast<Beam *>(params->m_beam);
     const int beamCount = beam->m_beamSegment.GetAdjacentElementsDuration(GetDrawingX()) - DUR_8;
+    const int currentBeamY = params->m_y1 + params->m_beamSlope * (params->m_x1 - this->GetDrawingX());
     if (params->m_directionBias > 0) {
-        leftMargin = GetContentTop() - params->m_y1 + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
-        rightMargin = GetContentTop() - params->m_y2 + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
+        margin = GetContentTop() - currentBeamY + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
     }
     else {
-        leftMargin = GetContentBottom() - params->m_y1 - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
-        rightMargin = GetContentBottom() - params->m_y2 - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
+        margin = GetContentBottom() - currentBeamY - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
     }
 
-    const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
+    const int overlapMargin = margin * params->m_directionBias;
     if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1407,10 +1407,11 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     assert(params);
 
     // ignore elements that are not in the beam or are direct children of the beam
-    if (!params->m_beam
-        || (!params->m_isOtherLayer && Is({ NOTE, CHORD }) && (GetFirstAncestor(BEAM) == params->m_beam)
-            && !IsGraceNote()))
-        return FUNCTOR_SIBLINGS;
+    if (!params->m_beam) return FUNCTOR_CONTINUE;
+    if (!params->m_isOtherLayer && (Is({ NOTE, CHORD }) || !Is(ACCID)) && (GetFirstAncestor(BEAM) == params->m_beam)
+        && !IsGraceNote())
+        return FUNCTOR_CONTINUE;
+    if (params->m_isOtherLayer && m_crossStaff) return FUNCTOR_CONTINUE;
     if (Is({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
@@ -1423,23 +1424,19 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     Beam *beam = vrv_cast<Beam *>(params->m_beam);
     const int beamCount = beam->m_beamSegment.GetAdjacentElementsDuration(GetDrawingX()) - DUR_8;
     if (params->m_directionBias > 0) {
-        leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
-            + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
-        rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
-            + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
+        leftMargin = GetContentTop() - params->m_y1 + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
+        rightMargin = GetContentTop() - params->m_y2 + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
     }
     else {
-        leftMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
-            - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
-        rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
-            - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
+        leftMargin = GetContentBottom() - params->m_y1 - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
+        rightMargin = GetContentBottom() - params->m_y2 - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
     }
 
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin
-            = (((overlapMargin + staffOffset - 1) / staffOffset + 1.5) * staffOffset) * params->m_directionBias;
+            = (((overlapMargin + staffOffset - 1) / staffOffset + 0.5) * staffOffset) * params->m_directionBias;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1421,17 +1421,18 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     int leftMargin = 0, rightMargin = 0;
 
     Beam *beam = vrv_cast<Beam *>(params->m_beam);
+    const int beamCount = beam->m_beamSegment.GetAdjacentElementsDuration(GetDrawingX()) - DUR_8;
     if (params->m_directionBias > 0) {
         leftMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
-            + (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+            + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
         rightMargin = GetDrawingTop(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
-            + (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+            + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
     }
     else {
         leftMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y1
-            - (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+            - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
         rightMargin = GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, true) - params->m_y2
-            - (beam->m_shortestDur - DUR_8) * beam->m_beamWidth;
+            - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
     }
 
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1422,18 +1422,21 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     assert(staff);
 
     // check if top/bottom of the element overlaps with beam coordinates
-    int margin = 0;
+    int leftMargin = 0, rightMargin = 0;
     Beam *beam = vrv_cast<Beam *>(params->m_beam);
     const int beamCount = beam->m_beamSegment.GetAdjacentElementsDuration(GetDrawingX()) - DUR_8;
-    const int currentBeamY = params->m_y1 + params->m_beamSlope * (this->GetDrawingX() - params->m_x1);
+    const int currentBeamYLeft = params->m_y1 + params->m_beamSlope * (this->GetContentLeft() - params->m_x1);
+    const int currentBeamYRight = params->m_y1 + params->m_beamSlope * (this->GetContentRight() - params->m_x1);
     if (params->m_directionBias > 0) {
-        margin = GetContentTop() - currentBeamY + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
+        leftMargin = GetContentTop() - currentBeamYLeft + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
+        rightMargin = GetContentTop() - currentBeamYRight + beamCount * beam->m_beamWidth + beam->m_beamWidthBlack;
     }
     else {
-        margin = GetContentBottom() - currentBeamY - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
+        leftMargin = GetContentBottom() - currentBeamYLeft - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
+        rightMargin = GetContentBottom() - currentBeamYRight - beamCount * beam->m_beamWidth - beam->m_beamWidthBlack;
     }
 
-    const int overlapMargin = margin * params->m_directionBias;
+    const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_directionBias * params->m_overlapMargin) {
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1411,8 +1411,12 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     if (!params->m_isOtherLayer && (Is({ NOTE, CHORD }) || !Is(ACCID)) && (GetFirstAncestor(BEAM) == params->m_beam)
         && !IsGraceNote())
         return FUNCTOR_CONTINUE;
+    // ignore elements that are both on other layer and cross-staff
     if (params->m_isOtherLayer && m_crossStaff) return FUNCTOR_CONTINUE;
+    // ignore specific elemtns, since they should not be influencing beam positiong
     if (Is({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
+    // ignore elements that start before the beam
+    if (this->GetDrawingX() < params->m_x1) return FUNCTOR_CONTINUE;
 
     Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
     assert(staff);


### PR DESCRIPTION
1. Improved overlaps for accidentals that collide with beams.

Before:
![image](https://user-images.githubusercontent.com/1819669/130215612-29c36f49-beaf-43c4-b4ab-b0ad048a04ce.png)
After:
![image](https://user-images.githubusercontent.com/1819669/130215649-bb3c1dfa-a3d9-49e3-ae18-7d4c6551b885.png)

2. Improved overlaps for the beams on multiple layers.

Before:
![image](https://user-images.githubusercontent.com/1819669/130215786-63442c77-3584-4d48-96a2-3dac0bf7da02.png)
After:
![image](https://user-images.githubusercontent.com/1819669/130215770-0aa3baf1-0d64-4f3f-a168-039dd152ca69.png)
