### PR TITLE
Set right alignment for the pedal elements that are drawn at the right barline

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2078,7 +2078,13 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
         data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_center;
         // center the pedal only with @startid
         if (pedal->GetStart()->Is(TIMESTAMP_ATTR)) {
-            alignment = HORIZONTALALIGNMENT_left;
+            if (pedal->GetStart()->GetAlignment()->GetTime()
+                == measure->m_measureAligner.GetRightBarLineAlignment()->GetTime()) {
+                alignment = HORIZONTALALIGNMENT_right;
+            }
+            else {
+                alignment = HORIZONTALALIGNMENT_left;
+            }
         }
 
         std::vector<Staff *>::iterator staffIter;


### PR DESCRIPTION
closes #949

![image](https://user-images.githubusercontent.com/1819669/137714746-df437066-2cfc-4f2a-9654-53e4b971a238.png)