### PR TITLE
Fix dangling staff alignment

### DIFF
--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -204,6 +204,11 @@ public:
     virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams);
 
     /**
+     * See Object::CastOffEncoding
+     */
+    virtual int CastOffEncoding(FunctorParams *functorParams);
+
+    /**
      * See Object::ResetDrawing
      */
     virtual int ResetDrawing(FunctorParams *functorParams);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1205,7 +1205,7 @@ int Measure::CastOffEncoding(FunctorParams *functorParams)
 
     MoveItselfTo(params->m_currentSystem);
 
-    return FUNCTOR_SIBLINGS;
+    return FUNCTOR_CONTINUE;
 }
 
 int Measure::FillStaffCurrentTimeSpanningEnd(FunctorParams *functorParams)

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -593,6 +593,13 @@ int Staff::FillStaffCurrentTimeSpanning(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Staff::CastOffEncoding(FunctorParams *functorParams)
+{
+    // Staff alignments must be reset, otherwise they would dangle whenever they belong to a deleted system
+    m_staffAlignment = NULL;
+    return FUNCTOR_SIBLINGS;
+}
+
 int Staff::ResetDrawing(FunctorParams *functorParams)
 {
     m_timeSpanningElements.clear();

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -614,12 +614,12 @@ float View::CalcInitialSlur(
     // This might be refined later, since using the entire bounding box of a tie for collision avoidance with slurs is
     // coarse.
     ArrayOfFloatingPositioners tiePositioners = staff->GetAlignment()->FindAllFloatingPositioners(TIE);
-    if (startStaff && (startStaff != staff)) {
+    if (startStaff && (startStaff != staff) && startStaff->GetAlignment()) {
         const ArrayOfFloatingPositioners startTiePositioners
             = startStaff->GetAlignment()->FindAllFloatingPositioners(TIE);
         std::copy(startTiePositioners.begin(), startTiePositioners.end(), std::back_inserter(tiePositioners));
     }
-    else if (endStaff && (endStaff != staff)) {
+    else if (endStaff && (endStaff != staff) && endStaff->GetAlignment()) {
         const ArrayOfFloatingPositioners endTiePositioners = endStaff->GetAlignment()->FindAllFloatingPositioners(TIE);
         std::copy(endTiePositioners.begin(), endTiePositioners.end(), std::back_inserter(tiePositioners));
     }


### PR DESCRIPTION
This PR fixes an issue with a dangling staff alignment in `CastOffEncodingDoc`.

By loading the following MEI with `--breaks "encoded"`, this can somewhat be confirmed. It rarely crashes in Verovio, but when setting a breakpoint in `Doc::CastOffEncodingDoc` after `delete unCastOffPage`, it can be seen that all staff alignments of measure 11 are dangling.

<details>
  <summary>Show MEI</summary>

```xml
<?xml version="1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Ballade No. 1 in G minor, op. 23</title>
                <respStmt>
                    <persName role="composer">Chopin, Frederic</persName>
                </respStmt>
            </titleStmt>
            <pubStmt />
        </fileDesc>
    </meiHead>
    <music>
        <body>
            <mdiv type="placeholder" n="1" filename="C191_Frederic_Chopin_Ballade_No_1_in_G_minor_op_23_PWM_Polskie_Wydawnictwo_Muzyczne.mei">
                <score>
                    <scoreDef xmlns="http://www.music-encoding.org/ns/mei">
                        <staffGrp xml:id="synzk1t">
                            <staffGrp xml:id="S1-ty9q8jPDVsCWNSEmZ4EMBA" bar.thru="true">
                                <staffDef xml:id="s8li4mm" n="1" lines="5">
                                    <clef xml:id="clef-1" shape="G" line="2" />
                                    <keySig xml:id="key-1" sig="2f" />
                                    <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                                </staffDef>
                                <staffDef xml:id="sndeemw" n="2" lines="5">
                                    <clef xml:id="clef-2" shape="F" line="4" />
                                    <keySig xml:id="key-2" sig="2f" />
                                    <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                                </staffDef>
                                <grpSym xml:id="glxvukl" symbol="brace" />
                            </staffGrp>
                        </staffGrp>
                    </scoreDef>
                    <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="szc3jyo">
                        <measure xml:id="measure-0006-9390-10430-1-mdiv-1" n="5">
                            <staff xml:id="s1eh3oo" n="1">
                                <layer xml:id="ldrvtrj" n="1">
                                    <beam xml:id="b3uuji4">
                                        <note xml:id="note-0006-9540-10520-1" dots="1" dur="8" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                                        <note xml:id="note-0006-9610-10530-1" dur="16" oct="5" pname="d" stem.dir="up" />
                                        <tuplet xml:id="tczshft" num="3" numbase="2" num.format="count">
                                            <note xml:id="note-0006-9660-10510-1" dur="8" oct="5" pname="f" stem.dir="up">
                                                <accid xml:id="asxwoq3" accid="n" accid.ges="n" />
                                            </note>
                                            <note xml:id="note-0006-9700-10520-1" dur="8" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                                            <note xml:id="note-0006-9740-10530-1" dur="8" oct="5" pname="d" stem.dir="up" />
                                        </tuplet>
                                    </beam>
                                    <note xml:id="note-0006-9780-10530-1" dur="4" oct="5" pname="d" stem.dir="up" />
                                    <rest xml:id="rest-0006-9870-10520" dur="4" />
                                </layer>
                                <layer xml:id="lobjro2" n="2">
                                    <beam xml:id="bqoxe9j">
                                        <note xml:id="note-0006-9540-10580-2" dots="1" dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
                                        <note xml:id="note-0006-9610-10590-2" dur="16" oct="4" pname="d" stem.dir="down" />
                                        <note xml:id="note-0006-9660-10570-2" dur="8" oct="4" pname="f" stem.dir="down">
                                            <accid xml:id="afuepe6" accid="n" accid.ges="n" />
                                        </note>
                                        <note xml:id="note-0006-9700-10580-2" dur="8" oct="4" pname="e" stem.dir="down" accid.ges="f" />
                                        <note xml:id="note-0006-9740-10590-2" dur="8" oct="4" pname="d" stem.dir="down" />
                                    </beam>
                                    <note xml:id="note-0006-9790-10590-2" dur="4" oct="4" pname="d" stem.dir="down" />
                                    <rest xml:id="rest-0006-9870-10620" dur="4" />
                                </layer>
                            </staff>
                            <staff xml:id="sob25q3" n="2">
                                <layer xml:id="lqedcxy" n="1">
                                    <mSpace xml:id="meipej1" />
                                </layer>
                            </staff>
                        </measure>
                        <sb />
                        <pb />
                        <measure xml:id="measure-0006-9920-10430-1-mdiv-1" n="6">
                            <staff xml:id="s27svif" n="1">
                                <layer xml:id="lyelvv6" n="1">
                                    <rest xml:id="rest-0006-9980-10550" dur="2" />
                                    <note xml:id="note-0006-10080-10540-1" dots="1" dur="4" oct="5" pname="c" stem.dir="up" />
                                    <note xml:id="note-0006-10180-10560-1" dur="8" oct="4" pname="g" stem.dir="up" />
                                </layer>
                            </staff>
                            <staff xml:id="sazczdy" n="2">
                                <layer xml:id="lph9hws" n="5">
                                    <rest xml:id="rest-0006-9980-10750" dur="2" />
                                    <chord xml:id="cdaew7i" dur="2" stem.dir="down">
                                        <note xml:id="note-0006-10080-10700-2" oct="4" pname="c" />
                                        <note xml:id="note-0006-10080-10740-2" oct="3" pname="e" accid.ges="f" />
                                        <note xml:id="note-0006-10080-10720-2" oct="3" pname="g" />
                                    </chord>
                                </layer>
                            </staff>
                            <slur xml:id="bow-0006-10320-10460" startid="#note-0006-10080-10540-1" endid="#note-0006-10540-10550-1" curvedir="above" />
                            <slur xml:id="bow-0006-10190-10670" startid="#note-0006-10080-10700-2" endid="#note-0006-10300-10680-0" curvedir="above" />
                            <hairpin xml:id="wedge-0006-10100-10590" staff="1" tstamp="3.0" tstamp2="0m+4.0000" form="dim" opening="3.000000vu" place="below" vgrp="40" />
                            <hairpin xml:id="wedge-0006-10230-10610" staff="1" tstamp="4.5" tstamp2="1m+0.5000" form="cres" opening="3.000000vu" place="below" vgrp="50" />
                        </measure>
                        <measure xml:id="measure-0006-10230-10430-1-mdiv-1" right="dbl" n="7">
                            <staff xml:id="scezo2g" n="1">
                                <layer xml:id="lua3cgm" n="1">
                                    <note xml:id="note-0006-10300-10550-0" dur="1" oct="4" pname="b" accid.ges="f" />
                                </layer>
                            </staff>
                            <staff xml:id="sbuy1qt" n="2">
                                <layer xml:id="laefem5" n="5">
                                    <chord xml:id="cbk54uv" dur="1">
                                        <note xml:id="note-0006-10300-10680-0" oct="4" pname="e" accid.ges="f" />
                                        <note xml:id="note-0006-10300-10720-0" oct="3" pname="g" />
                                        <note xml:id="note-0006-10300-10750-0" oct="3" pname="d" />
                                    </chord>
                                </layer>
                            </staff>
                            <arpeg xml:id="a2yojpg" plist="#cbk54uv" />
                        </measure>
                        <scoreDef>
                            <meterSig xml:id="time-3" count="6" unit="4" />
                        </scoreDef>
                        <measure xml:id="measure-0006-10450-10430-1-mdiv-1" n="8">
                            <staff xml:id="s2qmwcy" n="1">
                                <layer xml:id="l9xajox" n="1">
                                    <note xml:id="note-0006-10540-10550-1" dots="1" dur="2" oct="4" pname="b" stem.dir="up" accid.ges="f" />
                                    <rest xml:id="rest-0006-10680-10570" dur="8" />
                                    <beam xml:id="bxecprh">
                                        <note xml:id="note-0006-10720-10600-1" dur="8" oct="4" pname="d" />
                                        <note xml:id="note-0006-10770-10590-1" dur="8" oct="4" pname="d" stem.dir="up" />
                                        <note xml:id="note-0006-10840-10570-1" dur="8" oct="4" pname="f" stem.dir="up">
                                            <accid xml:id="atogtcr" accid="s" accid.ges="s" />
                                        </note>
                                        <note xml:id="note-0006-10890-10550-1" dur="8" oct="4" pname="b" stem.dir="up" accid.ges="f" />
                                        <note xml:id="note-0006-10940-10560-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                    </beam>
                                </layer>
                                <layer xml:id="lrw0xvg" n="2">
                                    <space xml:id="sc0ymfi" dur="2" />
                                    <space xml:id="sr8a8s5" dur="2" />
                                    <space xml:id="sm260zt" dur="8" />
                                    <note xml:id="note-0006-10840-10570-2" dur="4" oct="4" pname="f" stem.dir="down">
                                        <accid xml:id="a78wj07" accid="s" accid.ges="s" />
                                    </note>
                                </layer>
                                <layer xml:id="liilghy" n="3">
                                    <space xml:id="suhp3lj" dur="2" />
                                    <space xml:id="sxu7pcq" dur="2" />
                                    <note xml:id="note-0006-10770-10590-2" dur="4" oct="4" pname="d" stem.dir="down" />
                                </layer>
                                <layer xml:id="l1xqcvy" n="4">
                                    <space xml:id="s12akq5" dur="2" />
                                    <space xml:id="s9r1p2e" dur="4" />
                                    <space xml:id="sslavwc" dur="8" />
                                    <note xml:id="note-0006-10720-10600-2" dur="2" oct="4" pname="c" stem.dir="down" />
                                </layer>
                            </staff>
                            <staff xml:id="s7tbc6g" n="2">
                                <layer xml:id="l5qnj4a" n="5">
                                    <rest xml:id="rest-0006-10550-10750" dots="1" dur="2" />
                                    <note xml:id="note-0006-10670-10810-1" dur="4" oct="2" pname="d" stem.dir="up">
                                        <artic xml:id="afny2t7" artic="stacc" place="below" />
                                    </note>
                                    <rest xml:id="rest-0006-10780-10770" dur="4" />
                                    <rest xml:id="rest-0006-10900-10770" dur="4" />
                                </layer>
                            </staff>
                            <tempo xml:id="tyf11c1" place="above" staff="1" tstamp="1.0" xml:lang="it" midi.bpm="116.000000">Moderato</tempo>
                            <slur xml:id="bow-0006-10880-10490" startid="#note-0006-10720-10600-1" endid="#note-0006-11020-10570-1" curvedir="above" />
                            <hairpin xml:id="wedge-0006-10740-10660" staff="1" tstamp="4.5" tstamp2="0m+4.5000" form="dim" opening="3.000000vu" place="below" vgrp="80" />
                            <pedal xml:id="ps2q27h" staff="2" tstamp="4.0" dir="down" place="below" vgrp="50" />
                            <pedal xml:id="pwa9zz0" staff="2" tstamp="6.9" dir="up" place="below" vgrp="50" />
                        </measure>
                        <measure xml:id="measure-0006-10980-10430-1-mdiv-1" n="9">
                            <staff xml:id="sswkwx4" n="1">
                                <layer xml:id="liwqc1e" n="1">
                                    <note xml:id="note-0006-11020-10570-1" dots="1" dur="2" oct="4" pname="g" stem.dir="up" />
                                    <note xml:id="note-0006-11240-10530-1" dots="1" dur="2" oct="5" pname="d" stem.dir="up" />
                                </layer>
                                <layer xml:id="lafbzjc" n="2">
                                    <rest xml:id="rest-0006-11030-10640" dur="4" />
                                    <chord xml:id="cyam94f" dur="4" stem.dir="down">
                                        <artic xml:id="ag8h9c6" artic="stacc" place="below" />
                                        <note xml:id="note-0006-11100-10590-2" oct="4" pname="d" />
                                        <note xml:id="note-0006-11100-10610-2" oct="3" pname="b" accid.ges="f" />
                                    </chord>
                                    <chord xml:id="cssuh83" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-11170-10590-2" oct="4" pname="d" />
                                        <note xml:id="note-0006-11170-10610-2" oct="3" pname="b" accid.ges="f" />
                                    </chord>
                                    <rest xml:id="rest-0006-11250-10620" dur="4" />
                                    <chord xml:id="c56ib75" dur="4" stem.dir="down">
                                        <artic xml:id="a9j4g2f" artic="stacc" place="below" />
                                        <note xml:id="note-0006-11320-10570-2" oct="4" pname="g" />
                                        <note xml:id="note-0006-11320-10590-2" oct="4" pname="d" />
                                    </chord>
                                    <chord xml:id="c6sz7w1" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-11390-10570-2" oct="4" pname="g" />
                                        <note xml:id="note-0006-11390-10590-2" oct="4" pname="d" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="sxuhkqh" n="2">
                                <layer xml:id="l9xca22" n="5">
                                    <rest xml:id="rest-0006-11030-10770" dur="4" />
                                    <note xml:id="note-0006-11100-10790-1" dur="4" oct="2" pname="g" stem.dir="up">
                                        <artic xml:id="aluohqi" artic="stacc" place="below" />
                                    </note>
                                    <note xml:id="note-0006-11170-10790-1" dur="4" oct="2" pname="g" stem.dir="up">
                                        <artic xml:id="akiipcq" artic="stacc" place="below" />
                                    </note>
                                    <rest xml:id="rest-0006-11250-10770" dur="4" />
                                    <note xml:id="note-0006-11320-10710-2" dur="4" oct="3" pname="b" stem.dir="down" accid.ges="f">
                                        <artic xml:id="akac4sz" artic="stacc" place="above" />
                                    </note>
                                    <note xml:id="note-0006-11390-10710-2" dur="4" oct="3" pname="b" stem.dir="down" accid.ges="f">
                                        <artic xml:id="a109d5l" artic="stacc" place="above" />
                                    </note>
                                </layer>
                            </staff>
                            <slur xml:id="bow-0006-11350-10460" startid="#note-0006-11240-10530-1" endid="#note-0006-9540-11020-1" curvedir="above" />
                            <slur xml:id="bow-0006-11130-10670" startid="#note-0006-11100-10610-2" endid="#note-0006-11170-10590-2" curvedir="below" />
                        </measure>
                        <measure xml:id="measure-0006-9390-10920-1-mdiv-1" n="10">
                            <staff xml:id="sr6b4f2" n="1">
                                <layer xml:id="l1cz1vq" n="1">
                                    <note xml:id="note-0006-9540-11020-1" dots="1" dur="2" oct="5" pname="c" stem.dir="up" />
                                    <rest xml:id="rest-0006-9740-11050" dur="8" />
                                    <beam xml:id="b4zp0rh">
                                        <note xml:id="note-0006-9770-11080-1" dur="8" oct="4" pname="c" stem.dir="up" />
                                        <note xml:id="note-0006-9820-11070-1" dur="8" oct="4" pname="d" stem.dir="up" />
                                        <note xml:id="note-0006-9890-11060-1" dur="8" oct="4" pname="f" stem.dir="up">
                                            <accid xml:id="a6oo4ey" accid="s" accid.ges="s" />
                                        </note>
                                        <note xml:id="note-0006-9940-11030-1" dur="8" oct="4" pname="b" stem.dir="up" accid.ges="f" />
                                        <note xml:id="note-0006-9980-11040-1" dur="8" oct="4" pname="a" stem.dir="up" />
                                    </beam>
                                </layer>
                                <layer xml:id="lntpu37" n="2">
                                    <rest xml:id="rest-0006-9550-11090" dur="4" />
                                    <chord xml:id="c8lhxwm" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-9610-11050-2" oct="4" pname="g" />
                                        <note xml:id="note-0006-9610-11070-2" oct="4" pname="e" accid.ges="f" />
                                        <note xml:id="note-0006-9610-11080-2" oct="4" pname="c" />
                                    </chord>
                                    <chord xml:id="cwl5goa" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-9670-11050-2" oct="4" pname="g" />
                                        <note xml:id="note-0006-9670-11070-2" oct="4" pname="e" accid.ges="f" />
                                        <note xml:id="note-0006-9670-11080-2" oct="4" pname="c" />
                                    </chord>
                                    <space xml:id="s41bueh" dur="8" />
                                    <note xml:id="note-0006-9770-11080-2" dur="2" oct="4" pname="c" stem.dir="down" />
                                </layer>
                                <layer xml:id="lge2icp" n="3">
                                    <space xml:id="s1gzcbo" dur="2" />
                                    <space xml:id="skdhe5q" dur="2" />
                                    <space xml:id="su8cm0m" dur="8" />
                                    <note xml:id="note-0006-9890-11060-2" dur="4" oct="4" pname="f" stem.dir="down">
                                        <accid xml:id="amgnw6l" accid="s" accid.ges="s" />
                                    </note>
                                </layer>
                                <layer xml:id="lsvff69" n="4">
                                    <space xml:id="scetkx6" dur="2" />
                                    <space xml:id="sdpf1up" dur="2" />
                                    <note xml:id="note-0006-9820-11070-2" dots="1" dur="4" oct="4" pname="d" stem.dir="down" />
                                </layer>
                            </staff>
                            <staff xml:id="sifc1s3" n="2">
                                <layer xml:id="lkakbvv" n="5">
                                    <rest xml:id="rest-0006-9540-11260" dur="4" />
                                    <note xml:id="note-0006-9600-11200-2" dur="4" oct="3" pname="a" stem.dir="down">
                                        <artic xml:id="ahuypp" artic="stacc" place="above" />
                                    </note>
                                    <note xml:id="note-0006-9670-11200-2" dur="4" oct="3" pname="a" stem.dir="down">
                                        <artic xml:id="arbaivr" artic="stacc" place="above" />
                                    </note>
                                    <rest xml:id="rest-0006-9730-11250" dur="4" />
                                    <note xml:id="note-0006-9820-11290-1" dur="4" oct="2" pname="d" stem.dir="up">
                                        <artic xml:id="argu6hi" artic="stacc" place="below" />
                                    </note>
                                    <note xml:id="note-0006-9940-11290-1" dur="4" oct="2" pname="d" stem.dir="up">
                                        <artic xml:id="a9zzqv1" artic="stacc" place="below" />
                                    </note>
                                </layer>
                            </staff>
                            <slur xml:id="bow-0006-9930-10970" startid="#note-0006-9770-11080-1" endid="#note-0006-10070-11050-1" curvedir="above" />
                            <hairpin xml:id="wedge-0006-9790-11140" staff="1" tstamp="4.0" tstamp2="0m+4.5000" form="dim" opening="3.000000vu" place="below" vgrp="80" />
                        </measure>
                        <sb />
                        <pb />
                        <measure xml:id="measure-0006-10020-10920-1-mdiv-1" n="11">
                            <staff xml:id="suud1o5" n="1">
                                <layer xml:id="loixft5" n="1">
                                    <note xml:id="note-0006-10070-11050-1" dots="1" dur="2" oct="4" pname="g" stem.dir="up" />
                                    <note xml:id="note-0006-10270-11070-1" dots="1" dur="2" oct="4" pname="e" stem.dir="up">
                                        <accid xml:id="aedjtqt" accid="n" accid.ges="n" />
                                    </note>
                                </layer>
                                <layer xml:id="linvvuw" n="2">
                                    <rest xml:id="rest-0006-10070-11120" dur="4" />
                                    <chord xml:id="c3jf14z" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-10140-11070-2" oct="4" pname="d" />
                                        <note xml:id="note-0006-10140-11090-2" oct="3" pname="b" accid.ges="f" />
                                    </chord>
                                    <chord xml:id="cm26yan" dur="4" stem.dir="down">
                                        <artic xml:id="aax376l" artic="stacc" place="below" />
                                        <note xml:id="note-0006-10200-11070-2" oct="4" pname="d" />
                                        <note xml:id="note-0006-10200-11090-2" oct="3" pname="b" accid.ges="f" />
                                    </chord>
                                    <rest xml:id="rest-0006-10270-11130" dur="4" />
                                    <chord xml:id="cuba7x1" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-10350-11080-2" oct="4" pname="c">
                                            <accid xml:id="a1y95og" accid="s" accid.ges="s" />
                                        </note>
                                        <note xml:id="note-0006-10330-11110-2" oct="3" pname="g" />
                                        <note xml:id="note-0006-10350-11100-2" oct="3" pname="a" />
                                    </chord>
                                    <chord xml:id="c7isni4" dur="4" stem.dir="down">
                                        <note xml:id="note-0006-10430-11080-2" oct="4" pname="c" accid.ges="s" />
                                        <note xml:id="note-0006-10400-11110-2" oct="3" pname="g" />
                                        <note xml:id="note-0006-10430-11100-2" oct="3" pname="a" />
                                    </chord>
                                </layer>
                            </staff>
                            <staff xml:id="sbllfth" n="2">
                                <layer xml:id="l2ulo6p" n="5">
                                    <rest xml:id="rest-0006-10070-11260" dur="4" />
                                    <note xml:id="note-0006-10130-11270-1" dur="4" oct="2" pname="g" stem.dir="up">
                                        <artic xml:id="awbwn03" artic="stacc" place="below" />
                                    </note>
                                    <note xml:id="note-0006-10200-11270-1" dur="4" oct="2" pname="g" stem.dir="up">
                                        <artic xml:id="auv6hiq" artic="stacc" place="below" />
                                    </note>
                                    <rest xml:id="rest-0006-10270-11260" dur="4" />
                                    <note xml:id="note-0006-10350-11260-1" dur="4" oct="2" pname="a" stem.dir="up">
                                        <artic xml:id="aj0nj0e" artic="stacc" place="below" />
                                    </note>
                                    <note xml:id="note-0006-10420-11260-1" dur="4" oct="2" pname="a" stem.dir="up">
                                        <artic xml:id="aso1ns8" artic="stacc" place="below" />
                                    </note>
                                </layer>
                            </staff>
                            <slur xml:id="bow-0006-10170-11160" startid="#note-0006-10140-11090-2" endid="#note-0006-10200-11070-2" curvedir="below" />
                            <slur xml:id="bow-0006-10390-11170" startid="#note-0006-10330-11110-2" endid="#note-0006-10430-11080-2" curvedir="below" />
                        </measure>
                        <scoreDef>
                            <meterSig xml:id="time-5" count="2" sym="cut" unit="2" />
                        </scoreDef>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
</details>