### PR TITLE
Fix stem position after vertical justification

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -853,18 +853,24 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
 
         const int shift = getShift(extremalStaves.back()) - getShift(extremalStaves.front());
 
-        // Add the shift to the stem length of the chord.
+        // Add the shift to the stem length of the chord
         Stem *stem = vrv_cast<Stem *>(this->FindDescendantByType(STEM));
         if (!stem) return FUNCTOR_CONTINUE;
 
         const int stemLen = stem->GetDrawingStemLen();
         if (stem->GetDrawingStemDir() == STEMDIRECTION_up) {
             stem->SetDrawingStemLen(stemLen - shift);
-            stem->SetDrawingYRel(stem->GetDrawingYRel() - shift);
         }
         else {
             stem->SetDrawingStemLen(stemLen + shift);
         }
+
+        // Reposition the stem
+        Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+        assert(staff);
+        Staff *rootStaff
+            = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? extremalStaves.back() : extremalStaves.front();
+        stem->SetDrawingYRel(stem->GetDrawingYRel() + getShift(staff) - getShift(rootStaff));
 
         // Add the shift to the flag position
         Flag *flag = vrv_cast<Flag *>(stem->FindDescendantByType(FLAG));


### PR DESCRIPTION
This PR fixes the stem position of the cross staff chord for a case missed in #2288 - when the chord is defined in the lower staff. To reproduce the issue, vertical justification must be enabled.

| Before | After |
| ------ | ----- |
| <img width="559" alt="Before" src="https://user-images.githubusercontent.com/63608463/134685455-a8f93166-f799-480f-9530-23fe8441208c.png"> | <img width="552" alt="After" src="https://user-images.githubusercontent.com/63608463/134685477-4f49baf9-b356-47e7-ad3f-0ccc2fb501d1.png"> |

