### PR TITLE
Implement tie length option

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -682,6 +682,7 @@ public:
     OptionDbl m_thickBarlineThickness;
     OptionDbl m_tieEndpointThickness;
     OptionDbl m_tieMidpointThickness;
+    OptionDbl m_tieMinLength;
     OptionDbl m_tupletBracketThickness;
     OptionBool m_tupletNumHead;
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1886,11 +1886,11 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     auto it = std::find_if(params->m_measureTieEndpoints.begin(), params->m_measureTieEndpoints.end(),
         [this](const std::pair<LayerElement *, LayerElement *> &pair) { return pair.second == this; });
     if (it != params->m_measureTieEndpoints.end()) {
-        const int minTiedDistance = 7 * drawingUnit;
-        const int alignmentDistance = it->second->GetAlignment()->GetXRel() - it->first->GetAlignment()->GetXRel();
-        if ((alignmentDistance < minTiedDistance)
+        const int minTieLength = params->m_doc->GetOptions()->m_tieMinLength.GetValue() * drawingUnit;
+        const int currentTieLength = it->second->GetContentLeft() - it->first->GetContentRight() - drawingUnit;
+        if ((currentTieLength < minTieLength)
             && ((this->GetFirstAncestor(CHORD) != NULL) || (it->first->FindDescendantByType(FLAG) != NULL))) {
-            const int adjust = minTiedDistance - alignmentDistance;
+            const int adjust = minTieLength - currentTieLength;
             this->GetAlignment()->SetXRel(this->GetAlignment()->GetXRel() + adjust);
             // Also move the accumulated x shift and the minimum position for the next alignment accordingly
             params->m_cumulatedXShift += adjust;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1323,6 +1323,10 @@ Options::Options()
     m_tieMidpointThickness.Init(0.5, 0.2, 1.0);
     this->Register(&m_tieMidpointThickness, "tieMidpointThickness", &m_generalLayout);
 
+    m_tieMinLength.SetInfo("Tie minimum length", "The minimum length of tie in MEI units");
+    m_tieMinLength.Init(2.0, 0.0, 10.0);
+    this->Register(&m_tieMinLength, "tieMinimumLength", &m_generalLayout);    
+
     m_tupletBracketThickness.SetInfo("Tuplet bracket thickness", "The thickness of the tuplet bracket");
     m_tupletBracketThickness.Init(0.2, 0.1, 0.8);
     this->Register(&m_tupletBracketThickness, "tupletBracketThickness", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1325,7 +1325,7 @@ Options::Options()
 
     m_tieMinLength.SetInfo("Tie minimum length", "The minimum length of tie in MEI units");
     m_tieMinLength.Init(2.0, 0.0, 10.0);
-    this->Register(&m_tieMinLength, "tieMinimumLength", &m_generalLayout);    
+    this->Register(&m_tieMinLength, "tieMinLength", &m_generalLayout);    
 
     m_tupletBracketThickness.SetInfo("Tuplet bracket thickness", "The thickness of the tuplet bracket");
     m_tupletBracketThickness.Init(0.2, 0.1, 0.8);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1325,7 +1325,7 @@ Options::Options()
 
     m_tieMinLength.SetInfo("Tie minimum length", "The minimum length of tie in MEI units");
     m_tieMinLength.Init(2.0, 0.0, 10.0);
-    this->Register(&m_tieMinLength, "tieMinLength", &m_generalLayout);    
+    this->Register(&m_tieMinLength, "tieMinLength", &m_generalLayout);
 
     m_tupletBracketThickness.SetInfo("Tuplet bracket thickness", "The thickness of the tuplet bracket");
     m_tupletBracketThickness.Init(0.2, 0.1, 0.8);


### PR DESCRIPTION
Option `--tie-min-length` has been added. 
Default value 2:
![image](https://user-images.githubusercontent.com/1819669/131107841-f8da6fe0-a669-4e5d-b60d-6577acbf2d68.png)

Max. value (10):
![image](https://user-images.githubusercontent.com/1819669/131107853-2c477271-ac94-4db2-9b12-380b0ea436a4.png)

Min. value (0):
![image](https://user-images.githubusercontent.com/1819669/131107868-8f1f1399-0eae-4412-8929-5b921045b072.png)


