### PR TITLE
Develop mensural

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -75,7 +75,7 @@ public:
      * Retrieve SMuFL string for the accidental.
      * This will include brackets
      */
-    std::wstring GetSymbolStr(const data_NOTATIONTYPE) const;
+    std::wstring GetSymbolStr(const data_NOTATIONTYPE notationType) const;
 
     /**
      * Adjust X position of accid in relation to other element

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -75,7 +75,7 @@ public:
      * Retrieve SMuFL string for the accidental.
      * This will include brackets
      */
-    std::wstring GetSymbolStr(data_NOTATIONTYPE) const;
+    std::wstring GetSymbolStr(const data_NOTATIONTYPE) const;
 
     /**
      * Adjust X position of accid in relation to other element

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -75,7 +75,7 @@ public:
      * Retrieve SMuFL string for the accidental.
      * This will include brackets
      */
-    std::wstring GetSymbolStr() const;
+    std::wstring GetSymbolStr(data_NOTATIONTYPE) const;
 
     /**
      * Adjust X position of accid in relation to other element

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -62,7 +62,7 @@ public:
     /**
      * Retrieves the appropriate SMuFL code for a data_CLEFSHAPE
      */
-    wchar_t GetClefGlyph(data_NOTATIONTYPE) const;
+    wchar_t GetClefGlyph(const data_NOTATIONTYPE) const;
 
     //----------//
     // Functors //

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -62,7 +62,7 @@ public:
     /**
      * Retrieves the appropriate SMuFL code for a data_CLEFSHAPE
      */
