### PR TITLE
Improve enharmonic tie overlap with accidentals

### DIFF
--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -67,8 +67,8 @@ public:
 
 private:
     // Update tie positioning based overlaps with accidentals in cases with enharmonic ties
-    bool AdjustEnharmonicTies(FloatingCurvePositioner *curve, Point bezier[4], Note *startNote, Note *endNote,
-        curvature_CURVEDIR drawingCurveDir, int drawingRadius);
+    bool AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote,
+        Note *endNote, curvature_CURVEDIR drawingCurveDir);
 
     // Calculate initial position X position and return stem direction of the startNote
     void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -67,8 +67,8 @@ public:
 
 private:
     // Update tie positioning based overlaps with accidentals in cases with enharmonic ties
-    bool AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote,
-        Note *endNote, curvature_CURVEDIR drawingCurveDir);
+    bool AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote, Note *endNote,
+        curvature_CURVEDIR drawingCurveDir);
 
     // Calculate initial position X position and return stem direction of the startNote
     void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -66,6 +66,10 @@ public:
     ///@}
 
 private:
+    // Update tie positioning based overlaps with accidentals in cases with enharmonic ties
+    bool AdjustEnharmonicTies(FloatingCurvePositioner *curve, Point bezier[4], Note *startNote, Note *endNote,
+        curvature_CURVEDIR drawingCurveDir, int drawingRadius);
+
     // Calculate initial position X position and return stem direction of the startNote
     void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
         bool isOuterChordNote, Point &startPoint, Point &endPoint);
@@ -75,7 +79,7 @@ private:
     curvature_CURVEDIR GetPreferredCurveDirection(
         Layer *layer, Note *note, Chord *startParentChord, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
 
-    // Update tie positioning based on the overlaps with posible layerElements such as dots/flags
+    // Update tie positioning based on the overlaps with possible layerElements such as dots/flags
     void UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], LayerElement *durElement,
         Note *startNote, int height, curvature_CURVEDIR drawingCurveDir);
 

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -97,16 +97,23 @@ bool Tie::AdjustEnharmonicTies(FloatingCurvePositioner *curve, Point bezier[4], 
     bezier[0].x = startNote->GetDrawingX() + drawingRadius;
     bezier[3].x = endNote->GetDrawingX() + drawingRadius;
     if (drawingCurveDir == curvature_CURVEDIR_below) {
-        if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc())
+        if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc()) {
             bezier[0].y += overlap / 2;
-        else if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc())
+            bezier[3].y = bezier[0].y;
+        }
+        else if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc()) {
             bezier[3].y += overlap / 2;
+            bezier[0].y = bezier[3].y;
+        }
     }
     else if (drawingCurveDir == curvature_CURVEDIR_above) {
-        if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc())
-            bezier[3].y -= overlap;
-        else if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc())
+        if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc()) {
+            bezier[3].y = bezier[0].y;
+        }
+        else if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc()) {
             bezier[3].y += overlap / 2;
+            bezier[0].y = bezier[3].y;
+        }
     }
 
     // adjust control points of the curve

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -75,6 +75,50 @@ void Tie::Reset()
     ResetCurveRend();
 }
 
