### PR TITLE
Fix articulation size

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -298,7 +298,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int x = artic->GetDrawingX();
     int y = artic->GetDrawingY();
 
-    const bool drawingCueSize = true;
+    const bool drawingCueSize = artic->GetDrawingCueSize();
 
     dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, drawingCueSize));
 


### PR DESCRIPTION
As @craigsapp pointed out in #2475 staccato dots are too small, which caught my attention, because this is not a font issue. 
Interestingly all articulation was hard coded to cue size, which I removed now.

See example `artic-001` from the test suite with Leland music font:
### before
![artic-leland](https://user-images.githubusercontent.com/7693447/141139345-ae6476bc-4196-41c0-bb1d-fe1dddb371ae.png)
### after
![artic-leland-new](https://user-images.githubusercontent.com/7693447/141139301-00f14681-dc32-4e61-bcd6-e0100af9b303.png)
