### PR TITLE
fix articulation size on cue notes

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1994,7 +1994,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
             if (note) m_drawingCueSize = note->GetDrawingCueSize();
         }
     }
-    else if (this->Is({ DOTS, FLAG, STEM })) {
+    else if (this->Is({ ARTIC, DOTS, FLAG, STEM })) {
         Note *note = dynamic_cast<Note *>(this->GetFirstAncestor(NOTE, MAX_NOTE_DEPTH));
         if (note)
             m_drawingCueSize = note->GetDrawingCueSize();


### PR DESCRIPTION
Minor follow up to #2479 in order to scale articulation properly to note size.