<details>
  <summary>MEI example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <mdiv type="movement" n="2" filename="Q492_Beethoven_Piano_Sonata_No_1_in_F_minor_op_2_mov_2.mei">
          <score>
            <scoreDef xmlns="http://www.music-encoding.org/ns/mei">
      <staffGrp xml:id="staffgrp-0000000663298501">
       <staffGrp xml:id="staffgrp-0000000190770464" bar.thru="true">
        <grpSym xml:id="grpsym-0000001537941263" symbol="brace"/>
        <staffGrp xml:id="S1-Piano" bar.thru="true">
         <staffDef xml:id="staffdef-0000000445560034" n="1" lines="5">
          <clef xml:id="clef-0000001240457764" shape="G" line="2"/>
          <keySig xml:id="keysig-0000000693306400" sig="1f"/>
          <meterSig xml:id="msig-0000002016120948" count="3" unit="4"/>
         </staffDef>
         <staffDef xml:id="staffdef-0000000452460799" n="2" lines="5">
          <clef xml:id="clef-0000002120419661" shape="F" line="4"/>
          <keySig xml:id="keysig-0000001839333951" sig="1f"/>
          <meterSig xml:id="msig-0000001557933027" count="3" unit="4"/>
         </staffDef>
        </staffGrp>
       </staffGrp>
      </staffGrp>
     </scoreDef>
            <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="section-0000000102945043">
      <measure xml:id="measure-42-mdiv-2" n="42">
       <staff xml:id="staff-0000001414788578" n="1">
        <layer xml:id="layer-0000000111269036" n="1">
         <note xml:id="note-875" dur="4" oct="6" pname="c" stem.dir="down"/>
         <beam xml:id="beam-0000000566610452">
          <note xml:id="note-876" dur="16" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001186855374" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-877" dur="16" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-878" dur="16" oct="6" pname="d" stem.dir="down"/>
          <note xml:id="note-879" dur="16" oct="6" pname="c" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000001859186368">
          <note xml:id="note-880" dur="16" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001057065865" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-881" dur="16" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-882" dur="16" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-883" dur="16" oct="5" pname="f" stem.dir="down"/>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000001478695932" n="2">
        <layer xml:id="layer-0000000920921237" n="2">
         <beam xml:id="beam-0000001049497310">
          <tuplet xml:id="tuplet-0000000189466594" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-884" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-885" dur="16" oct="3" pname="e" stem.dir="down"/>
           <note xml:id="note-886" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-887" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-888" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-889" dur="16" oct="3" pname="e" stem.dir="down"/>
          </tuplet>
         </beam>
         <beam xml:id="beam-0000002063177625">
          <tuplet xml:id="tuplet-0000000144991606" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-890" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-891" dur="16" oct="3" pname="e" stem.dir="down"/>
           <note xml:id="note-892" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-893" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-894" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-895" dur="16" oct="3" pname="e" stem.dir="down"/>
          </tuplet>
         </beam>
         <beam xml:id="beam-0000001212849467">
          <tuplet xml:id="tuplet-0000000661002528" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-896" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-897" dur="16" oct="3" pname="f" stem.dir="down"/>
           <note xml:id="note-898" dur="16" oct="3" pname="a" stem.dir="down"/>
           <note xml:id="note-899" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-900" dur="16" oct="3" pname="a" stem.dir="down"/>
           <note xml:id="note-901" dur="16" oct="3" pname="f" stem.dir="down"/>
          </tuplet>
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-118" startid="#note-875" endid="#note-883" curvedir="above"/>
      </measure>
      <sb xml:id="sb-0000000611994266"/>
      <measure xml:id="measure-43-mdiv-2" n="43">
       <staff xml:id="staff-0000001113004734" n="1">
        <layer xml:id="layer-0000001008693266" n="1">
         <note xml:id="note-902" dur="4" oct="5" pname="f" stem.dir="down"/>
         <beam xml:id="beam-0000000308708030">
          <note xml:id="note-903" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-904" dur="32" oct="5" pname="f" stem.dir="down"/>
          <note xml:id="note-905" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-906" dur="32" oct="5" pname="d" stem.dir="down"/>
          <note xml:id="note-907" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-908" dur="32" oct="5" pname="c" stem.dir="down"/>
          <note xml:id="note-909" dur="32" oct="5" pname="d" stem.dir="down"/>
          <note xml:id="note-910" dur="32" oct="5" pname="e" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000001853779854">
          <note xml:id="note-911" dots="1" dur="16" oct="5" pname="f" stem.dir="down"/>
          <note xml:id="note-912" dur="32" oct="5" pname="g" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000000566415542">
          <note xml:id="note-913" dots="1" dur="16" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-914" dur="32" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001918466837" accid="n" accid.ges="n"/>
          </note>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000000257281578" n="2">
        <layer xml:id="layer-0000000130639408" n="4">
         <tuplet xml:id="tuplet-0c000000019910542" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000977861419">
           <note xml:id="note-921" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-922" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-923" dur="16" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
           <note xml:id="note-924" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-925" dur="16" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
           <note xml:id="note-926" dur="16" oct="3" pname="g" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c000019910542" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000784628024">
           <note xml:id="note-927" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-928" dur="16" oct="3" pname="f" stem.dir="down"/>
           <note xml:id="note-929" dur="16" oct="3" pname="a" stem.dir="down"/>
           <note xml:id="note-930" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-931" dur="16" oct="3" pname="a" stem.dir="down"/>
           <note xml:id="note-932" dur="16" oct="3" pname="f" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c10542" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000478156949">
           <note xml:id="note-916" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-917" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-918" dur="16" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
           <note xml:id="note-915" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-919" dur="16" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
           <note xml:id="note-920" dur="16" oct="3" pname="g" stem.dir="down"/>
          </beam>
         </tuplet>
        </layer>
       </staff>
       <turn xml:id="turn-24" staff="1" tstamp="3.180000" place="above"/>
       <turn xml:id="turn-25" staff="1" tstamp="3.650000" place="above"/>
       <slur xml:id="slur-119" startid="#note-903" endid="#note-914" curvedir="above"/>
      </measure>
      <measure xml:id="measure-44-mdiv-2" n="44">
       <staff xml:id="staff-0000000455096073" n="1">
        <layer xml:id="layer-0000000963851834" n="1">
         <beam xml:id="beam-0000001529527671">
          <note xml:id="note-933" dur="8" oct="6" pname="d" stem.dir="down"/>
          <note xml:id="note-934" dur="8" oct="6" pname="c" stem.dir="down"/>
         </beam>
         <tuplet xml:id="tuplet-c43" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-935" dur="16"/>
          <beam xml:id="beam-0000001050110870">
           <note xml:id="note-936" dur="16" oct="5" pname="b" stem.dir="down">
            <accid xml:id="accid-0000001127612129" accid="n" accid.ges="n"/>
           </note>
           <note xml:id="note-937" dur="16" oct="6" pname="c" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c42" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-938" dur="16"/>
          <beam xml:id="beam-0000001246448457">
           <note xml:id="note-939" dur="16" oct="6" pname="d" stem.dir="down"/>
           <note xml:id="note-940" dur="16" oct="6" pname="c" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c44" num="3" numbase="2" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-941" dur="16"/>
          <beam xml:id="beam-0000000245408086">
           <note xml:id="note-942" dur="16" oct="6" pname="c" stem.dir="down"/>
           <note xml:id="note-943" dur="16" oct="5" pname="b" stem.dir="down" accid.ges="n"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c45" num="3" numbase="2" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-944" dur="16"/>
          <beam xml:id="beam-0000000648904818">
           <note xml:id="note-945" dur="16" oct="6" pname="c" stem.dir="down"/>
           <note xml:id="note-946" dur="16" oct="5" pname="b" stem.dir="down">
            <accid xml:id="accid-0000000728001305" accid="f" accid.ges="f"/>
           </note>
          </beam>
         </tuplet>
        </layer>
       </staff>
       <staff xml:id="staff-0000001167882322" n="2">
        <layer xml:id="layer-0000001758266763" n="2">
         <beam xml:id="beam-0000000677015426">
          <tuplet xml:id="tuplet-0000001969605320" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-947" dur="16" oct="3" pname="c" stem.dir="down"/>
           <note xml:id="note-948" dur="16" oct="3" pname="e" stem.dir="down"/>
           <note xml:id="note-949" dur="16" oct="3" pname="g" stem.dir="down"/>
           <note xml:id="note-950" dur="16" oct="4" pname="c" stem.dir="down"/>
           <note xml:id="note-951" dur="16" oct="4" pname="e" stem.dir="down"/>
           <note xml:id="note-952" dur="16" oct="4" pname="d" stem.dir="down"/>
          </tuplet>
         </beam>
         <clef xml:id="clef-0000000637804549" shape="G" line="2"/>
         <beam xml:id="beam-0000001977691031">
          <tuplet xml:id="tuplet-0000001008679337" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-953" dur="16" oct="4" pname="c" stem.dir="up"/>
           <note xml:id="note-954" dur="16" oct="4" pname="e" stem.dir="up"/>
           <note xml:id="note-955" dur="16" oct="4" pname="g" stem.dir="up"/>
           <note xml:id="note-956" dur="16" oct="5" pname="c" stem.dir="up"/>
           <note xml:id="note-957" dur="16" oct="4" pname="c" stem.dir="up"/>
           <note xml:id="note-958" dur="16" oct="4" pname="e" stem.dir="up"/>
          </tuplet>
         </beam>
         <beam xml:id="beam-0000000085036062">
          <tuplet xml:id="tuplet-0000000987474310" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="above" bracket.visible="false">
           <note xml:id="note-959" dur="16" oct="4" pname="d" stem.dir="up"/>
           <note xml:id="note-960" dur="16" oct="4" pname="f" stem.dir="up"/>
           <note xml:id="note-961" dur="16" oct="5" pname="c" stem.dir="up"/>
           <note xml:id="note-962" dur="16" oct="4" pname="e" stem.dir="up"/>
           <note xml:id="note-963" dur="16" oct="4" pname="g" stem.dir="up"/>
           <note xml:id="note-964" dur="16" oct="5" pname="c" stem.dir="up"/>
          </tuplet>
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-120" startid="#note-933" endid="#note-934" curvedir="above"/>
       <slur xml:id="slur-121" startid="#note-936" endid="#note-937" curvedir="above"/>
       <slur xml:id="slur-122" startid="#note-939" endid="#note-940" curvedir="above"/>
       <slur xml:id="slur-123" startid="#note-942" endid="#note-943" curvedir="above"/>
       <slur xml:id="slur-124" startid="#note-945" endid="#note-946" curvedir="above"/>
      </measure>
      <measure xml:id="measure-45-mdiv-2" n="45">
       <staff xml:id="staff-0000000910768892" n="1">
        <layer xml:id="layer-0000001263678598" n="1">
         <beam xml:id="beam-0000001938558812">
          <note xml:id="note-965" dots="1" dur="8" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-966" dur="16" oct="5" pname="a" stem.dir="down"/>
         </beam>
         <tuplet xml:id="tuplet-c53" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-967" dur="16"/>
          <beam xml:id="beam-0000001018652766">
           <note xml:id="note-968" dur="16" oct="6" pname="c" stem.dir="down"/>
           <note xml:id="note-969" dur="16" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c54" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-970" dur="16"/>
          <beam xml:id="beam-0000000983096032">
           <note xml:id="note-971" dur="16" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
           <note xml:id="note-972" dur="16" oct="5" pname="a" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c5" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-973" dur="16"/>
          <beam xml:id="beam-0000001546937377">
           <note xml:id="note-974" dur="16" oct="5" pname="a" stem.dir="down"/>
           <note xml:id="note-975" dur="16" oct="5" pname="g" stem.dir="down"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c56" num="3" numbase="2" num.place="below" num.visible="true" bracket.place="below" bracket.visible="false" num.format="count">
          <rest xml:id="note-976" dur="16"/>
          <beam xml:id="beam-0000000879760428">
           <note xml:id="note-977" dur="16" oct="5" pname="g" stem.dir="down"/>
           <note xml:id="note-978" dur="16" oct="5" pname="f" stem.dir="down"/>
          </beam>
         </tuplet>
        </layer>
       </staff>
       <staff xml:id="staff-0000001830270386" n="2">
        <layer xml:id="layer-0000001834643898" n="2">
         <tuplet xml:id="tuplet-c47" num="6" numbase="4" num.place="above" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000001858231971">
           <note xml:id="note-979" dur="16" oct="4" pname="f" stem.dir="up"/>
           <note xml:id="note-980" dur="16" oct="4" pname="a" stem.dir="up"/>
           <note xml:id="note-981" dur="16" oct="5" pname="c" stem.dir="up"/>
           <note xml:id="note-982" dur="16" oct="5" pname="f" stem.dir="up"/>
           <note xml:id="note-983" dur="16" oct="5" pname="e" stem.dir="up"/>
           <note xml:id="note-984" dur="16" oct="5" pname="e" stem.dir="up">
            <accid xml:id="accid-0000001718453668" accid="f" accid.ges="f"/>
           </note>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c57" num="3" numbase="2" num.place="below" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000935145547">
           <note xml:id="note-985" dur="16" oct="5" pname="d" stem.dir="up"/>
           <note xml:id="note-986" dur="16" oct="5" pname="f" stem.dir="up"/>
           <note xml:id="note-987" dur="16" oct="5" pname="d" stem.dir="up"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c58" num="3" numbase="2" num.place="below" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000055975487">
           <note xml:id="note-988" dur="16" oct="5" pname="c" stem.dir="up"/>
           <note xml:id="note-989" dur="16" oct="5" pname="e" stem.dir="up">
            <accid xml:id="accid-0000000883830143" accid="n" accid.ges="n"/>
           </note>
           <note xml:id="note-990" dur="16" oct="5" pname="c" stem.dir="up"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c59" num="3" numbase="2" num.place="below" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000001012938688">
           <note xml:id="note-991" dur="16" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
           <note xml:id="note-992" dur="16" oct="5" pname="d" stem.dir="up"/>
           <note xml:id="note-993" dur="16" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
          </beam>
         </tuplet>
         <tuplet xml:id="tuplet-c60" num="3" numbase="2" num.place="below" num.visible="false" bracket.place="below" bracket.visible="false" num.format="count">
          <beam xml:id="beam-0000000047573647">
           <note xml:id="note-994" dur="16" oct="4" pname="a" stem.dir="up"/>
           <note xml:id="note-995" dur="16" oct="5" pname="c" stem.dir="up"/>
           <note xml:id="note-996" dur="16" oct="4" pname="a" stem.dir="up"/>
          </beam>
         </tuplet>
         <clef xml:id="clef-0000001004725871" shape="F" line="4"/>
        </layer>
        <layer xml:id="layer-0000000668198144" n="3">
         <note xml:id="note-997" dur="2" oct="4" pname="f" stem.dir="down"/>
         <note xml:id="note-998" dur="4" oct="4" pname="f" stem.dir="down"/>
         <clef xml:id="clef-0000000155149344" sameas="#clef-0000001004725871"/>
        </layer>
       </staff>
       <turn xml:id="turn-0000001765290187" staff="1" startid="#note-966" place="above" form="upper"/>
       <slur xml:id="slur-125" startid="#note-968" endid="#note-969" curvedir="above"/>
       <slur xml:id="slur-126" startid="#note-971" endid="#note-972" curvedir="above"/>
       <slur xml:id="slur-127" startid="#note-974" endid="#note-975" curvedir="above"/>
       <slur xml:id="slur-128" startid="#note-977" endid="#note-978" curvedir="above"/>
      </measure>
      <sb xml:id="sb-0000000336933195"/>
      <measure xml:id="measure-46-mdiv-2" n="46">
       <staff xml:id="staff-0000000133220285" n="1">
        <layer xml:id="layer-0000001015264226" n="1">
         <chord xml:id="chord-0000001622008885" dur="4" stem.dir="down">
          <note xml:id="note-999" oct="5" pname="e"/>
          <note xml:id="note-1000" oct="5" pname="c"/>
         </chord>
         <chord xml:id="chord-0000000520099528" dur="4" stem.dir="down">
          <note xml:id="note-1001" oct="5" pname="d"/>
          <note xml:id="note-1002" oct="4" pname="b" accid.ges="f"/>
         </chord>
         <beam xml:id="beam-0000001325777726">
          <chord xml:id="chord-0000000570191512" dots="1" dur="8" stem.dir="down">
           <note xml:id="note-1003" oct="6" pname="d"/>
           <note xml:id="note-1004" oct="5" pname="d"/>
          </chord>
          <chord xml:id="chord-0000002052586519" dur="16" stem.dir="down">
           <note xml:id="note-1005" oct="6" pname="c"/>
           <note xml:id="note-1006" oct="5" pname="c"/>
          </chord>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000000288393788" n="2">
        <layer xml:id="layer-0000000369237912" n="2">
         <note xml:id="note-1007" dur="2" oct="4" pname="f" stem.dir="up"/>
         <note xml:id="note-1008" dur="4" oct="4" pname="f" stem.dir="up"/>
        </layer>
        <layer xml:id="layer-0000002070459314" n="3">
         <note xml:id="note-1009" dots="1" dur="4" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
         <note xml:id="note-1010" dur="8" oct="3" pname="a" stem.dir="down"/>
         <beam xml:id="beam-0000000791315894">
          <chord xml:id="chord-0000001957050534" dots="1" dur="8" stem.dir="down">
           <note xml:id="note-1011" oct="3" pname="b">
            <accid xml:id="accid-0000000955626940" accid="n" accid.ges="n"/>
           </note>
           <note xml:id="note-1012" oct="3" pname="g">
            <accid xml:id="accid-0000000702714764" accid="s" accid.ges="s"/>
           </note>
          </chord>
          <chord xml:id="chord-0000000432270520" dur="16" stem.dir="down">
           <note xml:id="note-1013" oct="4" pname="c"/>
           <note xml:id="note-1014" oct="3" pname="a"/>
          </chord>
         </beam>
        </layer>
       </staff>
       <dynam xml:id="dynam-c1956" place="below" staff="1" tstamp="3.000000">sf</dynam>
       <slur xml:id="slur-129" startid="#chord-0000001622008885" endid="#chord-0000000520099528" curvedir="above"/>
       <slur xml:id="slur-130" startid="#chord-0000000570191512" endid="#chord-0000002052586519" curvedir="above"/>
       <slur xml:id="slur-131" startid="#note-1009" endid="#note-1010" curvedir="below"/>
       <slur xml:id="slur-132" startid="#chord-0000001957050534" endid="#chord-0000000432270520" curvedir="below"/>
      </measure>
      <measure xml:id="measure-47-mdiv-2" n="47">
       <staff xml:id="staff-0000002030419173" n="1">
        <layer xml:id="layer-0000000423644643" n="1">
         <beam xml:id="beam-0000001371111515">
          <note xml:id="note-1015" dur="16" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1016" dur="8" oct="6" pname="f" stem.dir="down"/>
          <note xml:id="note-1017" dur="32" oct="6" pname="e" stem.dir="down"/>
          <note xml:id="note-1018" dur="32" oct="6" pname="d" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000001756339038">
          <note xml:id="note-1019" dur="32" oct="6" pname="c" stem.dir="down">
           <accid xml:id="accid-0000002133657912" accid="s" accid.ges="s"/>
          </note>
          <note xml:id="note-1020" dur="32" oct="6" pname="e" stem.dir="down"/>
          <note xml:id="note-1021" dur="32" oct="6" pname="d" stem.dir="down"/>
          <note xml:id="note-1022" dur="32" oct="6" pname="c" stem.dir="down">
           <accid xml:id="accid-0000000407011604" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1023" dur="32" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
          <note xml:id="note-1024" dur="32" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-1025" dur="32" oct="6" pname="c" stem.dir="down" accid.ges="n"/>
          <note xml:id="note-1026" dur="32" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
         </beam>
         <beam xml:id="beam-0000001531144492">
          <note xml:id="note-1027" dur="32" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-1028" dur="32" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-1029" dur="32" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
          <note xml:id="note-1030" dur="32" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-1031" dur="32" oct="5" pname="f" stem.dir="down"/>
          <note xml:id="note-1032" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-1033" dur="32" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-1034" dur="32" oct="5" pname="e" stem.dir="down"/>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000000302155492" n="2">
        <layer xml:id="layer-0000000513762920" n="2">
         <chord xml:id="chord-0000000781250556" dur="4" stem.dir="down">
          <note xml:id="note-1035" oct="4" pname="f"/>
          <note xml:id="note-1036" oct="3" pname="a"/>
          <note xml:id="note-1037" oct="4" pname="c"/>
         </chord>
         <clef xml:id="clef-0000000285230526" shape="G" line="2"/>
         <note xml:id="note-1038" dur="4" oct="3" pname="b" stem.dir="down" accid.ges="f"/>
         <note xml:id="note-1039" dur="4" oct="4" pname="c" stem.dir="down"/>
        </layer>
        <layer xml:id="layer-0000000260156656" n="3">
         <space xml:id="space-0000001307643106" dur="4"/>
         <clef xml:id="clef-0000000581844928" sameas="#clef-0000000285230526"/>
         <beam xml:id="beam-0000000139102532">
          <note xml:id="note-1040" dur="8" oct="4" pname="d" stem.dir="up"/>
          <note xml:id="note-1041" dur="8" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1042" dur="8" oct="4" pname="e" stem.dir="up"/>
          <note xml:id="note-1043" dur="8" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-133" startid="#note-1015" endid="#note-1018" curvedir="above"/>
       <dynam xml:id="dynam-0000000835281956" place="below" staff="1" tstamp="1.250000">sf</dynam>
       <hairpin xml:id="wedge-7914" staff="1" tstamp="2.000000" tstamp2="0m+2.8750" form="dim" place="below" vgrp="200"/>
       <slur xml:id="slur-134" startid="#note-1019" endid="#note-1033" curvedir="above"/>
       <dynam xml:id="dynam-0000000572228025" place="below" staff="1" tstamp="3.000000">pp</dynam>
      </measure>
      <measure xml:id="measure-48-mdiv-2" n="48">
       <staff xml:id="staff-0000001501951689" n="1">
        <layer xml:id="layer-0000000356374285" n="1">
         <chord xml:id="chord-0000000251620450" dur="4" stem.dir="down">
          <note xml:id="note-1044" oct="5" pname="g"/>
          <note xml:id="note-1045" oct="5" pname="e"/>
         </chord>
         <note xml:id="note-1046" dur="16" oct="5" pname="f" stem.dir="down"/>
         <beam xml:id="beam-0000001063264551">
          <note xml:id="note-1047" dur="16" oct="5" pname="c" stem.dir="down"/>
          <note xml:id="note-1048" dur="16" oct="5" pname="f" stem.dir="down"/>
          <note xml:id="note-1049" dur="16" oct="5" pname="c" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000001062584263">
          <note xml:id="note-1050" dur="16" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
          <note xml:id="note-1051" dur="16" oct="4" pname="a" stem.dir="up"/>
          <note xml:id="note-1052" dur="16" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1053" dur="16" oct="4" pname="f" stem.dir="up"/>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000001597148686" n="2">
        <layer xml:id="layer-0000001532970947" n="2">
         <note xml:id="note-1054" dur="4" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
         <note xml:id="note-1055" dur="8" oct="4" pname="a" stem.dir="up"/>
         <rest xml:id="note-1056" dur="8"/>
         <rest xml:id="note-1057" dur="4"/>
         <clef xml:id="clef-0000000793888048" shape="F" line="4"/>
        </layer>
        <layer xml:id="layer-0000000962796596" n="3">
         <note xml:id="note-1058" dots="1" dur="4" oct="4" pname="f" stem.dir="down"/>
         <clef xml:id="clef-0000001795645049" sameas="#clef-0000000793888048"/>
        </layer>
       </staff>
       <dynam xml:id="dynam-c0181956" place="below" staff="1" tstamp="4.000000">sf</dynam>
       <slur xml:id="slur-135" startid="#chord-0000000251620450" endid="#note-1046" curvedir="above"/>
       <slur xml:id="slur-136" startid="#note-1047" endid="#note-1053" curvedir="above"/>
       <slur xml:id="slur-137" startid="#note-1054" endid="#note-1055" curvedir="above"/>
      </measure>
      <measure xml:id="measure-49-mdiv-2" n="49">
       <staff xml:id="staff-0000000738076003" n="1">
        <layer xml:id="layer-0000001719093259" n="1">
         <beam xml:id="beam-0000000415608228">
          <note xml:id="note-1059" dur="8" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1060" dur="8" oct="4" pname="e" stem.dir="up"/>
         </beam>
         <beam xml:id="beam-0000000638601243">
          <note xml:id="note-1061" dur="32" oct="4" pname="e" stem.dir="up"/>
          <note xml:id="note-1062" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1063" dur="32" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1064" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1065" dur="32" oct="4" pname="e" stem.dir="up"/>
          <note xml:id="note-1066" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1067" dur="32" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1068" dur="32" oct="4" pname="e" stem.dir="up"/>
         </beam>
         <beam xml:id="beam-0000002057726728">
          <note xml:id="note-1069" dur="16" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1070" dur="16" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1071" dur="16" oct="4" pname="a" stem.dir="up"/>
          <note xml:id="note-1072" dur="16" oct="4" pname="f" stem.dir="up"/>
         </beam>
        </layer>
        <layer xml:id="layer-0000001262353352" n="2">
         <note xml:id="note-1073" dur="4" oct="3" pname="g" stem.dir="down"/>
         <space xml:id="space-0000000709037249" dur="4"/>
         <note xml:id="note-1074" dur="4" oct="4" pname="c" stem.dir="down"/>
        </layer>
       </staff>
       <staff xml:id="staff-0000000775164429" n="2">
        <layer xml:id="layer-0000000229908832" n="3">
         <note xml:id="note-1075" dur="4" oct="3" pname="c" stem.dir="up"/>
         <beam xml:id="beam-0000000488988291">
          <note xml:id="note-1076" dur="8" oct="3" pname="d" stem.dir="up">
           <accid xml:id="accid-0000000658845310" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-1077" dur="8" oct="3" pname="c" stem.dir="up"/>
          <note xml:id="note-1078" dur="8" oct="3" pname="a" stem.dir="up"/>
          <note xml:id="note-1079" dur="8" oct="3" pname="f" stem.dir="up"/>
         </beam>
        </layer>
        <layer xml:id="layer-0000000202538216" n="4">
         <note xml:id="note-1080" dur="2" oct="2" pname="b" stem.dir="down" accid.ges="f"/>
         <note xml:id="note-1081" dur="4" oct="2" pname="a" stem.dir="down"/>
        </layer>
       </staff>
       <slur xml:id="slur-138" startid="#note-1059" endid="#note-1068" curvedir="above"/>
       <tie xml:id="tied-c139" startid="#note-1060" endid="#note-1061" curvedir="above"/>
       <slur xml:id="slur-140" startid="#note-1069" endid="#note-1072" curvedir="above"/>
       <dynam xml:id="dynam-0000000292448096" place="below" staff="2" tstamp="2.000000">sf</dynam>
       <slur xml:id="slur-141" startid="#note-1076" endid="#note-1079" curvedir="above"/>
      </measure>
      <sb xml:id="sb-0000000413064509"/>
      <measure xml:id="measure-50-mdiv-2" n="50">
       <staff xml:id="staff-0000000894497455" n="1">
        <layer xml:id="layer-0000001880824549" n="1">
         <beam xml:id="beam-0000001339555260">
          <note xml:id="note-1082" dur="8" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1083" dur="8" oct="4" pname="e" stem.dir="up"/>
         </beam>
         <beam xml:id="beam-0000000288306595">
          <note xml:id="note-1084" dur="32" oct="4" pname="e" stem.dir="up"/>
          <note xml:id="note-1085" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1086" dur="32" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1087" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1088" dur="32" oct="4" pname="e" stem.dir="up"/>
          <note xml:id="note-1089" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1090" dur="32" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1091" dur="32" oct="4" pname="e" stem.dir="up"/>
         </beam>
         <beam xml:id="beam-0000000543237561">
          <note xml:id="note-1092" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1093" dur="32" oct="4" pname="a" stem.dir="up"/>
          <note xml:id="note-1094" dur="32" oct="5" pname="c" stem.dir="up"/>
          <note xml:id="note-1095" dur="32" oct="4" pname="b" stem.dir="up" accid.ges="f"/>
          <note xml:id="note-1096" dur="32" oct="4" pname="a" stem.dir="up"/>
          <note xml:id="note-1097" dur="32" oct="4" pname="g" stem.dir="up"/>
          <note xml:id="note-1098" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1099" dur="32" oct="4" pname="e" stem.dir="up">
           <accid xml:id="accid-0000001815183097" accid="f" accid.ges="f"/>
          </note>
         </beam>
        </layer>
        <layer xml:id="layer-0000001657416200" n="2">
         <note xml:id="note-1100" dur="4" oct="3" pname="g" stem.dir="down"/>
         <space xml:id="space-0000001739777741" dur="4"/>
         <note xml:id="note-1101" dur="4" oct="4" pname="c" stem.dir="down"/>
        </layer>
       </staff>
       <staff xml:id="staff-0000000825015184" n="2">
        <layer xml:id="layer-0000001025457343" n="3">
         <note xml:id="note-1102" dur="4" oct="3" pname="c" stem.dir="up"/>
         <beam xml:id="beam-0000000584647660">
          <note xml:id="note-1103" dur="8" oct="3" pname="d" stem.dir="up">
           <accid xml:id="accid-0000000901361363" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-1104" dur="8" oct="3" pname="c" stem.dir="up"/>
          <note xml:id="note-1105" dur="8" oct="3" pname="a" stem.dir="up"/>
          <note xml:id="note-1106" dur="8" oct="3" pname="f" stem.dir="up"/>
         </beam>
        </layer>
        <layer xml:id="layer-0000001667889744" n="4">
         <note xml:id="note-1107" dur="2" oct="2" pname="b" stem.dir="down" accid.ges="f"/>
         <note xml:id="note-1108" dur="4" oct="2" pname="a" stem.dir="down"/>
        </layer>
       </staff>
       <slur xml:id="slur-142" startid="#note-1082" endid="#note-1091" curvedir="above"/>
       <tie xml:id="tied-6" startid="#note-1083" endid="#note-1084" curvedir="above"/>
       <slur xml:id="slur-143" startid="#note-1092" endid="#note-1099" curvedir="above"/>
       <dynam xml:id="dynam-0000001484897044" place="below" staff="2" tstamp="2.000000">sf</dynam>
       <dynam xml:id="dynam-c11135281956" place="below" staff="1" tstamp="0.800000">sf</dynam>
       <slur xml:id="slur-144" startid="#note-1103" endid="#note-1106" curvedir="above"/>
      </measure>
      <measure xml:id="measure-51-mdiv-2" n="51">
       <staff xml:id="staff-0000001764075953" n="1">
        <layer xml:id="layer-0000001627454185" n="1">
         <beam xml:id="beam-0000000279942089">
          <note xml:id="note-1109" dur="32" oct="4" pname="d" stem.dir="up">
           <accid xml:id="accid-0000001842563301" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1110" dur="32" oct="4" pname="e" stem.dir="up">
           <accid xml:id="accid-0000000489856546" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-1111" dur="32" oct="4" pname="d" stem.dir="up" accid.ges="n"/>
          <note xml:id="note-1112" dur="32" oct="4" pname="c" stem.dir="up">
           <accid xml:id="accid-0000000847702608" accid="s" accid.ges="s"/>
          </note>
          <note xml:id="note-1113" dur="32" oct="4" pname="d" stem.dir="up" accid.ges="n"/>
          <note xml:id="note-1114" dur="32" oct="4" pname="e" stem.dir="up">
           <accid xml:id="accid-0000001714148513" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1115" dur="32" oct="4" pname="f" stem.dir="up"/>
          <note xml:id="note-1116" dur="32" oct="4" pname="f" stem.dir="up">
           <accid xml:id="accid-0000001503474954" accid="s" accid.ges="s"/>
          </note>
         </beam>
         <beam xml:id="beam-0000002113460903">
          <note xml:id="note-1117" dur="32" oct="4" pname="g" stem.dir="down"/>
          <note xml:id="note-1118" dur="32" oct="4" pname="a" stem.dir="down"/>
          <note xml:id="note-1119" dur="32" oct="4" pname="b" stem.dir="down" accid.ges="f"/>
          <note xml:id="note-1120" dur="32" oct="5" pname="c" stem.dir="down">
           <accid xml:id="accid-0000001355907564" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1121" dur="32" oct="5" pname="d" stem.dir="down"/>
          <note xml:id="note-1122" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-1123" dur="32" oct="5" pname="f" stem.dir="down">
           <accid xml:id="accid-0000001652927993" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1124" dur="32" oct="5" pname="f" stem.dir="down">
           <accid xml:id="accid-0000000865655156" accid="s" accid.ges="s"/>
          </note>
         </beam>
         <beam xml:id="beam-0000000209267880">
          <note xml:id="note-1125" dur="32" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-1126" dur="32" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-1127" dur="32" oct="5" pname="b" stem.dir="down" accid.ges="f"/>
          <note xml:id="note-1128" dur="32" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1129" dur="32" oct="6" pname="d" stem.dir="down"/>
          <note xml:id="note-1130" dur="32" oct="6" pname="e" stem.dir="down"/>
          <note xml:id="note-1131" dur="32" oct="6" pname="f" stem.dir="down">
           <accid xml:id="accid-0000001638515764" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1132" dur="32" oct="6" pname="d" stem.dir="down"/>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000000507433992" n="2">
        <layer xml:id="layer-0000001321478801" n="2">
         <chord xml:id="chord-0000001422009308" dur="8" stem.dir="up">
          <note xml:id="note-1133" oct="2" pname="b" accid.ges="f"/>
          <note xml:id="note-1134" oct="3" pname="d">
           <accid xml:id="accid-0000001297290987" accid="n" accid.ges="n"/>
          </note>
         </chord>
         <rest xml:id="note-1135" dur="8"/>
         <rest xml:id="note-1136" dur="4"/>
         <clef xml:id="clef-0000000388436148" shape="G" line="2"/>
         <chord xml:id="chord-0000000581434567" dur="8" stem.dir="up">
          <note xml:id="note-1137" oct="3" pname="b" accid.ges="f"/>
          <note xml:id="note-1138" oct="4" pname="g"/>
          <note xml:id="note-1139" oct="4" pname="d"/>
         </chord>
         <rest xml:id="note-1140" dur="8"/>
        </layer>
       </staff>
       <slur xml:id="slur-145" startid="#note-1109" endid="#note-1132" curvedir="above"/>
      </measure>
      <pb xml:id="pb-0000000153477693"/>
      <measure xml:id="measure-52-mdiv-2" n="52">
       <staff xml:id="staff-0000001630463814" n="1">
        <layer xml:id="layer-0000000042711764" n="1">
         <beam xml:id="beam-0000000519882909">
          <note xml:id="note-1141" dur="32" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1142" dur="32" oct="6" pname="d" stem.dir="down"/>
          <note xml:id="note-1143" dur="32" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1144" dur="32" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000002098513310" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1145" dur="32" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1146" dur="32" oct="6" pname="f" stem.dir="down"/>
          <note xml:id="note-1147" dur="32" oct="6" pname="e" stem.dir="down"/>
          <note xml:id="note-1148" dur="32" oct="6" pname="d" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000001513404612">
          <note xml:id="note-1149" dur="32" oct="6" pname="c" stem.dir="down"/>
          <note xml:id="note-1150" dur="32" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001319631876" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1151" dur="32" oct="5" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001498154780" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-1152" dur="32" oct="5" pname="a" stem.dir="down"/>
          <note xml:id="note-1153" dur="32" oct="5" pname="g" stem.dir="down"/>
          <note xml:id="note-1154" dur="32" oct="5" pname="f" stem.dir="down"/>
          <note xml:id="note-1155" dur="32" oct="5" pname="e" stem.dir="down"/>
          <note xml:id="note-1156" dur="32" oct="5" pname="d" stem.dir="down"/>
         </beam>
         <beam xml:id="beam-0000002136847977">
          <note xml:id="note-1157" dur="16" oct="5" pname="c" stem.dir="down">
           <artic xml:id="artic-0000001741840089" artic="stacc" place="above"/>
          </note>
          <note xml:id="note-1158" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="f">
           <artic xml:id="artic-0000001553209544" artic="stacc" place="above"/>
          </note>
          <note xml:id="note-1159" dur="16" oct="4" pname="a" stem.dir="down">
           <artic xml:id="artic-0000000669266064" artic="stacc" place="above"/>
          </note>
          <note xml:id="note-1160" dur="16" oct="4" pname="g" stem.dir="down">
           <artic xml:id="artic-0000000658442695" artic="stacc" place="above"/>
          </note>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000001608534171" n="2">
        <layer xml:id="layer-0000001706794750" n="2">
         <chord xml:id="chord-0000000342777992" dur="8" stem.dir="up">
          <note xml:id="note-1161" oct="4" pname="c"/>
          <note xml:id="note-1162" oct="4" pname="a"/>
          <note xml:id="note-1163" oct="4" pname="f"/>
         </chord>
         <rest xml:id="note-1164" dur="8"/>
         <rest xml:id="note-1165" dur="4"/>
         <clef xml:id="clef-0000000177011024" shape="F" line="4"/>
         <chord xml:id="chord-0000000403729642" dur="4" stem.dir="down">
          <note xml:id="note-1166" oct="3" pname="b" accid.ges="f"/>
          <note xml:id="note-1167" oct="3" pname="e"/>
          <note xml:id="note-1168" oct="3" pname="c"/>
         </chord>
        </layer>
       </staff>
       <slur xml:id="slur-146" startid="#note-1141" endid="#note-1156" curvedir="above"/>
       <dynam xml:id="dynam-0000001330606045" place="below" staff="1" tstamp="3.000000">pp</dynam>
       <slur xml:id="slur-147" startid="#note-1157" endid="#note-1160" curvedir="above"/>
      </measure>
      <measure xml:id="measure-53-mdiv-2" n="53">
       <staff xml:id="staff-0000001246330089" n="1">
        <layer xml:id="layer-0000000250651353" n="1">
         <note xml:id="note-1169" dur="2" oct="4" pname="f" stem.dir="up"/>
         <note xml:id="note-1170" dur="8" oct="4" pname="f" stem.dir="up"/>
         <beam xml:id="beam-0000001262978323">
          <chord xml:id="chord-0000000349763546" dur="16" stem.dir="up">
           <note xml:id="note-1171" staff="2" oct="3" pname="f"/>
           <note xml:id="note-1172" oct="4" pname="c"/>
          </chord>
          <note xml:id="note-1173" dur="16" oct="4" pname="f" stem.dir="up"/>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000000053998133" n="2">
        <layer xml:id="layer-0000001847435701" n="2">
         <rest xml:id="note-1174" dur="8"/>
         <beam xml:id="beam-0000001302276780">
          <note xml:id="note-1175" dur="8" oct="3" pname="f" stem.dir="up"/>
          <note xml:id="note-1176" dur="8" oct="3" pname="b" stem.dir="up" accid.ges="f"/>
          <note xml:id="note-1177" dur="8" oct="3" pname="a" stem.dir="up"/>
          <note xml:id="note-1178" dur="8" oct="3" pname="g" stem.dir="up"/>
         </beam>
        </layer>
        <layer xml:id="layer-0000001994694522" n="3">
         <rest xml:id="note-1179" dur="8"/>
         <beam xml:id="beam-0000001193069713">
          <note xml:id="note-1180" dur="8" oct="2" pname="a" stem.dir="down"/>
          <note xml:id="note-1181" dur="8" oct="3" pname="d" stem.dir="down"/>
          <note xml:id="note-1182" dur="8" oct="3" pname="c" stem.dir="down"/>
          <note xml:id="note-1183" dur="8" oct="2" pname="b" stem.dir="down" accid.ges="f"/>
          <note xml:id="note-1184" dur="8" oct="2" pname="a" stem.dir="down"/>
         </beam>
        </layer>
        <layer xml:id="layer-0000000549411751" n="4">
         <note xml:id="note-1185" dots="1" dur="2" oct="2" pname="f" stem.dir="down"/>
        </layer>
       </staff>
       <tie xml:id="tied-7" startid="#note-1169" endid="#note-1170" curvedir="below"/>
       <slur xml:id="slur-148" startid="#chord-0000000349763546" endid="#note-1173" curvedir="above"/>
       <slur xml:id="tied-8" staff="2" startid="#note-1175" endid="#note-1171" curvedir="above"/>
       <slur xml:id="slur-149" startid="#note-1180" endid="#note-1184" curvedir="below"/>
      </measure>
      <measure xml:id="measure-54-mdiv-2" n="54">
       <staff xml:id="staff-0000001490591127" n="1">
        <layer xml:id="layer-0000001299631365" n="1">
         <note xml:id="note-1186" dur="4" oct="4" pname="f" stem.dir="up"/>
         <note xml:id="note-1187" dur="4" oct="4" pname="e" stem.dir="up"/>
        </layer>
       </staff>
       <staff xml:id="staff-0000001907131981" n="2">
        <layer xml:id="layer-0000001692502302" n="2">
         <chord xml:id="chord-0000000654013046" dur="2" stem.dir="up">
          <note xml:id="note-1188" oct="3" pname="g"/>
          <note xml:id="note-1189" oct="3" pname="b" accid.ges="f"/>
          <note xml:id="note-1190" oct="4" pname="c"/>
         </chord>
         <chord xml:id="chord-0000000296141406" dur="4" stem.dir="up">
          <note xml:id="note-1191" oct="3" pname="g"/>
          <note xml:id="note-1192" oct="3" pname="b" accid.ges="f"/>
          <note xml:id="note-1193" oct="4" pname="c"/>
          <note xml:id="note-1194" staff="1" oct="4" pname="e"/>
         </chord>
        </layer>
        <layer xml:id="layer-0000000611470781" n="3">
         <chord xml:id="chord-0000001110314539" dur="4" stem.dir="down">
          <note xml:id="note-1195" oct="3" pname="c"/>
          <note xml:id="note-1196" oct="2" pname="c"/>
         </chord>
         <beam xml:id="beam-0000000144924322">
          <chord xml:id="chord-0000001151429478" dur="16" stem.dir="down">
           <note xml:id="note-1197" oct="3" pname="c"/>
           <note xml:id="note-1198" oct="2" pname="c"/>
          </chord>
          <note xml:id="note-1199" dur="32" oct="2" pname="d" stem.dir="down"/>
          <note xml:id="note-1200" dur="32" oct="2" pname="e" stem.dir="down"/>
          <note xml:id="note-1201" dur="32" oct="2" pname="f" stem.dir="down"/>
          <note xml:id="note-1202" dur="32" oct="2" pname="g" stem.dir="down"/>
          <note xml:id="note-1203" dur="32" oct="2" pname="a" stem.dir="down"/>
          <note xml:id="note-1204" dur="32" oct="2" pname="b" stem.dir="down" accid.ges="f"/>
         </beam>
         <beam xml:id="beam-0000001760285745">
          <note xml:id="note-1205" dur="32" oct="3" pname="c" stem.dir="down"/>
          <note xml:id="note-1206" dur="32" oct="2" pname="b" stem.dir="down">
           <accid xml:id="accid-0000001469303017" accid="n" accid.ges="n"/>
          </note>
          <note xml:id="note-1207" dur="32" oct="3" pname="c" stem.dir="down"/>
          <note xml:id="note-1208" dur="32" oct="3" pname="d" stem.dir="down"/>
          <note xml:id="note-1209" dur="32" oct="3" pname="c" stem.dir="down"/>
          <note xml:id="note-1210" dur="32" oct="2" pname="b" stem.dir="down">
           <accid xml:id="accid-0000000426879303" accid="f" accid.ges="f"/>
          </note>
          <note xml:id="note-1211" dur="32" oct="2" pname="a" stem.dir="down"/>
          <note xml:id="note-1212" dur="32" oct="2" pname="g" stem.dir="down"/>
         </beam>
        </layer>
       </staff>
       <dynam xml:id="dynam-0000000358076188" place="below" staff="1" tstamp="1.000000">fp</dynam>
       <slur xml:id="slur-150" startid="#note-1186" endid="#note-1187" curvedir="above"/>
       <tie xml:id="tied-9" startid="#note-1195" endid="#note-1197" curvedir="below"/>
       <slur xml:id="slur-151" startid="#chord-0000001110314539" endid="#note-1204" curvedir="below"/>
       <tie xml:id="tied-10" startid="#note-1196" endid="#note-1198" curvedir="below"/>
       <slur xml:id="slur-152" startid="#note-1205" endid="#note-1212" curvedir="below"/>
      </measure>
     </section>
          </score>
        </mdiv>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

 