### PR TITLE
Fix option autocompletion

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -199,7 +199,7 @@ void display_usage()
     }
 }
 
-bool optionExists(const std::string& option, int argc, char** argv, std::string& badOption) 
+bool optionExists(const std::string &option, int argc, char **argv, std::string &badOption)
 {
     for (int i = 0; i < argc; ++i) {
         if (!strncmp(option.c_str(), argv[i], option.size())) return true;

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -203,7 +203,7 @@ bool optionExists(const std::string &option, int argc, char **argv, std::string 
 {
     for (int i = 0; i < argc; ++i) {
         if (!strncmp(option.c_str(), argv[i], option.size())) return true;
-        if (option.find(argv[i]) != std::string::npos) badOption = argv[i];
+        if (option.rfind(argv[i], 0) == 0) badOption = argv[i];
     }
     return false;
 }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -199,6 +199,14 @@ void display_usage()
     }
 }
 
+bool optionExists(const std::string& option, int argc, char** argv) 
+{
+    for (int i = 0; i < argc; ++i) {
+        if (!strncmp(option.c_str(), argv[i], option.size())) return true;
+    }
+    return false;
+}
+
 int main(int argc, char **argv)
 {
     std::string infile;
@@ -288,6 +296,10 @@ int main(int argc, char **argv)
                 key = long_options[option_index].name;
                 opt = params->at(toCamelCase(key));
                 optBool = dynamic_cast<vrv::OptionBool *>(opt);
+                if (!optionExists("--" + key, argc, argv)) {
+                    vrv::LogError("Unrecognized option abbreviated from --%s has been skipped.", key.c_str());
+                    continue;
+                }
 
                 // Handle deprecated options
                 /*

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -199,10 +199,11 @@ void display_usage()
     }
 }
 
-bool optionExists(const std::string& option, int argc, char** argv) 
+bool optionExists(const std::string& option, int argc, char** argv, std::string& badOption) 
 {
     for (int i = 0; i < argc; ++i) {
         if (!strncmp(option.c_str(), argv[i], option.size())) return true;
+        if (option.find(argv[i]) != std::string::npos) badOption = argv[i];
     }
     return false;
 }
@@ -296,8 +297,8 @@ int main(int argc, char **argv)
                 key = long_options[option_index].name;
                 opt = params->at(toCamelCase(key));
                 optBool = dynamic_cast<vrv::OptionBool *>(opt);
-                if (!optionExists("--" + key, argc, argv)) {
-                    vrv::LogError("Unrecognized option abbreviated from --%s has been skipped.", key.c_str());
+                if (std::string badOption; !optionExists("--" + key, argc, argv, badOption)) {
+                    vrv::LogError("Unrecognized option %s has been skipped.", badOption.c_str());
                     continue;
                 }
 


### PR DESCRIPTION
Verovio autocompletes options on CLI. This has weird side effects, i.e. "--to mei" is transformed into "--top-margin-artic 0" without complaint.
This is caused by `getopt_long` accepting abbreviated options without any issue. This change adds error message in case such abbreviation is encountered.
`"[Error] Unrecognized option --to has been skipped."`