### PR TITLE
Improve fingering beam overlap

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -157,13 +157,13 @@ public:
     bool Encloses(const Point point) const;
 
     /**
-     * Return true if the bounding box intersects with the curve represented by the FloatingPositioner.
+     * Return intersection between the bounding box and the curve represented by the FloatingPositioner.
      * The Object pointed by the FloatingPositioner is expected to be a SLUR or a TIE
      */
     int Intersects(FloatingCurvePositioner *curve, Accessor type, int margin = 0) const;
 
     /**
-     * Return true if the bounding box intersects with the beam represented by the BeamDrawingInterface.
+     * Return intersection between the bounding box and the beam represented by the BeamDrawingInterface.
      * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
      * intersection.
      */

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -167,7 +167,7 @@ public:
      * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
      * intersection.
      */
-    int Intersects(BeamDrawingInterface *beamInterface, Accessor type) const;
+    int Intersects(BeamDrawingInterface *beamInterface, Accessor type, int additionalOffset = 0) const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -16,6 +16,7 @@ namespace vrv {
 
 #define BEZIER_APPROXIMATION 50.0
 
+class BeamDrawingInterface;
 class Doc;
 class FloatingCurvePositioner;
 class Glyph;
@@ -160,6 +161,13 @@ public:
      * The Object pointed by the FloatingPositioner is expected to be a SLUR or a TIE
      */
     int Intersects(FloatingCurvePositioner *curve, Accessor type, int margin = 0) const;
+
+    /**
+     * Return true if the bounding box intersects with the beam represented by the BeamDrawingInterface.
+     * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
+     * intersection.
+     */
+    int Intersects(BeamDrawingInterface *beamInterface, Accessor type) const;
 
     //----------------//
     // Static methods //

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -670,7 +670,6 @@ int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, 
     if (this->GetLeftBy(type) <= beamLeft.x) {
         // BB does not overlap horizontally with beam (left side of the beam)
         if (this->GetRightBy(type) < beamLeft.x) {
-
             return 0;
         }
         // BB overlaps with left side of the beam

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -15,9 +15,9 @@
 //----------------------------------------------------------------------------
 
 #include "beam.h"
-#include "drawinginterface.h"
 #include "devicecontextbase.h"
 #include "doc.h"
+#include "drawinginterface.h"
 #include "floatingobject.h"
 #include "glyph.h"
 #include "vrv.h"
@@ -670,7 +670,7 @@ int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type) 
     if (this->GetLeftBy(type) <= beamLeft.x) {
         // BB does not overlap horizontally with beam (left side of the beam)
         if (this->GetRightBy(type) < beamLeft.x) {
-            
+
             return 0;
         }
         // BB overlaps with left side of the beam

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -14,6 +14,8 @@
 
 //----------------------------------------------------------------------------
 
+#include "beam.h"
+#include "drawinginterface.h"
 #include "devicecontextbase.h"
 #include "doc.h"
 #include "floatingobject.h"
@@ -647,6 +649,75 @@ int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int m
     }
     else {
         LogDebug("This should not happen");
+    }
+
+    return 0;
+}
+
+int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type) const
+{
+    assert(beamInterface);
+    assert(!beamInterface->m_beamElementCoords.empty());
+
+    const Point beamLeft(
+        beamInterface->m_beamElementCoords.front()->m_x, beamInterface->m_beamElementCoords.front()->m_yBeam);
+    const Point beamRight(
+        beamInterface->m_beamElementCoords.back()->m_x, beamInterface->m_beamElementCoords.back()->m_yBeam);
+
+    Point leftIntersection(0, 0);
+    Point rightIntersection(0, 0);
+    const double beamSlope = this->CalcSlope(beamLeft, beamRight);
+    if (this->GetLeftBy(type) <= beamLeft.x) {
+        // BB does not overlap horizontally with beam (left side of the beam)
+        if (this->GetRightBy(type) < beamLeft.x) {
+            
+            return 0;
+        }
+        // BB overlaps with left side of the beam
+        else if (this->GetRightBy(type) < beamRight.x) {
+            leftIntersection = beamLeft;
+            rightIntersection.x = this->GetRightBy(type);
+            rightIntersection.y = beamLeft.y + beamSlope * (rightIntersection.x - beamLeft.x);
+        }
+        // BB covers the whole beam
+        else {
+            leftIntersection = beamLeft;
+            rightIntersection = beamRight;
+        }
+    }
+    else {
+        if (this->GetRightBy(type) > beamRight.x) {
+            // BB overlaps with right side of the beam
+            if (this->GetLeftBy(type) <= beamRight.x) {
+                leftIntersection.x = this->GetLeftBy(type);
+                leftIntersection.y = beamLeft.y + beamSlope * (leftIntersection.x - beamLeft.x);
+                rightIntersection = beamRight;
+            }
+            // BB does not overlap horizontally with beam (right side of the beam)
+            else {
+                return 0;
+            }
+        }
+        // BB is inside of the beam
+        else {
+            leftIntersection.x = this->GetLeftBy(type);
+            leftIntersection.y = beamLeft.y + beamSlope * (leftIntersection.x - beamLeft.x);
+            rightIntersection.x = this->GetRightBy(type);
+            rightIntersection.y = beamLeft.y + beamSlope * (rightIntersection.x - beamLeft.x);
+        }
+    }
+    // something went wrong if either for the points have X not set - return
+    if (!leftIntersection.x || !rightIntersection.x) return 0;
+    // calculate vertical overlap of the BB with beam section
+    if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
+        const int topY = std::max(leftIntersection.y, rightIntersection.y);
+        const int shift = topY - this->GetBottomBy(type);
+        if (shift > 0) return shift;
+    }
+    else if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
+        const int bottomY = std::min(leftIntersection.y, rightIntersection.y);
+        const int shift = bottomY - this->GetTopBy(type);
+        if (shift < 0) return shift;
     }
 
     return 0;

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -666,7 +666,7 @@ int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, 
 
     Point leftIntersection(0, 0);
     Point rightIntersection(0, 0);
