### PR TITLE
Rehearsal break positioning

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1140,6 +1140,11 @@ public:
     virtual int ResetDrawing(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Resolve Reh time pointing position in case none is set
+     */
+    virtual int ResolveRehPosition(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Go through all layer elements of the layer and return next/previous element relative to the specified
      * layer element. It will search recursively through children elements until note, chord or ftrem is found.
      * It can be used to look in neighboring layers for the similar search, but only first element will be checked.

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -60,6 +60,11 @@ public:
     // Functors //
     //----------//
 
+    /**
+     * See Object::ResolveRehPosition
+     */
+    virtual int ResolveRehPosition(FunctorParams *params);
+
 protected:
     //
 private:

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -537,6 +537,11 @@ void Doc::PrepareDrawing()
 
     /************ Resolve @starid (only) ************/
 
+    // Resolve <reh> elements first, since they can be encoded without @startid or @tstamp, but we need one internally
+    // for placement
+    Functor resolveRehPosition(&Object::ResolveRehPosition);
+    this->Process(&resolveRehPosition, NULL);
+
     // Try to match all time pointing elements (tempo, fermata, etc) by processing backwards
     PrepareTimePointingParams prepareTimePointingParams;
     Functor prepareTimePointing(&Object::PrepareTimePointing);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2270,7 +2270,6 @@ void MusicXmlInput::ReadMusicXmlDirection(
         const std::string lang = rehearsal.attribute("xml:lang") ? rehearsal.attribute("xml:lang").as_string() : "it";
         const std::string textStr = GetContent(rehearsal);
         reh->SetColor(rehearsal.attribute("color").as_string());
-        reh->SetTstamp(timeStamp);
         int staffNum = staffNode.text().as_int() + staffOffset;
         staffNum = (staffNum < 1) ? 1 : staffNum;
         reh->SetStaff(reh->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(staffNum)));
@@ -2278,7 +2277,8 @@ void MusicXmlInput::ReadMusicXmlDirection(
         Rend *rend = new Rend();
         rend->SetFontweight(rend->AttTypography::StrToFontweight(rehearsal.attribute("font-weight").as_string()));
         rend->SetHalign(rend->AttHorizontalAlign::StrToHorizontalalignment(halign));
-        rend->SetRend(ConvertEnclosure(rehearsal.attribute("enclosure").as_string()));
+        const std::string enclosure = rehearsal.attribute("enclosure").as_string();
+        rend->SetRend(enclosure.empty() ? TEXTRENDITION_box : ConvertEnclosure(enclosure));
         Text *text = new Text();
         text->SetText(UTF8to16(textStr));
         rend->AddChild(text);

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "editorial.h"
+#include "measure.h"
 #include "text.h"
 #include "verticalaligner.h"
 #include "vrv.h"
@@ -71,7 +72,8 @@ bool Reh::IsSupportedChild(Object *child)
 int Reh::ResolveRehPosition(FunctorParams *)
 {
     if (!this->HasStart() && !this->HasTstamp()) {
-        this->SetTstamp(0.0);
+        Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
+        if (measure->GetLeftBarLine()) this->SetStart(measure->GetLeftBarLine());
     }
 
     return FUNCTOR_SIBLINGS;

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -64,4 +64,17 @@ bool Reh::IsSupportedChild(Object *child)
     return true;
 }
 
+//----------------------------------------------------------------------------
+// Reh functor methods
+//----------------------------------------------------------------------------
+
+int Reh::ResolveRehPosition(FunctorParams *)
+{
+    if (!this->HasStart() && !this->HasTstamp()) {
+        this->SetTstamp(0.0);
+    }
+
+    return FUNCTOR_SIBLINGS;
+}
+
 } // namespace vrv

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2100,7 +2100,10 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
     TextDrawingParams params;
 
     params.m_x = reh->GetStart()->GetDrawingX();
-    if ((system->GetFirst(MEASURE) == measure) && reh->HasTstamp() && (reh->GetTstamp() == 0.0)) {
+    const bool adjustPosition = ((reh->HasTstamp() && (reh->GetTstamp() == 0.0))
+        || (reh->GetStart()->Is(BARLINE)
+            && vrv_cast<BarLine *>(reh->GetStart())->GetPosition() == BarLinePosition::Left));
+    if ((system->GetFirst(MEASURE) == measure) && adjustPosition) {
         // StaffDef information is always in the first layer
         Layer *layer = dynamic_cast<Layer *>(measure->FindDescendantByType(LAYER));
         assert(layer);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -19,6 +19,7 @@
 #include "bboxdevicecontext.h"
 #include "bracketspan.h"
 #include "breath.h"
+#include "clef.h"
 #include "comparison.h"
 #include "devicecontext.h"
 #include "dir.h"
@@ -2099,6 +2100,15 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
     TextDrawingParams params;
 
     params.m_x = reh->GetStart()->GetDrawingX();
+
+    if ((system->GetFirst(MEASURE) == measure) && !system->IsFirstOfMdiv()) {
+        // StaffDef information is always in the first layer
+        Layer *layer = dynamic_cast<Layer *>(measure->FindDescendantByType(LAYER));
+        assert(layer);
+        if (Clef *clef = layer->GetStaffDefClef(); clef) {
+            params.m_x = clef->GetDrawingX() + (clef->GetContentRight() - clef->GetContentLeft()) / 2;
+        }
+    }
 
     data_HORIZONTALALIGNMENT alignment = reh->GetChildRendAlignment();
     // Rehearsal marks are center aligned by default;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2100,13 +2100,19 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
     TextDrawingParams params;
 
     params.m_x = reh->GetStart()->GetDrawingX();
-
-    if ((system->GetFirst(MEASURE) == measure) && !system->IsFirstOfMdiv()) {
+    if ((system->GetFirst(MEASURE) == measure) && reh->HasTstamp() && (reh->GetTstamp() == 0.0)) {
         // StaffDef information is always in the first layer
         Layer *layer = dynamic_cast<Layer *>(measure->FindDescendantByType(LAYER));
         assert(layer);
-        if (Clef *clef = layer->GetStaffDefClef(); clef) {
-            params.m_x = clef->GetDrawingX() + (clef->GetContentRight() - clef->GetContentLeft()) / 2;
+        if (!system->IsFirstOfMdiv()) {
+            if (Clef *clef = layer->GetStaffDefClef(); clef) {
+                params.m_x = clef->GetDrawingX() + (clef->GetContentRight() - clef->GetContentLeft()) / 2;
+            }
+        }
+        else {
+            if (MeterSig *metersig = layer->GetStaffDefMeterSig(); metersig) {
+                params.m_x = metersig->GetDrawingX() + (metersig->GetContentRight() - metersig->GetContentLeft()) / 2;
+            }
         }
     }
 
@@ -2122,7 +2128,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         }
 
         params.m_boxedRend.clear();
-        params.m_y = reh->GetDrawingY();
+        params.m_y = reh->GetDrawingY() + 3 * m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize);
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
         rehTxt.SetPointSize(params.m_pointSize);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -43,6 +43,7 @@
 #include "page.h"
 #include "pageboundary.h"
 #include "pageelement.h"
+#include "reh.h"
 #include "smufl.h"
 #include "staff.h"
 #include "staffdef.h"
@@ -976,7 +977,10 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
 
     if (m_drawingScoreDef.GetMnumVisible() != BOOLEAN_false) {
         MNum *mnum = dynamic_cast<MNum *>(measure->FindDescendantByType(MNUM));
-        if (mnum) {
+        Reh *reh = dynamic_cast<Reh *>(measure->FindDescendantByType(REH));
+        const bool hasRehearsal
+            = reh && reh->HasTstamp() && (0.0 == reh->GetTstamp() && (system->GetFirst(MEASURE) == measure));
+        if (mnum && !hasRehearsal) {
             // this should be an option
             Measure *systemStart = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE));
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -978,8 +978,7 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
     if (m_drawingScoreDef.GetMnumVisible() != BOOLEAN_false) {
         MNum *mnum = dynamic_cast<MNum *>(measure->FindDescendantByType(MNUM));
         Reh *reh = dynamic_cast<Reh *>(measure->FindDescendantByType(REH));
-        const bool hasRehearsal
-            = reh && reh->HasTstamp() && (0.0 == reh->GetTstamp() && (system->GetFirst(MEASURE) == measure));
+        const bool hasRehearsal = reh && reh->HasTstamp() && (0.0 == reh->GetTstamp());
         if (mnum && !hasRehearsal) {
             // this should be an option
             Measure *systemStart = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE));

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -978,7 +978,10 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
     if (m_drawingScoreDef.GetMnumVisible() != BOOLEAN_false) {
         MNum *mnum = dynamic_cast<MNum *>(measure->FindDescendantByType(MNUM));
         Reh *reh = dynamic_cast<Reh *>(measure->FindDescendantByType(REH));
-        const bool hasRehearsal = reh && reh->HasTstamp() && (0.0 == reh->GetTstamp());
+        const bool hasRehearsal = reh
+            && ((reh->HasTstamp() && (reh->GetTstamp() == 0.0))
+                || (reh->GetStart()->Is(BARLINE)
+                    && vrv_cast<BarLine *>(reh->GetStart())->GetPosition() == BarLinePosition::Left));
         if (mnum && !hasRehearsal) {
             // this should be an option
             Measure *systemStart = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE));


### PR DESCRIPTION
- following MEI documentation removed requirement for `<reh>` @timestamp or @startid - if neither is provided, then it will be placed above barline (i.e. we'll assing timestamp of 0.0 to it);
- adjusted default enclosure for MusicXML element `<rehearsal>` to be `box` if not set otherwise;
- in first measure after system break `<reh>` is going to be placed above clef
- would override measure numbering if they coincide (e.g. with`--mnum-interval`)

Example without `<sb>`:
![image](https://user-images.githubusercontent.com/1819669/133647108-5e44dd44-9e2a-4706-b4e7-266e0c59775f.png)

with `<sb>`:
![image](https://user-images.githubusercontent.com/1819669/133647173-b8532697-4118-4926-ac38-bb514dd71392.png)

