### PR TITLE
Adjust ledger flag overlap

### DIFF
--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -15,7 +15,6 @@
 
 #include "btrem.h"
 #include "chord.h"
-#include "comparison.h"
 #include "doc.h"
 #include "functorparams.h"
 #include "layer.h"
@@ -387,33 +386,6 @@ void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int vertical
         const int heightToAdjust = (displacementMargin / adjustmentStep - 1) * adjustmentStep * directionBias - offset;
         SetDrawingStemLen(GetDrawingStemLen() + heightToAdjust);
         flag->SetDrawingYRel(-GetDrawingStemLen());
-    }
-
-    // As separate case we need to account for possible overlaps of flag bottom part with ledger lines when stem has up
-    // direction (i.e. note to the right is being shifted closer to current note and ledger lines end up overlapping)
-    if (stemDirection == STEMDIRECTION_up) {
-        Layer *layer = vrv_cast<Layer *>(parent->GetFirstAncestor(LAYER));
-        assert(layer);
-        ClassIdsComparison cmp({NOTE, CHORD});
-        Object *object = layer->FindNextChild(&cmp, parent);
-        if (object) {
-            Note *nextNote = NULL;
-            if (object->Is(NOTE)) {
-                nextNote = vrv_cast<Note *>(object);
-            }
-            else if (object->Is(CHORD)) {
-                nextNote = vrv_cast<Chord *>(object)->GetTopNote();
-            }
-            if (nextNote && (nextNote->GetDrawingLoc() < note->GetDrawingLoc())) {
-                const int flagBottom = GetDrawingY() - GetDrawingStemLen() - glyphHeight;
-                const int margin = ledgerPosition - flagBottom;
-                if (margin > 0) {
-                    const int heightToAdjust = ((margin - 1) / adjustmentStep + 1) * adjustmentStep;
-                    SetDrawingStemLen(GetDrawingStemLen() - heightToAdjust);
-                    flag->SetDrawingYRel(-GetDrawingStemLen());
-                }
-            }
-        }
     }
 }
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -342,7 +342,6 @@ void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int vertical
     wchar_t flagGlyph = SMUFL_E242_flag16thUp;
     if (duration < DURATION_16) flagGlyph = flag->GetFlagGlyph(stemDirection);
     const int glyphHeight = doc->GetGlyphHeight(flagGlyph, staffSize, GetDrawingCueSize());
-    const int relevantGlyphHeight = (stemDirection == STEMDIRECTION_up) ? glyphHeight / 2 : glyphHeight;
 
     // Make sure that flags don't overlap with notehead. Upward flags cannot overlap with noteheads so check
     // only downward ones
@@ -374,7 +373,7 @@ void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int vertical
 
     // Make sure that flags don't overlap with first (top or bottom) ledger line (effectively avoiding all ledgers)
     const int directionBias = (stemDirection == STEMDIRECTION_down) ? -1 : 1;
-    const int position = GetDrawingY() - GetDrawingStemLen() - directionBias * relevantGlyphHeight;
+    const int position = GetDrawingY() - GetDrawingStemLen() - directionBias * glyphHeight;
     const int ledgerPosition = verticalCenter - 6 * directionBias * adjustmentStep;
     const int displacementMargin = (position - ledgerPosition) * directionBias;
 


### PR DESCRIPTION
In some case flags on notes with up stem direction would overlap with ledger lines still:
![image](https://user-images.githubusercontent.com/1819669/141782155-72a59fae-3dca-44cb-b7fd-6da03de151ac.png)

Made small adjustment to make sure that this no longer happens - instead of taking middle point of flag (anchor point on the stem), endpoint of the flag is now being compared to the ledger lines. Previously it was done only for notes with down stem direction and now we doing same calculation for both directions.

No more overlaps:
![image](https://user-images.githubusercontent.com/1819669/141782447-1a584ff2-940a-444b-a06e-d7bd6e35b204.png)
