### PR TITLE
New slur adjustment algorithm

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -191,6 +191,11 @@ public:
     static Point CalcPositionAfterRotation(Point point, float alpha, Point center);
 
     /**
+     * Calculate the t parameter of a bezier at position x
+     */
+    static double CalcBezierParamAtPosition(const Point bezier[4], int x);
+
+    /**
      * Calculate the y position of a bezier at position x
      */
     static int CalcBezierAtPosition(const Point bezier[4], int x);

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -230,7 +230,7 @@ public:
      * @name Getter/setter for control point offset (as well as method to calculate it from options)
      */
     ///@{
-    void CalculateControlPointOffset(Doc *doc, int staffSize);
+    void CalculateControlPointOffset(Doc *doc);
     void SetControlPointOffset(int controlPointOffset)
     {
         m_leftControlPointOffset = m_rightControlPointOffset = controlPointOffset;
@@ -252,9 +252,11 @@ public:
     int GetRightControlHeight() const { return m_rightControlHeight; }
     ///@}
 
+    // Calculate control point offset and height from points
+    void UpdateControlPointParameters(curvature_CURVEDIR dir);
+
 private:
     // Control point X-axis offset for both start/end points
-    // In future, when more complex shapes are required, this should probably be changed to left/right offsets
     int m_leftControlPointOffset = 0;
     int m_rightControlPointOffset = 0;
     int m_leftControlHeight = 0;

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -231,7 +231,6 @@ public:
      * @name Getter/setter for control point offset (as well as method to calculate it from options)
      */
     ///@{
-    void CalculateControlPointOffset(Doc *doc);
     void SetControlPointOffset(int controlPointOffset)
     {
         m_leftControlPointOffset = m_rightControlPointOffset = controlPointOffset;
@@ -252,6 +251,11 @@ public:
     int GetLeftControlHeight() const { return m_leftControlHeight; }
     int GetRightControlHeight() const { return m_rightControlHeight; }
     ///@}
+
+    /**
+     * @name Initialize control point height and offset from end point positions
+     */
+    void CalcInitialControlPointParams(Doc *doc, float angle, int staffSize);
 
     /**
      * Calculate control point offset and height from points or vice versa

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -18,7 +18,6 @@
 namespace vrv {
 
 class Doc;
-class FloatingCurvePositioner;
 
 #define AxNONE -1
 #define AxWHITE 255 << 16 | 255 << 8 | 255
@@ -264,9 +263,6 @@ public:
     void UpdateControlPointParams(curvature_CURVEDIR dir);
     void UpdateControlPoints(curvature_CURVEDIR dir);
     ///@}
-
-    // Copy points from bezier curve to floating positioner
-    void CopyPointsTo(FloatingCurvePositioner *curve) const;
 
 private:
     // Control point X-axis offset for both start/end points

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -18,6 +18,7 @@
 namespace vrv {
 
 class Doc;
+class FloatingCurvePositioner;
 
 #define AxNONE -1
 #define AxWHITE 255 << 16 | 255 << 8 | 255
@@ -252,8 +253,16 @@ public:
     int GetRightControlHeight() const { return m_rightControlHeight; }
     ///@}
 
-    // Calculate control point offset and height from points
-    void UpdateControlPointParameters(curvature_CURVEDIR dir);
+    /**
+     * Calculate control point offset and height from points or vice versa
+     */
+    ///@{
+    void UpdateControlPointParams(curvature_CURVEDIR dir);
+    void UpdateControlPoints(curvature_CURVEDIR dir);
+    ///@}
+
+    // Copy points from bezier curve to floating positioner
+    void CopyPointsTo(FloatingCurvePositioner *curve) const;
 
 private:
     // Control point X-axis offset for both start/end points

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -282,9 +282,12 @@ public:
 
     /**
      * Update the curve parameters.
-     * Stored points are made relative to the curve darwingY.
+     * Stored points are made relative to the curve drawingY.
      */
+    ///@{
     void UpdateCurveParams(const Point points[4], float angle, int thickness, curvature_CURVEDIR curveDir);
+    void UpdatePoints(const BezierCurve &bezier);
+    ///@}
 
     /**
      * Moves bounding points vertically by a specified distance downward

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -217,7 +217,7 @@ public:
      */
     ///@{
     int GetDrawingYRel() const { return m_drawingYRel; }
-    virtual void SetDrawingYRel(int drawingYRel);
+    virtual void SetDrawingYRel(int drawingYRel, bool force = false);
     int GetDrawingXRel() const { return m_drawingXRel; }
     virtual void SetDrawingXRel(int drawingXRel);
     ///@}

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -301,7 +301,12 @@ public:
      * Calculate the adjustment needed for an element for the curve not to overlap with it.
      * Discard will be true if the element already fits.
      */
+    ///@{
     int CalcAdjustment(BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
+    // Refined version that returns the adjustments on the left and right hand side of the bounding box
+    std::pair<int, int> CalcLeftRightAdjustment(
+        BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
+    ///@}
 
     /**
      * @name Getters for the current parameters

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -495,22 +495,19 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: a flag indicating that at least one slur had to be adjusted
- * member 1: a flag indicating that there is at least one cross-staff slur
- * member 2: the doc
- * member 3: a pointer to the functor for passing it to the system aligner
+ * member 0: a flag indicating that there is at least one cross-staff slur
+ * member 1: the doc
+ * member 2: a pointer to the functor for passing it to the system aligner
  **/
 
 class AdjustSlursParams : public FunctorParams {
 public:
     AdjustSlursParams(Doc *doc, Functor *functor)
     {
-        m_adjusted = false;
         m_crossStaffSlurs = false;
         m_doc = doc;
         m_functor = functor;
     }
-    bool m_adjusted;
     bool m_crossStaffSlurs;
     Doc *m_doc;
     Functor *m_functor;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -111,6 +111,19 @@ private:
     void AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int unit);
     ///@}
 
+    /**
+     * Low level helper functions for slur adjustment
+     */
+    ///@{
+    // Shift end points for collisions nearby
+    void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection) const;
+
+    // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis
+    // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:
+    // tan(atan(doublingBound) + degrees * PI / 180.0) ≈ 2.0 * doublingBound
+    double RotateSlope(double slope, double degrees, double doublingBound, bool upwards) const;
+    ///@}
+
 public:
     //
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -56,8 +56,7 @@ public:
 
     bool AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 
-    int AdjustSlurCurve(Doc *doc, const ArrayOfCurveSpannedElements *spannedElements, BezierCurve &bezierCurve,
-        curvature_CURVEDIR curveDir, float angle, int staffSize, bool posRatio = true);
+    void AdjustControlPointHeight(Doc *doc, BezierCurve &bezierCurve, int staffSize);
 
     /**
      * Adjust slur position based on overlapping objects within its spanning elements
@@ -72,8 +71,6 @@ public:
 
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints);
     void GetControlPoints(BezierCurve &curve, curvature_CURVEDIR curveDir, bool ignoreAngle = false);
-    void GetSpannedPointPositions(Doc *doc, const ArrayOfCurveSpannedElements *spannedElements, Point p1, float angle,
-        curvature_CURVEDIR curveDir, int staffSize);
 
     //----------//
     // Functors //

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -81,6 +81,11 @@ public:
      */
     virtual int ResetDrawing(FunctorParams *functorParams);
 
+    /**
+     * See Object::AdjustCrossStaffContent
+     */
+    virtual int AdjustCrossStaffContent(FunctorParams *functorParams);
+
 private:
     //
 public:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -90,6 +90,9 @@ private:
      * Adjust slur position based on overlapping objects within its spanning elements
      */
     ///@{
+    // Discard certain spanned elements
+    void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -97,7 +97,8 @@ private:
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the horizontal control point offset
-    std::tuple<bool, int, int> CalcControlPointOffset(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve);
+    std::tuple<bool, int, int> CalcControlPointOffset(
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical control point shift
     std::pair<int, int> CalcControlPointVerticalShift(

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -14,9 +14,13 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
-// CPInequality
+// ControlPointConstraint
 //----------------------------------------------------------------------------
-struct CPInequality {
+/**
+ * This represents a constraint ax + by >= c where x and y are
+ * vertical control point adjustments
+ */
+struct ControlPointConstraint {
     double a;
     double b;
     double c;
@@ -67,18 +71,7 @@ public:
 
     void AdjustControlPointHeight(Doc *doc, BezierCurve &bezierCurve, float angle, int staffSize);
 
-    /**
-     * Adjust slur position based on overlapping objects within its spanning elements
-     */
-    void AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve);
-
-    std::pair<int, int> CalcEndShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
-    std::tuple<bool, int, int> CalcCPOffset(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve);
-    std::pair<int, int> CalcCPVerticalShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
-    std::pair<int, int> SolveCPConstraints(const std::list<CPInequality> &constraints);
-
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints);
-    void GetControlPoints(BezierCurve &curve, curvature_CURVEDIR curveDir, bool ignoreAngle = false);
 
     //----------//
     // Functors //
@@ -95,7 +88,26 @@ public:
     virtual int AdjustCrossStaffContent(FunctorParams *functorParams);
 
 private:
-    //
+    /**
+     * Adjust slur position based on overlapping objects within its spanning elements
+     */
+    ///@{
+    void AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve);
+
+    // Calculate the vertical shift of the slur end points
+    std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+
+    // Calculate the horizontal control point offset
+    std::tuple<bool, int, int> CalcControlPointOffset(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve);
+
+    // Calculate the vertical control point shift
+    std::pair<int, int> CalcControlPointVerticalShift(
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+
+    // Solve the constraints for vertical control point adjustment
+    std::pair<int, int> SolveControlPointConstraints(const std::list<ControlPointConstraint> &constraints);
+    ///@}
+
 public:
     //
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -67,9 +67,7 @@ public:
     bool HasDrawingCurvedir() const { return (m_drawingCurvedir != curvature_CURVEDIR_NONE); }
     ///@}
 
-    bool AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
-
-    void AdjustControlPointHeight(Doc *doc, BezierCurve &bezierCurve, float angle, int staffSize);
+    void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints);
 
@@ -92,8 +90,6 @@ private:
      * Adjust slur position based on overlapping objects within its spanning elements
      */
     ///@{
-    void AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve);
-
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -69,7 +69,7 @@ public:
 
     void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 
-    float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints);
+    float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
 
     //----------//
     // Functors //

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -106,6 +106,9 @@ private:
 
     // Solve the constraints for vertical control point adjustment
     std::pair<int, int> SolveControlPointConstraints(const std::list<ControlPointConstraint> &constraints);
+
+    // Improve the slur shape by adjusting the control point heights
+    void AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int unit);
     ///@}
 
 public:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -14,6 +14,15 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
+// CPInequality
+//----------------------------------------------------------------------------
+struct CPInequality {
+    double a;
+    double b;
+    double c;
+};
+
+//----------------------------------------------------------------------------
 // Slur
 //----------------------------------------------------------------------------
 
@@ -56,18 +65,17 @@ public:
 
     bool AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 
-    void AdjustControlPointHeight(Doc *doc, BezierCurve &bezierCurve, int staffSize);
+    void AdjustControlPointHeight(Doc *doc, BezierCurve &bezierCurve, float angle, int staffSize);
 
     /**
      * Adjust slur position based on overlapping objects within its spanning elements
      */
-    bool AdjustSlurPosition(
-        Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve, float &angle, bool forceBothSides);
-    /**
-     * Calculate slur left/right maximum shifts required for slur not to overlap with other objects
-     */
-    std::pair<int, int> CalculateAdjustedSlurShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
-        int margin, bool forceBothSides, bool &isNotAdjustable);
+    void AdjustSlurPosition(Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve);
+
+    std::pair<int, int> CalcEndShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+    std::tuple<bool, int, int> CalcCPOffset(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve);
+    std::pair<int, int> CalcCPVerticalShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+    std::pair<int, int> SolveCPConstraints(const std::list<CPInequality> &constraints);
 
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints);
     void GetControlPoints(BezierCurve &curve, curvature_CURVEDIR curveDir, bool ignoreAngle = false);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -714,12 +714,29 @@ pow (t, 3)* bezier[3].y;
 }
 */
 
