### PR TITLE
Slur collision avoidance with layers

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1480,9 +1480,11 @@ public:
  * member 1: the minimum position
  * member 2: the maximum position
  * member 3: the staff numbers to consider, any staff if empty
- * member 4: true if within measure range of timespanning interface, only this is searched
- * member 5: the timespanning interface
- * member 6: the class ids to keep
+ * member 4: the minimal layerN to consider, unbounded below if zero
+ * member 5: the maximal layerN to consider, unbounded above if zero
+ * member 6: true if within measure range of timespanning interface, only this is searched
+ * member 7: the timespanning interface
+ * member 8: the class ids to keep
  **/
 
 class FindSpannedLayerElementsParams : public FunctorParams {
@@ -1492,12 +1494,16 @@ public:
         m_interface = interface;
         m_minPos = 0;
         m_maxPos = 0;
+        m_minLayerN = 0;
+        m_maxLayerN = 0;
         m_inMeasureRange = false;
     }
     std::vector<LayerElement *> m_elements;
     int m_minPos;
     int m_maxPos;
     std::set<int> m_staffNs;
+    int m_minLayerN;
+    int m_maxLayerN;
     bool m_inMeasureRange;
     TimeSpanningInterface *m_interface;
     std::vector<ClassId> m_classIds;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -82,9 +82,19 @@ public:
      */
     std::vector<LayerElement *> CollectSpannedElements(Staff *staff, int xMin, int xMax, char spanningType);
 
+    /**
+     * Calculate the staff where the slur's floating curve positioner lives
+     */
+    Staff *CalculateExtremalStaff(Staff *staff, int xMin, int xMax, char spanningType);
+
+    /**
+     * Slur adjustment
+     */
+    ///@{
     void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
 
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
+    ///@}
 
     /**
      * Get preferred curve direction based on number of conditions: presence of other layers, stem direction, etc.

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -38,7 +38,8 @@ class Slur : public ControlElement,
              public TimeSpanningInterface,
              public AttColor,
              public AttCurvature,
-             public AttCurveRend {
+             public AttCurveRend,
+             public AttLayerIdent {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -83,6 +83,9 @@ class TupletBracket;
 class TupletNum;
 class Verse;
 
+// Helper enums
+enum class SlurHandling { Ignore, Initialize, Drawing };
+
 //----------------------------------------------------------------------------
 // View
 //----------------------------------------------------------------------------
@@ -180,9 +183,12 @@ public:
     ///@}
 
     /**
-     * Set whether slurs should be initialized when drawn
+     * Control how slurs are handled
      */
-    void ActivateSlurInitialization(bool active) { m_initializeSlurs = active; };
+    ///@{
+    SlurHandling GetSlurHandling() const { return m_slurHandling; }
+    void SetSlurHandling(SlurHandling slurHandling) { m_slurHandling = slurHandling; }
+    ///@}
 
 protected:
     /**
@@ -634,9 +640,9 @@ protected:
     ///@}
 
     /**
-     * Indicates whether slurs should be initialized when drawn
+     * Control the handling of slurs
      */
