### PR TITLE
Implement option for handwritten fonts

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -637,6 +637,7 @@ public:
     OptionBool m_graceRightAlign;
     OptionDbl m_hairpinSize;
     OptionDbl m_hairpinThickness;
+    OptionArray m_handwrittenFont;
     OptionDbl m_harmDist;
     OptionDbl m_justificationBraceGroup;
     OptionDbl m_justificationBracketGroup;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1138,7 +1138,7 @@ Options::Options()
     m_hairpinThickness.Init(0.2, 0.1, 0.8);
     this->Register(&m_hairpinThickness, "hairpinThickness", &m_generalLayout);
 
-    m_handwrittenFont.SetInfo("Handwritten font", "Font that emulate hand writing and require special handling");
+    m_handwrittenFont.SetInfo("Handwritten font", "Fonts that emulate hand writing and require special handling");
     m_handwrittenFont.Init();
     m_handwrittenFont.SetValue("Petaluma");
     this->Register(&m_handwrittenFont, "handwrittenFont", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1138,6 +1138,11 @@ Options::Options()
     m_hairpinThickness.Init(0.2, 0.1, 0.8);
     this->Register(&m_hairpinThickness, "hairpinThickness", &m_generalLayout);
 
+    m_handwrittenFont.SetInfo("Handwritten font", "Font that emulate hand writing and require special handling");
+    m_handwrittenFont.Init();
+    m_handwrittenFont.SetValue("Petaluma");
+    this->Register(&m_handwrittenFont, "handwrittenFont", &m_generalLayout);
+
     m_harmDist.SetInfo("Harm dist", "The default distance from the staff of harmonic indications");
     m_harmDist.Init(1.0, 0.5, 16.0);
     this->Register(&m_harmDist, "harmDist", &m_generalLayout);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1742,13 +1742,28 @@ int View::DrawMeterSigFigures(
     x += width / 2;
 
     if (den) {
-        DrawSmuflString(dc, x, y + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize), timeSigCombNumerator,
-            HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
-        DrawSmuflString(dc, x, y - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize), timeSigCombDenominator,
-            HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
+        int yNum = y + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        int yDen = y - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        // In case when one of the handwritten fonts is used, we need to make sure that meterSig is displayed properly
+        // for it, based on the height of corresponding glyphs
+        FontInfo *fontInfo = dc->GetFont();
+        std::vector<std::string> handwrittenFonts = m_doc->GetOptions()->m_handwrittenFont.GetValue();
+        if (const auto it = std::find(handwrittenFonts.begin(), handwrittenFonts.end(), fontInfo->GetFaceName());
+            it != handwrittenFonts.end()) {
+            TextExtend numExtend;
+            dc->GetSmuflTextExtent(timeSigCombNumerator, &numExtend);
+            yNum = y + numExtend.m_height / 2;
+
+            TextExtend denExtend;
+            dc->GetSmuflTextExtent(timeSigCombDenominator, &denExtend);
+            yDen = y - denExtend.m_height / 2;
+        }
+        DrawSmuflString(dc, x, yNum, timeSigCombNumerator, HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
+        DrawSmuflString(dc, x, yDen, timeSigCombDenominator, HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
     }
-    else
+    else {
         DrawSmuflString(dc, x, y, timeSigCombNumerator, HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
+    }
 
     dc->ResetFont();
 


### PR DESCRIPTION
closes #1184
Added option for handwritten-like font (e.g. Petaluma) to place metersig according to the glyph height, instead of centering them on 2nd and 4th staff lines.
Petaluma is used by default, and any other font can be added by option `--handwritten-font`
Resulting rendering:
![image](https://user-images.githubusercontent.com/1819669/133773824-1725826e-4bd2-47a7-aab9-106c83355146.png)
