### PR TITLE
Rendering portato slurs

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -32,6 +32,9 @@ struct ControlPointConstraint {
     double c;
 };
 
+// Helper enum classes
+enum class PortatoSlurType { None, StemSide, Centered };
+
 //----------------------------------------------------------------------------
 // Slur
 //----------------------------------------------------------------------------
@@ -109,7 +112,7 @@ private:
      */
     ///@{
     // Check if the slur resembles portato
-    bool IsPortatoSlur(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const;
+    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord) const;
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -13,8 +13,10 @@
 
 namespace vrv {
 
+class Chord;
 class Doc;
 class Layer;
+class Note;
 class Staff;
 
 //----------------------------------------------------------------------------
@@ -102,6 +104,14 @@ public:
     virtual int ResetDrawing(FunctorParams *functorParams);
 
 private:
+    /**
+     * Helper for calculating the initial slur start and end points
+     */
+    ///@{
+    // Check if the slur resembles portato
+    bool IsPortatoSlur(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const;
+    ///@}
+
     /**
      * Adjust slur position based on overlapping objects within its spanning elements
      */

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -112,7 +112,7 @@ private:
      */
     ///@{
     // Check if the slur resembles portato
-    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord) const;
+    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord, curvature_CURVEDIR curveDir) const;
     ///@}
 
     /**

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -729,19 +729,21 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             else if (isShortSlur) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
+            // portato slurs
+            else if (portatoSlurType != PortatoSlurType::None) {
+                y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                Note *refNote = startChord ? startChord->GetBottomNote() : startNote;
+                x1 = refNote->GetDrawingX() + startRadius;
+                if (portatoSlurType == PortatoSlurType::StemSide) {
+                    x1 += startRadius;
+                }
+            }
             // same but in beam - adjust the x too
             else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
                 || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))
                 || isGraceToNoteSlur) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
                 x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-            }
-            // similar for portato slurs
-            else if (portatoSlurType != PortatoSlurType::None) {
-                y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
-                if (portatoSlurType == PortatoSlurType::StemSide) {
-                    x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-                }
             }
             // d(^)
             else {
@@ -773,18 +775,20 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             else if (isShortSlur) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
+            // portato slurs
+            else if (portatoSlurType != PortatoSlurType::None) {
+                y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                Note *refNote = startChord ? startChord->GetTopNote() : startNote;
+                x1 = refNote->GetDrawingX();
+                if (portatoSlurType == PortatoSlurType::Centered) {
+                    x1 += startRadius;
+                }
+            }
             // same but in beam
             else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
                 || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                 x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-            }
-            // similar for portato slurs
-            else if (portatoSlurType != PortatoSlurType::None) {
-                y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                if (portatoSlurType == PortatoSlurType::StemSide) {
-                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-                }
             }
             // P(_)
             else {
@@ -814,13 +818,6 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             else if (isShortSlur) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
-            // same but in beam - adjust the x too
-            else if ((((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
-                         || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end)))
-                && !isGraceToNoteSlur) {
-                y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
-                x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-            }
             else if (isGraceToNoteSlur) {
                 if (start->IsInBeam()) {
                     x2 += 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
@@ -843,9 +840,20 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
-            // similar to beam for portato slurs
+            // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                Note *refNote = endChord ? endChord->GetBottomNote() : endNote;
+                x2 = refNote->GetDrawingX() + endRadius;
+                if (portatoSlurType == PortatoSlurType::StemSide) {
+                    x2 += endRadius;
+                }
+            }
+            // same but in beam - adjust the x too
+            else if (((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
+                || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
+                y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // (^)d
             else {
@@ -867,14 +875,6 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             else if (isShortSlur && !isGraceToNoteSlur) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
-            // same but in beam
-            else if ((((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
-                         || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end)))
-                && !isGraceToNoteSlur) {
-
-                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-            }
             else if (isGraceToNoteSlur) {
                 if (start->IsInBeam()) {
                     x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
@@ -894,12 +894,21 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     x2 -= endRadius;
                 }
             }
-            // similar to beam for portato slurs
+            // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                if (portatoSlurType == PortatoSlurType::StemSide) {
-                    x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                Note *refNote = endChord ? endChord->GetTopNote() : endNote;
+                x2 = refNote->GetDrawingX();
+                if (portatoSlurType == PortatoSlurType::Centered) {
+                    x2 += endRadius;
                 }
+            }
+            // same but in beam
+            else if (((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
+                || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
+
+                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // (_)P
             else {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -995,7 +995,7 @@ PortatoSlurType Slur::IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord
 
     // Stem directions are not considered here and must be checked on client side
     PortatoSlurType type = PortatoSlurType::None;
-    if (artics.size() == 1) {
+    if (!artics.empty()) {
         type = PortatoSlurType::Centered;
         Artic *artic = vrv_cast<Artic *>(artics.front());
         if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -690,6 +690,8 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     const bool isGraceToNoteSlur
         = !start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && start->IsGraceNote() && !end->IsGraceNote();
 
+    const bool isPortatoSlur = this->IsPortatoSlur(startNote, startChord, endNote, endChord);
+
     int x1, x2, y1, y2;
     std::tie(x1, x2, y1, y2) = std::tie(points.first.x, points.second.x, points.first.y, points.second.y);
 
@@ -733,6 +735,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
                 x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
+            // similar for portato slurs
+            else if (isPortatoSlur) {
+                y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                    x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+            }
             // d(^)
             else {
                 // put it on the side, move it left, but not if we have a @tstamp
@@ -767,6 +776,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                 x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+            }
+            // similar for portato slurs
+            else if (isPortatoSlur) {
+                y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
             }
             // P(_)
             else {
@@ -824,6 +840,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
+            // similar to beam for portato slurs
+            else if (isPortatoSlur) {
+                y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+            }
             // (^)d
             else {
                 // put it on the side, no need to move it right
@@ -869,6 +892,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 else {
                     y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                     x2 -= endRadius;
+                }
+            }
+            // similar to beam for portato slurs
+            else if (isPortatoSlur) {
+                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                    x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
             // (_)P
@@ -933,6 +963,15 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     }
 
     return std::make_pair(Point(x1, y1), Point(x2, y2));
+}
+
+bool Slur::IsPortatoSlur(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const
+{
+    const bool startHasArtic
+        = startChord ? (startChord->GetChildCount(ARTIC) == 1) : (startNote && (startNote->GetChildCount(ARTIC) == 1));
+    const bool endHasArtic
+        = endChord ? (endChord->GetChildCount(ARTIC) == 1) : (endNote && (endNote->GetChildCount(ARTIC) == 1));
+    return (startHasArtic && endHasArtic);
 }
 
 //----------------------------------------------------------------------------

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -690,7 +690,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     const bool isGraceToNoteSlur
         = !start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && start->IsGraceNote() && !end->IsGraceNote();
 
-    const bool isPortatoSlur = this->IsPortatoSlur(startNote, startChord, endNote, endChord);
+    const PortatoSlurType portatoSlurType = this->IsPortatoSlur(doc, startNote, startChord);
 
     int x1, x2, y1, y2;
     std::tie(x1, x2, y1, y2) = std::tie(points.first.x, points.second.x, points.first.y, points.second.y);
@@ -722,8 +722,12 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
         // slur is up
         if (drawingCurveDir == curvature_CURVEDIR_above) {
             // P(^)
-            if (startStemDir == STEMDIRECTION_down || startStemLen == 0)
+            if (startStemDir == STEMDIRECTION_down || startStemLen == 0) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                if (portatoSlurType != PortatoSlurType::None) {
+                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+            }
             //  d(^)d
             else if (isShortSlur) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
@@ -736,10 +740,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // similar for portato slurs
-            else if (isPortatoSlur) {
+            else if (portatoSlurType != PortatoSlurType::None) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
-                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                if (portatoSlurType == PortatoSlurType::StemSide) {
                     x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+                else {
+                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
             // d(^)
@@ -765,8 +772,12 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 }
             }
             // d(_)
-            else if (startStemDir == STEMDIRECTION_up || startStemLen == 0)
+            else if (startStemDir == STEMDIRECTION_up || startStemLen == 0) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                if (portatoSlurType != PortatoSlurType::None) {
+                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+            }
             // P(_)P
             else if (isShortSlur) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
@@ -778,11 +789,9 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // similar for portato slurs
-            else if (isPortatoSlur) {
+            else if (portatoSlurType != PortatoSlurType::None) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
-                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-                }
+                x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // P(_)
             else {
@@ -805,8 +814,12 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
         // slur is up
         if (drawingCurveDir == curvature_CURVEDIR_above) {
             // (^)P
-            if (endStemDir == STEMDIRECTION_down || endStemLen == 0)
+            if (endStemDir == STEMDIRECTION_down || endStemLen == 0) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                if (portatoSlurType != PortatoSlurType::None) {
+                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+            }
             // d(^)d
             else if (isShortSlur) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
@@ -841,11 +854,9 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 }
             }
             // similar to beam for portato slurs
-            else if (isPortatoSlur) {
+            else if (portatoSlurType != PortatoSlurType::None) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
-                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
-                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-                }
+                x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // (^)d
             else {
@@ -862,6 +873,9 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             // (_)d
             if (endStemDir == STEMDIRECTION_up || endStemLen == 0) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                if (portatoSlurType != PortatoSlurType::None) {
+                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
             }
             // P(_)P
             else if (isShortSlur && !isGraceToNoteSlur) {
@@ -895,10 +909,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 }
             }
             // similar to beam for portato slurs
-            else if (isPortatoSlur) {
+            else if (portatoSlurType != PortatoSlurType::None) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+                if (portatoSlurType == PortatoSlurType::StemSide) {
                     x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                }
+                else {
+                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
             // (_)P
@@ -965,13 +982,30 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     return std::make_pair(Point(x1, y1), Point(x2, y2));
 }
 
-bool Slur::IsPortatoSlur(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const
+PortatoSlurType Slur::IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord) const
 {
-    const bool startHasArtic
-        = startChord ? (startChord->GetChildCount(ARTIC) == 1) : (startNote && (startNote->GetChildCount(ARTIC) == 1));
-    const bool endHasArtic
-        = endChord ? (endChord->GetChildCount(ARTIC) == 1) : (endNote && (endNote->GetChildCount(ARTIC) == 1));
-    return (startHasArtic && endHasArtic);
+    ListOfObjects artics;
+    ClassIdComparison cmp(ARTIC);
+    if (startChord) {
+        startChord->FindAllDescendantByComparison(&artics, &cmp, 1);
+    }
+    else if (startNote) {
+        startNote->FindAllDescendantByComparison(&artics, &cmp, 1);
+    }
+
+    // Stem directions are not considered here and must be checked on client side
+    PortatoSlurType type = PortatoSlurType::None;
+    if (artics.size() == 1) {
+        type = PortatoSlurType::Centered;
+        Artic *artic = vrv_cast<Artic *>(artics.front());
+        if (!doc->GetOptions()->m_staccatoCenter.GetValue()) {
+            const data_ARTICULATION articType = artic->GetArticFirst();
+            if ((articType == ARTICULATION_stacc) || (articType == ARTICULATION_stacciss)) {
+                type = PortatoSlurType::StemSide;
+            }
+        }
+    }
+    return type;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the rendering of portato slurs. Works with stem side or centered staccato as well as with other articulations.

| Before | After |
| ------ | ----- |
| ![Before1](https://user-images.githubusercontent.com/63608463/140875781-a00e7309-aa52-4d94-b838-0d0f039465c8.png) | <img width="512" alt="Example1" src="https://user-images.githubusercontent.com/63608463/141751493-a60cef9d-58d7-4638-a574-e0361a0f5b89.png"> |
| ![Before2](https://user-images.githubusercontent.com/63608463/140875836-59eb90ac-8127-4cfe-ad45-85ea0f97f382.png) | <img width="516" alt="Example2" src="https://user-images.githubusercontent.com/63608463/141751546-cdc27fb7-81c7-476f-814b-02e7a7fd94ed.png"> |
| ![Before3](https://user-images.githubusercontent.com/63608463/140875871-98efeb8a-9d5d-4406-a061-9ebd489c1362.png) | <img width="516" alt="Example3" src="https://user-images.githubusercontent.com/63608463/141751598-592bb9c7-703f-4434-b9e0-ee5955bb2fee.png"> |


<details>
  <summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-07-30" type="encoding-date">2021-07-30</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-xwopln">
         <appInfo xml:id="appinfo-a209u3">
            <application xml:id="application-oqlg5f" isodate="2021-10-07T15:48:50" version="3.7.0-dev-ab9a2ad">
               <name xml:id="name-54q3e8">Verovio</name>
               <p xml:id="p-9bogng">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mlj4v68">
            <score xml:id="sdie2kd">
               <scoreDef xml:id="sqosio4">
                  <staffGrp xml:id="s2kukk6">
                     <staffGrp xml:id="S1-ty9q8jPDVsCWNSEmZ4EMBA" bar.thru="true">
                        <staffDef xml:id="sbx4ten" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <keySig xml:id="key-1" sig="2f" />
                           <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                        </staffDef>
                        <staffDef xml:id="spk2jp7" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <keySig xml:id="key-2" sig="2f" />
                           <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                        </staffDef>
                        <grpSym xml:id="gn2ijqh" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="svuhz75">
                  <pb xml:id="py6q87o" />
                  <measure xml:id="measure-0006-11020-10920-1-mdiv-1" n="13">
                     <staff xml:id="smgu9ou" n="1">
                        <layer xml:id="lawwt1f" n="1">
                           <note xml:id="note-0006-11060-11050-1" dots="1" dur.ppq="12" dur="2" oct="4" pname="g" stem.dir="up" />
                           <note xml:id="note-0006-11260-10990-1" dots="1" dur.ppq="12" dur="2" oct="5" pname="g" stem.dir="up" />
                        </layer>
                        <layer xml:id="lgm9mkr" n="2">
                           <rest xml:id="rest-0006-11070-11120" dur.ppq="4" dur="4" />
                           <chord xml:id="co7zcdo" dur.ppq="4" dur="4" stem.dir="down">
                              <artic xml:id="abas6oy" artic="stacc" place="below" />
                              <note xml:id="note-0006-11130-11080-2" oct="4" pname="d" />
                              <note xml:id="note-0006-11130-11090-2" oct="3" pname="b" accid.ges="f" />
                           </chord>
                           <note xml:id="note-0006-11200-11080-2" dur.ppq="4" dur="4" oct="4" pname="c" stem.dir="down">
                              <artic xml:id="arny5z0" artic="stacc" place="below" />
                           </note>
                           <rest xml:id="rest-0006-11270-11080" dur.ppq="4" dur="4" />
                           <chord xml:id="cyiejwb" dur.ppq="4" dur="4" stem.dir="down">
                              <artic xml:id="arcvmfc" artic="stacc" place="below" />
                              <note xml:id="note-0006-11330-11020-2" oct="5" pname="d">
                                 <accid xml:id="a129g6r" accid="f" accid.ges="f" />
                              </note>
                              <note xml:id="note-0006-11330-11030-2" oct="4" pname="b" accid.ges="f" />
                              <note xml:id="note-0006-11330-11050-2" oct="4" pname="g" />
                           </chord>
                           <chord xml:id="chi0avh" dur.ppq="4" dur="4" stem.dir="down">
                              <artic xml:id="arcvmfd" artic="stacc" place="below" />
                              <note xml:id="note-0006-11400-11020-2" oct="5" pname="d" accid.ges="f" />
                              <note xml:id="note-0006-11400-11030-2" oct="4" pname="b" accid.ges="f" />
                              <note xml:id="note-0006-11400-11050-2" oct="4" pname="g" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="sg0qc6i" n="2">
                        <layer xml:id="lqfgtco" n="5">
                           <rest xml:id="rest-0006-11070-11260" dur.ppq="4" dur="4" />
                           <note xml:id="note-0006-11130-11270-1" dur.ppq="4" dur="4" oct="2" pname="g" stem.dir="up">
                              <artic xml:id="am2q1ou" artic="stacc" place="below" />
                           </note>
                           <note xml:id="note-0006-11200-11270-1" dur.ppq="4" dur="4" oct="2" pname="g" stem.dir="up">
                              <artic xml:id="arw4ykl" artic="stacc" place="below" />
                           </note>
                           <rest xml:id="rest-0006-11270-11260" dur.ppq="4" dur="4" />
                           <note xml:id="note-0006-11330-11170-2" dur.ppq="4" dur="4" oct="4" pname="e" stem.dir="down">
                              <accid xml:id="ayxcu0h" accid="n" accid.ges="n" />
                              <artic xml:id="aiq1w51" artic="stacc" place="above" />
                           </note>
                           <note xml:id="note-0006-11400-11170-2" dur.ppq="4" dur="4" oct="4" pname="e" stem.dir="down" accid.ges="n">
                              <artic xml:id="afbbodv" artic="stacc" place="above" />
                           </note>
                        </layer>
                     </staff>
                     <slur xml:id="bow-0006-11350-10920" startid="#note-0006-11260-10990-1" endid="#note-0006-9540-11480-1" curvedir="above" />
                     <slur xml:id="bow-0006-11160-11160" startid="#note-0006-11130-11080-2" endid="#note-0006-11200-11080-2" curvedir="below" />
                     <slur xml:id="bow-0006-11360-11120" startid="#note-0006-11330-11030-2" endid="#note-0006-11400-11050-2" curvedir="below" />
                     <slur xml:id="bow-0006-11160-11300" startid="#note-0006-11130-11270-1" endid="#note-0006-11200-11270-1" />
                     <slur xml:id="bow-0006-11360-11140" startid="#note-0006-11330-11170-2" endid="#note-0006-11400-11170-2" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
 