### PR TITLE
Fix large staff space

### DIFF
--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -167,6 +167,16 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
             m_crossStaffContent = staff;
             m_crossStaffRel = current->GetCrossStaffRel();
         }
+        // Check if some beam chord has cross staff content
+        else if (current->Is(CHORD)) {
+            Chord *chord = vrv_cast<Chord *>(current);
+            for (Note *note : { chord->GetTopNote(), chord->GetBottomNote() }) {
+                if (note->m_crossStaff && (note->m_crossStaff != m_beamStaff)) {
+                    m_crossStaffContent = note->m_crossStaff;
+                    m_crossStaffRel = note->GetCrossStaffRel();
+                }
+            }
+        }
 
         // Skip rests
         if (current->Is({ NOTE, CHORD })) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -259,33 +259,28 @@ data_STAFFREL_basic LayerElement::GetCrossStaffRel()
 void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlignment *&below)
 {
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+    Layer *crossLayer = NULL;
+    Staff *crossStaff = this->GetCrossStaff(crossLayer);
+    if (crossStaff) staff = crossStaff;
     assert(staff);
 
-    // By default use the alignment of the parent staff
+    // By default use the alignment of the staff
     above = staff->GetAlignment();
     below = above;
 
     // Chord and beam parent (if any)
-    Chord *chord = dynamic_cast<Chord *>(this->GetFirstAncestor(CHORD));
-    Beam *beam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM));
+    Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
+    Beam *beam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
 
