### PR TITLE
Fix degenerated slurs

### DIFF
--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -131,6 +131,11 @@ public:
     ///@}
 
     /**
+     * @return (cross) layer number, parent layer number for cross staff elements
+     */
+    int GetOriginalLayerN();
+
+    /**
      * @name Get the X and Y drawing position
      */
     ///@{

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -232,6 +232,15 @@ Beam *LayerElement::IsInBeam()
     return NULL;
 }
 
+int LayerElement::GetOriginalLayerN()
+{
+    int layerN = this->GetAlignmentLayerN();
+    if (layerN < 0) {
+        layerN = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER))->GetN();
+    }
+    return layerN;
+}
+
 Staff *LayerElement::GetCrossStaff(Layer *&layer) const
 {
     if (m_crossStaff) {
@@ -2341,10 +2350,7 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         }
 
         // Skip if layer number is outside given bounds
-        int layerN = this->GetAlignmentLayerN();
-        if (layerN < 0) {
-            layerN = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER))->GetN();
-        }
+        const int layerN = this->GetOriginalLayerN();
         if (params->m_minLayerN && (params->m_minLayerN > layerN)) {
             return FUNCTOR_CONTINUE;
         }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2332,7 +2332,9 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         && (this->GetContentLeft() < params->m_maxPos)) {
 
         // We skip the start or end of the slur
-        if ((this == params->m_interface->GetStart()) || (this == params->m_interface->GetEnd())) {
+        LayerElement *start = params->m_interface->GetStart();
+        LayerElement *end = params->m_interface->GetEnd();
+        if ((this == start) || (this == end)) {
             return FUNCTOR_CONTINUE;
         }
 
@@ -2356,6 +2358,28 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         }
         if (params->m_maxLayerN && (params->m_maxLayerN < layerN)) {
             return FUNCTOR_CONTINUE;
+        }
+
+        // Skip elements aligned at start/end, but on a different staff
+        if (this->GetAlignment() == start->GetAlignment()) {
+            Layer *layer = NULL;
+            Staff *staff = this->GetCrossStaff(layer);
+            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+            Staff *startStaff = start->GetCrossStaff(layer);
+            if (!startStaff) startStaff = vrv_cast<Staff *>(start->GetFirstAncestor(STAFF));
+            if (staff->GetN() != startStaff->GetN()) {
+                return FUNCTOR_CONTINUE;
+            }
+        }
+        if (this->GetAlignment() == end->GetAlignment()) {
+            Layer *layer = NULL;
+            Staff *staff = this->GetCrossStaff(layer);
+            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+            Staff *endStaff = end->GetCrossStaff(layer);
+            if (!endStaff) endStaff = vrv_cast<Staff *>(end->GetFirstAncestor(STAFF));
+            if (staff->GetN() != endStaff->GetN()) {
+                return FUNCTOR_CONTINUE;
+            }
         }
 
         params->m_elements.push_back(this);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -187,10 +187,7 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
     }
     else {
         for (LayerElement *element : { this->GetStart(), this->GetEnd() }) {
-            int layerN = element->GetAlignmentLayerN();
-            if (layerN < 0) {
-                layerN = vrv_cast<Layer *>(element->GetFirstAncestor(LAYER))->GetN();
-            }
+            const int layerN = element->GetOriginalLayerN();
             layersN.insert(layerN);
         }
     }
@@ -200,10 +197,7 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
     // Check whether outside layers exist
     const bool hasOutsideLayers = std::any_of(findSpannedLayerElementsParams.m_elements.cbegin(),
         findSpannedLayerElementsParams.m_elements.cend(), [minLayerN, maxLayerN](LayerElement *element) {
-            int layerN = element->GetAlignmentLayerN();
-            if (layerN < 0) {
-                layerN = vrv_cast<Layer *>(element->GetFirstAncestor(LAYER))->GetN();
-            }
+            const int layerN = element->GetOriginalLayerN();
             return ((layerN < minLayerN) || (layerN > maxLayerN));
         });
 
