### PR TITLE
Implement text circle enclosure

### DIFF
--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -97,6 +97,7 @@ public:
         m_alignment = HORIZONTALALIGNMENT_left;
         m_pointSize = 0;
         m_actualWidth = 0;
+        m_enclose = TEXTRENDITION_NONE;
     }
     virtual ~TextDrawingParams(){};
 
@@ -112,7 +113,8 @@ public:
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;
-    std::vector<TextElement *> m_boxedRend;
+    std::vector<TextElement *> m_enclosedRend;
+    data_TEXTRENDITION m_enclose;
 };
 
 } // namespace vrv

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -534,6 +534,7 @@ protected:
         int staffSize = 100, bool dimin = false, bool setBBGlyph = false);
     void DrawLyricString(DeviceContext *dc, std::wstring str, int staffSize = 100,
         std::optional<TextDrawingParams> params = std::nullopt);
+    void DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, bool isCircle);
     void DrawFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2);
     void DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, int radius);
     void DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int radius);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -534,7 +534,7 @@ protected:
         int staffSize = 100, bool dimin = false, bool setBBGlyph = false);
     void DrawLyricString(DeviceContext *dc, std::wstring str, int staffSize = 100,
         std::optional<TextDrawingParams> params = std::nullopt);
-    void DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, bool isCircle);
+    void DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness);
     void DrawFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2);
     void DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, int radius);
     void DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int radius);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -368,7 +368,7 @@ protected:
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
-    void DrawTextBox(DeviceContext *dc, const std::vector<TextElement *> &boxedRend, const int staffSize);
+    void DrawTextBoxes(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
 
     /**
      * @name Method for drawing Beam and FTrem.

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -368,7 +368,7 @@ protected:
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
-    void DrawTextBoxes(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
+    void DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
 
     /**
      * @name Method for drawing Beam and FTrem.

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1503,7 +1503,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+        DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dir, this);
@@ -1585,7 +1585,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             dc->ResetFont();
             dc->ResetBrush();
         }
-        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+        DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dynam, this);
@@ -1752,7 +1752,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+        DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(fing, this);
@@ -1912,7 +1912,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             dc->ResetFont();
             dc->ResetBrush();
 
-            DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+            DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
         }
     }
 
@@ -2154,7 +2154,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+        DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(reh, this);
@@ -2216,7 +2216,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
+        DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(tempo, this);
@@ -2581,25 +2581,21 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         dc->EndGraphic(ending, this);
 }
 
-void View::DrawTextBoxes(DeviceContext *dc, const TextDrawingParams &params, int staffSize)
+void View::DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params, int staffSize)
 {
     assert(dc);
     const int lineThickness = m_options->m_textEnclosureThickness.GetValue() * staffSize;
-    const int margin = staffSize / 2;
 
     for (const auto rend : params.m_enclosedRend) {
+        int x1 = rend->GetContentLeft() - staffSize;
+        int x2 = rend->GetContentRight() + staffSize;
+        int y1 = rend->GetContentBottom() - staffSize / 2;
+        int y2 = rend->GetContentTop() + staffSize;
+
         if (params.m_enclose == TEXTRENDITION_box) {
-            const int y1 = rend->GetContentBottom() - staffSize / 2;
-            const int y2 = rend->GetContentTop() + staffSize;
-            int x1 = rend->GetContentLeft() - staffSize;
-            int x2 = rend->GetContentRight() + staffSize;
             DrawNotFilledRectangle(dc, x1, y1, x2, y2, lineThickness, 0);
         }
         else if (params.m_enclose == TEXTRENDITION_circle) {
-            int x1 = rend->GetContentLeft() - margin;
-            int y1 = rend->GetContentBottom() - margin;
-            int x2 = rend->GetContentRight() + margin;
-            int y2 = rend->GetContentTop() + margin;
             const int width = std::abs(x2 - x1);
             const int height = std::abs(y2 - y1);
             if (width > height) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2599,12 +2599,14 @@ void View::DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params,
             const int width = std::abs(x2 - x1);
             const int height = std::abs(y2 - y1);
             if (width > height) {
+                y1 -= (width - height) / 2;
                 y2 += (width - height) / 2;
             }
             else if (height > width) {
                 x1 -= (height - width) / 2;
+                x2 += (height - width) / 2;
             }
-            DrawNotFilledEllipse(dc, x1, y1, x2, y2, lineThickness, true);
+            DrawNotFilledEllipse(dc, x1, y1, x2, y2, lineThickness);
         }
     }
 }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1480,7 +1480,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
             continue;
         }
 
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = dir->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -1503,7 +1503,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dir, this);
@@ -1554,7 +1554,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             continue;
         }
 
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = dynam->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -1585,7 +1585,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             dc->ResetFont();
             dc->ResetBrush();
         }
-        DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(dynam, this);
@@ -1735,7 +1735,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
             continue;
         }
 
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = fing->GetDrawingY();
 
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
@@ -1752,7 +1752,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(fing, this);
@@ -1891,7 +1891,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             continue;
         }
 
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = harm->GetDrawingY();
 
         if (harm->GetFirst() && harm->GetFirst()->Is(FB)) {
@@ -1912,7 +1912,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             dc->ResetFont();
             dc->ResetBrush();
 
-            DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+            DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
         }
     }
 
@@ -2138,7 +2138,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
             continue;
         }
 
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = reh->GetDrawingY() + 3 * m_doc->GetDrawingUnit((*staffIter)->m_drawingStaffSize);
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -2154,7 +2154,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(reh, this);
@@ -2193,7 +2193,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         }
 
         params.m_x = tempo->GetDrawingXRelativeToStaff((*staffIter)->GetN());
-        params.m_boxedRend.clear();
+        params.m_enclosedRend.clear();
         params.m_y = tempo->GetDrawingY();
         params.m_pointSize = m_doc->GetDrawingLyricFont((*staffIter)->m_drawingStaffSize)->GetPointSize();
 
@@ -2216,7 +2216,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         dc->ResetFont();
         dc->ResetBrush();
 
-        DrawTextBox(dc, params.m_boxedRend, (*staffIter)->m_drawingStaffSize);
+        DrawTextBoxes(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 
     dc->EndGraphic(tempo, this);
@@ -2581,18 +2581,35 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         dc->EndGraphic(ending, this);
 }
 
-void View::DrawTextBox(DeviceContext *dc, const std::vector<TextElement *> &boxedRend, const int staffSize)
+void View::DrawTextBoxes(DeviceContext *dc, const TextDrawingParams &params, int staffSize)
 {
     assert(dc);
     const int lineThickness = m_options->m_textEnclosureThickness.GetValue() * staffSize;
+    const int margin = staffSize / 2;
 
-    for (const auto rend : boxedRend) {
-        const int y1 = rend->GetContentBottom() - staffSize / 2;
-        const int y2 = rend->GetContentTop() + staffSize;
-        int x1 = rend->GetContentLeft() - staffSize;
-        int x2 = rend->GetContentRight() + staffSize;
-
-        DrawNotFilledRectangle(dc, x1, y1, x2, y2, lineThickness, 0);
+    for (const auto rend : params.m_enclosedRend) {
+        if (params.m_enclose == TEXTRENDITION_box) {
+            const int y1 = rend->GetContentBottom() - staffSize / 2;
+            const int y2 = rend->GetContentTop() + staffSize;
+            int x1 = rend->GetContentLeft() - staffSize;
+            int x2 = rend->GetContentRight() + staffSize;
+            DrawNotFilledRectangle(dc, x1, y1, x2, y2, lineThickness, 0);
+        }
+        else if (params.m_enclose == TEXTRENDITION_circle) {
+            int x1 = rend->GetContentLeft() - margin;
+            int y1 = rend->GetContentBottom() - margin;
+            int x2 = rend->GetContentRight() + margin;
+            int y2 = rend->GetContentTop() + margin;
+            const int width = std::abs(x2 - x1);
+            const int height = std::abs(y2 - y1);
+            if (width > height) {
+                y2 += (width - height) / 2;
+            }
+            else if (height > width) {
+                x1 -= (height - width) / 2;
+            }
+            DrawNotFilledEllipse(dc, x1, y1, x2, y2, lineThickness, true);
+        }
     }
 }
 

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -81,6 +81,28 @@ void View::DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine 
     }
 }
 
+void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, bool isCircle)
+{
+    assert(dc); // DC cannot be NULL
+
+    BoundingBox::Swap(y1, y2);
+
+    dc->SetPen(m_currentColour, lineThinkness, AxSOLID);
+    dc->SetBrush(m_currentColour, AxTRANSPARENT);
+
+    int width = x2 - x1;
+    int height = y1 - y2;
+    if (isCircle) {
+        width = height > width ? height : width;
+        height = width > height ? width : height;
+    }
+
+    dc->DrawEllipse(ToDeviceContextX(x1), ToDeviceContextY(y1), width, height);
+
+    dc->ResetPen();
+    dc->ResetBrush();
+}
+
 /*
  * Draw rectangle partly filled in, as specified by <fillSection>: 1=top, 2=bottom, 3=left side,
  * 4=right side; 0=don't fill in any part. FIXME: <fillSection> IS IGNORED.

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -81,21 +81,17 @@ void View::DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine 
     }
 }
 
-void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, bool isCircle)
+void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThickness)
 {
     assert(dc); // DC cannot be NULL
 
     BoundingBox::Swap(y1, y2);
 
-    dc->SetPen(m_currentColour, lineThinkness, AxSOLID);
+    dc->SetPen(m_currentColour, lineThickness, AxSOLID);
     dc->SetBrush(m_currentColour, AxTRANSPARENT);
 
     int width = x2 - x1;
     int height = y1 - y2;
-    if (isCircle) {
-        width = height > width ? height : width;
-        height = width > height ? width : height;
-    }
 
     dc->DrawEllipse(ToDeviceContextX(x1), ToDeviceContextY(y1), width, height);
 
@@ -126,13 +122,13 @@ void View::DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, in
     return;
 }
 
-void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThinkness, int radius = 0)
+void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int lineThickness, int radius = 0)
 {
     assert(dc); // DC cannot be NULL
 
     BoundingBox::Swap(y1, y2);
 
-    const int penWidth = lineThinkness;
+    const int penWidth = lineThickness;
     dc->SetPen(m_currentColour, penWidth, AxSOLID);
     dc->SetBrush(m_currentColour, AxTRANSPARENT);
 

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -357,10 +357,11 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         dc->GetFont()->SetPointSize(dc->GetFont()->GetPointSize() / SUPER_SCRIPT_FACTOR);
     }
 
-    if (rend->GetRend() == TEXTRENDITION_box) {
-        params.m_boxedRend.push_back(rend);
+    if ((rend->GetRend() == TEXTRENDITION_box) || (rend->GetRend() == TEXTRENDITION_circle)) {
+        params.m_enclosedRend.push_back(rend);
         params.m_x = rend->GetContentRight() + m_doc->GetDrawingUnit(100);
         params.m_explicitPosition = true;
+        params.m_enclose = rend->GetRend();
     }
 
     if (customFont) dc->ResetFont();


### PR DESCRIPTION
Added support for the ```@rend="circle"```:
![image](https://user-images.githubusercontent.com/1819669/134684264-e28aefd8-5e30-4d7d-ae96-20709b67dede.png)