+double BoundingBox::CalcBezierParamAtPosition(const Point bezier[4], int x)
+{
+    double left = (bezier[0].x <= bezier[3].x) ? 0.0 : 1.0;
+    double right = (bezier[0].x <= bezier[3].x) ? 1.0 : 0.0;
+    for (int i = 0; i < 12; ++i) {
+        const double middle = (left + right) / 2.0;
+        Point p = BoundingBox::CalcDeCasteljau(bezier, middle);
+        if (p.x < x) {
+            left = middle;
+        }
+        else if (p.x > x) {
+            right = middle;
+        }
+        else {
+            return middle;
+        }
+    }
+    return (left + right) / 2.0;
+}
+
 int BoundingBox::CalcBezierAtPosition(const Point bezier[4], int x)
 {
-    double t = 0.0;
-    // avoid division by 0
-    if (bezier[3].x != bezier[0].x) t = (double)(x - bezier[0].x) / (double)(bezier[3].x - bezier[0].x);
-    t = std::min(1.0, std::max(0.0, t));
+    const double t = BoundingBox::CalcBezierParamAtPosition(bezier, x);
 
     Point p = BoundingBox::CalcDeCasteljau(bezier, t);
 

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -17,6 +17,7 @@
 
 #include "boundingbox.h"
 #include "doc.h"
+#include "floatingobject.h"
 #include "glyph.h"
 #include "vrv.h"
 
@@ -32,17 +33,36 @@ void BezierCurve::Rotate(float angle, const Point &rotationPoint)
 
 void BezierCurve::CalculateControlPointOffset(Doc *doc)
 {
-    m_rightControlPointOffset = abs(p2.x - p1.x) / (2.0 + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
+    m_rightControlPointOffset = std::abs(p2.x - p1.x) / (2.0 + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
     m_leftControlPointOffset = m_rightControlPointOffset;
 }
 
-void BezierCurve::UpdateControlPointParameters(curvature_CURVEDIR dir)
+void BezierCurve::UpdateControlPointParams(curvature_CURVEDIR dir)
 {
     m_leftControlPointOffset = c1.x - p1.x;
     m_rightControlPointOffset = p2.x - c2.x;
     const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
     m_leftControlHeight = sign * (c1.y - p1.y);
     m_rightControlHeight = sign * (c2.y - p2.y);
+}
+
+void BezierCurve::UpdateControlPoints(curvature_CURVEDIR dir)
+{
+    c1.x = p1.x + m_leftControlPointOffset;
+    c2.x = p2.x - m_rightControlPointOffset;
+    const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
+    c1.y = p1.y + sign * m_leftControlHeight;
+    c2.y = p2.y + sign * m_rightControlHeight;
+}
+
+void BezierCurve::CopyPointsTo(FloatingCurvePositioner *curve) const
+{
+    Point points[4];
+    points[0] = p1;
+    points[1] = c1;
+    points[2] = c2;
+    points[3] = p2;
+    curve->UpdateCurveParams(points, curve->GetAngle(), curve->GetThickness(), curve->GetDir());
 }
 
 //----------------------------------------------------------------------------

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -50,7 +50,7 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     int height = std::max<int>(
         doc->GetOptions()->m_slurMinHeight.GetValue() * unit, dist / doc->GetOptions()->m_slurHeightFactor.GetValue());
     height = std::min<int>(doc->GetOptions()->m_slurMaxHeight.GetValue() * unit, height);
-    height *= sqrt(doc->GetOptions()->m_slurCurveFactor.GetValue()) / 2.0;
+    height *= sqrt(doc->GetOptions()->m_slurCurveFactor.GetValue()) / 3.0;
     height = std::min(height, 2 * doc->GetDrawingOctaveSize(staffSize));
     height = std::min<int>(height, 2 * offset * cos(angle));
     this->SetControlHeight(height);

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -36,7 +36,13 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     const int unit = doc->GetDrawingUnit(staffSize);
 
     // Initialize offset
-    const int offset = dist / (2.0 + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
+    const double ratio = double(dist) / double(unit);
+    double baseVal = (ratio > 4.0) ? 2.0 : 5.0;
+    if ((ratio > 4.0) && (ratio < 32.0)) {
+        // interpolate baseVal between 5.0 and 2.0
+        baseVal = 7.0 - log2(ratio);
+    }
+    const int offset = dist / (baseVal + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
     m_leftControlPointOffset = offset;
     m_rightControlPointOffset = offset;
 
@@ -44,9 +50,9 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     int height = std::max<int>(
         doc->GetOptions()->m_slurMinHeight.GetValue() * unit, dist / doc->GetOptions()->m_slurHeightFactor.GetValue());
     height = std::min<int>(doc->GetOptions()->m_slurMaxHeight.GetValue() * unit, height);
-    height *= sqrt(doc->GetOptions()->m_slurCurveFactor.GetValue()) / 3.0;
+    height *= sqrt(doc->GetOptions()->m_slurCurveFactor.GetValue()) / 2.0;
     height = std::min(height, 2 * doc->GetDrawingOctaveSize(staffSize));
-    height = std::min<int>(height, offset * cos(angle));
+    height = std::min<int>(height, 2 * offset * cos(angle));
     this->SetControlHeight(height);
 }
 

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -17,7 +17,6 @@
 
 #include "boundingbox.h"
 #include "doc.h"
-#include "floatingobject.h"
 #include "glyph.h"
 #include "vrv.h"
 
@@ -67,16 +66,6 @@ void BezierCurve::UpdateControlPoints(curvature_CURVEDIR dir)
     const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
     c1.y = p1.y + sign * m_leftControlHeight;
     c2.y = p2.y + sign * m_rightControlHeight;
-}
-
-void BezierCurve::CopyPointsTo(FloatingCurvePositioner *curve) const
-{
-    Point points[4];
-    points[0] = p1;
-    points[1] = c1;
-    points[2] = c2;
-    points[3] = p2;
-    curve->UpdateCurveParams(points, curve->GetAngle(), curve->GetThickness(), curve->GetDir());
 }
 
 //----------------------------------------------------------------------------

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -30,11 +30,19 @@ void BezierCurve::Rotate(float angle, const Point &rotationPoint)
     c2 = BoundingBox::CalcPositionAfterRotation(c2, angle, rotationPoint);
 }
 
-void BezierCurve::CalculateControlPointOffset(Doc *doc, int staffSize)
+void BezierCurve::CalculateControlPointOffset(Doc *doc)
 {
-    m_rightControlPointOffset = std::min(
-        (p2.x - p1.x) / doc->GetOptions()->m_slurControlPoints.GetValue(), doc->GetDrawingStaffSize(staffSize));
+    m_rightControlPointOffset = abs(p2.x - p1.x) / (2.0 + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
     m_leftControlPointOffset = m_rightControlPointOffset;
+}
+
+void BezierCurve::UpdateControlPointParameters(curvature_CURVEDIR dir)
+{
+    m_leftControlPointOffset = c1.x - p1.x;
+    m_rightControlPointOffset = p2.x - c2.x;
+    const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
+    m_leftControlHeight = sign * (c1.y - p1.y);
+    m_rightControlHeight = sign * (c2.y - p2.y);
 }
 
 //----------------------------------------------------------------------------

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -332,8 +332,11 @@ void FloatingPositioner::SetDrawingYRel(int drawingYRel)
     if (m_place == STAFFREL_above) {
         if (drawingYRel < m_drawingYRel) m_drawingYRel = drawingYRel;
     }
-    else {
+    else if (m_place == STAFFREL_below) {
         if (drawingYRel > m_drawingYRel) m_drawingYRel = drawingYRel;
+    }
+    else {
+        m_drawingYRel = drawingYRel;
     }
 }
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -612,7 +612,7 @@ int FloatingCurvePositioner::CalcAdjustment(BoundingBox *boundingBox, bool &disc
             return 0;
         }
         // Return the maximum adjustment required
-        return std::max(boundingBox->GetTopBy(type) - leftY, boundingBox->GetBottomBy(type) - rightY);
+        return std::max(boundingBox->GetTopBy(type) - leftY, boundingBox->GetTopBy(type) - rightY);
     }
     else {
         // The curve is below the content - if the element needs to be kept inside (e.g. a note), then do not return.

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -326,16 +326,18 @@ void FloatingPositioner::SetDrawingXRel(int drawingXRel)
     m_drawingXRel = drawingXRel;
 }
 
-void FloatingPositioner::SetDrawingYRel(int drawingYRel)
+void FloatingPositioner::SetDrawingYRel(int drawingYRel, bool force)
 {
-    ResetCachedDrawingY();
+    bool setValue = force;
     if (m_place == STAFFREL_above) {
-        if (drawingYRel < m_drawingYRel) m_drawingYRel = drawingYRel;
-    }
-    else if (m_place == STAFFREL_below) {
-        if (drawingYRel > m_drawingYRel) m_drawingYRel = drawingYRel;
+        if (drawingYRel < m_drawingYRel) setValue = true;
     }
     else {
+        if (drawingYRel > m_drawingYRel) setValue = true;
+    }
+
+    if (setValue) {
+        ResetCachedDrawingY();
         m_drawingYRel = drawingYRel;
     }
 }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -517,6 +517,16 @@ void FloatingCurvePositioner::UpdateCurveParams(
     m_cachedMinMaxY = VRV_UNSET;
 }
 
+void FloatingCurvePositioner::UpdatePoints(const BezierCurve &bezier)
+{
+    Point points[4];
+    points[0] = bezier.p1;
+    points[1] = bezier.c1;
+    points[2] = bezier.c2;
+    points[3] = bezier.p2;
+    this->UpdateCurveParams(points, m_angle, m_thickness, m_dir);
+}
+
 void FloatingCurvePositioner::MoveFrontVertical(int distance)
 {
     m_points[0].y += distance;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2272,13 +2272,6 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         if ((this == params->m_interface->GetStart()) || (this == params->m_interface->GetEnd())) {
             return FUNCTOR_CONTINUE;
         }
-        if (params->m_interface->GetStart()->HasDescendant(this)
-            || this->HasDescendant(params->m_interface->GetStart())) {
-            return FUNCTOR_CONTINUE;
-        }
-        if (params->m_interface->GetEnd()->HasDescendant(this) || this->HasDescendant(params->m_interface->GetEnd())) {
-            return FUNCTOR_CONTINUE;
-        }
 
         params->m_elements.push_back(this);
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1252,7 +1252,7 @@ Options::Options()
     this->Register(&m_slurMaxHeight, "slurMaxHeight", &m_generalLayout);
 
     m_slurMaxSlope.SetInfo("Slur max slope", "The maximum slur slope in degrees");
-    m_slurMaxSlope.Init(20, 0, 60);
+    m_slurMaxSlope.Init(40, 0, 80);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);
 
     m_slurEndpointThickness.SetInfo("Slur Endpoint thickness", "The Endpoint slur thickness in MEI units");

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -475,15 +475,12 @@ void Page::LayOutVertically()
     AdjustSlursParams adjustSlursParams(doc, &adjustSlurs);
     this->Process(&adjustSlurs, &adjustSlursParams);
 
-    // If slurs were adjusted we need to redraw to adjust the bounding boxes
-    if (adjustSlursParams.m_adjusted) {
-        // There is a problem here with cross-staff slurs: if they have been adjusted, the
-        // Slur::m_isCrossStaff flag will trigger View::DrawSlurInitial to be called again.
-        // The slur will then remain not adjusted. It will again when AdjustSlurs is called below,
-        // but in between, we can have wrong collisions detections. To be improved
-        view.SetPage(this->GetIdx(), false);
-        view.DrawCurrentPage(&bBoxDC, false);
-    }
+    // There is a problem here with cross-staff slurs: the Slur::m_isCrossStaff flag
+    // will trigger View::DrawSlurInitial to be called again.
+    // The slur will then remain not adjusted. It will again when AdjustSlurs is called below,
+    // but in between, we can have wrong collisions detections. To be improved
+    view.SetPage(this->GetIdx(), false);
+    view.DrawCurrentPage(&bBoxDC, false);
 
     // Fill the arrays of bounding boxes (above and below) for each staff alignment for which the box overflows.
     SetOverflowBBoxesParams setOverflowBBoxesParams(doc);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -579,11 +579,11 @@ int Slur::AdjustCrossStaffContent(FunctorParams *functorParams)
 
             // Apply the shift
             if ((curve->GetAlignment() == topStaff->GetAlignment()) && (curve->GetDir() == curvature_CURVEDIR_below)) {
-                curve->SetDrawingYRel(curve->GetDrawingYRel() + shift);
+                curve->SetDrawingYRel(curve->GetDrawingYRel() + shift, true);
             }
             if ((curve->GetAlignment() == bottomStaff->GetAlignment())
                 && (curve->GetDir() == curvature_CURVEDIR_above)) {
-                curve->SetDrawingYRel(curve->GetDrawingYRel() - shift);
+                curve->SetDrawingYRel(curve->GetDrawingYRel() - shift, true);
             }
         }
     }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -313,10 +313,14 @@ std::tuple<bool, int, int> Slur::CalcControlPointOffset(
 
     // Calculate offset from extremal slope, but use 1/20 of horizontal distance as minimum
     const int minOffset = (bezierCurve.p2.x - bezierCurve.p1.x) / 20;
-    int leftOffset = std::abs(bezierCurve.GetLeftControlHeight()) / leftSlopeMax;
-    leftOffset = std::max(leftOffset, minOffset);
-    int rightOffset = std::abs(bezierCurve.GetRightControlHeight()) / rightSlopeMax;
-    rightOffset = std::max(rightOffset, minOffset);
+    int leftOffset = minOffset;
+    if (bezierCurve.GetLeftControlPointOffset() > 0) {
+        leftOffset = std::max<int>(leftOffset, std::abs(bezierCurve.GetLeftControlHeight()) / leftSlopeMax);
+    }
+    int rightOffset = minOffset;
+    if (bezierCurve.GetRightControlPointOffset() > 0) {
+        rightOffset = std::max<int>(rightOffset, std::abs(bezierCurve.GetRightControlHeight()) / rightSlopeMax);
+    }
 
     return { true, leftOffset, rightOffset };
 }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -426,7 +426,10 @@ int Slur::AdjustCrossStaffContent(FunctorParams *functorParams)
     AdjustCrossStaffContentParams *params = vrv_params_cast<AdjustCrossStaffContentParams *>(functorParams);
     assert(params);
 
