### PR TITLE
Develop mdiv leak

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -210,6 +210,14 @@ public:
     bool IsSavingSinglePage() const { return (m_page != -1); }
 
     /**
+     * @name Gettersto improve code readability
+     */
+    ///@{
+    bool IsScoreBasedMEI() const { return m_scoreBasedMEI; }
+    bool IsPageBasedMEI() const { return !m_scoreBasedMEI; }
+    ///@}
+
+    /**
      * Setter for indent for the MEI output (default is 3, -1 for tabs)
      */
     void SetIndent(int indent) { m_indent = indent; }

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -197,9 +197,12 @@ public:
     std::string GetOutput(int page = -1);
 
     /**
-     * Setter for score-based MEI output
+     * @name Setter and getter for score-based MEI output
      */
+    ///@{
     void SetScoreBasedMEI(bool scoreBasedMEI) { m_scoreBasedMEI = scoreBasedMEI; }
+    bool GetScoreBasedMEI() { return m_scoreBasedMEI; }
+    ///@}
 
     /**
      * Setter for indent for the MEI output (default is 3, -1 for tabs)

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -201,8 +201,13 @@ public:
      */
     ///@{
     void SetScoreBasedMEI(bool scoreBasedMEI) { m_scoreBasedMEI = scoreBasedMEI; }
-    bool GetScoreBasedMEI() { return m_scoreBasedMEI; }
+    bool GetScoreBasedMEI() const { return m_scoreBasedMEI; }
     ///@}
+
+    /**
+     * Return true when the MEIOutput object is currently saving single page
+     */
+    bool IsSavingSinglePage() const { return (m_page != -1); }
 
     /**
      * Setter for indent for the MEI output (default is 3, -1 for tabs)

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -53,6 +53,15 @@ public:
     //----------//
 
     /**
+     * See Object::Save
+     * Invisible Mdiv elements are not saved in page-based MEI
+     */
+    ///@{
+    virtual int Save(FunctorParams *functorParams);
+    virtual int SaveEnd(FunctorParams *functorParams);
+    ///@}
+
+    /**
      * See Object::ConvertToPageBased
      */
     ///@{

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1179,7 +1179,7 @@ public:
     ///@{
 
     /**
-     * Fill a page by adding systems with the appropriate length.
+     * @name Fill a page by adding systems with the appropriate length.
      * At the end, add all the pending objects where reaching the end
      */
     ///@{
@@ -1188,9 +1188,12 @@ public:
     ///@}
 
     /**
-     *
+     * @name Fill a doc by adding pages with the appropriate length.
      */
