### PR TITLE
Enforce minimal white space between systems

### DIFF
--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -282,7 +282,7 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
 
     // This should never happen because we always have at least barline alignments - even empty
     if (!previousAlignment || !nextAlignment) {
-        LogDebug("No aligment found before and after the clef change");
+        LogDebug("No alignment found before and after the clef change");
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1821,7 +1821,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     int selfLeft;
     const int drawingUnit = params->m_doc->GetDrawingUnit(params->m_staffSize);
 
-    // Nested aligment of bounding boxes is performed only when both the previous alignment and
+    // Nested alignment of bounding boxes is performed only when both the previous alignment and
     // the current one allow it. For example, when one of them is a barline, we do not look how
     // bounding boxes can be nested but instead only look at the horizontal position
     bool performBoundingBoxAlignment = (params->m_previousAlignment.m_alignment

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -491,7 +491,7 @@ void Page::LayOutVertically()
     AdjustFloatingPositionersParams adjustFloatingPositionersParams(doc, &adjustFloatingPositioners);
     this->Process(&adjustFloatingPositioners, &adjustFloatingPositionersParams);
 
-    // Adjust the overlap of the staff aligments by looking at the overflow bounding boxes params.clear();
+    // Adjust the overlap of the staff alignments by looking at the overflow bounding boxes
     Functor adjustStaffOverlap(&Object::AdjustStaffOverlap);
     AdjustStaffOverlapParams adjustStaffOverlapParams(doc, &adjustStaffOverlap);
     this->Process(&adjustStaffOverlap, &adjustStaffOverlapParams);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1039,7 +1039,9 @@ int StaffAlignment::AdjustYPos(FunctorParams *functorParams)
     const int minSpacing = CalcMinimumRequiredSpacing(params->m_doc);
 
     if (m_spacingType == SystemAligner::SpacingType::System) {
-        params->m_cumulatedShift += minSpacing;
+        // Ensure minimal white space between consecutive systems by adding one staff space
+        const int unit = params->m_doc->GetDrawingUnit(GetStaffSize());
+        params->m_cumulatedShift += minSpacing + 2 * unit;
     }
     else if (minSpacing > defaultSpacing) {
         params->m_cumulatedShift += minSpacing - defaultSpacing;


### PR DESCRIPTION
This PR ensures that there is a minimal white space of vertically one staff space between consecutive systems. This prevents the content below (pedal lines, slurs) from being very close to the content above of the following system (slurs, ottava lines). Before this sometimes happened (even with vertical justification).

| Before | After |
| ------ | ----- |
| <img width="645" alt="Before" src="https://user-images.githubusercontent.com/63608463/141128028-c53fb5ba-e48e-4dcd-8cf4-019675568d6b.png"> | <img width="624" alt="After" src="https://user-images.githubusercontent.com/63608463/141129387-e8053d55-2389-4316-8b7f-2b9d2e6460ff.png"> |
 