### PR TITLE
Measure runtime

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -1252,6 +1252,12 @@
 		BDEF9ECA26725234008A3A47 /* caesura.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDEF9EC626725234008A3A47 /* caesura.cpp */; };
 		BDEF9ECC26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
 		BDEF9ECD26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
+		E79ADDC426BD1AE900527E4B /* runtimeclock.h in Headers */ = {isa = PBXBuildFile; fileRef = E79ADDC326BD1AE900527E4B /* runtimeclock.h */; };
+		E79ADDC526BD1AE900527E4B /* runtimeclock.h in Headers */ = {isa = PBXBuildFile; fileRef = E79ADDC326BD1AE900527E4B /* runtimeclock.h */; };
+		E79ADDC726BD645B00527E4B /* runtimeclock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79ADDC626BD645B00527E4B /* runtimeclock.cpp */; };
+		E79ADDC826BD645B00527E4B /* runtimeclock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79ADDC626BD645B00527E4B /* runtimeclock.cpp */; };
+		E79ADDC926BD645B00527E4B /* runtimeclock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79ADDC626BD645B00527E4B /* runtimeclock.cpp */; };
+		E79ADDCA26BD645B00527E4B /* runtimeclock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79ADDC626BD645B00527E4B /* runtimeclock.cpp */; };
 		E79C87C3269440570098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
 		E79C87C4269440790098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
 		E79C87C52694407A0098FE85 /* lv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E79C87C2269440570098FE85 /* lv.cpp */; };
@@ -1721,6 +1727,8 @@
 		BDC366C62576AF9300E4D826 /* grpsym.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = grpsym.h; path = include/vrv/grpsym.h; sourceTree = "<group>"; };
 		BDEF9EC626725234008A3A47 /* caesura.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = caesura.cpp; path = src/caesura.cpp; sourceTree = "<group>"; };
 		BDEF9ECB26725248008A3A47 /* caesura.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = caesura.h; path = include/vrv/caesura.h; sourceTree = "<group>"; };
+		E79ADDC326BD1AE900527E4B /* runtimeclock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = runtimeclock.h; path = include/vrv/runtimeclock.h; sourceTree = "<group>"; };
+		E79ADDC626BD645B00527E4B /* runtimeclock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = runtimeclock.cpp; path = src/runtimeclock.cpp; sourceTree = "<group>"; };
 		E79C87C1269440420098FE85 /* lv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = lv.h; path = include/vrv/lv.h; sourceTree = "<group>"; };
 		E79C87C2269440570098FE85 /* lv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lv.cpp; path = src/lv.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -2196,6 +2204,8 @@
 				8F59292418854BF800FE51AD /* object.h */,
 				4DA80D951A6ACF5D0089802D /* options.cpp */,
 				4DA80D941A6940120089802D /* options.h */,
+				E79ADDC626BD645B00527E4B /* runtimeclock.cpp */,
+				E79ADDC326BD1AE900527E4B /* runtimeclock.h */,
 				4D1D733B1A1D0390001E08F6 /* smufl.h */,
 				4D98CCDA25D26E3C00DC7A2C /* smufl.cpp */,
 				8F086EBF188539540037FD8E /* toolkit.cpp */,
@@ -2513,6 +2523,7 @@
 				4DA1448D1C2AB29400CB7CEE /* textelement.h in Headers */,
 				4DB787662022F0BF00394520 /* jsonxx.h in Headers */,
 				E79C87C7269440800098FE85 /* lv.h in Headers */,
+				E79ADDC426BD1AE900527E4B /* runtimeclock.h in Headers */,
 				8F59294918854BF800FE51AD /* multirest.h in Headers */,
 				8F59294A18854BF800FE51AD /* note.h in Headers */,
 				8F59294B18854BF800FE51AD /* object.h in Headers */,
@@ -2720,6 +2731,7 @@
 				BB4C4ACC22A932B6001F6AF0 /* pb.h in Headers */,
 				BB4C4B1222A932C8001F6AF0 /* expansion.h in Headers */,
 				BB4C4AC822A932B6001F6AF0 /* page.h in Headers */,
+				E79ADDC526BD1AE900527E4B /* runtimeclock.h in Headers */,
 				4D2E758922BC2B25004C51F0 /* atts_frettab.h in Headers */,
 				BB4C4A9722A9328F001F6AF0 /* functorparams.h in Headers */,
 				BB4C4B0222A932BC001F6AF0 /* unclear.h in Headers */,
@@ -3138,6 +3150,7 @@
 				4D4C26EE1EF7E75400681770 /* label.cpp in Sources */,
 				4D1694331E3A44F300569BF4 /* section.cpp in Sources */,
 				4D1694341E3A44F300569BF4 /* MidiMessage.cpp in Sources */,
