### PR TITLE
Check time spanning order

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -436,6 +436,11 @@ public:
     bool DeleteChild(Object *child);
 
     /**
+     * Returns all ancestors
+     */
+    ListOfObjects GetAncestors() const;
+
+    /**
      * Return the first ancestor of the specified type.
      * The maxSteps parameter limits the search to a certain number of level if not -1.
      */
@@ -539,6 +544,11 @@ public:
     static std::string GenerateRandUuid();
 
     static bool sortByUlx(Object *a, Object *b);
+
+    /**
+     * @Return true if left appears before right in preorder traversal
+     */
+    static bool IsPreOrdered(Object *left, Object *right);
 
     //----------//
     // Functors //

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -179,12 +179,21 @@ public:
     void SetUuidStr();
 
     /**
+     * Check if the end points are temporally ordered
+     * @Return true if end temporally occurs after start
+     */
+    ///@{
+    bool IsOrdered();
+    bool IsOrdered(LayerElement *start, LayerElement *end);
+    ///@}
+
+    /**
      * Check if the slur or tie needs to be taken into account as overflow above or below in case of cross-staff end
      * points. This methods assumes staff@n to be greater for the staff below.
      */
 
     void GetCrossStaffOverflows(
-        StaffAlignment *alignment, curvature_CURVEDIR cuvreDir, bool &skipAbove, bool &skipBelow);
+        StaffAlignment *alignment, curvature_CURVEDIR curveDir, bool &skipAbove, bool &skipBelow);
 
     //-----------------//
     // Pseudo functors //

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -516,7 +516,7 @@ void Doc::PrepareDrawing()
         this->Process(&resetDrawing, NULL);
     }
 
-    /************ Resolve @starid / @endid ************/
+    /************ Resolve @startid / @endid ************/
 
     // Try to match all spanning elements (slur, tie, etc) by processing backwards
     PrepareTimeSpanningParams prepareTimeSpanningParams;
@@ -535,7 +535,17 @@ void Doc::PrepareDrawing()
         this->Process(&prepareTimeSpanning, &prepareTimeSpanningParams);
     }
 
-    /************ Resolve @starid (only) ************/
+    // Display warning if some elements were not matched
+    const size_t unmatchedElements = std::count_if(prepareTimeSpanningParams.m_timeSpanningInterfaces.cbegin(),
+        prepareTimeSpanningParams.m_timeSpanningInterfaces.cend(),
+        [](const ListOfSpanningInterClassIdPairs::value_type &entry) {
+            return (entry.first->HasStartid() && entry.first->HasEndid());
+        });
+    if (unmatchedElements > 0) {
+        LogWarning("%d time spanning element(s) with startid and endid could not be matched.", unmatchedElements);
+    }
+
+    /************ Resolve @startid (only) ************/
 
     // Resolve <reh> elements first, since they can be encoded without @startid or @tstamp, but we need one internally
     // for placement
@@ -559,7 +569,7 @@ void Doc::PrepareDrawing()
 
     // If some are still there, then it is probably an issue in the encoding
     if (!prepareTimestampsParams.m_timeSpanningInterfaces.empty()) {
-        LogWarning("%d time spanning element(s) could not be matched",
+        LogWarning("%d time spanning element(s) with timestamps could not be matched.",
             prepareTimestampsParams.m_timeSpanningInterfaces.size());
     }
 

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -213,8 +213,28 @@ bool TimeSpanningInterface::IsSpanningMeasures()
     return (this->GetStartMeasure() != this->GetEndMeasure());
 }
 