-    Layer *crossLayer = NULL;
-    Staff *crossStaff = this->GetCrossStaff(crossLayer);
-
-    // By default for cross-staff element, use the cross-staff alignment
-    if (crossStaff && crossStaff->GetAlignment()) {
-        above = crossStaff->GetAlignment();
-        below = above;
-    }
     // Dots, flags and stems with cross-staff chords need special treatment
     if (this->Is({ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
         Staff *staffAbove = NULL;
         Staff *staffBelow = NULL;
         chord->GetCrossStaffExtremes(staffAbove, staffBelow);
-        if (staffAbove) {
+        if (staffAbove && (staffAbove->GetN() < staff->GetN())) {
             above = staffAbove->GetAlignment();
         }
-        if (staffBelow) {
+        if (staffBelow && (staffBelow->GetN() > staff->GetN())) {
             below = staffBelow->GetAlignment();
         }
     }


### PR DESCRIPTION
This PR fixes two situations where undetected cross staff content led to a big space between the staves.

1. This happened when a (cross staff) chord was defined in one staff with all notes in the other staff.

| Before | After |
| ------ | ----- |
| <img width="677" alt="Before1" src="https://user-images.githubusercontent.com/63608463/134690092-a32286f5-2eca-4cb3-ac14-9104bb82b22c.png"> | <img width="691" alt="After1" src="https://user-images.githubusercontent.com/63608463/134690142-c9b82026-1041-4375-8b3a-6f533d02649b.png"> |

<details>
  <summary>MEI example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
    <respStmt />
   </titleStmt>
   <pubStmt>
    <availability />
   </pubStmt>
  </fileDesc>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mdiv-0000001824254219">
    <score xml:id="score-0000001630509050">
     <scoreDef xml:id="scoredef-0000001763645034">
      <staffGrp xml:id="staffgrp-0000001746345139">
       <staffGrp xml:id="staffgrp-0000000435802570" symbol="brace" bar.thru="true">
        <staffGrp xml:id="P1-NULL" bar.thru="true">
         <staffDef xml:id="staffdef-0000001789269193" n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="4s" meter.count="3" meter.unit="4" />
         <staffDef xml:id="staffdef-0000000374059713" n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="4s" meter.count="3" meter.unit="4" />
        </staffGrp>
       </staffGrp>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-0000001009056701">
      <measure xml:id="measure-142-mdiv-1" n="142">
       <staff xml:id="staff-0000001939371766" n="1">
        <layer xml:id="layer-0000001242628351" n="1">
         <beam xml:id="beam-0000002087729402">
          <note xml:id="note-1434" dur.ppq="2" dur="8" oct="4" pname="b" stem.dir="up" />
          <note xml:id="note-1435" dur.ppq="2" dur="8" oct="4" pname="b" stem.dir="up" />
          <note xml:id="note-1436" dur.ppq="2" dur="8" oct="4" pname="b" stem.dir="up" />
          <note xml:id="note-1437" dur.ppq="2" dur="8" oct="5" pname="c" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1438" dur.ppq="2" dur="8" oct="5" pname="c" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1439" dur.ppq="2" dur="8" oct="5" pname="c" stem.dir="up">
           <accid xml:id="accid-0000002072495837" accid="x" accid.ges="ss" />
          </note>
         </beam>
        </layer>
        <layer xml:id="layer-0000000734099031" n="2">
         <note xml:id="note-1440" dur.ppq="8" dur="2" oct="4" pname="g" stem.dir="down" accid.ges="s" />
         <note xml:id="note-1441" dur.ppq="4" dur="4" oct="4" pname="g" stem.dir="down" accid.ges="s" />
        </layer>
       </staff>
       <staff xml:id="staff-0000000115303166" n="2">
        <layer xml:id="layer-0000001721564745" n="3">
         <space xml:id="space-0000001876965312" dur.ppq="4" dur="4" />
         <chord xml:id="chord-0000001563461344" dur.ppq="4" dur="4" stem.dir="up">
          <note xml:id="note-1442" oct="3" pname="b" />
          <note xml:id="note-1443" oct="4" pname="e" />
         </chord>
         <chord xml:id="chord-0000001455007186" dur.ppq="4" dur="4" stem.dir="up">
          <note xml:id="note-1444" oct="3" pname="a">
           <accid xml:id="accid-0000001405299752" accid="s" accid.ges="s" />
          </note>
          <note xml:id="note-1445" oct="4" pname="e" />
         </chord>
        </layer>
        <layer xml:id="layer-0000000133830865" n="4">
         <note xml:id="note-1446" dots="1" dur.ppq="12" dur="2" oct="3" pname="e" stem.dir="down" />
        </layer>
       </staff>
       <slur xml:id="slur-8600088" startid="#note-1435" endid="#note-1495" curvedir="above" />
       <hairpin xml:id="hairpin-0000002111287409" staff="2" tstamp="1.000000" tstamp2="1m+3.0000" form="cres" place="above" vgrp="200" />
      </measure>
      <measure xml:id="measure-143-mdiv-1" n="143">
       <staff xml:id="staff-0000000242016363" n="1">
        <layer xml:id="layer-0000000830937398" n="1">
         <beam xml:id="beam-0000001104525381">
          <note xml:id="note-1447" dur.ppq="2" dur="8" oct="5" pname="c" stem.dir="up">
           <accid xml:id="accid-0000000003625269" accid="x" accid.ges="ss" />
          </note>
          <note xml:id="note-1448" dur.ppq="2" dur="8" oct="5" pname="d" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1449" dur.ppq="2" dur="8" oct="5" pname="d" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1450" dur.ppq="2" dur="8" oct="5" pname="g" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1451" dur.ppq="2" dur="8" oct="5" pname="g" stem.dir="up" accid.ges="s" />
          <note xml:id="note-1452" dur.ppq="2" dur="8" oct="5" pname="f" stem.dir="up">
           <accid xml:id="accid-0000001554169922" accid="x" accid.ges="ss" />
          </note>
         </beam>
        </layer>
       </staff>
       <staff xml:id="staff-0000001170502192" n="2">
        <layer xml:id="layer-0000000168135813" n="2">
         <note xml:id="note-1453" dur.ppq="4" dur="4" oct="3" pname="d" stem.dir="down" accid.ges="s" />
         <chord xml:id="chord-0000000713562972" dur.ppq="4" dur="4" stem.dir="down">
          <note xml:id="note-1454" staff="1" oct="4" pname="b" />
          <note xml:id="note-1455" staff="1" oct="3" pname="b" />
          <note xml:id="note-14551" staff="1" oct="3" pname="g" />
          <note xml:id="note-1456" staff="1" oct="4" pname="d" accid.ges="s" />
          <note xml:id="note-1457" staff="1" oct="4" pname="g" accid.ges="s" />
         </chord>
         <rest xml:id="note-1458" dur.ppq="4" dur="4" />
        </layer>
       </staff>
       <pedal vgrp="10" xml:id="pedal-235" staff="2" tstamp="1.000000" dir="down" place="below" />
       <pedal vgrp="10" xml:id="pedal-236" staff="2" tstamp="3.50000" dir="up" place="below" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>


2. It also happened for beams with cross staff chords.

| Before | After |
| ------ | ----- |
| <img width="402" alt="Before2" src="https://user-images.githubusercontent.com/63608463/134690933-e5ffbaec-ecae-4997-b1ba-8243e6089dd7.png"> | <img width="408" alt="After2" src="https://user-images.githubusercontent.com/63608463/134690976-0c8a33be-726a-473e-b5a4-6a00ccb3cc0b.png"> |

<details>
  <summary>MEI example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-05-29" type="encoding-date">2021-05-29</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000001810151067">
         <appInfo xml:id="appinfo-0000001955639667">
            <application xml:id="application-0000001198665934" isodate="2021-06-30T08:29:30" version="3.5.0-dev-a2dcf5d">
               <name xml:id="name-0000000434260231">Verovio</name>
               <p xml:id="p-0000001462269911">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000567537909">
            <score xml:id="score-0000001634760236">
               <scoreDef xml:id="scoredef-0000000258995444">
                  <staffGrp xml:id="staffgrp-0000001262377749">
                     <staffGrp xml:id="S1-Piano" bar.thru="true">
                        <staffDef xml:id="staffdef-0000001942633229" n="1" lines="5" ppq="2">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <keySig xml:id="key-1" sig="0" />
                           <meterSig xml:id="time-1" count="2" sym="cut" unit="2" />
                        </staffDef>
                        <staffDef xml:id="staffdef-0000002113281130" n="2" lines="5" ppq="2">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <keySig xml:id="key-2" sig="0" />
                           <meterSig xml:id="time-2" count="2" sym="cut" unit="2" />
                        </staffDef>
                        <grpSym xml:id="grpsym-0000002105846375" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000509506734">
                 <measure xml:id="measure-0177-11030-10450-1-mdiv-1" n="35">
                    <staff xml:id="staff-0000001275715552" n="1">
                       <layer xml:id="layer-0000000021299554" n="1">
                          <chord xml:id="chord-0000000475873634" dur.ppq="6" dur="4" stem.dir="up">
                             <note xml:id="note-0177-11120-10650-1" oct="3" pname="b" />
                             <note xml:id="note-0177-11120-10580-1" oct="4" pname="b" />
                          </chord>
                          <chord xml:id="chord-0000001165420732" dur.ppq="6" dur="4" stem.dir="up">
                             <note xml:id="note-0177-11200-10660-1" oct="3" pname="a" />
                             <note xml:id="note-0177-11200-10590-1" oct="4" pname="a" />
                          </chord>
                          <chord xml:id="chord-0000001493857207" dur.ppq="6" dur="4" stem.dir="up">
                             <note xml:id="note-0177-11280-10670-1" oct="3" pname="g" />
                             <note xml:id="note-0177-11280-10600-1" oct="4" pname="g" />
                             <note xml:id="note-0177-11280-10640-1" oct="4" pname="c" />
                             <note xml:id="note-0177-11280-10620-1" oct="4" pname="e" />
                          </chord>
                          <chord xml:id="chord-0000001149061878" dur.ppq="6" dur="4" staff="2" stem.dir="down">
                             <artic xml:id="artic-0000002110029722" artic="acc" place="below" />
                             <note xml:id="note-0177-11360-10880-2" oct="2" pname="f" accid.ges="n" />
                             <note xml:id="note-0177-11360-10950-2" oct="1" pname="f" accid.ges="n" />
                          </chord>
                       </layer>
                       <layer xml:id="layer-0000002003401217" n="2">
                          <note xml:id="note-0177-11100-10630-2" dur.ppq="12" dur="2" oct="4" pname="d" stem.dir="down">
                             <accid xml:id="accid-0000001820008325" accid="s" accid.ges="s" />
                          </note>
                          <chord xml:id="chord-0000001015005682" dur.ppq="6" dur="4" stem.dir="down">
                             <note xml:id="note-0177-11350-10640-2" oct="4" pname="c" />
                             <note xml:id="note-0177-11350-10660-2" oct="3" pname="a" />
                          </chord>
                       </layer>
                    </staff>
                    <staff xml:id="staff-0000000474550816" n="2">
                       <layer xml:id="layer-0000000779592324" n="5">
                          <chord xml:id="chord-0000000336714129" dur.ppq="6" dur="4" stem.dir="up">
                             <artic xml:id="artic-0000000534956258" artic="acc" place="below" />
                             <note xml:id="note-0177-11120-10950-1" oct="1" pname="f">
                                <accid xml:id="accid-0000002045157373" accid="s" accid.ges="s" />
                             </note>
                             <note xml:id="note-0177-11120-10880-1" oct="2" pname="f">
                                <accid xml:id="accid-0000001998587828" accid="s" accid.ges="s" />
                             </note>
                          </chord>
                          <chord xml:id="chord-0000001526885891" dur.ppq="6" dur="4" stem.dir="up">
                             <artic xml:id="artic-0000002089072034" artic="acc" place="below" />
                             <note xml:id="note-0177-11200-10950-1" oct="1" pname="f">
                                <accid xml:id="accid-0000000654928338" accid="n" accid.ges="n" />
                             </note>
                             <note xml:id="note-0177-11200-10880-1" oct="2" pname="f">
                                <accid xml:id="accid-0000002129634911" accid="n" accid.ges="n" />
                             </note>
                          </chord>
                          <chord xml:id="chord-0000001600752984" dur.ppq="6" dur="4" stem.dir="up">
                             <artic xml:id="artic-0000000180272472" artic="acc" place="below" />
                             <note xml:id="note-0177-11280-10960-1" oct="1" pname="e" />
                             <note xml:id="note-0177-11280-10890-1" oct="2" pname="e" />
                          </chord>
                          <beam xml:id="beam-0000000493880154">
                             <chord xml:id="chord-0000000139514105" dur.ppq="3" dur="8" stem.dir="up">
                                <note xml:id="note-0177-11360-10810-1" oct="3" pname="f" />
                                <note xml:id="note-0177-11360-10610-1" staff="1" oct="4" pname="f" />
                             </chord>
                             <chord xml:id="chord-0000000556792465" dur.ppq="3" dur="8" stem.dir="up">
                                <note xml:id="note-0177-11410-10820-1" oct="3" pname="e" />
                                <note xml:id="note-0177-11410-10620-1" staff="1" oct="4" pname="e" />
                             </chord>
                          </beam>
                       </layer>
                    </staff>
                    <dir xml:id="dir-0000001823530635" place="above" staff="2" tstamp="1.750000" vgrp="200">ritard.</dir>
                 </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>



