### PR TITLE
Fix export crash

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -832,6 +832,9 @@ bool MEIOutput::WriteObjectEnd(Object *object)
     else if (m_scoreBasedMEI && (object->Is(PAGES))) {
         return true;
     }
+    else if (m_scoreBasedMEI && (object->Is(PAGE_ELEMENT_END)) && m_nodeStack.empty()) {
+        return true;
+    }
 
     if (object->HasClosingComment()) {
         m_currentNode.append_child(pugi::node_comment).set_value(object->GetClosingComment().c_str());


### PR DESCRIPTION
Verovio currently crashes when doing a score based MEI export of the last page via `Toolkit::GetMEI()`. This seems to be a regression of #2347 .

This PR fixes the crash.