-    const double beamSlope = this->CalcSlope(beamLeft, beamRight);
+    const double beamSlope = BoundingBox::CalcSlope(beamLeft, beamRight);
     if (this->GetLeftBy(type) <= beamLeft.x) {
         // BB does not overlap horizontally with beam (left side of the beam)
         if (this->GetRightBy(type) < beamLeft.x) {
@@ -705,8 +705,7 @@ int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, 
             rightIntersection.y = beamLeft.y + beamSlope * (rightIntersection.x - beamLeft.x);
         }
     }
-    // something went wrong if either for the points have X not set - return
-    if (!leftIntersection.x || !rightIntersection.x) return 0;
+
     // calculate vertical overlap of the BB with beam section
     if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
         const int topY = std::max(leftIntersection.y, rightIntersection.y);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -654,7 +654,7 @@ int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int m
     return 0;
 }
 
-int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type) const
+int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, int additionalOffset) const
 {
     assert(beamInterface);
     assert(!beamInterface->m_beamElementCoords.empty());
@@ -712,12 +712,12 @@ int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type) 
     if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
         const int topY = std::max(leftIntersection.y, rightIntersection.y);
         const int shift = topY - this->GetBottomBy(type);
-        if (shift > 0) return shift;
+        if (shift > 0) return shift + additionalOffset;
     }
     else if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
         const int bottomY = std::min(leftIntersection.y, rightIntersection.y);
         const int shift = bottomY - this->GetTopBy(type);
-        if (shift < 0) return shift;
+        if (shift < 0) return shift - additionalOffset;
     }
 
     return 0;

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -386,7 +386,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 }
                 return true;
             }
