### PR TITLE
Marking virtual functions as override

### DIFF
--- a/include/vrv/abbr.h
+++ b/include/vrv/abbr.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Abbr();
     virtual ~Abbr();
-    virtual Object *Clone() const { return new Abbr(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Abbr"; }
+    Object *Clone() const override { return new Abbr(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Abbr"; }
     ///@}
 
 private:

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -40,12 +40,12 @@ public:
     ///@{
     Accid();
     virtual ~Accid();
-    virtual Object *Clone() const { return new Accid(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Accid"; }
+    Object *Clone() const override { return new Accid(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Accid"; }
     ///@}
 
-    virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
 
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -48,7 +48,7 @@ public:
     PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * @name Set and get drawing octave flag

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -101,12 +101,12 @@ public:
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/add.h
+++ b/include/vrv/add.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Add();
     virtual ~Add();
-    virtual Object *Clone() const { return new Add(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Add"; }
+    Object *Clone() const override { return new Add(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Add"; }
     ///@}
 
 private:

--- a/include/vrv/anchoredtext.h
+++ b/include/vrv/anchoredtext.h
@@ -31,23 +31,23 @@ public:
     ///@{
     AnchoredText();
     virtual ~AnchoredText();
-    virtual Object *Clone() const { return new AnchoredText(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "AnchoredText"; }
+    Object *Clone() const override { return new AnchoredText(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "AnchoredText"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a tempo.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/annot.h
+++ b/include/vrv/annot.h
@@ -30,16 +30,16 @@ public:
     Annot();
     virtual ~Annot();
     // This fails because of the copy contructor in ObjectListInterface (TextListInterface parent)
-    // virtual Object *Clone() const { return new Annot(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Annot"; }
+    // Object *Clone() const override { return new Annot(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Annot"; }
     ///@}
 
     /**
      * Add a text element to an annotation.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -26,9 +26,9 @@ public:
     App();
     App(EditorialLevel level);
     virtual ~App();
-    virtual Object *Clone() const { return new App(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "App"; }
+    Object *Clone() const override { return new App(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "App"; }
     ///@}
 
     /** Getter for level **/
@@ -37,7 +37,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     /** We store the level of the <app> for integrity check */

--- a/include/vrv/areaposinterface.h
+++ b/include/vrv/areaposinterface.h
@@ -32,7 +32,7 @@ public:
     AreaPosInterface();
     virtual ~AreaPosInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_AREA_POS; }
+    InterfaceId IsInterface() const override { return INTERFACE_AREA_POS; }
     ///@}
 
 private:

--- a/include/vrv/areaposinterface.h
+++ b/include/vrv/areaposinterface.h
@@ -31,7 +31,7 @@ public:
     ///@{
     AreaPosInterface();
     virtual ~AreaPosInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_AREA_POS; }
     ///@}
 

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -89,19 +89,19 @@ public:
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArpeg
      */
     ///@{
-    virtual int AdjustArpeg(FunctorParams *functorParams);
+    int AdjustArpeg(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -80,7 +80,7 @@ public:
     /**
      * Custom method for @plist validation
      */
-    virtual bool IsValidRef(Object *ref);
+    bool IsValidRef(Object *ref) const override;
 
     //----------//
     // Functors //

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -38,16 +38,16 @@ public:
     ///@{
     Arpeg();
     virtual ~Arpeg();
-    virtual Object *Clone() const { return new Arpeg(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Arpeg"; }
+    Object *Clone() const override { return new Arpeg(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Arpeg"; }
     ///@}
 
     /**
      * @name Get the X drawing position (relative to the top note)
      */
     ///@{
-    virtual int GetDrawingX() const;
+    int GetDrawingX() const override;
     ///@}
 
     /**
@@ -65,8 +65,8 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual PlistInterface *GetPlistInterface() { return dynamic_cast<PlistInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    PlistInterface *GetPlistInterface() override { return dynamic_cast<PlistInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ////@}
 
     /**

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -38,10 +38,10 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /** Override the method since it is align to the staff */
-    virtual bool IsRelativeToStaff() const { return true; }
+    bool IsRelativeToStaff() const override { return true; }
 
     data_ARTICULATION GetArticFirst() const;
 

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -32,9 +32,9 @@ public:
     ///@{
     Artic();
     virtual ~Artic();
-    virtual Object *Clone() const { return new Artic(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Artic"; }
+    Object *Clone() const override { return new Artic(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Artic"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -110,32 +110,32 @@ public:
     /**
      * See Object::ConvertMarkupArtic
      */
-    virtual int ConvertMarkupArtic(FunctorParams *functorParams);
+    int ConvertMarkupArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcArtic
      */
-    virtual int CalcArtic(FunctorParams *functorParams);
+    int CalcArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArtic
      */
-    virtual int AdjustArtic(FunctorParams *functorParams);
+    int AdjustArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArticWithSlurs
      */
-    virtual int AdjustArticWithSlurs(FunctorParams *functorParams);
+    int AdjustArticWithSlurs(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     bool IsInsideArtic(data_ARTICULATION artic) const;

--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -285,7 +285,7 @@ public:
      * Virtual method returning the InterfaceId of the interface.
      * Needs to be overridden in child classes.
      */
-    virtual InterfaceId IsInterface() { return INTERFACE; }
+    virtual InterfaceId IsInterface() const { return INTERFACE; }
 
 private:
     /**

--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -276,6 +276,12 @@ public:
     std::vector<AttClassId> *GetAttClasses() { return &m_interfaceAttClasses; }
 
     /**
+     * Virtual reset method.
+     * Needs to be overridden in child classes.
+     */
+    virtual void Reset() {}
+
+    /**
      * Virtual method returning the InterfaceId of the interface.
      * Needs to be overridden in child classes.
      */

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -36,9 +36,9 @@ public:
     BarLine();
     BarLine(ClassId classId);
     virtual ~BarLine();
-    virtual Object *Clone() const { return new BarLine(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "BarLine"; }
+    Object *Clone() const override { return new BarLine(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "BarLine"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -42,7 +42,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Use to set the alignment for the Measure BarLine members.

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -68,7 +68,7 @@ public:
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -49,96 +49,96 @@ public:
      * @name Setters
      */
     ///@{
-    virtual void SetBackground(int colour, int style = AxSOLID);
-    virtual void SetBackgroundImage(void *image, double opacity = 1.0){};
-    virtual void SetBackgroundMode(int mode);
-    virtual void SetTextForeground(int colour);
-    virtual void SetTextBackground(int colour);
-    virtual void SetLogicalOrigin(int x, int y);
-    virtual void SetUserScale(double xScale, double yScale);
+    void SetBackground(int colour, int style = AxSOLID) override;
+    void SetBackgroundImage(void *image, double opacity = 1.0) override{};
+    void SetBackgroundMode(int mode) override;
+    void SetTextForeground(int colour) override;
+    void SetTextBackground(int colour) override;
+    void SetLogicalOrigin(int x, int y) override;
+    void SetUserScale(double xScale, double yScale);
     ///@}
 
     /**
      * @name Getters
      */
     ///@{
-    virtual Point GetLogicalOrigin();
+    Point GetLogicalOrigin() override;
     ///@}
 
     /**
      * @name Drawing methods
      */
     ///@{
-    virtual void DrawQuadBezierPath(Point bezier[3]);
-    virtual void DrawCubicBezierPath(Point bezier[4]);
-    virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]);
-    virtual void DrawCircle(int x, int y, int radius);
-    virtual void DrawEllipse(int x, int y, int width, int height);
-    virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end);
-    virtual void DrawLine(int x1, int y1, int x2, int y2);
-    virtual void DrawPolygon(int n, Point points[], int xOffset, int yOffset, int fillStyle = AxODDEVEN_RULE);
-    virtual void DrawRectangle(int x, int y, int width, int height);
-    virtual void DrawRotatedText(const std::string &text, int x, int y, double angle);
-    virtual void DrawRoundedRectangle(int x, int y, int width, int height, int radius);
-    virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET,
-        int width = VRV_UNSET, int height = VRV_UNSET);
-    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
-    virtual void DrawSpline(int n, Point points[]);
-    virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);
-    virtual void DrawBackgroundImage(int x = 0, int y = 0){};
+    void DrawQuadBezierPath(Point bezier[3]) override;
+    void DrawCubicBezierPath(Point bezier[4]) override;
+    void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
+    void DrawCircle(int x, int y, int radius) override;
+    void DrawEllipse(int x, int y, int width, int height) override;
+    void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
+    void DrawLine(int x1, int y1, int x2, int y2) override;
+    void DrawPolygon(int n, Point points[], int xOffset, int yOffset, int fillStyle = AxODDEVEN_RULE) override;
+    void DrawRectangle(int x, int y, int width, int height) override;
+    void DrawRotatedText(const std::string &text, int x, int y, double angle) override;
+    void DrawRoundedRectangle(int x, int y, int width, int height, int radius) override;
+    void DrawText(const std::string &text, const std::wstring &wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET,
+        int width = VRV_UNSET, int height = VRV_UNSET) override;
+    void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) override;
+    void DrawSpline(int n, Point points[]) override;
+    void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg) override;
+    void DrawBackgroundImage(int x = 0, int y = 0) override{};
     ///@}
 
     /**
      * Special method for forcing bounding boxes to be updated
      * Used for invisible elements (e.g. <space>) that needs to be take into account in spacing
      */
-    virtual void DrawPlaceholder(int x, int y);
+    void DrawPlaceholder(int x, int y) override;
 
     /**
      * @name Method for starting and ending a text
      */
     ///@{
-    virtual void StartText(int x, int y, data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_left);
-    virtual void EndText();
+    void StartText(int x, int y, data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_left) override;
+    void EndText() override;
 
     /**
      * @name Move a text to the specified position, for example when starting a new line.
      */
     ///@{
-    virtual void MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignment);
-    virtual void MoveTextVerticallyTo(int y);
+    void MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignment) override;
+    void MoveTextVerticallyTo(int y) override;
     ///@}
 
     /**
      * @name Method for starting and ending a graphic
      */
     ///@{
-    virtual void StartGraphic(
-        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false);
-    virtual void EndGraphic(Object *object, View *view);
+    void StartGraphic(
+        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false) override;
+    void EndGraphic(Object *object, View *view) override;
     ///@}
 
     /**
      * @name Methods for re-starting and ending a graphic for objects drawn in separate steps
      */
     ///@{
-    virtual void ResumeGraphic(Object *object, std::string gId);
-    virtual void EndResumedGraphic(Object *object, View *view);
+    void ResumeGraphic(Object *object, std::string gId) override;
+    void EndResumedGraphic(Object *object, View *view) override;
     ///@}
 
     /**
      * @name Method for rotating a graphic (clockwise).
      */
     ///@{
-    virtual void RotateGraphic(Point const &orig, double angle);
+    void RotateGraphic(Point const &orig, double angle) override;
     ///@}
 
     /**
      * @name Method for starting and ending page
      */
     ///@{
-    virtual void StartPage();
-    virtual void EndPage();
+    void StartPage() override;
+    void EndPage() override;
     ///@}
 
     bool UpdateHorizontalValues() { return (m_update != BBOX_VERTICAL_ONLY); }
@@ -148,7 +148,7 @@ public:
      * @name Method for adding description element
      */
     ///@{
-    virtual void AddDescription(const std::string &text){};
+    void AddDescription(const std::string &text) override{};
     ///@}
 
 private:

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -164,22 +164,22 @@ public:
     /**
      * See Object::AdjustBeams
      */
-    virtual int AdjustBeams(FunctorParams *);
+    int AdjustBeams(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustBeamsEnd
      */
-    virtual int AdjustBeamsEnd(FunctorParams *);
+    int AdjustBeamsEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *functorParams);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -139,9 +139,9 @@ public:
     ///@{
     Beam();
     virtual ~Beam();
-    virtual Object *Clone() const { return new Beam(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Beam"; }
+    Object *Clone() const override { return new Beam(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Beam"; }
     ///@}
 
     int GetNoteCount() const { return this->GetChildCount(NOTE); }
@@ -150,7 +150,7 @@ public:
      * Add an element (a note or a rest) to a beam.
      * Only Note or Rest elements will be actually added to the beam.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      *

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -186,7 +186,7 @@ protected:
      * Filter the flat list and keep only Note and Chords elements.
      * This also initializes the m_beamElementCoords vector
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
     /**
      * Helper function to calculate overlap with layer elements that

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -37,7 +37,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Returns the duration (in double) for the BeatRpt.

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -31,9 +31,9 @@ public:
     ///@{
     BeatRpt();
     virtual ~BeatRpt();
-    virtual Object *Clone() const { return new BeatRpt(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "BeatRpt"; }
+    Object *Clone() const override { return new BeatRpt(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "BeatRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -60,7 +60,7 @@ public:
      * @name See Object::GenerateMIDI
      */
     ///@{
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/bracketspan.h
+++ b/include/vrv/bracketspan.h
@@ -35,17 +35,17 @@ public:
     ///@{
     BracketSpan();
     virtual ~BracketSpan();
-    virtual Object *Clone() const { return new BracketSpan(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "BracketSpan"; }
+    Object *Clone() const override { return new BracketSpan(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "BracketSpan"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/breath.h
+++ b/include/vrv/breath.h
@@ -30,16 +30,16 @@ public:
     ///@{
     Breath();
     virtual ~Breath();
-    virtual Object *Clone() const { return new Breath(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Breath"; }
+    Object *Clone() const override { return new Breath(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Breath"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -29,16 +29,16 @@ public:
     ///@{
     BTrem();
     virtual ~BTrem();
-    virtual Object *Clone() const { return new BTrem(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "BTrem"; }
+    Object *Clone() const override { return new BTrem(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "BTrem"; }
     ///@}
 
     /**
      * Add an element (a note or a chord) to a fTrem.
      * Only Note or Chord elements will be actually added to the fTrem.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -47,7 +47,7 @@ public:
     /**
      * See Object::GenerateMIDI
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -30,16 +30,16 @@ public:
     ///@{
     Caesura();
     virtual ~Caesura();
-    virtual Object *Clone() const { return new Caesura(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Caesura"; }
+    Object *Clone() const override { return new Caesura(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Caesura"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -26,10 +26,10 @@ public:
     ///@{
     Choice();
     Choice(EditorialLevel level);
-    virtual Object *Clone() const { return new Choice(*this); }
+    Object *Clone() const override { return new Choice(*this); }
     virtual ~Choice();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Choice"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Choice"; }
     ///@}
 
     /** Getter for level **/
@@ -38,7 +38,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     /** We store the level of the <choice> for integrity check */

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -66,7 +66,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add an element (only note supported) to a chord.
@@ -130,9 +130,9 @@ public:
      * If necessary look at the glyph anchor (if any).
      */
     ///@{
-    virtual Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize);
-    virtual Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize);
-    virtual int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir);
+    Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize) override;
+    Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize) override;
+    int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) override;
     ///@}
 
     /**
@@ -154,8 +154,8 @@ public:
      * Helper to adjust overlapping layers for chords
      * Returns the shift of the adjustment
      */
-    virtual int AdjustOverlappingLayers(
-        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
+    int AdjustOverlappingLayers(
+        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison) override;
 
     //----------//
     // Functors //
@@ -218,14 +218,14 @@ protected:
     /**
      * The note locations w.r.t. each staff
      */
-    virtual MapOfNoteLocs CalcNoteLocations();
+    MapOfNoteLocs CalcNoteLocations() override;
 
     /**
      * The dot locations w.r.t. each staff
      * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
      * secondary
      */
-    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary);
+    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) override;
 
     /**
      * Clear the m_clusters vector and delete all the objects.
@@ -235,7 +235,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    virtual void FilterList(ArrayOfObjects *childlist);
+    void FilterList(ArrayOfObjects *childList) override;
 
 public:
     mutable std::list<ChordCluster *> m_clusters;

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -49,17 +49,17 @@ public:
     ///@{
     Chord();
     virtual ~Chord();
-    virtual Object *Clone() const { return new Chord(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Chord"; }
+    Object *Clone() const override { return new Chord(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Chord"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
-    virtual StemmedDrawingInterface *GetStemmedDrawingInterface()
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
+    StemmedDrawingInterface *GetStemmedDrawingInterface() override
     {
         return dynamic_cast<StemmedDrawingInterface *>(this);
     }
@@ -71,12 +71,12 @@ public:
     /**
      * Add an element (only note supported) to a chord.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Overwritten method for chord
      */
-    virtual void AddChild(Object *object);
+    void AddChild(Object *object) override;
 
     /**
      * Return the maximum and minimum Y positions of the notes in the chord

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -164,55 +164,55 @@ public:
     /**
      * See Object::AdjustCrossStaffYPos
      */
-    virtual int AdjustCrossStaffYPos(FunctorParams *functorParams);
+    int AdjustCrossStaffYPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArtic
      */
-    virtual int AdjustArtic(FunctorParams *functorParams);
+    int AdjustArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertMarkupAnalytical
      */
     ///@{
-    virtual int ConvertMarkupAnalytical(FunctorParams *functorParams);
-    virtual int ConvertMarkupAnalyticalEnd(FunctorParams *functorParams);
+    int ConvertMarkupAnalytical(FunctorParams *functorParams) override;
+    int ConvertMarkupAnalyticalEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::CalcArtic
      */
-    virtual int CalcArtic(FunctorParams *functorParams);
+    int CalcArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *functorParams);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcDots
      */
-    virtual int CalcDots(FunctorParams *functorParams);
+    int CalcDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareLayerElementParts
      */
-    virtual int PrepareLayerElementParts(FunctorParams *functorParams);
+    int PrepareLayerElementParts(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcOnsetOffsetEnd
      */
-    virtual int CalcOnsetOffsetEnd(FunctorParams *functorParams);
+    int CalcOnsetOffsetEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustCrossStaffContent
      */
-    virtual int AdjustCrossStaffContent(FunctorParams *functorParams);
+    int AdjustCrossStaffContent(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -45,10 +45,10 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /** Override the method since check is required */
-    virtual bool IsScoreDefElement() const { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
+    bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     /**
      * Return the offset of the clef

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -39,9 +39,9 @@ public:
     ///@{
     Clef();
     virtual ~Clef();
-    virtual Object *Clone() const { return new Clef(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Clef"; }
+    Object *Clone() const override { return new Clef(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Clef"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -71,12 +71,12 @@ public:
     /**
      * See Object::AdjustBeams
      */
-    virtual int AdjustBeams(FunctorParams *functorParams);
+    int AdjustBeams(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustClefChanges
      */
-    virtual int AdjustClefChanges(FunctorParams *functorParams);
+    int AdjustClefChanges(FunctorParams *functorParams) override;
 
 private:
 public:

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -60,7 +60,7 @@ class ClassIdComparison : public Comparison {
 public:
     ClassIdComparison(ClassId classId) { m_classId = classId; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (object->Is(m_classId)) {
             return true;
@@ -70,7 +70,7 @@ public:
 
     ClassId GetType() { return m_classId; }
 
-    bool MatchesType(Object *object)
+    bool MatchesType(Object *object) override
     {
         if (object->Is(m_classId)) {
             return true;
@@ -95,7 +95,7 @@ public:
         m_supportReverse = true;
     }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (object->Is(m_classIds)) {
             return Result(true);
@@ -103,7 +103,7 @@ public:
         return Result(false);
     }
 
-    bool MatchesType(Object *object) { return true; }
+    bool MatchesType(Object *object) override { return true; }
 
 protected:
     std::vector<ClassId> m_classIds;
@@ -118,7 +118,7 @@ class InterfaceComparison : public Comparison {
 public:
     InterfaceComparison(InterfaceId interfaceId) { m_interfaceId = interfaceId; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (object->HasInterface(m_interfaceId)) {
             return true;
@@ -126,7 +126,7 @@ public:
         return false;
     }
 
-    bool MatchesType(Object *object) { return true; }
+    bool MatchesType(Object *object) override { return true; }
 
 protected:
     InterfaceId m_interfaceId;
@@ -144,7 +144,7 @@ public:
         m_pointingTo = pointingTo;
     }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         TimePointInterface *interface = object->GetTimePointInterface();
@@ -168,7 +168,7 @@ public:
         m_pointingTo = pointingTo;
     }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         TimeSpanningInterface *interface = object->GetTimeSpanningInterface();
@@ -192,13 +192,13 @@ class IsEditorialElementComparison : public Comparison {
 public:
     IsEditorialElementComparison() : Comparison() { m_supportReverse = true; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (object->IsEditorialElement()) return Result(true);
         return Result(false);
     }
 
-    bool MatchesType(Object *object) { return true; }
+    bool MatchesType(Object *object) override { return true; }
 };
 
 //----------------------------------------------------------------------------
@@ -213,7 +213,7 @@ class IsEmptyComparison : public ClassIdComparison {
 public:
     IsEmptyComparison(ClassId classId) : ClassIdComparison(classId) { m_supportReverse = true; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         if (object->GetChildCount() == 0) {
@@ -237,7 +237,7 @@ class IsAttributeComparison : public ClassIdComparison {
 public:
     IsAttributeComparison(ClassId classId) : ClassIdComparison(classId) {}
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         if (object->IsAttribute()) return true;
@@ -259,7 +259,7 @@ public:
 
     void SetN(int n) { m_n = n; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
@@ -288,7 +288,7 @@ public:
     void SetNs(std::vector<int> ns) { m_ns = ns; }
     void AppendN(int n) { m_ns.push_back(n); }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
@@ -316,7 +316,7 @@ public:
 
     void SetN(std::string n) { m_n = n; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
@@ -351,7 +351,7 @@ public:
             m_extremeDur = VRV_UNSET;
     }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!object->HasInterface(INTERFACE_DURATION)) return false;
         DurationInterface *interface = dynamic_cast<DurationInterface *>(object);
@@ -388,7 +388,7 @@ public:
         m_isVisible = isVisible;
     };
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         if (!object->HasAttClass(ATT_VISIBILITY)) return false;
@@ -415,7 +415,7 @@ public:
 
     void SetType(AlignmentType type) { m_type = type; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         Alignment *alignment = vrv_cast<Alignment *>(object);
@@ -441,7 +441,7 @@ public:
 
     void SetTime(int time) { m_time = time; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         Measure *measure = vrv_cast<Measure *>(object);
@@ -467,7 +467,7 @@ public:
 
     void SetTime(int time) { m_time = time; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         Note *note = vrv_cast<Note *>(object);
@@ -493,7 +493,7 @@ public:
 
     void SetUuid(const std::string &uuid) { m_uuid = uuid; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
         return object->GetUuid() == m_uuid;
@@ -517,7 +517,7 @@ public:
 
     void Skip(const Object *objectToExclude) { m_objectToExclude = objectToExclude; }
 
-    virtual bool operator()(Object *object)
+    bool operator()(Object *object) override
     {
         if (object == m_objectToExclude || !ClassIdsComparison::operator()(object)) return false;
 

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -63,12 +63,12 @@ public:
     /**
      * See Object::AdjustXOverflow
      */
-    virtual int AdjustXOverflow(FunctorParams *functorParams);
+    int AdjustXOverflow(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -34,14 +34,14 @@ public:
     ControlElement(ClassId classId);
     ControlElement(ClassId classId, const std::string &classIdStr);
     virtual ~ControlElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual LinkingInterface *GetLinkingInterface() { return dynamic_cast<LinkingInterface *>(this); }
+    LinkingInterface *GetLinkingInterface() override { return dynamic_cast<LinkingInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/corr.h
+++ b/include/vrv/corr.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Corr();
     virtual ~Corr();
-    virtual Object *Clone() const { return new Corr(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Corr"; }
+    Object *Clone() const override { return new Corr(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Corr"; }
     ///@}
 
 private:

--- a/include/vrv/course.h
+++ b/include/vrv/course.h
@@ -29,15 +29,15 @@ public:
     ///@{
     Course();
     virtual ~Course();
-    virtual Object *Clone() const { return new Course(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Course"; };
+    Object *Clone() const override { return new Course(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Course"; }
     ///@}
 
     /**
      * Add an element to a element.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     //

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -57,12 +57,12 @@ public:
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -43,7 +43,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add an accid to a custos.

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -30,16 +30,16 @@ public:
     ///@{
     Custos();
     virtual ~Custos();
-    virtual Object *Clone() const { return new Custos(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Custos"; }
+    Object *Clone() const override { return new Custos(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Custos"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */
@@ -48,7 +48,7 @@ public:
     /**
      * Add an accid to a custos.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/damage.h
+++ b/include/vrv/damage.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Damage();
     virtual ~Damage();
-    virtual Object *Clone() const { return new Damage(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Damage"; }
+    Object *Clone() const override { return new Damage(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Damage"; }
     ///@}
 
 private:

--- a/include/vrv/del.h
+++ b/include/vrv/del.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Del();
     virtual ~Del();
-    virtual Object *Clone() const { return new Del(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Del"; }
+    Object *Clone() const override { return new Del(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Del"; }
     ///@}
 
 private:

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -163,8 +163,8 @@ public:
     virtual void DrawRectangle(int x, int y, int width, int height) = 0;
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle) = 0;
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, int radius) = 0;
-    virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET,
-        int width = VRV_UNSET, int height = VRV_UNSET)
+    virtual void DrawText(const std::string &text, const std::wstring &wtext = L"", int x = VRV_UNSET,
+        int y = VRV_UNSET, int width = VRV_UNSET, int height = VRV_UNSET)
         = 0;
     virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) = 0;
     virtual void DrawSpline(int n, Point points[]) = 0;

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -76,7 +76,7 @@ public:
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -39,25 +39,25 @@ public:
     ///@{
     Dir();
     virtual ~Dir();
-    virtual Object *Clone() const { return new Dir(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Dir"; }
+    Object *Clone() const override { return new Dir(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Dir"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a dir.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * See FloatingObject::IsExtenderElement

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -62,7 +62,7 @@ public:
     /**
      * See FloatingObject::IsExtenderElement
      */
-    virtual bool IsExtenderElement() const { return GetExtender() == BOOLEAN_true; }
+    bool IsExtenderElement() const override { return GetExtender() == BOOLEAN_true; }
 
     /**
      * Check whether one of the children has hAlign attribute set to `alignment` value

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -417,12 +417,12 @@ public:
     /**
      * See Object::PrepareLyricsEnd
      */
-    virtual int PrepareLyricsEnd(FunctorParams *functorParams);
+    int PrepareLyricsEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimestampsEnd
      */
-    virtual int PrepareTimestampsEnd(FunctorParams *functorParams);
+    int PrepareTimestampsEnd(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -51,12 +51,12 @@ public:
     /**
      * Add a page to the document
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Clear the content of the document.
      */
-    virtual void Reset();
+    void Reset() override;
 
     /**
      * Refreshes the views from Doc.

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -28,16 +28,16 @@ public:
     ///@{
     Dot();
     virtual ~Dot();
-    virtual Object *Clone() const { return new Dot(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Dot"; }
+    Object *Clone() const override { return new Dot(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Dot"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -41,7 +41,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     //----------//
     // Functors //

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -50,17 +50,17 @@ public:
     /**
      * See Object::PreparePointersByLayer
      */
-    virtual int PreparePointersByLayer(FunctorParams *functorParams);
+    int PreparePointersByLayer(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -44,7 +44,7 @@ public:
     DurationInterface();
     virtual ~DurationInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_DURATION; }
+    InterfaceId IsInterface() const override { return INTERFACE_DURATION; }
     ///@}SetDurationGes
 
     /**

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -43,7 +43,7 @@ public:
     ///@{
     DurationInterface();
     virtual ~DurationInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_DURATION; }
     ///@}SetDurationGes
 

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -72,7 +72,7 @@ public:
     /**
      * See FloatingObject::IsExtenderElement
      */
-    virtual bool IsExtenderElement() const { return GetExtender() == BOOLEAN_true; }
+    bool IsExtenderElement() const override { return GetExtender() == BOOLEAN_true; }
 
     //----------------//
     // Static methods //

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -91,7 +91,7 @@ public:
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -38,25 +38,25 @@ public:
     ///@{
     Dynam();
     virtual ~Dynam();
-    virtual Object *Clone() const { return new Dynam(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Dynam"; }
+    Object *Clone() const override { return new Dynam(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Dynam"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a dynam.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Return true if the dynam text is only composed of f, p, r, z, etc. letters (e.g. sfz)

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -63,28 +63,28 @@ public:
     /**
      * See Object::ConvertToPageBased
      */
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
+    int ConvertToPageBasedEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareBoundaries
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams);
+    int PrepareBoundaries(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -46,14 +46,14 @@ public:
     EditorialElement(ClassId classId);
     EditorialElement(ClassId classId, const std::string &classIdStr);
     virtual ~EditorialElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * @name Add children to an editorial element.
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     //----------//

--- a/include/vrv/editortoolkit_cmn.h
+++ b/include/vrv/editortoolkit_cmn.h
@@ -29,12 +29,12 @@ namespace vrv {
 class EditorToolkitCMN : public EditorToolkit {
 public:
     EditorToolkitCMN(Doc *doc, View *view) : EditorToolkit(doc, view) {}
-    virtual bool ParseEditorAction(const std::string &json_editorAction)
+    bool ParseEditorAction(const std::string &json_editorAction) override
     {
         return ParseEditorAction(json_editorAction, false);
     }
     bool ParseEditorAction(const std::string &json_editorAction, bool commitOnly = false);
-    virtual std::string EditInfo();
+    std::string EditInfo() override;
 
 protected:
     /**

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -33,8 +33,8 @@ public:
     ///@{
     Dots();
     virtual ~Dots();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Dots"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Dots"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -109,8 +109,8 @@ public:
     ///@{
     Flag();
     virtual ~Flag();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Flag"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Flag"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -164,8 +164,8 @@ public:
     ///@{
     TupletBracket();
     virtual ~TupletBracket();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "TupletBracket"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "TupletBracket"; }
     ///@}
 
     /**
@@ -257,8 +257,8 @@ public:
     ///@{
     TupletNum();
     virtual ~TupletNum();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "TupletNum"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "TupletNum"; }
     ///@}
 
     /**
@@ -328,8 +328,8 @@ public:
     ///@{
     Stem();
     virtual ~Stem();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Stem"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Stem"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -338,7 +338,7 @@ public:
     /**
      * Add an element (only flag supported) to a stem.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * @name Setter and getter for darwing stem direction and length

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -54,16 +54,11 @@ public:
     //----------//
 
     /**
-     * See Object::CalcStem
-     */
-    // virtual int CalcStem(FunctorParams *functorParams);
-
-    /**
      * Overwritten version of Save that avoids anything to be written
      */
     ///@{
-    virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
+    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
@@ -77,12 +72,12 @@ public:
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
 private:
     //
@@ -134,14 +129,14 @@ public:
      * Overwritten version of Save that avoids anything to be written
      */
     ///@{
-    virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
+    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //
@@ -212,19 +207,19 @@ public:
      * Overwritten version of Save that avoids anything to be written
      */
     ///@{
-    virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
+    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
 private:
     //
@@ -294,19 +289,19 @@ public:
      * Overwritten version of Save that avoids anything to be written
      */
     ///@{
-    virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
+    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
 private:
     //
@@ -375,20 +370,20 @@ public:
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *functorParams);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * Overwritten version of Save that avoids anything to be written
      */
     ///@{
-    virtual int Save(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int SaveEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
+    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -38,7 +38,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     std::set<int> GetDotLocsForStaff(Staff *staff) const;
     std::set<int> &ModifyDotLocsForStaff(Staff *staff);
@@ -114,7 +114,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     wchar_t GetFlagGlyph(data_STEMDIRECTION stemDir) const;
 
@@ -333,7 +333,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add an element (only flag supported) to a stem.

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -52,34 +52,34 @@ public:
      * See Object::ConvertToPageBased
      */
     ///@{
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
+    int ConvertToPageBasedEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PrepareBoundaries
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams);
+    int PrepareBoundaries(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -34,15 +34,15 @@ public:
     ///@{
     Ending();
     virtual ~Ending();
-    virtual Object *Clone() const { return new Ending(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Ending"; }
+    Object *Clone() const override { return new Ending(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Ending"; }
     ///@}
 
     /**
      * Method for adding allowed content
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/expan.h
+++ b/include/vrv/expan.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Expan();
     virtual ~Expan();
-    virtual Object *Clone() const { return new Expan(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Expan"; }
+    Object *Clone() const override { return new Expan(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Expan"; }
     ///@}
 
 private:

--- a/include/vrv/expansion.h
+++ b/include/vrv/expansion.h
@@ -32,16 +32,16 @@ public:
     ///@{
     Expansion();
     virtual ~Expansion();
-    virtual Object *Clone() const { return new Expansion(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Expansion"; }
+    Object *Clone() const override { return new Expansion(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Expansion"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual PlistInterface *GetPlistInterface() { return dynamic_cast<PlistInterface *>(this); }
+    PlistInterface *GetPlistInterface() override { return dynamic_cast<PlistInterface *>(this); }
     ////@}
 
     //----------//

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -30,24 +30,24 @@ public:
     ///@{
     F();
     virtual ~F();
-    virtual Object *Clone() const { return new F(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "F"; }
+    Object *Clone() const override { return new F(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "F"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a rend.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -59,27 +59,27 @@ public:
     /**
      * See Object::FillStaffCurrentTimeSpanning
      */
-    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams);
+    int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimePointing
      */
-    virtual int PrepareTimePointing(FunctorParams *functorParams);
+    int PrepareTimePointing(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimeSpanning
      */
-    virtual int PrepareTimeSpanning(FunctorParams *functorParams);
+    int PrepareTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimestamps
      */
-    virtual int PrepareTimestamps(FunctorParams *functorParams);
+    int PrepareTimestamps(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -37,11 +37,11 @@ public:
     ///@{
     Facsimile();
     virtual ~Facsimile();
-    virtual Object *Clone() const { return new Facsimile(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "facsimile"; }
+    Object *Clone() const override { return new Facsimile(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Facsimile"; }
     ///@}
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     Zone *FindZoneByUuid(std::string zoneId);
     int GetMaxY();

--- a/include/vrv/facsimileinterface.h
+++ b/include/vrv/facsimileinterface.h
@@ -30,7 +30,7 @@ public:
     FacsimileInterface();
     virtual ~FacsimileInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_FACSIMILE; }
+    InterfaceId IsInterface() const override { return INTERFACE_FACSIMILE; }
     ///@}
 
     virtual int GetDrawingX() const;

--- a/include/vrv/facsimileinterface.h
+++ b/include/vrv/facsimileinterface.h
@@ -29,7 +29,7 @@ public:
     ///@{
     FacsimileInterface();
     virtual ~FacsimileInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_FACSIMILE; }
     ///@}
 

--- a/include/vrv/fb.h
+++ b/include/vrv/fb.h
@@ -29,16 +29,16 @@ public:
     ///@{
     Fb();
     virtual ~Fb();
-    virtual Object *Clone() const { return new Fb(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Fb"; }
+    Object *Clone() const override { return new Fb(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Fb"; }
     ///@}
 
     /**
      * Add an element (f) to an fb.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 private:
     //

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -40,16 +40,16 @@ public:
     ///@{
     Fermata();
     virtual ~Fermata();
-    virtual Object *Clone() const { return new Fermata(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Fermata"; }
+    Object *Clone() const override { return new Fermata(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Fermata"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -29,9 +29,9 @@ public:
     ///@{
     Fig();
     virtual ~Fig();
-    virtual Object *Clone() const { return new Fig(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Fig"; }
+    Object *Clone() const override { return new Fig(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Fig"; }
     ///@}
 
     /**
@@ -45,7 +45,7 @@ public:
      * Add an element (svg) to an fig.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -55,7 +55,7 @@ public:
      * See Object::AlignVertically
      */
     ///@{
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -31,24 +31,24 @@ public:
     ///@{
     Fing();
     virtual ~Fing();
-    virtual Object *Clone() const { return new Fing(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Fing"; }
+    Object *Clone() const override { return new Fing(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Fing"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend) to a fing.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -92,42 +92,42 @@ public:
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::FillStaffCurrentTimeSpanning
      */
-    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams);
+    int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimePointing
      */
-    virtual int PrepareTimePointing(FunctorParams *functorParams);
+    int PrepareTimePointing(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimeSpanning
      */
-    virtual int PrepareTimeSpanning(FunctorParams *functorParams);
+    int PrepareTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimestamps
      */
-    virtual int PrepareTimestamps(FunctorParams *functorParams);
+    int PrepareTimestamps(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnCastOff
      */
-    virtual int UnCastOff(FunctorParams *functorParams);
+    int UnCastOff(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -36,7 +36,7 @@ public:
     FloatingObject(ClassId classId);
     FloatingObject(ClassId classId, const std::string &classIdStr);
     virtual ~FloatingObject();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     virtual void UpdateContentBBoxX(int x1, int x2);
@@ -48,8 +48,8 @@ public:
      * @name Get and set the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     void SetCurrentFloatingPositioner(FloatingPositioner *boundingBox);
@@ -174,12 +174,12 @@ public:
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
-    virtual void ResetCachedDrawingX() const;
-    virtual void ResetCachedDrawingY() const;
+    void ResetCachedDrawingX() const override;
+    void ResetCachedDrawingY() const override;
 
     /**
      * @name Setter and getters for the objectX and Y

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -39,10 +39,10 @@ public:
     void Reset() override;
     ///@}
 
-    virtual void UpdateContentBBoxX(int x1, int x2);
-    virtual void UpdateContentBBoxY(int y1, int y2);
-    virtual void UpdateSelfBBoxX(int x1, int x2);
-    virtual void UpdateSelfBBoxY(int y1, int y2);
+    void UpdateContentBBoxX(int x1, int x2) override;
+    void UpdateContentBBoxY(int y1, int y2) override;
+    void UpdateSelfBBoxX(int x1, int x2) override;
+    void UpdateSelfBBoxY(int y1, int y2) override;
 
     /**
      * @name Get and set the X and Y drawing position
@@ -166,7 +166,7 @@ public:
     // constructors and destructors
     FloatingPositioner(FloatingObject *object, StaffAlignment *alignment, char spanningType);
     virtual ~FloatingPositioner(){};
-    virtual ClassId GetClassId() const { return FLOATING_POSITIONER; }
+    ClassId GetClassId() const override { return FLOATING_POSITIONER; }
 
     virtual void ResetPositioner();
 
@@ -270,9 +270,9 @@ public:
     // constructors and destructors
     FloatingCurvePositioner(FloatingObject *object, StaffAlignment *alignment, char spanningType);
     virtual ~FloatingCurvePositioner();
-    virtual ClassId GetClassId() const { return FLOATING_CURVE_POSITIONER; }
+    ClassId GetClassId() const override { return FLOATING_CURVE_POSITIONER; }
 
-    virtual void ResetPositioner();
+    void ResetPositioner() override;
 
     /**
      * Reset the curve parameters in FloatingCurvePositioner::FloatingCurvePositioner and in

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -72,7 +72,7 @@ protected:
     /**
      * Filter the flat list and keep only Note or Chords elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 public:
     /** */

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -54,17 +54,17 @@ public:
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *functorParams);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::GenerateMIDI
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -31,16 +31,16 @@ public:
     ///@{
     FTrem();
     virtual ~FTrem();
-    virtual Object *Clone() const { return new FTrem(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "FTrem"; }
+    Object *Clone() const override { return new FTrem(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "FTrem"; }
     ///@}
 
     /**
      * Add an element (a note or a chord) to a fTrem.
      * Only Note or Chord elements will be actually added to the fTrem.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      *

--- a/include/vrv/gliss.h
+++ b/include/vrv/gliss.h
@@ -35,17 +35,17 @@ public:
     ///@{
     Gliss();
     virtual ~Gliss();
-    virtual Object *Clone() const { return new Gliss(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Gliss"; }
+    Object *Clone() const override { return new Gliss(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Gliss"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -26,15 +26,15 @@ public:
     ///@{
     GraceGrp();
     virtual ~GraceGrp();
-    virtual Object *Clone() const { return new GraceGrp(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "GraceGrp"; };
+    Object *Clone() const override { return new GraceGrp(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "GraceGrp"; }
     ///@}
 
     /**
      * Add childElement to a element.
      */
-    virtual bool IsSupportedChild(Object *childElement);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     //

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -66,7 +66,7 @@ public:
     /**
      * See Object::ScoreDefSetGrpSym
      */
-    virtual int ScoreDefSetGrpSym(FunctorParams *functorParams);
+    int ScoreDefSetGrpSym(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -36,9 +36,9 @@ public:
     ///@{
     GrpSym();
     virtual ~GrpSym();
-    virtual Object *Clone() const { return new GrpSym(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "GrpSym"; }
+    Object *Clone() const override { return new GrpSym(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "GrpSym"; }
     ///@}
 
     /**
@@ -55,8 +55,8 @@ public:
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     //----------//

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -85,12 +85,12 @@ public:
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -37,17 +37,17 @@ public:
     ///@{
     Hairpin();
     virtual ~Hairpin();
-    virtual Object *Clone() const { return new Hairpin(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Hairpin"; }
+    Object *Clone() const override { return new Hairpin(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Hairpin"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -38,7 +38,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     //----------//
     // Functors //

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -48,13 +48,13 @@ public:
      * @name See Object::GenerateMIDI
      */
     ///@{
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PrepareRpt
      */
-    virtual int PrepareRpt(FunctorParams *functorParams);
+    int PrepareRpt(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -32,9 +32,9 @@ public:
     ///@{
     HalfmRpt();
     virtual ~HalfmRpt();
-    virtual Object *Clone() const { return new HalfmRpt(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "HalfmRpt"; }
+    Object *Clone() const override { return new HalfmRpt(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "HalfmRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -73,17 +73,17 @@ public:
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustHarmGrpsSpacing
      */
-    virtual int AdjustHarmGrpsSpacing(FunctorParams *functorParams);
+    int AdjustHarmGrpsSpacing(FunctorParams *functorParams) override;
 
     /**
      * See Object::Transpose
      */
-    virtual int Transpose(FunctorParams *functorParams);
+    int Transpose(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -38,25 +38,25 @@ public:
     ///@{
     Harm();
     virtual ~Harm();
-    virtual Object *Clone() const { return new Harm(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Harm"; }
+    Object *Clone() const override { return new Harm(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Harm"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a harm.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Transposition related. The int tracks where we have iterated through the string.

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -202,44 +202,44 @@ public:
      * Set the position of the Alignment.
      * Looks at the time different with the previous Alignment.
      */
-    virtual int SetAlignmentXPos(FunctorParams *functorParams);
+    int SetAlignmentXPos(FunctorParams *functorParams) override;
 
     /**
      * Justify the X positions
      * Special case of functor redirected from Measure.
      */
-    virtual int JustifyX(FunctorParams *functorParams);
+    int JustifyX(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArpeg
      */
-    virtual int AdjustArpeg(FunctorParams *functorParams);
+    int AdjustArpeg(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustGraceXPos
      */
     ///@{
-    virtual int AdjustGraceXPos(FunctorParams *functorParams);
-    virtual int AdjustGraceXPosEnd(FunctorParams *functorParams);
+    int AdjustGraceXPos(FunctorParams *functorParams) override;
+    int AdjustGraceXPosEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AdjustXPos
      */
     ///@{
-    virtual int AdjustXPos(FunctorParams *functorParams);
-    virtual int AdjustXPosEnd(FunctorParams *functorParams);
+    int AdjustXPos(FunctorParams *functorParams) override;
+    int AdjustXPosEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AjustAccidX
      */
-    virtual int AdjustAccidX(FunctorParams *functorParams);
+    int AdjustAccidX(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustDotsEnd
      */
-    virtual int AdjustDotsEnd(FunctorParams *);
+    int AdjustDotsEnd(FunctorParams *functorParams) override;
 
 private:
     /**
@@ -338,23 +338,23 @@ public:
     /**
      * See Object::AdjustLayers
      */
-    virtual int AdjustLayers(FunctorParams *functorParams);
-    virtual int AdjustLayersEnd(FunctorParams *functorParams);
+    int AdjustLayers(FunctorParams *functorParams) override;
+    int AdjustLayersEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustGraceXPos
      */
-    virtual int AdjustGraceXPos(FunctorParams *functorParams);
+    int AdjustGraceXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AjustAccidX
      */
-    virtual int AdjustAccidX(FunctorParams *functorParams);
+    int AdjustAccidX(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
 private:
     //
@@ -522,13 +522,13 @@ public:
      * Looks at the time different with the previous Alignment.
      * For each MeasureAlignment, we need to reset the previous time position.
      */
-    virtual int SetAlignmentXPos(FunctorParams *functorParams);
+    int SetAlignmentXPos(FunctorParams *functorParams) override;
 
     /**
      * Justify the X positions
      * Special case of functor redirected from Measure.
      */
-    virtual int JustifyX(FunctorParams *functorParams);
+    int JustifyX(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -75,7 +75,7 @@ public:
     Alignment();
     Alignment(double time, AlignmentType type = ALIGNMENT_DEFAULT);
     virtual ~Alignment();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
@@ -86,7 +86,7 @@ public:
     /**
      * Override the method of adding AlignmentReference children
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * @name Set and get the xRel value of the alignment
@@ -298,18 +298,18 @@ public:
     AlignmentReference();
     AlignmentReference(int staffN);
     virtual ~AlignmentReference();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * Override the method of adding AlignmentReference children
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Overwritten method for AlignmentReference children
      */
-    virtual void AddChild(Object *object);
+    void AddChild(Object *object) override;
 
     /**
      * Add an accidental to the accidSpace of the AlignmentReference.
@@ -390,13 +390,13 @@ public:
     ///@(
     HorizontalAligner(ClassId classId);
     virtual ~HorizontalAligner();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * Do not copy children for HorizontalAligner
      */
-    virtual bool CopyChildren() const { return false; }
+    bool CopyChildren() const override { return false; }
 
     int GetAlignmentCount() const { return (int)GetChildren()->size(); }
 
@@ -440,7 +440,7 @@ public:
     ///@(
     MeasureAligner();
     virtual ~MeasureAligner();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
@@ -576,7 +576,7 @@ public:
     ///@(
     GraceAligner();
     virtual ~GraceAligner();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
@@ -660,7 +660,7 @@ public:
     /**
      * Reset the aligner (clear the content)
      */
-    virtual void Reset();
+    void Reset() override;
 
     /**
      * Look for an existing TimestampAttr at a certain time.

--- a/include/vrv/instrdef.h
+++ b/include/vrv/instrdef.h
@@ -35,9 +35,9 @@ public:
     ///@{
     InstrDef();
     virtual ~InstrDef();
-    virtual Object *Clone() const { return new InstrDef(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "InstrDef"; }
+    Object *Clone() const override { return new InstrDef(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "InstrDef"; }
     ///@}
 
     //----------//

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -46,7 +46,7 @@ public:
     ABCInput(Doc *doc);
     virtual ~ABCInput();
 
-    virtual bool Import(const std::string &abc);
+    bool Import(const std::string &abc) override;
 
 #ifndef NO_ABC_SUPPORT
 

--- a/include/vrv/iodarms.h
+++ b/include/vrv/iodarms.h
@@ -40,7 +40,7 @@ public:
     DarmsInput(Doc *doc);
     virtual ~DarmsInput();
 
-    virtual bool Import(const std::string &data);
+    bool Import(const std::string &data) override;
 
 private:
     int do_Note(int pos, const char *data, bool rest);

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -393,7 +393,7 @@ public:
     HumdrumInput(vrv::Doc *doc);
     virtual ~HumdrumInput();
 
-    virtual bool Import(const std::string &humdrum);
+    bool Import(const std::string &humdrum) override;
 
     void parseEmbeddedOptions(vrv::Doc *doc);
     void finalizeDocument(vrv::Doc *doc);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -184,12 +184,12 @@ public:
     /**
      * The main method for write objects.
      */
-    virtual bool WriteObject(Object *object);
+    bool WriteObject(Object *object) override;
 
     /**
      * Writing object method that must be overridden in the child class.
      */
-    virtual bool WriteObjectEnd(Object *object);
+    bool WriteObjectEnd(Object *object) override;
 
     /**
      * Return the output as a string by writing it to the stringstream member.
@@ -481,7 +481,7 @@ public:
     MEIInput(Doc *doc);
     virtual ~MEIInput();
 
-    virtual bool Import(const std::string &mei);
+    bool Import(const std::string &mei) override;
 
 private:
     bool ReadDoc(pugi::xml_node root);

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -174,7 +174,7 @@ public:
     virtual ~MusicXmlInput();
 
 #ifndef NO_MUSICXML_SUPPORT
-    virtual bool Import(std::string const &musicxml);
+    bool Import(const std::string &musicxml) override;
 
 private:
     /*

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -84,12 +84,12 @@ public:
     /**
      * The main method for write objects.
      */
-    virtual bool WriteObject(Object *object);
+    bool WriteObject(Object *object) override;
 
     /**
      * Writing object method that must be overridden in the child class.
      */
-    virtual bool WriteObjectEnd(Object *object);
+    bool WriteObjectEnd(Object *object) override;
 
 private:
     bool WriteDoc(Doc *doc);
@@ -405,7 +405,7 @@ public:
     virtual ~PAEInput();
 
 #ifndef NO_PAE_SUPPORT
-    virtual bool Import(const std::string &pae);
+    bool Import(const std::string &pae) override;
 
 private:
     // function declarations:
@@ -518,7 +518,7 @@ public:
     jsonxx::Object GetValidationLog();
 
 #ifndef NO_PAE_SUPPORT
-    virtual bool Import(const std::string &input);
+    bool Import(const std::string &input) override;
 
 private:
     /**

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -34,12 +34,12 @@ public:
     ///@{
     KeyAccid();
     virtual ~KeyAccid();
-    virtual Object *Clone() const { return new KeyAccid(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "KeyAccid"; }
+    Object *Clone() const override { return new KeyAccid(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "KeyAccid"; }
     ///@}
 
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
 
     /**
      * Retrieve SMuFL string for the accidental.

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -42,9 +42,9 @@ public:
     ///@{
     KeySig();
     virtual ~KeySig();
-    virtual Object *Clone() const { return new KeySig(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "KeySig"; }
+    Object *Clone() const override { return new KeySig(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "KeySig"; }
 
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }
@@ -55,7 +55,7 @@ public:
     /**
      * Add an element (a keyAccid) to a keySig.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /** Accid number getter */
     int GetAccidCount();

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -94,7 +94,7 @@ public:
     /**
      * See Object::Transpose
      */
-    virtual int Transpose(FunctorParams *);
+    int Transpose(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -47,10 +47,10 @@ public:
     std::string GetClassName() const override { return "KeySig"; }
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /** Override the method since check is required */
-    virtual bool IsScoreDefElement() const { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
+    bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     /**
      * Add an element (a keyAccid) to a keySig.
@@ -100,7 +100,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     //

--- a/include/vrv/label.h
+++ b/include/vrv/label.h
@@ -29,16 +29,16 @@ public:
     ///@{
     Label();
     virtual ~Label();
-    virtual Object *Clone() const { return new Label(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Label"; }
+    Object *Clone() const override { return new Label(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Label"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     //----------//

--- a/include/vrv/labelabbr.h
+++ b/include/vrv/labelabbr.h
@@ -29,16 +29,16 @@ public:
     ///@{
     LabelAbbr();
     virtual ~LabelAbbr();
-    virtual Object *Clone() const { return new LabelAbbr(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "LabelAbbr"; }
+    Object *Clone() const override { return new LabelAbbr(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "LabelAbbr"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     //----------//

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -192,66 +192,59 @@ public:
     /**
      * See Object::ConvertMarkupArtic
      */
-    virtual int ConvertMarkupArticEnd(FunctorParams *functorParams);
+    int ConvertMarkupArticEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToUnCastOffMensural
      */
-    virtual int ConvertToUnCastOffMensural(FunctorParams *params);
+    int ConvertToUnCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontally
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontallyEnd
      */
-    virtual int AlignHorizontallyEnd(FunctorParams *functorParams);
+    int AlignHorizontallyEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareProcessingLists
      */
-    virtual int PrepareProcessingLists(FunctorParams *functorParams);
+    int PrepareProcessingLists(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareRpt
      */
-    virtual int PrepareRpt(FunctorParams *functorParams);
+    int PrepareRpt(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcOnsetOffset
      */
     ///@{
-    virtual int CalcOnsetOffset(FunctorParams *functorParams);
+    int CalcOnsetOffset(FunctorParams *functorParams) override;
     ///@}
 
     /**
-     * See Object::GenerateTimemap
-     * To be added once Layer implements LinkingInterface
-     */
-    // virtual int GenerateTimemap(FunctorParams *functorParams);
-
-    /**
      * See Object::ResetDrawing
-     * To be added once Layer implements LinkingInterface
      */
-    virtual int ResetDrawing(FunctorParams *);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -44,21 +44,21 @@ public:
     ///@{
     Layer();
     virtual ~Layer();
-    virtual Object *Clone() const { return new Layer(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Layer"; }
+    Object *Clone() const override { return new Layer(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Layer"; }
     ///@}
 
     /**
      * Overriding CloneReset() method to be called after copy / assignment calls.
      */
-    virtual void CloneReset();
+    void CloneReset() override;
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -52,20 +52,20 @@ public:
     LayerElement(ClassId classId);
     LayerElement(ClassId classId, const std::string &classIdStr);
     virtual ~LayerElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * Overriding CloneReset() method to be called after copy / assignment calls.
      */
-    virtual void CloneReset();
+    void CloneReset() override;
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual FacsimileInterface *GetFacsimileInterface() { return dynamic_cast<FacsimileInterface *>(this); }
-    virtual LinkingInterface *GetLinkingInterface() { return dynamic_cast<LinkingInterface *>(this); }
+    FacsimileInterface *GetFacsimileInterface() override { return dynamic_cast<FacsimileInterface *>(this); }
+    LinkingInterface *GetLinkingInterface() override { return dynamic_cast<LinkingInterface *>(this); }
     ///@}
 
     /**
@@ -134,8 +134,8 @@ public:
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -244,148 +244,148 @@ public:
     /**
      * See Object::AdjustBeams
      */
-    virtual int AdjustBeams(FunctorParams *);
+    int AdjustBeams(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustDots
      */
-    virtual int AdjustDots(FunctorParams *);
+    int AdjustDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
-     * See Object::ResetHorizontalAlignment
+     * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ApplyPPUFactor
      */
-    virtual int ApplyPPUFactor(FunctorParams *functorParams);
+    int ApplyPPUFactor(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontally
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustLayers
      */
-    virtual int AdjustLayers(FunctorParams *functorParams);
+    int AdjustLayers(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustGraceXPos
      */
     ///@{
-    virtual int AdjustGraceXPos(FunctorParams *functorParams);
+    int AdjustGraceXPos(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AdjustTupletNumOverlap
      */
-    virtual int AdjustTupletNumOverlap(FunctorParams *functorParams);
+    int AdjustTupletNumOverlap(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustXPos
      */
-    virtual int AdjustXPos(FunctorParams *functorParams);
+    int AdjustXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustXRelForTranscription
      */
-    virtual int AdjustXRelForTranscription(FunctorParams *);
+    int AdjustXRelForTranscription(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareDrawingCueSize
      */
-    virtual int PrepareDrawingCueSize(FunctorParams *functorParams);
+    int PrepareDrawingCueSize(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareCrossStaff
      */
     ///@{
-    virtual int PrepareCrossStaff(FunctorParams *functorParams);
-    virtual int PrepareCrossStaffEnd(FunctorParams *functorParams);
+    int PrepareCrossStaff(FunctorParams *functorParams) override;
+    int PrepareCrossStaffEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PreparePointersByLayer
      */
-    virtual int PreparePointersByLayer(FunctorParams *functorParams);
+    int PreparePointersByLayer(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareDelayedTurns
      */
-    virtual int PrepareDelayedTurns(FunctorParams *functorParams);
+    int PrepareDelayedTurns(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimePointing
      */
-    virtual int PrepareTimePointing(FunctorParams *functorParams);
+    int PrepareTimePointing(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimeSpanning
      */
-    virtual int PrepareTimeSpanning(FunctorParams *functorParams);
+    int PrepareTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::SetAlignmentPitchPos
      */
-    virtual int SetAlignmentPitchPos(FunctorParams *functorParams);
+    int SetAlignmentPitchPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::FindSpannedLayerElements
      */
-    virtual int FindSpannedLayerElements(FunctorParams *functorParams);
+    int FindSpannedLayerElements(FunctorParams *functorParams) override;
 
     /**
      * See Object::LayerCountInTimeSpan
      */
-    virtual int LayerCountInTimeSpan(FunctorParams *functorParams);
+    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
 
     /**
      * See Object::LayerElementsInTimeSpan
      */
-    virtual int LayerElementsInTimeSpan(FunctorParams *functorParams);
+    int LayerElementsInTimeSpan(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcOnsetOffset
      */
     ///@{
-    virtual int CalcOnsetOffset(FunctorParams *functorParams);
+    int CalcOnsetOffset(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::ResolveMIDITies
      */
     ///@{
-    virtual int ResolveMIDITies(FunctorParams *);
+    int ResolveMIDITies(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * @name See Object::GenerateMIDI
      */
     ///@{
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::GenerateTimemap
      */
-    virtual int GenerateTimemap(FunctorParams *functorParams);
+    int GenerateTimemap(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::GetRelativeLayerElement
      */
-    virtual int GetRelativeLayerElement(FunctorParams *functorParams);
+    int GetRelativeLayerElement(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/lb.h
+++ b/include/vrv/lb.h
@@ -29,15 +29,15 @@ public:
     ///@{
     Lb();
     virtual ~Lb();
-    virtual Object *Clone() const { return new Lb(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Lb"; }
+    Object *Clone() const override { return new Lb(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Lb"; }
     ///@}
 
     /**
      * Lb is an empty element
      */
-    virtual void AddChild(Object *object){};
+    void AddChild(Object *object) override{};
 
 private:
     //

--- a/include/vrv/lem.h
+++ b/include/vrv/lem.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Lem();
     virtual ~Lem();
-    virtual Object *Clone() const { return new Lem(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Lem"; }
+    Object *Clone() const override { return new Lem(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Lem"; }
     ///@}
 
 private:

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -70,12 +70,12 @@ public:
     /**
      * See Object::CalcLigatureNotePos
      */
-    virtual int CalcLigatureNotePos(FunctorParams *functorParams);
+    int CalcLigatureNotePos(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -40,7 +40,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add children (notes or editorial markup)
@@ -86,7 +86,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    virtual void FilterList(ArrayOfObjects *childlist);
+    void FilterList(ArrayOfObjects *childList) override;
 
 public:
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -34,9 +34,9 @@ public:
     ///@{
     Ligature();
     virtual ~Ligature();
-    virtual Object *Clone() const { return new Ligature(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Ligature"; }
+    Object *Clone() const override { return new Ligature(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Ligature"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -45,7 +45,7 @@ public:
     /**
      * Add children (notes or editorial markup)
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Return the first or last note

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -35,7 +35,7 @@ public:
     LinkingInterface();
     virtual ~LinkingInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_LINKING; }
+    InterfaceId IsInterface() const override { return INTERFACE_LINKING; }
     ///@}
 
     /**

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -34,7 +34,7 @@ public:
     ///@{
     LinkingInterface();
     virtual ~LinkingInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_LINKING; }
     ///@}
 

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -33,7 +33,7 @@ public:
     std::string GetClassName() const override { return "Lv"; }
     ///@}
 
-    virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
+    bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]) override;
 
     //----------//
     // Functors //

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -28,9 +28,9 @@ public:
     ///@{
     Lv();
     virtual ~Lv();
-    virtual Object *Clone() const { return new Lv(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Lv"; }
+    Object *Clone() const override { return new Lv(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Lv"; }
     ///@}
 
     virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -57,8 +57,8 @@ public:
      * Invisible Mdiv elements are not saved in page-based MEI
      */
     ///@{
-    virtual int Save(FunctorParams *functorParams);
-    virtual int SaveEnd(FunctorParams *functorParams);
+    int Save(FunctorParams *functorParams) override;
+    int SaveEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -65,8 +65,8 @@ public:
      * See Object::ConvertToPageBased
      */
     ///@{
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
+    int ConvertToPageBasedEnd(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -31,16 +31,16 @@ public:
     ///@{
     Mdiv();
     virtual ~Mdiv();
-    virtual Object *Clone() const { return new Mdiv(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Mdiv"; }
+    Object *Clone() const override { return new Mdiv(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Mdiv"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -51,15 +51,15 @@ public:
     ///@{
     Measure(bool measuredMusic = true, int logMeasureNb = -1);
     virtual ~Measure();
-    virtual Object *Clone() const { return new Measure(*this); };
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Measure"; }
+    Object *Clone() const override { return new Measure(*this); };
+    void Reset() override;
+    std::string GetClassName() const override { return "Measure"; }
     ///@}
 
     /**
      * Overriding CloneReset() method to be called after copy / assignment calls.
      */
-    virtual void CloneReset();
+    void CloneReset() override;
 
     /**
      * Return true if measured music (otherwise we have fake measures)
@@ -69,7 +69,7 @@ public:
     /**
      * Methods for adding allowed content
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Specific method for measures
@@ -85,12 +85,12 @@ public:
     /**
      * Get the X drawing position
      */
-    virtual int GetDrawingX() const;
+    int GetDrawingX() const override;
 
     /**
      * Reset the cached values of the drawingX values.
      */
-    virtual void ResetCachedDrawingX() const;
+    void ResetCachedDrawingX() const override;
 
     /**
      * @name Get and set the X drawing relative positions

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -265,205 +265,205 @@ public:
     /**
      * See Object::ConvertMarkupAnalytical
      */
-    virtual int ConvertMarkupAnalyticalEnd(FunctorParams *functorParams);
+    int ConvertMarkupAnalyticalEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToPageBased
      */
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToUnCastOffMensural
      */
-    virtual int ConvertToUnCastOffMensural(FunctorParams *params);
+    int ConvertToUnCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::Save
      */
     ///@{
-    virtual int Save(FunctorParams *functorParams);
-    virtual int SaveEnd(FunctorParams *functorParams);
+    int Save(FunctorParams *functorParams) override;
+    int SaveEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
     /**
      * See Object::ScoreDefOptimize
      */
-    virtual int ScoreDefOptimize(FunctorParams *functorParams);
+    int ScoreDefOptimize(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ApplyPPUFactor
      */
-    virtual int ApplyPPUFactor(FunctorParams *functorParams);
+    int ApplyPPUFactor(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontally
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams);
-    virtual int AlignHorizontallyEnd(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
+    int AlignHorizontallyEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignVertically
      */
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
 
     /**
      * See Object::SetAlignmentXPos
      */
-    virtual int SetAlignmentXPos(FunctorParams *functorParams);
+    int SetAlignmentXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustArpeg
      */
-    virtual int AdjustArpegEnd(FunctorParams *functorParams);
+    int AdjustArpegEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustClefChanges
      */
-    virtual int AdjustClefChanges(FunctorParams *functorParams);
+    int AdjustClefChanges(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustDots
      */
-    virtual int AdjustDots(FunctorParams *);
+    int AdjustDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustLayers
      */
-    virtual int AdjustLayers(FunctorParams *functorParams);
+    int AdjustLayers(FunctorParams *functorParams) override;
 
     /**
      * See Object::AjustAccidX
      */
-    virtual int AdjustAccidX(FunctorParams *functorParams);
+    int AdjustAccidX(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustGraceXPos
      */
-    virtual int AdjustGraceXPos(FunctorParams *functorParams);
+    int AdjustGraceXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustXOverflow
      */
-    virtual int AdjustXOverflow(FunctorParams *functorParams);
+    int AdjustXOverflow(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustXPos
      */
-    virtual int AdjustXPos(FunctorParams *functorParams);
+    int AdjustXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustHarmGrpsSpacing
      */
-    virtual int AdjustHarmGrpsSpacingEnd(FunctorParams *functorParams);
+    int AdjustHarmGrpsSpacingEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustSylSpacing
      */
-    virtual int AdjustSylSpacingEnd(FunctorParams *functorParams);
+    int AdjustSylSpacingEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignMeasures
      */
-    virtual int AlignMeasures(FunctorParams *functorParams);
+    int AlignMeasures(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyX
      */
-    virtual int JustifyX(FunctorParams *functorParams);
+    int JustifyX(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::FillStaffCurrentTimeSpanningEnd
      */
-    virtual int FillStaffCurrentTimeSpanningEnd(FunctorParams *functorParams);
+    int FillStaffCurrentTimeSpanningEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareCrossStaff
      */
-    virtual int PrepareCrossStaff(FunctorParams *functorParams);
+    int PrepareCrossStaff(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::PrepareFloatingGrps
      */
     ///@{
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
-    virtual int PrepareFloatingGrpsEnd(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
+    int PrepareFloatingGrpsEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PrepareTimePointingEnd
      */
-    virtual int PrepareTimePointingEnd(FunctorParams *functorParams);
+    int PrepareTimePointingEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareTimeSpanningEnd
      */
-    virtual int PrepareTimeSpanningEnd(FunctorParams *functorParams);
+    int PrepareTimeSpanningEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareBoundaries
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams);
+    int PrepareBoundaries(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::GenerateMIDI
      */
     ///@{
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * @name See Object::GenerateTimemap
      */
     ///@{
-    virtual int GenerateTimemap(FunctorParams *functorParams);
+    int GenerateTimemap(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::CalcMaxMeasureDuration
      */
-    virtual int CalcMaxMeasureDuration(FunctorParams *functorParams);
+    int CalcMaxMeasureDuration(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcOnsetOffset
      */
     ///@{
-    virtual int CalcOnsetOffset(FunctorParams *functorParams);
+    int CalcOnsetOffset(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PrepareTimestamps
      */
-    virtual int PrepareTimestampsEnd(FunctorParams *functorParams);
+    int PrepareTimestampsEnd(FunctorParams *functorParams) override;
 
 public:
     // flags for drawing measure barline based on visibility or other conditions

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -258,8 +258,8 @@ public:
      * See Object::FindSpannedLayerElements
      */
     ///@{
-    virtual int FindSpannedLayerElements(FunctorParams *functorParams);
-    virtual int FindSpannedLayerElementsEnd(FunctorParams *functorParams);
+    int FindSpannedLayerElements(FunctorParams *functorParams) override;
+    int FindSpannedLayerElementsEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -40,9 +40,9 @@ public:
     ///@{
     Mensur();
     virtual ~Mensur();
-    virtual Object *Clone() const { return new Mensur(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Mensur"; }
+    Object *Clone() const override { return new Mensur(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Mensur"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -46,10 +46,10 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /** Override the method since check is required */
-    virtual bool IsScoreDefElement() const { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
+    bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     //----------//
     // Functors //

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -58,7 +58,7 @@ public:
     /**
      * See Object::LayerCountInTimeSpan
      */
-    virtual int LayerCountInTimeSpan(FunctorParams *functorParams);
+    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -59,7 +59,7 @@ public:
     /**
      * See Object::LayerCountInTimeSpan
      */
-    virtual int LayerCountInTimeSpan(FunctorParams *functorParams);
+    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -38,10 +38,10 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /** Override the method since check is required */
-    virtual bool IsScoreDefElement() const { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
+    bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     /** Evaluate additive meter counts */
     int GetTotalCount() const;

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -32,9 +32,9 @@ public:
     ///@{
     MeterSig();
     virtual ~MeterSig();
-    virtual Object *Clone() const { return new MeterSig(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MeterSig"; }
+    Object *Clone() const override { return new MeterSig(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MeterSig"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -42,23 +42,23 @@ public:
     ///@{
     MeterSigGrp();
     virtual ~MeterSigGrp();
-    virtual Object *Clone() const { return new MeterSigGrp(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MeterSigGrp"; }
+    Object *Clone() const override { return new MeterSigGrp(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MeterSigGrp"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual LinkingInterface *GetLinkingInterface() { return this; }
+    LinkingInterface *GetLinkingInterface() override { return this; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -82,7 +82,7 @@ public:
     /**
      * See Object::AlignHorizontally
      */
-    int AlignHorizontally(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -88,7 +88,7 @@ protected:
     /**
      * Filter the flat list and keep only meterSigGrp elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     // vector with alternating measures to be used only with meterSigGrpLog_FUNC_alternating

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -38,24 +38,24 @@ public:
     ///@{
     MNum();
     virtual ~MNum();
-    virtual Object *Clone() const { return new MNum(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MNum"; }
+    Object *Clone() const override { return new MNum(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MNum"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a dynam.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * @name Setter and getter of the generated flag

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -73,8 +73,8 @@ public:
      * See Object::Save
      */
     ///@{
-    virtual int Save(FunctorParams *functorParams);
-    virtual int SaveEnd(FunctorParams *functorParams);
+    int Save(FunctorParams *functorParams) override;
+    int SaveEnd(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/mordent.h
+++ b/include/vrv/mordent.h
@@ -38,16 +38,16 @@ public:
     ///@{
     Mordent();
     virtual ~Mordent();
-    virtual Object *Clone() const { return new Mordent(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Mordent"; }
+    Object *Clone() const override { return new Mordent(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Mordent"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -62,17 +62,17 @@ public:
     /**
      * See Object::ConvertMarkupAnalytical
      */
-    virtual int ConvertMarkupAnalytical(FunctorParams *functorParams);
+    int ConvertMarkupAnalytical(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -38,16 +38,16 @@ public:
     ///@{
     MRest();
     virtual ~MRest();
-    virtual Object *Clone() const { return new MRest(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MRest"; }
+    Object *Clone() const override { return new MRest(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MRest"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -32,9 +32,9 @@ public:
     ///@{
     MRpt();
     virtual ~MRpt();
-    virtual Object *Clone() const { return new MRpt(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MRpt"; }
+    Object *Clone() const override { return new MRpt(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MRpt"; }
     ///@}
 
     //----------//

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -45,13 +45,13 @@ public:
      * @name See Object::GenerateMIDI
      */
     ///@{
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::PrepareRpt
      */
-    virtual int PrepareRpt(FunctorParams *functorParams);
+    int PrepareRpt(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/mrpt2.h
+++ b/include/vrv/mrpt2.h
@@ -32,9 +32,9 @@ public:
     ///@{
     MRpt2();
     virtual ~MRpt2();
-    virtual Object *Clone() const { return new MRpt2(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MRpt2"; }
+    Object *Clone() const override { return new MRpt2(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MRpt2"; }
     ///@}
 
 private:

--- a/include/vrv/mspace.h
+++ b/include/vrv/mspace.h
@@ -28,9 +28,9 @@ public:
     ///@{
     MSpace();
     virtual ~MSpace();
-    virtual Object *Clone() const { return new MSpace(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MSpace"; }
+    Object *Clone() const override { return new MSpace(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MSpace"; }
     ///@}
 
     //----------//

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -38,9 +38,9 @@ public:
     ///@{
     MultiRest();
     virtual ~MultiRest();
-    virtual Object *Clone() const { return new MultiRest(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MultiRest"; }
+    Object *Clone() const override { return new MultiRest(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MultiRest"; }
     ///@}
 
     /**

--- a/include/vrv/multirpt.h
+++ b/include/vrv/multirpt.h
@@ -31,9 +31,9 @@ public:
     ///@{
     MultiRpt();
     virtual ~MultiRpt();
-    virtual Object *Clone() const { return new MultiRpt(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "MultiRpt"; }
+    Object *Clone() const override { return new MultiRpt(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "MultiRpt"; }
     ///@}
 
 private:

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -45,17 +45,17 @@ public:
     ///@{
     Nc();
     virtual ~Nc();
-    virtual Object *Clone() const { return new Nc(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Nc"; }
+    Object *Clone() const override { return new Nc(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Nc"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
     ///@}
 
 private:

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -77,8 +77,7 @@ public:
      */
     bool IsSupportedChild(Object *object) override;
 
-    virtual int GetPosition(LayerElement *element);
-    virtual bool IsLastInNeume(LayerElement *element);
+    bool IsLastInNeume(LayerElement *element);
 
     bool GenerateChildMelodic();
 
@@ -90,7 +89,8 @@ public:
     PitchInterface *GetLowestPitch();
 
 private:
-    //
+    int GetPosition(LayerElement *element);
+
 public:
     //----------------//
     // Static members //

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -66,16 +66,16 @@ public:
     ///@{
     Neume();
     virtual ~Neume();
-    virtual void Reset();
-    virtual Object *Clone() const { return new Neume(*this); }
-    virtual std::string GetClassName() const { return "Neume"; }
+    void Reset() override;
+    Object *Clone() const override { return new Neume(*this); }
+    std::string GetClassName() const override { return "Neume"; }
     ///@}
 
     /**
      * Add an element (a note or a rest) to a syllable.
      * Only syl or neume will be added.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     virtual int GetPosition(LayerElement *element);
     virtual bool IsLastInNeume(LayerElement *element);

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -69,18 +69,18 @@ public:
     ///@{
     Note();
     virtual ~Note();
-    virtual Object *Clone() const { return new Note(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Note"; }
+    Object *Clone() const override { return new Note(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Note"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
-    virtual StemmedDrawingInterface *GetStemmedDrawingInterface()
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
+    StemmedDrawingInterface *GetStemmedDrawingInterface() override
     {
         return dynamic_cast<StemmedDrawingInterface *>(this);
     }
@@ -96,12 +96,12 @@ public:
      * Add an element (a verse or an accid) to a note.
      * Only Verse and Accid elements will be actually added to the note.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Overwritten method for note
      */
-    virtual void AddChild(Object *object);
+    void AddChild(Object *object) override;
 
     /**
      * Align dots shift for two notes. Should be used for unison notes to align dots positioning

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -90,7 +90,7 @@ public:
      * Override the method since alignment is required.
      * For notes we want not to align notes within a ligature (except first and last)
      */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add an element (a verse or an accid) to a note.
@@ -185,9 +185,9 @@ public:
      * If necessary look at the glyph anchor (if any).
      */
     ///@{
-    virtual Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize);
-    virtual Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize);
-    virtual int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir);
+    Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize) override;
+    Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize) override;
+    int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) override;
     ///@}
 
     /**
@@ -313,14 +313,14 @@ protected:
     /**
      * The note locations w.r.t. each staff
      */
-    virtual MapOfNoteLocs CalcNoteLocations();
+    MapOfNoteLocs CalcNoteLocations() override;
 
     /**
      * The dot locations w.r.t. each staff
      * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
      * secondary
      */
-    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary);
+    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) override;
 
 private:
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -242,72 +242,72 @@ public:
     /**
      * See Object::AdjustArtic
      */
-    virtual int AdjustArtic(FunctorParams *functorParams);
+    int AdjustArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertMarkupAnalytical
      */
-    virtual int ConvertMarkupAnalytical(FunctorParams *functorParams);
+    int ConvertMarkupAnalytical(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcArtic
      */
-    virtual int CalcArtic(FunctorParams *functorParams);
+    int CalcArtic(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *functorParams);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcChordNoteHeads
      */
-    virtual int CalcChordNoteHeads(FunctorParams *functorParams);
+    int CalcChordNoteHeads(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcDots
      */
-    virtual int CalcDots(FunctorParams *functorParams);
+    int CalcDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcLedgerLines
      */
-    virtual int CalcLedgerLines(FunctorParams *functorParams);
+    int CalcLedgerLines(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareLayerElementParts
      */
-    virtual int PrepareLayerElementParts(FunctorParams *functorParams);
+    int PrepareLayerElementParts(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareLyrics
      */
-    virtual int PrepareLyrics(FunctorParams *functorParams);
+    int PrepareLyrics(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::GenerateMIDI
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
 
     /**
      * See Object::GenerateTimemap
      */
-    virtual int GenerateTimemap(FunctorParams *functorParams);
+    int GenerateTimemap(FunctorParams *functorParams) override;
 
     /**
      * See Object::Transpose
      */
-    virtual int Transpose(FunctorParams *);
+    int Transpose(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -30,15 +30,15 @@ public:
     ///@{
     Num();
     virtual ~Num();
-    virtual Object *Clone() const { return new Num(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Num"; }
+    Object *Clone() const override { return new Num(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Num"; }
     ///@}
 
     /**
      * Add an element (text) to a num.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Return a pointer to the current text object.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -327,8 +327,8 @@ public:
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     /**
@@ -336,8 +336,8 @@ public:
      * Reset all children recursively
      */
     ///@{
-    virtual void ResetCachedDrawingX() const;
-    virtual void ResetCachedDrawingY() const;
+    void ResetCachedDrawingX() const override;
+    void ResetCachedDrawingY() const override;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -868,13 +868,10 @@ public:
     virtual int AdjustArticWithSlurs(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
-     * @name Adjust the position of cross-staff element after the adjustment of the staves.
-     * This is called by Chords and Tuplets with cross-staff content
+     * Adjust the position of cross-staff elements after the adjustment of the staves.
+     * This is called by chords and tuplets with cross-staff content.
      */
-    ///@{
     virtual int AdjustCrossStaffYPos(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    virtual int AdjustCrossStaffYPosEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
-    ///@}
 
     /**
      * Adjust the position of all floating positionners, staff by staff.
@@ -932,7 +929,7 @@ public:
     ///@}
 
     /**
-     * @name Functors for aligning the content vertically.
+     * @name Functors for aligning the pages.
      */
     ///@{
 
@@ -1494,26 +1491,21 @@ private:
 };
 
 //----------------------------------------------------------------------------
-// abstract base class Functor
+// Functor
 //----------------------------------------------------------------------------
 
-/**
- * This class is an abstact Functor for the object hierarchy.
- * Needs testing.
- */
 class Functor {
 private:
     int (Object::*obj_fpt)(FunctorParams *functorParams); // pointer to member function
 
 public:
-    // constructor - takes pointer to an object and pointer to a member and stores
-    // them in two private variables
+    // constructor - takes pointer to a functor method and stores it
     Functor();
     Functor(int (Object::*_obj_fpt)(FunctorParams *));
     virtual ~Functor(){};
 
-    // override function "Call"
-    virtual void Call(Object *ptr, FunctorParams *functorParams);
+    // Call the internal functor method
+    void Call(Object *ptr, FunctorParams *functorParams);
 
 private:
     //

--- a/include/vrv/octave.h
+++ b/include/vrv/octave.h
@@ -38,17 +38,17 @@ public:
     ///@{
     Octave();
     virtual ~Octave();
-    virtual Object *Clone() const { return new Octave(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Octave"; }
+    Object *Clone() const override { return new Octave(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Octave"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -157,16 +157,16 @@ public:
     // constructors and destructors
     OptionBool() { m_defaultValue = false; }
     virtual ~OptionBool() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init(bool defaultValue);
 
-    virtual bool SetValueBool(bool value);
-    virtual bool SetValueDbl(double value);
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValueBool(bool value) override;
+    bool SetValueDbl(double value) override;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
-    virtual void Reset();
+    void Reset() override;
 
     bool GetValue() const { return m_value; }
     bool GetDefault() const { return m_defaultValue; }
@@ -198,15 +198,15 @@ public:
         m_maxValue = 0.0;
     }
     virtual ~OptionDbl() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init(double defaultValue, double minValue, double maxValue);
 
-    virtual bool SetValueDbl(double value);
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValueDbl(double value) override;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
-    virtual void Reset();
+    void Reset() override;
 
     double GetValue() const { return m_value; }
     double GetDefault() const { return m_defaultValue; }
@@ -242,15 +242,15 @@ public:
         m_maxValue = 0;
     }
     virtual ~OptionInt() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init(int defaultValue, int minValue, int maxValue, bool definitionFactor = false);
 
-    virtual bool SetValueDbl(double value);
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValueDbl(double value) override;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
-    virtual void Reset();
+    void Reset() override;
 
     int GetValue() const;
     int GetUnfactoredValue() const;
@@ -283,17 +283,17 @@ public:
     // constructors and destructors
     OptionString() {}
     virtual ~OptionString() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init(const std::string &defaultValue);
 
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const { return m_value; }
-    virtual std::string GetDefaultStrValue() const { return m_defaultValue; }
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override { return m_value; }
+    std::string GetDefaultStrValue() const override { return m_defaultValue; }
 
     std::string GetValue() const { return m_value; }
     std::string GetDefault() const { return m_defaultValue; }
 
-    virtual void Reset();
+    void Reset() override;
 
 private:
     //
@@ -316,19 +316,19 @@ public:
     // constructors and destructors
     OptionArray() {}
     virtual ~OptionArray() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init();
 
-    virtual bool SetValueArray(const std::vector<std::string> &values);
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValueArray(const std::vector<std::string> &values) override;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
     std::vector<std::string> GetValue() const { return m_values; }
     std::vector<std::string> GetDefault() const { return m_defaultValues; }
     bool SetValue(std::vector<std::string> const &values);
 
-    virtual void Reset();
+    void Reset() override;
 
 private:
     //
@@ -351,12 +351,12 @@ public:
     // constructors and destructors
     OptionIntMap();
     virtual ~OptionIntMap() {}
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     void Init(int defaultValue, const std::map<int, std::string> *values);
 
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
     int GetValue() const { return m_value; }
     int GetDefault() const { return m_defaultValue; }
@@ -365,7 +365,7 @@ public:
     std::vector<std::string> GetStrValues(bool withoutDefault) const;
     std::string GetStrValuesAsStr(bool withoutDefault) const;
 
-    virtual void Reset();
+    void Reset() override;
 
 private:
     //
@@ -389,15 +389,15 @@ public:
     // constructors and destructors
     OptionStaffrel(){};
     virtual ~OptionStaffrel(){};
-    virtual void CopyTo(Option *option);
+    void CopyTo(Option *option) override;
     // Alternate type style cannot have a restricted list of possible values
     void Init(data_STAFFREL defaultValue);
 
-    virtual bool SetValue(const std::string &value);
-    virtual std::string GetStrValue() const;
-    virtual std::string GetDefaultStrValue() const;
+    bool SetValue(const std::string &value) override;
+    std::string GetStrValue() const override;
+    std::string GetDefaultStrValue() const override;
 
-    virtual void Reset();
+    void Reset() override;
 
     // For alternate types return a reference to the value
     // Alternatively we can have a values vector for each sub-type

--- a/include/vrv/orig.h
+++ b/include/vrv/orig.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Orig();
     virtual ~Orig();
-    virtual Object *Clone() const { return new Orig(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Orig"; }
+    Object *Clone() const override { return new Orig(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Orig"; }
     ///@}
 
 private:

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -173,6 +173,11 @@ public:
     int AlignSystemsEnd(FunctorParams *functorParams) override;
     ///@}
 
+    /**
+     * See Object::CastOffPages
+     */
+    int CastOffPagesEnd(FunctorParams *functorParams) override;
+
 private:
     /**
      * Adjust the horizontal postition of the syl processing verse by verse

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -141,42 +141,37 @@ public:
     /**
      * See Object::ScoreDefSetCurrentPage
      */
-    virtual int ScoreDefSetCurrentPageEnd(FunctorParams *functorParams);
+    int ScoreDefSetCurrentPageEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
     /**
      * Apply the Pixel Per Unit factor of the page to its elements.
      */
-    virtual int ApplyPPUFactor(FunctorParams *functorParams);
+    int ApplyPPUFactor(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignVertically
      */
     ///@{
-    virtual int AlignVerticallyEnd(FunctorParams *functorParams);
+    int AlignVerticallyEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AlignSystems
      */
     ///@{
-    virtual int AlignSystems(FunctorParams *functorParams);
-    virtual int AlignSystemsEnd(FunctorParams *functorParams);
+    int AlignSystems(FunctorParams *functorParams) override;
+    int AlignSystemsEnd(FunctorParams *functorParams) override;
     ///@}
-
-    /**
-     * See Object::CastOffPages
-     */
-    virtual int CastOffPagesEnd(FunctorParams *functorParams);
 
 private:
     /**

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -38,15 +38,15 @@ public:
     ///@{
     Page();
     virtual ~Page();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Page"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Page"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/pageboundary.h
+++ b/include/vrv/pageboundary.h
@@ -54,22 +54,22 @@ public:
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffPages
      */
-    virtual int CastOffPages(FunctorParams *functorParams);
+    int CastOffPages(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnCastOff
      */
-    virtual int UnCastOff(FunctorParams *functorParams);
+    int UnCastOff(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/pageboundary.h
+++ b/include/vrv/pageboundary.h
@@ -32,8 +32,8 @@ public:
     ///@{
     PageElementEnd(Object *start);
     virtual ~PageElementEnd();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PageElementEnd"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "PageElementEnd"; }
     ///@}
 
     // void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/pageelement.h
+++ b/include/vrv/pageelement.h
@@ -33,7 +33,7 @@ public:
     PageElement(ClassId classId);
     PageElement(ClassId classId, const std::string &classIdStr);
     virtual ~PageElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     //----------//

--- a/include/vrv/pageelement.h
+++ b/include/vrv/pageelement.h
@@ -43,22 +43,22 @@ public:
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffPages
      */
-    virtual int CastOffPages(FunctorParams *functorParams);
+    int CastOffPages(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnCastOff
      */
-    virtual int UnCastOff(FunctorParams *functorParams);
+    int UnCastOff(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/pages.h
+++ b/include/vrv/pages.h
@@ -32,15 +32,15 @@ public:
     ///@{
     Pages();
     virtual ~Pages();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Pages"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Pages"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/pb.h
+++ b/include/vrv/pb.h
@@ -42,7 +42,7 @@ public:
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/pb.h
+++ b/include/vrv/pb.h
@@ -30,9 +30,9 @@ public:
     ///@{
     Pb();
     virtual ~Pb();
-    virtual Object *Clone() const { return new Pb(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Pb"; }
+    Object *Clone() const override { return new Pb(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Pb"; }
     ///@}
 
     //----------//

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -78,12 +78,12 @@ public:
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
     /**
      * See Object::GenerateMIDI
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -40,17 +40,17 @@ public:
     ///@{
     Pedal();
     virtual ~Pedal();
-    virtual Object *Clone() const { return new Pedal(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Pedal"; }
+    Object *Clone() const override { return new Pedal(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Pedal"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ////@}
 
     /**

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -28,8 +28,8 @@ public:
     ///@{
     PgFoot();
     virtual ~PgFoot();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PgFoot"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "PgFoot"; }
     ///@}
 
     //----------//

--- a/include/vrv/pgfoot2.h
+++ b/include/vrv/pgfoot2.h
@@ -28,8 +28,8 @@ public:
     ///@{
     PgFoot2();
     virtual ~PgFoot2();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PgFoot2"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "PgFoot2"; }
     ///@}
 
     //----------//

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -28,8 +28,8 @@ public:
     ///@{
     PgHead();
     virtual ~PgHead();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PgHead"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "PgHead"; }
     ///@}
 
     bool GenerateFromMEIHeader(pugi::xml_document &header);

--- a/include/vrv/pghead2.h
+++ b/include/vrv/pghead2.h
@@ -28,8 +28,8 @@ public:
     ///@{
     PgHead2();
     virtual ~PgHead2();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PgHead2"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "PgHead2"; }
     ///@}
 
     //----------//

--- a/include/vrv/phrase.h
+++ b/include/vrv/phrase.h
@@ -25,9 +25,9 @@ public:
     ///@{
     Phrase();
     virtual ~Phrase();
-    virtual Object *Clone() const { return new Phrase(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Phrase"; }
+    Object *Clone() const override { return new Phrase(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Phrase"; }
     ///@}
 
     //----------//

--- a/include/vrv/pitchinflection.h
+++ b/include/vrv/pitchinflection.h
@@ -29,17 +29,17 @@ public:
     ///@{
     PitchInflection();
     virtual ~PitchInflection();
-    virtual Object *Clone() const { return new PitchInflection(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "PitchInflection"; }
+    Object *Clone() const override { return new PitchInflection(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "PitchInflection"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/pitchinterface.h
+++ b/include/vrv/pitchinterface.h
@@ -33,7 +33,7 @@ public:
     ///@{
     PitchInterface();
     virtual ~PitchInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_PITCH; }
     ///@}
 

--- a/include/vrv/pitchinterface.h
+++ b/include/vrv/pitchinterface.h
@@ -34,7 +34,7 @@ public:
     PitchInterface();
     virtual ~PitchInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_PITCH; }
+    InterfaceId IsInterface() const override { return INTERFACE_PITCH; }
     ///@}
 
     /**

--- a/include/vrv/plica.h
+++ b/include/vrv/plica.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Plica();
     virtual ~Plica();
-    virtual Object *Clone() const { return new Plica(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Plica"; }
+    Object *Clone() const override { return new Plica(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Plica"; }
 
     //----------//
     // Functors //

--- a/include/vrv/plistinterface.h
+++ b/include/vrv/plistinterface.h
@@ -33,7 +33,7 @@ public:
     ///@{
     PlistInterface();
     virtual ~PlistInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_PLIST; }
     ///@}
 

--- a/include/vrv/plistinterface.h
+++ b/include/vrv/plistinterface.h
@@ -34,7 +34,7 @@ public:
     PlistInterface();
     virtual ~PlistInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_PLIST; }
+    InterfaceId IsInterface() const override { return INTERFACE_PLIST; }
     ///@}
 
     /**
@@ -86,7 +86,7 @@ protected:
      * Method to be redefined in the child class if specific validation is required.
      * The method is called from PlistInterface::SetRef
      */
-    virtual bool IsValidRef(Object *ref) { return true; }
+    virtual bool IsValidRef(Object *ref) const { return true; }
 
 private:
     //

--- a/include/vrv/positioninterface.h
+++ b/include/vrv/positioninterface.h
@@ -34,7 +34,7 @@ public:
     ///@{
     PositionInterface();
     virtual ~PositionInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_POSITION; }
     ///@}
 

--- a/include/vrv/positioninterface.h
+++ b/include/vrv/positioninterface.h
@@ -35,7 +35,7 @@ public:
     PositionInterface();
     virtual ~PositionInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_POSITION; }
+    InterfaceId IsInterface() const override { return INTERFACE_POSITION; }
     ///@}
 
     /**

--- a/include/vrv/proport.h
+++ b/include/vrv/proport.h
@@ -35,7 +35,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
 private:
     //

--- a/include/vrv/proport.h
+++ b/include/vrv/proport.h
@@ -29,9 +29,9 @@ public:
     ///@{
     Proport();
     virtual ~Proport();
-    virtual Object *Clone() const { return new Proport(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Proport"; }
+    Object *Clone() const override { return new Proport(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Proport"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/rdg.h
+++ b/include/vrv/rdg.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Rdg();
     virtual ~Rdg();
-    virtual Object *Clone() const { return new Rdg(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Rdg"; }
+    Object *Clone() const override { return new Rdg(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Rdg"; }
     ///@}
 
 private:

--- a/include/vrv/ref.h
+++ b/include/vrv/ref.h
@@ -29,9 +29,9 @@ public:
     ///@{
     Ref();
     virtual ~Ref();
-    virtual Object *Clone() const { return new Ref(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Ref"; }
+    Object *Clone() const override { return new Ref(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Ref"; }
     ///@}
 
     //----------//

--- a/include/vrv/reg.h
+++ b/include/vrv/reg.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Reg();
     virtual ~Reg();
-    virtual Object *Clone() const { return new Reg(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Reg"; }
+    Object *Clone() const override { return new Reg(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Reg"; }
     ///@}
 
 private:

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -37,24 +37,24 @@ public:
     ///@{
     Reh();
     virtual ~Reh();
-    virtual Object *Clone() const { return new Reh(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Reh"; }
+    Object *Clone() const override { return new Reh(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Reh"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a reh.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -63,7 +63,7 @@ public:
     /**
      * See Object::ResolveRehPosition
      */
-    virtual int ResolveRehPosition(FunctorParams *params);
+    int ResolveRehPosition(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -36,9 +36,9 @@ public:
     ///@{
     Rend();
     virtual ~Rend();
-    virtual Object *Clone() const { return new Rend(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Rend"; }
+    Object *Clone() const override { return new Rend(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Rend"; }
     ///@}
 
     /**
@@ -52,7 +52,7 @@ public:
      * Add an element (text, rend. etc.) to a rend.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -62,7 +62,7 @@ public:
      * See Object::AlignVertically
      */
     ///@{
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -73,7 +73,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Get the SMuFL glyph or a rest considering its actual duration.

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -48,28 +48,28 @@ public:
     ///@{
     Rest();
     virtual ~Rest();
-    virtual Object *Clone() const { return new Rest(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Rest"; }
+    Object *Clone() const override { return new Rest(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Rest"; }
     ///@}
 
     /**
      * Add an element to a rest.
      * Only Dots elements will be actually added to the rest.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Overwritten method for rest
      */
-    virtual void AddChild(Object *object);
+    void AddChild(Object *object) override;
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual PositionInterface *GetPositionInterface() { return dynamic_cast<PositionInterface *>(this); }
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -88,37 +88,37 @@ public:
     /**
      * See Object::AdjustBeams
      */
-    virtual int AdjustBeams(FunctorParams *functorParams);
+    int AdjustBeams(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertMarkupAnalytical
      */
-    virtual int ConvertMarkupAnalytical(FunctorParams *functorParams);
+    int ConvertMarkupAnalytical(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcDots
      */
-    virtual int CalcDots(FunctorParams *functorParams);
+    int CalcDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareLayerElementParts
      */
-    virtual int PrepareLayerElementParts(FunctorParams *functorParams);
+    int PrepareLayerElementParts(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::Transpose
      */
-    virtual int Transpose(FunctorParams *);
+    int Transpose(FunctorParams *functorParams) override;
 
     /**
      * Get the vertical location for the rests that are located on other layers

--- a/include/vrv/restore.h
+++ b/include/vrv/restore.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Restore();
     virtual ~Restore();
-    virtual Object *Clone() const { return new Restore(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Restore"; }
+    Object *Clone() const override { return new Restore(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Restore"; }
     ///@}
 
 private:

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -150,7 +150,7 @@ protected:
      * Filter the list for a specific class.
      * Keep only the top <rend> and <fig>
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     /**

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -36,20 +36,20 @@ public:
     RunningElement(ClassId classId);
     RunningElement(ClassId classId, const std::string &classIdStr);
     virtual ~RunningElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * Disable cloning of the running elements (for now?).
      * It does not make sense you carry copying the running element across the systems.
      */
-    virtual Object *Clone() const { return NULL; }
+    Object *Clone() const override { return NULL; }
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**
@@ -64,8 +64,8 @@ public:
      * @name Get and set the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     int GetWidth() const;

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -134,15 +134,15 @@ public:
      * See Object::Save
      */
     ///@{
-    virtual int Save(FunctorParams *functorParams);
-    virtual int SaveEnd(FunctorParams *functorParams);
+    int Save(FunctorParams *functorParams) override;
+    int SaveEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AlignVertically
      */
     ///@{
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
     ///@}
 
 protected:

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -30,9 +30,9 @@ public:
     ///@{
     Sb();
     virtual ~Sb();
-    virtual Object *Clone() const { return new Sb(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Sb"; }
+    Object *Clone() const override { return new Sb(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Sb"; }
     ///@}
 
     //----------//

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -42,12 +42,12 @@ public:
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -35,15 +35,15 @@ public:
     ///@{
     Score();
     virtual ~Score();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Score"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Score"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -76,45 +76,45 @@ public:
     /**
      * See Object::AdjustDots
      */
-    virtual int AdjustDots(FunctorParams *);
+    int AdjustDots(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustLayers
      */
-    virtual int AdjustLayers(FunctorParams *functorParams);
+    int AdjustLayers(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustXPos
      */
-    virtual int AdjustXPos(FunctorParams *functorParams);
+    int AdjustXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustGraceXPos
      */
-    virtual int AdjustGraceXPos(FunctorParams *functorParams);
+    int AdjustGraceXPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToPageBased
      */
     ///@{
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
+    int ConvertToPageBasedEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::CastOffPages
      */
-    virtual int CastOffPages(FunctorParams *functorParams);
+    int CastOffPages(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnCastOff
      */
-    virtual int UnCastOff(FunctorParams *functorParams);
+    int UnCastOff(FunctorParams *functorParams) override;
 
     /**
      * See Object::ScoreDefOptimize
      */
-    virtual int ScoreDefOptimize(FunctorParams *functorParams);
+    int ScoreDefOptimize(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -216,38 +216,38 @@ public:
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToPageBased
      */
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
 
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignMeasures
      */
-    virtual int AlignMeasures(FunctorParams *functorParams);
+    int AlignMeasures(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyX
      */
-    virtual int JustifyX(FunctorParams *functorParams);
+    int JustifyX(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -50,14 +50,14 @@ public:
     ScoreDefElement(ClassId classId);
     ScoreDefElement(ClassId classId, const std::string &classIdStr);
     virtual ~ScoreDefElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual ScoreDefInterface *GetScoreDefInterface() { return dynamic_cast<ScoreDefInterface *>(this); }
+    ScoreDefInterface *GetScoreDefInterface() override { return dynamic_cast<ScoreDefInterface *>(this); }
     ///@}
 
     /**
@@ -126,12 +126,12 @@ public:
     ///@{
     ScoreDef();
     virtual ~ScoreDef();
-    virtual Object *Clone() const { return new ScoreDef(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "ScoreDef"; }
+    Object *Clone() const override { return new ScoreDef(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "ScoreDef"; }
     ///@}
 
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Replace the scoreDef with the content of the newScoreDef.

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -253,7 +253,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     //

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -43,7 +43,7 @@ public:
     ///@{
     ScoreDefInterface();
     virtual ~ScoreDefInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_SCOREDEF; }
     ///@}
 

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -44,7 +44,7 @@ public:
     ScoreDefInterface();
     virtual ~ScoreDefInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_SCOREDEF; }
+    InterfaceId IsInterface() const override { return INTERFACE_SCOREDEF; }
     ///@}
 
 private:

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -52,24 +52,24 @@ public:
      * See Object::ConvertToPageBased
      */
     ///@{
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
-    virtual int ConvertToPageBasedEnd(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
+    int ConvertToPageBasedEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::ConvertToUnCastOffMensural
      */
-    virtual int ConvertToUnCastOffMensural(FunctorParams *params);
+    int ConvertToUnCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareBoundaries
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams);
+    int PrepareBoundaries(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -34,15 +34,15 @@ public:
     ///@{
     Section();
     virtual ~Section();
-    virtual Object *Clone() const { return new Section(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Section"; }
+    Object *Clone() const override { return new Section(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Section"; }
     ///@}
 
     /**
      * Method for adding allowed content
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/sic.h
+++ b/include/vrv/sic.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Sic();
     virtual ~Sic();
-    virtual Object *Clone() const { return new Sic(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Sic"; }
+    Object *Clone() const override { return new Sic(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Sic"; }
     ///@}
 
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -49,17 +49,17 @@ public:
     Slur(ClassId classId);
     Slur(ClassId classId, const std::string &classIdStr);
     virtual ~Slur();
-    virtual Object *Clone() const { return new Slur(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Slur"; }
+    Object *Clone() const override { return new Slur(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Slur"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -99,7 +99,7 @@ public:
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/space.h
+++ b/include/vrv/space.h
@@ -29,16 +29,16 @@ public:
     ///@{
     Space();
     virtual ~Space();
-    virtual Object *Clone() const { return new Space(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Space"; }
+    Object *Clone() const override { return new Space(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Space"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
     ///@}
 
     //----------//

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -58,7 +58,7 @@ public:
     /**
      * Return a const pointer to the children
      */
-    virtual const ArrayOfObjects *GetChildren(bool docChildren = true) const;
+    const ArrayOfObjects *GetChildren(bool docChildren = true) const override;
 
     /**
      * Delete all the legder line arrays.

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -206,7 +206,7 @@ public:
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -161,47 +161,47 @@ public:
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
     /**
      * See Object::ScoreDefOptimize
      */
-    virtual int ScoreDefOptimize(FunctorParams *functorParams);
+    int ScoreDefOptimize(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ApplyPPUFactor
      */
-    virtual int ApplyPPUFactor(FunctorParams *functorParams);
+    int ApplyPPUFactor(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontally
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignVertically
      */
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcLedgerLinesEnd
      */
-    virtual int CalcLedgerLinesEnd(FunctorParams *functorParams);
+    int CalcLedgerLinesEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::FillStaffCurrentTimeSpanning
      */
-    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams);
+    int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
@@ -211,34 +211,34 @@ public:
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareRpt
      */
-    virtual int PrepareRpt(FunctorParams *functorParams);
+    int PrepareRpt(FunctorParams *functorParams) override;
 
     /**
      * See Object::CalcOnsetOffset
      */
     ///@{
-    virtual int CalcOnsetOffset(FunctorParams *functorParams);
+    int CalcOnsetOffset(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::CalcStem
      */
-    virtual int CalcStem(FunctorParams *);
+    int CalcStem(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustSylSpacing
      */
-    virtual int AdjustSylSpacing(FunctorParams *functorParams);
+    int AdjustSylSpacing(FunctorParams *functorParams) override;
 
     /**
      * See Object::GenerateMIDI
      */
-    virtual int GenerateMIDI(FunctorParams *functorParams);
+    int GenerateMIDI(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -43,17 +43,17 @@ public:
     ///@{
     Staff(int n = 1);
     virtual ~Staff();
-    virtual Object *Clone() const { return new Staff(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Staff"; }
+    Object *Clone() const override { return new Staff(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Staff"; }
     ///@}
 
     /**
      * Overriding CloneReset() method to be called after copy / assignment calls.
      */
-    virtual void CloneReset();
+    void CloneReset() override;
 
-    virtual FacsimileInterface *GetFacsimileInterface() { return dynamic_cast<FacsimileInterface *>(this); }
+    FacsimileInterface *GetFacsimileInterface() override { return dynamic_cast<FacsimileInterface *>(this); }
 
     /**
      * Return a const pointer to the children
@@ -69,15 +69,15 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**
      * @name Get the X, Y, and angle of drawing position
      */
     ///@{
-    virtual int GetDrawingY() const;
-    virtual int GetDrawingX() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     virtual double GetDrawingRotate() const;
     ///@}
 

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -41,16 +41,16 @@ public:
     ///@{
     StaffDef();
     virtual ~StaffDef();
-    virtual Object *Clone() const { return new StaffDef(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "StaffDef"; }
+    Object *Clone() const override { return new StaffDef(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "StaffDef"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * @name Setter and getter of the drawing visible flag

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -67,12 +67,12 @@ public:
     /**
      * See Object::ReplaceDrawingValuesInStaffDef
      */
-    virtual int ReplaceDrawingValuesInStaffDef(FunctorParams *functorParams);
+    int ReplaceDrawingValuesInStaffDef(FunctorParams *functorParams) override;
 
     /**
      * See Object::SetStaffDefRedrawFlags
      */
-    virtual int SetStaffDefRedrawFlags(FunctorParams *functorParams);
+    int SetStaffDefRedrawFlags(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -44,16 +44,16 @@ public:
     ///@{
     StaffGrp();
     virtual ~StaffGrp();
-    virtual Object *Clone() const { return new StaffGrp(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "StaffGrp"; }
+    Object *Clone() const override { return new StaffGrp(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "StaffGrp"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -109,7 +109,7 @@ public:
     /**
      * See Object::ScoreDefOptimize
      */
-    virtual int ScoreDefOptimizeEnd(FunctorParams *functorParams);
+    int ScoreDefOptimizeEnd(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -115,7 +115,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     //

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -29,9 +29,9 @@ public:
     Subst();
     Subst(EditorialLevel level);
     virtual ~Subst();
-    virtual Object *Clone() const { return new Subst(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Subst"; }
+    Object *Clone() const override { return new Subst(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Subst"; }
     ///@}
 
     /** Getter for level **/
@@ -40,7 +40,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     /** We store the level of the <subst> for integrity check */

--- a/include/vrv/supplied.h
+++ b/include/vrv/supplied.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Supplied();
     virtual ~Supplied();
-    virtual Object *Clone() const { return new Supplied(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Supplied"; }
+    Object *Clone() const override { return new Supplied(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Supplied"; }
     ///@}
 
 private:

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -35,10 +35,10 @@ public:
     ///@{
     Surface();
     virtual ~Surface();
-    virtual Object *Clone() const { return new Surface(*this); }
-    virtual void Reset();
+    Object *Clone() const override { return new Surface(*this); }
+    void Reset() override;
     ///@}
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     int GetMaxX();
     int GetMaxY();

--- a/include/vrv/svg.h
+++ b/include/vrv/svg.h
@@ -26,8 +26,8 @@ public:
     ///@{
     Svg();
     virtual ~Svg();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Svg"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "Svg"; }
     ///@}
 
     /**

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -48,19 +48,19 @@ public:
      * @name Setters
      */
     ///@{
-    virtual void SetBackground(int colour, int style = AxSOLID);
-    virtual void SetBackgroundImage(void *image, double opacity = 1.0);
-    virtual void SetBackgroundMode(int mode);
-    virtual void SetTextForeground(int colour);
-    virtual void SetTextBackground(int colour);
-    virtual void SetLogicalOrigin(int x, int y);
+    void SetBackground(int colour, int style = AxSOLID) override;
+    void SetBackgroundImage(void *image, double opacity = 1.0) override;
+    void SetBackgroundMode(int mode) override;
+    void SetTextForeground(int colour) override;
+    void SetTextBackground(int colour) override;
+    void SetLogicalOrigin(int x, int y) override;
     ///@}
 
     /**
      * @name Getters
      */
     ///@{
-    virtual Point GetLogicalOrigin();
+    Point GetLogicalOrigin() override;
     ///}
 
     /**
@@ -73,93 +73,93 @@ public:
      * @name Drawing methods
      */
     ///@{
-    virtual void DrawQuadBezierPath(Point bezier[3]);
-    virtual void DrawCubicBezierPath(Point bezier[4]);
-    virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]);
-    virtual void DrawCircle(int x, int y, int radius);
-    virtual void DrawEllipse(int x, int y, int width, int height);
-    virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end);
-    virtual void DrawLine(int x1, int y1, int x2, int y2);
-    virtual void DrawPolygon(int n, Point points[], int xoffset, int yoffset, int fill_style = AxODDEVEN_RULE);
-    virtual void DrawRectangle(int x, int y, int width, int height);
-    virtual void DrawRotatedText(const std::string &text, int x, int y, double angle);
-    virtual void DrawRoundedRectangle(int x, int y, int width, int height, int radius);
-    virtual void DrawText(const std::string &text, const std::wstring wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET,
-        int width = VRV_UNSET, int height = VRV_UNSET);
-    virtual void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false);
-    virtual void DrawSpline(int n, Point points[]);
-    virtual void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg);
-    virtual void DrawBackgroundImage(int x = 0, int y = 0);
+    void DrawQuadBezierPath(Point bezier[3]) override;
+    void DrawCubicBezierPath(Point bezier[4]) override;
+    void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
+    void DrawCircle(int x, int y, int radius) override;
+    void DrawEllipse(int x, int y, int width, int height) override;
+    void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
+    void DrawLine(int x1, int y1, int x2, int y2) override;
+    void DrawPolygon(int n, Point points[], int xoffset, int yoffset, int fill_style = AxODDEVEN_RULE) override;
+    void DrawRectangle(int x, int y, int width, int height) override;
+    void DrawRotatedText(const std::string &text, int x, int y, double angle) override;
+    void DrawRoundedRectangle(int x, int y, int width, int height, int radius) override;
+    void DrawText(const std::string &text, const std::wstring &wtext = L"", int x = VRV_UNSET, int y = VRV_UNSET,
+        int width = VRV_UNSET, int height = VRV_UNSET) override;
+    void DrawMusicText(const std::wstring &text, int x, int y, bool setSmuflGlyph = false) override;
+    void DrawSpline(int n, Point points[]) override;
+    void DrawSvgShape(int x, int y, int width, int height, pugi::xml_node svg) override;
+    void DrawBackgroundImage(int x = 0, int y = 0) override;
     ///@}
 
     /**
      * @name Method for starting and ending a text
      */
     ///@{
-    virtual void StartText(int x, int y, data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_left);
-    virtual void EndText();
+    void StartText(int x, int y, data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_left) override;
+    void EndText() override;
 
     /**
      * @name Move a text to the specified position, for example when starting a new line.
      */
     ///@{
-    virtual void MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignment);
-    virtual void MoveTextVerticallyTo(int y);
+    void MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignment) override;
+    void MoveTextVerticallyTo(int y) override;
     ///@}
 
     /**
      * @name Method for starting and ending a graphic
      */
     ///@{
-    virtual void StartGraphic(
-        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false);
-    virtual void EndGraphic(Object *object, View *view);
+    void StartGraphic(
+        Object *object, std::string gClass, std::string gId, bool primary = true, bool prepend = false) override;
+    void EndGraphic(Object *object, View *view) override;
     ///@}
 
     /**
      * @name Method for starting and ending a graphic custom graphic that do not correspond to an Object
      */
     ///@{
-    virtual void StartCustomGraphic(std::string name, std::string gClass = "", std::string gId = "");
-    virtual void EndCustomGraphic();
+    void StartCustomGraphic(std::string name, std::string gClass = "", std::string gId = "") override;
+    void EndCustomGraphic() override;
     ///@}
 
     /**
      * @name Methods for re-starting and ending a graphic for objects drawn in separate steps
      */
     ///@{
-    virtual void ResumeGraphic(Object *object, std::string gId);
-    virtual void EndResumedGraphic(Object *object, View *view);
+    void ResumeGraphic(Object *object, std::string gId) override;
+    void EndResumedGraphic(Object *object, View *view) override;
     ///@}
 
     /**
      * @name Method for starting and ending a text (<tspan>) text graphic
      */
     ///@{
-    virtual void StartTextGraphic(Object *object, std::string gClass, std::string gId);
-    virtual void EndTextGraphic(Object *object, View *view);
+    void StartTextGraphic(Object *object, std::string gClass, std::string gId) override;
+    void EndTextGraphic(Object *object, View *view) override;
     ///@}
 
     /**
      * @name Method for rotating a graphic (clockwise).
      */
     ///@{
-    virtual void RotateGraphic(Point const &orig, double angle);
+    void RotateGraphic(Point const &orig, double angle) override;
     ///@}
 
     /**
      * @name Method for starting and ending page
      */
     ///@{
-    virtual void StartPage();
-    virtual void EndPage();
+    void StartPage() override;
+    void EndPage() override;
     ///@}
 
     /**
      * @name Method for adding description element
      */
     ///@{
-    virtual void AddDescription(const std::string &text);
+    void AddDescription(const std::string &text) override;
     ///@}
 
     /**
@@ -175,7 +175,7 @@ public:
     /**
      * In SVG use global styling but not with mm output (for pdf generation)
      */
-    virtual bool UseGlobalStyling() { return !m_mmOutput; }
+    bool UseGlobalStyling() override { return !m_mmOutput; }
 
     /**
      * Setting mm output flag (false by default)

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -43,9 +43,9 @@ public:
     ///@{
     Syl();
     virtual ~Syl();
-    virtual Object *Clone() const { return new Syl(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Syl"; }
+    Object *Clone() const override { return new Syl(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Syl"; }
     ///@}
 
     /** Override the method since it is align to the staff */
@@ -55,15 +55,15 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a syl.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Calculate the spacing needed depending on the @worpos and @con

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -80,17 +80,17 @@ public:
     /**
      * See Object::PrepareLyrics
      */
-    virtual int PrepareLyrics(FunctorParams *functorParams);
+    int PrepareLyrics(FunctorParams *functorParams) override;
 
     /**
      * See Object::FillStaffCurrentTimeSpanning
      */
-    virtual int FillStaffCurrentTimeSpanning(FunctorParams *functorParams);
+    int FillStaffCurrentTimeSpanning(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /** Create a default zone for a syl based on syllable. */
     bool CreateDefaultZone(Doc *doc);

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -49,7 +49,7 @@ public:
     ///@}
 
     /** Override the method since it is align to the staff */
-    virtual bool IsRelativeToStaff() const { return true; }
+    bool IsRelativeToStaff() const override { return true; }
 
     /**
      * @name Getter to interfaces

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -44,7 +44,7 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add a default syl to this syllable if one does not exist.

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -32,16 +32,16 @@ public:
     Syllable();
     void Init();
     virtual ~Syllable();
-    virtual Object *Clone() const { return new Syllable(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Syllable"; }
+    Object *Clone() const override { return new Syllable(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Syllable"; }
     ///@}
 
     /**
      * Add an element (a note or a rest) to a syllable.
      * Only syl or neume will be added.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /** Override the method since alignment is required */
     virtual bool HasToBeAligned() const { return true; }

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -160,148 +160,148 @@ public:
     /**
      * See Object::UnscoreDefSetCurrent
      */
-    virtual int ScoreDefUnsetCurrent(FunctorParams *functorParams);
+    int ScoreDefUnsetCurrent(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::ScoreDefOptimize
      */
     ///@{
-    virtual int ScoreDefOptimize(FunctorParams *functorParams);
-    virtual int ScoreDefOptimizeEnd(FunctorParams *functorParams);
+    int ScoreDefOptimize(FunctorParams *functorParams) override;
+    int ScoreDefOptimizeEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::ScoreDefSetGrpSym
      */
-    virtual int ScoreDefSetGrpSym(FunctorParams *functorParams);
+    int ScoreDefSetGrpSym(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ApplyPPUFactor
      */
-    virtual int ApplyPPUFactor(FunctorParams *functorParams);
+    int ApplyPPUFactor(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignHorizontally
      */
-    virtual int AlignHorizontally(FunctorParams *functorParams);
+    int AlignHorizontally(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::AdjustXOverflow
      */
     ///@{
-    virtual int AdjustXOverflow(FunctorParams *functorParams);
-    virtual int AdjustXOverflowEnd(FunctorParams *functorParams);
+    int AdjustXOverflow(FunctorParams *functorParams) override;
+    int AdjustXOverflowEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * @name See Object::AdjustHarmGrpsSpacing
      */
     ///@{
-    virtual int AdjustHarmGrpsSpacing(FunctorParams *functorParams);
-    virtual int AdjustHarmGrpsSpacingEnd(FunctorParams *functorParams);
+    int AdjustHarmGrpsSpacing(FunctorParams *functorParams) override;
+    int AdjustHarmGrpsSpacingEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * @name See Object::AdjustSylSpacing
      */
     ///@{
-    virtual int AdjustSylSpacing(FunctorParams *functorParams);
-    virtual int AdjustSylSpacingEnd(FunctorParams *functorParams);
+    int AdjustSylSpacing(FunctorParams *functorParams) override;
+    int AdjustSylSpacingEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AdjustTempo
      */
-    virtual int AdjustTempo(FunctorParams *functorParams);
+    int AdjustTempo(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::AlignVertically
      */
     ///@{
-    virtual int AlignVertically(FunctorParams *functorParams);
-    virtual int AlignVerticallyEnd(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
+    int AlignVerticallyEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::AdjustYPos
      */
-    virtual int AdjustYPos(FunctorParams *functorParams);
+    int AdjustYPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AlignSystems
      */
-    virtual int AlignSystems(FunctorParams *functorParams);
+    int AlignSystems(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::AlignMeasures
      */
     ///@{
-    virtual int AlignMeasures(FunctorParams *functorParams);
-    virtual int AlignMeasuresEnd(FunctorParams *functorParams);
+    int AlignMeasures(FunctorParams *functorParams) override;
+    int AlignMeasuresEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::JustifyX
      */
-    virtual int JustifyX(FunctorParams *functorParams);
+    int JustifyX(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyY
      */
-    virtual int JustifyY(FunctorParams *functorParams);
+    int JustifyY(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustStaffOverlap
      */
-    virtual int AdjustStaffOverlap(FunctorParams *functorParams);
+    int AdjustStaffOverlap(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustFloatingPositioners
      */
-    virtual int AdjustFloatingPositioners(FunctorParams *functorParams);
+    int AdjustFloatingPositioners(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustFloatingPositionersBetween
      */
-    virtual int AdjustFloatingPositionersBetween(FunctorParams *functorParams);
+    int AdjustFloatingPositionersBetween(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustSlurs
      */
-    virtual int AdjustSlurs(FunctorParams *functorParams);
+    int AdjustSlurs(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffPages
      */
-    virtual int CastOffPages(FunctorParams *functorParams);
+    int CastOffPages(FunctorParams *functorParams) override;
 
     /**
      * @name See Object::CastOffSystems
      */
     ///@{
-    virtual int CastOffSystems(FunctorParams *functorParams);
-    virtual int CastOffSystemsEnd(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
+    int CastOffSystemsEnd(FunctorParams *functorParams) override;
     ///@}
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
     /**
      * See Object::UnCastOff
      */
-    virtual int UnCastOff(FunctorParams *functorParams);
+    int UnCastOff(FunctorParams *functorParams) override;
 
 public:
     SystemAligner m_systemAligner;

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -42,23 +42,23 @@ public:
     ///@{
     System();
     virtual ~System();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "System"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "System"; }
     ///@}
 
     /**
      * @name Methods for adding allowed content
      */
     ///@{
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
     ///@}
 
     /**
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     /**

--- a/include/vrv/systemboundary.h
+++ b/include/vrv/systemboundary.h
@@ -32,8 +32,8 @@ public:
     ///@{
     SystemElementEnd(Object *start);
     virtual ~SystemElementEnd();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "systemElementEnd"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "SystemElementEnd"; }
     ///@}
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/systemboundary.h
+++ b/include/vrv/systemboundary.h
@@ -54,22 +54,22 @@ public:
     /**
      * See Object::PrepareBoundaries
      */
-    virtual int PrepareBoundaries(FunctorParams *functorParams);
+    int PrepareBoundaries(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareFloatingGrps
      */
-    virtual int PrepareFloatingGrps(FunctorParams *functoParams);
+    int PrepareFloatingGrps(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -43,22 +43,22 @@ public:
     /**
      * See Object::ConvertToPageBased
      */
-    virtual int ConvertToPageBased(FunctorParams *functorParams);
+    int ConvertToPageBased(FunctorParams *functorParams) override;
 
     /**
      * See Object::ConvertToCastOffMensural
      */
-    virtual int ConvertToCastOffMensural(FunctorParams *params);
+    int ConvertToCastOffMensural(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffSystems
      */
-    virtual int CastOffSystems(FunctorParams *functorParams);
+    int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
      * See Object::CastOffEncoding
      */
-    virtual int CastOffEncoding(FunctorParams *functorParams);
+    int CastOffEncoding(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -33,7 +33,7 @@ public:
     SystemElement(ClassId classId);
     SystemElement(ClassId classId, const std::string &classIdStr);
     virtual ~SystemElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     //----------//

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -34,7 +34,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Add an element to a element.

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -29,8 +29,8 @@ public:
     ///@{
     TabDurSym();
     virtual ~TabDurSym();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "TabDurSym"; };
+    void Reset() override;
+    std::string GetClassName() const override { return "TabDurSym"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -39,7 +39,7 @@ public:
     /**
      * Add an element to a element.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     //----------//
     // Functors //

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -29,21 +29,21 @@ public:
     ///@{
     TabGrp();
     virtual ~TabGrp();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "TabGrp"; };
+    void Reset() override;
+    std::string GetClassName() const override { return "TabGrp"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual DurationInterface *GetDurationInterface() { return dynamic_cast<DurationInterface *>(this); }
+    DurationInterface *GetDurationInterface() override { return dynamic_cast<DurationInterface *>(this); }
     ///@}
 
     /**
      * Add an element to a element.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
 protected:
     //

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -38,24 +38,24 @@ public:
     ///@{
     Tempo();
     virtual ~Tempo();
-    virtual Object *Clone() const { return new Tempo(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Tempo"; }
+    Object *Clone() const override { return new Tempo(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Tempo"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TextDirInterface *GetTextDirInterface() { return dynamic_cast<TextDirInterface *>(this); }
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TextDirInterface *GetTextDirInterface() override { return dynamic_cast<TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**
      * Add an element (text, rend. etc.) to a tempo.
      * Only supported elements will be actually added to the child list.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * @name Get the X drawing position

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -70,12 +70,12 @@ public:
     /**
      * See Object::AdjustTempoX
      */
-    virtual int AdjustTempo(FunctorParams *functorParams);
+    int AdjustTempo(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -29,9 +29,9 @@ public:
     ///@{
     Text();
     virtual ~Text();
-    virtual Object *Clone() const { return new Text(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Text"; }
+    Object *Clone() const override { return new Text(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Text"; }
     ///@}
 
     /**

--- a/include/vrv/textdirinterface.h
+++ b/include/vrv/textdirinterface.h
@@ -31,7 +31,7 @@ public:
     ///@{
     TextDirInterface();
     virtual ~TextDirInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_TEXT_DIR; }
     ///@}
 

--- a/include/vrv/textdirinterface.h
+++ b/include/vrv/textdirinterface.h
@@ -32,7 +32,7 @@ public:
     TextDirInterface();
     virtual ~TextDirInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_TEXT_DIR; }
+    InterfaceId IsInterface() const override { return INTERFACE_TEXT_DIR; }
     ///@}
 
     /**

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -58,7 +58,7 @@ public:
     /**
      * See Object::ResetVerticalAlignment
      */
-    virtual int ResetVerticalAlignment(FunctorParams *functorParams);
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -30,15 +30,15 @@ public:
     TextElement(ClassId classId);
     TextElement(ClassId classId, const std::string &classIdStr);
     virtual ~TextElement();
-    virtual void Reset();
+    void Reset() override;
     ///@}
 
     /**
      * @name Get the X and Y drawing position
      */
     ///@{
-    virtual int GetDrawingX() const;
-    virtual int GetDrawingY() const;
+    int GetDrawingX() const override;
+    int GetDrawingY() const override;
     ///@}
 
     /**

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -62,7 +62,7 @@ public:
      * see Object::ResolveMIDITies
      */
     ///@{
-    virtual int ResolveMIDITies(FunctorParams *functorParams);
+    int ResolveMIDITies(FunctorParams *functorParams) override;
     ///@}
 
 private:

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -39,17 +39,17 @@ public:
     Tie(ClassId classId);
     Tie(ClassId classId, const std::string &classIdStr);
     virtual ~Tie();
-    virtual Object *Clone() const { return new Tie(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Tie"; }
+    Object *Clone() const override { return new Tie(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Tie"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -37,7 +37,7 @@ public:
     TimePointInterface();
     virtual ~TimePointInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_TIME_POINT; }
+    InterfaceId IsInterface() const override { return INTERFACE_TIME_POINT; }
     ///@}
 
     /**
@@ -141,7 +141,7 @@ public:
     TimeSpanningInterface();
     virtual ~TimeSpanningInterface();
     void Reset() override;
-    virtual InterfaceId IsInterface() { return INTERFACE_TIME_SPANNING; }
+    InterfaceId IsInterface() const override { return INTERFACE_TIME_SPANNING; }
     ///@}
 
     /**
@@ -210,12 +210,12 @@ public:
     /**
      * See Object::PrepareTimestamps
      */
-    virtual int InterfacePrepareTimestamps(FunctorParams *functorParams, Object *object);
+    int InterfacePrepareTimestamps(FunctorParams *functorParams, Object *object) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int InterfaceResetDrawing(FunctorParams *functorParams, Object *object);
+    int InterfaceResetDrawing(FunctorParams *functorParams, Object *object) override;
 
 private:
     //

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -36,7 +36,7 @@ public:
     ///@{
     TimePointInterface();
     virtual ~TimePointInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_TIME_POINT; }
     ///@}
 
@@ -140,11 +140,9 @@ public:
     ///@{
     TimeSpanningInterface();
     virtual ~TimeSpanningInterface();
-    virtual void Reset();
+    void Reset() override;
     virtual InterfaceId IsInterface() { return INTERFACE_TIME_SPANNING; }
     ///@}
-
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
 
     /**
      * @name Set and get the first and second LayerElement

--- a/include/vrv/timestamp.h
+++ b/include/vrv/timestamp.h
@@ -25,8 +25,8 @@ public:
     ///@{
     TimestampAttr();
     virtual ~TimestampAttr();
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "TimestampAttr"; }
+    void Reset() override;
+    std::string GetClassName() const override { return "TimestampAttr"; }
     ///@}
 
     /**

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -40,17 +40,17 @@ public:
     ///@{
     Trill();
     virtual ~Trill();
-    virtual Object *Clone() const { return new Trill(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Trill"; }
+    Object *Clone() const override { return new Trill(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Trill"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
-    virtual TimeSpanningInterface *GetTimeSpanningInterface() { return dynamic_cast<TimeSpanningInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return dynamic_cast<TimeSpanningInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -29,15 +29,15 @@ public:
     ///@{
     Tuning();
     virtual ~Tuning();
-    virtual Object *Clone() const { return new Tuning(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Tuning"; };
+    Object *Clone() const override { return new Tuning(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Tuning"; }
     ///@}
 
     /**
      * Add an element to a element.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Return the line for a the tuning and a given course and a notation type

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -90,27 +90,27 @@ public:
     /**
      * See Object::PrepareLayerElementParts
      */
-    virtual int PrepareLayerElementParts(FunctorParams *functorParams);
+    int PrepareLayerElementParts(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustTupletsX
      */
-    virtual int AdjustTupletsX(FunctorParams *);
+    int AdjustTupletsX(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustTupletsY
      */
-    virtual int AdjustTupletsY(FunctorParams *);
+    int AdjustTupletsY(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetHorizontalAlignment
      */
-    virtual int ResetHorizontalAlignment(FunctorParams *functorParams);
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -116,7 +116,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfObjects *childList) override;
 
 private:
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -35,21 +35,21 @@ public:
     ///@{
     Tuplet();
     virtual ~Tuplet();
-    virtual Object *Clone() const { return new Tuplet(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Tuplet"; }
+    Object *Clone() const override { return new Tuplet(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Tuplet"; }
     ///@}
 
     /**
      * Add an element (a note or a rest) to a tuplet.
      * Only Note or Rest elements will be actually added to the beam.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Overwritten method for tuplet
      */
-    virtual void AddChild(Object *object);
+    void AddChild(Object *object) override;
 
     /**
      * @name Setter and getter for darwing elements and position

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -62,12 +62,12 @@ public:
     /**
      * See Object::PrepareDelayedTurns
      */
-    virtual int PrepareDelayedTurns(FunctorParams *functorParams);
+    int PrepareDelayedTurns(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 protected:
     //

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -38,16 +38,16 @@ public:
     ///@{
     Turn();
     virtual ~Turn();
-    virtual Object *Clone() const { return new Turn(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Turn"; }
+    Object *Clone() const override { return new Turn(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Turn"; }
     ///@}
 
     /**
      * @name Getter to interfaces
      */
     ///@{
-    virtual TimePointInterface *GetTimePointInterface() { return dynamic_cast<TimePointInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return dynamic_cast<TimePointInterface *>(this); }
     ///@}
 
     /**

--- a/include/vrv/unclear.h
+++ b/include/vrv/unclear.h
@@ -26,9 +26,9 @@ public:
     ///@{
     Unclear();
     virtual ~Unclear();
-    virtual Object *Clone() const { return new Unclear(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Unclear"; }
+    Object *Clone() const override { return new Unclear(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Unclear"; }
     ///@}
 
 private:

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -54,22 +54,22 @@ public:
     /**
      * See Object::AlignVertically
      */
-    virtual int AlignVertically(FunctorParams *functorParams);
+    int AlignVertically(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustSylSpacing
      */
-    virtual int AdjustSylSpacing(FunctorParams *functorParams);
+    int AdjustSylSpacing(FunctorParams *functorParams) override;
 
     /**
      * See Object::PrepareProcessingLists
      */
-    virtual int PrepareProcessingLists(FunctorParams *functorParams);
+    int PrepareProcessingLists(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetDrawing
      */
-    virtual int ResetDrawing(FunctorParams *functorParams);
+    int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
     //

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -29,16 +29,16 @@ public:
     ///@{
     Verse();
     virtual ~Verse();
-    virtual Object *Clone() const { return new Verse(*this); }
-    virtual void Reset();
-    virtual std::string GetClassName() const { return "Verse"; }
+    Object *Clone() const override { return new Verse(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Verse"; }
     ///@}
 
     /**
      * Add an element (a syl) to a verse.
      * Only Syl elements will be actually added to the verse.
      */
-    virtual bool IsSupportedChild(Object *object);
+    bool IsSupportedChild(Object *object) override;
 
     /**
      * Calculate the adjustment according to the overlap and the free space available before.

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -288,42 +288,42 @@ public:
     /**
      * See Object::AlignVertically
      */
-    virtual int AlignVerticallyEnd(FunctorParams *functorParams);
+    int AlignVerticallyEnd(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustYPos
      */
-    virtual int AdjustYPos(FunctorParams *functorParams);
+    int AdjustYPos(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustStaffOverlap
      */
-    virtual int AdjustStaffOverlap(FunctorParams *functorParams);
+    int AdjustStaffOverlap(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustFloatingPositioners
      */
-    virtual int AdjustFloatingPositioners(FunctorParams *functorParams);
+    int AdjustFloatingPositioners(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustFloatingPositionersBetween
      */
-    virtual int AdjustFloatingPositionersBetween(FunctorParams *functorParams);
+    int AdjustFloatingPositionersBetween(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustFloatingPositionerGrps
      */
-    virtual int AdjustFloatingPositionerGrps(FunctorParams *functorParams);
+    int AdjustFloatingPositionerGrps(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustSlurs
      */
-    virtual int AdjustSlurs(FunctorParams *functorParams);
+    int AdjustSlurs(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyY
      */
-    virtual int JustifyY(FunctorParams *functorParams);
+    int JustifyY(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -43,12 +43,12 @@ public:
     /**
      * Do not copy children for HorizontalAligner
      */
-    virtual bool CopyChildren() const { return false; }
+    bool CopyChildren() const override { return false; }
 
     /**
      * Reset the aligner (clear the content) and creates the end (bottom) alignement
      */
-    virtual void Reset();
+    void Reset() override;
 
     /**
      * Get bottom StaffAlignment for the system.

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -35,8 +35,8 @@ public:
     ///@{
     Zone();
     virtual ~Zone();
-    virtual Object *Clone() const { return new Zone(*this); }
-    virtual void Reset();
+    Object *Clone() const override { return new Zone(*this); }
+    void Reset() override;
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
     int GetLogicalUly();

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -75,7 +75,7 @@ int Arpeg::GetDrawingX() const
     return measure->GetDrawingX() + this->GetDrawingXRel();
 }
 
-bool Arpeg::IsValidRef(Object *ref)
+bool Arpeg::IsValidRef(Object *ref) const
 {
     if (!ref->Is({ CHORD, NOTE })) {
         LogWarning(

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -307,7 +307,8 @@ void BBoxDeviceContext::MoveTextVerticallyTo(int y)
     // m_textY = y;
 }
 
-void BBoxDeviceContext::DrawText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height)
+void BBoxDeviceContext::DrawText(
+    const std::string &text, const std::wstring &wtext, int x, int y, int width, int height)
 {
     assert(m_fontStack.top());
 

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -88,7 +88,7 @@ bool Dir::AreChildrenAlignedTo(data_HORIZONTALALIGNMENT alignment) const
 // Dir functor methods
 //----------------------------------------------------------------------------
 
-int Dir::PrepareFloatingGrps(FunctorParams *functorParams)
+int Dir::PrepareFloatingGrps(FunctorParams *)
 {
     if (this->HasVgrp()) {
         this->SetDrawingGrpId(-this->GetVgrp());

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -88,7 +88,7 @@ bool Dir::AreChildrenAlignedTo(data_HORIZONTALALIGNMENT alignment) const
 // Dir functor methods
 //----------------------------------------------------------------------------
 
-int Dir::PrepareFloatingGrps(FunctorParams *)
+int Dir::PrepareFloatingGrps(FunctorParams *functorParams)
 {
     if (this->HasVgrp()) {
         this->SetDrawingGrpId(-this->GetVgrp());

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -80,7 +80,7 @@ int GrpSym::GetDrawingY() const
 // GrpSym functor methods
 //----------------------------------------------------------------------------
 
-int GrpSym::ScoreDefSetGrpSym(FunctorParams *functorParams)
+int GrpSym::ScoreDefSetGrpSym(FunctorParams *)
 {
     // For the grpSym that is encoded in the scope of the staffGrp just get first and last staffDefs and set then as
     // starting and ending points

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -80,7 +80,7 @@ int GrpSym::GetDrawingY() const
 // GrpSym functor methods
 //----------------------------------------------------------------------------
 
-int GrpSym::ScoreDefSetGrpSym(FunctorParams *)
+int GrpSym::ScoreDefSetGrpSym(FunctorParams *functorParams)
 {
     // For the grpSym that is encoded in the scope of the staffGrp just get first and last staffDefs and set then as
     // starting and ending points

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -108,7 +108,7 @@ MusicXmlInput::~MusicXmlInput() {}
 
 #ifndef NO_MUSICXML_SUPPORT
 
-bool MusicXmlInput::Import(std::string const &musicxml)
+bool MusicXmlInput::Import(const std::string &musicxml)
 {
     try {
         m_doc->Reset();

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -734,32 +734,4 @@ int Layer::ResetDrawing(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-/*
-int Layer::GenerateMIDI(FunctorParams *functorParams)
-{
-    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
-    assert(params);
-
-    if (this->HasSameasLink()) {
-        assert(this->GetSameasLink());
-        this->GetSameasLink()->Process(params->m_functor, functorParams);
-    }
-
-    return FUNCTOR_CONTINUE;
-}
-
-int Layer::GenerateTimemap(FunctorParams *functorParams)
-{
-    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
-    assert(params);
-
-    if (this->HasSameasLink()) {
-        assert(this->GetSameasLink());
-        this->GetSameasLink()->Process(params->m_functor, functorParams);
-    }
-
-    return FUNCTOR_CONTINUE;
- }
- */
-
 } // namespace vrv

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1943,7 +1943,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-int LayerElement::AdjustXRelForTranscription(FunctorParams *)
+int LayerElement::AdjustXRelForTranscription(FunctorParams *functorParams)
 {
     if (m_xAbs == VRV_UNSET) return FUNCTOR_CONTINUE;
 
@@ -2417,7 +2417,7 @@ int LayerElement::CalcOnsetOffset(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int LayerElement::ResolveMIDITies(FunctorParams *)
+int LayerElement::ResolveMIDITies(FunctorParams *functorParams)
 {
     return FUNCTOR_CONTINUE;
 }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1943,7 +1943,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-int LayerElement::AdjustXRelForTranscription(FunctorParams *functorParams)
+int LayerElement::AdjustXRelForTranscription(FunctorParams *)
 {
     if (m_xAbs == VRV_UNSET) return FUNCTOR_CONTINUE;
 
@@ -2417,7 +2417,7 @@ int LayerElement::CalcOnsetOffset(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int LayerElement::ResolveMIDITies(FunctorParams *functorParams)
+int LayerElement::ResolveMIDITies(FunctorParams *)
 {
     return FUNCTOR_CONTINUE;
 }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -168,7 +168,7 @@ void MeterSigGrp::SetMeasureBasedCount(Measure *measure)
 // Functors methods
 //----------------------------------------------------------------------------
 
-int MeterSigGrp::AlignHorizontally(FunctorParams *functorParams)
+int MeterSigGrp::AlignHorizontally(FunctorParams *)
 {
     return this->IsScoreDefElement() ? FUNCTOR_STOP : FUNCTOR_CONTINUE;
 }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -168,7 +168,7 @@ void MeterSigGrp::SetMeasureBasedCount(Measure *measure)
 // Functors methods
 //----------------------------------------------------------------------------
 
-int MeterSigGrp::AlignHorizontally(FunctorParams *)
+int MeterSigGrp::AlignHorizontally(FunctorParams *functorParams)
 {
     return this->IsScoreDefElement() ? FUNCTOR_STOP : FUNCTOR_CONTINUE;
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -509,9 +509,8 @@ void Page::LayOutVertically()
     this->Process(&adjustFloatingPositionersBetween, &adjustFloatingPositionersBetweenParams);
 
     Functor adjustCrossStaffYPos(&Object::AdjustCrossStaffYPos);
-    Functor adjustCrossStaffYPosEnd(&Object::AdjustCrossStaffYPosEnd);
     FunctorDocParams adjustCrossStaffYPosParams(doc);
-    this->Process(&adjustCrossStaffYPos, &adjustCrossStaffYPosParams, &adjustCrossStaffYPosEnd);
+    this->Process(&adjustCrossStaffYPos, &adjustCrossStaffYPosParams);
 
     // Redraw are re-adjust the position of the slurs when we have cross-staff ones
     if (adjustSlursParams.m_crossStaffSlurs) {
@@ -857,22 +856,6 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
         else {
             footer->SetDrawingYRel(footer->GetTotalHeight());
         }
-    }
-
-    return FUNCTOR_CONTINUE;
-}
-
-int Page::CastOffPagesEnd(FunctorParams *functorParams)
-{
-    CastOffPagesParams *params = vrv_params_cast<CastOffPagesParams *>(functorParams);
-    assert(params);
-
-    if (params->m_pendingPageElements.empty()) return FUNCTOR_CONTINUE;
-
-    // Otherwise add all pendings objects
-    ArrayOfObjects::iterator iter;
-    for (iter = params->m_pendingPageElements.begin(); iter != params->m_pendingPageElements.end(); ++iter) {
-        params->m_currentPage->AddChild(*iter);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -861,4 +861,20 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Page::CastOffPagesEnd(FunctorParams *functorParams)
+{
+    CastOffPagesParams *params = vrv_params_cast<CastOffPagesParams *>(functorParams);
+    assert(params);
+
+    if (params->m_pendingPageElements.empty()) return FUNCTOR_CONTINUE;
+
+    // Otherwise add all pendings objects
+    ArrayOfObjects::iterator iter;
+    for (iter = params->m_pendingPageElements.begin(); iter != params->m_pendingPageElements.end(); ++iter) {
+        params->m_currentPage->AddChild(*iter);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -69,7 +69,7 @@ bool Reh::IsSupportedChild(Object *child)
 // Reh functor methods
 //----------------------------------------------------------------------------
 
-int Reh::ResolveRehPosition(FunctorParams *functorParams)
+int Reh::ResolveRehPosition(FunctorParams *)
 {
     if (!this->HasStart() && !this->HasTstamp()) {
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -69,7 +69,7 @@ bool Reh::IsSupportedChild(Object *child)
 // Reh functor methods
 //----------------------------------------------------------------------------
 
-int Reh::ResolveRehPosition(FunctorParams *)
+int Reh::ResolveRehPosition(FunctorParams *functorParams)
 {
     if (!this->HasStart() && !this->HasTstamp()) {
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -647,7 +647,7 @@ int Staff::CalcOnsetOffset(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Staff::CalcStem(FunctorParams *)
+int Staff::CalcStem(FunctorParams *functorParams)
 {
     ClassIdComparison isLayer(LAYER);
     ListOfObjects layers;

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -647,7 +647,7 @@ int Staff::CalcOnsetOffset(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Staff::CalcStem(FunctorParams *functorParams)
+int Staff::CalcStem(FunctorParams *)
 {
     ClassIdComparison isLayer(LAYER);
     ListOfObjects layers;

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -220,7 +220,7 @@ LabelAbbr *StaffGrp::GetLabelAbbrCopy()
 // StaffGrp functor methods
 //----------------------------------------------------------------------------
 
-int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *functorParams)
+int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *)
 {
     this->SetDrawingVisibility(OPTIMIZATION_HIDDEN);
 

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -220,11 +220,8 @@ LabelAbbr *StaffGrp::GetLabelAbbrCopy()
 // StaffGrp functor methods
 //----------------------------------------------------------------------------
 
-int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *)
+int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *functorParams)
 {
-    // ScoreDefOptimize *params = vrv_params_cast<ScoreDefOptimize *>(functorParams);
-    // assert(params);
-
     this->SetDrawingVisibility(OPTIMIZATION_HIDDEN);
 
     for (auto &child : *this->GetChildren()) {

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -812,7 +812,7 @@ void SvgDeviceContext::EndText()
 
 // draw text element with optional parameters to specify the bounding box of the text
 // if the bounding box is specified then append a rect child
-void SvgDeviceContext::DrawText(const std::string &text, const std::wstring wtext, int x, int y, int width, int height)
+void SvgDeviceContext::DrawText(const std::string &text, const std::wstring &wtext, int x, int y, int width, int height)
 {
     assert(m_fontStack.top());
 

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -412,7 +412,7 @@ void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], 
 // Tie functor methods
 //----------------------------------------------------------------------------
 
-int Tie::ResolveMIDITies(FunctorParams *)
+int Tie::ResolveMIDITies(FunctorParams *functorParams)
 {
     Note *note1 = dynamic_cast<Note *>(this->GetStart());
     Note *note2 = dynamic_cast<Note *>(this->GetEnd());

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -412,7 +412,7 @@ void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], 
 // Tie functor methods
 //----------------------------------------------------------------------------
 
-int Tie::ResolveMIDITies(FunctorParams *functorParams)
+int Tie::ResolveMIDITies(FunctorParams *)
 {
     Note *note1 = dynamic_cast<Note *>(this->GetStart());
     Note *note2 = dynamic_cast<Note *>(this->GetEnd());


### PR DESCRIPTION
This PR resolves #2371 by adding `override` to virtual functions which were defined in some base class.