### PR TITLE
Enclose for MeterSig

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -83,9 +83,9 @@ public:
     wchar_t GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const;
 
     /**
-     * Retrieves parentheses / brackets from the enclose attribute
+     * Retrieve parentheses / brackets from the enclose attribute
      */
-    wchar_t GetEnclosingGlyph(bool beforeArtic) const;
+    std::pair<wchar_t, wchar_t> GetEnclosingGlyphs() const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -64,9 +64,9 @@ public:
     wchar_t GetFermataGlyph() const;
 
     /**
-     * Retrieves parentheses / brackets from the enclose attribute
+     * Retrieve parentheses / brackets from the enclose attribute
      */
-    wchar_t GetEnclosingGlyph(bool beforeFermata) const;
+    std::pair<wchar_t, wchar_t> GetEnclosingGlyphs() const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -23,7 +23,7 @@ class ScoreDefInterface;
 /**
  * This class models the MEI <meterSig> element.
  */
-class MeterSig : public LayerElement, public AttMeterSigLog, public AttMeterSigVis {
+class MeterSig : public LayerElement, public AttEnclosingChars, public AttMeterSigLog, public AttMeterSigVis {
 public:
     /**
      * @name Constructors, destructors, and other standard methods
@@ -45,6 +45,12 @@ public:
 
     /** Evaluate additive meter counts */
     int GetTotalCount() const;
+
+    /** Retrieves the symbol glyph */
+    wchar_t GetSymbolGlyph() const;
+
+    /** Retrieves parentheses from the enclose attribute */
+    wchar_t GetEnclosingGlyph(bool beforeMeterSig) const;
 
     //----------//
     // Functors //

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -49,8 +49,8 @@ public:
     /** Retrieves the symbol glyph */
     wchar_t GetSymbolGlyph() const;
 
-    /** Retrieves parentheses from the enclose attribute */
-    wchar_t GetEnclosingGlyph(bool beforeMeterSig) const;
+    /** Retrieve parentheses from the enclose attribute */
+    std::pair<wchar_t, wchar_t> GetEnclosingGlyphs(bool small) const;
 
     //----------//
     // Functors //

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -327,6 +327,7 @@ protected:
     ///@{
     void DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff);
     void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff);
+    void DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int horizOffset);
     /** Returns the width of the drawn figures */
     int DrawMeterSigFigures(
         DeviceContext *dc, int x, int y, const std::vector<int> &numSummands, int den, Staff *staff);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -327,7 +327,8 @@ protected:
     ///@{
     void DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff);
     void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff);
-    void DrawMeterSigFigures(
+    /** Returns the width of the drawn figures */
+    int DrawMeterSigFigures(
         DeviceContext *dc, int x, int y, const std::vector<int> &numSummands, int den, Staff *staff);
     void DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smulfCode, int num, bool line, Staff *staff);
     ///@}

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -263,21 +263,19 @@ wchar_t Artic::GetArticGlyph(data_ARTICULATION artic, data_STAFFREL place) const
         return 0;
 }
 
-wchar_t Artic::GetEnclosingGlyph(bool beforeArtic) const
+std::pair<wchar_t, wchar_t> Artic::GetEnclosingGlyphs() const
 {
-    wchar_t glyph = 0;
+    std::pair<wchar_t, wchar_t> glyphs(0, 0);
     if (this->HasEnclose()) {
         switch (this->GetEnclose()) {
             case ENCLOSURE_brack:
-                glyph = beforeArtic ? SMUFL_E26C_accidentalBracketLeft : SMUFL_E26D_accidentalBracketRight;
+                glyphs = { SMUFL_E26C_accidentalBracketLeft, SMUFL_E26D_accidentalBracketRight };
                 break;
-            case ENCLOSURE_paren:
-                glyph = beforeArtic ? SMUFL_E26A_accidentalParensLeft : SMUFL_E26B_accidentalParensRight;
-                break;
+            case ENCLOSURE_paren: glyphs = { SMUFL_E26A_accidentalParensLeft, SMUFL_E26B_accidentalParensRight }; break;
             default: break;
         }
     }
-    return glyph;
+    return glyphs;
 }
 
 //----------------------------------------------------------------------------

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -101,21 +101,19 @@ wchar_t Fermata::GetFermataGlyph() const
     return SMUFL_E4C0_fermataAbove;
 }
 
