### PR TITLE
Add support for num.place on multiRest

### DIFF
--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -28,6 +28,7 @@ class MultiRest : public LayerElement,
                   public AttColor,
                   public AttMultiRestVis,
                   public AttNumbered,
+                  public AttNumberPlacement,
                   public AttWidth {
 public:
     /**

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1949,6 +1949,7 @@ void MEIOutput::WriteMultiRest(pugi::xml_node currentNode, MultiRest *multiRest)
     multiRest->WriteColor(currentNode);
     multiRest->WriteMultiRestVis(currentNode);
     multiRest->WriteNumbered(currentNode);
+    multiRest->WriteNumberPlacement(currentNode);
     multiRest->WriteWidth(currentNode);
 }
 
@@ -5501,6 +5502,7 @@ bool MEIInput::ReadMultiRest(Object *parent, pugi::xml_node multiRest)
     vrvMultiRest->ReadColor(multiRest);
     vrvMultiRest->ReadMultiRestVis(multiRest);
     vrvMultiRest->ReadNumbered(multiRest);
+    vrvMultiRest->ReadNumberPlacement(multiRest);
     vrvMultiRest->ReadWidth(multiRest);
 
     parent->AddChild(vrvMultiRest);

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -25,12 +25,14 @@ MultiRest::MultiRest()
     , AttColor()
     , AttMultiRestVis()
     , AttNumbered()
+    , AttNumberPlacement()
     , AttWidth()
 {
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_MULTIRESTVIS);
     RegisterAttClass(ATT_NUMBERED);
+    RegisterAttClass(ATT_NUMBERPLACEMENT);
     RegisterAttClass(ATT_WIDTH);
     Reset();
 }
@@ -44,6 +46,7 @@ void MultiRest::Reset()
     ResetColor();
     ResetMultiRestVis();
     ResetNumbered();
+    ResetNumberPlacement();
     ResetWidth();
 }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1296,12 +1296,9 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
         const int staffHeight = (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
-        y1 = (staff->GetDrawingY() > y1) ? staff->GetDrawingY() : y1;
-        y2 = ((staff->GetDrawingY() - staffHeight) < y2) ? staff->GetDrawingY() - staffHeight : y2;
-
         const int y = (multiRest->GetNumPlace() == STAFFREL_basic_below)
-            ? y2 - 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
-            : y1 + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            ? std::min(staff->GetDrawingY() - staffHeight, y2) - 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
+            : std::max(staff->GetDrawingY(), y1) + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
         DrawSmuflString(dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center);
         dc->ResetFont();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1290,12 +1290,22 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         if (count) DrawSmuflCode(dc, x1, y1, SMUFL_E4E3_restWhole, staff->m_drawingStaffSize, false);
     }
 
-    // Draw the text above
-    dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
-    int y = (staff->GetDrawingY() > y1) ? staff->GetDrawingY() + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
-                                        : y1 + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    DrawSmuflString(dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center);
-    dc->ResetFont();
+    // Draw the number
+    if (multiRest->GetNumVisible() != BOOLEAN_false) {
+        dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
+
+        const int staffHeight = (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+
+        y1 = (staff->GetDrawingY() > y1) ? staff->GetDrawingY() : y1;
+        y2 = ((staff->GetDrawingY() - staffHeight) < y2) ? staff->GetDrawingY() - staffHeight : y2;
+
+        const int y = (multiRest->GetNumPlace() == STAFFREL_basic_below)
+            ? y2 - 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
+            : y1 + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+
+        DrawSmuflString(dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center);
+        dc->ResetFont();
+    }
 
     dc->EndGraphic(element, this);
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1295,10 +1295,11 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
         dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
 
         const int staffHeight = (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        const int offset = 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
         const int y = (multiRest->GetNumPlace() == STAFFREL_basic_below)
-            ? std::min(staff->GetDrawingY() - staffHeight, y2) - 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
-            : std::max(staff->GetDrawingY(), y1) + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            ? std::min(staff->GetDrawingY() - staffHeight, y2) - offset
+            : std::max(staff->GetDrawingY(), y1) + offset;
 
         DrawSmuflString(dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center);
         dc->ResetFont();


### PR DESCRIPTION
This PR adds support for the rendering of numbers of multi-measure rests below the staff. 

![rest-012](https://user-images.githubusercontent.com/7693447/134427310-9e7f1470-5e16-4e53-a314-83661539a4a2.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Positioning of numbers on multi-measure rests</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2021-09-22">2021-09-22</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef meter.count="4" meter.unit="4" meter.sym="cut">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="0" num="2" width="4" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="2" num="4" width="6" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="4" num="6" width="8" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="6" num="8" width="10" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="8" num="10" width="12" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <multiRest num.place="below" block="true" loc="10" num="12" width="14" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
