### PR TITLE
Do not ignore system scoreDef clefs

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1826,10 +1826,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         assert(currentLayer);
         // set scoreDef attr
         if (currentLayer->GetStaffDefClef()) {
-            // Ignore system scoreDef clefs - clefs changes withing a staff are still taken into account
-            if (currentLayer->GetStaffDefClef()->GetScoreDefRole() != SCOREDEF_SYSTEM) {
-                currentLayer->GetStaffDefClef()->SetOverflowBBoxes(params);
-            }
+            currentLayer->GetStaffDefClef()->SetOverflowBBoxes(params);
         }
         if (currentLayer->GetStaffDefKeySig()) {
             currentLayer->GetStaffDefKeySig()->SetOverflowBBoxes(params);


### PR DESCRIPTION
closes #1960

Fix for the issue that BB of scoreDef clefs is being ignored which, with options like `--adjust-page-height` might lead to clef truncation:
Before:
![image](https://user-images.githubusercontent.com/1819669/134175015-1d084782-7cf6-40f2-802b-293e8ee6850f.png)
After fix:
![image](https://user-images.githubusercontent.com/1819669/134175131-c7225fe7-d255-4bb2-8a71-d659f8670d37.png)

However, given that BB is not ignored anymore leads placing first staff that has G-clef a bit lower (since upper part of the clef is now counted towards overlaps of the system):
![image](https://user-images.githubusercontent.com/1819669/134175499-3bc449c3-8ef8-4bf6-a533-9b5992c575b8.png)
After:
![image](https://user-images.githubusercontent.com/1819669/134175533-99436eb9-a8b2-42f6-baf9-1cfcf1a0d6e3.png)