+				E79ADDC826BD645B00527E4B /* runtimeclock.cpp in Sources */,
 				4D1694351E3A44F300569BF4 /* editorial.cpp in Sources */,
 				4D1694361E3A44F300569BF4 /* tempo.cpp in Sources */,
 				4DA0EACC22BB779400A7EBEB /* zone.cpp in Sources */,
@@ -3234,6 +3247,7 @@
 				4DB3D8961F7C2B0E00B5FC2B /* lb.cpp in Sources */,
 				8F086EE6188539540037FD8E /* beam.cpp in Sources */,
 				4DAA46681DA2B3E600FF1E1A /* artic.cpp in Sources */,
+				E79ADDC726BD645B00527E4B /* runtimeclock.cpp in Sources */,
 				40E1CEDE205060E20007C8AF /* labelabbr.cpp in Sources */,
 				4D674B46255F40B7008AEF4C /* plica.cpp in Sources */,
 				403B050F244F3E2900EE4F71 /* gliss.cpp in Sources */,
@@ -3565,6 +3579,7 @@
 				4D2073F722A3BCE000E0765F /* tuning.cpp in Sources */,
 				4DB3D8F61F83D1DC00B5FC2B /* view_mensural.cpp in Sources */,
 				4DB3D8E41F83D16400B5FC2B /* elementpart.cpp in Sources */,
+				E79ADDC926BD645B00527E4B /* runtimeclock.cpp in Sources */,
 				8F3DD33818854B250051330C /* system.cpp in Sources */,
 				4D72A5E1208A37F0009DEC1E /* mnum.cpp in Sources */,
 				8F3DD32418854B090051330C /* io.cpp in Sources */,
@@ -3779,6 +3794,7 @@
 				BB4C4AEB22A932BC001F6AF0 /* editorial.cpp in Sources */,
 				BB4C4B8F22A932DF001F6AF0 /* text.cpp in Sources */,
 				BB4C4ADF22A932BC001F6AF0 /* annot.cpp in Sources */,
+				E79ADDCA26BD645B00527E4B /* runtimeclock.cpp in Sources */,
 				BB4C4B1522A932C8001F6AF0 /* systemelement.cpp in Sources */,
 				4DA0EACE22BB779400A7EBEB /* zone.cpp in Sources */,
 				BB4C4B5B22A932D7001F6AF0 /* mensur.cpp in Sources */,

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,6 +18,7 @@ option(NO_MUSICXML_SUPPORT      "Disable MusicXML support"                     O
 option(NO_MXL_SUPPORT           "Disable compressed MusicXML support"          OFF)
 option(NO_HUMDRUM_SUPPORT       "Disable Humdrum support"                      OFF)
 option(MUSICXML_DEFAULT_HUMDRUM "Enable MusicXML to Humdrum by default"        OFF)
+option(NO_RUNTIME               "Disable runtime clock support"                ON)
 option(BUILD_AS_LIBRARY         "Build verovio as library"                     OFF)
 
 if (NO_HUMDRUM_SUPPORT AND MUSICXML_DEFAULT_HUMDRUM)
@@ -132,6 +133,10 @@ else()
     if (MUSICXML_DEFAULT_HUMDRUM)
         add_definitions(-DMUSICXML_DEFAULT_HUMDRUM)
     endif()
+endif()
+
+if(NO_RUNTIME)
+    add_definitions(-DNO_RUNTIME)
 endif()
 
 file(GLOB verovio_SRC "../src/*.cpp")

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -601,6 +601,7 @@ public:
     OptionInt m_pageWidth;
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
+    OptionBool m_showRuntime;
     OptionBool m_shrinkToFit;
     OptionBool m_staccatoCenter;
     OptionBool m_svgBoundingBoxes;

--- a/include/vrv/runtimeclock.h
+++ b/include/vrv/runtimeclock.h
@@ -8,6 +8,8 @@
 #ifndef __VRV_RUNTIMECLOCK_H__
 #define __VRV_RUNTIMECLOCK_H__
 
+#ifndef NO_RUNTIME
+
 #include <chrono>
 
 //----------------------------------------------------------------------------
@@ -48,4 +50,5 @@ private:
 
 } // namespace vrv
 
+#endif // NO_RUNTIME
 #endif // __VRV_RUNTIMECLOCK_H__

