### PR TITLE
Slur collision detection with content from other staves

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1479,8 +1479,10 @@ public:
  * member 0: a pointer to the vector of LayerElement pointer to fill
  * member 1: the minimum position
  * member 2: the maximum position
- * member 3: the timespanning interface
- * member 4: the class Ids to keep
+ * member 3: the staff numbers to consider, any staff if empty
+ * member 4: true if within measure range of timespanning interface, only this is searched
+ * member 5: the timespanning interface
+ * member 6: the class ids to keep
  **/
 
 class FindSpannedLayerElementsParams : public FunctorParams {
@@ -1490,10 +1492,13 @@ public:
         m_interface = interface;
         m_minPos = 0;
         m_maxPos = 0;
+        m_inMeasureRange = false;
     }
     std::vector<LayerElement *> m_elements;
     int m_minPos;
     int m_maxPos;
+    std::set<int> m_staffNs;
+    bool m_inMeasureRange;
     TimeSpanningInterface *m_interface;
     std::vector<ClassId> m_classIds;
 };

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -255,6 +255,14 @@ public:
     //----------//
 
     /**
+     * See Object::FindSpannedLayerElements
+     */
+    ///@{
+    virtual int FindSpannedLayerElements(FunctorParams *functorParams);
+    virtual int FindSpannedLayerElementsEnd(FunctorParams *functorParams);
+    ///@}
+
+    /**
      * See Object::ConvertMarkupAnalytical
      */
     virtual int ConvertMarkupAnalyticalEnd(FunctorParams *functorParams);

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -596,7 +596,10 @@ public:
     /**
      * Retrieve the layer elements spanned by two points
      */
+    ///@{
     virtual int FindSpannedLayerElements(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int FindSpannedLayerElementsEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    ///@}
 
     /**
      * Retrieve the minimum left and maximum right for an alignment.

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -80,7 +80,7 @@ public:
     /**
      * Determine layer elements spanned by the slur
      */
-    std::vector<LayerElement *> CollectSpannedElements(Staff *staff, int xMin, int xMax);
+    std::vector<LayerElement *> CollectSpannedElements(Staff *staff, int xMin, int xMax, char spanningType);
 
     void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2293,10 +2293,20 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
             return FUNCTOR_CONTINUE;
         }
 
+        // Skip if neither parent staff nor cross staff matches the given staff number
+        if (!params->m_staffNs.empty()) {
+            Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+            assert(staff);
+            if (params->m_staffNs.find(staff->GetN()) == params->m_staffNs.end()) {
+                Layer *layer = NULL;
+                staff = this->GetCrossStaff(layer);
+                if (!staff || (params->m_staffNs.find(staff->GetN()) == params->m_staffNs.end())) {
+                    return FUNCTOR_CONTINUE;
+                }
+            }
+        }
+
         params->m_elements.push_back(this);