+bool Tie::AdjustEnharmonicTies(FloatingCurvePositioner *curve, Point bezier[4], Note *startNote, Note *endNote,
+    curvature_CURVEDIR drawingCurveDir, int drawingRadius)
+{
+    ListOfObjects objects;
+    ClassIdComparison cmp(ACCID);
+    endNote->FindAllDescendantByComparison(&objects, &cmp);
+    if (objects.empty()) return false;
+
+    int overlap = 0;
+    bool discard = false;
+    for (auto object : objects) {
+        overlap = curve->CalcAdjustment(object, discard);
+    }
+    if (!overlap) return false;
+
+    // adjust overlap with regards to direction
+    overlap *= (drawingCurveDir == curvature_CURVEDIR_below) ? -1 : 1;
+
+    // adjust endpoints of curve
+    bezier[0].x = startNote->GetDrawingX() + drawingRadius;
+    bezier[3].x = endNote->GetDrawingX() + drawingRadius;
+    if (drawingCurveDir == curvature_CURVEDIR_below) {
+        if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc())
+            bezier[0].y += overlap / 2;
+        else if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc())
+            bezier[3].y += overlap / 2;
+    }
+    else if (drawingCurveDir == curvature_CURVEDIR_above) {
+        if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc())
+            bezier[3].y -= overlap;
+        else if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc())
+            bezier[3].y += overlap / 2;
+    }
+
+    // adjust control points of the curve
+    const int length = endNote->GetDrawingX() - startNote->GetDrawingX();
+    bezier[1].x = bezier[0].x + 0.25 * length;
+    bezier[1].y += 1.2 * overlap;
+    bezier[2].x = bezier[0].x + 0.75 * length;
+    bezier[2].y += 1.2 * overlap;
+
+    return true;
+}
+
 bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
 {
     if (!doc || !staff) return false;
@@ -203,6 +247,11 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     if ((!startParentChord || isOuterChordNote) && durElement && (spanningType != SPANNING_END)) {
         UpdateTiePositioning(curve, bezier, durElement, note1, drawingUnit, drawingCurveDir);
         curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
+    }
+    if (!startParentChord && !endParentChord && note1 && note2) {
+        if (AdjustEnharmonicTies(curve, bezier, note1, note2, drawingCurveDir, note1->GetDrawingRadius(doc))) {
+            curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
+        }
     }
 
     return true;


### PR DESCRIPTION
followup for #2500

Improve rendering of enharmonic ties when there is accidental drawn with second note:
![image](https://user-images.githubusercontent.com/1819669/143229450-d7d62799-2c3e-455e-95e4-4929aafeb262.png)

<details><summary>Example MEI</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-11-12" type="encoding-date">2021-11-12</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-257">
         <appInfo xml:id="appinfo-bwp">
            <application xml:id="application-jz1" isodate="2021-11-18T16:58:57" version="3.7.0-dev-[undefined]">
               <name xml:id="name-ha7">Verovio</name>
               <p xml:id="p-2lq">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m28e">
            <score xml:id="s6s1">
               <scoreDef xml:id="s5lb">
                  <staffGrp xml:id="sap5">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="2">
                        <label xml:id="lk6">Piano</label>
                        <labelAbbr xml:id="l4hm">Pno.</labelAbbr>
                        <instrDef xml:id="ib4o" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="c6o5" shape="G" line="2" />
                        <keySig xml:id="klht" sig="0" />
                        <meterSig xml:id="mbkn" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="shbl">
                  <measure xml:id="mf91" n="1">
                     <staff xml:id="s3c2" n="1">
                        <layer xml:id="l8su" n="1">
                           <beam xml:id="b7oe">
                              <note xml:id="n2p0" dur.ppq="1" dur="8" oct="4" pname="f" stem.dir="up" accid="s" />
                              <note xml:id="n15j" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up" accid="f" />
                              <note xml:id="new4" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="up" accid="f" />
                              <note xml:id="n61h" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="up" accid="s" />
                           </beam>
                           <beam xml:id="b46g">
                              <note xml:id="n3xc" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down" accid="s" />
                              <note xml:id="nb1n" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid="x" accid.ges="ss" />
                              <note xml:id="negv" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down" accid="ff" />
                              <note xml:id="njs2" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid="f" />
                           </beam>
                        </layer>
                     </staff>
                     <tie xml:id="tv9" startid="#n2p0" endid="#n15j" />
                     <tie xml:id="t61d" startid="#new4" endid="#n61h" />
                     <tie xml:id="t101" startid="#n3xc" endid="#nb1n" />
                     <tie xml:id="tma7" startid="#negv" endid="#njs2" />
                  </measure>
                  <measure xml:id="mngt" right="end" n="2">
                     <staff xml:id="s38d" n="1">
                        <layer xml:id="l7m7" n="1">
                           <beam xml:id="b7qu">
                              <note xml:id="no73" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="up" accid="f" />
                              <note xml:id="nc7y" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="up" accid="n" />
                              <note xml:id="nod0" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up" accid="s" />
                              <note xml:id="nnr4" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="up" accid="f" />
                           </beam>
                           <beam xml:id="bby0">
                              <note xml:id="n802" dur.ppq="1" dur="8" oct="4" pname="e" stem.dir="up" accid="s" />
                              <note xml:id="n282" dur.ppq="1" dur="8" oct="4" pname="f" stem.dir="up" />
                              <note xml:id="nl46" dur.ppq="1" dur="8" oct="4" pname="d" stem.dir="up" accid="f" />
                              <note xml:id="nn2y" dur.ppq="1" dur="8" oct="4" pname="c" stem.dir="up" accid="s" />
                           </beam>
                        </layer>
                     </staff>
                     <tie xml:id="t3u0" startid="#no73" endid="#nc7y" />
                     <tie xml:id="t55n" startid="#nod0" endid="#nnr4" />
                     <tie xml:id="tpl" startid="#n802" endid="#n282" />
                     <tie xml:id="tvz" startid="#nl46" endid="#nn2y" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>