--- a/include/vrv/runtimeclock.h
+++ b/include/vrv/runtimeclock.h
@@ -1,0 +1,51 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        runtimeclock.h
+// Author:      David Bauer
+// Created:     06/08/2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_RUNTIMECLOCK_H__
+#define __VRV_RUNTIMECLOCK_H__
+
+#include <chrono>
+
+//----------------------------------------------------------------------------
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// RuntimeClock
+//----------------------------------------------------------------------------
+
+/**
+ * This class represents a clock to measure runtime.
+ */
+class RuntimeClock {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     */
+    ///@{
+    RuntimeClock();
+    ///@}
+
+    /** Resets the clock */
+    void Reset();
+
+    /** Get current runtime in seconds */
+    double GetSeconds() const;
+
+private:
+    //
+public:
+    //
+private:
+    /** The time point at which the clock was started */
+    std::chrono::time_point<std::chrono::steady_clock> m_start;
+
+}; // class RuntimeClock
+
+} // namespace vrv
+
+#endif // __VRV_RUNTIMECLOCK_H__

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -729,8 +729,10 @@ private:
 
     EditorToolkit *m_editorToolkit;
 
+#ifndef NO_RUNTIME
     /** Measuring runtime */
     RuntimeClock *m_runtimeClock;
+#endif
 
     //----------------//
     // Static members //

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -20,6 +20,7 @@
 namespace vrv {
 
 class EditorToolkit;
+class RuntimeClock;
 
 enum FileFormat {
     UNKNOWN = 0,
@@ -678,6 +679,18 @@ public:
      */
     int GetOutputTo() { return m_outputTo; }
 
+    /**
+     * Measuring runtime.
+     *
+     * @ingroup nodoc
+     */
+    ///@{
+    void InitClock();
+    void ResetClock();
+    double GetRuntimeInSeconds() const;
+    void LogRuntime() const;
+    ///@}
+
     ///@}
 
 protected:
@@ -715,6 +728,9 @@ private:
     char *m_cString;
 
     EditorToolkit *m_editorToolkit;
+
+    /** Measuring runtime */
+    RuntimeClock *m_runtimeClock;
 
     //----------------//
     // Static members //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1002,6 +1002,10 @@ Options::Options()
     m_removeIds.Init(false);
     this->Register(&m_removeIds, "removeIds", &m_general);
 
+    m_showRuntime.SetInfo("Show runtime on CLI", "Display the total runtime on command-line");
+    m_showRuntime.Init(false);
+    this->Register(&m_showRuntime, "showRuntime", &m_general);
+
     m_shrinkToFit.SetInfo("Shrink content to fit page", "Scale down page content to fit the page height if needed");
     m_shrinkToFit.Init(false);
     this->Register(&m_shrinkToFit, "shrinkToFit", &m_general);

--- a/src/runtimeclock.cpp
+++ b/src/runtimeclock.cpp
@@ -1,0 +1,35 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        runtimeclock.cpp
+// Author:      David Bauer
+// Created:     06/08/2021
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "runtimeclock.h"
+
+//----------------------------------------------------------------------------
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// RuntimeClock
+//----------------------------------------------------------------------------
+
+RuntimeClock::RuntimeClock()
+{
+    this->Reset();
+}
+
+void RuntimeClock::Reset()
+{
+    m_start = std::chrono::steady_clock::now();
+}
+
+double RuntimeClock::GetSeconds() const
+{
+    using namespace std::chrono;
+    steady_clock::duration timeDiff = steady_clock::now() - m_start;
+    return duration<double, seconds::period>(timeDiff).count();
+}
+
+} // namespace vrv

--- a/src/runtimeclock.cpp
+++ b/src/runtimeclock.cpp
@@ -7,6 +7,8 @@
 
 #include "runtimeclock.h"
 
+#ifndef NO_RUNTIME
+
 //----------------------------------------------------------------------------
 
 namespace vrv {
@@ -33,3 +35,5 @@ double RuntimeClock::GetSeconds() const
 }
 
 } // namespace vrv
+
+#endif // NO_RUNTIME

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -33,6 +33,7 @@
 #include "note.h"
 #include "options.h"
 #include "page.h"
+#include "runtimeclock.h"
 #include "slur.h"
 #include "staff.h"
 #include "svgdevicecontext.h"
@@ -81,6 +82,8 @@ Toolkit::Toolkit(bool initFont)
     m_options = m_doc.GetOptions();
 
     m_editorToolkit = NULL;
+
+    m_runtimeClock = NULL;
 }
 
 Toolkit::~Toolkit()
@@ -96,6 +99,10 @@ Toolkit::~Toolkit()
     if (m_editorToolkit) {
         delete m_editorToolkit;
         m_editorToolkit = NULL;
+    }
+    if (m_runtimeClock) {
+        delete m_runtimeClock;
+        m_runtimeClock = NULL;
     }
 }
 
@@ -1745,6 +1752,52 @@ std::string Toolkit::ConvertHumdrumToHumdrum(const std::string &humdrumData)
 #else
     return "";
 #endif
