### PR TITLE
Change how automatic beam direction works

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -107,10 +107,10 @@ public:
     bool m_extendedToCenter; // the stem where extended to touch the center staff line
     double m_beamSlope; // the slope of the beam
     int m_verticalCenter;
-    int m_avgY;
     int m_ledgerLinesAbove;
     int m_ledgerLinesBelow;
     int m_uniformStemLength;
+    data_BEAMPLACE m_weightedPlace;
 
     BeamElementCoord *m_firstNoteOrChord;
     BeamElementCoord *m_lastNoteOrChord;


### PR DESCRIPTION
- changed code to used max/min position for chords to improve automatic beam placement
- instead of calculating average y across the beam, find max/min points and determine beam placement based on their distance to the vertical center of the beam

closes #1962

![image](https://user-images.githubusercontent.com/1819669/140716654-0e503b1d-9bca-413c-b23b-c5a49e39ddfb.png)