-    }
-    else if (this->GetDrawingX() > params->m_maxPos) {
-        return FUNCTOR_STOP;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -644,6 +644,34 @@ std::vector<std::pair<LayerElement *, LayerElement *>> Measure::GetInternalTieEn
 // Measure functor methods
 //----------------------------------------------------------------------------
 
+int Measure::FindSpannedLayerElements(FunctorParams *functorParams)
+{
+    FindSpannedLayerElementsParams *params = vrv_params_cast<FindSpannedLayerElementsParams *>(functorParams);
+    assert(params);
+
+    if (params->m_interface->GetStartMeasure() == this) {
+        params->m_inMeasureRange = true;
+    }
+
+    if (!params->m_inMeasureRange) {
+        return FUNCTOR_SIBLINGS;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+int Measure::FindSpannedLayerElementsEnd(FunctorParams *functorParams)
+{
+    FindSpannedLayerElementsParams *params = vrv_params_cast<FindSpannedLayerElementsParams *>(functorParams);
+    assert(params);
+
+    if (params->m_interface->GetEndMeasure() == this) {
+        params->m_inMeasureRange = false;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Measure::ConvertMarkupAnalyticalEnd(FunctorParams *functorParams)
 {
     ConvertMarkupAnalyticalParams *params = vrv_params_cast<ConvertMarkupAnalyticalParams *>(functorParams);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -276,7 +276,8 @@ curvature_CURVEDIR System::GetPreferredCurveDirection(LayerElement *start, Layer
     assert(layerStart);
 
     Functor findSpannedLayerElements(&Object::FindSpannedLayerElements);
-    Process(&findSpannedLayerElements, &findSpannedLayerElementsParams, NULL);
+    Functor findSpannedLayerElementsEnd(&Object::FindSpannedLayerElementsEnd);
+    this->Process(&findSpannedLayerElements, &findSpannedLayerElementsParams, &findSpannedLayerElementsEnd);
 
     curvature_CURVEDIR preferredDirection = curvature_CURVEDIR_NONE;
     for (auto element : findSpannedLayerElementsParams.m_elements) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -287,7 +287,8 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
             // corresponding to whether the slur is curved above/below
             if (element->Is(SLUR)) {
                 Slur *slur = vrv_cast<Slur *>(element);
-                const std::vector<LayerElement *> spannedElements = slur->CollectSpannedElements(staff, x1, x2);
+                const std::vector<LayerElement *> spannedElements
+                    = slur->CollectSpannedElements(staff, x1, x2, spanningType);
                 for (LayerElement *element : spannedElements) {
                     Layer *elementLayer = NULL;
                     Staff *elementStaff = element->GetCrossStaff(elementLayer);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -264,7 +264,8 @@ float View::CalcInitialSlur(
 
     /************** content **************/
 
-    const std::vector<LayerElement *> elements = slur->CollectSpannedElements(staff, bezier.p1.x, bezier.p2.x);
+    const std::vector<LayerElement *> elements
+        = slur->CollectSpannedElements(staff, bezier.p1.x, bezier.p2.x, curve->GetSpanningType());
 
     Staff *startStaff = slur->GetStart()->m_crossStaff ? slur->GetStart()->m_crossStaff
                                                        : vrv_cast<Staff *>(slur->GetStart()->GetFirstAncestor(STAFF));


### PR DESCRIPTION
This PR improves the collision detection for slurs with content defined in another staff. The difficulty of the example below is that the slur starts and ends on the upper staff, but the content to avoid is partially defined on the lower staff.

| Before | After |
| ------ | ----- |
| <img width="1060" alt="Before" src="https://user-images.githubusercontent.com/63608463/138649704-5b2197d2-13c5-4611-8682-23f2e203eb7f.png"> | <img width="1036" alt="After" src="https://user-images.githubusercontent.com/63608463/138649729-b5c908e7-5e7d-4d14-8d3d-2d8ef3343a67.png"> |

<details>
  <summary>Show MEI</summary>
  
```xml
  <?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000000598885773">
         <appInfo xml:id="appinfo-0000000217333322">
            <application xml:id="application-0000001998942954" isodate="2020-12-16T17:33:42" version="3.1.0-dev-805efc0-dirty">
               <name xml:id="name-0000001000054210">Verovio</name>
               <p xml:id="p-0000001704086048">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000001732292344">
            <score xml:id="score-0000001201623229">
               <scoreDef xml:id="scoredef-0000001867147059" midi.bpm="172">
                  <staffGrp xml:id="staffgrp-0000001555012954">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <grpSym xml:id="grpsym-0000001062516020" symbol="brace" />
                        <label xml:id="label-0000000226733888">Piano</label>
                        <staffDef xml:id="staffdef-0000001380223335" n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.mode="major" key.sig="4s" meter.count="4" meter.unit="4" meter.sym="common" />
                        <staffDef xml:id="staffdef-0000001137783949" n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.mode="major" key.sig="4s" meter.count="4" meter.unit="4" meter.sym="common" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000745393415">
                  <measure xml:id="measure-0000001926443233" n="179">
                     <staff xml:id="staff-0000000483534351" n="1">
                        <layer xml:id="layer-0000001880485787" n="1">
                           <beam xml:id="beam-0000000807789210">
                              <tuplet xml:id="tuplet-0000000121636136" num="3" numbase="2" bracket.visible="true">
                                 <note xml:id="note-0000002081589455" dur.ppq="4" dur="8" oct="5" pname="a" stem.dir="down" />
                                 <note xml:id="note-0000001573759511" dur.ppq="4" dur="8" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                                 <note xml:id="note-0000000313985524" dur.ppq="4" dur="8" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000000721410709">
                              <tuplet xml:id="tuplet-0000000057115201" num="3" numbase="2" bracket.visible="true">
                                 <note xml:id="note-0000000009992998" dur.ppq="4" dur="8" oct="4" pname="a" stem.dir="up" />
                                 <note xml:id="note-0000000448592920" dur.ppq="4" dur="8" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                                 <note xml:id="note-0000001016799840" dur.ppq="4" dur="8" oct="4" pname="c" stem.dir="up" accid.ges="s" />
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000002014179313">
                              <tuplet xml:id="tuplet-0000001526985930" num="3" numbase="2" bracket.visible="true">
                                 <note xml:id="note-0000001622943860" dur.ppq="4" dur="8" oct="4" pname="a" stem.dir="up" />
                                 <note xml:id="note-0000001627654473" dur.ppq="4" dur="8" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                                 <note xml:id="note-0000000514861134" dur.ppq="4" dur="8" oct="4" pname="c" stem.dir="up" accid.ges="s" />
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000001647640348">
                              <tuplet xml:id="tuplet-0000000089700771" num="3" numbase="2" bracket.visible="true">
                                 <note xml:id="note-0000000067338003" dur.ppq="4" dur="8" staff="2" oct="3" pname="a" stem.dir="up" />
                                 <note xml:id="note-0000000025934452" dur.ppq="4" dur="8" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="s" />
                                 <note xml:id="note-0000000972348628" dur.ppq="4" dur="8" staff="2" oct="3" pname="c" stem.dir="up" accid.ges="s" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000683717009" n="2">
                        <layer xml:id="layer-0000001784907583" n="3">
                           <chord xml:id="chord-0000000732448716" dur.ppq="48" dur="1" stem.dir="up">
                              <note xml:id="note-0000000742682538" oct="2" pname="f" accid.ges="s" />
                              <note xml:id="note-0000000066447736" oct="2" pname="c" accid.ges="s" />
                              <note xml:id="note-0000002081793214" oct="1" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <dynam xml:id="dynam-0000000046775166" place="below" staff="1" tstamp="1.000000">f</dynam>
                     <slur xml:id="slur-0000000617876908" startid="#note-0000002081589455" endid="#note-0000002140675496" />
                     <tie xml:id="tie-0000000889305208" startid="#note-0000000742682538" endid="#note-0000001881443311" />
                     <tie xml:id="tie-0000000473651228" startid="#note-0000000066447736" endid="#note-0000000429164090" />
                     <tie xml:id="tie-0000001591313608" startid="#note-0000002081793214" endid="#note-0000000320135545" />
                  </measure>
                  <measure xml:id="measure-0000000446469918" n="180">
                     <staff xml:id="staff-0000001313330044" n="1">
                        <layer xml:id="layer-0000001063663818" n="1">
                           <mSpace xml:id="mSpace-0000001343911498" />
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001301125642" n="2">
                        <layer xml:id="layer-0000000192687693" n="1">
                           <beam xml:id="beam-0000000096716575">
                              <note xml:id="note-0000002017838893" dur.ppq="1" dur="16" oct="3" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000756521227" dur.ppq="1" dur="16" oct="3" pname="f" stem.dir="up" accid.ges="s" />
                              <note xml:id="note-0000001896086707" dur.ppq="1" dur="16" oct="3" pname="c" stem.dir="up" accid.ges="s" />
                              <note xml:id="note-0000001216420046" dur.ppq="1" dur="16" oct="2" pname="a" stem.dir="up" />
                           </beam>
                           <beam xml:id="beam-0000000327393682">
                              <note xml:id="note-0000000652509760" dur.ppq="1" dur="16" oct="3" pname="c" stem.dir="up" accid.ges="s" />
                              <note xml:id="note-0000001228850810" dur.ppq="1" dur="16" oct="3" pname="f" stem.dir="up" accid.ges="s" />
                              <note xml:id="note-0000001085205591" dur.ppq="1" dur="16" oct="3" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000471753966" dur.ppq="1" dur="16" oct="4" pname="c" stem.dir="up" accid.ges="s" />
                           </beam>
                           <beam xml:id="beam-0000000505531503">
                              <note xml:id="note-0000001022663389" dur.ppq="1" dur="16" staff="1" oct="4" pname="f" stem.dir="down" accid.ges="s" />
                              <note xml:id="note-0000000438203501" dur.ppq="1" dur="16" staff="1" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="note-0000001164815744" dur.ppq="1" dur="16" staff="1" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                              <note xml:id="note-0000001202798214" dur.ppq="1" dur="16" staff="1" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                           </beam>
                           <beam xml:id="beam-0000001400397134">
                              <note xml:id="note-0000000053860018" dur.ppq="1" dur="16" staff="1" oct="5" pname="a" stem.dir="down" />
                              <note xml:id="note-0000001134707139" dur.ppq="1" dur="16" staff="1" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                              <note xml:id="note-0000000546148662" dur.ppq="1" dur="16" staff="1" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                              <note xml:id="note-0000002140675496" dur.ppq="1" dur="16" staff="1" oct="4" pname="a" stem.dir="down" />
                           </beam>
                        </layer>
                        <layer xml:id="layer-0000001539523081" n="3">
                           <chord xml:id="chord-0000001386619962" dur.ppq="16" dur="1" stem.dir="up">
                              <note xml:id="note-0000001881443311" oct="2" pname="f" accid.ges="s" />
                              <note xml:id="note-0000000429164090" oct="2" pname="c" accid.ges="s" />
                              <note xml:id="note-0000000320135545" oct="1" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
  