-    FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(this->GetCurrentFloatingPositioner());
+    FloatingPositioner *positioner = this->GetCurrentFloatingPositioner();
+    if (!positioner) return FUNCTOR_CONTINUE;
+
+    FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(positioner);
     assert(curve);
 
     if (curve->IsCrossStaff()) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -488,31 +488,27 @@ void Slur::AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int
     bezierCurve.UpdateControlPoints(dir);
 }
 
-float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints)
+float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir)
 {
     float slurAngle = (p1 == p2) ? 0 : atan2(p2.y - p1.y, p2.x - p1.x);
-    float maxSlope = (float)doc->GetOptions()->m_slurMaxSlope.GetValue() * M_PI / 180.0;
-
-    // For slurs without spanning points allow for double angle
-    // This normally looks better with slurs with two notes and high ambitus
-    if (!withPoints) maxSlope *= 2.0;
+    const float maxAngle = (float)doc->GetOptions()->m_slurMaxSlope.GetValue() * M_PI / 180.0;
 
     // the slope of the slur is high and needs to be corrected
-    if (fabs(slurAngle) > maxSlope) {
-        int side = (p2.x - p1.x) * sin(maxSlope) / sin(M_PI / 2 - maxSlope);
+    if (fabs(slurAngle) > maxAngle) {
+        int side = (p2.x - p1.x) * tan(maxAngle);
         if (p2.y > p1.y) {
             if (curveDir == curvature_CURVEDIR_above)
                 p1.y = p2.y - side;
             else
                 p2.y = p1.y + side;
-            slurAngle = maxSlope;
+            slurAngle = maxAngle;
         }
         else {
             if (curveDir == curvature_CURVEDIR_above)
                 p2.y = p1.y - side;
             else
                 p1.y = p2.y + side;
-            slurAngle = -maxSlope;
+            slurAngle = -maxAngle;
         }
     }
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -444,7 +444,6 @@ int Slur::AdjustCrossStaffContent(FunctorParams *functorParams)
         // Determine top and bottom staff
         Staff *topStaff = NULL;
         Staff *bottomStaff = NULL;
-        Staff *startStaff = NULL;
         for (LayerElement *element : slurElements) {
             Layer *layer = NULL;
             Staff *staff = element->GetCrossStaff(layer);
@@ -458,7 +457,6 @@ int Slur::AdjustCrossStaffContent(FunctorParams *functorParams)
             else { // first iteration => initialize everything
                 topStaff = staff;
                 bottomStaff = staff;
-                startStaff = staff;
             }
         }
 
@@ -475,10 +473,11 @@ int Slur::AdjustCrossStaffContent(FunctorParams *functorParams)
             const int shift = getShift(bottomStaff) - getShift(topStaff);
 
             // Apply the shift
-            if ((startStaff == topStaff) && (curve->GetDir() == curvature_CURVEDIR_below)) {
+            if ((curve->GetAlignment() == topStaff->GetAlignment()) && (curve->GetDir() == curvature_CURVEDIR_below)) {
                 curve->SetDrawingYRel(curve->GetDrawingYRel() + shift);
             }
-            if ((startStaff == bottomStaff) && (curve->GetDir() == curvature_CURVEDIR_above)) {
+            if ((curve->GetAlignment() == bottomStaff->GetAlignment())
+                && (curve->GetDir() == curvature_CURVEDIR_above)) {
                 curve->SetDrawingYRel(curve->GetDrawingYRel() - shift);
             }
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -181,7 +181,7 @@ bool Slur::AdjustSlurPosition(
     Doc *doc, FloatingCurvePositioner *curve, BezierCurve &bezierCurve, float &angle, bool forceBothSides)
 {
     bool isNotAdjustable = false;
-    const int margin = doc->GetDrawingUnit(100);
+    const int margin = (curve->IsCrossStaff() ? 2 : 1) * doc->GetDrawingUnit(100);
     int maxShiftLeft = 0;
     int maxShiftRight = 0;
     std::tie(maxShiftLeft, maxShiftRight)
@@ -196,17 +196,17 @@ bool Slur::AdjustSlurPosition(
             if ((bezierCurve.c1.x < bezierCurve.p1.x) || (bezierCurve.c2.x > bezierCurve.p2.x)) return true;
             bezierCurve.SetLeftControlPointOffset(0.5 * bezierCurve.GetLeftControlPointOffset());
             bezierCurve.SetRightControlPointOffset(0.5 * bezierCurve.GetRightControlPointOffset());
-            bezierCurve.SetLeftControlHeight(bezierCurve.GetLeftControlHeight() + 1.1 * maxShiftLeft);
-            bezierCurve.SetRightControlHeight(bezierCurve.GetRightControlHeight() + 1.1 * maxShiftRight);
-            if ((maxShiftLeft > maxShiftRight) && (maxShiftRight == 0)) {
-                bezierCurve.SetLeftControlHeight(1.5 * bezierCurve.GetLeftControlHeight());
+            bezierCurve.SetLeftControlHeight(bezierCurve.GetLeftControlHeight() + 1.2 * maxShiftLeft);
+            bezierCurve.SetRightControlHeight(bezierCurve.GetRightControlHeight() + 1.2 * maxShiftRight);
+            if ((maxShiftLeft > 0) && (maxShiftRight == 0)) {
+                bezierCurve.SetLeftControlHeight(2.0 * bezierCurve.GetLeftControlHeight());
                 bezierCurve.SetRightControlPointOffset(2 * bezierCurve.GetRightControlPointOffset());
-                bezierCurve.SetRightControlHeight(0.5 * bezierCurve.GetRightControlHeight());
+                bezierCurve.SetRightControlHeight(0.75 * bezierCurve.GetRightControlHeight());
             }
-            else if ((maxShiftRight > maxShiftLeft) && (maxShiftLeft == 0)) {
-                bezierCurve.SetRightControlHeight(1.5 * bezierCurve.GetRightControlHeight());
+            else if ((maxShiftRight > 0) && (maxShiftLeft == 0)) {
+                bezierCurve.SetRightControlHeight(2.0 * bezierCurve.GetRightControlHeight());
                 bezierCurve.SetLeftControlPointOffset(2 * bezierCurve.GetLeftControlPointOffset());
-                bezierCurve.SetLeftControlHeight(0.5 * bezierCurve.GetLeftControlHeight());
+                bezierCurve.SetLeftControlHeight(0.75 * bezierCurve.GetLeftControlHeight());
             }
             if (std::abs(double(bezierCurve.p2.y - bezierCurve.p1.y) / double(bezierCurve.p2.x - bezierCurve.p1.x))
                 > 2.0) {
@@ -376,13 +376,11 @@ std::pair<int, int> Slur::CalculateAdjustedSlurShift(FloatingCurvePositioner *cu
         if (rightPointMaxHeight + margin < 0) maxShiftRight = 0;
     }
     else {
-        if (leftPointMaxHeight + margin > 0) maxShiftLeft = 0;
-        if (rightPointMaxHeight + margin > 0) maxShiftRight = 0;
+        if (leftPointMaxHeight - margin > 0) maxShiftLeft = 0;
+        if (rightPointMaxHeight - margin > 0) maxShiftRight = 0;
     }
 
     return { maxShiftLeft, maxShiftRight };
-    // Unrotated the slur
-    //*p2 = BoundingBox::CalcPositionAfterRotation(*p2, (*angle), *p1)
 }
 
 float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir, bool withPoints)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -902,7 +902,6 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
         positioners.push_back(curve);
 
         slur->AdjustSlur(params->m_doc, curve, this->GetStaff());
-        params->m_adjusted = true;
 
         if (curve->IsCrossStaff()) {
             params->m_crossStaffSlurs = true;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -901,10 +901,9 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
         if (!curve->HasContentBB()) continue;
         positioners.push_back(curve);
 
-        bool adjusted = slur->AdjustSlur(params->m_doc, curve, this->GetStaff());
-        if (adjusted) {
-            params->m_adjusted = true;
-        }
+        slur->AdjustSlur(params->m_doc, curve, this->GetStaff());
+        params->m_adjusted = true;
+
         if (curve->IsCrossStaff()) {
             params->m_crossStaffSlurs = true;
         }

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -532,7 +532,7 @@ float View::CalcInitialSlur(
     BezierCurve bezier;
     bezier.p1 = points[0];
     bezier.p2 = points[3];
-    bezier.CalculateControlPointOffset(m_doc, staff->m_drawingStaffSize);
+    bezier.CalculateControlPointOffset(m_doc);
 
     /************** height **************/
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -620,7 +620,6 @@ float View::CalcInitialSlur(
 
     /************** angle **************/
 
-    const ArrayOfCurveSpannedElements *spannedElements = curve->GetSpannedElements();
     bool dontAdjustAngle = curve->IsCrossStaff();
     // If slur is cross-staff (where we don't want to adjust angle) but x distance is too small - adjust angle anyway
     if ((bezier.p2.x - bezier.p1.x) != 0 && curve->IsCrossStaff()) {
@@ -629,9 +628,8 @@ float View::CalcInitialSlur(
 
     const float nonAdjustedAngle
         = (bezier.p2 == bezier.p1) ? 0 : atan2(bezier.p2.y - bezier.p1.y, bezier.p2.x - bezier.p1.x);
-    const float slurAngle = dontAdjustAngle
-        ? nonAdjustedAngle
-        : slur->GetAdjustedSlurAngle(m_doc, bezier.p1, bezier.p2, curveDir, (spannedElements->size() > 0));
+    const float slurAngle
+        = dontAdjustAngle ? nonAdjustedAngle : slur->GetAdjustedSlurAngle(m_doc, bezier.p1, bezier.p2, curveDir);
     bezier.p2 = BoundingBox::CalcPositionAfterRotation(bezier.p2, -slurAngle, bezier.p1);
 
     /************** control points **************/

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -528,24 +528,8 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 float View::CalcInitialSlur(
     FloatingCurvePositioner *curve, Slur *slur, Staff *staff, curvature_CURVEDIR curveDir, Point points[4])
 {
-    // For readability makes them p1 and p2
-    BezierCurve bezier;
-    bezier.p1 = points[0];
-    bezier.p2 = points[3];
-    bezier.CalculateControlPointOffset(m_doc);
-
-    /************** height **************/
-
-    // the 'height' of the bezier
-    int height;
-    int dist = abs(bezier.p2.x - bezier.p1.x);
-    height = std::max(int(m_options->m_slurMinHeight.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)),
-        dist / m_options->m_slurHeightFactor.GetValue());
-    height = std::min(
-        int(m_options->m_slurMaxHeight.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)), height);
-
-    // the height of the control points
-    height = height * 4 / 3;
+    // For now we pick C1 = P1 and C2 = P2
+    BezierCurve bezier(points[0], points[0], points[3], points[3]);
 
     /************** content **************/
 
@@ -652,8 +636,7 @@ float View::CalcInitialSlur(
 
     /************** control points **************/
 
-    Point rotatedC1, rotatedC2;
-    bezier.SetControlHeight(height);
+    bezier.CalcInitialControlPointParams(m_doc, slurAngle, staff->m_drawingStaffSize);
     bezier.UpdateControlPoints(curveDir);
     bezier.Rotate(slurAngle, bezier.p1);
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -654,7 +654,7 @@ float View::CalcInitialSlur(
 
     Point rotatedC1, rotatedC2;
     bezier.SetControlHeight(height);
-    slur->GetControlPoints(bezier, curveDir);
+    bezier.UpdateControlPoints(curveDir);
     bezier.Rotate(slurAngle, bezier.p1);
 
     points[0] = bezier.p1;


### PR DESCRIPTION
This PR implements a new slur adjustment algorithm that mainly adjusts the control points of the slur bezier curve.

Slurs now more accurately curve around obstacles while preserving the position of the slur endpoints as much as possible.

| Before | After |
| ------ | ----- |
| ![Before1](https://user-images.githubusercontent.com/63608463/133742968-40177d29-d58f-48c3-a6eb-abf6b3517573.png) | <img width="219" alt="After1" src="https://user-images.githubusercontent.com/63608463/133743026-9094a5d9-5e5f-4bd1-b356-34163f1da143.png"> |

**Before**
<img width="1533" alt="Before2" src="https://user-images.githubusercontent.com/63608463/133743711-f6f18bd7-4e85-4d32-a0d7-0bfb7c6ff6c6.png">
**After**
<img width="1546" alt="After2" src="https://user-images.githubusercontent.com/63608463/133743751-577f342e-df35-43ce-9339-9d55ad893df4.png">

This particularly improves long slurs where endpoints before appeared lifted off.

**Before**
<img width="800" alt="Before3" src="https://user-images.githubusercontent.com/63608463/133744015-7eb5aaba-22f3-4d8e-a804-3c49060551b6.png">
<img width="500" alt="Before4" src="https://user-images.githubusercontent.com/63608463/133744052-af1d446f-ab4c-49f6-9f5c-ef8d7d114300.png">

**After**
<img width="800" alt="After3" src="https://user-images.githubusercontent.com/63608463/133744089-fabb60a1-2acc-464a-9ae3-4fa7d52ddc8f.png">
<img width="500" alt="After4" src="https://user-images.githubusercontent.com/63608463/133744124-9c59131d-91f4-4e0f-b286-5a6a812556dd.png">

The new algorithm consists of three steps:

1. Vertical end point adjustment. This shifts the slur vertically. Only collisions near the endpoints are taken into account.
2. Horizontal control point adjustment. The idea is to shift control points to the outside if there is an obstacle in the vicinity of the corresponding endpoint.
3. Vertical control point adjustment. For each colliding bounding box we formulate a constraint `ax + by >= c` where x, y denote the vertical adjustments of the control points and c is the size of the collision. The coefficients a, b are calculated from the Bezier curve equation. After collecting all constraints we calculate a solution.

<img width="600" alt="AlgoSteps" src="https://user-images.githubusercontent.com/63608463/133747895-f009ee9b-d6df-4bf6-a2d7-c3caded86f3d.png">

Moreover:
- We fix an error in the calculation of `t` in `BoundingBox::CalcBezierAtPosition`. This error means that previously the slur was evaluated at the wrong horizontal position in order to calculate intersections with bounding boxes. To accurately calculate `t` one has to solve a cubic equation. For now we determine an approximate solution by interval bisection, this might be refined in a later PR.
- We adjust cross staff slurs after vertical justification. This fixes part of #2309 .


 