### PR TITLE
Improve pedal lines

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1858,11 +1858,10 @@ public:
     PrepareFloatingGrpsParams(Doc *doc)
     {
         m_previousEnding = NULL;
-        m_pedalLine = NULL;
         m_doc = doc;
     }
     Ending *m_previousEnding;
-    Pedal *m_pedalLine;
+    std::list<Pedal *> m_pedalLines;
     std::vector<Dynam *> m_dynams;
     std::vector<Hairpin *> m_hairpins;
     std::map<std::string, Harm *> m_harms;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -23,6 +23,7 @@
 #include "functorparams.h"
 #include "hairpin.h"
 #include "page.h"
+#include "pedal.h"
 #include "staff.h"
 #include "staffdef.h"
 #include "syl.h"
@@ -1306,6 +1307,33 @@ int Measure::PrepareFloatingGrpsEnd(FunctorParams *functorParams)
         }
         else {
             ++iter;
+        }
+    }
+
+    // Match down and up pedal lines
+    using pedalIter = std::list<Pedal *>::iterator;
+    pedalIter pIter = params->m_pedalLines.begin();
+    while (pIter != params->m_pedalLines.end()) {
+        if ((*pIter)->GetDir() != pedalLog_DIR_down) {
+            ++pIter;
+            continue;
+        }
+        pedalIter up = std::find_if(params->m_pedalLines.begin(), params->m_pedalLines.end(), [&pIter](Pedal *pedal) {
+            if (((*pIter)->GetStaff() == pedal->GetStaff()) && (pedal->GetDir() != pedalLog_DIR_down)) {
+                return true;
+            }
+            return false;
+        });
+        if (up != params->m_pedalLines.end()) {
+            (*pIter)->SetEnd((*up)->GetStart());
+            if ((*up)->GetDir() == pedalLog_DIR_bounce) {
+                (*pIter)->EndsWithBounce(true);
+            }
+            params->m_pedalLines.erase(up);
+            pIter = params->m_pedalLines.erase(pIter);
+        }
+        else {
+            ++pIter;
         }
     }
 

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -155,14 +155,10 @@ int Pedal::PrepareFloatingGrps(FunctorParams *functorParams)
 
     if (!this->HasDir()) return FUNCTOR_CONTINUE;
 
-    if (!params->m_pedalLines.empty() && (this->GetDir() != pedalLog_DIR_down)) {
-        params->m_pedalLines.push_back(this);
-    }
-
     System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     pedalVis_FORM form = this->GetPedalForm(params->m_doc, system);
-    if ((this->GetDir() != pedalLog_DIR_up) && (form == pedalVis_FORM_line)) {
+    if (form == pedalVis_FORM_line) {
         params->m_pedalLines.push_back(this);
     }
 

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -155,19 +155,15 @@ int Pedal::PrepareFloatingGrps(FunctorParams *functorParams)
 
     if (!this->HasDir()) return FUNCTOR_CONTINUE;
 
-    if (params->m_pedalLine && (this->GetDir() != pedalLog_DIR_down)) {
-        params->m_pedalLine->SetEnd(this->GetStart());
-        if (this->GetDir() == pedalLog_DIR_bounce) {
-            params->m_pedalLine->EndsWithBounce(true);
-        }
-        params->m_pedalLine = NULL;
+    if (!params->m_pedalLines.empty() && (this->GetDir() != pedalLog_DIR_down)) {
+        params->m_pedalLines.push_back(this);
     }
 
     System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     pedalVis_FORM form = this->GetPedalForm(params->m_doc, system);
     if ((this->GetDir() != pedalLog_DIR_up) && (form == pedalVis_FORM_line)) {
-        params->m_pedalLine = this;
+        params->m_pedalLines.push_back(this);
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
closes #1575

Improve rendering for the pedal lines that have different `@staff` attribute.

![image](https://user-images.githubusercontent.com/1819669/138237571-a58484e2-4abe-4d10-a19b-78f090ab347f.png)
