### PR TITLE
Improve import of enharmonic ties from MusicXML

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -201,6 +201,11 @@ public:
     wchar_t GetNoteheadGlyph(const int duration) const;
 
     /**
+     * Check whether current note is enharmonic with another
+     */
+    bool IsEnharmonicWith(Note *note);
+
+    /**
      * Check if a note or its parent chord are visible
      */
     bool IsVisible() const;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3495,9 +3495,7 @@ void MusicXmlInput::ReadMusicXmlTies(
 
     const std::string tieType = xmlTie.node().attribute("type").as_string();
     if ("stop" == tieType) { // add to stack if (endTie) or if pitch/oct match to open tie on m_tieStack
-        if (!m_tieStack.empty()
-            && ((note->GetDiatonicPitch() - m_tieStack.back().second->GetDiatonicPitch() == 0)
-                || (note->IsEnharmonicWith(m_tieStack.back().second)))) {
+        if (!m_tieStack.empty() && note->IsEnharmonicWith(m_tieStack.back().second)) {
             m_tieStack.back().first->SetEndid("#" + note->GetUuid());
             m_tieStack.pop_back();
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3495,8 +3495,9 @@ void MusicXmlInput::ReadMusicXmlTies(
 
     const std::string tieType = xmlTie.node().attribute("type").as_string();
     if ("stop" == tieType) { // add to stack if (endTie) or if pitch/oct match to open tie on m_tieStack
-        if (!m_tieStack.empty() && note->GetPname() == m_tieStack.back().second->GetPname()
-            && note->GetOct() == m_tieStack.back().second->GetOct()) {
+        if (!m_tieStack.empty()
+            && ((note->GetDiatonicPitch() - m_tieStack.back().second->GetDiatonicPitch() == 0)
+                || (note->IsEnharmonicWith(m_tieStack.back().second)))) {
             m_tieStack.back().first->SetEndid("#" + note->GetUuid());
             m_tieStack.pop_back();
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -551,6 +551,14 @@ bool Note::IsVisible() const
     return true;
 }
 
+bool Note::IsEnharmonicWith(Note *note)
+{
+    this->CalcMIDIPitch(0);
+    note->CalcMIDIPitch(0);
+
+    return (this->GetMIDIPitch() == note->GetMIDIPitch());
+}
+
 void Note::SetScoreTimeOnset(double scoreTime)
 {
     m_scoreTimeOnset = scoreTime;


### PR DESCRIPTION
When enharmonic ties are encoded in MusicXML, Verovio imported them in a weird way (since it didn't recognize them as such):
![image](https://user-images.githubusercontent.com/1819669/142905339-eb3e335f-0905-4cf5-b199-c2beacdb8355.png)

Changed code to compare pitch of the tied notes, instead of comparing their locations. This improves import and allows for enharmonic ties to be encoded:
![image](https://user-images.githubusercontent.com/1819669/142906327-c7171af7-d7bd-4ef5-9176-b6d048e00244.png)
(overlaps with accidentals will be addressed in separate PR)

<details><summary>MusicXML:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <identification>
    <encoding>
      <software>MuseScore 3.5.2</software>
      <encoding-date>2021-11-12</encoding-date>
      <supports element="accidental" type="yes"/>
      <supports element="beam" type="yes"/>
      <supports element="print" attribute="new-page" type="yes" value="yes"/>
      <supports element="print" attribute="new-system" type="yes" value="yes"/>
      <supports element="stem" type="yes"/>
      </encoding>
    </identification>
  <defaults>
    <scaling>
      <millimeters>7.05556</millimeters>
      <tenths>40</tenths>
      </scaling>
    <page-layout>
      <page-height>1683.36</page-height>
      <page-width>1190.88</page-width>
      <page-margins type="even">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      <page-margins type="odd">
        <left-margin>56.6929</left-margin>
        <right-margin>56.6929</right-margin>
        <top-margin>56.6929</top-margin>
        <bottom-margin>113.386</bottom-margin>
        </page-margins>
      </page-layout>
    <word-font font-family="FreeSerif" font-size="10"/>
    <lyric-font font-family="FreeSerif" font-size="11"/>
    </defaults>
  <part-list>
    <score-part id="P1">
      <part-name>Piano</part-name>
      <part-abbreviation>Pno.</part-abbreviation>
      <score-instrument id="P1-I1">
        <instrument-name>Piano</instrument-name>
        </score-instrument>
      <midi-device id="P1-I1" port="1"></midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>1</midi-program>
        <volume>78.7402</volume>
        <pan>0</pan>
        </midi-instrument>
      </score-part>
    </part-list>
  <part id="P1">
    <measure number="1" width="583.30">
      <print>
        <system-layout>
          <system-margins>
            <left-margin>0.00</left-margin>
            <right-margin>0.00</right-margin>
            </system-margins>
          <top-system-distance>70.00</top-system-distance>
          </system-layout>
        </print>
      <attributes>
        <divisions>2</divisions>
        <key>
          <fifths>0</fifths>
          </key>
        <time>
          <beats>4</beats>
          <beat-type>4</beat-type>
          </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
          </clef>
        </attributes>
      <note default-x="92.48" default-y="-35.00">
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>up</stem>
        <beam number="1">begin</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="153.64" default-y="-30.00">
        <pitch>
          <step>G</step>
          <alter>-1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="214.79" default-y="-20.00">
        <pitch>
          <step>B</step>
          <alter>-1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="275.94" default-y="-25.00">
        <pitch>
          <step>A</step>
          <alter>1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>up</stem>
        <beam number="1">end</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="337.09" default-y="-15.00">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>5</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>down</stem>
        <beam number="1">begin</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="398.24" default-y="-20.00">
        <pitch>
          <step>B</step>
          <alter>2</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>double-sharp</accidental>
        <stem>down</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="459.39" default-y="-15.00">
        <pitch>
          <step>C</step>
          <alter>-2</alter>
          <octave>5</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat-flat</accidental>
        <stem>down</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="520.54" default-y="-20.00">
        <pitch>
          <step>B</step>
          <alter>-1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>down</stem>
        <beam number="1">end</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      </measure>
    <measure number="2" width="494.20">
      <note default-x="16.27" default-y="-15.00">
        <pitch>
          <step>C</step>
          <alter>-1</alter>
          <octave>5</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <beam number="1">begin</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="74.68" default-y="-20.00">
        <pitch>
          <step>B</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>natural</accidental>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="133.10" default-y="-30.00">
        <pitch>
          <step>G</step>
          <alter>1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="191.52" default-y="-25.00">
        <pitch>
          <step>A</step>
          <alter>-1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <beam number="1">end</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="249.93" default-y="-40.00">
        <pitch>
          <step>E</step>
          <alter>1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>up</stem>
        <beam number="1">begin</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="308.35" default-y="-35.00">
        <pitch>
          <step>F</step>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <note default-x="366.77" default-y="-45.00">
        <pitch>
          <step>D</step>
          <alter>-1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="start"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <beam number="1">continue</beam>
        <notations>
          <tied type="start"/>
          </notations>
        </note>
      <note default-x="425.18" default-y="-50.00">
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
          </pitch>
        <duration>1</duration>
        <tie type="stop"/>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>sharp</accidental>
        <stem>up</stem>
        <beam number="1">end</beam>
        <notations>
          <tied type="stop"/>
          </notations>
        </note>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
        </barline>
      </measure>
    </part>
  </score-partwise>

```

</details>