### PR TITLE
Ignore hidden mdivs

### DIFF
--- a/src/pageelement.cpp
+++ b/src/pageelement.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "functorparams.h"
+#include "mdiv.h"
 #include "page.h"
 
 namespace vrv {
@@ -70,6 +71,15 @@ int PageElement::CastOffPages(FunctorParams *functorParams)
 {
     CastOffPagesParams *params = vrv_params_cast<CastOffPagesParams *>(functorParams);
     assert(params);
+
+    // Hidden mdivs must be ignored
+    if (this->Is(MDIV)) {
+        Mdiv *mdiv = vrv_cast<Mdiv *>(this);
+        assert(mdiv);
+        if (mdiv->m_visibility == Hidden) {
+            return FUNCTOR_CONTINUE;
+        }
+    }
 
     PageElement *element = dynamic_cast<PageElement *>(params->m_contentPage->Relinquish(this->GetIdx()));
     assert(element);

--- a/src/pageelement.cpp
+++ b/src/pageelement.cpp
@@ -73,12 +73,9 @@ int PageElement::CastOffPages(FunctorParams *functorParams)
     assert(params);
 
     // Hidden mdivs must be ignored
-    if (this->Is(MDIV)) {
-        Mdiv *mdiv = vrv_cast<Mdiv *>(this);
-        assert(mdiv);
-        if (mdiv->m_visibility == Hidden) {
-            return FUNCTOR_CONTINUE;
-        }
+    Mdiv *mdiv = dynamic_cast<Mdiv *>(this);
+    if (mdiv && (mdiv->m_visibility == Hidden)) {
+        return FUNCTOR_CONTINUE;
     }
 
     PageElement *element = dynamic_cast<PageElement *>(params->m_contentPage->Relinquish(this->GetIdx()));


### PR DESCRIPTION
This PR fixes a regression of #2347 concerning the option `--mdiv-x-path-query`: When filtering the example below with `//mdiv/mdiv[@type='movement' and @n='2']`, then the object tree still contains full mdiv 1 after layout. Moreover, those mdivs which were removed (mdiv 3 and 4 in the example) got memory leaked.

<details>
  <summary>MEI example</summary>

```xml
<?xml version="1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>String Quartet No. 1 in G major, KV 80</title>
                <respStmt>
                    <persName role="composer">Mozart, Wolfgang Amadeus</persName>
                </respStmt>
            </titleStmt>
            <pubStmt />
        </fileDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <mdiv type="movement" n="1" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_1_P1_Violin_I.mei">
                    <score>
                        <scoreDef xmlns="http://www.music-encoding.org/ns/mei" dynam.dist="4">
                            <staffGrp xml:id="sl7qnrr">
                                <staffGrp xml:id="swui1zy" bar.thru="true">
                                    <staffDef xml:id="P1-V8s3TJGdWUOHMPpUWs4d5w" n="1" lines="5">
                                        <label xml:id="lp7ligu">Violin I</label>
                                        <clef xml:id="clef-1" shape="G" line="2" />
                                        <keySig xml:id="key-1" sig="1s" />
                                        <meterSig xml:id="time-1" count="3" unit="4" />
                                    </staffDef>
                                </staffGrp>
                            </staffGrp>
                        </scoreDef>
                        <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="snsy8xz">
                            <pb xml:id="pq2a7vy" />
                            <measure xml:id="measure-0028-9460-9930-1-mdiv-1" n="1">
                                <staff xml:id="sxwd520" n="1">
                                    <layer xml:id="le9kxnx" n="1">
                                        <note xml:id="note-0028-9640-10020-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0028-9770-10020-2" dots="1" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0028-9940-9990-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                    </layer>
                                </staff>
                                <tempo xml:id="t6b17l2" place="above" staff="1" tstamp="1.0" xml:lang="it" midi.bpm="66.000000">Adagio</tempo>
                                <dynam xml:id="d561et" place="below" staff="1" tstamp="1.0">p</dynam>
                            </measure>
                            <measure xml:id="measure-0028-10000-9930-1-mdiv-1" n="2">
                                <staff xml:id="s9ktbuw" n="1">
                                    <layer xml:id="lqhtfb0" n="1">
                                        <note xml:id="note-0028-10020-9980-1" dur="16" oct="5" pname="a" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0028-10050-9990-2" dur="4" oct="5" pname="g" stem.dir="down" />
                                        <note xml:id="note-0028-10180-10000-2" dots="1" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        <note xml:id="note-0028-10350-9990-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-10410-9930-1-mdiv-1" n="3">
                                <staff xml:id="s8std90" n="1">
                                    <layer xml:id="lh03n47" n="1">
                                        <beam xml:id="b4xayv9">
                                            <note xml:id="note-0028-10450-9990-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0028-10510-10000-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        </beam>
                                        <note xml:id="note-0028-10570-10020-2" dots="1" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0028-10750-10030-2" dur="8" oct="5" pname="c" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-10810-9930-1-mdiv-1" n="4">
                                <staff xml:id="sedmh2d" n="1">
                                    <layer xml:id="lcmgpbo" n="1">
                                        <note xml:id="note-0028-10830-10020-1" dur="16" oct="5" pname="d" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0028-10860-10030-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                        <note xml:id="note-0028-10980-10030-2" dur="4" oct="4" pname="b" stem.dir="down" />
                                        <rest xml:id="rest-0028-11150-10060" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <sb xml:id="stgxajl" />
                            <measure xml:id="measure-0028-9250-10570-1-mdiv-1" n="5">
                                <staff xml:id="sphdgnn" n="1">
                                    <layer xml:id="l4bls1f" n="1">
                                        <note xml:id="note-0028-9380-10610-2" dur="8" oct="6" pname="c" stem.dir="down" />
                                        <note xml:id="note-0028-9450-10660-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                        <beam xml:id="bse176d">
                                            <note xml:id="note-0028-9590-10650-2" dur="16" oct="5" pname="e" stem.dir="down" />
                                            <note xml:id="note-0028-9640-10650-2" dur="16" oct="5" pname="d" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="b92wsc3">
                                            <note xml:id="note-0028-9690-10640-2" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0028-9740-10650-2" dur="16" oct="5" pname="e" stem.dir="down" />
                                            <note xml:id="note-0028-9790-10650-2" dur="16" oct="5" pname="d" stem.dir="down" />
                                            <note xml:id="note-0028-9840-10660-2" dur="16" oct="5" pname="c" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-9880-10570-1-mdiv-1" n="6">
                                <staff xml:id="st82tc5" n="1">
                                    <layer xml:id="l19n1ou" n="1">
                                        <beam xml:id="bg1pp1l">
                                            <note xml:id="note-0028-9930-10670-2" dur="16" oct="4" pname="b" stem.dir="down" />
                                            <note xml:id="note-0028-9980-10650-2" dur="16" oct="5" pname="d" stem.dir="down">
                                                <artic xml:id="a60j4pp" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0028-10030-10650-2" dur="16" oct="5" pname="e" stem.dir="down">
                                                <artic xml:id="attbne" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0028-10080-10640-2" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s">
                                                <artic xml:id="at7uitr" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                        <beam xml:id="b5uyq5p">
                                            <note xml:id="note-0028-10120-10630-2" dur="16" oct="5" pname="g" stem.dir="down">
                                                <artic xml:id="atgozd4" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0028-10170-10620-2" dur="16" oct="5" pname="a" stem.dir="down">
                                                <artic xml:id="avsnvmm" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0028-10220-10610-2" dur="16" oct="5" pname="b" stem.dir="down">
                                                <artic xml:id="aj0e9vd" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0028-10260-10610-2" dur="16" oct="6" pname="c" stem.dir="down">
                                                <artic xml:id="avx0iiv" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                        <note xml:id="note-0028-10310-10600-2" dur="4" oct="6" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-10500-10570-1-mdiv-1" n="7">
                                <staff xml:id="sptdan3" n="1">
                                    <layer xml:id="laf6580" n="1">
                                        <beam xml:id="bqhj2t0">
                                            <note xml:id="note-0028-10540-10600-2" dur="8" oct="6" pname="d" stem.dir="down" />
                                            <note xml:id="note-0028-10610-10590-2" dur="16" oct="6" pname="e" stem.dir="down" />
                                            <note xml:id="note-0028-10650-10600-2" dur="16" oct="6" pname="d" stem.dir="down" />
                                        </beam>
                                        <note xml:id="note-0028-10700-10610-2" dur="4" oct="6" pname="c" stem.dir="down" />
                                        <note xml:id="note-0028-10830-10610-2" dur="4" oct="5" pname="b" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-10940-10570-1-mdiv-1" n="8">
                                <staff xml:id="ssv8p8c" n="1">
                                    <layer xml:id="ljv92sx" n="1">
                                        <note xml:id="note-0028-10990-10610-2" dur="4" oct="5" pname="b" stem.dir="down" />
                                        <note xml:id="note-0028-11070-10620-2" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <rest xml:id="rest-0028-11210-10690" dur="4" />
                                    </layer>
                                </staff>
                                <trill xml:id="tla7zp7" staff="1" startid="#note-0028-10990-10610-2" place="above" />
                            </measure>
                            <sb xml:id="svt1ton" />
                            <measure xml:id="measure-0028-9250-11200-1-mdiv-1" n="9">
                                <staff xml:id="szfsawk" n="1">
                                    <layer xml:id="leorqri" n="1">
                                        <note xml:id="note-0028-9390-11260-2" dots="1" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <beam xml:id="bdkr3ls">
                                            <note xml:id="note-0028-9600-11250-2" dur="16" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0028-9650-11260-2" dur="16" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="bcxu86v">
                                            <note xml:id="note-0028-9710-11240-2" dur="16" oct="6" pname="d" stem.dir="down" />
                                            <note xml:id="note-0028-9760-11240-2" dur="16" oct="6" pname="c" stem.dir="down">
                                                <accid xml:id="ajb2q9n" accid="s" accid.ges="s" />
                                            </note>
                                            <note xml:id="note-0028-9810-11250-2" dur="16" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0028-9870-11260-2" dur="16" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0028-9910-11200-1-mdiv-1" n="10">
                                <staff xml:id="svmcvyv" n="1">
                                    <layer xml:id="lelm1je" n="1">
                                        <beam xml:id="bmsae0y">
                                            <note xml:id="note-0028-9950-11260-2" dots="1" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0028-10060-11250-2" dur="16" oct="5" pname="b" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="b17etmd">
                                            <note xml:id="note-0028-10100-11260-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0028-10170-11260-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0028-10230-11260-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0028-10300-11260-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                        </section>
                    </score>
                </mdiv>
                <mdiv n="2" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_2_P1_Violin_I.mei">
                    <score>
                        <scoreDef xmlns="http://www.music-encoding.org/ns/mei" dynam.dist="4">
                            <staffGrp xml:id="skx6r2p">
                                <staffGrp xml:id="s9hud18" bar.thru="true">
                                    <staffDef xml:id="P1-V8s3TJGdWUOHMPpUWs4d5w" n="1" lines="5">
                                        <label xml:id="lnes803">Violin I</label>
                                        <clef xml:id="clef-1" shape="G" line="2" />
                                        <keySig xml:id="key-1" sig="1s" />
                                        <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                                    </staffDef>
                                </staffGrp>
                            </staffGrp>
                        </scoreDef>
                        <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="s31ci9b">
                            <pb xml:id="p32hnhr" />
                            <measure xml:id="measure-0032-9380-9930-1-mdiv-2" n="1">
                                <staff xml:id="s6h2lqu" n="1">
                                    <layer xml:id="l1ruhe2" n="1">
                                        <chord xml:id="cy42h1s" dur="4" stem.dir="up">
                                            <note xml:id="note-0032-9570-10080-1" oct="4" pname="d" />
                                            <note xml:id="note-0032-9570-10030-1" oct="4" pname="b" />
                                            <note xml:id="note-0032-9560-9990-1" oct="5" pname="g" />
                                        </chord>
                                        <note xml:id="note-0032-9630-9990-1" dur="16" oct="5" pname="a" grace="acc" stem.dir="up" />
                                        <beam xml:id="bjb7we4">
                                            <note xml:id="note-0032-9670-9990-2" dur="16" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-9700-10000-2" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0032-9740-9990-2" dur="16" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-9770-9990-2" dur="16" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="buqb12v">
                                            <note xml:id="note-0032-9810-9990-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-9860-9990-2" dur="8" oct="5" pname="g" stem.dir="down">
                                                <artic xml:id="akg0kzk" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-9910-10000-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s">
                                                <artic xml:id="ajr79jp" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-9960-9990-2" dur="8" oct="5" pname="a" stem.dir="down">
                                                <artic xml:id="au7yz1i" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                    </layer>
                                </staff>
                                <tempo xml:id="tjvj0j9" place="above" staff="1" tstamp="1.0" xml:lang="it" midi.bpm="116.000000">Allegro</tempo>
                            </measure>
                            <measure xml:id="measure-0032-10000-9930-1-mdiv-2" n="2">
                                <staff xml:id="sk6v879" n="1">
                                    <layer xml:id="ljpyjuz" n="1">
                                        <beam xml:id="by7vnlw">
                                            <note xml:id="note-0032-10040-9990-2" dur="8" oct="5" pname="g" stem.dir="down">
                                                <artic xml:id="a27i2ke" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-10090-9980-2" dur="8" oct="5" pname="b" stem.dir="down">
                                                <artic xml:id="a11gyy8" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-10140-9990-2" dur="8" oct="5" pname="a" stem.dir="down">
                                                <artic xml:id="anyiblr" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-10190-9970-2" dur="8" oct="6" pname="c" stem.dir="down">
                                                <artic xml:id="adqdm98" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                        <note xml:id="note-0032-10240-9980-2" dur="8" oct="5" pname="b" stem.dir="down">
                                            <artic xml:id="aqqvasq" artic="stacciss" place="above" />
                                        </note>
                                        <rest xml:id="rest-0032-10300-10050" dur="8" />
                                        <rest xml:id="rest-0032-10340-10060" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-10390-9930-1-mdiv-2" n="3">
                                <staff xml:id="s6ug8la" n="1">
                                    <layer xml:id="lw8u8zw" n="1">
                                        <chord xml:id="cmy4900" dur="2" stem.dir="up">
                                            <note xml:id="note-0032-10430-10110-1" oct="3" pname="g" />
                                            <note xml:id="note-0032-10430-10000-1" oct="5" pname="g" />
                                            <note xml:id="note-0032-10430-10040-1" oct="4" pname="b" />
                                            <note xml:id="note-0032-10430-10080-1" oct="4" pname="d" />
                                        </chord>
                                        <note xml:id="note-0032-10510-10020-2" dur="2" oct="5" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-10570-9930-1-mdiv-2" n="4">
                                <staff xml:id="slmvnpp" n="1">
                                    <layer xml:id="lw9h0uk" n="1">
                                        <note xml:id="note-0032-10600-10030-1" dur="16" oct="5" pname="c" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0032-10630-10040-2" dur="4" oct="4" pname="b" stem.dir="down" />
                                        <beam xml:id="bt3yty">
                                            <note xml:id="note-0032-10700-10040-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                            <note xml:id="note-0032-10740-10050-1" dur="8" oct="4" pname="g" stem.dir="up" />
                                        </beam>
                                        <note xml:id="note-0032-10800-10020-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0032-10860-10080-1" dur="4" oct="4" pname="d" stem.dir="up" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-10920-9930-1-mdiv-2" n="5">
                                <staff xml:id="ss5stwe" n="1">
                                    <layer xml:id="lpnjy7a" n="1">
                                        <note xml:id="note-0032-10960-10050-1" dur="4" oct="4" pname="g" stem.dir="up" />
                                        <note xml:id="note-0032-11030-9990-1" dur="16" oct="5" pname="a" grace="acc" stem.dir="up" />
                                        <beam xml:id="b4cidix">
                                            <note xml:id="note-0032-11060-10000-2" dur="16" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-11100-10000-2" dur="16" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0032-11130-10000-2" dur="16" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-11160-9990-2" dur="16" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="brh3ndy">
                                            <note xml:id="note-0032-11200-10000-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0032-11250-10000-2" dur="8" oct="5" pname="g" stem.dir="down">
                                                <artic xml:id="amjjwgm" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-11300-10000-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s">
                                                <artic xml:id="abhlbvv" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-11350-9990-2" dur="8" oct="5" pname="a" stem.dir="down">
                                                <artic xml:id="auqy45g" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <sb xml:id="scjl1l1" />
                            <measure xml:id="measure-0032-9310-10650-1-mdiv-2" n="6">
                                <staff xml:id="sd9q7l0" n="1">
                                    <layer xml:id="l3752xy" n="1">
                                        <beam xml:id="blumdfp">
                                            <note xml:id="note-0032-9460-10720-2" dur="8" oct="5" pname="g" stem.dir="down">
                                                <artic xml:id="atorc8z" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-9500-10700-2" dur="8" oct="5" pname="b" stem.dir="down">
                                                <artic xml:id="amfbckp" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-9550-10710-2" dur="8" oct="5" pname="a" stem.dir="down">
                                                <artic xml:id="arcqb41" artic="stacciss" place="above" />
                                            </note>
                                            <note xml:id="note-0032-9600-10690-2" dur="8" oct="6" pname="c" stem.dir="down">
                                                <artic xml:id="akxs34t" artic="stacciss" place="above" />
                                            </note>
                                        </beam>
                                        <note xml:id="note-0032-9640-10700-2" dur="8" oct="5" pname="b" stem.dir="down">
                                            <artic xml:id="ak82ync" artic="stacciss" place="above" />
                                        </note>
                                        <rest xml:id="rest-0032-9700-10770" dur="8" />
                                        <rest xml:id="rest-0032-9740-10780" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-9790-10650-1-mdiv-2" n="7">
                                <staff xml:id="sfbpf8t" n="1">
                                    <layer xml:id="l2z3ma" n="1">
                                        <chord xml:id="cy1wm39" dur="2" stem.dir="up">
                                            <note xml:id="note-0032-9830-10830-1" oct="3" pname="g" />
                                            <note xml:id="note-0032-9830-10790-1" oct="4" pname="d" />
                                            <note xml:id="note-0032-9830-10750-1" oct="4" pname="b" />
                                            <note xml:id="note-0032-9830-10720-1" oct="5" pname="g" />
                                        </chord>
                                        <note xml:id="note-0032-9910-10740-2" dur="2" oct="5" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-9970-10650-1-mdiv-2" n="8">
                                <staff xml:id="sycquaj" n="1">
                                    <layer xml:id="lrzp7y6" n="1">
                                        <note xml:id="note-0032-9990-10750-1" dur="16" oct="5" pname="c" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0032-10020-10750-2" dur="4" oct="4" pname="b" stem.dir="down" />
                                        <beam xml:id="bsmu6v6">
                                            <note xml:id="note-0032-10080-10760-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                            <note xml:id="note-0032-10130-10770-1" dur="8" oct="4" pname="g" stem.dir="up" />
                                        </beam>
                                        <note xml:id="note-0032-10180-10740-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0032-10240-10790-1" dur="4" oct="4" pname="d" stem.dir="up" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-10290-10650-1-mdiv-2" n="9">
                                <staff xml:id="shz0oeh" n="1">
                                    <layer xml:id="lytmh58" n="1">
                                        <chord xml:id="c9ln7uq" dur="4" stem.dir="up">
                                            <note xml:id="note-0032-10330-10830-1" oct="3" pname="g" />
                                            <note xml:id="note-0032-10330-10770-1" oct="4" pname="g" />
                                        </chord>
                                        <rest xml:id="rest-0032-10470-10770" dur="4" />
                                        <note xml:id="note-0032-10600-10720-2" dots="1" dur="4" oct="5" pname="g" stem.dir="down" />
                                        <beam xml:id="blshhe2">
                                            <note xml:id="note-0032-10800-10700-2" dur="16" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0032-10830-10720-2" dur="16" oct="5" pname="g" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0032-10860-10650-1-mdiv-2" n="10">
                                <staff xml:id="smaco0g" n="1">
                                    <layer xml:id="lqtlf1j" n="1">
                                        <note xml:id="note-0032-10890-10720-2" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        <rest xml:id="rest-0032-11030-10780" dur="4" />
                                        <note xml:id="note-0032-11140-10710-2" dots="1" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <beam xml:id="bkeheho">
                                            <note xml:id="note-0032-11330-10690-2" dur="16" oct="6" pname="c" stem.dir="down" />
                                            <note xml:id="note-0032-11370-10710-2" dur="16" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                        </section>
                    </score>
                </mdiv>
                <mdiv type="movement" n="3" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_3_P1_Violin_I.mei">
                    <score>
                        <scoreDef xmlns="http://www.music-encoding.org/ns/mei" dynam.dist="4">
                            <staffGrp xml:id="skx6r2p">
                                <staffGrp xml:id="s9hud18" bar.thru="true">
                                    <staffDef xml:id="P1-V8s3TJGdWUOHMPpUWs4d5w" n="1" lines="5">
                                        <label xml:id="lnes803">Violin I</label>
                                        <clef xml:id="clef-1" shape="G" line="2" />
                                        <keySig xml:id="key-1" sig="1s" />
                                        <meterSig xml:id="time-1" count="3" unit="4" />
                                    </staffDef>
                                </staffGrp>
                            </staffGrp>
                        </scoreDef>
                        <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="s31ci9b">
                            <pb xml:id="p32hnhr" />
                            <measure xml:id="measure-0037-9630-9920-1-mdiv-3" n="1">
                                <staff xml:id="s6h2lqu" n="1">
                                    <layer xml:id="l1ruhe2" n="1">
                                        <note xml:id="note-0037-9810-10020-2" dots="1" dur="2" oct="5" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                                <dynam xml:id="dy42h1s" place="below" staff="1" tstamp="1.0">f</dynam>
                            </measure>
                            <measure xml:id="measure-0037-10000-9920-1-mdiv-3" n="2">
                                <staff xml:id="src5788" n="1">
                                    <layer xml:id="lcwp2r2" n="1">
                                        <note xml:id="note-0037-10040-9970-2" dots="1" dur="2" oct="6" pname="c" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-10220-9920-1-mdiv-3" n="3">
                                <staff xml:id="sn9oll6" n="1">
                                    <layer xml:id="lc1qgai" n="1">
                                        <note xml:id="note-0037-10260-9980-2" dur="4" oct="5" pname="b" stem.dir="down" />
                                        <note xml:id="note-0037-10300-9960-1" dur="16" oct="6" pname="d" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0037-10340-9970-2" dur="4" oct="6" pname="c" stem.dir="down" />
                                        <note xml:id="note-0037-10390-9980-1" dur="16" oct="5" pname="b" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0037-10420-9980-2" dur="4" oct="5" pname="a" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-10480-9920-1-mdiv-3" n="4">
                                <staff xml:id="sdqdm98" n="1">
                                    <layer xml:id="l1cndd9" n="1">
                                        <note xml:id="note-0037-10520-9990-2" dur="2" oct="5" pname="g" stem.dir="down" />
                                        <note xml:id="note-0037-10630-10000-2" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-10690-9920-1-mdiv-3" n="5">
                                <staff xml:id="sw8u8zw" n="1">
                                    <layer xml:id="lz8xhnw" n="1">
                                        <note xml:id="note-0037-10730-9990-2" dur="4" oct="5" pname="g" stem.dir="down" />
                                        <note xml:id="note-0037-10790-9980-2" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <note xml:id="note-0037-10850-9970-2" dur="4" oct="5" pname="b" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-10910-9920-1-mdiv-3" n="6">
                                <staff xml:id="sith7gb" n="1">
                                    <layer xml:id="llmvnpp" n="1">
                                        <note xml:id="note-0037-10950-9960-2" dur="4" oct="6" pname="c" stem.dir="down">
                                            <artic xml:id="aa1sh9h" artic="stacciss" place="above" />
                                        </note>
                                        <note xml:id="note-0037-11020-10020-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                        <note xml:id="note-0037-11090-10030-2" dur="4" oct="4" pname="b" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-11150-9920-1-mdiv-3" n="7">
                                <staff xml:id="sp13tp" n="1">
                                    <layer xml:id="lskztwb" n="1">
                                        <beam xml:id="bnit9pv">
                                            <note xml:id="note-0037-11180-10040-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                            <note xml:id="note-0037-11230-10030-1" dur="8" oct="4" pname="b" stem.dir="up" />
                                        </beam>
                                        <note xml:id="note-0037-11280-10050-1" dur="4" oct="4" pname="g" stem.dir="up" />
                                        <note xml:id="note-0037-11340-10060-1" dur="4" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-11390-9920-1-mdiv-3" right="rptend" n="8">
                                <staff xml:id="spl47jc" n="1">
                                    <layer xml:id="lu0v8v7" n="1">
                                        <note xml:id="note-0037-11430-10050-1" dur="2" oct="4" pname="g" stem.dir="up" />
                                        <rest xml:id="rest-0037-11570-10050" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <sb xml:id="siq76ug" />
                            <measure xml:id="measure-0037-9680-10640-1-mdiv-3" left="rptstart" n="9">
                                <staff xml:id="sp1vwzw" n="1">
                                    <layer xml:id="ljwc8o7" n="1">
                                        <beam xml:id="bd255q7">
                                            <note xml:id="note-0037-9740-10690-2" dur="8" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0037-9770-10690-2" dur="8" oct="6" pname="c" stem.dir="down" />
                                        </beam>
                                        <note xml:id="note-0037-9800-10700-2" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <rest xml:id="rest-0037-9860-10770" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0037-9900-10640-1-mdiv-3" n="x10">
                                <staff xml:id="s6bk9lt" n="1">
                                    <layer xml:id="l792u4f" n="1">
                                        <beam xml:id="boxkhcw">
                                            <note xml:id="note-0037-9930-10710-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0037-9960-10700-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                        <note xml:id="note-0037-10000-10720-2" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        <rest xml:id="rest-0037-10080-10770" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                        </section>
                    </score>
                </mdiv>
                <mdiv type="movement" n="4" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_4_P1_Violin_I.mei">
                    <score>
                        <scoreDef xmlns="http://www.music-encoding.org/ns/mei" dynam.dist="4">
                            <staffGrp xml:id="skx6r2p">
                                <staffGrp xml:id="s9hud18" bar.thru="true">
                                    <staffDef xml:id="P1-V8s3TJGdWUOHMPpUWs4d5w" n="1" lines="5">
                                        <label xml:id="lnes803">Violin I</label>
                                        <clef xml:id="clef-1" shape="G" line="2" />
                                        <keySig xml:id="key-1" sig="1s" />
                                        <meterSig xml:id="time-1" count="2" sym="cut" unit="2" />
                                    </staffDef>
                                </staffGrp>
                            </staffGrp>
                        </scoreDef>
                        <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="s31ci9b">
                            <measure xml:id="measure-0038-9970-11470-1-mdiv-4" n="x0">
                                <staff xml:id="s32hnhr" n="1">
                                    <layer xml:id="lgu6i9y" n="1">
                                        <note xml:id="note-0038-10150-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0038-10200-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                                <dynam xml:id="djvj0j9" place="below" staff="1" tstamp="1.0">p</dynam>
                            </measure>
                            <measure xml:id="measure-0038-10230-11470-1-mdiv-4" n="1">
                                <staff xml:id="s4qh9yv" n="1">
                                    <layer xml:id="luqb12v" n="1">
                                        <note xml:id="note-0038-10250-11550-1" dur="16" oct="5" pname="e" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0038-10280-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <beam xml:id="brisxuh">
                                            <note xml:id="note-0038-10320-11570-2" dur="8" oct="5" pname="c" stem.dir="down" />
                                            <note xml:id="note-0038-10350-11570-2" dur="8" oct="4" pname="b" stem.dir="down" />
                                        </beam>
                                        <note xml:id="note-0038-10380-11550-2" dur="4" oct="5" pname="e" stem.dir="down" />
                                        <note xml:id="note-0038-10420-11550-2" dur="4" oct="5" pname="e" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-10450-11470-1-mdiv-4" n="2">
                                <staff xml:id="sk6v879" n="1">
                                    <layer xml:id="ljpyjuz" n="1">
                                        <note xml:id="note-0038-10500-11550-2" dur="2" oct="5" pname="e" stem.dir="down" />
                                        <note xml:id="note-0038-10600-11570-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                        <note xml:id="note-0038-10640-11570-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-10670-11470-1-mdiv-4" n="3">
                                <staff xml:id="sr3r19h" n="1">
                                    <layer xml:id="lq9vik1" n="1">
                                        <note xml:id="note-0038-10690-11560-1" dur="16" oct="5" pname="d" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0038-10720-11570-2" dur="4" oct="5" pname="c" stem.dir="down" />
                                        <beam xml:id="bdmsfw9">
                                            <note xml:id="note-0038-10760-11570-1" dur="8" oct="4" pname="b" stem.dir="up" />
                                            <note xml:id="note-0038-10790-11580-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                        </beam>
                                        <note xml:id="note-0038-10820-11580-1" dur="4" oct="4" pname="a" stem.dir="up" />
                                        <note xml:id="note-0038-10860-11580-1" dur="4" oct="4" pname="a" stem.dir="up" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-10900-11470-1-mdiv-4" n="4">
                                <staff xml:id="su2b3r" n="1">
                                    <layer xml:id="lva68ns" n="1">
                                        <note xml:id="note-0038-10910-11570-1" dur="16" oct="4" pname="b" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0038-10940-11580-1" dur="4" oct="4" pname="a" stem.dir="up" />
                                        <beam xml:id="b7wi1gg">
                                            <note xml:id="note-0038-10990-11590-1" dur="8" oct="4" pname="g" stem.dir="up" />
                                            <note xml:id="note-0038-11020-11600-1" dur="8" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                                        </beam>
                                        <note xml:id="note-0038-11050-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <note xml:id="note-0038-11090-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-11120-11470-1-mdiv-4" n="5">
                                <staff xml:id="s3yqvtd" n="1">
                                    <layer xml:id="lsumd7z" n="1">
                                        <note xml:id="note-0038-11140-11550-1" dur="16" oct="5" pname="e" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0038-11170-11560-2" dur="4" oct="5" pname="d" stem.dir="down" />
                                        <beam xml:id="bnit9pv">
                                            <note xml:id="note-0038-11210-11570-2" dur="8" oct="5" pname="c" stem.dir="down" />
                                            <note xml:id="note-0038-11250-11570-2" dur="8" oct="4" pname="b" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="bpnjy7a">
                                            <note xml:id="note-0038-11280-11550-2" dur="8" oct="5" pname="e" stem.dir="down" />
                                            <note xml:id="note-0038-11310-11560-2" dur="8" oct="5" pname="d" stem.dir="down" />
                                            <note xml:id="note-0038-11340-11550-2" dur="8" oct="5" pname="e" stem.dir="down" />
                                            <note xml:id="note-0038-11370-11540-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-11390-11470-1-mdiv-4" n="6">
                                <staff xml:id="sdx87oa" n="1">
                                    <layer xml:id="lutz7p5" n="1">
                                        <beam xml:id="bbhlbvv">
                                            <note xml:id="note-0038-11430-11530-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0038-11460-11540-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0038-11490-11530-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0038-11520-11530-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="bi1630q">
                                            <note xml:id="note-0038-11550-11520-2" dur="8" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0038-11580-11530-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0038-11610-11520-2" dur="8" oct="5" pname="b" stem.dir="down" />
                                            <note xml:id="note-0038-11640-11510-2" dur="8" oct="6" pname="c" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-11660-11470-1-mdiv-4" n="7">
                                <staff xml:id="srm4wg1" n="1">
                                    <layer xml:id="lrcqb41" n="1">
                                        <note xml:id="note-0038-11700-11500-2" dur="4" oct="6" pname="d" stem.dir="down" />
                                        <rest xml:id="rest-0038-11750-11600" dur="4" />
                                        <note xml:id="note-0038-11790-11580-1" dur="2" oct="4" pname="a" stem.dir="up" />
                                    </layer>
                                </staff>
                                <trill xml:id="tk82ync" staff="1" startid="#note-0038-11790-11580-1" place="above" />
                            </measure>
                            <measure xml:id="measure-0038-11840-11470-1-mdiv-4" right="rptend" n="8">
                                <staff xml:id="s8rmoue" n="1">
                                    <layer xml:id="llckfrc" n="1">
                                        <note xml:id="note-0038-11880-11590-1" dur="4" oct="4" pname="g" stem.dir="up" />
                                        <rest xml:id="rest-0038-11930-11600" dur="4" />
                                    </layer>
                                </staff>
                            </measure>
                            <sb xml:id="soc9w3i" />
                            <measure xml:id="measure-0038-10020-12190-1-mdiv-4" left="rptstart" n="9">
                                <staff xml:id="slbdvp9" n="1">
                                    <layer xml:id="l8ep2u0" n="1">
                                        <note xml:id="note-0038-10080-12250-2" dur="4" oct="5" pname="g" stem.dir="down" />
                                        <beam xml:id="bg6g67z">
                                            <note xml:id="note-0038-10140-12250-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0038-10180-12240-2" dur="8" oct="5" pname="b" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-10220-12190-1-mdiv-4" n="x9">
                                <staff xml:id="s95ho3z" n="1">
                                    <layer xml:id="litiuia" n="1">
                                        <note xml:id="note-0038-10240-12240-1" dur="16" oct="5" pname="b" grace="acc" stem.dir="up" />
                                        <note xml:id="note-0038-10270-12250-2" dur="4" oct="5" pname="a" stem.dir="down" />
                                        <beam xml:id="btjj7w5">
                                            <note xml:id="note-0038-10330-12250-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0038-10370-12260-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                        </beam>
                                        <note xml:id="note-0038-10400-12260-1" dur="16" oct="5" pname="f" grace="acc" stem.dir="up" accid.ges="s" />
                                        <note xml:id="note-0038-10430-12270-2" dur="4" oct="5" pname="e" stem.dir="down" />
                                        <beam xml:id="blvjdka">
                                            <note xml:id="note-0038-10490-12280-2" dur="8" oct="5" pname="d" stem.dir="down" />
                                            <note xml:id="note-0038-10540-12280-2" dur="8" oct="5" pname="c" stem.dir="down">
                                                <accid xml:id="aua8gea" accid="s" accid.ges="s" />
                                            </note>
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                            <measure xml:id="measure-0038-10580-12190-1-mdiv-4" n="10">
                                <staff xml:id="sgrp9do" n="1">
                                    <layer xml:id="ltoh80y" n="1">
                                        <beam xml:id="bmaco0g">
                                            <note xml:id="note-0038-10630-12270-2" dur="8" oct="5" pname="e" stem.dir="down" />
                                            <note xml:id="note-0038-10670-12280-2" dur="8" oct="5" pname="d" stem.dir="down" />
                                            <note xml:id="note-0038-10710-12260-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0038-10760-12270-2" dur="8" oct="5" pname="e" stem.dir="down" />
                                        </beam>
                                        <beam xml:id="b45lqfm">
                                            <note xml:id="note-0038-10810-12250-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                            <note xml:id="note-0038-10850-12260-2" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                            <note xml:id="note-0038-10890-12250-2" dur="8" oct="5" pname="a" stem.dir="down" />
                                            <note xml:id="note-0038-10930-12250-2" dur="8" oct="5" pname="g" stem.dir="down" />
                                        </beam>
                                    </layer>
                                </staff>
                            </measure>
                        </section>
                    </score>
                </mdiv>
            </mdiv>
        </body>
    </music>
</mei>

```
</details>