### PR TITLE
Change xml:id to shorter encoded strings. Fixes #2354

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -8,9 +8,9 @@ jobs:
       matrix:
         path:
           - check: "include"
-            exclude: "(hum|midi|json|pugi|utf8|win32|zip)"
+            exclude: "(hum|crc|midi|json|pugi|utf8|win32|zip)"
           - check: "src"
-            exclude: "(hum|midi|json|pugi)"
+            exclude: "(hum|crc|midi|json|pugi)"
           - check: "tools"
     steps:
       - uses: actions/checkout@v2

--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -634,6 +634,12 @@
 		4DCA95D81A515D0E008AD7E9 /* editorial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCA95D71A515D0E008AD7E9 /* editorial.cpp */; };
 		4DCA95D91A515D0E008AD7E9 /* editorial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCA95D71A515D0E008AD7E9 /* editorial.cpp */; };
 		4DCA95DB1A515D33008AD7E9 /* editorial.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCA95DA1A515D33008AD7E9 /* editorial.h */; };
+		4DCB7A9E26D3C94C0047F01D /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB7A9D26D3C94C0047F01D /* crc.cpp */; };
+		4DCB7A9F26D3C94C0047F01D /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB7A9D26D3C94C0047F01D /* crc.cpp */; };
+		4DCB7AA026D3C94C0047F01D /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB7A9D26D3C94C0047F01D /* crc.cpp */; };
+		4DCB7AA126D3C94C0047F01D /* crc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB7A9D26D3C94C0047F01D /* crc.cpp */; };
+		4DCB7AA326D3C9600047F01D /* crc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCB7AA226D3C9600047F01D /* crc.h */; };
+		4DCB7AA426D3C9600047F01D /* crc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCB7AA226D3C9600047F01D /* crc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD11DC42240E78B00A405D8 /* c_wrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD11DC22240E78B00A405D8 /* c_wrapper.cpp */; };
 		4DD11DC52240E78B00A405D8 /* c_wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD11DC32240E78B00A405D8 /* c_wrapper.h */; };
 		4DDBBB571C7AE43E00054AFF /* hairpin.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DDBBB551C7AE43E00054AFF /* hairpin.h */; };