+}
+
+void Toolkit::InitClock()
+{
+    if (!m_runtimeClock) {
+        m_runtimeClock = new RuntimeClock();
+    }
+}
+
+void Toolkit::ResetClock()
+{
+    if (m_runtimeClock) {
+        m_runtimeClock->Reset();
+    }
+    else {
+        LogWarning("No clock available. Please call 'InitClock' to create one.");
+    }
+}
+
+double Toolkit::GetRuntimeInSeconds() const
+{
+    if (m_runtimeClock) {
+        return m_runtimeClock->GetSeconds();
+    }
+    else {
+        LogWarning("No clock available. Please call 'InitClock' to create one.");
+        return 0.0;
+    }
+}
+
+void Toolkit::LogRuntime() const
+{
+    if (m_runtimeClock) {
+        double seconds = m_runtimeClock->GetSeconds();
+        const int minutes = seconds / 60.0;
+        if (minutes > 0) {
+            seconds -= 60.0 * minutes;
+            LogMessage("Total runtime is %d min %.3f s.", minutes, seconds);
+        }
+        else {
+            LogMessage("Total runtime is %.3f s.", seconds);
+        }
+    }
+    else {
+        LogWarning("No clock available. Please call 'InitClock' to create one.");
+    }
 }
 
 } // namespace vrv

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -83,7 +83,9 @@ Toolkit::Toolkit(bool initFont)
 
     m_editorToolkit = NULL;
 
+#ifndef NO_RUNTIME
     m_runtimeClock = NULL;
+#endif
 }
 
 Toolkit::~Toolkit()
@@ -100,10 +102,12 @@ Toolkit::~Toolkit()
         delete m_editorToolkit;
         m_editorToolkit = NULL;
     }
+#ifndef NO_RUNTIME
     if (m_runtimeClock) {
         delete m_runtimeClock;
         m_runtimeClock = NULL;
     }
+#endif
 }
 
 bool Toolkit::SetResourcePath(const std::string &path)
@@ -1756,23 +1760,32 @@ std::string Toolkit::ConvertHumdrumToHumdrum(const std::string &humdrumData)
 
 void Toolkit::InitClock()
 {
+#ifndef NO_RUNTIME
     if (!m_runtimeClock) {
         m_runtimeClock = new RuntimeClock();
     }
+#else
+    LogError("Runtime clock is not supported in this build.");
+#endif
 }
 
 void Toolkit::ResetClock()
 {
+#ifndef NO_RUNTIME
     if (m_runtimeClock) {
         m_runtimeClock->Reset();
     }
     else {
         LogWarning("No clock available. Please call 'InitClock' to create one.");
     }
+#else
+    LogError("Runtime clock is not supported in this build.");
+#endif
 }
 
 double Toolkit::GetRuntimeInSeconds() const
 {
+#ifndef NO_RUNTIME
     if (m_runtimeClock) {
         return m_runtimeClock->GetSeconds();
     }
@@ -1780,10 +1793,15 @@ double Toolkit::GetRuntimeInSeconds() const
         LogWarning("No clock available. Please call 'InitClock' to create one.");
         return 0.0;
     }
+#else
+    LogError("Runtime clock is not supported in this build.");
+    return 0.0;
+#endif
 }
 
 void Toolkit::LogRuntime() const
 {
+#ifndef NO_RUNTIME
     if (m_runtimeClock) {
         double seconds = m_runtimeClock->GetSeconds();
         const int minutes = seconds / 60.0;
@@ -1798,6 +1816,9 @@ void Toolkit::LogRuntime() const
     else {
         LogWarning("No clock available. Please call 'InitClock' to create one.");
     }
+#else
+    LogError("Runtime clock is not supported in this build.");
+#endif
 }
 
 } // namespace vrv

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -377,6 +377,11 @@ int main(int argc, char **argv)
         exit(0);
     }
 
+    // Start the clock if desired
+    if (options->m_showRuntime.GetValue()) {
+        toolkit.InitClock();
+    }
+
     std::cerr << infile;
     if (optind <= argc - 1) {
         infile = std::string(argv[optind]);
@@ -649,6 +654,11 @@ int main(int argc, char **argv)
                 std::cerr << "Output written to " << outfile << "." << std::endl;
             }
         }
+    }
+
+    // Display runtime if desired
+    if (options->m_showRuntime.GetValue()) {
+        toolkit.LogRuntime();
     }
 
     free(long_options);


### PR DESCRIPTION
This PR adds a clock to Verovio to measure runtime.

![Runtime](https://user-images.githubusercontent.com/63608463/135277741-3ec51680-d57c-4917-b21c-7cdfdff31f46.png)

- There is a CLI option `--showRuntime` to output total runtime.
- On the toolkit there is an API to access the clock via `InitClock, ResetClock, GetRuntimeInSeconds, LogRuntime`.
- There is a cmake option to include/exclude the clock in the build.

