### PR TITLE
Change graceGrp handling

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -931,8 +931,7 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place)
     // make adjustments for the grace notes length
     for (auto coord : m_beamElementCoordRefs) {
         if (coord->m_element) {
-            const bool isInGraceGroup = coord->m_element->GetFirstAncestor(GRACEGRP);
-            if (coord->m_element->IsGraceNote() || isInGraceGroup) {
+            if (coord->m_element->IsGraceNote()) {
                 m_uniformStemLength *= 0.75;
                 break;
             }
@@ -1127,14 +1126,13 @@ void Beam::FilterList(ArrayOfObjects *childList)
             // if we are at the beginning of the beam
             // and the note is cueSize
             // assume all the beam is of grace notes
-            const bool isInGraceGroup = element->GetFirstAncestor(GRACEGRP);
             if (childList->begin() == iter) {
-                if (element->IsGraceNote() || isInGraceGroup) firstNoteGrace = true;
+                if (element->IsGraceNote()) firstNoteGrace = true;
             }
             // if the first note in beam was NOT a grace
             // we have grace notes embedded in a beam
             // drop them
-            if (!firstNoteGrace && (element->IsGraceNote() || isInGraceGroup)) {
+            if (!firstNoteGrace && (element->IsGraceNote())) {
                 iter = childList->erase(iter);
                 continue;
             }
@@ -1181,7 +1179,9 @@ void Beam::FilterList(ArrayOfObjects *childList)
     */
 
     this->InitCoords(childList, beamStaff, this->GetPlace());
-    this->InitCue(this->GetCue() == BOOLEAN_true);
+
+    const bool isCue = ((this->GetCue() == BOOLEAN_true) || this->GetFirstAncestor(GRACEGRP));
+    this->InitCue(isCue);
 }
 
 const ArrayOfBeamElementCoords *Beam::GetElementCoords()
@@ -1278,8 +1278,7 @@ void BeamElementCoord::SetDrawingStemDir(
 
     m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
 
-    const bool isInGraceGroup = m_element->GetFirstAncestor(GRACEGRP);
-    if (m_element->IsGraceNote() || isInGraceGroup) return;
+    if (m_element->IsGraceNote()) return;
 
     // Make sure the stem reaches the center of the staff
     // Mark the segment as extendedToCenter since we then want a reduced slope

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -152,6 +152,8 @@ LayerElement *LayerElement::ThisOrSameasAsLink()
 
 bool LayerElement::IsGraceNote()
 {
+    // First, regardless of the type, check whether it's part of GRACEGRP
+    if (this->GetFirstAncestor(GRACEGRP)) return true;
     // For note, we need to look at it or at the parent chord
     if (this->Is(NOTE)) {
         Note const *note = vrv_cast<Note const *>(this);
@@ -1104,6 +1106,9 @@ int LayerElement::AlignHorizontally(FunctorParams *functorParams)
         assert(note);
         m_alignment = note->GetAlignment();
     }
+    else if (this->Is(GRACEGRP)) {
+        return FUNCTOR_CONTINUE;
+    }
     else if (this->IsGraceNote()) {
         type = ALIGNMENT_GRACENOTE;
     }
@@ -1966,7 +1971,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
 {
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
-    if (this->IsGraceNote() || this->GetFirstAncestor(GRACEGRP)) {
+    if (this->IsGraceNote()) {
         m_drawingCueSize = true;
     }
     // This cover the case when the @size is given on the element


### PR DESCRIPTION
- changed code for layer elements to account for graceGrp ancestor when IsGraceNote check is done
- added graceGrp to the AlignHorizontally so that it's not added as separate element to the GraceAligner

closes #2469

This basically aligns behavior of notes that have `grace/cue` attributes and notes, that are part of `graceGrp`:
![image](https://user-images.githubusercontent.com/1819669/142192517-adb18149-a698-4d54-a8ac-0f2a10400242.png)