-            else if (m_object->Is({ DYNAM, FING }) && horizOverlapingBBox->Is(BEAM)) {
+            else if (m_object->Is({ DYNAM, FING, MORDENT, TURN }) && horizOverlapingBBox->Is(BEAM)) {
                 // Try to avoid comparing with BEAM BB since it might be much larger overlap while having a lot of
                 // whitespace. For such cases, DYNAM should be compared to individual elements of BEAM instead
                 return true;

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -390,7 +390,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
+                const int shift = this->Intersects(vrv_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
@@ -423,7 +423,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
+                const int shift = this->Intersects(vrv_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -351,6 +351,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
     int staffSize = staffAlignment->GetStaffSize();
     int yRel;
 
+    const int unit = doc->GetDrawingUnit(staffSize);
     if (horizOverlapingBBox == NULL) {
         // Apply element margin and enforce minimal staff distance
         int staffIndex = staffAlignment->GetStaff()->GetN();
@@ -361,13 +362,13 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         }
         if (m_place == STAFFREL_above) {
             yRel = this->GetContentY1();
-            yRel -= doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+            yRel -= doc->GetBottomMargin(m_object->GetClassId()) * unit;
             this->SetDrawingYRel(yRel);
             this->SetDrawingYRel(-minStaffDistance);
         }
         else {
             yRel = staffAlignment->GetStaffHeight() + this->GetContentY2();
-            yRel += doc->GetTopMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+            yRel += doc->GetTopMargin(m_object->GetClassId()) * unit;
             this->SetDrawingYRel(yRel);
             this->SetDrawingYRel(minStaffDistance + staffAlignment->GetStaffHeight());
         }
@@ -377,19 +378,19 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         if (curve) {
             assert(curve->m_object);
         }
-        int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
+        int margin = doc->GetBottomMargin(m_object->GetClassId()) * unit;
         const bool isExtender = m_object->Is({ DIR, DYNAM }) && m_object->IsExtenderElement();
 
         if (m_place == STAFFREL_above) {
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
-                const int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
+                const int shift = this->Intersects(curve, CONTENT, unit);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT);
+                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
@@ -415,14 +416,14 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         }
         else {
             if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
-                const int shift = this->Intersects(curve, CONTENT, doc->GetDrawingUnit(staffSize));
+                const int shift = this->Intersects(curve, CONTENT, unit);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT);
+                const int shift = this->Intersects(dynamic_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -386,7 +386,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 }
                 return true;
             }
-            else if (m_object->Is(DYNAM) && horizOverlapingBBox->Is(BEAM)) {
+            else if (m_object->Is({ DYNAM, FING }) && horizOverlapingBBox->Is(BEAM)) {
                 // Try to avoid comparing with BEAM BB since it might be much larger overlap while having a lot of
                 // whitespace. For such cases, DYNAM should be compared to individual elements of BEAM instead
                 return true;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -731,9 +731,9 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
             LayerElement *element = dynamic_cast<LayerElement *>(*i);
-            const int margin = ((*iter)->GetObject()->Is({ DYNAM, FING }) && element && element->GetFirstAncestor(BEAM))
-                ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
-                : 0;
+            const bool avoidsBeams = ((*iter)->GetObject()->Is({ DYNAM, FING, MORDENT, TURN }) && element
+                && element->GetFirstAncestor(BEAM));
+            const int margin = avoidsBeams ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
                 if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -730,7 +730,10 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
-            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM));
+            LayerElement *element = dynamic_cast<LayerElement *>(*i);
+            const bool additionalMargin
+                = ((*iter)->GetObject()->Is(DYNAM) && element && element->GetFirstAncestor(BEAM));
+            const int margin = additionalMargin ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
                 if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -730,10 +730,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
-            LayerElement *element = dynamic_cast<LayerElement *>(*i);
-            const bool avoidsBeams = ((*iter)->GetObject()->Is({ DYNAM, FING, MORDENT, TURN }) && element
-                && element->GetFirstAncestor(BEAM));
-            const int margin = avoidsBeams ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
+            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM));
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
                 if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -730,7 +730,8 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
-            const int margin = ((*iter)->GetObject()->Is(DYNAM) && GetFirstAncestor(BEAM))
+            LayerElement *element = dynamic_cast<LayerElement *>(*i);
+            const int margin = ((*iter)->GetObject()->Is({ DYNAM, FING }) && element && element->GetFirstAncestor(BEAM))
                 ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize)
                 : 0;
             i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {


### PR DESCRIPTION
closes #2466

Fix for fingerings and some other control elements overlap (turn, mordent):
![image](https://user-images.githubusercontent.com/1819669/143017337-882f412d-7b43-47c2-b0a5-32d04ad386d6.png)
