### PR TITLE
Implement pedal style option

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1853,20 +1853,23 @@ public:
  * member 2: the dynam in the current measure
  * member 3: the current hairpins to be linked / grouped
  * member 4: the map of existing harms (based on @n)
+ * member 5: a pointer to the doc scoreDef
  **/
 
 class PrepareFloatingGrpsParams : public FunctorParams {
 public:
-    PrepareFloatingGrpsParams()
+    PrepareFloatingGrpsParams(Doc *doc)
     {
         m_previousEnding = NULL;
         m_pedalLine = NULL;
+        m_doc = doc;
     }
     Ending *m_previousEnding;
     Pedal *m_pedalLine;
     std::vector<Dynam *> m_dynams;
     std::vector<Hairpin *> m_hairpins;
     std::map<std::string, Harm *> m_harms;
+    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -66,7 +66,7 @@ enum option_MULTIRESTSTYLE {
     MULTIRESTSTYLE_symbols
 };
 
-enum option_PEDALSTILE { PEDALSTILE_none = 0, PEDALSTILE_line, PEDALSTILE_pedstar, PEDALSTILE_altpedstar };
+enum option_PEDALSTYLE { PEDALSTYLE_none = 0, PEDALSTYLE_line, PEDALSTYLE_pedstar, PEDALSTYLE_altpedstar };
 
 enum option_SYSTEMDIVIDER { SYSTEMDIVIDER_none = 0, SYSTEMDIVIDER_auto, SYSTEMDIVIDER_left, SYSTEMDIVIDER_left_right };
 

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -66,6 +66,8 @@ enum option_MULTIRESTSTYLE {
     MULTIRESTSTYLE_symbols
 };
 
+enum option_PEDALSTILE { PEDALSTILE_none = 0, PEDALSTILE_line, PEDALSTILE_pedstar, PEDALSTILE_altpedstar };
+
 enum option_SYSTEMDIVIDER { SYSTEMDIVIDER_none = 0, SYSTEMDIVIDER_auto, SYSTEMDIVIDER_left, SYSTEMDIVIDER_left_right };
 
 //----------------------------------------------------------------------------
@@ -127,6 +129,7 @@ public:
     static const std::map<int, std::string> s_footer;
     static const std::map<int, std::string> s_header;
     static const std::map<int, std::string> s_multiRestStyle;
+    static const std::map<int, std::string> s_pedalStyle;
     static const std::map<int, std::string> s_systemDivider;
 
 protected:
@@ -599,6 +602,7 @@ public:
     OptionInt m_pageMarginRight;
     OptionInt m_pageMarginTop;
     OptionInt m_pageWidth;
+    OptionIntMap m_pedalStyle;
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
     OptionBool m_shrinkToFit;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -66,7 +66,7 @@ enum option_MULTIRESTSTYLE {
     MULTIRESTSTYLE_symbols
 };
 
-enum option_PEDALSTYLE { PEDALSTYLE_none = 0, PEDALSTYLE_line, PEDALSTYLE_pedstar, PEDALSTYLE_altpedstar };
+enum option_PEDALSTYLE { PEDALSTYLE_auto = 0, PEDALSTYLE_line, PEDALSTYLE_pedstar, PEDALSTYLE_altpedstar };
 
 enum option_SYSTEMDIVIDER { SYSTEMDIVIDER_none = 0, SYSTEMDIVIDER_auto, SYSTEMDIVIDER_left, SYSTEMDIVIDER_left_right };
 

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -16,6 +16,7 @@
 
 namespace vrv {
 
+class System;
 //----------------------------------------------------------------------------
 // Pedal
 //----------------------------------------------------------------------------
@@ -64,6 +65,11 @@ public:
      * Get the SMuFL glyph for the pedal based on function or glyph.num
      */
     wchar_t GetPedalGlyph() const;
+
+    /**
+     * Get the pedal form based on the options and corresponding attributes from <pedal> and <scoreDef>
+     */
+    pedalVis_FORM GetPedalForm(Doc *doc, System *system) const;
 
     //----------//
     // Functors //

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -31,6 +31,7 @@ class ScoreDefInterface : public Interface,
                           public AttMeasureNumbers,
                           public AttMidiTempo,
                           public AttMultinumMeasures,
+                          public AttPianoPedals,
                           public AttSpacing,
                           public AttSystems {
 public:

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -9,6 +9,7 @@
 #define __VRV_SCOREDEF_INTERFACE_H__
 
 #include "atts_analytical.h"
+#include "atts_cmn.h"
 #include "atts_mensural.h"
 #include "atts_midi.h"
 #include "atts_shared.h"

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -747,7 +747,7 @@ void Doc::PrepareDrawing()
     /************ Resolve floating groups for vertical alignment ************/
 
     // Prepare the floating drawing groups
-    PrepareFloatingGrpsParams prepareFloatingGrpsParams;
+    PrepareFloatingGrpsParams prepareFloatingGrpsParams(this);
     Functor prepareFloatingGrps(&Object::PrepareFloatingGrps);
     Functor prepareFloatingGrpsEnd(&Object::PrepareFloatingGrpsEnd);
     this->Process(&prepareFloatingGrps, &prepareFloatingGrpsParams, &prepareFloatingGrpsEnd);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2292,6 +2292,7 @@ void MEIOutput::WriteScoreDefInterface(pugi::xml_node element, ScoreDefInterface
     interface->WriteLyricStyle(element);
     interface->WriteMidiTempo(element);
     interface->WriteMultinumMeasures(element);
+    interface->WritePianoPedals(element);
 }
 
 void MEIOutput::WriteTextDirInterface(pugi::xml_node element, TextDirInterface *interface)
@@ -5971,6 +5972,7 @@ bool MEIInput::ReadScoreDefInterface(pugi::xml_node element, ScoreDefInterface *
     interface->ReadLyricStyle(element);
     interface->ReadMidiTempo(element);
     interface->ReadMultinumMeasures(element);
+    interface->ReadPianoPedals(element);
     return true;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,6 +36,9 @@ const std::map<int, std::string> Option::s_header
 const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
+const std::map<int, std::string> Option::s_pedalStyle = { { PEDALSTILE_none, "none" }, { PEDALSTILE_line, "line" },
+    { PEDALSTILE_pedstar, "pedstar" }, { PEDALSTILE_altpedstar, "altpedstar" } };
+
 const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
     { SYSTEMDIVIDER_auto, "auto" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
 
@@ -993,6 +996,10 @@ Options::Options()
     m_pageWidth.SetInfo("Page width", "The page width");
     m_pageWidth.Init(2100, 100, 60000, true);
     this->Register(&m_pageWidth, "pageWidth", &m_general);
+
+    m_pedalStyle.SetInfo("Pedal style", "The global pedal style");
+    m_pedalStyle.Init(PEDALSTILE_none, &Option::s_pedalStyle);
+    this->Register(&m_pedalStyle, "pedalStyle", &m_general);
 
     m_preserveAnalyticalMarkup.SetInfo("Preserve analytical markup", "Preserves the analytical markup in MEI");
     m_preserveAnalyticalMarkup.Init(false);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,7 +36,7 @@ const std::map<int, std::string> Option::s_header
 const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
-const std::map<int, std::string> Option::s_pedalStyle = { { PEDALSTYLE_none, "none" }, { PEDALSTYLE_line, "line" },
+const std::map<int, std::string> Option::s_pedalStyle = { { PEDALSTYLE_auto, "auto" }, { PEDALSTYLE_line, "line" },
     { PEDALSTYLE_pedstar, "pedstar" }, { PEDALSTYLE_altpedstar, "altpedstar" } };
 
 const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
@@ -998,7 +998,7 @@ Options::Options()
     this->Register(&m_pageWidth, "pageWidth", &m_general);
 
     m_pedalStyle.SetInfo("Pedal style", "The global pedal style");
-    m_pedalStyle.Init(PEDALSTYLE_none, &Option::s_pedalStyle);
+    m_pedalStyle.Init(PEDALSTYLE_auto, &Option::s_pedalStyle);
     this->Register(&m_pedalStyle, "pedalStyle", &m_general);
 
     m_preserveAnalyticalMarkup.SetInfo("Preserve analytical markup", "Preserves the analytical markup in MEI");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,8 +36,8 @@ const std::map<int, std::string> Option::s_header
 const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
-const std::map<int, std::string> Option::s_pedalStyle = { { PEDALSTILE_none, "none" }, { PEDALSTILE_line, "line" },
-    { PEDALSTILE_pedstar, "pedstar" }, { PEDALSTILE_altpedstar, "altpedstar" } };
+const std::map<int, std::string> Option::s_pedalStyle = { { PEDALSTYLE_none, "none" }, { PEDALSTYLE_line, "line" },
+    { PEDALSTYLE_pedstar, "pedstar" }, { PEDALSTYLE_altpedstar, "altpedstar" } };
 
 const std::map<int, std::string> Option::s_systemDivider = { { SYSTEMDIVIDER_none, "none" },
     { SYSTEMDIVIDER_auto, "auto" }, { SYSTEMDIVIDER_left, "left" }, { SYSTEMDIVIDER_left_right, "left-right" } };
@@ -998,7 +998,7 @@ Options::Options()
     this->Register(&m_pageWidth, "pageWidth", &m_general);
 
     m_pedalStyle.SetInfo("Pedal style", "The global pedal style");
-    m_pedalStyle.Init(PEDALSTILE_none, &Option::s_pedalStyle);
+    m_pedalStyle.Init(PEDALSTYLE_none, &Option::s_pedalStyle);
     this->Register(&m_pedalStyle, "pedalStyle", &m_general);
 
     m_preserveAnalyticalMarkup.SetInfo("Preserve analytical markup", "Preserves the analytical markup in MEI");

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -85,7 +85,7 @@ wchar_t Pedal::GetPedalGlyph() const
     return (GetFunc() == "sostenuto") ? SMUFL_E659_keyboardPedalSost : SMUFL_E650_keyboardPedalPed;
 }
 
-pedalVis_FORM Pedal::GetPedalForm(Doc *doc, System *system) const 
+pedalVis_FORM Pedal::GetPedalForm(Doc *doc, System *system) const
 {
     const std::map<option_PEDALSTYLE, pedalVis_FORM> option2PedalVis = { { PEDALSTYLE_line, pedalVis_FORM_line },
         { PEDALSTYLE_pedstar, pedalVis_FORM_pedstar }, { PEDALSTYLE_altpedstar, pedalVis_FORM_altpedstar } };

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -87,25 +87,24 @@ wchar_t Pedal::GetPedalGlyph() const
 
 pedalVis_FORM Pedal::GetPedalForm(Doc *doc, System *system) const 
 {
-    const std::map<pedalVis_FORM, std::pair<option_PEDALSTYLE, pianoPedals_PEDALSTYLE>> pedalStyleValues
-        = { { pedalVis_FORM_line, { PEDALSTYLE_line, pianoPedals_PEDALSTYLE_line } },
-              { pedalVis_FORM_pedstar, { PEDALSTYLE_pedstar, pianoPedals_PEDALSTYLE_pedstar } },
-              { pedalVis_FORM_altpedstar, { PEDALSTYLE_altpedstar, pianoPedals_PEDALSTYLE_altpedstar } } };
+    const std::map<option_PEDALSTYLE, pedalVis_FORM> option2PedalVis = { { PEDALSTYLE_line, pedalVis_FORM_line },
+        { PEDALSTYLE_pedstar, pedalVis_FORM_pedstar }, { PEDALSTYLE_altpedstar, pedalVis_FORM_altpedstar } };
+    const std::map<pianoPedals_PEDALSTYLE, pedalVis_FORM> pianoPedals2PedalVis
+        = { { pianoPedals_PEDALSTYLE_line, pedalVis_FORM_line },
+              { pianoPedals_PEDALSTYLE_pedstar, pedalVis_FORM_pedstar },
+              { pianoPedals_PEDALSTYLE_altpedstar, pedalVis_FORM_altpedstar } };
 
     pedalVis_FORM style = pedalVis_FORM_NONE;
-    if (int option = doc->GetOptions()->m_pedalStyle.GetValue(); option != PEDALSTYLE_none) {
-        auto iter = std::find_if(pedalStyleValues.begin(), pedalStyleValues.end(),
-            [option](const auto &optionStylePair) { return option == optionStylePair.second.first; });
-        if (iter != pedalStyleValues.end()) style = iter->first;
+    if (option_PEDALSTYLE option = static_cast<option_PEDALSTYLE>(doc->GetOptions()->m_pedalStyle.GetValue());
+        option != PEDALSTYLE_auto) {
+        style = option2PedalVis.at(option);
     }
     else if (this->HasForm()) {
         style = this->GetForm();
     }
     else if (const ScoreDef *scoreDef = system->GetDrawingScoreDef(); scoreDef && scoreDef->HasPedalStyle()) {
         pianoPedals_PEDALSTYLE scoreDefStyle = scoreDef->GetPedalStyle();
-        auto iter = std::find_if(pedalStyleValues.begin(), pedalStyleValues.end(),
-            [scoreDefStyle](const auto &optionStylePair) { return scoreDefStyle == optionStylePair.second.second; });
-        if (iter != pedalStyleValues.end()) style = iter->first;
+        style = pianoPedals2PedalVis.at(scoreDefStyle);
     }
 
     return style;

--- a/src/scoredefinterface.cpp
+++ b/src/scoredefinterface.cpp
@@ -29,6 +29,7 @@ ScoreDefInterface::ScoreDefInterface()
     , AttMeasureNumbers()
     , AttMidiTempo()
     , AttMultinumMeasures()
+    , AttPianoPedals()
     , AttSpacing()
     , AttSystems()
 {
@@ -38,6 +39,7 @@ ScoreDefInterface::ScoreDefInterface()
     RegisterInterfaceAttClass(ATT_METERSIGDEFAULTVIS);
     RegisterInterfaceAttClass(ATT_MIDITEMPO);
     RegisterInterfaceAttClass(ATT_MULTINUMMEASURES);
+    RegisterInterfaceAttClass(ATT_PIANOPEDALS);
     RegisterInterfaceAttClass(ATT_SPACING);
     RegisterInterfaceAttClass(ATT_SYSTEMS);
 
@@ -52,6 +54,7 @@ void ScoreDefInterface::Reset()
     ResetMeasureNumbers();
     ResetMidiTempo();
     ResetMultinumMeasures();
+    ResetPianoPedals();
     ResetSpacing();
     ResetSystems();
 }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2025,11 +2025,13 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
 
     dc->StartGraphic(pedal, "", pedal->GetUuid());
 
+    pedalVis_FORM form = pedal->GetPedalForm(m_doc, system);
+
     // Draw a symbol, if it's not a line
-    if (pedal->GetForm() != pedalVis_FORM_line) {
+    if (form != pedalVis_FORM_line) {
 
         bool bounceStar = true;
-        if (pedal->GetForm() == pedalVis_FORM_altpedstar) bounceStar = false;
+        if (form == pedalVis_FORM_altpedstar) bounceStar = false;
 
         int x = pedal->GetStart()->GetDrawingX() + pedal->GetStart()->GetDrawingRadius(m_doc);
 


### PR DESCRIPTION
Added `--pedal-style` option to allow global setting for pedals. By default set to `auto` which follows encoded values. When any other option is set it will be prioritized and used to set the style.
For example, `pedal-001.mei` test file with option `--pedal-style line` looks as following:
![image](https://user-images.githubusercontent.com/1819669/133753269-11bb9ed7-dbea-4df4-b61d-5f16c8e41529.png)

Also added support for @pedal.style attribute to scoredef, but it's not covering all possible cases there due to order of processing.