-    bool m_initializeSlurs;
+    SlurHandling m_slurHandling;
 
     /**
      * The current drawing score def.

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1534,6 +1534,7 @@ void MEIOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
     slur->WriteColor(currentNode);
     slur->WriteCurvature(currentNode);
     slur->WriteCurveRend(currentNode);
+    slur->WriteLayerIdent(currentNode);
 }
 
 void MEIOutput::WriteStaff(pugi::xml_node currentNode, Staff *staff)
@@ -4770,6 +4771,7 @@ bool MEIInput::ReadPhrase(Object *parent, pugi::xml_node phrase)
     vrvPhrase->ReadColor(phrase);
     vrvPhrase->ReadCurvature(phrase);
     vrvPhrase->ReadCurveRend(phrase);
+    vrvPhrase->ReadLayerIdent(phrase);
 
     parent->AddChild(vrvPhrase);
     ReadUnsupportedAttr(phrase, vrvPhrase);
@@ -4813,6 +4815,7 @@ bool MEIInput::ReadSlur(Object *parent, pugi::xml_node slur)
     vrvSlur->ReadColor(slur);
     vrvSlur->ReadCurvature(slur);
     vrvSlur->ReadCurveRend(slur);
+    vrvSlur->ReadLayerIdent(slur);
 
     parent->AddChild(vrvSlur);
     ReadUnsupportedAttr(slur, vrvSlur);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2329,6 +2329,18 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
             }
         }
 
+        // Skip if layer number is outside given bounds
+        int layerN = this->GetAlignmentLayerN();
+        if (layerN < 0) {
+            layerN = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER))->GetN();
+        }
+        if (params->m_minLayerN && (params->m_minLayerN > layerN)) {
+            return FUNCTOR_CONTINUE;
+        }
+        if (params->m_maxLayerN && (params->m_maxLayerN < layerN)) {
+            return FUNCTOR_CONTINUE;
+        }
+
         params->m_elements.push_back(this);
     }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2308,7 +2308,7 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    if (this->HasContentBB() && (this->GetContentRight() > params->m_minPos)
+    if (this->HasContentBB() && !this->HasEmptyBB() && (this->GetContentRight() > params->m_minPos)
         && (this->GetContentLeft() < params->m_maxPos)) {
 
         // We skip the start or end of the slur

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -310,6 +310,7 @@ void Page::LayOutHorizontally()
     // Render it for filling the bounding box
     View view;
     view.SetDoc(doc);
+    view.SetSlurHandling(SlurHandling::Ignore);
     BBoxDeviceContext bBoxDC(&view, 0, 0, BBOX_HORIZONTAL_ONLY);
     // Do not do the layout in this view - otherwise we will loop...
     view.SetPage(this->GetIdx(), false);
@@ -476,7 +477,7 @@ void Page::LayOutVertically()
     this->Process(&adjustSlurs, &adjustSlursParams);
 
     // At this point slurs must not be reinitialized, otherwise the adjustment we just did was in vain
-    view.ActivateSlurInitialization(false);
+    view.SetSlurHandling(SlurHandling::Drawing);
     view.SetPage(this->GetIdx(), false);
     view.DrawCurrentPage(&bBoxDC, false);
 
@@ -515,7 +516,7 @@ void Page::LayOutVertically()
 
     // Redraw are re-adjust the position of the slurs when we have cross-staff ones
     if (adjustSlursParams.m_crossStaffSlurs) {
-        view.ActivateSlurInitialization(true);
+        view.SetSlurHandling(SlurHandling::Initialize);
         view.SetPage(this->GetIdx(), false);
         view.DrawCurrentPage(&bBoxDC, false);
         this->Process(&adjustSlurs, &adjustSlursParams);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -37,34 +37,53 @@ namespace vrv {
 
 static const ClassRegistrar<Slur> s_factory("slur", SLUR);
 
-Slur::Slur() : ControlElement(SLUR, "slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+Slur::Slur()
+    : ControlElement(SLUR, "slur-")
+    , TimeSpanningInterface()
+    , AttColor()
+    , AttCurvature()
+    , AttCurveRend()
+    , AttLayerIdent()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
     RegisterAttClass(ATT_CURVEREND);
+    RegisterAttClass(ATT_LAYERIDENT);
 
     Reset();
 }
 
 Slur::Slur(ClassId classId)
-    : ControlElement(classId, "slur-"), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+    : ControlElement(classId, "slur-")
+    , TimeSpanningInterface()
+    , AttColor()
+    , AttCurvature()
+    , AttCurveRend()
+    , AttLayerIdent()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
     RegisterAttClass(ATT_CURVEREND);
+    RegisterAttClass(ATT_LAYERIDENT);
 
     Reset();
 }
 
 Slur::Slur(ClassId classId, const std::string &classIdStr)
-    : ControlElement(classId, classIdStr), TimeSpanningInterface(), AttColor(), AttCurvature(), AttCurveRend()
+    : ControlElement(classId, classIdStr)
+    , TimeSpanningInterface()
+    , AttColor()
+    , AttCurvature()
+    , AttCurveRend()
+    , AttLayerIdent()
 {
     RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
     RegisterAttClass(ATT_CURVATURE);
     RegisterAttClass(ATT_CURVEREND);
+    RegisterAttClass(ATT_LAYERIDENT);
 
     Reset();
 }
@@ -78,6 +97,7 @@ void Slur::Reset()
     ResetColor();
     ResetCurvature();
     ResetCurveRend();
+    ResetLayerIdent();
 
     m_drawingCurvedir = curvature_CURVEDIR_NONE;
     // m_isCrossStaff = false;
@@ -117,12 +137,17 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
 
     // Now determine the minimal and maximal layer
     std::set<int> layersN;
-    for (LayerElement *element : { this->GetStart(), this->GetEnd() }) {
-        int layerN = element->GetAlignmentLayerN();
-        if (layerN < 0) {
-            layerN = vrv_cast<Layer *>(element->GetFirstAncestor(LAYER))->GetN();
+    if (this->HasLayer()) {
+        layersN = { this->GetLayer() };
+    }
+    else {
+        for (LayerElement *element : { this->GetStart(), this->GetEnd() }) {
+            int layerN = element->GetAlignmentLayerN();
+            if (layerN < 0) {
+                layerN = vrv_cast<Layer *>(element->GetFirstAncestor(LAYER))->GetN();
+            }
+            layersN.insert(layerN);
         }
-        layersN.insert(layerN);
     }
     const int minLayerN = *layersN.begin();
     const int maxLayerN = *layersN.rbegin();
@@ -192,8 +217,8 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
                   return true;
               });
 
-        // For separated voices rerun the search with layer bounds
-        if (layersAreSeparated) {
+        // For separated voices or prescribed layers rerun the search with layer bounds
+        if (layersAreSeparated || this->HasLayer()) {
             findSpannedLayerElementsParams.m_elements.clear();
             findSpannedLayerElementsParams.m_inMeasureRange
                 = ((spanningType == SPANNING_MIDDLE) || (spanningType == SPANNING_END));

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -31,7 +31,7 @@ View::View()
     m_pageIdx = 0;
     m_tieThicknessCoefficient = 0.0;
     m_slurThicknessCoefficient = 0.0;
-    m_initializeSlurs = true;
+    m_slurHandling = SlurHandling::Initialize;
 
     m_currentColour = AxNONE;
     m_currentElement = NULL;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -283,25 +283,11 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
         // TimeSpanning element are not necessary floating elements (e.g., syl) - we have a bounding box only for them
         if (element->IsControlElement()) {
             Staff *staff = *staffIter;
-            // The floating curve positioner of cross staff slurs should live in the upper/lower staff alignment
-            // corresponding to whether the slur is curved above/below
-            if (element->Is(SLUR)) {
+            if (element->Is({ PHRASE, SLUR })) {
+                if (this->GetSlurHandling() == SlurHandling::Ignore) break;
                 Slur *slur = vrv_cast<Slur *>(element);
-                const std::vector<LayerElement *> spannedElements
-                    = slur->CollectSpannedElements(staff, x1, x2, spanningType);
-                for (LayerElement *element : spannedElements) {
-                    Layer *elementLayer = NULL;
-                    Staff *elementStaff = element->GetCrossStaff(elementLayer);
-                    if (!elementStaff) elementStaff = vrv_cast<Staff *>(element->GetFirstAncestor(STAFF));
-                    assert(elementStaff);
-
-                    if ((slur->GetCurvedir() == curvature_CURVEDIR_above) && (elementStaff->GetN() < staff->GetN())) {
-                        staff = elementStaff;
-                    }
-                    if ((slur->GetCurvedir() == curvature_CURVEDIR_below) && (elementStaff->GetN() > staff->GetN())) {
-                        staff = elementStaff;
-                    }
-                }
+                assert(slur);
+                staff = slur->CalculateExtremalStaff(staff, x1, x2, spanningType);
             }
 
             // Create the floating positioner
@@ -344,6 +330,8 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
             DrawTie(dc, dynamic_cast<Tie *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
         else if (element->Is(PHRASE)) {
+            // Check if slurs should be ignored
+            if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
             // For phrases (slurs) we limit support to one value in @staff
             if (staffIter != staffList.begin()) continue;
             // cast to Slur check in DrawSlur
@@ -362,6 +350,8 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
                 dc, dynamic_cast<PitchInflection *>(element), x1, x2, *staffIter, spanningType, graphic);
         }
         else if (element->Is(SLUR)) {
+            // Check if slurs should be ignored
+            if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
             // For slurs we limit support to one value in @staff
             if (staffIter != staffList.begin()) continue;
             // cast to Slur check in DrawSlur

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -49,7 +49,7 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(positioner);
     assert(curve);
 
-    if (m_initializeSlurs && dc->Is(BBOX_DEVICE_CONTEXT)
+    if ((this->GetSlurHandling() == SlurHandling::Initialize) && dc->Is(BBOX_DEVICE_CONTEXT)
         && (curve->GetDir() == curvature_CURVEDIR_NONE || curve->IsCrossStaff())) {
         this->DrawSlurInitial(curve, slur, x1, x2, staff, spanningType);
     }


### PR DESCRIPTION
This PR improves the collision avoidance of slurs with respect to layers and fixes #2419 .

| Before | After |
| ------ | ----- |
| <img width="596" alt="Before" src="https://user-images.githubusercontent.com/63608463/141091517-1d39d1cf-189a-4018-87ce-bab04f1e1229.png"> | <img width="587" alt="After" src="https://user-images.githubusercontent.com/63608463/141091584-1cabf9c5-4474-493e-b8c0-ca39746624c2.png"> |
| <img width="321" alt="Before2" src="https://user-images.githubusercontent.com/63608463/141092092-7af5d5b9-228b-4954-b1d4-d5a8a5786bbc.png"> | <img width="342" alt="After2" src="https://user-images.githubusercontent.com/63608463/141092132-61628dc3-8caa-4413-a9b4-b258998fc0a3.png"> |

<details>
  <summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-07-30" type="encoding-date">2021-07-30</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-xwopln">
         <appInfo xml:id="appinfo-a209u3">
            <application xml:id="application-oqlg5f" isodate="2021-10-07T15:48:50" version="3.7.0-dev-ab9a2ad">
               <name xml:id="name-54q3e8">Verovio</name>
               <p xml:id="p-9bogng">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mlj4v68">
            <score xml:id="sdie2kd">
               <scoreDef xml:id="sqosio4">
                  <staffGrp xml:id="s2kukk6">
                     <staffGrp xml:id="S1-ty9q8jPDVsCWNSEmZ4EMBA" bar.thru="true">
                        <staffDef xml:id="sbx4ten" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <keySig xml:id="key-1" sig="2f" />
                           <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                        </staffDef>
                        <staffDef xml:id="spk2jp7" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <keySig xml:id="key-2" sig="2f" />
                           <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                        </staffDef>
                        <grpSym xml:id="gn2ijqh" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="svuhz75">
                  <pb xml:id="py6q87o" />
                  <measure xml:id="measure-0008-10000-12180-1-mdiv-1" n="54">
                     <staff xml:id="s6vtqyo" n="1">
                        <layer xml:id="lpaylkm" n="5">
                           <beam xml:id="bu9p4lc">
                              <chord xml:id="csna13c" dur.ppq="2" dur="8" staff="2" stem.dir="up">
                                 <note xml:id="note-0008-10050-12500-1" oct="3" pname="g" />
                                 <note xml:id="note-0008-10050-12470-1" oct="4" pname="c" />
                              </chord>
                              <note xml:id="note-0008-10100-12480-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="b" stem.dir="up" accid.ges="f" />
                              <note xml:id="note-0008-10140-12520-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="d" stem.dir="up" />
                              <chord xml:id="cg2dk31" dur.ppq="2" dur="8" staff="2" stem.dir="up">
                                 <note xml:id="note-0008-10200-12500-1" oct="3" pname="g" />
                                 <note xml:id="note-0008-10200-12460-1" oct="4" pname="d" />
                              </chord>
                              <note xml:id="note-0008-10250-12470-1" dur.ppq="2" dur="8" staff="2" oct="4" pname="c" stem.dir="up" />
                              <note xml:id="note-0008-10300-12510-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="f" />
                           </beam>
                           <beam xml:id="b3udms9">
                              <chord xml:id="cvdob60" dur.ppq="2" dur="8" staff="2" stem.dir="up">
                                 <note xml:id="note-0008-10350-12490-1" oct="3" pname="g" />
                                 <note xml:id="note-0008-10350-12470-1" oct="4" pname="c" />
                              </chord>
                              <note xml:id="note-0008-10400-12480-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="b" stem.dir="up" accid.ges="f" />
                              <note xml:id="note-0008-10450-12520-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="d" stem.dir="up" />
                              <chord xml:id="c7mr1so" dur.ppq="2" dur="8" staff="2" stem.dir="up">
                                 <note xml:id="note-0008-10500-12490-1" oct="3" pname="g" />
                                 <note xml:id="note-0008-10500-12460-1" oct="4" pname="d" />
                              </chord>
                              <note xml:id="note-0008-10560-12470-1" dur.ppq="2" dur="8" staff="2" oct="4" pname="c" stem.dir="up" />
                              <note xml:id="note-0008-10610-12510-1" dur.ppq="2" dur="8" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="f" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="sqnpo8p" n="2">
                        <layer xml:id="ln5whfo" n="6">
                           <chord xml:id="c2qebcg" dur.ppq="4" dur="4" stem.dir="down">
                              <note xml:id="note-0008-10040-12560-2" oct="2" pname="g" />
                              <note xml:id="note-0008-10050-12630-2" oct="1" pname="g" />
                           </chord>
                           <rest xml:id="rest-0008-10150-12620" dur.ppq="4" dur="4" />
                           <note xml:id="note-0008-10250-12600-2" dur.ppq="4" dur="4" oct="2" pname="c" stem.dir="down">
                              <accid xml:id="aph9j3c" accid="n" accid.ges="n" />
                           </note>
                           <chord xml:id="cr6c6hv" dur.ppq="4" dur="4" stem.dir="down">
                              <note xml:id="note-0008-10350-12560-2" oct="2" pname="g" />
                              <note xml:id="note-0008-10350-12630-2" oct="1" pname="g" />
                           </chord>
                           <rest xml:id="rest-0008-10450-12620" dur.ppq="4" dur="4" />
                           <note xml:id="note-0008-10560-12600-2" dur.ppq="4" dur="4" oct="2" pname="c" stem.dir="down" accid.ges="n" />
                        </layer>
                     </staff>
                     <slur xml:id="bow-0008-10300-12550" startid="#note-0008-10250-12600-2" endid="#note-0008-10350-12560-2" curvedir="above" />
                     <pedal xml:id="ph0kwwv" staff="2" tstamp="1.000000" dir="down" place="below" vgrp="80" />
                     <pedal xml:id="pjskz71" staff="2" tstamp="2.900000" dir="up" place="below" vgrp="80" />
                     <pedal xml:id="p3wmhv6" staff="2" tstamp="4.000000" dir="down" place="below" vgrp="80" />
                     <pedal xml:id="pjqk5qu" staff="2" tstamp="5.900000" dir="up" place="below" vgrp="80" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

There is a new auto detection for slurs which layers to avoid. Additionally, a single layer to avoid can now be prescribed in MEI.

The example above displays a typical two layer situation. The upper voice is on layer 5 while the lower voice is on layer 6.
<img width="500" alt="Layers1" src="https://user-images.githubusercontent.com/63608463/141092490-f72b3e0b-27d8-4229-9cf0-ac874c18521c.png">
If the layers are separable on the slur span (as indicated by the red line), then the slur on the lower voice only avoids the content of the lower layer.

If we change the example a little bit, then separation is not possible and the slur avoids both layers:
<img width="500" alt="Layers2" src="https://user-images.githubusercontent.com/63608463/141092655-62d902ab-3253-498c-8eb3-adb05b096d36.png">
However, it is now possible to use `layer="6"` on the slur. The slur then only avoids the prescribed layer:
<img width="500" alt="Layers3" src="https://user-images.githubusercontent.com/63608463/141092758-b41c05af-30f3-4551-a9de-48da9f53725e.png">

 