### PR TITLE
Improve engraving defaults file parsing

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -468,10 +468,17 @@ public:
     /**
      * Accessing all keys
      */
+    ///@{
     std::set<std::string> GetKeys() const;
+    std::set<std::string> GetKeysByNode(const std::string &nodeName, std::list<std::string> &jsonNodePath) const;
+    ///@}
 
 protected:
     JsonPath StringPath2NodePath(const jsonxx::Object &obj, const std::vector<std::string> &jsonNodePath) const;
+
+    // Find node by recursively processing all elements within. Only nodes of OBJECT_ type are processed
+    const jsonxx::Object *FindNodeByName(
+        const jsonxx::Object &obj, const std::string &jsonNodeName, std::list<std::string> &jsonNodePath) const;
 
     /// Read json from string or file
     bool ReadJson(jsonxx::Object &output, const std::string &input) const;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -815,7 +815,7 @@ const jsonxx::Object *OptionJson::FindNodeByName(
             if (result) {
                 jsonNodePath.emplace_front(mapEntry.first);
                 return result;
-            } 
+            }
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -762,8 +762,6 @@ std::set<std::string> OptionJson::GetKeysByNode(const std::string &nodeName, std
     for (const auto &mapEntry : node->kv_map()) {
         keys.insert(mapEntry.first);
     }
-    // reverse path for json node, since it has been saved in inverted order
-    jsonNodePath.reverse();
 
     return keys;
 }
@@ -815,7 +813,7 @@ const jsonxx::Object *OptionJson::FindNodeByName(
             const jsonxx::Object *result
                 = FindNodeByName(mapEntry.second->get<jsonxx::Object>(), jsonNodeName, jsonNodePath);
             if (result) {
-                jsonNodePath.emplace_back(mapEntry.first);
+                jsonNodePath.emplace_front(mapEntry.first);
                 return result;
             } 
         }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -751,6 +751,23 @@ std::set<std::string> OptionJson::GetKeys() const
     return keys;
 }
 
+std::set<std::string> OptionJson::GetKeysByNode(const std::string &nodeName, std::list<std::string> &jsonNodePath) const
+{
+    std::set<std::string> keys;
+
+    // Try to find node by the name, otherwise use root node
+    const jsonxx::Object *node = FindNodeByName(m_values, nodeName, jsonNodePath);
+    if (!node) node = &m_values;
+
+    for (const auto &mapEntry : node->kv_map()) {
+        keys.insert(mapEntry.first);
+    }
+    // reverse path for json node, since it has been saved in inverted order
+    jsonNodePath.reverse();
+
+    return keys;
+}
+
 OptionJson::JsonPath OptionJson::StringPath2NodePath(
     const jsonxx::Object &obj, const std::vector<std::string> &jsonNodePath) const
 {
@@ -780,6 +797,31 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
     }
 
     return path;
+}
+
+const jsonxx::Object *OptionJson::FindNodeByName(
+    const jsonxx::Object &obj, const std::string &jsonNodeName, std::list<std::string> &jsonNodePath) const
+{
+    for (const auto &mapEntry : obj.kv_map()) {
+        // skip non-objects
+        if (!mapEntry.second->is<jsonxx::Object>()) continue;
+        // return current object if name matches
+        if (mapEntry.first == jsonNodeName) {
+            jsonNodePath.emplace_back(mapEntry.first);
+            return &mapEntry.second->get<jsonxx::Object>();
+        }
+        // otherwise recursively process current object
+        else {
+            const jsonxx::Object *result
+                = FindNodeByName(mapEntry.second->get<jsonxx::Object>(), jsonNodeName, jsonNodePath);
+            if (result) {
+                jsonNodePath.emplace_back(mapEntry.first);
+                return result;
+            } 
+        }
+    }
+
+    return NULL;
 }
 
 //----------------------------------------------------------------------------
@@ -1631,7 +1673,8 @@ void Options::Sync()
 
     // We track all unmatched keys to generate appropriate errors later on
     std::set<std::string> unmatchedKeys = m_engravingDefaults.GetKeys();
-    std::set<std::string> otherKeys = m_engravingDefaultsFile.GetKeys();
+    std::list<std::string> engravingDefaultsPath;
+    std::set<std::string> otherKeys = m_engravingDefaultsFile.GetKeysByNode("engravingDefaults", engravingDefaultsPath);
     std::set_union(unmatchedKeys.begin(), unmatchedKeys.end(), otherKeys.begin(), otherKeys.end(),
         std::inserter(unmatchedKeys, unmatchedKeys.end()));
 
@@ -1661,13 +1704,15 @@ void Options::Sync()
     };
 
     for (const auto &pair : engravingDefaults) {
-        const std::vector<std::string> jsonNodePath = { pair.first };
+        std::vector<std::string> jsonNodePath = { engravingDefaultsPath.begin(), engravingDefaultsPath.end() };
+        jsonNodePath.emplace_back(pair.first);
+
         double jsonValue = 0.0;
         if (m_engravingDefaultsFile.HasValue(jsonNodePath)) {
             jsonValue = m_engravingDefaultsFile.GetDoubleValue(jsonNodePath);
         }
-        else if (m_engravingDefaults.HasValue(jsonNodePath)) {
-            jsonValue = m_engravingDefaults.GetDoubleValue(jsonNodePath);
+        else if (m_engravingDefaults.HasValue({ pair.first })) {
+            jsonValue = m_engravingDefaults.GetDoubleValue({ pair.first });
         }
         else
             continue;


### PR DESCRIPTION
Changed how engraving defaults is parsed when json file is specified via `--engraving-defaults-file`. `engravingDefaults` node is searched within file for matching node, and if not found root node is used.
This allows to use files that have `engravingDefaults` specified in them without breaking them down into smaller parts. This would allow for both previously accepted format:
```json
{
  "beamSpacing": 0.75, 
  "..."
}
```
and new format, where `engravingDefaults` are specified explicitly:
```json
{
  "options" : {
    "..."
  }
  "engravingDefaults" : {
    "beamSpacing": 0.75, 
    "..."
  }
}
```