### PR TITLE
Fix Toolkit::RedoLayout() to not cast off when breaks option is set to 'none'

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1112,7 +1112,7 @@ void Toolkit::RedoLayout()
     else if (m_options->m_breaks.GetValue() == BREAKS_smart) {
         m_doc.CastOffSmartDoc();
     }
-    else {
+    else if (m_options->m_breaks.GetValue() != BREAKS_none) {
         m_doc.CastOffDoc();
     }
 }


### PR DESCRIPTION
When calling `ToolKit::RedoLayout()`, casting off is performed even when the `breaks` option is `none`. This fixes it.
