### PR TITLE
Clean up slur options

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -211,9 +211,10 @@ public:
     static Point CalcPointAtBezier(const Point bezier[4], double t);
 
     /**
-     * Calculate thickness coeficient to be applient for bezier curve to fit MEI units thickness
+     * Calculate thickness coefficient to be applient for bezier curve to fit MEI units thickness
      */
-    static double GetBezierThicknessCoeficient(const Point bezier[4], int currentThickness, double angle, int penWidth);
+    static double GetBezierThicknessCoefficient(
+        const Point bezier[4], int currentThickness, double angle, int penWidth);
 
     /**
      * Calculate the point bezier point position for a t between 0.0 and 1.0

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -665,6 +665,7 @@ public:
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionDbl m_slurCurveFactor;
+    OptionDbl m_slurMargin;
     OptionInt m_slurMaxSlope;
     OptionDbl m_slurEndpointThickness;
     OptionDbl m_slurMidpointThickness;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -664,8 +664,7 @@ public:
     OptionDbl m_pedalLineThickness;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
-    OptionInt m_slurControlPoints;
-    OptionInt m_slurCurveFactor;
+    OptionDbl m_slurCurveFactor;
     OptionInt m_slurHeightFactor;
     OptionDbl m_slurMaxHeight;
     OptionInt m_slurMaxSlope;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -665,10 +665,7 @@ public:
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionDbl m_slurCurveFactor;
-    OptionInt m_slurHeightFactor;
-    OptionDbl m_slurMaxHeight;
     OptionInt m_slurMaxSlope;
-    OptionDbl m_slurMinHeight;
     OptionDbl m_slurEndpointThickness;
     OptionDbl m_slurMidpointThickness;
     OptionInt m_spacingBraceGroup;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -621,11 +621,11 @@ protected:
     int m_currentColour;
 
     /**
-     * Values to adjust tie/slur thickness by to have proper MEI values for thickness
+     * Values to adjust tie/slur thickness to have proper MEI values for thickness
      */
     ///@{
