### PR TITLE
Slurs at system break

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -13,6 +13,7 @@
 
 namespace vrv {
 
+class Chord;
 class Doc;
 class Layer;
 class Staff;
@@ -113,6 +114,17 @@ public:
     int ResetDrawing(FunctorParams *functorParams) override;
 
 private:
+    /**
+     * Helper for calculating the initial slur start and end points
+     */
+    ///@{
+    // Retrieve the start and end note locations of the slur
+    std::pair<int, int> GetStartEndLocs(
+        Note *startNote, Chord *startChord, Note *endNote, Chord *endChord, curvature_CURVEDIR dir) const;
+    // Calculate the break location at system start/end
+    int CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, curvature_CURVEDIR dir) const;
+    ///@}
+
     /**
      * Adjust slur position based on overlapping objects within its spanning elements
      */

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -121,8 +121,8 @@ private:
     // Retrieve the start and end note locations of the slur
     std::pair<int, int> GetStartEndLocs(
         Note *startNote, Chord *startChord, Note *endNote, Chord *endChord, curvature_CURVEDIR dir) const;
-    // Calculate the break location at system start/end
-    int CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, curvature_CURVEDIR dir) const;
+    // Calculate the break location at system start/end and the pitch difference
+    std::pair<int, int> CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, curvature_CURVEDIR dir) const;
     ///@}
 
     /**

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1112,23 +1112,22 @@ int Slur::CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, curvature_CURVED
     int brokenLoc = 0;
     if (dir == curvature_CURVEDIR_above) {
         const int staffTopLoc = 2 * (staff->m_drawingLines - 1);
-        const int midLoc = (std::max(startLoc, staffTopLoc) + std::max(endLoc, staffTopLoc)) / 2;
-        brokenLoc = std::max(midLoc, staffTopLoc + 2);
+        brokenLoc = (std::max(startLoc, staffTopLoc - 1) + std::max(endLoc, staffTopLoc - 1)) / 2;
     }
     else {
-        const int midLoc = (std::min(startLoc, 0) + std::min(endLoc, 0)) / 2;
-        brokenLoc = std::min(midLoc, -2);
+        brokenLoc = (std::min(startLoc, 1) + std::min(endLoc, 1)) / 2;
     }
 
     // Make sure that broken slurs do not look like ties
     const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
     for (int loc : { startLoc, endLoc }) {
-        if (std::abs(brokenLoc - loc) < 3) {
-            brokenLoc = loc + 3 * sign;
+        if (std::abs(brokenLoc - loc) < 2) {
+            brokenLoc = loc + 2 * sign;
         }
     }
 
-    return brokenLoc;
+    // Move position one unit outwards to match the upper/lower boundary of the corresponding note
+    return brokenLoc + sign;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves the vertical location of slur start and end points at system breaks. It is now influenced by the start and end pitch of the slur. Moreover, slurs at system breaks should not look like broken ties.

| Before | After |
| ------ | ----- |
| <img width="341" alt="Before1" src="https://user-images.githubusercontent.com/63608463/141426026-06e83ff4-050a-45dd-9fb8-ec4f69c89b58.png"> | <img width="343" alt="After1" src="https://user-images.githubusercontent.com/63608463/141426060-d7376c4d-fcd0-4450-94e3-91a799aa609b.png"> |
| <img width="342" alt="Before2" src="https://user-images.githubusercontent.com/63608463/141426101-34cad58b-276a-4509-ba3a-ac64d2138d70.png"> | <img width="347" alt="After2" src="https://user-images.githubusercontent.com/63608463/141426132-eb364b4d-5c4c-4fb7-8139-9108afccfda0.png"> |
| <img width="331" alt="Before3" src="https://user-images.githubusercontent.com/63608463/141426170-d69b1aff-35c1-4fb2-b034-5d024d4c6c39.png"> | <img width="340" alt="After3" src="https://user-images.githubusercontent.com/63608463/141426193-85340b66-7bce-4a71-a874-8826e5756b12.png"> |

All examples are a variation of the following MEI rendered with width 500.
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title />
            </titleStmt>
            <pubStmt />
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application isodate="2019-02-22T12:53:07" version="2.1.0-dev-f91c387">
                    <name>Verovio</name>
                    <p>Transcoded from Humdrum</p>
                </application>
            </appInfo>
        </encodingDesc>
        <workList>
            <work>
                <title />
            </work>
        </workList>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mdiv-0000000934020078">
                <score xml:id="score-0000001585897020">
                    <scoreDef xml:id="scoredef-0000001578636833">
                        <staffGrp xml:id="staffgrp-0000000535654688">
                            <staffDef xml:id="staffdef-0000000078919290" clef.shape="G" clef.line="2" n="1" lines="5">
                                <label xml:id="label-0000000895705575" />
                            </staffDef>
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="section-L1F1">
                        <measure xml:id="measure-L3">
                            <staff xml:id="staff-L3F1N1" n="1">
                                <layer xml:id="layer-L3F1N1" n="1">
                                    <rest xml:id="rest-L4F1" dur="4" />
                                    <rest xml:id="rest-L5F1" dur="4" />
                                    <rest xml:id="rest-L6F1" dur="4" />
                                    <note xml:id="note-L7F1" dur="4" oct="6" pname="e" accid.ges="n" />
                                </layer>
                            </staff>
                            <slur xml:id="slur-L7F1-L10F1" staff="1" startid="#note-L7F1" endid="#note-L10F1" />
                        </measure>
                        <measure xml:id="measure-L8">
                            <staff xml:id="staff-L8F1N1" n="1">
                                <layer xml:id="layer-L8F1N1" n="1">
                                    <beam xml:id="beam-L9F1-L10F1">
                                        <note xml:id="note-L9F1" dur="8" oct="5" pname="f" accid.ges="n" />
                                        <note xml:id="note-L10F1" dur="8" oct="4" pname="e" accid.ges="n" />
                                    </beam>
                                    <rest xml:id="rest-L11F1" dur="4" />
                                    <rest xml:id="rest-L12F1" dur="4" />
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
</details>
 