+bool TimeSpanningInterface::IsOrdered()
+{
+    return this->IsOrdered(m_start, m_end);
+}
+
+bool TimeSpanningInterface::IsOrdered(LayerElement *start, LayerElement *end)
+{
+    if (!start || !end) return true;
+    Measure *startMeasure = vrv_cast<Measure *>(start->GetFirstAncestor(MEASURE));
+    Measure *endMeasure = vrv_cast<Measure *>(end->GetFirstAncestor(MEASURE));
+
+    if (startMeasure == endMeasure) {
+        if (!start->GetAlignment() || !end->GetAlignment()) return true;
+        return Object::IsPreOrdered(start->GetAlignment(), end->GetAlignment());
+    }
+    else {
+        return Object::IsPreOrdered(startMeasure, endMeasure);
+    }
+}
+
 void TimeSpanningInterface::GetCrossStaffOverflows(
-    StaffAlignment *alignment, curvature_CURVEDIR cuvreDir, bool &skipAbove, bool &skipBelow)
+    StaffAlignment *alignment, curvature_CURVEDIR curveDir, bool &skipAbove, bool &skipBelow)
 {
     assert(alignment);
 
@@ -237,7 +257,7 @@ void TimeSpanningInterface::GetCrossStaffOverflows(
             Staff *staffAbove = NULL;
             Staff *staffBelow = NULL;
             chord->GetCrossStaffExtremes(staffAbove, staffBelow);
-            startStaff = (cuvreDir == curvature_CURVEDIR_above) ? staffAbove : staffBelow;
+            startStaff = (curveDir == curvature_CURVEDIR_above) ? staffAbove : staffBelow;
         }
     }
     else {
@@ -256,7 +276,7 @@ void TimeSpanningInterface::GetCrossStaffOverflows(
             Staff *staffAbove = NULL;
             Staff *staffBelow = NULL;
             chord->GetCrossStaffExtremes(staffAbove, staffBelow);
-            endStaff = (cuvreDir == curvature_CURVEDIR_above) ? staffAbove : staffBelow;
+            endStaff = (curveDir == curvature_CURVEDIR_above) ? staffAbove : staffBelow;
         }
     }
     else {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -41,6 +41,7 @@
 #include "note.h"
 #include "octave.h"
 #include "options.h"
+#include "page.h"
 #include "pedal.h"
 #include "pitchinflection.h"
 #include "reh.h"
@@ -188,7 +189,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     if (!start || !end) return;
     if (!interface->IsOrdered(start, end)) {
         // To avoid showing the same warning multiple times, display a warning only during actual drawing
-        if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
+        if (!dc->Is(BBOX_DEVICE_CONTEXT) && (m_currentPage == vrv_cast<Page *>(start->GetFirstAncestor(PAGE)))) {
             LogWarning("%s '%s' is ignored, since start '%s' does not occur temporally before end '%s'.",
                 element->GetClassName().c_str(), element->GetUuid().c_str(), start->GetUuid().c_str(),
                 end->GetUuid().c_str());

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -186,6 +186,15 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
         }
     }
     if (!start || !end) return;
+    if (!interface->IsOrdered(start, end)) {
+        // To avoid showing the same warning multiple times, display a warning only during actual drawing
+        if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
+            LogWarning("%s '%s' is ignored, since start '%s' does not occur temporally before end '%s'.",
+                element->GetClassName().c_str(), element->GetUuid().c_str(), start->GetUuid().c_str(),
+                end->GetUuid().c_str());
+        }
+        return;
+    }
 
     // Get the parent system of the first and last note
     System *parentSystem1 = dynamic_cast<System *>(start->GetFirstAncestor(SYSTEM));


### PR DESCRIPTION
There are various issues with elements whose time spanning is encoded in the wrong order:

- Slurs are rendered awkwardly:
![WrongSlur](https://user-images.githubusercontent.com/63608463/143184424-b8007977-8cac-4a9d-a106-b1679fb7983a.png)
- Hairpins are rendered with the opposite form:
![WrongHairpin](https://user-images.githubusercontent.com/63608463/143184496-0778172c-3dce-480c-9233-18b10c5be362.png)

This PR adds a check for the order of time spanning elements. If the order is wrong, then a warning is displayed and the element is ignored for drawing.

<details>
<summary>Show MEI of slur example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Slurs on mixed stem directions</title>
      </titleStmt>
      <pubStmt>
        <date isodate="2017">2017</date>
      </pubStmt>
      <seriesStmt>
        <title>Verovio test suite</title>
      </seriesStmt>
      <notesStmt>
        <annot>Slurs on notes with stems pointing both upwards and downwards are placed by default above the staff.</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="2.0.0" label="2">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef midi.bpm="240">
            <staffGrp symbol="brace" bar.thru="true">
              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="4f" meter.count="2" meter.unit="2" />
              <staffDef n="2" lines="5" clef.shape="F" clef.line="4" key.sig="4f" meter.count="2" meter.unit="2" />
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="0">
              <staff n="1">
                <layer n="1">
                  <note xml:id="note-L12F3" dur="4" oct="4" pname="c" stem.dir="up" accid.ges="n">
                    <artic artic="stacc" />
                  </note>
                </layer>
              </staff>
              <staff n="2">
                <layer n="1">
                  <rest dur="4" />
                </layer>
              </staff>
              <dynam place="below" staff="1" tstamp="1.000000">p</dynam>
              <slur staff="1" startid="#note-L17F3" endid="#note-L12F3" color="red" />
            </measure>
            <measure n="1">
              <staff n="1">
                <layer n="1">
                  <note dur="4" oct="4" pname="f" stem.dir="up" accid.ges="n">
                    <artic artic="stacc" />
                  </note>
                  <note dur="4" oct="4" pname="a" stem.dir="up" accid.ges="f">
                    <artic artic="stacc" />
                  </note>
                  <note dur="4" oct="5" pname="c" stem.dir="down" accid.ges="n">
                    <artic artic="stacc" />
                  </note>
                  <note xml:id="note-L17F3" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="n">
                    <artic artic="stacc" />
                  </note>
                </layer>
              </staff>
              <staff n="2">
                <layer n="1">
                  <mRest />
                </layer>
              </staff>
            </measure>
            <measure n="2">
              <staff n="1">
                <layer n="1">
                  <note xml:id="note-L19F3" dots="1" dur="4" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                  <beam>
                    <tuplet num="3" numbase="2" bracket.visible="false" num.format="count">
                      <note dur="16" oct="5" pname="g" stem.dir="down" accid.ges="n" />
                      <note dur="16" oct="5" pname="f" stem.dir="down" accid.ges="n" />
                      <note dur="16" oct="5" pname="e" stem.dir="down" accid="n" />
                    </tuplet>
                  </beam>
                  <note xml:id="note-L25F3" dur="4" oct="5" pname="f" stem.dir="down" accid.ges="n">
                    <artic artic="stacc" />
                  </note>
                  <rest dur="4" />
                </layer>
              </staff>
              <staff n="2">
                <layer n="1">
                  <rest dur="4" />
                  <chord dur="4" stem.dir="down">
                    <note oct="3" pname="f" accid.ges="n" />
                    <note oct="3" pname="a" accid.ges="f" />
                    <note oct="4" pname="c" accid.ges="n" />
                  </chord>
                  <chord dur="4" stem.dir="down">
                    <note oct="3" pname="f" accid.ges="n" />
                    <note oct="3" pname="a" accid.ges="f" />
                    <note oct="4" pname="c" accid.ges="n" />
                  </chord>
                  <chord dur="4" stem.dir="down">
                    <note oct="3" pname="f" accid.ges="n" />
                    <note oct="3" pname="a" accid.ges="f" />
                    <note oct="4" pname="c" accid.ges="n" />
                  </chord>
                </layer>
              </staff>
              <slur staff="1" startid="#note-L19F3" endid="#note-L25F3" />
              <dynam staff="2" tstamp="1.500000">p</dynam>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

<details>
<summary>Show MEI of hairpin example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Hairpin example with different widths</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-15</date>
         </pubStmt>
         <notesStmt>
            <annot>Short hairpin ends are not as wide as the ends of long hairpins.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="c" accid.ges="n" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="cres" />
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="d" accid.ges="n" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="e" accid.ges="n" />
                              <note dur="8" oct="4" pname="f" accid.ges="n" />
                           </beam>
                           <space dots="1" dur="2" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="2.500000" tstamp2="1.0000" form="cres" color="red" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>