-    double m_tieThicknessCoeficient;
-    double m_slurThicknessCoeficient;
+    double m_tieThicknessCoefficient;
+    double m_slurThicknessCoefficient;
     ///@}
 
     /**

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -762,7 +762,7 @@ Point BoundingBox::CalcPointAtBezier(const Point bezier[4], double t)
     return midPoint;
 }
 
-double BoundingBox::GetBezierThicknessCoeficient(
+double BoundingBox::GetBezierThicknessCoefficient(
     const Point bezier[4], int currentThickness, double angle, int penWidth)
 {
     Point top[4], bottom[4];

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -47,9 +47,8 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     m_rightControlPointOffset = offset;
 
     // Initialize height
-    int height = std::max<int>(
-        doc->GetOptions()->m_slurMinHeight.GetValue() * unit, dist / doc->GetOptions()->m_slurHeightFactor.GetValue());
-    height = std::min<int>(doc->GetOptions()->m_slurMaxHeight.GetValue() * unit, height);
+    int height = std::max<int>(1.2 * unit, dist / 5);
+    height = std::min<int>(3.0 * unit, height);
     height *= doc->GetOptions()->m_slurCurveFactor.GetValue();
     height = std::min(height, 2 * doc->GetDrawingOctaveSize(staffSize));
     height = std::min<int>(height, 2 * offset * cos(angle));

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -37,12 +37,12 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
 
     // Initialize offset
     const double ratio = double(dist) / double(unit);
-    double baseVal = (ratio > 4.0) ? 2.0 : 5.0;
+    double baseVal = (ratio > 4.0) ? 3.0 : 6.0;
     if ((ratio > 4.0) && (ratio < 32.0)) {
-        // interpolate baseVal between 5.0 and 2.0
-        baseVal = 7.0 - log2(ratio);
+        // interpolate baseVal between 6.0 and 3.0
+        baseVal = 8.0 - log2(ratio);
     }
-    const int offset = dist / (baseVal + doc->GetOptions()->m_slurControlPoints.GetValue() / 5.0);
+    const int offset = dist / baseVal;
     m_leftControlPointOffset = offset;
     m_rightControlPointOffset = offset;
 
@@ -50,7 +50,7 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     int height = std::max<int>(
         doc->GetOptions()->m_slurMinHeight.GetValue() * unit, dist / doc->GetOptions()->m_slurHeightFactor.GetValue());
     height = std::min<int>(doc->GetOptions()->m_slurMaxHeight.GetValue() * unit, height);
-    height *= sqrt(doc->GetOptions()->m_slurCurveFactor.GetValue()) / 3.0;
+    height *= doc->GetOptions()->m_slurCurveFactor.GetValue();
     height = std::min(height, 2 * doc->GetDrawingOctaveSize(staffSize));
     height = std::min<int>(height, 2 * offset * cos(angle));
     this->SetControlHeight(height);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1246,6 +1246,10 @@ Options::Options()
     m_slurCurveFactor.Init(1.0, 0.2, 5.0);
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
+    m_slurMargin.SetInfo("Slur margin", "Slur safety distance in MEI units to obstacles");
+    m_slurMargin.Init(1.0, 0.1, 4.0);
+    this->Register(&m_slurMargin, "slurMargin", &m_generalLayout);
+
     m_slurMaxSlope.SetInfo("Slur max slope", "The maximum slur slope in degrees");
     m_slurMaxSlope.Init(40, 0, 80);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1242,13 +1242,8 @@ Options::Options()
     m_repeatEndingLineThickness.Init(0.15, 0.10, 2.0);
     this->Register(&m_repeatEndingLineThickness, "repeatEndingLineThickness", &m_generalLayout);
 
-    m_slurControlPoints.SetInfo(
-        "Slur control points", "Slur control points - higher value means more curved at the end");
-    m_slurControlPoints.Init(5, 1, 10);
-    this->Register(&m_slurControlPoints, "slurControlPoints", &m_generalLayout);
-
     m_slurCurveFactor.SetInfo("Slur curve factor", "Slur curve factor - high value means rounder slurs");
-    m_slurCurveFactor.Init(10, 1, 100);
+    m_slurCurveFactor.Init(1.0, 0.2, 5.0);
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
     m_slurHeightFactor.SetInfo("Slur height factor", "Slur height factor -  high value means flatter slurs");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1246,18 +1246,6 @@ Options::Options()
     m_slurCurveFactor.Init(1.0, 0.2, 5.0);
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
-    m_slurHeightFactor.SetInfo("Slur height factor", "Slur height factor -  high value means flatter slurs");
-    m_slurHeightFactor.Init(5, 1, 100);
-    this->Register(&m_slurHeightFactor, "slurHeightFactor", &m_generalLayout);
-
-    m_slurMinHeight.SetInfo("Slur min height", "The minimum slur height in MEI units");
-    m_slurMinHeight.Init(1.2, 0.3, 2.0);
-    this->Register(&m_slurMinHeight, "slurMinHeight", &m_generalLayout);
-
-    m_slurMaxHeight.SetInfo("Slur max height", "The maximum slur height in MEI units");
-    m_slurMaxHeight.Init(3.0, 2.0, 6.0);
-    this->Register(&m_slurMaxHeight, "slurMaxHeight", &m_generalLayout);
-
     m_slurMaxSlope.SetInfo("Slur max slope", "The maximum slur slope in degrees");
     m_slurMaxSlope.Init(40, 0, 80);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -89,7 +89,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     BezierCurve bezier(points[0], points[1], points[2], points[3]);
     bezier.UpdateControlPointParams(curve->GetDir());
 
-    const int margin = doc->GetDrawingUnit(100);
+    const int margin = doc->GetOptions()->m_slurMargin.GetValue() * doc->GetDrawingUnit(100);
 
     // STEP 1: Filter spanned elements and discard certain bounding boxes even though they collide
     this->FilterSpannedElements(curve, bezier, margin);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -29,8 +29,8 @@ View::View()
     m_doc = NULL;
     m_options = NULL;
     m_pageIdx = 0;
-    m_tieThicknessCoeficient = 0.0;
-    m_slurThicknessCoeficient = 0.0;
+    m_tieThicknessCoefficient = 0.0;
+    m_slurThicknessCoefficient = 0.0;
 
     m_currentColour = AxNONE;
     m_currentElement = NULL;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -902,11 +902,11 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_doc->GetOptions()->m_tieMidpointThickness.GetValue();
     const int penWidth
         = m_doc->GetOptions()->m_tieEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (m_tieThicknessCoeficient <= 0) {
-        m_tieThicknessCoeficient = BoundingBox::GetBezierThicknessCoeficient(bezier, thickness, 0, penWidth);
+    if (m_tieThicknessCoefficient <= 0) {
+        m_tieThicknessCoefficient = BoundingBox::GetBezierThicknessCoefficient(bezier, thickness, 0, penWidth);
     }
     DrawThickBezierCurve(
-        dc, bezier, m_tieThicknessCoeficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
+        dc, bezier, m_tieThicknessCoefficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -71,11 +71,11 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     }
     const int penWidth
         = m_doc->GetOptions()->m_slurEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (m_slurThicknessCoeficient <= 0) {
-        m_slurThicknessCoeficient
-            = BoundingBox::GetBezierThicknessCoeficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
+    if (m_slurThicknessCoefficient <= 0) {
+        m_slurThicknessCoefficient
+            = BoundingBox::GetBezierThicknessCoefficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
     }
-    DrawThickBezierCurve(dc, points, m_slurThicknessCoeficient * curve->GetThickness(), staff->m_drawingStaffSize,
+    DrawThickBezierCurve(dc, points, m_slurThicknessCoefficient * curve->GetThickness(), staff->m_drawingStaffSize,
         penWidth, curve->GetAngle(), penStyle);
 
     /*


### PR DESCRIPTION
This PR cleans up the slur options:
* The options for `slurControlPoints`, `slurMinHeight`, `slurMaxHeight` and `slurHeightFactor` are removed.
* The range for `slurCurveFactor` is adjusted.
* There is a new option `slurMargin`. It can be used to set the safety distance in MEI units by which slurs curve around obstacles.

| Slur margin 1 (default) | Slur margin 2 |
| ---------------------- | ------------- |
| <img width="526" alt="Margin-Standard" src="https://user-images.githubusercontent.com/63608463/135983901-1c2dc9c1-4f77-483b-a8ca-7a3e92ed2995.png"> | <img width="535" alt="Margin2" src="https://user-images.githubusercontent.com/63608463/135983948-75b84d6b-3e7b-4ad7-8ff5-a0e936aced03.png"> |

 