### PR TITLE
Fix sign error

### DIFF
--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -590,7 +590,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcLeftRightAdjustment(
 
     // first check if they overlap at all
     if (horizontalOverlap) {
-        if (p2.x < boundingBox->GetLeftBy(type) + margin) return { 0, 0 };
+        if (p2.x < boundingBox->GetLeftBy(type) - margin) return { 0, 0 };
         if (p1.x > boundingBox->GetRightBy(type) + margin) return { 0, 0 };
     }
 


### PR DESCRIPTION
This PR fixes a sign error which mostly became visible as collisions of slurs and articulations.

| Before | After |
| ------  | ----- |
| <img width="328" alt="Before" src="https://user-images.githubusercontent.com/63608463/140269076-e42aafc7-c1a5-42d4-8c2b-3556132478c4.png"> | <img width="324" alt="After" src="https://user-images.githubusercontent.com/63608463/140269180-da6ea733-eafa-4f44-b9e2-c60ab63b0d5f.png"> |
  