### PR TITLE
Remove invalid and redundant function for cross staff element search

### DIFF
--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -750,20 +750,6 @@ void AlignmentReference::AdjustAccidWithAccidSpace(Accid *accid, Doc *doc, int s
     }
 }
 
-bool AlignmentReference::HasCrossStaffElements()
-{
-    ListOfObjects children;
-    ClassIdComparison classId(LAYER_ELEMENT);
-    FindAllDescendantByComparison(&children, &classId);
-
-    for (auto child : children) {
-        LayerElement *layerElement = vrv_cast<LayerElement *>(child);
-        if (layerElement && layerElement->m_crossStaff) return true;
-    }
-
-    return false;
-}
-
 //----------------------------------------------------------------------------
 // TimestampAligner
 //----------------------------------------------------------------------------

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1871,8 +1871,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     AlignmentReference *currentReference = GetAlignment()->GetReferenceWithElement(this, params->m_staffN);
     Alignment *nextAlignment = vrv_cast<Alignment *>(GetAlignment()->GetParent()->GetNext(GetAlignment(), ALIGNMENT));
     AlignmentType next = nextAlignment ? nextAlignment->GetType() : ALIGNMENT_DEFAULT;
-    if (Is({ DOTS, FLAG }) && (currentReference->HasMultipleLayer() || currentReference->HasCrossStaffElements())
-        && (next != ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
+    if (Is({ DOTS, FLAG }) && currentReference->HasMultipleLayer() && (next != ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
         const int additionalOffset = selfRight - params->m_upcomingMinPos;
         if (additionalOffset > params->m_currentAlignment.m_offset) {
             params->m_currentAlignment.m_offset = additionalOffset;


### PR DESCRIPTION
- removed redundant code in the flag/dot collision code - it has never been working, is redundant and is contrary to recent changes of ClassId
This function wasn't working as intended, returning false in all cases. This also wouldn't work with recent performance changes of #2351. Rendering is still good, even without this code:
![image](https://user-images.githubusercontent.com/1819669/131108374-541391ae-11c3-434a-818b-418ad67b1c2b.png)