@@ -1523,6 +1529,8 @@
 		4DC3B9E6239E2AD9007F185E /* transposition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = transposition.h; path = include/vrv/transposition.h; sourceTree = "<group>"; };
 		4DCA95D71A515D0E008AD7E9 /* editorial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = editorial.cpp; path = src/editorial.cpp; sourceTree = "<group>"; };
 		4DCA95DA1A515D33008AD7E9 /* editorial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = editorial.h; path = include/vrv/editorial.h; sourceTree = "<group>"; };
+		4DCB7A9D26D3C94C0047F01D /* crc.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = crc.cpp; path = src/crc/crc.cpp; sourceTree = SOURCE_ROOT; };
+		4DCB7AA226D3C9600047F01D /* crc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc.h; path = include/crc/crc.h; sourceTree = SOURCE_ROOT; };
 		4DD11DC22240E78B00A405D8 /* c_wrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = c_wrapper.cpp; path = tools/c_wrapper.cpp; sourceTree = "<group>"; };
 		4DD11DC32240E78B00A405D8 /* c_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = c_wrapper.h; path = tools/c_wrapper.h; sourceTree = "<group>"; };
 		4DDBBB551C7AE43E00054AFF /* hairpin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hairpin.h; path = include/vrv/hairpin.h; sourceTree = "<group>"; };
@@ -1993,6 +2001,15 @@
 			name = interfaces;
 			sourceTree = "<group>";
 		};
+		4DCB7A9C26D3C7BA0047F01D /* crc */ = {
+			isa = PBXGroup;
+			children = (
+				4DCB7AA226D3C9600047F01D /* crc.h */,
+				4DCB7A9D26D3C94C0047F01D /* crc.cpp */,
+			);
+			path = crc;
+			sourceTree = "<group>";
+		};
 		4DEE28EC1940BCA100C76319 /* libmei */ = {
 			isa = PBXGroup;
 			children = (
@@ -2111,6 +2128,7 @@
 				4D7D8A3C1886E36200D78B62 /* tools */,
 				8F086F351885397A0037FD8E /* source */,
 				4DB787602022EFA700394520 /* json */,
+				4DCB7A9C26D3C7BA0047F01D /* crc */,
 				4D1BE7751C688F6F0086DC0E /* midi */,
 				4D22C42118891D7300D0831F /* pugixml */,
 				4DBC09271B51960100B1832C /* utf8 */,
@@ -2392,6 +2410,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4DCB7AA326D3C9600047F01D /* crc.h in Headers */,
 				4DEC4DD421C8295700D1D273 /* expan.h in Headers */,
 				4DB3D8A51F828E9100B5FC2B /* areaposinterface.h in Headers */,
 				4DEC4DD321C8295700D1D273 /* restore.h in Headers */,
@@ -2682,6 +2701,7 @@
 				BB4C4AF422A932BC001F6AF0 /* rdg.h in Headers */,
 				BB4C4A7F22A9321F001F6AF0 /* atts_pagebased.h in Headers */,
 				BB4C4B2022A932CF001F6AF0 /* breath.h in Headers */,
+				4DCB7AA426D3C9600047F01D /* crc.h in Headers */,
 				BB4C4B7222A932D7001F6AF0 /* rest.h in Headers */,
 				BB4C4B3A22A932CF001F6AF0 /* turn.h in Headers */,
 				BDA81C21268B38760065B802 /* metersiggrp.h in Headers */,
@@ -3015,6 +3035,7 @@
 				4DA0EAC422BB779400A7EBEB /* surface.cpp in Sources */,
 				4D1694051E3A44F300569BF4 /* iodarms.cpp in Sources */,
 				4DEC4DAF21C81F0600D1D273 /* sic.cpp in Sources */,
+				4DCB7A9F26D3C94C0047F01D /* crc.cpp in Sources */,
 				4D81351F2322C41800F59C01 /* keyaccid.cpp in Sources */,
 				4D79642226C167100026288B /* pageboundary.cpp in Sources */,
 				4DB3D8E31F83D16300B5FC2B /* elementpart.cpp in Sources */,
@@ -3221,6 +3242,7 @@
 				8F086EEC188539540037FD8E /* io.cpp in Sources */,
 				4D796B5E1D78641900A15238 /* harm.cpp in Sources */,
 				4DB3072F1AC9ED2500EE0982 /* space.cpp in Sources */,
+				4DCB7A9E26D3C94C0047F01D /* crc.cpp in Sources */,
 				4DEC4D7E21C804C500D1D273 /* add.cpp in Sources */,
 				8F086EED188539540037FD8E /* iodarms.cpp in Sources */,
 				8F086EEE188539540037FD8E /* iomei.cpp in Sources */,
@@ -3438,6 +3460,7 @@
 				4D1BE7861C6A40A80086DC0E /* pugixml.cpp in Sources */,
 				400FEDD5206FA74D000D3233 /* gracegrp.cpp in Sources */,
 				4DA0EAC522BB779400A7EBEB /* surface.cpp in Sources */,
+				4DCB7AA026D3C94C0047F01D /* crc.cpp in Sources */,
 				4DB726C61B8BB0E80040231B /* text.cpp in Sources */,
 				4D79642326C167100026288B /* pageboundary.cpp in Sources */,
 				4DB3D8F51F83D1D600B5FC2B /* view_control.cpp in Sources */,
@@ -3650,6 +3673,7 @@
 				4DF092A82497711800239195 /* phrase.cpp in Sources */,
 				BB4C4ABF22A932B6001F6AF0 /* labelabbr.cpp in Sources */,
 				4DA0EAC622BB779400A7EBEB /* surface.cpp in Sources */,
+				4DCB7AA126D3C94C0047F01D /* crc.cpp in Sources */,
 				BB4C4ADB22A932BC001F6AF0 /* abbr.cpp in Sources */,
 				4D79642426C167100026288B /* pageboundary.cpp in Sources */,
 				BB4C4A9322A9328F001F6AF0 /* doc.cpp in Sources */,

--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -22,6 +22,7 @@ FILES="$SRCFILES \
  ../../src/midi/MidiMessage.cpp \
  ../../src/hum/humlib.cpp \
  ../../src/json/jsonxx.cc \
+ ../../src/crc/crc.cpp \
  ../../libmei/attconverter.cpp \
  ../../libmei/atts_analytical.cpp \
  ../../libmei/atts_cmn.cpp \
@@ -40,7 +41,7 @@ FILES="$SRCFILES \
  ../../libmei/atts_shared.cpp \
  ../../libmei/atts_visual.cpp"
 
-CXXOPTS="-g -fpic -std=c++17 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/midi -I../../include/pugi -I../../include/utf8 -I../../include/zip -I../../libmei -I/opt/local/include/ "
+CXXOPTS="-g -fpic -std=c++17 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/crc -I../../include/midi -I../../include/pugi -I../../include/utf8 -I../../include/zip -I../../libmei -I/opt/local/include/ "
 
 PATHS=""
 unamestr=$(uname)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 include_directories(
     ../include
+    ../include/crc
     ../include/midi
     ../include/hum
     ../include/json
@@ -135,6 +136,7 @@ endif()
 
 file(GLOB verovio_SRC "../src/*.cpp")
 file(GLOB midi_SRC "../src/midi/*.cpp")
+file(GLOB crc_SRC "../src/crc/*.cpp")
 
 # Add header files to custom target, otherwise they are not shown in some IDEs (e.g. QtCreator)
 file(GLOB_RECURSE LibFiles "../include/*.h")
@@ -143,6 +145,7 @@ add_custom_target(headers SOURCES ${LibFiles})
 set(all_SRC
     ${verovio_SRC}
     ${hum_SRC}
+    ${crc_SRC}
     ${midi_SRC}
     ../src/json/jsonxx.cc
     ../src/pugi/pugixml.cpp

--- a/include/crc/crc.h
+++ b/include/crc/crc.h
@@ -1,0 +1,86 @@
+/**********************************************************************
+ *
+ * Filename:    crc.h
+ * 
+ * Description: A header file describing the various CRC standards.
+ *
+ * Notes:       
+ *
+ * 
+ * Copyright (c) 2000 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+#ifndef _crc_h
+#define _crc_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FALSE	0
+#define TRUE	!FALSE
+
+/*
+ * Select the CRC standard from the list that follows.
+ */
+#define CRC32
+
+
+#if defined(CRC_CCITT)
+
+typedef unsigned short  crc;
+
+#define CRC_NAME			"CRC-CCITT"
+#define POLYNOMIAL			0x1021
+#define INITIAL_REMAINDER	0xFFFF
+#define FINAL_XOR_VALUE		0x0000
+#define REFLECT_DATA		FALSE
+#define REFLECT_REMAINDER	FALSE
+#define CHECK_VALUE			0x29B1
+
+#elif defined(CRC16)
+
+typedef unsigned short  crc;
+
+#define CRC_NAME			"CRC-16"
+#define POLYNOMIAL			0x8005
+#define INITIAL_REMAINDER	0x0000
+#define FINAL_XOR_VALUE		0x0000
+#define REFLECT_DATA		TRUE
+#define REFLECT_REMAINDER	TRUE
+#define CHECK_VALUE			0xBB3D
+
+#elif defined(CRC32)
+
+typedef unsigned int  crc;
+
+#define CRC_NAME			"CRC-32"
+#define POLYNOMIAL			0x04C11DB7
+#define INITIAL_REMAINDER	0xFFFFFFFF
+#define FINAL_XOR_VALUE		0xFFFFFFFF
+#define REFLECT_DATA		TRUE
+#define REFLECT_REMAINDER	TRUE
+#define CHECK_VALUE			0xCBF43926
+
+#else
+
+#error "One of CRC_CCITT, CRC16, or CRC32 must be #define'd."
+
+#endif
+
+
+void  crcInit(void);
+crc   crcSlow(unsigned char const message[], int nBytes);
+crc   crcFast(unsigned char const message[], int nBytes);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _crc_h */

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -613,6 +613,7 @@ public:
     OptionBool m_usePgFooterForAll;
     OptionBool m_usePgHeaderForAll;
     OptionBool m_useBraceGlyph;
+    OptionBool m_xmlIdChecksum;
 
     /**
      * General layout

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -91,6 +91,12 @@ std::string GetFilename(std::string fullpath);
 std::string GetVersion();
 
 /**
+ * Encode the integer value using the specified base (max is 62)
+ * Base 36 uses 0-9 and a-z, base 62 also A-Z.
+ */
+std::string BaseEncodeInt(int value, int base);
+
+/**
  *
  */
 extern bool logging;

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ else:
 verovio_module = Extension('verovio._verovio',
                            sources=glob('./src/*.cpp') + glob('./src/hum/*.cpp') +
                            [
+                               './src/crc/crc.cpp',
                                './src/json/jsonxx.cc',
                                './src/pugi/pugixml.cpp',
                                './src/midi/Binasc.cpp',
@@ -119,6 +120,7 @@ verovio_module = Extension('verovio._verovio',
                            swig_opts=['-c++', '-outdir',
                                       './bindings/python', '-py3'],
                            include_dirs=['./include/vrv',
+                                         './include/crc',
                                          './include/json',
                                          './include/midi',
                                          './include/hum',

--- a/src/crc/crc.cpp
+++ b/src/crc/crc.cpp
@@ -1,0 +1,238 @@
+/**********************************************************************
+ *
+ * Filename:    crc.c
+ * 
+ * Description: Slow and fast implementations of the CRC standards.
+ *
+ * Notes:       The parameters for each supported CRC standard are
+ *				defined in the header file crc.h.  The implementations
+ *				here should stand up to further additions to that list.
+ *
+ * 
+ * Copyright (c) 2000 by Michael Barr.  This software is placed into
+ * the public domain and may be used for any purpose.  However, this
+ * notice must not be changed or removed and no warranty is either
+ * expressed or implied by its publication or distribution.
+ **********************************************************************/
+
+
+#include "crc.h"
+
+extern "C" {
+
+/*
+ * Derive parameters from the standard-specific parameters in crc.h.
+ */
+#define WIDTH    (8 * sizeof(crc))
+#define TOPBIT   (1 << (WIDTH - 1))
+
+#if (REFLECT_DATA == TRUE)
+#undef  REFLECT_DATA
+#define REFLECT_DATA(X)			((unsigned char) reflect((X), 8))
+#else
+#undef  REFLECT_DATA
+#define REFLECT_DATA(X)			(X)
+#endif
+
+#if (REFLECT_REMAINDER == TRUE)
+#undef  REFLECT_REMAINDER
+#define REFLECT_REMAINDER(X)	((crc) reflect((X), WIDTH))
+#else
+#undef  REFLECT_REMAINDER
+#define REFLECT_REMAINDER(X)	(X)
+#endif
+
+
+/*********************************************************************
+ *
+ * Function:    reflect()
+ * 
+ * Description: Reorder the bits of a binary sequence, by reflecting
+ *				them about the middle position.
+ *
+ * Notes:		No checking is done that nBits <= 32.
+ *
+ * Returns:		The reflection of the original data.
+ *
+ *********************************************************************/
+static unsigned int
+reflect(unsigned int data, unsigned char nBits)
+{
+	unsigned int  reflection = 0x00000000;
+	unsigned char  bit;
+
+	/*
+	 * Reflect the data about the center bit.
+	 */
+	for (bit = 0; bit < nBits; ++bit)
+	{
+		/*
+		 * If the LSB bit is set, set the reflection of it.
+		 */
+		if (data & 0x01)
+		{
+			reflection |= (1 << ((nBits - 1) - bit));
+		}
+
+		data = (data >> 1);
+	}
+
+	return (reflection);
+
+}	/* reflect() */
+
+
+/*********************************************************************
+ *
+ * Function:    crcSlow()
+ * 
+ * Description: Compute the CRC of a given message.
+ *
+ * Notes:		
+ *
+ * Returns:		The CRC of the message.
+ *
+ *********************************************************************/
+crc
+crcSlow(unsigned char const message[], int nBytes)
+{
+    crc            remainder = INITIAL_REMAINDER;
+	int            byte;
+	unsigned char  bit;
+
+
+    /*
+     * Perform modulo-2 division, a byte at a time.
+     */
+    for (byte = 0; byte < nBytes; ++byte)
+    {
+        /*
+         * Bring the next byte into the remainder.
+         */
+        remainder ^= (REFLECT_DATA(message[byte]) << (WIDTH - 8));
+
+        /*
+         * Perform modulo-2 division, a bit at a time.
+         */
+        for (bit = 8; bit > 0; --bit)
+        {
+            /*
+             * Try to divide the current data bit.
+             */
+            if (remainder & TOPBIT)
+            {
+                remainder = (remainder << 1) ^ POLYNOMIAL;
+            }
+            else
+            {
+                remainder = (remainder << 1);
+            }
+        }
+    }
+
+    /*
+     * The final remainder is the CRC result.
+     */
+    return (REFLECT_REMAINDER(remainder) ^ FINAL_XOR_VALUE);
+
+}   /* crcSlow() */
+
+
+crc  crcTable[256];
+
+
+/*********************************************************************
+ *
+ * Function:    crcInit()
+ * 
+ * Description: Populate the partial CRC lookup table.
+ *
+ * Notes:		This function must be rerun any time the CRC standard
+ *				is changed.  If desired, it can be run "offline" and
+ *				the table results stored in an embedded system's ROM.
+ *
+ * Returns:		None defined.
+ *
+ *********************************************************************/
+void
+crcInit(void)
+{
+    crc			   remainder;
+	int			   dividend;
+	unsigned char  bit;
+
+
+    /*
+     * Compute the remainder of each possible dividend.
+     */
+    for (dividend = 0; dividend < 256; ++dividend)
+    {
+        /*
+         * Start with the dividend followed by zeros.
+         */
+        remainder = dividend << (WIDTH - 8);
+
+        /*
+         * Perform modulo-2 division, a bit at a time.
+         */
+        for (bit = 8; bit > 0; --bit)
+        {
+            /*
+             * Try to divide the current data bit.
+             */			
+            if (remainder & TOPBIT)
+            {
+                remainder = (remainder << 1) ^ POLYNOMIAL;
+            }
+            else
+            {
+                remainder = (remainder << 1);
+            }
+        }
+
+        /*
+         * Store the result into the table.
+         */
+        crcTable[dividend] = remainder;
+    }
+
+}   /* crcInit() */
+
+
+/*********************************************************************
+ *
+ * Function:    crcFast()
+ * 
+ * Description: Compute the CRC of a given message.
+ *
+ * Notes:		crcInit() must be called first.
+ *
+ * Returns:		The CRC of the message.
+ *
+ *********************************************************************/
+crc
+crcFast(unsigned char const message[], int nBytes)
+{
+    crc	           remainder = INITIAL_REMAINDER;
+    unsigned char  data;
+	int            byte;
+
+
+    /*
+     * Divide the message by the polynomial, a byte at a time.
+     */
+    for (byte = 0; byte < nBytes; ++byte)
+    {
+        data = REFLECT_DATA(message[byte]) ^ (remainder >> (WIDTH - 8));
+  		remainder = crcTable[data] ^ (remainder << 8);
+    }
+
+    /*
+     * The final remainder is the CRC.
+     */
+    return (REFLECT_REMAINDER(remainder) ^ FINAL_XOR_VALUE);
+
+}   /* crcFast() */
+
+} // extern C
+

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -172,6 +172,7 @@ Object::~Object()
 
 void Object::Init(const std::string &classid)
 {
+    assert(classid.size());
     m_classid = classid;
     m_parent = NULL;
     // Flags
@@ -594,7 +595,7 @@ bool Object::DeleteChild(Object *child)
 
 void Object::GenerateUuid()
 {
-    m_uuid = m_classid + Object::GenerateRandUuid();
+    m_uuid = m_classid.at(0) + Object::GenerateRandUuid();
 }
 
 void Object::ResetUuid()
@@ -946,11 +947,12 @@ void Object::SeedUuid(unsigned int seed)
 std::string Object::GenerateRandUuid()
 {
     int nr = std::rand();
-    char str[17];
-    // I do not want to use a stream for doing this!
-    snprintf(str, 17, "%016d", nr);
 
-    return std::string(str);
+    // char str[17];
+    // snprintf(str, 17, "%016d", nr);
+    // return std::string(str);
+
+    return BaseEncodeInt(nr, 36);
 }
 
 bool Object::sortByUlx(Object *a, Object *b)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1055,6 +1055,11 @@ Options::Options()
     m_usePgHeaderForAll.Init(false);
     this->Register(&m_usePgHeaderForAll, "usePgHeaderForAll", &m_general);
 
+    m_xmlIdChecksum.SetInfo(
+        "XML IDs based on checksum", "Seed the generator for XML IDs using the checksum of the input data");
+    m_xmlIdChecksum.Init(false);
+    this->Register(&m_xmlIdChecksum, "xmlIdChecksum", &m_general);
+
     /********* General layout *********/
 
     m_generalLayout.SetLabel("General layout options", "2-generalLayout");

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -42,6 +42,7 @@
 
 #include "MidiFile.h"
 #include "checked.h"
+#include "crc.h"
 #include "jsonxx.h"
 #include "unchecked.h"
 
@@ -417,6 +418,12 @@ bool Toolkit::LoadData(const std::string &data)
 {
     std::string newData;
     Input *input = NULL;
+
+    if (m_options->m_xmlIdChecksum.GetValue()) {
+        crcInit();
+        unsigned int cr = crcFast((unsigned char *)data.c_str(), (int)data.size());
+        Object::SeedUuid(cr);
+    }
 
 #ifndef NO_HUMDRUM_SUPPORT
     ClearHumdrumBuffer();

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -520,6 +520,25 @@ std::string GetVersion()
     return StringFormat("%d.%d.%d%s-%s", VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION, dev.c_str(), GIT_COMMIT);
 }
 
+static const std::string base62Chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+std::string BaseEncodeInt(int value, int base)
+{
+    assert(base > 10);
+    assert(base < 63);
+
+    std::string base62;
+    if (value < base) return std::string(1, base62Chars[value]);
+
+    while (value) {
+        base62 += base62Chars[value % base];
+        value /= base;
+    }
+
+    reverse(base62.begin(), base62.end());
+    return base62;
+}
+
 //----------------------------------------------------------------------------
 // Base64 code borrowed
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Numbers are represented with 0-9 and a-z. Also `note-` prefixes are simply `n`.

Before
```xml
<g id="layer-0000001474833169" class="layer">
```

After
```xml
<g id="liuw7pj" class="layer">
```