### PR TITLE
Fix accidental positioning in chords

### DIFF
--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -749,6 +749,12 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
     for (auto child : *this->GetChildren()) {
         accid->AdjustX(dynamic_cast<LayerElement *>(child), doc, staffSize, leftAccids, adjustedAccids);
     }
+
+    // if current accidental is not in the list then XRel wasn't adjusted and position is fine as it is - add it to the
+    // list. Generally this would happen with octave accidentals, that are processed first and most likely have no
+    // overlaps with other elements
+    if (std::find(adjustedAccids.begin(), adjustedAccids.end(), accid) == adjustedAccids.end())
+        adjustedAccids.push_back(accid);
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
- fixed one of the octave accidentals not being counted as adjusted, which led to overlapping accidentals

Fixes regression introduced by #2431
![image](https://user-images.githubusercontent.com/1819669/140028670-9b0afe82-dda9-4db5-a3ac-141528dde2fd.png)

![image](https://user-images.githubusercontent.com/1819669/140028710-e56ea5fe-8ebc-46b4-a6e3-d6531b04eb4b.png)
