### PR TITLE
Calculating the slur curve direction

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2387,6 +2387,20 @@ public:
     int modifications = 0;
 };
 
+//----------------------------------------------------------------------------
+// PrepareSlursParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the doc
+ **/
+
+class PrepareSlursParams : public FunctorParams {
+public:
+    PrepareSlursParams(Doc *doc) { m_doc = doc; }
+    Doc *m_doc;
+};
+
 } // namespace vrv
 
 #endif

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -387,6 +387,11 @@ public:
      */
     int GetRelativeLayerElement(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::PrepareSlurs
+     */
+    int PrepareSlurs(FunctorParams *functorParams) override;
+
 protected:
     /**
      * Helper to figure whether two chords are in fully in unison based on the locations of the notes.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -803,6 +803,11 @@ public:
      */
     virtual int AdjustTupletsX(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
+    /**
+     * Calculate the slur direction
+     */
+    virtual int PrepareSlurs(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -78,6 +78,14 @@ public:
     ///@}
 
     /**
+     * @name Get layer / cross staff by only considering the slur boundary
+     */
+    ///@{
+    std::pair<Layer *, LayerElement *> GetBoundaryLayer();
+    Staff *GetBoundaryCrossStaff();
+    ///@}
+
+    /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
     std::pair<Point, Point> AdjustCoordinates(

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -78,14 +78,6 @@ public:
     ///@}
 
     /**
-     * @name Get layer / cross staff by only considering the slur boundary
-     */
-    ///@{
-    std::pair<Layer *, LayerElement *> GetBoundaryLayer();
-    Staff *GetBoundaryCrossStaff();
-    ///@}
-
-    /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
     std::pair<Point, Point> AdjustCoordinates(
@@ -110,12 +102,6 @@ public:
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
     ///@}
 
-    /**
-     * Get preferred curve direction based on number of conditions: presence of other layers, stem direction, etc.
-     */
-    curvature_CURVEDIR GetPreferredCurveDirection(
-        Doc *doc, Layer *layer, LayerElement *layerElement, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
-
     //----------//
     // Functors //
     //----------//
@@ -131,6 +117,18 @@ public:
     int PrepareSlurs(FunctorParams *functorParams) override;
 
 private:
+    /**
+     * Helper for calculating the slur direction
+     */
+    ///@{
+    // Get layer by only considering the slur boundary
+    std::pair<Layer *, LayerElement *> GetBoundaryLayer();
+    // Get cross staff by only considering the slur boundary
+    Staff *GetBoundaryCrossStaff();
+    // Get preferred curve direction based on various conditions
+    curvature_CURVEDIR GetPreferredCurveDirection(Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
+    ///@}
+
     /**
      * Helper for calculating the initial slur start and end points
      */

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -117,6 +117,11 @@ public:
      */
     int ResetDrawing(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::PrepareSlurs
+     */
+    int PrepareSlurs(FunctorParams *functorParams) override;
+
 private:
     /**
      * Helper for calculating the initial slur start and end points

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2512,4 +2512,9 @@ int LayerElement::GetRelativeLayerElement(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int LayerElement::PrepareSlurs(FunctorParams *)
+{
+    return FUNCTOR_SIBLINGS;
+}
+
 } // namespace vrv

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -409,16 +409,21 @@ void Page::LayOutHorizontally()
     this->Process(&adjustTupletsX, &adjustTupletsXParams);
 
     // Prevent a margin overflow
-    Functor adjustXOverlfow(&Object::AdjustXOverflow);
-    Functor adjustXOverlfowEnd(&Object::AdjustXOverflowEnd);
+    Functor adjustXOverflow(&Object::AdjustXOverflow);
+    Functor adjustXOverflowEnd(&Object::AdjustXOverflowEnd);
     AdjustXOverflowParams adjustXOverflowParams(doc->GetDrawingUnit(100));
-    this->Process(&adjustXOverlfow, &adjustXOverflowParams, &adjustXOverlfowEnd);
+    this->Process(&adjustXOverflow, &adjustXOverflowParams, &adjustXOverflowEnd);
 
     // Adjust measure X position
     AlignMeasuresParams alignMeasuresParams(doc);
     Functor alignMeasures(&Object::AlignMeasures);
     Functor alignMeasuresEnd(&Object::AlignMeasuresEnd);
     this->Process(&alignMeasures, &alignMeasuresParams, &alignMeasuresEnd);
+
+    // Calculate the slur direction
+    PrepareSlursParams prepareSlursParams(doc);
+    Functor prepareSlurs(&Object::PrepareSlurs);
+    this->Process(&prepareSlurs, &prepareSlursParams);
 }
 
 void Page::LayOutVertically()

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1239,4 +1239,12 @@ int Slur::ResetDrawing(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Slur::PrepareSlurs(FunctorParams *functorParams)
+{
+    PrepareSlursParams *params = vrv_params_cast<PrepareSlursParams *>(functorParams);
+    assert(params);
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1298,13 +1298,16 @@ int Slur::PrepareSlurs(FunctorParams *functorParams)
     // Retrieve boundary, staves and system
     LayerElement *start = this->GetStart();
     LayerElement *end = this->GetEnd();
-    std::vector<Staff *> staffList = this->GetTstampStaves(this->GetStartMeasure(), this);
-
-    if (!start || !end || staffList.empty()) {
+    if (!start || !end) {
         this->SetDrawingCurvedir(curvature_CURVEDIR_above);
         return FUNCTOR_CONTINUE;
     }
 
+    std::vector<Staff *> staffList = this->GetTstampStaves(this->GetStartMeasure(), this);
+    if (staffList.empty()) {
+        this->SetDrawingCurvedir(curvature_CURVEDIR_above);
+        return FUNCTOR_CONTINUE;
+    }
     Staff *staff = staffList.at(0);
     Staff *crossStaff = this->GetBoundaryCrossStaff();
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -95,62 +95,12 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
 
 void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, int x2, Staff *staff, char spanningType)
 {
-    /************** parent layers **************/
-
     LayerElement *start = slur->GetStart();
     LayerElement *end = slur->GetEnd();
 
-    if (!start || !end) {
-        // no start and end, obviously nothing to do...
-        return;
-    }
+    if (!start || !end) return;
 
-    StemmedDrawingInterface *startStemDrawInterface = dynamic_cast<StemmedDrawingInterface *>(start);
-    StemmedDrawingInterface *endStemDrawInterface = dynamic_cast<StemmedDrawingInterface *>(end);
-
-    data_STEMDIRECTION startStemDir = STEMDIRECTION_NONE;
-    if (startStemDrawInterface) {
-        startStemDir = startStemDrawInterface->GetDrawingStemDir();
-    }
-    data_STEMDIRECTION endStemDir = STEMDIRECTION_NONE;
-    if (endStemDrawInterface) {
-        endStemDir = endStemDrawInterface->GetDrawingStemDir();
-    }
-
-    Layer *layer = NULL;
-    LayerElement *layerElement = NULL;
-    std::tie(layer, layerElement) = slur->GetBoundaryLayer();
-
-    // At this stage layer can still be NULL for slurs with @tstamp and @tstamp2
-    Staff *crossStaff = slur->GetBoundaryCrossStaff();
-    if (crossStaff) curve->SetCrossStaff(crossStaff);
-
-    /************** note stem dir **************/
-
-    data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
-    if (spanningType == SPANNING_START_END) {
-        stemDir = startStemDir;
-    }
-    // This is the case when the slur is split over two system of two pages.
-    // In this case, we are now drawing its beginning to the end of the measure (i.e., the last aligner)
-    else if (spanningType == SPANNING_START) {
-        stemDir = startStemDir;
-    }
-    // Now this is the case when the slur is split but we are drawing the end of it
-    else if (spanningType == SPANNING_END) {
-        stemDir = endStemDir;
-    }
-    // Finally, slur accross an entire system; use the staff position and up (see below)
-    else {
-        stemDir = STEMDIRECTION_down;
-    }
-
-    /************** direction **************/
-
-    const int center = staff->GetDrawingY() - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) / 2;
-    const bool isAboveStaffCenter = start->GetDrawingY() > center;
-    curvature_CURVEDIR drawingCurveDir
-        = slur->GetPreferredCurveDirection(m_doc, layer, layerElement, stemDir, isAboveStaffCenter);
+    const curvature_CURVEDIR drawingCurveDir = slur->GetDrawingCurvedir();
 
     /************** adjusting y position **************/
 
@@ -219,8 +169,6 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
             }
         }
     }
-
-    return;
 }
 
 float View::CalcInitialSlur(

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -119,44 +119,11 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 
     Layer *layer = NULL;
     LayerElement *layerElement = NULL;
-    // For now, with timestamps, get the first layer. We should eventually look at the @layerident (not implemented)
-    if (!start->Is(TIMESTAMP_ATTR)) {
-        layer = dynamic_cast<Layer *>(start->GetFirstAncestor(LAYER));
-        layerElement = start;
-    }
-    else if (!end->Is(TIMESTAMP_ATTR)) {
-        layer = dynamic_cast<Layer *>(end->GetFirstAncestor(LAYER));
-        layerElement = end;
-    }
-    if (layerElement && layerElement->m_crossStaff) layer = layerElement->m_crossLayer;
+    std::tie(layer, layerElement) = slur->GetBoundaryLayer();
 
     // At this stage layer can still be NULL for slurs with @tstamp and @tstamp2
-
-    if (start->m_crossStaff != end->m_crossStaff) {
-        curve->SetCrossStaff(end->m_crossStaff);
-    }
-    // Check if the two elements are in different staves (but themselves not cross-staff)
-    else {
-        Staff *startStaff = vrv_cast<Staff *>(start->GetFirstAncestor(STAFF));
-        Staff *endStaff = vrv_cast<Staff *>(end->GetFirstAncestor(STAFF));
-        if (startStaff && endStaff && (startStaff->GetN() != endStaff->GetN())) curve->SetCrossStaff(endStaff);
-    }
-
-    if (!start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && (spanningType == SPANNING_START_END)) {
-        System *system = vrv_cast<System *>(staff->GetFirstAncestor(SYSTEM));
-        assert(system);
-        // If we have a start to end situation, then store the curvedir in the slur for mixed drawing stem dir
-        // situations
-        if (system->HasMixedDrawingStemDir(start, end)) {
-            if (!curve->IsCrossStaff()) {
-                slur->SetDrawingCurvedir(curvature_CURVEDIR_above);
-            }
-            else {
-                curvature_CURVEDIR curveDir = system->GetPreferredCurveDirection(start, end, slur);
-                slur->SetDrawingCurvedir(curveDir != curvature_CURVEDIR_NONE ? curveDir : curvature_CURVEDIR_above);
-            }
-        }
-    }
+    Staff *crossStaff = slur->GetBoundaryCrossStaff();
+    if (crossStaff) curve->SetCrossStaff(crossStaff);
 
     /************** note stem dir **************/
 


### PR DESCRIPTION
This PR fixes #2484 and moves the calculation of the slur curve direction into a separate functor which is executed at the end of horizontal layout.

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/142390806-d269b4f5-b206-4551-a2b0-ec19b0775d4c.png) | ![After](https://user-images.githubusercontent.com/63608463/142390850-1410558d-b0b1-4647-8738-1ef90688dea2.png) |
  