### PR TITLE
Add multiRestThickness option

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -668,6 +668,7 @@ public:
     OptionInt m_measureMinWidth;
     OptionInt m_mnumInterval;
     OptionIntMap m_multiRestStyle;
+    OptionDbl m_multiRestThickness;
     OptionBool m_octaveAlternativeSymbols;
     OptionDbl m_octaveLineThickness;
     OptionDbl m_pedalLineThickness;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1269,6 +1269,10 @@ Options::Options()
     m_multiRestStyle.Init(MULTIRESTSTYLE_auto, &Option::s_multiRestStyle);
     this->Register(&m_multiRestStyle, "multiRestStyle", &m_generalLayout);
 
+    m_multiRestThickness.SetInfo("Multi rest thickness", "The thickness of the multi rest in unit");
+    m_multiRestThickness.Init(2.0, 0.50, 6.00);
+    this->Register(&m_multiRestThickness, "multiRestThickness", &m_generalLayout);
+
     m_octaveAlternativeSymbols.SetInfo("Alternative octave symbols", "Use alternative symbols for displaying octaves");
     m_octaveAlternativeSymbols.Init(false);
     this->Register(&m_octaveAlternativeSymbols, "octaveAlternativeSymbols", &m_generalLayout);
@@ -1698,7 +1702,8 @@ void Options::Sync()
         { "repeatEndingLineThickness", &m_repeatEndingLineThickness }, //
         { "lyricLineThickness", &m_lyricLineThickness }, //
         { "tupletBracketThickness", &m_tupletBracketThickness }, //
-        { "textEnclosureThickness", &m_textEnclosureThickness } //
+        { "textEnclosureThickness", &m_textEnclosureThickness }, //
+        { "hBarThickness", &m_multiRestThickness } //
     };
 
     for (const auto &pair : engravingDefaults) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1218,12 +1218,15 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     // We do not support more than three chars
     const int num = std::min(multiRest->GetNum(), 999);
 
+    const int mutliRestThickness
+        = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_doc->GetOptions()->m_multiRestThickness.GetValue();
     // Position centered in staff
-    int y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
+    int y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1)
+        - mutliRestThickness / 2;
     if (multiRest->HasLoc()) {
         y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
     }
-    int y1 = y2 + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    int y1 = y2 + mutliRestThickness;
 
     if (multiRest->UseBlockStyle(m_doc)) {
         // This is 1/2 the length of the black rectangle


### PR DESCRIPTION
Added option `--multi-rest-thickness`. Default value set to 2 units, which corresponds to previous drawing default.

Example with 3 unit thickness:
![image](https://user-images.githubusercontent.com/1819669/143228984-6435f277-8b09-4d60-866f-b0c61ffacc5e.png)
