### PR TITLE
Fix crash caused by hidden note

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1700,10 +1700,12 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     Flag *flag = dynamic_cast<Flag *>(stem->GetFirst(FLAG));
     if (flag) {
         const wchar_t glyph = flag->GetFlagGlyph(stemDir);
-        const int slashAdjust = (stemDir == STEMDIRECTION_up)
-            ? m_doc->GetGlyphTop(glyph, staff->m_drawingStaffSize, true)
-            : m_doc->GetGlyphBottom(glyph, staff->m_drawingStaffSize, true);
-        y += slashAdjust;
+        if (glyph) {
+            const int slashAdjust = (stemDir == STEMDIRECTION_up)
+                ? m_doc->GetGlyphTop(glyph, staff->m_drawingStaffSize, true)
+                : m_doc->GetGlyphBottom(glyph, staff->m_drawingStaffSize, true);
+            y += slashAdjust;
+        }
     }
     if ((stemDir == STEMDIRECTION_down) && (!flag || (flag->GetFlagGlyph(stemDir) == SMUFL_E241_flag8thDown))) {
         y -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 3;


### PR DESCRIPTION
This PR fixes a crash caused by hidden notes with acciaccatura.

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2020-09-04" type="encoding-date">2020-09-04</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-qsr9j5">
         <appInfo xml:id="appinfo-pnak1">
            <application xml:id="application-4w83m0" isodate="2021-11-26T11:46:42" version="3.8.0-dev-6f67c0a-dirty">
               <name xml:id="name-itaebo">Verovio</name>
               <p xml:id="p-5qhahv">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m8owu9b">
            <score xml:id="sbhtrcq">
               <scoreDef xml:id="sv0w4ut" midi.bpm="120.000000">
                  <staffGrp xml:id="stv6q33">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <instrDef xml:id="in00xvi" midi.channel="0" midi.instrnum="0" midi.volume="79.00%" />
                        <staffDef xml:id="svj516q" n="1" lines="5" ppq="336">
                           <clef xml:id="cv53m28" shape="G" line="2" />
                           <keySig xml:id="k6x8rs1" mode="major" sig="1f" />
                           <meterSig xml:id="mdjmx1v" count="6" unit="8" />
                        </staffDef>
                        <staffDef xml:id="s4iktyn" n="2" lines="5" ppq="336">
                           <clef xml:id="cq7pbkg" shape="F" line="4" />
                           <keySig xml:id="k97fjfp" mode="major" sig="1f" />
                           <meterSig xml:id="mr8nh9j" count="6" unit="8" />
                        </staffDef>
                        <grpSym xml:id="gy6ru8b" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="svd8hho">
                  <measure xml:id="mfzakub" n="45">
                     <staff xml:id="se4z0gt" n="1">
                        <layer xml:id="lls0jbi" n="1">
                           <note xml:id="n3t4z38" dur="8" oct="3" pname="f" visible="false" />
                           <note xml:id="n3t4z38" dur="8" oct="3" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" visible="false" />
                        </layer>
                     </staff>
                     <staff xml:id="sl4fjm5" n="2">
                        <layer xml:id="lj2yqa5" n="3">
                           <space xml:id="rckkbwh" dur="4" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>