### PR TITLE
Scale multi measure rest width based on number attribute

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1039,7 +1039,8 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
     }
     // Adjust min width based on multirest attributes (@num and @width), but only if these values are larger than
     // current min width
-    else if (MultiRest *multiRest = vrv_cast<MultiRest *>(this->FindDescendantByType(MULTIREST)); multiRest) {
+    else if (this->FindDescendantByType(MULTIREST) != NULL) {
+        MultiRest *multiRest = vrv_cast<MultiRest *>(this->FindDescendantByType(MULTIREST));
         const int num = multiRest->GetNum();
         if (multiRest->HasWidth()) {
             const int fixedWidth

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -22,6 +22,7 @@
 #include "ending.h"
 #include "functorparams.h"
 #include "hairpin.h"
+#include "multirest.h"
 #include "page.h"
 #include "staff.h"
 #include "staffdef.h"
@@ -1035,6 +1036,19 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
     // Nothing if the measure has at least one note or @metcon="false"
     else if ((this->FindDescendantByType(NOTE) != NULL) || (this->GetMetcon() == BOOLEAN_false)) {
         minMeasureWidth = 0;
+    }
+    // Adjust min width based on multirest attributes (@num and @width), but only if these values are larger than
+    // current min width
+    else if (MultiRest *multiRest = vrv_cast<MultiRest *>(this->FindDescendantByType(MULTIREST)); multiRest) {
+        const int num = multiRest->GetNum();
+        if (multiRest->HasWidth()) {
+            const int fixedWidth
+                = multiRest->AttWidth::GetWidth() * (params->m_doc->GetDrawingUnit(params->m_staffSize) + 4);
+            if (minMeasureWidth < fixedWidth) minMeasureWidth = fixedWidth;
+        }
+        else if (num > 10) {
+            minMeasureWidth *= log1p(num) / 2;
+        }
     }
 
     int currentMeasureWidth = this->GetRightBarLineLeft() - this->GetLeftBarLineRight();


### PR DESCRIPTION
Added scaling to the minimum measure width. If `multiRest` is present within the measure, minimum width will have logarithmic scaling based on its @num attribute (if it's more than 10). Also made change so that @width attribute will increase minimum measure with, instead of being limited by it.

![image](https://user-images.githubusercontent.com/1819669/139238422-e37da1c3-73ac-4265-872a-fcfc2ca18111.png)

<details><summary>MEI:</summary>
<p>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2021-05-10" type="encoding-date">2021-05-10</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-dzc">
         <appInfo xml:id="appinfo-h7j">
            <application xml:id="application-gqk" isodate="2021-10-27T12:22:29" version="3.7.0-dev-[undefined]">
               <name xml:id="name-vi">Verovio</name>
               <p xml:id="p-60c">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m8wy">
            <score xml:id="s6xq">
               <scoreDef xml:id="smkd">
                  <staffGrp xml:id="s68f">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="ll8k">Piano</label>
                        <labelAbbr xml:id="lcru">Pno.</labelAbbr>
                        <instrDef xml:id="icnk" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="clk3" shape="G" line="2" />
                        <keySig xml:id="km4n" sig="0" />
                        <meterSig xml:id="mewm" count="4" unit="4" />
                     </staffDef>
                     <staffDef xml:id="P2" n="2" lines="5" ppq="1">
                        <label xml:id="lkvu">Tuba</label>
                        <labelAbbr xml:id="l4ci">Tba.</labelAbbr>
                        <instrDef xml:id="i9j5" midi.channel="1" midi.instrnum="58" midi.volume="78.00%" />
                        <clef xml:id="chju" shape="F" line="4" />
                        <keySig xml:id="k2sb" sig="0" />
                        <meterSig xml:id="m7h8" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="sl7c">
                  <pb/>
                  <measure xml:id="m8nb" n="1">
                     <staff xml:id="s3m8" n="1">
                        <layer xml:id="liu4" n="1">
                           <multiRest xml:id="me07" num="1" />
                        </layer>
                     </staff>
                     <staff xml:id="sblw" n="2">
                        <layer xml:id="l86u" n="1">
                           <multiRest xml:id="mcuv" num="1" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mjlo" right="dbl" n="2">
                     <staff xml:id="shey" n="1">
                        <layer xml:id="l1qs" n="1">
                           <multiRest xml:id="mn0h" num="2"/>
                        </layer>
                     </staff>
                     <staff xml:id="sjx9" n="2">
                        <layer xml:id="lnod" n="1">
                           <multiRest xml:id="mp7o" num="2" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mcsm" right="dbl" n="4">
                     <staff xml:id="s90x" n="1">
                        <layer xml:id="llyt" n="1">
                           <multiRest xml:id="m8nb" num="3" />
                        </layer>
                     </staff>
                     <staff xml:id="sf3g" n="2">
                        <layer xml:id="loxo" n="1">
                           <multiRest xml:id="m2a0" num="3" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mfd7" right="dbl" n="7">
                     <staff xml:id="shj4" n="1">
                        <layer xml:id="lcyg" n="1">
                           <multiRest xml:id="mi6t" num="4" />
                        </layer>
                     </staff>
                     <staff xml:id="s7od" n="2">
                        <layer xml:id="lbb" n="1">
                           <multiRest xml:id="m7ov" num="4" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mdpw" right="dbl" n="11">
                     <staff xml:id="si16" n="1">
                        <layer xml:id="l7hr" n="1">
                           <multiRest xml:id="mmf6" num="5" />
                        </layer>
                     </staff>
                     <staff xml:id="s9lo" n="2">
                        <layer xml:id="lkra" n="1">
                           <multiRest xml:id="m16v" num="5" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="maxo" right="dbl" n="16">
                     <staff xml:id="sgrc" n="1">
                        <layer xml:id="l19c" n="1">
                           <multiRest xml:id="m6ed" num="6" />
                        </layer>
                     </staff>
                     <staff xml:id="sbl6" n="2">
                        <layer xml:id="lisq" n="1">
                           <multiRest xml:id="me9l" num="6" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m324" right="dbl" n="22">
                     <staff xml:id="s5ky" n="1">
                        <layer xml:id="lhk7" n="1">
                           <multiRest xml:id="m1lx" num="7" />
                        </layer>
                     </staff>
                     <staff xml:id="sldn" n="2">
                        <layer xml:id="l7" n="1">
                           <multiRest xml:id="m6ze" num="7" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m9cm" right="dbl" n="29">
                     <staff xml:id="s2p9" n="1">
                        <layer xml:id="lc2z" n="1">
                           <multiRest xml:id="mbb8" num="8" />
                        </layer>
                     </staff>
                     <staff xml:id="sbkj" n="2">
                        <layer xml:id="lm78" n="1">
                           <multiRest xml:id="mlci" num="8" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mv4" right="dbl" n="37">
                     <staff xml:id="sedg" n="1">
                        <layer xml:id="l2hr" n="1">
                           <multiRest xml:id="ml2m" num="9" />
                        </layer>
                     </staff>
                     <staff xml:id="sa3h" n="2">
                        <layer xml:id="lhgx" n="1">
                           <multiRest xml:id="m7t7" num="9" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="me5v" right="dbl" n="46">
                     <staff xml:id="si0q" n="1">
                        <layer xml:id="lb8c" n="1">
                           <multiRest xml:id="mkzh" num="10" />
                        </layer>
                     </staff>
                     <staff xml:id="smvg" n="2">
                        <layer xml:id="lp3t" n="1">
                           <multiRest xml:id="m3ml" num="10" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mgdv" right="dbl" n="56">
                     <staff xml:id="s3un" n="1">
                        <layer xml:id="l3zy" n="1">
                           <multiRest xml:id="m428" num="11" />
                        </layer>
                     </staff>
                     <staff xml:id="slo6" n="2">
                        <layer xml:id="lah" n="1">
                           <multiRest xml:id="med5" num="11" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="marl" right="dbl" n="67">
                     <staff xml:id="snnl" n="1">
                        <layer xml:id="lj3x" n="1">
                           <multiRest xml:id="miz2" num="12" />
                        </layer>
                     </staff>
                     <staff xml:id="sfe6" n="2">
                        <layer xml:id="ljhc" n="1">
                           <multiRest xml:id="mogl" num="12" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mony" right="dbl" n="79">
                     <staff xml:id="s5r9" n="1">
                        <layer xml:id="lcul" n="1">
                           <multiRest xml:id="me2d" num="13" />
                        </layer>
                     </staff>
                     <staff xml:id="s80x" n="2">
                        <layer xml:id="lm13" n="1">
                           <multiRest xml:id="mj2v" num="13" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="me3m" right="dbl" n="92">
                     <staff xml:id="si12" n="1">
                        <layer xml:id="lkjb" n="1">
                           <multiRest xml:id="m5yf" num="14" />
                        </layer>
                     </staff>
                     <staff xml:id="sd4j" n="2">
                        <layer xml:id="la4y" n="1">
                           <multiRest xml:id="mdc4" num="14" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m9i6" right="dbl" n="106">
                     <staff xml:id="s4q6" n="1">
                        <layer xml:id="l6pl" n="1">
                           <multiRest xml:id="m67q" num="15" />
                        </layer>
                     </staff>
                     <staff xml:id="s3yz" n="2">
                        <layer xml:id="lnns" n="1">
                           <multiRest xml:id="mlpm" num="15" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m5qm" right="dbl" n="121">
                     <staff xml:id="s7pv" n="1">
                        <layer xml:id="l464" n="1">
                           <multiRest xml:id="mbvy" num="16" />
                        </layer>
                     </staff>
                     <staff xml:id="sjst" n="2">
                        <layer xml:id="l2s0" n="1">
                           <multiRest xml:id="mea3" num="16" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mm83" right="dbl" n="137">
                     <staff xml:id="sob8" n="1">
                        <layer xml:id="lgeu" n="1">
                           <multiRest xml:id="mobm" num="17" />
                        </layer>
                     </staff>
                     <staff xml:id="s3uv" n="2">
                        <layer xml:id="li3y" n="1">
                           <multiRest xml:id="mk5p" num="17" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="md72" right="dbl" n="154">
                     <staff xml:id="s6k4" n="1">
                        <layer xml:id="l528" n="1">
                           <multiRest xml:id="mmt8" num="18" />
                        </layer>
                     </staff>
                     <staff xml:id="snim" n="2">
                        <layer xml:id="lkho" n="1">
                           <multiRest xml:id="mk80" num="18" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m3e8" right="dbl" n="172">
                     <staff xml:id="sdw6" n="1">
                        <layer xml:id="lie0" n="1">
                           <multiRest xml:id="m96n" num="19" />
                        </layer>
                     </staff>
                     <staff xml:id="sicq" n="2">
                        <layer xml:id="lju4" n="1">
                           <multiRest xml:id="mh2m" num="19" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m2rl" right="dbl" n="191">
                     <staff xml:id="scmy" n="1">
                        <layer xml:id="lnyy" n="1">
                           <multiRest xml:id="mom6" num="20" />
                        </layer>
                     </staff>
                     <staff xml:id="s4jz" n="2">
                        <layer xml:id="lm9p" n="1">
                           <multiRest xml:id="m5l" num="20" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mowv" right="dbl" n="211">
                     <staff xml:id="sgvr" n="1">
                        <layer xml:id="l7a2" n="1">
                           <multiRest xml:id="m1xe" num="21" />
                        </layer>
                     </staff>
                     <staff xml:id="s7zi" n="2">
                        <layer xml:id="l2v0" n="1">
                           <multiRest xml:id="mh00" num="21" />
                        </layer>
                     </staff>
                  </measure>
                  <pb/>
                  <measure xml:id="mfq2" right="dbl" n="232">
                     <staff xml:id="sdq2" n="1">
                        <layer xml:id="led" n="1">
                           <multiRest xml:id="mc0n" num="22" />
                        </layer>
                     </staff>
                     <staff xml:id="sm6j" n="2">
                        <layer xml:id="l1oe" n="1">
                           <multiRest xml:id="mhyb" num="22" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mgws" right="dbl" n="254">
                     <staff xml:id="sddq" n="1">
                        <layer xml:id="ll3t" n="1">
                           <multiRest xml:id="m97b" num="23" />
                        </layer>
                     </staff>
                     <staff xml:id="sm3k" n="2">
                        <layer xml:id="ldnf" n="1">
                           <multiRest xml:id="me15" num="23" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mgwt" right="dbl" n="277">
                     <staff xml:id="sl59" n="1">
                        <layer xml:id="lgcj" n="1">
                           <multiRest xml:id="mdcr" num="24" />
                        </layer>
                     </staff>
                     <staff xml:id="s183" n="2">
                        <layer xml:id="lctp" n="1">
                           <multiRest xml:id="md0g" num="24" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mg5k" right="dbl" n="301">
                     <staff xml:id="siuu" n="1">
                        <layer xml:id="lhx4" n="1">
                           <multiRest xml:id="mala" num="25" />
                        </layer>
                     </staff>
                     <staff xml:id="scac" n="2">
                        <layer xml:id="l91m" n="1">
                           <multiRest xml:id="mkjo" num="25" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mbzb" right="dbl" n="326">
                     <staff xml:id="s5ow" n="1">
                        <layer xml:id="lmty" n="1">
                           <multiRest xml:id="m4r7" num="26" />
                        </layer>
                     </staff>
                     <staff xml:id="s26y" n="2">
                        <layer xml:id="lmim" n="1">
                           <multiRest xml:id="m18i" num="26" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="meu" right="dbl" n="352">
                     <staff xml:id="s8z2" n="1">
                        <layer xml:id="l8fw" n="1">
                           <multiRest xml:id="m73e" num="27" />
                        </layer>
                     </staff>
                     <staff xml:id="s2yn" n="2">
                        <layer xml:id="lr1" n="1">
                           <multiRest xml:id="mam6" num="27" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m3fp" right="dbl" n="379">
                     <staff xml:id="sdnn" n="1">
                        <layer xml:id="loo7" n="1">
                           <multiRest xml:id="mh3y" num="28" />
                        </layer>
                     </staff>
                     <staff xml:id="se61" n="2">
                        <layer xml:id="lieg" n="1">
                           <multiRest xml:id="mdpf" num="28" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mgr3" right="dbl" n="407">
                     <staff xml:id="sol4" n="1">
                        <layer xml:id="levj" n="1">
                           <multiRest xml:id="m9ky" num="29" />
                        </layer>
                     </staff>
                     <staff xml:id="sc8q" n="2">
                        <layer xml:id="lq6" n="1">
                           <multiRest xml:id="m5mz" num="29" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="md22" right="dbl" n="436">
                     <staff xml:id="s7xo" n="1">
                        <layer xml:id="lflt" n="1">
                           <multiRest xml:id="m5zg" num="30" />
                        </layer>
                     </staff>
                     <staff xml:id="s3oq" n="2">
                        <layer xml:id="lj51" n="1">
                           <multiRest xml:id="mkv" num="30" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mm8f" right="dbl" n="466">
                     <staff xml:id="s1rg" n="1">
                        <layer xml:id="l7lr" n="1">
                           <multiRest xml:id="mhr6" num="31" />
                        </layer>
                     </staff>
                     <staff xml:id="s1ab" n="2">
                        <layer xml:id="lkag" n="1">
                           <multiRest xml:id="mo28" num="31" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mizg" right="dbl" n="497">
                     <staff xml:id="sfo3" n="1">
                        <layer xml:id="lhp1" n="1">
                           <multiRest xml:id="mfhg" num="32" />
                        </layer>
                     </staff>
                     <staff xml:id="shda" n="2">
                        <layer xml:id="lbw4" n="1">
                           <multiRest xml:id="m3mu" num="32" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="miiv" right="dbl" n="529">
                     <staff xml:id="s9ic" n="1">
                        <layer xml:id="lm0u" n="1">
                           <multiRest xml:id="mewp" num="33" />
                        </layer>
                     </staff>
                     <staff xml:id="s3rx" n="2">
                        <layer xml:id="lltq" n="1">
                           <multiRest xml:id="mlmw" num="33" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m9qu" right="dbl" n="562">
                     <staff xml:id="sxy" n="1">
                        <layer xml:id="lmrb" n="1">
                           <multiRest xml:id="m3x9" num="34" />
                        </layer>
                     </staff>
                     <staff xml:id="s9k9" n="2">
                        <layer xml:id="ljdk" n="1">
                           <multiRest xml:id="mfx9" num="34" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m1n" right="dbl" n="596">
                     <staff xml:id="sa9r" n="1">
                        <layer xml:id="lf5" n="1">
                           <multiRest xml:id="m3sa" num="35" />
                        </layer>
                     </staff>
                     <staff xml:id="s5pp" n="2">
                        <layer xml:id="l2c" n="1">
                           <multiRest xml:id="mog2" num="35" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m3id" right="dbl" n="631">
                     <staff xml:id="sir8" n="1">
                        <layer xml:id="lct9" n="1">
                           <multiRest xml:id="me06" num="36" />
                        </layer>
                     </staff>
                     <staff xml:id="s1ur" n="2">
                        <layer xml:id="lie0" n="1">
                           <multiRest xml:id="m8xn" num="36" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mj2c" right="dbl" n="667">
                     <staff xml:id="s2u9" n="1">
                        <layer xml:id="lg9v" n="1">
                           <multiRest xml:id="m7nx" num="37" />
                        </layer>
                     </staff>
                     <staff xml:id="s5dq" n="2">
                        <layer xml:id="lfyr" n="1">
                           <multiRest xml:id="mowv" num="37" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m7b0" right="dbl" n="704">
                     <staff xml:id="si6s" n="1">
                        <layer xml:id="l8ys" n="1">
                           <multiRest xml:id="m4tc" num="38" />
                        </layer>
                     </staff>
                     <staff xml:id="si6f" n="2">
                        <layer xml:id="ld6n" n="1">
                           <multiRest xml:id="mu7" num="38" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mdqm" right="dbl" n="742">
                     <staff xml:id="sgq7" n="1">
                        <layer xml:id="llb6" n="1">
                           <multiRest xml:id="mbe5" num="39" />
                        </layer>
                     </staff>
                     <staff xml:id="sl8" n="2">
                        <layer xml:id="l66w" n="1">
                           <multiRest xml:id="mk0m" num="39" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mhb6" right="dbl" n="781">
                     <staff xml:id="s2ot" n="1">
                        <layer xml:id="lmbx" n="1">
                           <multiRest xml:id="m31c" num="40" />
                        </layer>
                     </staff>
                     <staff xml:id="sn3a" n="2">
                        <layer xml:id="lavv" n="1">
                           <multiRest xml:id="me47" num="40" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m5y1" right="dbl" n="821">
                     <staff xml:id="s8k5" n="1">
                        <layer xml:id="l9r" n="1">
                           <multiRest xml:id="mjd6" num="41" />
                        </layer>
                     </staff>
                     <staff xml:id="s4e2" n="2">
                        <layer xml:id="lar" n="1">
                           <multiRest xml:id="mer6" num="41" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m9o1" right="dbl" n="862">
                     <staff xml:id="sgjy" n="1">
                        <layer xml:id="l83e" n="1">
                           <multiRest xml:id="mh4g" num="42" />
                        </layer>
                     </staff>
                     <staff xml:id="sewj" n="2">
                        <layer xml:id="l1s" n="1">
                           <multiRest xml:id="mnpk" num="42" />
                        </layer>
                     </staff>
                  </measure>
                  <pb/>
                  <measure xml:id="mbi1" right="dbl" n="904">
                     <staff xml:id="segx" n="1">
                        <layer xml:id="l2f4" n="1">
                           <multiRest xml:id="m2vr" num="43" />
                        </layer>
                     </staff>
                     <staff xml:id="sdda" n="2">
                        <layer xml:id="lce1" n="1">
                           <multiRest xml:id="mg41" num="43" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mmyf" right="dbl" n="947">
                     <staff xml:id="s84m" n="1">
                        <layer xml:id="lp10" n="1">
                           <multiRest xml:id="mhu6" num="44" />
                        </layer>
                     </staff>
                     <staff xml:id="skue" n="2">
                        <layer xml:id="l891" n="1">
                           <multiRest xml:id="mm3u" num="44" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mgrc" right="dbl" n="991">
                     <staff xml:id="s294" n="1">
                        <layer xml:id="loi7" n="1">
                           <multiRest xml:id="mf0b" num="45" />
                        </layer>
                     </staff>
                     <staff xml:id="s4dt" n="2">
                        <layer xml:id="lbs4" n="1">
                           <multiRest xml:id="mhk4" num="45" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m3mf" right="dbl" n="1036">
                     <staff xml:id="sove" n="1">
                        <layer xml:id="liw6" n="1">
                           <multiRest xml:id="mag9" num="46" />
                        </layer>
                     </staff>
                     <staff xml:id="sjiz" n="2">
                        <layer xml:id="lb43" n="1">
                           <multiRest xml:id="modn" num="46" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mlkh" right="dbl" n="1082">
                     <staff xml:id="s4se" n="1">
                        <layer xml:id="lnaz" n="1">
                           <multiRest xml:id="mhua" num="47" />
                        </layer>
                     </staff>
                     <staff xml:id="sabm" n="2">
                        <layer xml:id="ln8x" n="1">
                           <multiRest xml:id="moms" num="47" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="ml6w" right="dbl" n="1129">
                     <staff xml:id="s71g" n="1">
                        <layer xml:id="ldk0" n="1">
                           <multiRest xml:id="mlm1" num="48" />
                        </layer>
                     </staff>
                     <staff xml:id="siaa" n="2">
                        <layer xml:id="lli3" n="1">
                           <multiRest xml:id="md62" num="48" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mm6t" right="dbl" n="1177">
                     <staff xml:id="s3sx" n="1">
                        <layer xml:id="l76c" n="1">
                           <multiRest xml:id="m3oq" num="49" />
                        </layer>
                     </staff>
                     <staff xml:id="sm0y" n="2">
                        <layer xml:id="l2vj" n="1">
                           <multiRest xml:id="mkgp" num="49" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mivm" right="dbl" n="1226">
                     <staff xml:id="secg" n="1">
                        <layer xml:id="l1uf" n="1">
                           <multiRest xml:id="mva" num="50" />
                        </layer>
                     </staff>
                     <staff xml:id="s78v" n="2">
                        <layer xml:id="l4vk" n="1">
                           <multiRest xml:id="mm3" num="50" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="ma08" right="dbl" n="1276">
                     <staff xml:id="sj1p" n="1">
                        <layer xml:id="l4cx" n="1">
                           <multiRest xml:id="m5mx" num="51" />
                        </layer>
                     </staff>
                     <staff xml:id="sjsn" n="2">
                        <layer xml:id="lkhh" n="1">
                           <multiRest xml:id="mmyr" num="51" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m9ue" right="dbl" n="1327">
                     <staff xml:id="sof" n="1">
                        <layer xml:id="lgkj" n="1">
                           <multiRest xml:id="mg4t" num="52" />
                        </layer>
                     </staff>
                     <staff xml:id="shp5" n="2">
                        <layer xml:id="l2v" n="1">
                           <multiRest xml:id="m4y0" num="52" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mbc2" right="dbl" n="1379">
                     <staff xml:id="snnq" n="1">
                        <layer xml:id="l957" n="1">
                           <multiRest xml:id="mmsk" num="53" />
                        </layer>
                     </staff>
                     <staff xml:id="s824" n="2">
                        <layer xml:id="lfdm" n="1">
                           <multiRest xml:id="m643" num="53" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mb44" right="dbl" n="1432">
                     <staff xml:id="slt2" n="1">
                        <layer xml:id="l2f2" n="1">
                           <multiRest xml:id="m9ts" num="54" />
                        </layer>
                     </staff>
                     <staff xml:id="s6n1" n="2">
                        <layer xml:id="lfqj" n="1">
                           <multiRest xml:id="mhl7" num="54" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mgls" right="dbl" n="1486">
                     <staff xml:id="sedv" n="1">
                        <layer xml:id="l729" n="1">
                           <multiRest xml:id="mbvr" num="55" />
                        </layer>
                     </staff>
                     <staff xml:id="s2ml" n="2">
                        <layer xml:id="lad8" n="1">
                           <multiRest xml:id="me0w" num="55" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="milg" right="dbl" n="1541">
                     <staff xml:id="sgf2" n="1">
                        <layer xml:id="ljpl" n="1">
                           <multiRest xml:id="mnp" num="56" />
                        </layer>
                     </staff>
                     <staff xml:id="smln" n="2">
                        <layer xml:id="l5nx" n="1">
                           <multiRest xml:id="mbdj" num="56" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m177" right="dbl" n="1597">
                     <staff xml:id="s93z" n="1">
                        <layer xml:id="l384" n="1">
                           <multiRest xml:id="ml2q" num="57" />
                        </layer>
                     </staff>
                     <staff xml:id="sl4e" n="2">
                        <layer xml:id="l9o" n="1">
                           <multiRest xml:id="mcph" num="57" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="mn68" right="dbl" n="1654">
                     <staff xml:id="sk50" n="1">
                        <layer xml:id="llhk" n="1">
                           <multiRest xml:id="mn2t" num="58" />
                        </layer>
                     </staff>
                     <staff xml:id="sknp" n="2">
                        <layer xml:id="lof2" n="1">
                           <multiRest xml:id="mf3j" num="58" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mcny" right="dbl" n="1712">
                     <staff xml:id="sm9l" n="1">
                        <layer xml:id="l39n" n="1">
                           <multiRest xml:id="maxj" num="59" />
                        </layer>
                     </staff>
                     <staff xml:id="soz" n="2">
                        <layer xml:id="lkji" n="1">
                           <multiRest xml:id="magg" num="59" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mhbr" right="end" n="1771">
                     <staff xml:id="s3go" n="1">
                        <layer xml:id="ld0i" n="1">
                           <multiRest xml:id="m6os" num="60" />
                        </layer>
                     </staff>
                     <staff xml:id="s9at" n="2">
                        <layer xml:id="l6ra" n="1">
                           <multiRest xml:id="m1m3" num="60" />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure xml:id="m8hnb" n="1831">
                     <staff xml:id="s3m8" n="1">
                        <layer xml:id="liu4" n="1"/>
                     </staff>
                     <staff xml:id="sblw" n="2">
                        <layer xml:id="l86u" n="1"/>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>