### PR TITLE
Activate att.staffLoc on accid

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -45,6 +45,9 @@ public:
     std::string GetClassName() const override { return "Accid"; }
     ///@}
 
+    /** Override the method since it is align to the staff */
+    bool IsRelativeToStaff() const override { return (this->HasLoc() || (this->HasOloc() && this->HasPloc())); }
+
     PositionInterface *GetPositionInterface() override { return dynamic_cast<PositionInterface *>(this); }
 
     /** Override the method since alignment is required */

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1190,7 +1190,7 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 m_alignment->AddToAccidSpace(accid);
         }
         else if (this->GetFirstAncestor(CUSTOS)) {
-            m_alignment->AddToAccidSpace(accid); // If this is not added, the custos is drawn an octave below the custos
+            m_alignment->AddToAccidSpace(accid); // If this is not added, the accidental is drawn an octave below the custos
         }
         else {
             // do something for accid that are not children of a note - e.g., mensural?

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1190,7 +1190,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
                 m_alignment->AddToAccidSpace(accid);
         }
         else if (this->GetFirstAncestor(CUSTOS)) {
-            m_alignment->AddToAccidSpace(accid); // If this is not added, the accidental is drawn an octave below the custos
+            m_alignment->AddToAccidSpace(
+                accid); // If this is not added, the accidental is drawn an octave below the custos
         }
         else {
             // do something for accid that are not children of a note - e.g., mensural?
@@ -1198,7 +1199,8 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
         }
         // override if staff position is set explicitly
         if (accid->HasPloc() && accid->HasOloc()) {
-            accid->SetDrawingLoc(PitchInterface::CalcLoc(accid->GetPloc(), accid->GetOloc(), layerY->GetClefLocOffset(layerElementY)));
+            accid->SetDrawingLoc(
+                PitchInterface::CalcLoc(accid->GetPloc(), accid->GetOloc(), layerY->GetClefLocOffset(layerElementY)));
             this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, accid->GetDrawingLoc()));
         }
         else if (accid->HasLoc()) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1189,17 +1189,21 @@ int LayerElement::SetAlignmentPitchPos(FunctorParams *functorParams)
             else
                 m_alignment->AddToAccidSpace(accid);
         }
+        else if (this->GetFirstAncestor(CUSTOS)) {
+            m_alignment->AddToAccidSpace(accid); // If this is not added, the custos is drawn an octave below the custos
+        }
         else {
-            Custos *custos = vrv_cast<Custos *>(this->GetFirstAncestor(CUSTOS));
-            if (custos) {
-                m_alignment->AddToAccidSpace(
-                    accid); // If this is not added, the custos is drawn an octave below the custos
-            }
-            else {
-                // do something for accid that are not children of a note - e.g., mensural?
-                this->SetDrawingYRel(
-                    staffY->CalcPitchPosYRel(params->m_doc, accid->CalcDrawingLoc(layerY, layerElementY)));
-            }
+            // do something for accid that are not children of a note - e.g., mensural?
+            this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, accid->CalcDrawingLoc(layerY, layerElementY)));
+        }
+        // override if staff position is set explicitly
+        if (accid->HasPloc() && accid->HasOloc()) {
+            accid->SetDrawingLoc(PitchInterface::CalcLoc(accid->GetPloc(), accid->GetOloc(), layerY->GetClefLocOffset(layerElementY)));
+            this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, accid->GetDrawingLoc()));
+        }
+        else if (accid->HasLoc()) {
+            accid->SetDrawingLoc(accid->GetLoc());
+            this->SetDrawingYRel(staffY->CalcPitchPosYRel(params->m_doc, accid->GetLoc()));
         }
     }
     else if (this->Is(CHORD)) {


### PR DESCRIPTION
This activates support for `@loc` and `@oloc`/`@ploc` on `accid`.

![accid-010](https://user-images.githubusercontent.com/7693447/141120119-61c495b1-7831-45a7-b892-7b611102966b.png)

```xml
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Accidental locations</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
            </respStmt>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="invis">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="c" loc="1">
                              <accid accid="bms" ploc="f" oloc="4" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="kms" ploc="a" oloc="4" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="bs" ploc="c" oloc="5" />
                           </note>
                           <note dur="4" oct="5" pname="c" loc="0">
                              <accid accid="ks" loc="2" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="kf" loc="3" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="bf" loc="8" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="kmf" loc="7" />
                           </note>
                           <note dur="4" oct="5" pname="c">
                              <accid accid="bmf" />
                           </note>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
