### PR TITLE
Add PAE validation

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -189,6 +189,7 @@ $exports .= "'_vrvToolkit_renderToSVG',";
 $exports .= "'_vrvToolkit_renderToTimemap',";
 $exports .= "'_vrvToolkit_resetXmlIdSeed',";
 $exports .= "'_vrvToolkit_setOptions',";
+$exports .= "'_vrvToolkit_validatePAE',";
 $exports .= "'_malloc',";
 $exports .= "'_free'";
 $exports .= "]\"";

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -105,6 +105,9 @@ verovio.vrvToolkit.resetXmlIdSeed = Module.cwrap( 'vrvToolkit_resetXmlIdSeed', n
 // void setOptions(Toolkit *ic, const char *options) 
 verovio.vrvToolkit.setOptions = Module.cwrap( 'vrvToolkit_setOptions', null, ['number', 'string'] );
 
+// char *validatePAE(Toolkit *ic, const char *options)
+verovio.vrvToolkit.validatePAE = Module.cwrap( 'vrvToolkit_validatePAE', 'string', ['number', 'string'] );
+
 // A pointer to the object - only one instance can be created for now
 verovio.instances = [];
 
@@ -318,6 +321,15 @@ verovio.toolkit.prototype.resetXmlIdSeed = function ( seed )
 verovio.toolkit.prototype.setOptions = function ( options )
 {
     verovio.vrvToolkit.setOptions( this.ptr, JSON.stringify( options ) );
+};
+
+verovio.toolkit.prototype.validatePAE = function ( data )
+{
+    if ( data instanceof Object )
+    {
+        data = JSON.stringify( data )
+    }
+    return JSON.parse( verovio.vrvToolkit.validatePAE( this.ptr, data ) );
 };
 
 /***************************************************************************************************************************/

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -510,6 +510,13 @@ public:
     PAEInput(Doc *doc);
     virtual ~PAEInput();
 
+    /**
+     * Return a JSON object with the validation log
+     * It is a single object when an input error is encountered.
+     * Otherwise, validation log errors/warnings are listed in their respective JSON input keys
+     */
+    jsonxx::Object GetValidationLog();
+
 #ifndef NO_PAE_SUPPORT
     virtual bool Import(const std::string &input);
 
@@ -679,6 +686,19 @@ private:
     bool m_hasKeySig;
     bool m_hasMeterSig;
     bool m_hasMensur;
+    ///@}
+
+    /**
+     * @name The jsonxx members to store the validation logs
+     * ScoreDef and input members are single objects that can log one entry
+     * Data is an array that can store multiple entries
+     */
+    ///@{
+    jsonxx::Object m_clefLog;
+    jsonxx::Object m_keysigLog;
+    jsonxx::Object m_timesigLog;
+    jsonxx::Object m_inputLog;
+    jsonxx::Array m_dataLog;
     ///@}
 };
 

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -164,6 +164,30 @@ public:
     bool LoadZipDataBuffer(const unsigned char *data, int length);
 
     /**
+     * Validate the Plaine and Easie file from the file system.
+     *
+     * The method calls Toolkit::ValidatePAE.
+     * This methods is not available in the JavaScript version of the toolkit.
+     *
+     * @param filename The filename to be validated
+     * @return A stringified JSON object with the validation warnings or errors
+     */
+    std::string ValidatePAEFile(const std::string &filename);
+
+    /**
+     * Validate the Plaine and Easie code passed in the string data.
+     *
+     * A single JSON object is returned when there is a global input error.
+     * When reading the input succeeds, validation is grouped by input keys.
+     * The methods always returns errors in PAE pedantic mode.
+     * No data remains loaded after the validation.
+     *
+     * @param data A string with the data in JSON or with PAE `@` keys
+     * @return A stringified JSON object with the validation warnings or errors
+     */
+    std::string ValidatePAE(const std::string &data);
+
+    /**
      * Return the number of pages in the loaded document
      *
      * The number of pages depends one the page size and if encoded layout was taken into account or not.

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2227,7 +2227,7 @@ namespace pae {
     enum status_CHORD { CHORD_NONE = 0, CHORD_MARKER, CHORD_NOTE };
 
     // specific positions with negative numbers
-    enum { UNKOWN_POS = -1, KEYSIG_POS = -2, CLEF_POS = -3, TIMESIG_POS = -4 };
+    enum { UNKOWN_POS = -1, KEYSIG_POS = -2, CLEF_POS = -3, TIMESIG_POS = -4, INPUT_POS = -5 };
 
     Token::Token(char c, int position, Object *object)
     {
@@ -2280,10 +2280,56 @@ void PAEInput::ClearTokenObjects()
     m_pae.clear();
 }
 
+jsonxx::Object PAEInput::GetValidationLog()
+{
+    jsonxx::Object log;
+    // If we have an input error, that is the only one to log
+    if (!m_inputLog.empty()) {
+        log = m_inputLog;
+        return log;
+    }
+    if (!m_keysigLog.empty()) log << "keysig" << m_keysigLog;
+    if (!m_clefLog.empty()) log << "clef" << m_clefLog;
+    if (!m_timesigLog.empty()) log << "timesig" << m_timesigLog;
+    if (!m_dataLog.empty()) log << "data" << m_dataLog;
+    // LogDebug("%s", log.json().c_str());
+    return log;
+}
+
 #ifndef NO_PAE_SUPPORT
 
 void PAEInput::LogPAE(std::string msg, pae::Token &token)
 {
+    jsonxx::Object logEntry;
+    // Row is always 0
+    logEntry << "row" << 0;
+    int column = 0;
+    switch (token.m_position) {
+        case pae::KEYSIG_POS:
+        case pae::CLEF_POS:
+        case pae::TIMESIG_POS:
+        case pae::INPUT_POS: column = 0; break;
+        // Putting -1 when the position is unknown - maybe this could cause problems for tools that use it?
+        case pae::UNKOWN_POS: column = -1; break;
+        default: column = token.m_position;
+    }
+    logEntry << "column" << column;
+    logEntry << "text" << msg;
+    // Input log entry are always and error, include in non-pedantic mode because parsing fails and stops
+    std::string logType = (m_pedanticMode || token.m_position == pae::INPUT_POS) ? "error" : "warning";
+    logEntry << "type" << logType;
+
+    switch (token.m_position) {
+        case pae::KEYSIG_POS: m_keysigLog = logEntry; break;
+        case pae::CLEF_POS: m_clefLog = logEntry; break;
+        case pae::TIMESIG_POS: m_timesigLog = logEntry; break;
+        case pae::INPUT_POS: m_inputLog = logEntry; break;
+        // Other log entries go in the 'data' array
+        default: m_dataLog << logEntry;
+    }
+
+    // LogDebug("%s", m_validationLog.json().c_str());
+
     m_hasErrors = true;
     token.m_isError = true;
     std::string posStr;
@@ -2291,6 +2337,7 @@ void PAEInput::LogPAE(std::string msg, pae::Token &token)
         case pae::KEYSIG_POS: posStr = posStr = "(keysig input key)"; break;
         case pae::CLEF_POS: posStr = "(clef input key)"; break;
         case pae::TIMESIG_POS: posStr = "(timesig input key)"; break;
+        case pae::INPUT_POS: posStr = "(global input error)"; break;
         case pae::UNKOWN_POS: posStr = "(unspecified position)"; break;
         default: posStr = StringFormat("(character %d)", token.m_position);
     }
@@ -2431,17 +2478,25 @@ bool PAEInput::Import(const std::string &input)
 {
     this->ClearTokenObjects();
 
+    m_inputLog.reset();
+    m_keysigLog.reset();
+    m_clefLog.reset();
+    m_timesigLog.reset();
+    m_dataLog.reset();
+
     m_hasErrors = false;
 
     if (input.size() == 0) {
-        LogError("PAE: Input is empty");
+        pae::Token inputToken(0, pae::INPUT_POS);
+        LogPAE("Input is empty", inputToken);
         return false;
     }
 
     jsonxx::Object jsonInput;
     if (input.at(0) == '{') {
         if (!jsonInput.parse(input)) {
-            LogError("PAE: Cannot parse the JSON input");
+            pae::Token inputToken(0, pae::INPUT_POS);
+            LogPAE("Cannot parse the JSON input", inputToken);
             return false;
         }
     }
@@ -2499,7 +2554,8 @@ bool PAEInput::Import(const std::string &input)
 
     // No data - we can stop here
     if (!jsonInput.has<jsonxx::String>("data")) {
-        LogError("PAE: No 'data' key in the JSON input");
+        pae::Token inputToken(0, pae::INPUT_POS);
+        LogPAE("No 'data' key in the JSON input", inputToken);
         return false;
     }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -778,6 +778,24 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
     return output;
 }
 
+std::string Toolkit::ValidatePAEFile(const std::string &filename)
+{
+    std::ifstream inFile;
+    inFile.open(filename);
+
+    std::stringstream sstream;
+    sstream << inFile.rdbuf();
+    return this->ValidatePAE(sstream.str());
+}
+
+std::string Toolkit::ValidatePAE(const std::string &data)
+{
+    PAEInput input(&m_doc);
+    input.Import(data);
+    m_doc.Reset();
+    return input.GetValidationLog().json();
+}
+
 bool Toolkit::SaveFile(const std::string &filename, const std::string &jsonOptions)
 {
     std::string output = GetMEI(jsonOptions);

--- a/tools/c_wrapper.cpp
+++ b/tools/c_wrapper.cpp
@@ -264,4 +264,11 @@ void vrvToolkit_setOptions(void *tkPtr, const char *options)
     }
 }
 
+const char *vrvToolkit_validatePAE(void *tkPtr, const char *data)
+{
+    Toolkit *tk = static_cast<Toolkit *>(tkPtr);
+    tk->SetCString(tk->ValidatePAE(data));
+    return tk->GetCString();
+}
+
 } // extern C

--- a/tools/c_wrapper.h
+++ b/tools/c_wrapper.h
@@ -47,6 +47,7 @@ void vrvToolkit_redoPagePitchPosLayout(void *tkPtr);
 const char *vrvToolkit_renderData(void *tkPtr, const char *data, const char *options);
 void vrvToolkit_resetXmlIdSeed(void *tkPtr, int seed);
 void vrvToolkit_setOptions(void *tkPtr, const char *options);
+const char *vrvToolkit_validatePAE(void *tkPtr, const char *data);
 
 #ifdef __cplusplus
 } // extern C


### PR DESCRIPTION
#### PAE Validation

The toolkit can be used to validate Plaine & Easie input data with the `ValidatePAE` or `ValidatePAEFile` methods. The methods load the PAE data passed as a string or from a file respectively. They both return a stringified JSON object with validation error or warning messages.

The JSON object can contain one or more validation messages. When a global input error is encountered (e.g, `data` is missing in the input), a single object is returned. Otherwise, the object is structured with keys corresponding to the JSON input keys (`clef`, `keysig`, `timesig` and `data`). Each key can have one single validation message, except for `data` that contains an array of one or more messages. Only keys for which a validation message is given will exist in the validation object. In non-pendantic mode, syntax problems are marked as `warning` as long as parsing can continue.

Each validation message is structured as follow:
```json
{
  "column": 0,
  "row": 0,
  "text": "A description of the validation problem",
  "type": "error"
}
```

* The `column` indicates the position where the problem occurs in the input string. It is always `0` for `clef`, `keysig` and `timesig`. It can be `-1` in `data` when no position can be indicated.
* The `row` is always `0`.
* The `type` can be `error` or `warning`.

Here is an example of invalid input data and the object returned by the validation call:
```json
{ 
    "clef": "GG2",
    "keysig": "bB",
    "data": "=1/4-''DC'tB/''tCC"
}
```

```json
{
  "clef": {
    "column": 0,
    "row": 0,
    "text": "Unexpected second character in clef sign",
    "type": "warning"
  },
  "data": [
    {
      "column": 10,
      "row": 0,
      "text": "Invalid t not after a note",
      "type": "warning"
    },
    {
      "column": 15,
      "row": 0,
      "text": "Invalid t not after a note",
      "type": "warning"
    }
  ]
}
```