@@ -233,10 +227,7 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
         for (Object *object : notes) {
             Note *note = vrv_cast<Note *>(object);
             assert(note);
-            int layerN = note->GetAlignmentLayerN();
-            if (layerN < 0) {
-                layerN = vrv_cast<Layer *>(note->GetFirstAncestor(LAYER))->GetN();
-            }
+            const int layerN = note->GetOriginalLayerN();
             if (layerN == maxLayerN) {
                 minPitch = std::min(note->GetDiatonicPitch(), minPitch);
             }
@@ -249,10 +240,7 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
         const bool layersAreSeparated
             = std::all_of(notes.cbegin(), notes.cend(), [minLayerN, maxLayerN, minPitch, maxPitch](Object *object) {
                   Note *note = vrv_cast<Note *>(object);
-                  int layerN = note->GetAlignmentLayerN();
-                  if (layerN < 0) {
-                      layerN = vrv_cast<Layer *>(note->GetFirstAncestor(LAYER))->GetN();
-                  }
+                  const int layerN = note->GetOriginalLayerN();
                   if (layerN < minLayerN) {
                       return (note->GetDiatonicPitch() > maxPitch);
                   }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -584,7 +584,7 @@ std::pair<int, int> Slur::CalcControlPointVerticalShift(
             const int xLeft = std::max(bezierCurve.p1.x, spannedElement->m_boundingBox->GetSelfLeft());
             float distanceRatio = float(xLeft - bezierCurve.p1.x) / float(dist);
             // Ignore obstacles close to the endpoints, because this would result in very large shifts
-            if (std::abs(0.5 - distanceRatio) < 0.45) {
+            if ((std::abs(0.5 - distanceRatio) < 0.45) && (intersectionLeft > 0)) {
                 const double t = BoundingBox::CalcBezierParamAtPosition(points, xLeft);
                 constraints.push_back(
                     { 3.0 * pow(1.0 - t, 2.0) * t, 3.0 * (1.0 - t) * pow(t, 2.0), double(intersectionLeft) });
@@ -594,7 +594,7 @@ std::pair<int, int> Slur::CalcControlPointVerticalShift(
             const int xRight = std::min(bezierCurve.p2.x, spannedElement->m_boundingBox->GetSelfRight());
             distanceRatio = float(xRight - bezierCurve.p1.x) / float(dist);
             // Ignore obstacles close to the endpoints, because this would result in very large shifts
-            if (std::abs(0.5 - distanceRatio) < 0.45) {
+            if ((std::abs(0.5 - distanceRatio) < 0.45) && (intersectionRight > 0)) {
                 const double t = BoundingBox::CalcBezierParamAtPosition(points, xRight);
                 constraints.push_back(
                     { 3.0 * pow(1.0 - t, 2.0) * t, 3.0 * (1.0 - t) * pow(t, 2.0), double(intersectionRight) });


### PR DESCRIPTION
This PR fixes #2460 and #2461 (duplicate).

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/143392947-726f604e-ff64-4b44-9f5a-32ec11707b79.png) | ![After](https://user-images.githubusercontent.com/63608463/143392967-895f5728-b12a-4c15-92bc-683d866ab3dd.png) |

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2021-11-01T05:19:48" version="3.7.0-dev-09f2846-dirty">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mbymbwm">
    <score xml:id="sk8gkjw">
     <scoreDef xml:id="s1i5af4">
      <staffGrp xml:id="sxd93cj" bar.thru="true" symbol="brace">
       <staffDef xml:id="spto94t" n="1" lines="5">
        <clef xml:id="clef-L4F2" shape="G" line="2" />
        <keySig xml:id="keysig-L5F2" pname="e" mode="minor" sig="1s" />
        <meterSig xml:id="metersig-L7F2" count="6" unit="8" />
       </staffDef>
       <staffDef xml:id="sqk4ec8" n="2" lines="5">
        <clef xml:id="clef-L4F1" shape="F" line="4" />
        <keySig xml:id="keysig-L5F1" pname="e" mode="minor" sig="1s" />
        <meterSig xml:id="metersig-L7F1" count="6" unit="8" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <pb xml:id="pr4nvo" />
      <measure xml:id="measure-L105" n="13">
       <staff xml:id="staff-L105F2N1" n="1">
        <layer xml:id="layer-L105F2N1" n="1">
         <beam xml:id="beam-L107F2-L109F2">
          <chord xml:id="chord-L107F2" type="placed" dots="1" dur="8" stem.dir="down">
           <note xml:id="note-L107F2S1" oct="4" pname="b" accid.ges="n" />
           <note xml:id="note-L107F2S2" oct="5" pname="d" accid="s" />
           <note xml:id="note-L107F2S3" oct="5" pname="g" accid="s" />
          </chord>
          <chord xml:id="chord-L108F2" type="placed" dur="16" stem.dir="down">
           <note xml:id="note-L108F2S1" oct="5" pname="c" accid="s" />
           <note xml:id="note-L108F2S2" oct="5" pname="e" accid.ges="n" />
           <note xml:id="note-L108F2S3" oct="5" pname="a" accid="s" />
          </chord>
          <chord xml:id="chord-L109F2" type="placed" dur="8" stem.dir="down">
           <note xml:id="note-L109F2S1" oct="5" pname="d" accid.ges="s" />
           <note xml:id="note-L109F2S2" oct="5" pname="f" accid.ges="s" />
           <note xml:id="note-L109F2S3" oct="5" pname="b" accid.ges="n" />
          </chord>
         </beam>
         <chord xml:id="chord-L111F2" type="placed" dur="4" stem.dir="down">
          <note xml:id="note-L111F2S1" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L111F2S2" oct="5" pname="g" accid.ges="s" />
          <note xml:id="note-L111F2S3" oct="6" pname="c" accid="s" />
         </chord>
         <chord xml:id="chord-L115F2" type="placed" dur="8" stem.dir="up">
          <note xml:id="note-L115F2S1" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L115F2S2" oct="5" pname="g" accid.ges="s" />
         </chord>
        </layer>
       </staff>
       <staff xml:id="staff-L105F1N1" n="2">
        <layer xml:id="layer-L105F1N1" n="1">
         <note xml:id="note-L107F1" type="placed" dots="1" dur="4" oct="4" pname="f" stem.dir="down" accid.ges="s" />
         <beam xml:id="beam-L111F1-L115F1">
          <note xml:id="note-L111F1" type="placed" dur="16" oct="3" pname="f" stem.dir="down" accid.ges="s" />
          <note xml:id="note-L112F1" type="placed" dur="16" oct="4" pname="c" stem.dir="down" accid="s" />
          <note xml:id="note-L113F1" type="placed" dur="16" staff="1" oct="4" pname="e" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L114F1" type="placed" dur="16" staff="1" oct="4" pname="g" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L115F1" type="placed" dur="8" staff="1" oct="5" pname="c" stem.dir="down" accid.ges="n" />
         </beam>
        </layer>
       </staff>
       <dynam xml:id="dynam-L107F3" place="below" staff="2" tstamp="1.000000">sf</dynam>
       <hairpin xml:id="hairpin-L111F3" staff="2" tstamp="4.000000" tstamp2="1m+1.0000" form="cres" place="below" />
       <slur xml:id="slur-L111F1-L114F1" staff="2" startid="#note-L111F1" endid="#note-L114F1" />
      </measure>
      <measure xml:id="measure-L116" n="14">
       <staff xml:id="staff-L116F2N1" n="1">
        <layer xml:id="layer-L116F2N1" n="1">
         <beam xml:id="beam-L118F2-L120F2">
          <chord xml:id="chord-L118F2" type="placed" dots="1" dur="8" stem.dir="up">
           <note xml:id="note-L118F2S1" oct="5" pname="a" accid="s" />
           <note xml:id="note-L118F2S2" oct="6" pname="d" accid="s" />
          </chord>
          <note xml:id="note-L119F2" type="placed" dur="16" oct="6" pname="c" stem.dir="up" accid="s" />
          <note xml:id="note-L120F2" type="placed" dur="8" oct="5" pname="a" stem.dir="up" accid.ges="s" />
         </beam>
         <chord xml:id="chord-L122F2" type="placed" dur="4" stem.dir="up">
          <note xml:id="note-L122F2S1" oct="4" pname="a" accid="s" />
          <note xml:id="note-L122F2S2" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L122F2S3" oct="5" pname="g" accid.ges="n" />
         </chord>
         <chord xml:id="chord-L126F2" type="placed" dur="8" stem.dir="up">
          <note xml:id="note-L126F2S1" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L126F2S2" oct="5" pname="f" accid.ges="s" />
         </chord>
        </layer>
        <layer xml:id="layer-L118F3N2" n="2">
         <chord xml:id="chord-L118F3" type="placed" dur="4" stem.dir="down">
          <note xml:id="note-L118F3S1" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L118F3S2" oct="5" pname="f" accid.ges="s" />
         </chord>
         <chord xml:id="chord-L120F3" type="placed" dur="8" stem.dir="down">
          <note xml:id="note-L120F3S1" oct="5" pname="c" accid.ges="n" />
          <note xml:id="note-L120F3S2" oct="5" pname="e" accid.ges="n" />
          <note xml:id="note-L120F3S3" oct="5" pname="f" accid.ges="s" />
         </chord>
         <space xml:id="space-L122F3" dur="8" />
         <space xml:id="space-L124F3" dur="4" />
        </layer>
       </staff>
       <staff xml:id="staff-L116F1N1" n="2">
        <layer xml:id="layer-L116F1N1" n="1">
         <note xml:id="note-L118F1" type="placed" dots="1" dur="4" oct="4" pname="f" stem.dir="down" accid.ges="s" />
         <beam xml:id="beam-L122F1-L126F1">
          <note xml:id="note-L122F1" type="placed" dur="16" oct="3" pname="f" stem.dir="down" accid.ges="s" />
          <note xml:id="note-L123F1" type="placed" dur="16" oct="4" pname="c" stem.dir="down" accid="s" />
          <note xml:id="note-L124F1" type="placed" dur="16" staff="1" oct="4" pname="e" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L125F1" type="placed" dur="16" staff="1" oct="4" pname="g" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L126F1" type="placed" dur="8" staff="1" oct="5" pname="c" stem.dir="down" accid.ges="n" />
         </beam>
        </layer>
       </staff>
       <dynam xml:id="dynam-L118F4" place="between" staff="1 2" tstamp="1.000000">sf</dynam>
       <hairpin xml:id="hairpin-L122F4" staff="2" tstamp="4.000000" tstamp2="0m+7.0000" form="cres" place="below" />
       <slur xml:id="slur-L122F1-L125F1" staff="2" startid="#note-L122F1" endid="#note-L125F1" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>
 