### PR TITLE
Adjust grace note placement with regards to accidentals

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -185,6 +185,11 @@ public:
         double intervalTime, int maxActualDur, double spacingLinear, double spacingNonLinear);
 
     /**
+     * Return true if there is vertical overlap with accidentals from another alignment for specific staffN
+     */
+    bool HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN);
+
+    /**
      * Return true if the alignment contains at least one reference with staffN
      */
     bool HasAlignmentReference(int staffN);
@@ -320,6 +325,11 @@ public:
      * See Object::AjustAccidX
      */
     void AdjustAccidWithAccidSpace(Accid *accid, Doc *doc, int staffSize, std::vector<Accid *> &adjustedAccids);
+
+    /**
+     * Return true if one of objects overlaps with accidentals from current reference (i.e. if there are accidentals)
+     */
+    bool HasAccidVerticalOverlap(const ArrayOfObjects *objects);
 
     /**
      * Return true if the reference has elements from multiple layers.

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -477,6 +477,18 @@ bool Alignment::IsSupportedChild(Object *child)
     return true;
 }
 
+bool Alignment::HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN)
+{
+    AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
+    // get alignment references for both alignments
+    AlignmentReference *currentRef = vrv_cast<AlignmentReference *>(this->FindDescendantByComparison(&matchStaff, 1));
+    AlignmentReference *otherRef
+        = vrv_cast<AlignmentReference *>(otherAlignment->FindDescendantByComparison(&matchStaff, 1));
+    if (!currentRef || !otherRef) return false;
+
+    return otherRef->HasAccidVerticalOverlap(currentRef->GetChildren());
+}
+
 bool Alignment::HasAlignmentReference(int staffN)
 {
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
@@ -757,6 +769,19 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
         adjustedAccids.push_back(accid);
 }
 
+bool AlignmentReference::HasAccidVerticalOverlap(const ArrayOfObjects *objects)
+{
+    for (const auto child : *this->GetChildren()) {
+        if (!child->Is(ACCID)) continue;
+        Accid *accid = vrv_cast<Accid *>(child);
+        if (!accid->HasAccid()) continue;
+        for (const auto object : *objects) {
+            if (accid->VerticalContentOverlap(object)) return true;
+        }
+    }
+    return false;
+}
+
 //----------------------------------------------------------------------------
 // TimestampAligner
 //----------------------------------------------------------------------------
@@ -964,6 +989,18 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
         std::vector<int>::iterator iter;
         ArrayOfComparisons filters;
         for (iter = params->m_staffNs.begin(); iter != params->m_staffNs.end(); ++iter) {
+            const int graceAlignerId = params->m_doc->GetOptions()->m_graceRhythmAlign.GetValue() ? 0 : *iter;
+
+            std::vector<ClassId> exclude;
+            if (HasGraceAligner(graceAlignerId)) {
+                GraceAligner *graceAligner = GetGraceAligner(graceAlignerId);
+                // last alignment of GraceAligner is rightmost one, so get it
+                Alignment *alignment = vrv_cast<Alignment *>(graceAligner->GetLast(ALIGNMENT));
+                // if there is no overlap with accidentals, exclude them when getting left-right margins of alignment
+                if (!alignment->HasAccidVerticalOverlap(params->m_rightDefaultAlignment, graceAlignerId)) {
+                    exclude.push_back(ACCID);
+                }
+            }
 
             // Rescue value, used at the end of a measure without a barline
             int graceMaxPos = this->GetXRel() - params->m_doc->GetDrawingUnit(100);
@@ -971,7 +1008,7 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
             // Get its minimum left and make it the max right position of the grace group
             if (params->m_rightDefaultAlignment) {
                 int minLeft, maxRight;
-                params->m_rightDefaultAlignment->GetLeftRight(*iter, minLeft, maxRight);
+                params->m_rightDefaultAlignment->GetLeftRight(*iter, minLeft, maxRight, exclude);
                 if (minLeft != -VRV_UNSET)
                     graceMaxPos = minLeft - params->m_doc->GetLeftMargin(NOTE) * params->m_doc->GetDrawingUnit(75);
             }
@@ -980,7 +1017,8 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
                 int minLeft, maxRight;
                 assert(measureAligner->GetRightBarLineAlignment());
                 // staffN -1 is barline
-                measureAligner->GetRightBarLineAlignment()->GetLeftRight(BARLINE_REFERENCES, minLeft, maxRight);
+                measureAligner->GetRightBarLineAlignment()->GetLeftRight(
+                    BARLINE_REFERENCES, minLeft, maxRight, exclude);
                 if (minLeft != -VRV_UNSET)
                     graceMaxPos = minLeft - params->m_doc->GetLeftMargin(NOTE) * params->m_doc->GetDrawingUnit(75);
             }
@@ -992,8 +1030,6 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
             // Create ad comparison object for each type / @n
             AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, (*iter));
             filters.push_back(&matchStaff);
-
-            int graceAlignerId = params->m_doc->GetOptions()->m_graceRhythmAlign.GetValue() ? 0 : *iter;
 
             if (HasGraceAligner(graceAlignerId)) {
                 GetGraceAligner(graceAlignerId)

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -479,6 +479,8 @@ bool Alignment::IsSupportedChild(Object *child)
 
 bool Alignment::HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN)
 {
+    if (!otherAlignment) return false;
+
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
     // get alignment references for both alignments
     AlignmentReference *currentRef = vrv_cast<AlignmentReference *>(this->FindDescendantByComparison(&matchStaff, 1));
@@ -992,8 +994,8 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
             const int graceAlignerId = params->m_doc->GetOptions()->m_graceRhythmAlign.GetValue() ? 0 : *iter;
 
             std::vector<ClassId> exclude;
-            if (HasGraceAligner(graceAlignerId)) {
-                GraceAligner *graceAligner = GetGraceAligner(graceAlignerId);
+            if (this->HasGraceAligner(graceAlignerId) && params->m_rightDefaultAlignment) {
+                GraceAligner *graceAligner = this->GetGraceAligner(graceAlignerId);
                 // last alignment of GraceAligner is rightmost one, so get it
                 Alignment *alignment = vrv_cast<Alignment *>(graceAligner->GetLast(ALIGNMENT));
                 // if there is no overlap with accidentals, exclude them when getting left-right margins of alignment

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -997,7 +997,7 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
                 // last alignment of GraceAligner is rightmost one, so get it
                 Alignment *alignment = vrv_cast<Alignment *>(graceAligner->GetLast(ALIGNMENT));
                 // if there is no overlap with accidentals, exclude them when getting left-right margins of alignment
-                if (!alignment->HasAccidVerticalOverlap(params->m_rightDefaultAlignment, graceAlignerId)) {
+                if (alignment && !alignment->HasAccidVerticalOverlap(params->m_rightDefaultAlignment, graceAlignerId)) {
                     exclude.push_back(ACCID);
                 }
             }


### PR DESCRIPTION
- excluded accidentals from overlaps with grace notes if they do not overlap vertically with them

closes #1811 

No overlap:
![image](https://user-images.githubusercontent.com/1819669/141781742-014025a8-2880-43f0-9e06-27ac00110494.png)

Overlap:
![image](https://user-images.githubusercontent.com/1819669/141781790-252fbd4a-5338-4b8b-8b1d-3a38b3174b12.png)