-wchar_t Fermata::GetEnclosingGlyph(bool beforeFermata) const
+std::pair<wchar_t, wchar_t> Fermata::GetEnclosingGlyphs() const
 {
-    wchar_t glyph = 0;
+    std::pair<wchar_t, wchar_t> glyphs(0, 0);
     if (this->HasEnclose()) {
         switch (this->GetEnclose()) {
             case ENCLOSURE_brack:
-                glyph = beforeFermata ? SMUFL_E26C_accidentalBracketLeft : SMUFL_E26D_accidentalBracketRight;
+                glyphs = { SMUFL_E26C_accidentalBracketLeft, SMUFL_E26D_accidentalBracketRight };
                 break;
-            case ENCLOSURE_paren:
-                glyph = beforeFermata ? SMUFL_E26A_accidentalParensLeft : SMUFL_E26B_accidentalParensRight;
-                break;
+            case ENCLOSURE_paren: glyphs = { SMUFL_E26A_accidentalParensLeft, SMUFL_E26B_accidentalParensRight }; break;
             default: break;
         }
     }
-    return glyph;
+    return glyphs;
 }
 
 //----------------------------------------------------------------------------

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1881,6 +1881,7 @@ void MEIOutput::WriteMeterSig(pugi::xml_node currentNode, MeterSig *meterSig)
     }
 
     WriteLayerElement(currentNode, meterSig);
+    meterSig->WriteEnclosingChars(currentNode);
     meterSig->WriteMeterSigLog(currentNode);
     meterSig->WriteMeterSigVis(currentNode);
 }
@@ -5385,6 +5386,7 @@ bool MEIInput::ReadMeterSig(Object *parent, pugi::xml_node meterSig)
     MeterSig *vrvMeterSig = new MeterSig();
     ReadLayerElement(meterSig, vrvMeterSig);
 
+    vrvMeterSig->ReadEnclosingChars(meterSig);
     vrvMeterSig->ReadMeterSigLog(meterSig);
     vrvMeterSig->ReadMeterSigVis(meterSig);
 

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -16,6 +16,7 @@
 
 #include "functorparams.h"
 #include "scoredefinterface.h"
+#include "smufl.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -26,8 +27,9 @@ namespace vrv {
 
 static const ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
 