-    wchar_t GetClefGlyph(const data_NOTATIONTYPE) const;
+    wchar_t GetClefGlyph(const data_NOTATIONTYPE notationType) const;
 
     //----------//
     // Functors //

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -21,7 +21,8 @@ namespace vrv {
 // Custos
 //----------------------------------------------------------------------------
 
-class Custos : public LayerElement, public PitchInterface, public PositionInterface, public AttColor {
+class Custos : public LayerElement, public PitchInterface, public PositionInterface, public AttColor, public AttExtSym
+{
 public:
     /**
      * @name Constructors, destructors, and other standard methods
@@ -49,6 +50,11 @@ public:
      * Add an accid to a custos.
      */
     bool IsSupportedChild(Object *object) override;
+
+    /**
+     * Return a SMuFL code for the custos
+     */
+    wchar_t GetCustosGlyph(const data_NOTATIONTYPE) const;
 
     //----------//
     // Functors //

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -21,8 +21,7 @@ namespace vrv {
 // Custos
 //----------------------------------------------------------------------------
 
-class Custos : public LayerElement, public PitchInterface, public PositionInterface, public AttColor, public AttExtSym
-{
+class Custos : public LayerElement, public PitchInterface, public PositionInterface, public AttColor, public AttExtSym {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -53,7 +53,7 @@ public:
     /**
      * Return a SMuFL code for the custos
      */
-    wchar_t GetCustosGlyph(const data_NOTATIONTYPE) const;
+    wchar_t GetCustosGlyph(const data_NOTATIONTYPE notationType) const;
 
     //----------//
     // Functors //

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -66,7 +66,7 @@ void Accid::Reset()
     m_drawingUnison = NULL;
 }
 
-std::wstring Accid::GetSymbolStr() const
+std::wstring Accid::GetSymbolStr(data_NOTATIONTYPE notationType) const
 {
     if (!this->HasAccid()) return L"";
 
@@ -82,10 +82,20 @@ std::wstring Accid::GetSymbolStr() const
         wchar_t code = Resources::GetGlyphCode(GetGlyphName());
         if (NULL == Resources::GetGlyph(code)) code = 0;
     }
+    else {
+        switch (notationType) {
+            case NOTATIONTYPE_mensural:
+            case NOTATIONTYPE_mensural_black:
+            case NOTATIONTYPE_mensural_white:
+                code = (GetAccid() == ACCIDENTAL_WRITTEN_f)? SMUFL_E9E0_medRenFlatSoftB : SMUFL_E9E3_medRenSharpCroix;
+                break;
+                
+            default:
+                code = GetAccidGlyph(GetAccid()); break;
+        }
+    }
 
-    if (code == 0) code = GetAccidGlyph(this->GetAccid());
     std::wstring symbolStr;
-
     if (this->HasEnclose()) {
         if (this->GetEnclose() == ENCLOSURE_brack) {
             symbolStr.push_back(SMUFL_E26C_accidentalBracketLeft);
@@ -199,41 +209,40 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
 
 wchar_t Accid::GetAccidGlyph(data_ACCIDENTAL_WRITTEN accid)
 {
-    int symc = SMUFL_E261_accidentalNatural;
     switch (accid) {
-        case ACCIDENTAL_WRITTEN_s: symc = SMUFL_E262_accidentalSharp; break;
-        case ACCIDENTAL_WRITTEN_f: symc = SMUFL_E260_accidentalFlat; break;
-        case ACCIDENTAL_WRITTEN_ss: symc = SMUFL_E269_accidentalSharpSharp; break;
-        case ACCIDENTAL_WRITTEN_x: symc = SMUFL_E263_accidentalDoubleSharp; break;
-        case ACCIDENTAL_WRITTEN_ff: symc = SMUFL_E264_accidentalDoubleFlat; break;
-        case ACCIDENTAL_WRITTEN_sx: symc = SMUFL_E265_accidentalTripleSharp; break; // Missing in SMuFL
-        case ACCIDENTAL_WRITTEN_xs: symc = SMUFL_E265_accidentalTripleSharp; break;
-        case ACCIDENTAL_WRITTEN_ts: symc = SMUFL_E265_accidentalTripleSharp; break; // Missing in SMuFL
-        case ACCIDENTAL_WRITTEN_tf: symc = SMUFL_E266_accidentalTripleFlat; break;
-        case ACCIDENTAL_WRITTEN_n: symc = SMUFL_E261_accidentalNatural; break;
-        case ACCIDENTAL_WRITTEN_nf: symc = SMUFL_E267_accidentalNaturalFlat; break;
-        case ACCIDENTAL_WRITTEN_ns: symc = SMUFL_E268_accidentalNaturalSharp; break;
-        case ACCIDENTAL_WRITTEN_su: symc = SMUFL_E274_accidentalThreeQuarterTonesSharpArrowUp; break;
-        case ACCIDENTAL_WRITTEN_sd: symc = SMUFL_E275_accidentalQuarterToneSharpArrowDown; break;
-        case ACCIDENTAL_WRITTEN_fu: symc = SMUFL_E270_accidentalQuarterToneFlatArrowUp; break;
-        case ACCIDENTAL_WRITTEN_fd: symc = SMUFL_E271_accidentalThreeQuarterTonesFlatArrowDown; break;
-        case ACCIDENTAL_WRITTEN_nu: symc = SMUFL_E272_accidentalQuarterToneSharpNaturalArrowUp; break;
-        case ACCIDENTAL_WRITTEN_nd: symc = SMUFL_E273_accidentalQuarterToneFlatNaturalArrowDown; break;
-        case ACCIDENTAL_WRITTEN_1qf: symc = SMUFL_E280_accidentalQuarterToneFlatStein; break;
-        case ACCIDENTAL_WRITTEN_3qf: symc = SMUFL_E281_accidentalThreeQuarterTonesFlatZimmermann; break;
-        case ACCIDENTAL_WRITTEN_1qs: symc = SMUFL_E282_accidentalQuarterToneSharpStein; break;
-        case ACCIDENTAL_WRITTEN_3qs: symc = SMUFL_E283_accidentalThreeQuarterTonesSharpStein; break;
-        case ACCIDENTAL_WRITTEN_bms: symc = SMUFL_E447_accidentalBuyukMucennebSharp; break;
-        case ACCIDENTAL_WRITTEN_kms: symc = SMUFL_E446_accidentalKucukMucennebSharp; break;
-        case ACCIDENTAL_WRITTEN_bs: symc = SMUFL_E445_accidentalBakiyeSharp; break;
-        case ACCIDENTAL_WRITTEN_ks: symc = SMUFL_E444_accidentalKomaSharp; break;
-        case ACCIDENTAL_WRITTEN_kf: symc = SMUFL_E443_accidentalKomaFlat; break;
-        case ACCIDENTAL_WRITTEN_bf: symc = SMUFL_E442_accidentalBakiyeFlat; break;
-        case ACCIDENTAL_WRITTEN_kmf: symc = SMUFL_E441_accidentalKucukMucennebFlat; break;
-        case ACCIDENTAL_WRITTEN_bmf: symc = SMUFL_E440_accidentalBuyukMucennebFlat; break;
+        case ACCIDENTAL_WRITTEN_s: return SMUFL_E262_accidentalSharp; break;
+        case ACCIDENTAL_WRITTEN_f: return SMUFL_E260_accidentalFlat; break;
+        case ACCIDENTAL_WRITTEN_ss: return SMUFL_E269_accidentalSharpSharp; break;
+        case ACCIDENTAL_WRITTEN_x: return SMUFL_E263_accidentalDoubleSharp; break;
+        case ACCIDENTAL_WRITTEN_ff: return SMUFL_E264_accidentalDoubleFlat; break;
+        case ACCIDENTAL_WRITTEN_sx: return SMUFL_E265_accidentalTripleSharp; break; // Missing in SMuFL
+        case ACCIDENTAL_WRITTEN_xs: return SMUFL_E265_accidentalTripleSharp; break;
+        case ACCIDENTAL_WRITTEN_ts: return SMUFL_E265_accidentalTripleSharp; break; // Missing in SMuFL
+        case ACCIDENTAL_WRITTEN_tf: return SMUFL_E266_accidentalTripleFlat; break;
+        case ACCIDENTAL_WRITTEN_n: return SMUFL_E261_accidentalNatural; break;
+        case ACCIDENTAL_WRITTEN_nf: return SMUFL_E267_accidentalNaturalFlat; break;
+        case ACCIDENTAL_WRITTEN_ns: return SMUFL_E268_accidentalNaturalSharp; break;
+        case ACCIDENTAL_WRITTEN_su: return SMUFL_E274_accidentalThreeQuarterTonesSharpArrowUp; break;
+        case ACCIDENTAL_WRITTEN_sd: return SMUFL_E275_accidentalQuarterToneSharpArrowDown; break;
+        case ACCIDENTAL_WRITTEN_fu: return SMUFL_E270_accidentalQuarterToneFlatArrowUp; break;
+        case ACCIDENTAL_WRITTEN_fd: return SMUFL_E271_accidentalThreeQuarterTonesFlatArrowDown; break;
+        case ACCIDENTAL_WRITTEN_nu: return SMUFL_E272_accidentalQuarterToneSharpNaturalArrowUp; break;
+        case ACCIDENTAL_WRITTEN_nd: return SMUFL_E273_accidentalQuarterToneFlatNaturalArrowDown; break;
+        case ACCIDENTAL_WRITTEN_1qf: return SMUFL_E280_accidentalQuarterToneFlatStein; break;
+        case ACCIDENTAL_WRITTEN_3qf: return SMUFL_E281_accidentalThreeQuarterTonesFlatZimmermann; break;
+        case ACCIDENTAL_WRITTEN_1qs: return SMUFL_E282_accidentalQuarterToneSharpStein; break;
+        case ACCIDENTAL_WRITTEN_3qs: return SMUFL_E283_accidentalThreeQuarterTonesSharpStein; break;
+        case ACCIDENTAL_WRITTEN_bms: return SMUFL_E447_accidentalBuyukMucennebSharp; break;
+        case ACCIDENTAL_WRITTEN_kms: return SMUFL_E446_accidentalKucukMucennebSharp; break;
+        case ACCIDENTAL_WRITTEN_bs: return SMUFL_E445_accidentalBakiyeSharp; break;
+        case ACCIDENTAL_WRITTEN_ks: return SMUFL_E444_accidentalKomaSharp; break;
+        case ACCIDENTAL_WRITTEN_kf: return SMUFL_E443_accidentalKomaFlat; break;
+        case ACCIDENTAL_WRITTEN_bf: return SMUFL_E442_accidentalBakiyeFlat; break;
+        case ACCIDENTAL_WRITTEN_kmf: return SMUFL_E441_accidentalKucukMucennebFlat; break;
+        case ACCIDENTAL_WRITTEN_bmf: return SMUFL_E440_accidentalBuyukMucennebFlat; break;
         default: break;
     }
-    return symc;
+    return 0;
 }
 
 //----------------------------------------------------------------------------

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -66,7 +66,7 @@ void Accid::Reset()
     m_drawingUnison = NULL;
 }
 
-std::wstring Accid::GetSymbolStr(data_NOTATIONTYPE notationType) const
+std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const
 {
     if (!this->HasAccid()) return L"";
 

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -87,11 +87,15 @@ std::wstring Accid::GetSymbolStr(data_NOTATIONTYPE notationType) const
             case NOTATIONTYPE_mensural:
             case NOTATIONTYPE_mensural_black:
             case NOTATIONTYPE_mensural_white:
-                code = (GetAccid() == ACCIDENTAL_WRITTEN_f)? SMUFL_E9E0_medRenFlatSoftB : SMUFL_E9E3_medRenSharpCroix;
+                switch (GetAccid()) {
+                    case ACCIDENTAL_WRITTEN_s: code = SMUFL_E9E3_medRenSharpCroix; break;
+                    case ACCIDENTAL_WRITTEN_f: code = SMUFL_E9E0_medRenFlatSoftB; break;
+                    case ACCIDENTAL_WRITTEN_n: code = SMUFL_E9E2_medRenNatural; break;
+                    // we do not want to ignore non-mensural accidentals
+                    default: code = GetAccidGlyph(GetAccid()); break;
+                }
                 break;
-                
-            default:
-                code = GetAccidGlyph(GetAccid()); break;
+            default: code = GetAccidGlyph(GetAccid()); break;
         }
     }
 
@@ -159,7 +163,7 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
     if (element->Is(ACCID) && (this->GetDrawingY() == element->GetDrawingY())) {
         Accid *accid = vrv_cast<Accid *>(element);
         assert(accid);
-        if (this->GetSymbolStr() == accid->GetSymbolStr()) {
+        if (this->GetSymbolStr(NOTATIONTYPE_NONE) == accid->GetSymbolStr(NOTATIONTYPE_NONE)) {
             // There is the same accidental, so we leave it a the same place
             // This should also work for the chords on multiple layers by setting unison accidental
             accid->SetDrawingUnisonAccid(this);

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -282,7 +282,7 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
 
     // This should never happen because we always have at least barline alignments - even empty
     if (!previousAlignment || !nextAlignment) {
-        LogDebug("No aligment found before and after the clef change");
+        LogDebug("No alignment found before and after the clef change");
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -94,7 +94,7 @@ int Clef::GetClefLocOffset() const
 // Static methods for Clef
 //----------------------------------------------------------------------------
 
-wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
+wchar_t Clef::GetClefGlyph(const data_NOTATIONTYPE notationtype) const
 {
     // If there is glyph.num, prioritize it
     if (HasGlyphNum()) {
@@ -110,18 +110,18 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
     switch (notationtype) {
         case NOTATIONTYPE_neume:
             // neume clefs
-            return (this->GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;
+            return (GetShape() == CLEFSHAPE_F) ? SMUFL_E902_chantFclef : SMUFL_E906_chantCclef;
             break;
         case NOTATIONTYPE_mensural:
         case NOTATIONTYPE_mensural_white:
             // mensural clefs
-            switch (this->GetShape()) {
+            switch (GetShape()) {
                 case CLEFSHAPE_G: return SMUFL_E901_mensuralGclefPetrucci; break;
                 case CLEFSHAPE_F: return SMUFL_E904_mensuralFclefPetrucci; break;
                 default: return SMUFL_E909_mensuralCclefPetrucciPosMiddle; break;
             }
         case NOTATIONTYPE_mensural_black:
-            switch (this->GetShape()) {
+            switch (GetShape()) {
                 case CLEFSHAPE_C: return SMUFL_E906_chantCclef; break;
                 case CLEFSHAPE_F: return SMUFL_E902_chantFclef; break;
                 default:
@@ -131,9 +131,9 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
             [[fallthrough]];
         default:
             // cmn clefs
-            switch (this->GetShape()) {
+            switch (GetShape()) {
                 case CLEFSHAPE_G:
-                    switch (this->GetDis()) {
+                    switch (GetDis()) {
                         case OCTAVE_DIS_8:
                             return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E053_gClef8va
                                                                                  : SMUFL_E052_gClef8vb;
@@ -146,7 +146,7 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
                     }
                 case CLEFSHAPE_GG: return SMUFL_E055_gClef8vbOld;
                 case CLEFSHAPE_F:
-                    switch (this->GetDis()) {
+                    switch (GetDis()) {
                         case OCTAVE_DIS_8:
                             return (this->GetDisPlace() == STAFFREL_basic_above) ? SMUFL_E065_fClef8va
                                                                                  : SMUFL_E064_fClef8vb;
@@ -158,7 +158,7 @@ wchar_t Clef::GetClefGlyph(data_NOTATIONTYPE notationtype) const
                         default: return SMUFL_E062_fClef; break;
                     }
                 case CLEFSHAPE_C:
-                    switch (this->GetDis()) {
+                    switch (GetDis()) {
                         case OCTAVE_DIS_8: return SMUFL_E05D_cClef8vb; break;
                         default: return SMUFL_E05C_cClef; break;
                     }

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -23,11 +23,12 @@ namespace vrv {
 
 static const ClassRegistrar<Custos> s_factory("custos", CUSTOS);
 
-Custos::Custos() : LayerElement(CUSTOS, "custos-"), PitchInterface(), PositionInterface(), AttColor()
+Custos::Custos() : LayerElement(CUSTOS, "custos-"), PitchInterface(), PositionInterface(), AttColor(), AttExtSym()
 {
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     RegisterAttClass(ATT_COLOR);
+    RegisterAttClass(ATT_EXTSYM);
 
     Reset();
 }
@@ -40,6 +41,7 @@ void Custos::Reset()
     PitchInterface::Reset();
     PositionInterface::Reset();
     ResetColor();
+    ResetExtSym();
 }
 
 bool Custos::IsSupportedChild(Object *child)
@@ -51,6 +53,29 @@ bool Custos::IsSupportedChild(Object *child)
         return false;
     }
     return true;
+}
+
+wchar_t Custos::GetCustosGlyph(const data_NOTATIONTYPE notationtype) const
+{
+    // If there is glyph.num, prioritize it
+    if (HasGlyphNum()) {
+        wchar_t code = GetGlyphNum();
+        if (NULL != Resources::GetGlyph(code)) return code;
+    }
+    // If there is glyph.name (second priority)
+    else if (HasGlyphName()) {
+        wchar_t code = Resources::GetGlyphCode(GetGlyphName());
+        if (NULL != Resources::GetGlyph(code)) return code;
+    }
+    
+    switch (notationtype) {
+        case NOTATIONTYPE_neume:
+            return SMUFL_EA06_chantCustosStemUpPosMiddle; // chantCustosStemUpPosMiddle
+            break;
+        default:
+            return SMUFL_EA02_mensuralCustosUp; // mensuralCustosUp
+            break;
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -67,7 +67,7 @@ wchar_t Custos::GetCustosGlyph(const data_NOTATIONTYPE notationtype) const
         wchar_t code = Resources::GetGlyphCode(GetGlyphName());
         if (NULL != Resources::GetGlyph(code)) return code;
     }
-    
+
     switch (notationtype) {
         case NOTATIONTYPE_neume:
             return SMUFL_EA06_chantCustosStemUpPosMiddle; // chantCustosStemUpPosMiddle

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1759,6 +1759,7 @@ void MEIOutput::WriteCustos(pugi::xml_node currentNode, Custos *custos)
     WritePositionInterface(currentNode, custos);
     WriteLayerElement(currentNode, custos);
     custos->WriteColor(currentNode);
+    custos->WriteExtSym(currentNode);
 }
 
 void MEIOutput::WriteDot(pugi::xml_node currentNode, Dot *dot)
@@ -5352,6 +5353,7 @@ bool MEIInput::ReadCustos(Object *parent, pugi::xml_node custos)
     ReadPitchInterface(custos, vrvCustos);
     ReadPositionInterface(custos, vrvCustos);
     vrvCustos->ReadColor(custos);
+    vrvCustos->ReadExtSym(custos);
 
     ReadAccidAttr(custos, vrvCustos);
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1827,7 +1827,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     int selfLeft;
     const int drawingUnit = params->m_doc->GetDrawingUnit(params->m_staffSize);
 
-    // Nested aligment of bounding boxes is performed only when both the previous alignment and
+    // Nested alignment of bounding boxes is performed only when both the previous alignment and
     // the current one allow it. For example, when one of them is a barline, we do not look how
     // bounding boxes can be nested but instead only look at the horizontal position
     bool performBoundingBoxAlignment = (params->m_previousAlignment.m_alignment

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -492,7 +492,7 @@ void Page::LayOutVertically()
     AdjustFloatingPositionersParams adjustFloatingPositionersParams(doc, &adjustFloatingPositioners);
     this->Process(&adjustFloatingPositioners, &adjustFloatingPositionersParams);
 
-    // Adjust the overlap of the staff aligments by looking at the overflow bounding boxes params.clear();
+    // Adjust the overlap of the staff alignments by looking at the overflow bounding boxes params.clear();
     Functor adjustStaffOverlap(&Object::AdjustStaffOverlap);
     AdjustStaffOverlapParams adjustStaffOverlapParams(doc, &adjustStaffOverlap);
     this->Process(&adjustStaffOverlap, &adjustStaffOverlapParams);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -714,16 +714,8 @@ void View::DrawCustos(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int sym = 0;
     // Select glyph to use for this custos
-    switch (staff->m_drawingNotationType) {
-        case NOTATIONTYPE_neume:
-            sym = SMUFL_EA06_chantCustosStemUpPosMiddle; // chantCustosStemUpPosMiddle
-            break;
-        default:
-            sym = SMUFL_EA02_mensuralCustosUp; // mensuralCustosUp
-            break;
-    }
+    const int sym = custos->GetCustosGlyph(staff->m_drawingNotationType);
 
     int x, y;
     if (custos->HasFacs() && m_doc->GetType() == Facs) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -249,9 +249,8 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    /************** editorial accidental **************/
-
-    std::wstring accidStr = accid->GetSymbolStr();
+    const data_NOTATIONTYPE notationType = staff->m_drawingNotationType;
+    std::wstring accidStr = accid->GetSymbolStr(notationType);
 
     int x = accid->GetDrawingX();
     int y = accid->GetDrawingY();
@@ -271,7 +270,7 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         }
         TextExtend extend;
         dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, accid->GetDrawingCueSize()));
-        dc->GetSmuflTextExtent(accid->GetSymbolStr(), &extend);
+        dc->GetSmuflTextExtent(accid->GetSymbolStr(notationType), &extend);
         dc->ResetFont();
         y += extend.m_descent + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }


### PR DESCRIPTION
This PR changes default accidentals for mensural notation to use the glyphs from _Medieval and Renaissance accidentals_ range. And it adds support for `att.extSym` on `custos`, bringing it in line with corresponding methods. 
Additionally I made some small refinements.

![mensacc](https://user-images.githubusercontent.com/7693447/141813194-c24c12fc-b69e-4878-bb7b-293d23e1c1b8.png)

```xml
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Mensural accidentals</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2021-11-15">2021-11-15</date>
         </pubStmt>
         <notesStmt>
            <annot>Verovio uses appropriate glyphs for accidentals in mensural notation.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" notationtype="mensural" >
                        <clef shape="C" line="1"/>
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <note dur="semibrevis" oct="4" pname="f">
                           <accid accid="s" />
                        </note>
                        <note dur="semibrevis" oct="4" pname="b">
                           <accid accid="f" />
                        </note>
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```