### PR TITLE
Check for missing staffDef

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3282,12 +3282,6 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
     // This actually sets the Doc::m_scoreDef
     bool success = ReadScoreDef(vrvScore, scoreDef);
 
-    // Missing staffDefs lead to crashes in the ScoreDefSetCurrent functor
-    if (success && !vrvScore->GetScoreDef()->FindDescendantByType(STAFFDEF)) {
-        LogError("The initial <scoreDef> of each <score> must contain at least one <staffDef>.");
-        success = false;
-    }
-
     if (!success) return false;
 
     pugi::xml_node current;
@@ -3895,6 +3889,7 @@ bool MEIInput::ReadStaffGrpChildren(Object *parent, pugi::xml_node parentNode)
     assert(dynamic_cast<StaffGrp *>(parent) || dynamic_cast<EditorialElement *>(parent));
 
     bool success = true;
+    bool missingStaffDef = true;
     pugi::xml_node current;
     for (current = parentNode.first_child(); current; current = current.next_sibling()) {
         if (!success) break;
@@ -3917,9 +3912,11 @@ bool MEIInput::ReadStaffGrpChildren(Object *parent, pugi::xml_node parentNode)
         }
         else if (std::string(current.name()) == "staffGrp") {
             success = ReadStaffGrp(parent, current);
+            missingStaffDef = false; // innermost staffGrp child will report missing staffDef
         }
         else if (std::string(current.name()) == "staffDef") {
             success = ReadStaffDef(parent, current);
+            missingStaffDef = false;
         }
         // xml comment
         else if (std::string(current.name()) == "") {
@@ -3929,6 +3926,13 @@ bool MEIInput::ReadStaffGrpChildren(Object *parent, pugi::xml_node parentNode)
             LogWarning("Unsupported '<%s>' within <staffGrp>", current.name());
         }
     }
+
+    // Missing staffDefs lead to crashes in the ScoreDefSetCurrent functor
+    if (success && missingStaffDef) {
+        LogError("Each <staffGrp> must contain at least one <staffDef>.");
+        success = false;
+    }
+
     return success;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3851,6 +3851,13 @@ bool MEIInput::ReadScoreDefChildren(Object *parent, pugi::xml_node parentNode)
             LogWarning("Unsupported '<%s>' within <scoreDef>", current.name());
         }
     }
+
+    // Missing staffDefs lead to crashes in the ScoreDefSetCurrent functor
+    if ((parent->Is(SCOREDEF)) && (!parent->FindDescendantByType(STAFFDEF))) {
+        LogError("Each <scoreDef> must contain at least one <staffDef>.");
+        return false;
+    }
+
     return success;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3282,6 +3282,12 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
     // This actually sets the Doc::m_scoreDef
     bool success = ReadScoreDef(vrvScore, scoreDef);
 
+    // Missing staffDefs lead to crashes in the ScoreDefSetCurrent functor
+    if (success && !vrvScore->GetScoreDef()->FindDescendantByType(STAFFDEF)) {
+        LogError("The initial <scoreDef> of each <score> must contain at least one <staffDef>.");
+        success = false;
+    }
+
     if (!success) return false;
 
     pugi::xml_node current;
@@ -3851,13 +3857,6 @@ bool MEIInput::ReadScoreDefChildren(Object *parent, pugi::xml_node parentNode)
             LogWarning("Unsupported '<%s>' within <scoreDef>", current.name());
         }
     }
-
-    // Missing staffDefs lead to crashes in the ScoreDefSetCurrent functor
-    if ((parent->Is(SCOREDEF)) && (!parent->FindDescendantByType(STAFFDEF))) {
-        LogError("Each <scoreDef> must contain at least one <staffDef>.");
-        return false;
-    }
-
     return success;
 }
 


### PR DESCRIPTION
Verovio crashes when using staves with missing staffDef. This PR adds a simple check for `<staffGrp>` to ensure that it contains at least one `<staffDef>`.