-MeterSig::MeterSig() : LayerElement(METERSIG, "msig-"), AttMeterSigLog(), AttMeterSigVis()
+MeterSig::MeterSig() : LayerElement(METERSIG, "msig-"), AttEnclosingChars(), AttMeterSigLog(), AttMeterSigVis()
 {
+    RegisterAttClass(ATT_ENCLOSINGCHARS);
     RegisterAttClass(ATT_METERSIGLOG);
     RegisterAttClass(ATT_METERSIGVIS);
 
@@ -39,6 +41,7 @@ MeterSig::~MeterSig() {}
 void MeterSig::Reset()
 {
     LayerElement::Reset();
+    ResetEnclosingChars();
     ResetMeterSigLog();
     ResetMeterSigVis();
 }
@@ -47,6 +50,25 @@ int MeterSig::GetTotalCount() const
 {
     const data_SUMMAND_List &summands = this->GetCount();
     return std::accumulate(summands.cbegin(), summands.cend(), 0);
+}
+
+wchar_t MeterSig::GetSymbolGlyph() const
+{
+    wchar_t glyph = 0;
+    switch (this->GetSym()) {
+        case METERSIGN_common: glyph = SMUFL_E08A_timeSigCommon; break;
+        case METERSIGN_cut: glyph = SMUFL_E08B_timeSigCutCommon; break;
+        default: break;
+    }
+    return glyph;
+}
+
+wchar_t MeterSig::GetEnclosingGlyph(bool beforeMeterSig) const
+{
+    if (this->GetEnclose() == ENCLOSURE_paren) {
+        return beforeMeterSig ? SMUFL_E094_timeSigParensLeft : SMUFL_E095_timeSigParensRight;
+    }
+    return 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -63,12 +63,17 @@ wchar_t MeterSig::GetSymbolGlyph() const
     return glyph;
 }
 
-wchar_t MeterSig::GetEnclosingGlyph(bool beforeMeterSig) const
+std::pair<wchar_t, wchar_t> MeterSig::GetEnclosingGlyphs(bool small) const
 {
     if (this->GetEnclose() == ENCLOSURE_paren) {
-        return beforeMeterSig ? SMUFL_E094_timeSigParensLeft : SMUFL_E095_timeSigParensRight;
+        if (small) {
+            return { SMUFL_E092_timeSigParensLeftSmall, SMUFL_E093_timeSigParensRightSmall };
+        }
+        else {
+            return { SMUFL_E094_timeSigParensLeft, SMUFL_E095_timeSigParensRight };
+        }
     }
-    return 0;
+    return { 0, 0 };
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1600,8 +1600,8 @@ void View::DrawFermata(DeviceContext *dc, Fermata *fermata, Measure *measure, Sy
     dc->StartGraphic(fermata, "", fermata->GetUuid());
 
     const wchar_t code = fermata->GetFermataGlyph();
-    const wchar_t enclosingFront = fermata->GetEnclosingGlyph(true);
-    const wchar_t enclosingBack = fermata->GetEnclosingGlyph(false);
+    wchar_t enclosingFront, enclosingBack;
+    std::tie(enclosingFront, enclosingBack) = fermata->GetEnclosingGlyphs();
 
     const int x = fermata->GetStart()->GetDrawingX() + fermata->GetStart()->GetDrawingRadius(m_doc);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -306,8 +306,8 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     const data_STAFFREL place = artic->GetDrawingPlace();
 
     const wchar_t code = artic->GetArticGlyph(articValue, place);
-    const wchar_t enclosingFront = artic->GetEnclosingGlyph(true);
-    const wchar_t enclosingBack = artic->GetEnclosingGlyph(false);
+    wchar_t enclosingFront, enclosingBack;
+    std::tie(enclosingFront, enclosingBack) = artic->GetEnclosingGlyphs();
 
     // Skip it if we do not have it in the font (for now - we should log / document this somewhere)
     if (code == 0) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1037,9 +1037,11 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
 {
     if (meterSig->GetForm() == METERFORM_invis) return;
 
-    const wchar_t enclosingFront = meterSig->GetEnclosingGlyph(true);
-    const wchar_t enclosingBack = meterSig->GetEnclosingGlyph(false);
-    if (meterSig->HasEnclose() && (meterSig->GetEnclose() != ENCLOSURE_paren)) {
+    const bool hasSmallEnclosing = (meterSig->HasSym() || (meterSig->GetForm() == METERFORM_num));
+    wchar_t enclosingFront, enclosingBack;
+    std::tie(enclosingFront, enclosingBack) = meterSig->GetEnclosingGlyphs(hasSmallEnclosing);
+    if (meterSig->HasEnclose() && (meterSig->GetEnclose() != ENCLOSURE_none)
+        && (meterSig->GetEnclose() != ENCLOSURE_paren)) {
         LogWarning("Only drawing of enclosing parentheses is supported for metersig.");
     }
 
@@ -1048,10 +1050,9 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
     int y = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
     int x = meterSig->GetDrawingX() + horizOffset;
 
-    const bool diminEncl = (meterSig->HasSym() || meterSig->GetForm() == METERFORM_num);
     if (enclosingFront) {
-        DrawSmuflCode(dc, x, y, enclosingFront, staff->m_drawingStaffSize, diminEncl);
-        x += m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, diminEncl);
+        DrawSmuflCode(dc, x, y, enclosingFront, staff->m_drawingStaffSize, false);
+        x += m_doc->GetGlyphWidth(enclosingFront, staff->m_drawingStaffSize, false);
     }
 
     if (meterSig->HasSym()) {
@@ -1067,7 +1068,7 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
     }
 
     if (enclosingBack) {
-        DrawSmuflCode(dc, x, y, enclosingBack, staff->m_drawingStaffSize, diminEncl);
+        DrawSmuflCode(dc, x, y, enclosingBack, staff->m_drawingStaffSize, false);
     }
 
     dc->EndGraphic(meterSig, this);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1051,25 +1051,21 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
         MeterSig *meterSig = vrv_cast<MeterSig *>(*iter);
         assert(meterSig);
 
-        dc->StartGraphic(meterSig, "", meterSig->GetUuid());
-        int y = staff->GetDrawingY() - unit * (staff->m_drawingLines - 1);
-        int x = meterSig->GetDrawingX() + offset;
-
         if (meterSig->HasCount()) {
-            DrawMeterSigFigures(dc, x, y, meterSig->GetCount(), meterSig->GetUnit(), staff);
+            DrawMeterSig(dc, meterSig, staff, offset);
         }
 
-        dc->EndGraphic(meterSig, this);
-        int margin = unit / 2;
+        const int y = staff->GetDrawingY() - unit * (staff->m_drawingLines - 1);
+        const int x = meterSig->GetDrawingX() + offset;
         const int width = meterSig->GetContentRight() - meterSig->GetContentLeft();
         if ((meterSigGrp->GetFunc() == meterSigGrpLog_FUNC_mixed) && (iter != std::prev(childList->end()))) {
             // draw plus sign here
-            const int plusX = x + width;
+            const int plusX = x + width + unit / 2;
             DrawSmuflCode(dc, plusX, y, SMUFL_E08C_timeSigPlus, staff->m_drawingStaffSize, false);
-            offset += width + m_doc->GetGlyphWidth(SMUFL_E08C_timeSigPlus, staff->m_drawingStaffSize, false);
+            offset += width + unit + m_doc->GetGlyphWidth(SMUFL_E08C_timeSigPlus, staff->m_drawingStaffSize, false);
         }
         else {
-            offset += width + margin * 2;
+            offset += width + unit;
         }
     }
 


### PR DESCRIPTION
The PR implements the drawing of enclosing parentheses for MeterSig.

![MeterSig1](https://user-images.githubusercontent.com/63608463/131491067-e269294c-9978-4ad1-84e9-5eaef522bbc1.png)

This also works with complex meter signatures.

![MeterSig2](https://user-images.githubusercontent.com/63608463/131491881-762edf5b-318e-42ba-837b-ea4a1727db57.png)

<details>
  <summary>MEI for example 1</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Support for invisible or one-number meter</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2017-04-28">28 Apr 2017</date>
            <pubPlace>
               <ref target="https://github.com/rism-digital/verovio/pull/563" />
            </pubPlace>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio supports the display of single-number time signatures, and also offers the possibility of rendering the time signature invisible.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" key.mode="major" key.sig="0">
                        <clef shape="G" line="2" />
                        <meterSig count="3" enclose="paren" unit="8" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="a" />
                              <note dur="8" oct="4" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef n="1">
                     <meterSig count="3" enclose="paren" unit="8" form="num"/>
                  </scoreDef>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="a" />
                              <note dur="8" oct="4" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef n="1">
                     <meterSig sym="cut" enclose="paren"/>
                  </scoreDef>
                  <measure right="end" n="1">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="a" />
                              <note dur="8" oct="4" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
  <summary>MEI for example 2</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Complex meter signature examples</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2021-06-14">2021-06-14</date>
            <pubPlace>
               <ref target="https://github.com/rism-digital/verovio/issues/2271" />
            </pubPlace>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio renders .</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.5.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <label>Flute</label>
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig enclose="paren" count="2+3" unit="8" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSig enclose="paren" count="2+3+4" unit="8" />
                  </scoreDef>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSig enclose="paren" count="2+3+4+5" unit="8" />
                  </scoreDef>
                  <measure right="dbl" n="3">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                              <note dur="8" oct="5" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSigGrp func="mixed">
                        <meterSig enclose="paren" count="1" unit="4" />
                        <meterSig enclose="paren" count="3" unit="8" />
                     </meterSigGrp>
                  </scoreDef>
                  <measure n="4">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSigGrp func="mixed">
                        <meterSig enclose="paren" count="1" unit="4" />
                        <meterSig enclose="paren" count="3" unit="8" />
                        <meterSig enclose="paren" count="2" unit="4" />
                     </meterSigGrp>
                  </scoreDef>
                  <measure n="5">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSigGrp func="mixed">
                        <meterSig enclose="paren" count="1" unit="4" />
                        <meterSig enclose="paren" count="3" unit="8" />
                        <meterSig enclose="paren" count="2" unit="4" />
                        <meterSig enclose="paren" count="5" unit="8" />
                     </meterSigGrp>
                  </scoreDef>
                  <measure right="dbl" n="6">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                              <note dur="8" oct="5" pname="e" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                     <meterSigGrp func="interchanging">
                        <meterSig enclose="paren" count="2" unit="4" />
                        <meterSig enclose="paren" count="3" unit="4" enclose="paren" />
                     </meterSigGrp>
                  </scoreDef>
                  <measure n="7">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end" n="8">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="4" pname="g" />
                              <note dur="8" oct="4" pname="b" />
                              <note dur="8" oct="5" pname="c" />
                              <note dur="8" oct="5" pname="d">
                                 <accid accid="s" />
                              </note>
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
