### PR TITLE
Make xml:ids of expanded sections predictable

### DIFF
--- a/include/vrv/expansionmap.h
+++ b/include/vrv/expansionmap.h
@@ -43,15 +43,15 @@ public:
      */
     void Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &existingList, Object *prevSection);
 
-    bool UpdateIds(Object *object);
-
     std::vector<std::string> GetExpansionIdsForElement(const std::string &xmlId);
+
+private:
+    bool UpdateIds(Object *object);
 
     void GetUuidList(Object *object, std::vector<std::string> &idList);
 
     void GeneratePredictableIds(Object *source, Object *target);
 
-private:
     /** Ads an id string to an original/notated id */
     bool AddExpandedIdToExpansionMap(const std::string &origXmlId, std::string newXmlId);
 

--- a/include/vrv/expansionmap.h
+++ b/include/vrv/expansionmap.h
@@ -49,6 +49,8 @@ public:
 
     void GetUuidList(Object *object, std::vector<std::string> &idList);
 
+    void GeneratePredictableIds(Object *source, Object *target);
+
 private:
     /** Ads an id string to an original/notated id */
     bool AddExpandedIdToExpansionMap(const std::string &origXmlId, std::string newXmlId);

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -72,18 +72,19 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
                 // clone current section/ending/rdg/lem and rename it, adding -"rend2" for the first repetition etc.
                 Object *clonedObject = currSect->Clone();
                 clonedObject->CloneReset();
+                GeneratePredictableIds(currSect, clonedObject);
                 clonedObject->SetUuid(currSect->GetUuid() + "-rend"
                     + std::to_string(GetExpansionIdsForElement(currSect->GetUuid()).size() + 1));
 
                 // get IDs of old and new sections and add them to m_map
                 std::vector<std::string> oldIds;
                 oldIds.push_back(currSect->GetUuid());
-                this->GetUuidList(currSect, oldIds);
+                GetUuidList(currSect, oldIds);
                 std::vector<std::string> clonedIds;
                 clonedIds.push_back(clonedObject->GetUuid());
-                this->GetUuidList(clonedObject, clonedIds);
+                GetUuidList(clonedObject, clonedIds);
                 for (int i = 0; (i < (int)oldIds.size()) && (i < (int)clonedIds.size()); i++) {
-                    this->AddExpandedIdToExpansionMap(oldIds.at(i), clonedIds.at(i));
+                    AddExpandedIdToExpansionMap(oldIds.at(i), clonedIds.at(i));
                 }
 
                 // go through cloned objects, find TimePointing/SpanningInterface, PListInterface, LinkingInterface
@@ -243,6 +244,18 @@ void ExpansionMap::GetUuidList(Object *object, std::vector<std::string> &idList)
     for (Object *o : *object->GetChildren()) {
         idList.push_back(o->GetUuid());
         GetUuidList(o, idList);
+    }
+}
+
+void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
+{
+    unsigned i = 0;
+    ArrayOfObjects targetObjects = *target->GetChildren();
+    for (Object *s : *source->GetChildren()) {
+        std::string id = s->GetUuid() + "-rend" + std::to_string(GetExpansionIdsForElement(s->GetUuid()).size() + 1);
+        targetObjects[i]->SetUuid(id);
+        GeneratePredictableIds(s, targetObjects[i]);
+        i++;
     }
 }
 

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -247,20 +247,16 @@ void ExpansionMap::GetUuidList(Object *object, std::vector<std::string> &idList)
 
 void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
 {
-    ArrayOfObjects sourceObjects = *source->GetChildren();
-    ArrayOfObjects targetObjects = *target->GetChildren();
-    if (sourceObjects.size() != targetObjects.size()) return;
-
     target->SetUuid(
         source->GetUuid() + "-rend" + std::to_string(this->GetExpansionIdsForElement(source->GetUuid()).size() + 1));
 
+    ArrayOfObjects sourceObjects = *source->GetChildren();
+    ArrayOfObjects targetObjects = *target->GetChildren();
+    if (sourceObjects.size() <= 0 || sourceObjects.size() != targetObjects.size()) return;
+
     unsigned i = 0;
     for (Object *s : sourceObjects) {
-        std::string id
-            = s->GetUuid() + "-rend" + std::to_string(this->GetExpansionIdsForElement(s->GetUuid()).size() + 1);
-        targetObjects.at(i)->SetUuid(id);
-        this->GeneratePredictableIds(s, targetObjects.at(i));
-        i++;
+        this->GeneratePredictableIds(s, targetObjects.at(i++));
     }
 }
 


### PR DESCRIPTION
Currently, when executing an `--expand` command, cloned sections (or endings, lemma, readings) obtain new random `xml:ids`. However, in order to reproduce the `xml:id`s of expanded sections such as for previously matched  performances, we need to be able to predict them from the original MEI score. 

This PR introduces a predictable scheme for added `xml:id`s in the form `"[oldId]-rendx"` while `x` being the nth rendering of that section. E.g. a `note-000321` in the score of a Minuet would appear as `note-000321-rend2` in its expanded repetition, and as `note-000321-rend2` in its first da-capo appearance (and as `note-000321-rend3` if  repeated in da capo).