### PR TITLE
Fix crash in LayerElement::SetAlignmentPitchPos(...)

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1301,7 +1301,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 beam->ResetList(beam);
 
                 const ArrayOfObjects *beamList = beam->GetList(beam);
-                int restIndex = beam->GetChildIndex(rest);
+                const int restIndex = beam->GetListIndex(rest);
+                assert(restIndex >= 0);
 
                 int leftLoc = loc;
                 ArrayOfObjects::const_iterator it = beamList->begin();


### PR DESCRIPTION
This PR fixes a crash due to using the wrong index.

<details>
  <summary>MEI example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
  </meiHead>
  <music>
    <body>
      <mdiv type="placeholder" n="1" filename="Frederic_Chopin_Mazurkas_Series_A_PWM_p31_33.mei">
        <score>
          <scoreDef xmlns="http://www.music-encoding.org/ns/mei" xml:id="scoredef-0000000556624474">
                  <staffGrp xml:id="staffgrp-0000002045679495">
                     <staffGrp xml:id="S1-Piano" bar.thru="true">
                        <label xml:id="label-0000000709947253">Piano</label>
                        <staffDef xml:id="staffdef-0000000659952013" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-0000001670860054" shape="G" line="2"/>
                           <keySig xml:id="key-1" sig="1s"/>
                           <meterSig xml:id="msig-0000000220885825" form="invis"/>
                        </staffDef>
                        <staffDef xml:id="staffdef-0000000031464511" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-0000000693263122" shape="F" line="4"/>
                           <keySig xml:id="key-2" sig="1s"/>
                           <meterSig xml:id="msig-0000000612127830" form="invis"/>
                        </staffDef>
                        <grpSym xml:id="grpsym-0000001791762714" symbol="brace"/>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
          <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="section-0000000692007518">
                  <measure xml:id="measure-9-mdiv-1" n="9">
                     <staff xml:id="staff-0000000797437290" n="1">
                        <layer xml:id="layer-0000001073801156" n="1">
                           <beam xml:id="beam-0000000059759095">
                              <note xml:id="note-92" dur.ppq="2" dur="8" oct="5" pname="a" stem.dir="down">
                                 <accid xml:id="accid-0000001116102062" accid="s" accid.ges="s"/>
                                 <artic xml:id="artic-0000001038975985" artic="stacc" place="above"/>
                              </note>
                              <space xml:id="space-0000001879998712" dur.ppq="8" dur="2"/>
                              <space xml:id="space-0000002091292586" dur.ppq="2" dur="8"/>
                              <rest xml:id="note-93" dur.ppq="1" dur="16"/>
                              <note xml:id="note-94" dur.ppq="1" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s"/>
                              <note xml:id="note-95" dur.ppq="2" dur="8" oct="5" pname="a" stem.dir="down" accid.ges="s"/>
                              <space xml:id="space-0000001122089371" dur.ppq="2" dur="8"/>
                              <rest xml:id="note-96" dur.ppq="1" dur="16"/>
                              <note xml:id="note-97" dur.ppq="1" dur="16" oct="5" pname="a" stem.dir="down">
                                 <accid xml:id="accid-0000001163919271" accid="n" accid.ges="n"/>
                              </note>
                           </beam>
                           <note xml:id="note-98" dur.ppq="4" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="s"/>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000549481741" n="2">
                        <layer xml:id="layer-0000001397407724" n="5">
                           <rest xml:id="note-99" dur.ppq="4" dur="4"/>
                           <space xml:id="space-0000001340244185" dur.ppq="8" dur="2"/>
                           <space xml:id="space-0000000929166636" dur.ppq="2" dur="8"/>
                           <chord xml:id="chord-0000001550144853" dur.ppq="4" dur="4" stem.dir="up">
                              <note xml:id="note-100" oct="3" pname="a">
                                 <accid xml:id="accid-0000002134570753" accid="s" accid.ges="s"/>
                              </note>
                              <note xml:id="note-101" oct="4" pname="f" accid.ges="s"/>
                              <note xml:id="note-102" oct="4" pname="c">
                                 <accid xml:id="accid-0000001821843764" accid="s" accid.ges="s"/>
                              </note>
                           </chord>
                           <space xml:id="space-0000001613175486" dur.ppq="2" dur="8"/>
                           <chord xml:id="chord-0000000328492048" dur.ppq="4" dur="4" stem.dir="up">
                              <note xml:id="note-103" oct="3" pname="a">
                                 <accid xml:id="accid-0000001786363022" accid="n" accid.ges="n"/>
                              </note>
                              <note xml:id="note-104" oct="4" pname="f" accid.ges="s"/>
                              <note xml:id="note-105" oct="4" pname="c">
                                 <accid xml:id="accid-0000000621664298" accid="n" accid.ges="n"/>
                              </note>
                           </chord>
                        </layer>
                        <layer xml:id="layer-0000001805006409" n="6">
                           <note xml:id="note-106" dots="1" dur.ppq="12" dur="2" oct="3" pname="e" stem.dir="down"/>
                        </layer>
                     </staff>
                     <slur xml:id="slur-7" startid="#note-94" endid="#note-95" curvedir="above"/>
                     <slur xml:id="slur-8" startid="#note-97" endid="#note-98" curvedir="above"/>
                  </measure>
               </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>