### PR TITLE
Do not attempt to import multimetric music

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -756,6 +756,16 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
 {
     assert(root);
 
+    // check for multimetric music
+    bool multiMetric = root.select_node("/score-partwise/part/measure[@non-controlling]")
+                           .node()
+                           .attribute("non-controlling")
+                           .as_bool();
+    if (multiMetric) {
+        LogError("MusicXML import: Multimetric music detected. Import cancelled.");
+        exit(1);
+    }
+
     ReadMusicXmlTitle(root);
 
     // the mdiv

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -757,10 +757,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     assert(root);
 
     // check for multimetric music
-    bool multiMetric = root.select_node("/score-partwise/part/measure[@non-controlling]")
-                           .node()
-                           .attribute("non-controlling")
-                           .as_bool();
+    bool multiMetric = root.select_node("/score-partwise/part/measure[@non-controlling='yes']");
     if (multiMetric) {
         LogError("MusicXML import: Multimetric music detected. Import cancelled.");
         exit(1);


### PR DESCRIPTION
This PR tries to deal with #2427 by simply not importing problematic MusicXML files. 
In some cases Verovio manages to deal with these encodings, but loses too much information on the way anyway and throws way too many warnings and errors, so with this approach it gives just a clear error message. 