+    ///@{
     virtual int CastOffPages(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int CastOffPagesEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    ///@}
 
     /**
      * Cast off the document according to the encoding provided (pb and sb)

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -972,8 +972,9 @@ void Doc::CastOffDocBase(bool useSb, bool usePb, bool smart)
     castOffPagesParams.m_leftoverSystem = leftoverSystem;
 
     Functor castOffPages(&Object::CastOffPages);
+    Functor castOffPagesEnd(&Object::CastOffPagesEnd);
     pages->AddChild(castOffFirstPage);
-    castOffSinglePage->Process(&castOffPages, &castOffPagesParams);
+    castOffSinglePage->Process(&castOffPages, &castOffPagesParams, &castOffPagesEnd);
     delete castOffSinglePage;
 
     this->ScoreDefSetCurrentDoc(true);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3040,24 +3040,12 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     pugi::xml_node pages;
     pugi::xml_node back;
 
-    // single-page doc
-    pugi::xml_document singlePageDoc;
-
     if (std::string(root.name()) == "music") {
         music = root;
-    }
-    else if (std::string(root.name()) == "score") {
-        music = singlePageDoc.append_child("music");
-        body = music.append_child("body");
-        pugi::xml_node mdiv = body.append_child("mdiv");
-        // Copy the score to the new document. This is not very efficient but it is not possible move a node to another
-        // document. Nonetheless acceptable since we are dealing with a single page
-        mdiv.append_copy(root);
     }
     else {
         music = root.child("music");
     }
-
     if (music.empty()) {
         LogError("No <music> element found in the MEI data");
         return false;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3039,12 +3039,24 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     pugi::xml_node pages;
     pugi::xml_node back;
 
+    // single-page doc
+    pugi::xml_document singlePageDoc;
+
     if (std::string(root.name()) == "music") {
         music = root;
+    }
+    else if (std::string(root.name()) == "score") {
+        music = singlePageDoc.append_child("music");
+        body = music.append_child("body");
+        pugi::xml_node mdiv = body.append_child("mdiv");
+        // Copy the score to the new document. This is not very efficient but it is not possible move a node to another
+        // document. Nonetheless acceptable since we are dealing with a single page
+        mdiv.append_copy(root);
     }
     else {
         music = root.child("music");
     }
+
     if (music.empty()) {
         LogError("No <music> element found in the MEI data");
         return false;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3050,8 +3050,8 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
         music = singlePageDoc.append_child("music");
         body = music.append_child("body");
         pugi::xml_node mdiv = body.append_child("mdiv");
-        // Copy the score to the new document. This is not very efficient but it is not possible move a node to another
-        // document. Nonetheless acceptable since we are dealing with a single page
+        // Copy the score to the new document. This is not very efficient but it is not possible to move a node to
+        // another document. Nonetheless acceptable since we are dealing with a single page
         mdiv.append_copy(root);
     }
     else {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3050,8 +3050,8 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
         music = singlePageDoc.append_child("music");
         body = music.append_child("body");
         pugi::xml_node mdiv = body.append_child("mdiv");
-        // Copy the score to the new document. This is not very efficient but it is not possible to move a node to
-        // another document. Nonetheless acceptable since we are dealing with a single page
+        // Copy the score to the new document. This is not very efficient but it is not possible move a node to another
+        // document. Nonetheless acceptable since we are dealing with a single page
         mdiv.append_copy(root);
     }
     else {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -227,7 +227,6 @@ bool MEIOutput::Export()
             assert(page);
 
             m_currentNode = meiDoc.append_child("score");
-            m_currentNode = m_currentNode.append_child("section");
             m_nodeStack.push_back(m_currentNode);
             // First save the main scoreDef
             m_doc->GetCurrentScoreDef()->Save(this);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -227,6 +227,7 @@ bool MEIOutput::Export()
             assert(page);
 
             m_currentNode = meiDoc.append_child("score");
+            m_currentNode = m_currentNode.append_child("section");
             m_nodeStack.push_back(m_currentNode);
             // First save the main scoreDef
             m_doc->GetCurrentScoreDef()->Save(this);

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -84,12 +84,11 @@ int Mdiv::Save(FunctorParams *functorParams)
     assert(params);
 
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
-    if (m_visibility == Hidden && meiOutput && !meiOutput->GetScoreBasedMEI()) {
-        return FUNCTOR_SIBLINGS;
+    if (m_visibility == Hidden && meiOutput) {
+        // Do not output hidden mdivs in page-based MEI or when saving a single score-based MEI page
+        if (!meiOutput->GetScoreBasedMEI() || meiOutput->IsSavingSinglePage()) return FUNCTOR_SIBLINGS;
     }
-    else {
-        return Object::Save(functorParams);
-    }
+    return Object::Save(functorParams);
 }
 
 int Mdiv::SaveEnd(FunctorParams *functorParams)
@@ -98,12 +97,11 @@ int Mdiv::SaveEnd(FunctorParams *functorParams)
     assert(params);
 
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
-    if (m_visibility == Hidden && meiOutput && !meiOutput->GetScoreBasedMEI()) {
-        return FUNCTOR_SIBLINGS;
+    if (m_visibility == Hidden && meiOutput) {
+        // Do not output hidden mdivs in page-based MEI or when saving a single score-based MEI page
+        if (!meiOutput->GetScoreBasedMEI() || meiOutput->IsSavingSinglePage()) return FUNCTOR_SIBLINGS;
     }
-    else {
-        return Object::SaveEnd(functorParams);
-    }
+    return Object::SaveEnd(functorParams);
 }
 
 int Mdiv::ConvertToPageBased(FunctorParams *functorParams)

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "functorparams.h"
+#include "iomei.h"
 #include "page.h"
 #include "pages.h"
 #include "score.h"
@@ -76,6 +77,34 @@ void Mdiv::MakeVisible()
 //----------------------------------------------------------------------------
 // Functor methods
 //----------------------------------------------------------------------------
+
+int Mdiv::Save(FunctorParams *functorParams)
+{
+    SaveParams *params = vrv_params_cast<SaveParams *>(functorParams);
+    assert(params);
+
+    MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
+    if (m_visibility == Hidden && meiOutput && !meiOutput->GetScoreBasedMEI()) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return Object::Save(functorParams);
+    }
+}
+
+int Mdiv::SaveEnd(FunctorParams *functorParams)
+{
+    SaveParams *params = vrv_params_cast<SaveParams *>(functorParams);
+    assert(params);
+
+    MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
+    if (m_visibility == Hidden && meiOutput && !meiOutput->GetScoreBasedMEI()) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return Object::SaveEnd(functorParams);
+    }
+}
 
 int Mdiv::ConvertToPageBased(FunctorParams *functorParams)
 {

--- a/src/pageboundary.cpp
+++ b/src/pageboundary.cpp
@@ -97,7 +97,16 @@ int PageElementEnd::CastOffPages(FunctorParams *functorParams)
     assert(params);
 
     assert(params->m_currentPage);
-    this->MoveItselfTo(params->m_currentPage);
+
+    PageElementEnd *endBoundary = dynamic_cast<PageElementEnd *>(params->m_contentPage->Relinquish(this->GetIdx()));
+    // End boundaries can be added to the page only if the pending list is empty
+    // Otherwise we are going to mess up the order
+    if (params->m_pendingPageElements.empty()) {
+        params->m_currentPage->AddChild(endBoundary);
+    }
+    else {
+        params->m_pendingPageElements.push_back(endBoundary);
+    }
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/systemboundary.cpp
+++ b/src/systemboundary.cpp
@@ -126,10 +126,12 @@ int SystemElementEnd::CastOffSystems(FunctorParams *functorParams)
         = dynamic_cast<SystemElementEnd *>(params->m_contentSystem->Relinquish(this->GetIdx()));
     // End boundaries are not added to the pending objects because we do not want them to be placed at the beginning of
     // the next system but only if the pending object array it empty (otherwise it will mess up the MEI tree)
-    if (params->m_pendingElements.empty())
+    if (params->m_pendingElements.empty()) {
         params->m_currentSystem->AddChild(endBoundary);
-    else
+    }
+    else {
         params->m_pendingElements.push_back(endBoundary);
+    }
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -229,7 +229,7 @@ FileFormat Toolkit::IdentifyInputFrom(const std::string &data)
         // <score-timewise> == root node for time-wise organization of MusicXML data
         // <opus> == root node for multi-movement/work organization of MusicXML data
 
-        if (std::regex_search(initial, std::regex("<(mei|music|pages)[\\s\\n>]"))) {
+        if (std::regex_search(initial, std::regex("<(mei|music|pages|score[^-])[\\s\\n>]"))) {
             return MEI;
         }
         if (std::regex_search(initial, std::regex("<(!DOCTYPE )?(score-partwise|opus|score-timewise)[\\s\\n>]"))) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -230,7 +230,7 @@ FileFormat Toolkit::IdentifyInputFrom(const std::string &data)
         // <score-timewise> == root node for time-wise organization of MusicXML data
         // <opus> == root node for multi-movement/work organization of MusicXML data
 
-        if (std::regex_search(initial, std::regex("<(mei|music|pages|score[^-])[\\s\\n>]"))) {
+        if (std::regex_search(initial, std::regex("<(mei|music|pages)[\\s\\n>]"))) {
             return MEI;
         }
         if (std::regex_search(initial, std::regex("<(!DOCTYPE )?(score-partwise|opus|score-timewise)[\\s\\n>]"))) {


### PR DESCRIPTION
The PR does two things
* Fix a memory leak when some mdivs are loaded but not made visible
* Remove non visible mdivs from the page-based MEI output.

With the input example of [this](https://github.com/rism-digital/verovio/pull/2392#issue-1005496335) PR (xml:id on mdiv have been added for clarity) we have the same MEI structure when outputting score-based MEI.

When outputting page-based MEI with `--mdiv-all`, the sturcture is (score and system elements are empty here for legibility)
```xml
<mei>
   <music>
      <body>
         <pages type="raw" xml:id="p8o229d">
            <!--Coordinates in MEI axis direction-->
            <page xml:id="pl4icow">
               <mdiv xml:id="mdiv1" />
               <mdiv xml:id="mdiv2" n="1" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_1_P1_Violin_I.mei" />
               <score xml:id="s6cv6km"></score>
               <system xml:id="sunw8wy" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="s24n5ul" system.leftmar="0" system.rightmar="0"></system>
               <pageElementEnd xml:id="p6pjew1" startid="s6cv6km" type="score" />
               <pageElementEnd xml:id="p3q5d66" startid="mdiv2" type="mdiv" />
               <mdiv xml:id="mdiv3" n="2" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_2_P1_Violin_I.mei" />
               <score xml:id="s5wyvki"></score>
               <system xml:id="s73stxk" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="s7h0lwl" system.leftmar="0" system.rightmar="0"></system>
               <pageElementEnd xml:id="pom8454" startid="s5wyvki" type="score" />
               <pageElementEnd xml:id="poo2dzd" startid="mdiv3" type="mdiv" />
               <mdiv xml:id="mdiv4" n="3" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_3_P1_Violin_I.mei" />
               <score xml:id="shm621o"></score>
               <system xml:id="s2sdnd6" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="swb0115" system.leftmar="0" system.rightmar="0"></system>
               <pageElementEnd xml:id="pxmfjaf" startid="shm621o" type="score" />
               <pageElementEnd xml:id="ph1i9ug" startid="mdiv4" type="mdiv" />
               <mdiv xml:id="mdiv5" n="4" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_4_P1_Violin_I.mei" />
               <score xml:id="s9vtcem"></score>
               <system xml:id="snse0t6" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="sxhdq9v" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="sgadmns" system.leftmar="0" system.rightmar="0"></system>
               <pageElementEnd xml:id="pwzv1se" startid="s9vtcem" type="score" />
               <pageElementEnd xml:id="psijzhc" startid="mdiv5" type="mdiv" />
               <pageElementEnd xml:id="pd5k09i" startid="mdiv1" type="mdiv" />
            </page>
         </pages>
      </body>
   </music>
</mei>
```

With `--mdiv-x-path-query="//mdiv/mdiv[@type='movement' and @n='2']"`
```xml
<mei>
   <music>
      <body>
         <pages type="raw" xml:id="p297jzt">
            <!--Coordinates in MEI axis direction-->
            <page xml:id="p5uverk">
               <mdiv xml:id="mdiv1" />
               <mdiv xml:id="mdiv3" n="2" type="movement" filename="R269_Wolfgang_Amadeus_Mozart_String_Quartet_No_1_in_G_Major_KV80_Baerenreiter_mov_2_P1_Violin_I.mei" />
               <score xml:id="sa1jidl"></score>
               <system xml:id="srk5iq" system.leftmar="0" system.rightmar="0"></system>
               <system xml:id="sbzitgl" system.leftmar="0" system.rightmar="0"></system>
               <pageElementEnd xml:id="pgpbazk" startid="sa1jidl" type="score" />
               <pageElementEnd xml:id="pfzu16o" startid="mdiv3" type="mdiv" />
               <pageElementEnd xml:id="pi5ftox" startid="mdiv1" type="mdiv" />
            </page>
         </pages>
      </body>
   </music>
</mei>
```

@DavidBauer1984 does it look as expected for you?

Of course, there is still the problem when exporting a single page in page-based MEI because it will not necessarily contain the `pageElementEnd` for an `mdiv` or a `score` started on the page, or vice versa. Reload it that remains a problem.

