### PR TITLE
FindDescendantsByType

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1382,6 +1382,7 @@ public:
 /**
  * member 0: the attComparision text
  * member 1: an array of all matching objects
+ * member 2: flag indicating whether descendants of matches should be searched as well
  **/
 
 class FindAllByComparisonParams : public FunctorParams {
@@ -1390,9 +1391,11 @@ public:
     {
         m_comparison = comparison;
         m_elements = elements;
+        m_continueDepthSearchForMatches = true;
     }
     Comparison *m_comparison;
     ListOfObjects *m_elements;
+    bool m_continueDepthSearchForMatches;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -394,6 +394,12 @@ public:
         Comparison *comparison, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
 
     /**
+     * Return all the objects with specified type
+     */
+    ListOfObjects FindAllDescendantByType(
+        ClassId classId, bool continueDepthSearchForMatches = true, int deepness = UNLIMITED_DEPTH);
+
+    /**
      * Return all the objects matching the Comparison functor
      * Deepness allow to limit the depth search (EditorialElements are not count)
      */

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -232,7 +232,7 @@ public:
     ///@{
     int GetChildCount() const { return (int)m_children.size(); }
     int GetChildCount(const ClassId classId) const;
-    int GetChildCount(const ClassId classId, int deepth);
+    int GetChildCount(const ClassId classId, int depth);
     ///@}
 
     /**
@@ -348,7 +348,7 @@ public:
     /**
      * Look for all Objects of a class and return its position (-1 if not found)
      */
-    int GetDescendantIndex(const Object *child, const ClassId classId, int deepth);
+    int GetDescendantIndex(const Object *child, const ClassId classId, int depth);
 
     /**
      * Insert an element at the idx position.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -396,21 +396,21 @@ public:
     /**
      * Return all the objects with specified type
      */
-    ListOfObjects FindAllDescendantByType(
+    ListOfObjects FindAllDescendantsByType(
         ClassId classId, bool continueDepthSearchForMatches = true, int deepness = UNLIMITED_DEPTH);
 
     /**
      * Return all the objects matching the Comparison functor
      * Deepness allow to limit the depth search (EditorialElements are not count)
      */
-    void FindAllDescendantByComparison(ListOfObjects *objects, Comparison *comparison, int deepness = UNLIMITED_DEPTH,
+    void FindAllDescendantsByComparison(ListOfObjects *objects, Comparison *comparison, int deepness = UNLIMITED_DEPTH,
         bool direction = FORWARD, bool clear = true);
 
     /**
      * Return all the objects matching the Comparison functor and being between start and end in the tree.
      * The start and end objects are included in the result set.
      */
-    void FindAllDescendantBetween(
+    void FindAllDescendantsBetween(
         ListOfObjects *objects, Comparison *comparison, Object *start, Object *end, bool clear = true);
 
     /**

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -138,7 +138,7 @@ void Artic::GetAllArtics(bool direction, std::vector<Artic *> &artics)
     Object *last = (direction == BACKWARD) ? this : parentNoteOrChord->GetLast();
     ClassIdComparison matchType(ARTIC);
     ListOfObjects children;
-    parentNoteOrChord->FindAllDescendantBetween(&children, &matchType, first, last);
+    parentNoteOrChord->FindAllDescendantsBetween(&children, &matchType, first, last);
     for (auto &child : children) {
         if (child == this) continue;
         Artic *artic = vrv_cast<Artic *>(child);

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -98,7 +98,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     if (chord) {
         ListOfObjects notes;
         ClassIdComparison noteComparison(NOTE);
-        chord->FindAllDescendantByComparison(&notes, &noteComparison);
+        chord->FindAllDescendantsByComparison(&notes, &noteComparison);
         std::for_each(notes.begin(), notes.end(), expandNote);
     }
     else {

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -96,9 +96,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     // Apply expansion either to all notes in chord or to first note
     Chord *chord = vrv_cast<Chord *>(this->FindDescendantByType(CHORD));
     if (chord) {
-        ListOfObjects notes;
-        ClassIdComparison noteComparison(NOTE);
-        chord->FindAllDescendantsByComparison(&notes, &noteComparison);
+        ListOfObjects notes = chord->FindAllDescendantsByType(NOTE, false);
         std::for_each(notes.begin(), notes.end(), expandNote);
     }
     else {

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -155,9 +155,7 @@ bool Doc::GenerateDocumentScoreDef()
         return false;
     }
 
-    ListOfObjects staves;
-    ClassIdComparison matchType(STAFF);
-    measure->FindAllDescendantsByComparison(&staves, &matchType);
+    ListOfObjects staves = measure->FindAllDescendantsByType(STAFF, false);
 
     if (staves.empty()) {
         LogError("No staff found for generating a scoreDef");
@@ -226,9 +224,7 @@ bool Doc::GenerateHeader()
 
 bool Doc::GenerateMeasureNumbers()
 {
-    ClassIdComparison matchType(MEASURE);
-    ListOfObjects measures;
-    this->FindAllDescendantsByComparison(&measures, &matchType);
+    ListOfObjects measures = this->FindAllDescendantsByType(MEASURE, false);
 
     // run through all measures and generate missing mNum from attribute
     for (auto &object : measures) {
@@ -805,9 +801,7 @@ void Doc::PrepareDrawing()
     */
 
     /************ Add default syl for syllables (if applicable) ************/
-    ListOfObjects syllables;
-    ClassIdComparison comp(SYLLABLE);
-    this->FindAllDescendantsByComparison(&syllables, &comp);
+    ListOfObjects syllables = this->FindAllDescendantsByType(SYLLABLE);
     for (auto it = syllables.begin(); it != syllables.end(); ++it) {
         Syllable *syllable = dynamic_cast<Syllable *>(*it);
         syllable->MarkupAddSyl();
@@ -1107,9 +1101,7 @@ void Doc::ConvertToCastOffMensuralDoc(bool castOff)
 
     contentPage->LayOutHorizontally();
 
-    ListOfObjects systems;
-    ClassIdComparison cmp(SYSTEM);
-    contentPage->FindAllDescendantsByComparison(&systems, &cmp, 1);
+    ListOfObjects systems = contentPage->FindAllDescendantsByType(SYSTEM, false, 1);
     for (const auto item : systems) {
         System *system = vrv_cast<System *>(item);
         assert(system);
@@ -1309,9 +1301,7 @@ bool Doc::HasPage(int pageIdx)
 std::list<Score *> Doc::GetScores()
 {
     std::list<Score *> scores;
-    ListOfObjects objects;
-    ClassIdComparison cmp(SCORE);
-    this->FindAllDescendantsByComparison(&objects, &cmp, 3);
+    ListOfObjects objects = this->FindAllDescendantsByType(SCORE, false, 3);
     for (const auto object : objects) {
         Score *score = vrv_cast<Score *>(object);
         assert(score);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -157,7 +157,7 @@ bool Doc::GenerateDocumentScoreDef()
 
     ListOfObjects staves;
     ClassIdComparison matchType(STAFF);
-    measure->FindAllDescendantByComparison(&staves, &matchType);
+    measure->FindAllDescendantsByComparison(&staves, &matchType);
 
     if (staves.empty()) {
         LogError("No staff found for generating a scoreDef");
@@ -228,7 +228,7 @@ bool Doc::GenerateMeasureNumbers()
 {
     ClassIdComparison matchType(MEASURE);
     ListOfObjects measures;
-    this->FindAllDescendantByComparison(&measures, &matchType);
+    this->FindAllDescendantsByComparison(&measures, &matchType);
 
     // run through all measures and generate missing mNum from attribute
     for (auto &object : measures) {
@@ -807,7 +807,7 @@ void Doc::PrepareDrawing()
     /************ Add default syl for syllables (if applicable) ************/
     ListOfObjects syllables;
     ClassIdComparison comp(SYLLABLE);
-    this->FindAllDescendantByComparison(&syllables, &comp);
+    this->FindAllDescendantsByComparison(&syllables, &comp);
     for (auto it = syllables.begin(); it != syllables.end(); ++it) {
         Syllable *syllable = dynamic_cast<Syllable *>(*it);
         syllable->MarkupAddSyl();
@@ -1109,7 +1109,7 @@ void Doc::ConvertToCastOffMensuralDoc(bool castOff)
 
     ListOfObjects systems;
     ClassIdComparison cmp(SYSTEM);
-    contentPage->FindAllDescendantByComparison(&systems, &cmp, 1);
+    contentPage->FindAllDescendantsByComparison(&systems, &cmp, 1);
     for (const auto item : systems) {
         System *system = vrv_cast<System *>(item);
         assert(system);
@@ -1311,7 +1311,7 @@ std::list<Score *> Doc::GetScores()
     std::list<Score *> scores;
     ListOfObjects objects;
     ClassIdComparison cmp(SCORE);
-    this->FindAllDescendantByComparison(&objects, &cmp, 3);
+    this->FindAllDescendantsByComparison(&objects, &cmp, 3);
     for (const auto object : objects) {
         Score *score = vrv_cast<Score *>(object);
         assert(score);

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -462,7 +462,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
 
         ListOfObjects lyric;
         ClassIdsComparison lyricsComparison({ VERSE, SYL });
-        currentNote->FindAllDescendantByComparison(&lyric, &lyricsComparison);
+        currentNote->FindAllDescendantsByComparison(&lyric, &lyricsComparison);
         if (!lyric.empty()) {
             LogMessage("Inserting a note where a note has lyric content is not possible");
             return false;
@@ -488,7 +488,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
 
         ListOfObjects artics;
         ClassIdComparison articComparison(ARTIC);
-        currentNote->FindAllDescendantByComparison(&artics, &articComparison);
+        currentNote->FindAllDescendantsByComparison(&artics, &articComparison);
         for (auto &artic : artics) {
             artic->MoveItselfTo(chord);
         }
@@ -543,7 +543,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
 
             ListOfObjects artics;
             ClassIdComparison articComparison(ARTIC);
-            chord->FindAllDescendantByComparison(&artics, &articComparison, 1);
+            chord->FindAllDescendantsByComparison(&artics, &articComparison, 1);
             for (auto &artic : artics) {
                 artic->MoveItselfTo(otherNote);
             }

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -486,9 +486,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         Note *note = new Note();
         chord->AddChild(note);
 
-        ListOfObjects artics;
-        ClassIdComparison articComparison(ARTIC);
-        currentNote->FindAllDescendantsByComparison(&artics, &articComparison);
+        ListOfObjects artics = currentNote->FindAllDescendantsByType(ARTIC);
         for (auto &artic : artics) {
             artic->MoveItselfTo(chord);
         }
@@ -541,9 +539,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             chord->DetachChild(otherNote->GetIdx());
             parent->ReplaceChild(chord, otherNote);
 
-            ListOfObjects artics;
-            ClassIdComparison articComparison(ARTIC);
-            chord->FindAllDescendantsByComparison(&artics, &articComparison, 1);
+            ListOfObjects artics = chord->FindAllDescendantsByType(ARTIC, false, 1);
             for (auto &artic : artics) {
                 artic->MoveItselfTo(otherNote);
             }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -286,7 +286,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
         }
         else {
             ListOfObjects facsChildren;
-            element->FindAllDescendantByComparison(&facsChildren, &facsIC);
+            element->FindAllDescendantsByComparison(&facsChildren, &facsIC);
             for (auto it = facsChildren.begin(); it != facsChildren.end(); ++it) {
                 // don't change the text bbox position
                 if ((*it)->Is(SYL) || !(*it)->GetFacsimileInterface()->HasFacs()) {
@@ -401,10 +401,10 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
         Clef *precedingClefBefore = dynamic_cast<Clef *>(m_doc->GetDrawingPage()->FindPreviousChild(&ac, clef));
         Clef *nextClefBefore = dynamic_cast<Clef *>(m_doc->GetDrawingPage()->FindNextChild(&ac, clef));
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(&withThisClefBefore, &ic, clef,
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withThisClefBefore, &ic, clef,
             (nextClefBefore != layer->GetCurrentClef()) ? nextClefBefore : m_doc->GetDrawingPage()->GetLast());
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(&withPrecedingClefBefore, &ic, precedingClefBefore, clef);
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withPrecedingClefBefore, &ic, precedingClefBefore, clef);
 
         if (clef->HasFacs()) { // adjust facsimile for clef (if it exists)
             Zone *zone = clef->GetZone();
@@ -424,9 +424,9 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
             ListOfObjects withThisClefAfter;
             ListOfObjects withPrecedingClefAfter;
 
-            m_doc->GetDrawingPage()->FindAllDescendantBetween(&withThisClefAfter, &ic, clef,
+            m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withThisClefAfter, &ic, clef,
                 (nextClefAfter != NULL) ? nextClefAfter : m_doc->GetDrawingPage()->GetLast());
-            m_doc->GetDrawingPage()->FindAllDescendantBetween(&withPrecedingClefAfter, &ic, precedingClefBefore, clef);
+            m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withPrecedingClefAfter, &ic, precedingClefBefore, clef);
 
             if (withPrecedingClefBefore.size() > withPrecedingClefAfter.size()) {
                 ListOfObjects newlyWithThisClef;
@@ -484,13 +484,13 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
             ListOfObjects noLongerWithThisClef;
             ListOfObjects newlyWithThisClef;
 
-            m_doc->GetDrawingPage()->FindAllDescendantBetween(&withOldPrecedingClefAfter, &ic, precedingClefBefore,
+            m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withOldPrecedingClefAfter, &ic, precedingClefBefore,
                 (nextClefBefore != NULL) ? nextClefBefore : m_doc->GetDrawingPage()->GetLast());
 
-            m_doc->GetDrawingPage()->FindAllDescendantBetween(&withNewPrecedingClefBefore, &ic, precedingClefAfter,
+            m_doc->GetDrawingPage()->FindAllDescendantsBetween(&withNewPrecedingClefBefore, &ic, precedingClefAfter,
                 (nextClefAfter != NULL) ? nextClefAfter : m_doc->GetDrawingPage()->GetLast());
 
-            m_doc->GetDrawingPage()->FindAllDescendantBetween(
+            m_doc->GetDrawingPage()->FindAllDescendantsBetween(
                 &withNewPrecedingClefAfter, &ic, precedingClefAfter, clef);
 
             std::set_difference(withOldPrecedingClefAfter.begin(), withOldPrecedingClefAfter.end(),
@@ -526,7 +526,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
         // Move staff and all staff children with facsimiles
         ListOfObjects children;
         InterfaceComparison ic(INTERFACE_FACSIMILE);
-        staff->FindAllDescendantByComparison(&children, &ic);
+        staff->FindAllDescendantsByComparison(&children, &ic);
         std::set<Zone *> zones;
         zones.insert(staff->GetZone());
         for (auto it = children.begin(); it != children.end(); ++it) {
@@ -594,7 +594,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
     if (staffId == "auto") {
         ListOfObjects staves;
         ClassIdComparison ac(STAFF);
-        m_doc->FindAllDescendantByComparison(&staves, &ac);
+        m_doc->FindAllDescendantsByComparison(&staves, &ac);
         std::vector<Object *> stavesVector(staves.begin(), staves.end());
 
         ClosestBB comp;
@@ -653,7 +653,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         // Find index to insert new staff
         ListOfObjects staves;
         ClassIdComparison ac(STAFF);
-        parent->FindAllDescendantByComparison(&staves, &ac);
+        parent->FindAllDescendantsByComparison(&staves, &ac);
         std::vector<Object *> stavesVector(staves.begin(), staves.end());
         stavesVector.push_back(newStaff);
         StaffSort staffSort;
@@ -890,7 +890,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         ListOfObjects elements;
         InterfaceComparison ic(INTERFACE_PITCH);
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(
             &elements, &ic, clef, (nextClef != NULL) ? nextClef : m_doc->GetDrawingPage()->GetLast());
 
         for (auto it = elements.begin(); it != elements.end(); ++it) {
@@ -1211,7 +1211,7 @@ bool EditorToolkitNeume::SetClef(std::string elementId, std::string shape)
         assert(nextClef);
         InterfaceComparison ic(INTERFACE_PITCH);
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(
             &objects, &ic, clef, (nextClef != NULL) ? nextClef : m_doc->GetDrawingPage()->GetLast());
 
         // Adjust all elements who are positioned relative to clef by pitch
@@ -1301,7 +1301,7 @@ bool EditorToolkitNeume::Split(std::string elementId, int x)
             fi = NULL;
             ListOfObjects facsimileInterfaces;
             InterfaceComparison ic(INTERFACE_FACSIMILE);
-            child->FindAllDescendantByComparison(&facsimileInterfaces, &ic);
+            child->FindAllDescendantsByComparison(&facsimileInterfaces, &ic);
 
             for (auto it = facsimileInterfaces.begin(); it != facsimileInterfaces.end(); ++it) {
                 FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*it);
@@ -1347,7 +1347,7 @@ bool EditorToolkitNeume::Remove(std::string elementId)
     // Remove Zone for element (if any)
     InterfaceComparison ic(INTERFACE_FACSIMILE);
     ListOfObjects fiChildren;
-    obj->FindAllDescendantByComparison(&fiChildren, &ic);
+    obj->FindAllDescendantsByComparison(&fiChildren, &ic);
     FacsimileInterface *fi = dynamic_cast<FacsimileInterface *>(obj);
     if (fi != NULL && fi->HasFacs()) {
         fi->SetZone(NULL);
@@ -1377,7 +1377,7 @@ bool EditorToolkitNeume::Remove(std::string elementId)
         ListOfObjects elements;
         InterfaceComparison ic(INTERFACE_PITCH);
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(
             &elements, &ic, clef, (nextClef != NULL) ? nextClef : m_doc->GetDrawingPage()->GetLast());
 
         result = parent->DeleteChild(obj);
@@ -1642,7 +1642,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
     InterfaceComparison pitchComp(INTERFACE_PITCH);
     Clef *newClef = NULL;
 
-    m_doc->GetDrawingPage()->FindAllDescendantBetween(&clefs, &clefComp,
+    m_doc->GetDrawingPage()->FindAllDescendantsBetween(&clefs, &clefComp,
         sortedElements.front()->GetFirstAncestor(SYLLABLE), sortedElements.back()->GetFirstAncestor(SYLLABLE));
 
     // if there are clefs between the elements getting grouped
@@ -1723,7 +1723,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
                 else {
                     ListOfObjects children;
                     InterfaceComparison comp(INTERFACE_FACSIMILE);
-                    syl->GetFirstAncestor(SYLLABLE)->FindAllDescendantByComparison(&children, &comp);
+                    syl->GetFirstAncestor(SYLLABLE)->FindAllDescendantsByComparison(&children, &comp);
                     for (auto iter2 = children.begin(); iter2 != children.end(); ++iter2) {
                         FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*iter2);
                         assert(temp);
@@ -1903,7 +1903,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
         for (auto it = sortedSyllables.begin(); it != sortedSyllables.end(); ++it) {
             Syllable *syllable = dynamic_cast<Syllable *>(*it);
             if (clefsBefore[syllable] != newClef) {
-                syllable->FindAllDescendantByComparison(&pitchedChildren, &pitchComp);
+                syllable->FindAllDescendantsByComparison(&pitchedChildren, &pitchComp);
                 for (auto child = pitchedChildren.begin(); child != pitchedChildren.end(); ++child) {
                     (*child)->GetPitchInterface()->AdjustPitchForNewClef(clefsBefore[(syllable)], newClef);
                 }
@@ -2026,7 +2026,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
                     else {
                         ListOfObjects children;
                         InterfaceComparison comp(INTERFACE_FACSIMILE);
-                        syl->GetFirstAncestor(SYLLABLE)->FindAllDescendantByComparison(&children, &comp);
+                        syl->GetFirstAncestor(SYLLABLE)->FindAllDescendantsByComparison(&children, &comp);
                         for (auto iter2 = children.begin(); iter2 != children.end(); ++iter2) {
                             FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*iter2);
                             assert(temp);
@@ -2145,7 +2145,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
                 currentClef = dynamic_cast<Layer *>(sparent)->GetCurrentClef();
             }
             if (currentClef != oldClef) {
-                (*it)->FindAllDescendantByComparison(&pitchedChildren, &ic);
+                (*it)->FindAllDescendantsByComparison(&pitchedChildren, &ic);
                 for (auto pChild = pitchedChildren.begin(); pChild != pitchedChildren.end(); ++pChild) {
                     (*pChild)->GetPitchInterface()->AdjustPitchForNewClef(oldClef, currentClef);
                 }
@@ -2181,7 +2181,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
     // Get children of neume. Keep the first child and delete the others.
     ClassIdComparison ac(NC);
     ListOfObjects children;
-    el->FindAllDescendantByComparison(&children, &ac);
+    el->FindAllDescendantsByComparison(&children, &ac);
     for (auto it = children.begin(); it != children.end(); ++it) {
         if (children.begin() == it) {
             firstChild = dynamic_cast<Nc *>(*it);
@@ -2388,7 +2388,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
 
     ListOfObjects stavesList;
     ClassIdComparison ac(STAFF);
-    m_doc->FindAllDescendantByComparison(&stavesList, &ac);
+    m_doc->FindAllDescendantsByComparison(&stavesList, &ac);
 
     std::vector<Object *> staves(stavesList.begin(), stavesList.end());
 
@@ -2478,7 +2478,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
 
         nextClefBefore = dynamic_cast<Clef *>(m_doc->GetDrawingPage()->FindNextChild(&cic, element));
 
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(&oldPitchChildren, &ic, clef,
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(&oldPitchChildren, &ic, clef,
             (nextClefBefore != NULL) ? nextClefBefore : m_doc->GetDrawingPage()->GetLast());
 
         PitchInterface *pi;
@@ -2509,7 +2509,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
             previousClefAfter = layer->GetCurrentClef();
         }
         Clef *nextClefAfter = dynamic_cast<Clef *>(m_doc->GetDrawingPage()->FindNextChild(&cic, element));
-        m_doc->GetDrawingPage()->FindAllDescendantBetween(
+        m_doc->GetDrawingPage()->FindAllDescendantsBetween(
             &newPitchChildren, &ic, clef, (nextClefAfter != NULL) ? nextClefAfter : m_doc->GetDrawingPage()->GetLast());
 
         for (auto it = newPitchChildren.begin(); it != newPitchChildren.end(); ++it) {
@@ -2856,7 +2856,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
 
         ListOfObjects pitchedChildren;
         InterfaceComparison ic(INTERFACE_PITCH);
-        syl->FindAllDescendantByComparison(&pitchedChildren, &ic);
+        syl->FindAllDescendantsByComparison(&pitchedChildren, &ic);
 
         if (pitchedChildren.empty()) {
             LogWarning("Syllable had no pitched children to reorder for syllable %s", obj->GetUuid().c_str());

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -592,9 +592,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
 
     // Find closest valid staff
     if (staffId == "auto") {
-        ListOfObjects staves;
-        ClassIdComparison ac(STAFF);
-        m_doc->FindAllDescendantsByComparison(&staves, &ac);
+        ListOfObjects staves = m_doc->FindAllDescendantsByType(STAFF, false);
         std::vector<Object *> stavesVector(staves.begin(), staves.end());
 
         ClosestBB comp;
@@ -651,9 +649,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         newStaff->AddChild(newLayer);
 
         // Find index to insert new staff
-        ListOfObjects staves;
-        ClassIdComparison ac(STAFF);
-        parent->FindAllDescendantsByComparison(&staves, &ac);
+        ListOfObjects staves = parent->FindAllDescendantsByType(STAFF, false);
         std::vector<Object *> stavesVector(staves.begin(), staves.end());
         stavesVector.push_back(newStaff);
         StaffSort staffSort;
@@ -2179,9 +2175,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
     Nc *prevNc = NULL;
 
     // Get children of neume. Keep the first child and delete the others.
-    ClassIdComparison ac(NC);
-    ListOfObjects children;
-    el->FindAllDescendantsByComparison(&children, &ac);
+    ListOfObjects children = el->FindAllDescendantsByType(NC);
     for (auto it = children.begin(); it != children.end(); ++it) {
         if (children.begin() == it) {
             firstChild = dynamic_cast<Nc *>(*it);
@@ -2386,9 +2380,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
         return false;
     }
 
-    ListOfObjects stavesList;
-    ClassIdComparison ac(STAFF);
-    m_doc->FindAllDescendantsByComparison(&stavesList, &ac);
+    ListOfObjects stavesList = m_doc->FindAllDescendantsByType(STAFF, false);
 
     std::vector<Object *> staves(stavesList.begin(), stavesList.end());
 

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -52,9 +52,7 @@ Zone *Facsimile::FindZoneByUuid(std::string zoneId)
 
 int Facsimile::GetMaxX()
 {
-    ClassIdComparison ac(SURFACE);
-    ListOfObjects surfaces;
-    this->FindAllDescendantsByComparison(&surfaces, &ac);
+    ListOfObjects surfaces = this->FindAllDescendantsByType(SURFACE);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {
@@ -67,9 +65,7 @@ int Facsimile::GetMaxX()
 
 int Facsimile::GetMaxY()
 {
-    ClassIdComparison ac(SURFACE);
-    ListOfObjects surfaces;
-    this->FindAllDescendantsByComparison(&surfaces, &ac);
+    ListOfObjects surfaces = this->FindAllDescendantsByType(SURFACE);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -54,7 +54,7 @@ int Facsimile::GetMaxX()
 {
     ClassIdComparison ac(SURFACE);
     ListOfObjects surfaces;
-    this->FindAllDescendantByComparison(&surfaces, &ac);
+    this->FindAllDescendantsByComparison(&surfaces, &ac);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {
@@ -69,7 +69,7 @@ int Facsimile::GetMaxY()
 {
     ClassIdComparison ac(SURFACE);
     ListOfObjects surfaces;
-    this->FindAllDescendantByComparison(&surfaces, &ac);
+    this->FindAllDescendantsByComparison(&surfaces, &ac);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -358,12 +358,12 @@ void GraceAligner::AlignStack()
 
         ClassIdsComparison matchType({ ACCID, FLAG, NOTE, STEM });
         ListOfObjects children;
-        element->FindAllDescendantByComparison(&children, &matchType);
+        element->FindAllDescendantsByComparison(&children, &matchType);
         alignment->AddLayerElementRef(element);
 
         // Set the grace alignment to all children
         for (auto &child : children) {
-            // Trick : FindAllDescendantByComparison include the element, which is probably a problem.
+            // Trick : FindAllDescendantsByComparison include the element, which is probably a problem.
             // With note, we want to set only accid, so make sure we do not set it twice
             if (child == element) continue;
             LayerElement *childElement = vrv_cast<LayerElement *>(child);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -267,9 +267,7 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
 {
     // Since AddClef handles #sameas clef only for the future layers, we need to check any previous existing layers for
     // the same staff to see if we need to insert #sameas clef to them.
-    ListOfObjects staffLayers;
-    ClassIdComparison cmp(LAYER);
-    staff->FindAllDescendantsByComparison(&staffLayers, &cmp);
+    ListOfObjects staffLayers = staff->FindAllDescendantsByType(LAYER, false);
     for (const auto listLayer : staffLayers) {
         Layer *otherLayer = vrv_cast<Layer *>(listLayer);
         if (m_layerTimes.find(otherLayer) == m_layerTimes.end()) continue;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -269,7 +269,7 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
     // the same staff to see if we need to insert #sameas clef to them.
     ListOfObjects staffLayers;
     ClassIdComparison cmp(LAYER);
-    staff->FindAllDescendantByComparison(&staffLayers, &cmp);
+    staff->FindAllDescendantsByComparison(&staffLayers, &cmp);
     for (const auto listLayer : staffLayers) {
         Layer *otherLayer = vrv_cast<Layer *>(listLayer);
         if (m_layerTimes.find(otherLayer) == m_layerTimes.end()) continue;

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -226,7 +226,7 @@ Clef *Layer::GetClefFacs(LayerElement *test)
     if (doc->GetType() == Facs) {
         ListOfObjects clefs;
         ClassIdComparison ac(CLEF);
-        doc->FindAllDescendantBetween(&clefs, &ac, doc->GetFirst(CLEF), test);
+        doc->FindAllDescendantsBetween(&clefs, &ac, doc->GetFirst(CLEF), test);
         if (clefs.size() > 0) {
             return dynamic_cast<Clef *>(*clefs.rbegin());
         }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -833,9 +833,7 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
         // Find the first note on the other layer
         Alignment *alignment = this->GetAlignment();
         const int currentLayerN = abs(this->GetAlignmentLayerN());
-        ListOfObjects notes;
-        ClassIdComparison noteCmp(NOTE);
-        alignment->FindAllDescendantsByComparison(&notes, &noteCmp, 2);
+        ListOfObjects notes = alignment->FindAllDescendantsByType(NOTE, false);
         auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayerN](Object *obj) {
             const int otherLayerN = abs(vrv_cast<Note *>(obj)->GetAlignmentLayerN());
             return (currentLayerN != otherLayerN);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -439,7 +439,7 @@ int LayerElement::GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticTy
     ClassIdComparison isArtic(ARTIC);
     ListOfObjects artics;
     // Process backward because we want the farest away artic
-    this->FindAllDescendantByComparison(&artics, &isArtic, UNLIMITED_DEPTH, BACKWARD);
+    this->FindAllDescendantsByComparison(&artics, &isArtic, UNLIMITED_DEPTH, BACKWARD);
 
     Artic *artic = NULL;
     for (auto &child : artics) {
@@ -739,7 +739,7 @@ bool LayerElement::GenerateZoneBounds(int *ulx, int *uly, int *lrx, int *lry)
     *lry = INT_MIN;
     ListOfObjects childrenWithFacsimileInterface;
     InterfaceComparison ic(INTERFACE_FACSIMILE);
-    this->FindAllDescendantByComparison(&childrenWithFacsimileInterface, &ic);
+    this->FindAllDescendantsByComparison(&childrenWithFacsimileInterface, &ic);
     bool result = false;
     for (auto it = childrenWithFacsimileInterface.begin(); it != childrenWithFacsimileInterface.end(); ++it) {
         FacsimileInterface *fi = dynamic_cast<FacsimileInterface *>(*it);
@@ -835,7 +835,7 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
         const int currentLayerN = abs(this->GetAlignmentLayerN());
         ListOfObjects notes;
         ClassIdComparison noteCmp(NOTE);
-        alignment->FindAllDescendantByComparison(&notes, &noteCmp, 2);
+        alignment->FindAllDescendantsByComparison(&notes, &noteCmp, 2);
         auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayerN](Object *obj) {
             const int otherLayerN = abs(vrv_cast<Note *>(obj)->GetAlignmentLayerN());
             return (currentLayerN != otherLayerN);
@@ -2126,7 +2126,7 @@ int LayerElement::PrepareCrossStaffEnd(FunctorParams *functorParams)
         // If yes, make them cross-staff themselves.
         ListOfObjects durations;
         InterfaceComparison hasInterface(INTERFACE_DURATION);
-        this->FindAllDescendantByComparison(&durations, &hasInterface);
+        this->FindAllDescendantsByComparison(&durations, &hasInterface);
         Staff *crossStaff = NULL;
         Layer *crossLayer = NULL;
         for (auto object : durations) {

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -373,7 +373,7 @@ std::vector<Staff *> Measure::GetFirstStaffGrpStaves(ScoreDef *scoreDef)
     // First get all the staffGrps
     ClassIdComparison matchType(STAFFGRP);
     ListOfObjects staffGrps;
-    scoreDef->FindAllDescendantByComparison(&staffGrps, &matchType);
+    scoreDef->FindAllDescendantsByComparison(&staffGrps, &matchType);
 
     // Then the @n of each first staffDef
     for (auto &staffGrp : staffGrps) {
@@ -400,7 +400,7 @@ Staff *Measure::GetTopVisibleStaff()
     Staff *staff = NULL;
     ListOfObjects staves;
     ClassIdComparison matchType(STAFF);
-    this->FindAllDescendantByComparison(&staves, &matchType, 1);
+    this->FindAllDescendantsByComparison(&staves, &matchType, 1);
     for (auto &child : staves) {
         staff = vrv_cast<Staff *>(child);
         assert(staff);
@@ -417,7 +417,7 @@ Staff *Measure::GetBottomVisibleStaff()
     Staff *bottomStaff = NULL;
     ListOfObjects staves;
     ClassIdComparison matchType(STAFF);
-    this->FindAllDescendantByComparison(&staves, &matchType, 1);
+    this->FindAllDescendantsByComparison(&staves, &matchType, 1);
     for (const auto child : staves) {
         Staff *staff = vrv_cast<Staff *>(child);
         assert(staff);
@@ -627,7 +627,7 @@ std::vector<std::pair<LayerElement *, LayerElement *>> Measure::GetInternalTieEn
 {
     ListOfObjects children;
     ClassIdComparison comp(TIE);
-    this->FindAllDescendantByComparison(&children, &comp);
+    this->FindAllDescendantsByComparison(&children, &comp);
 
     std::vector<std::pair<LayerElement *, LayerElement *>> endpoints;
     for (Object *object : children) {

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -371,9 +371,7 @@ std::vector<Staff *> Measure::GetFirstStaffGrpStaves(ScoreDef *scoreDef)
     std::vector<int> staffList;
 
     // First get all the staffGrps
-    ClassIdComparison matchType(STAFFGRP);
-    ListOfObjects staffGrps;
-    scoreDef->FindAllDescendantsByComparison(&staffGrps, &matchType);
+    ListOfObjects staffGrps = scoreDef->FindAllDescendantsByType(STAFFGRP);
 
     // Then the @n of each first staffDef
     for (auto &staffGrp : staffGrps) {
@@ -398,9 +396,7 @@ std::vector<Staff *> Measure::GetFirstStaffGrpStaves(ScoreDef *scoreDef)
 Staff *Measure::GetTopVisibleStaff()
 {
     Staff *staff = NULL;
-    ListOfObjects staves;
-    ClassIdComparison matchType(STAFF);
-    this->FindAllDescendantsByComparison(&staves, &matchType, 1);
+    ListOfObjects staves = this->FindAllDescendantsByType(STAFF, false);
     for (auto &child : staves) {
         staff = vrv_cast<Staff *>(child);
         assert(staff);
@@ -415,9 +411,7 @@ Staff *Measure::GetTopVisibleStaff()
 Staff *Measure::GetBottomVisibleStaff()
 {
     Staff *bottomStaff = NULL;
-    ListOfObjects staves;
-    ClassIdComparison matchType(STAFF);
-    this->FindAllDescendantsByComparison(&staves, &matchType, 1);
+    ListOfObjects staves = this->FindAllDescendantsByType(STAFF, false);
     for (const auto child : staves) {
         Staff *staff = vrv_cast<Staff *>(child);
         assert(staff);
@@ -625,9 +619,7 @@ void Measure::SetInvisibleStaffBarlines(
 
 std::vector<std::pair<LayerElement *, LayerElement *>> Measure::GetInternalTieEndpoints()
 {
-    ListOfObjects children;
-    ClassIdComparison comp(TIE);
-    this->FindAllDescendantsByComparison(&children, &comp);
+    ListOfObjects children = this->FindAllDescendantsByType(TIE);
 
     std::vector<std::pair<LayerElement *, LayerElement *>> endpoints;
     for (Object *object : children) {

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -98,7 +98,7 @@ int MRest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocati
 
     ListOfObjects layers;
     ClassIdComparison matchType(LAYER);
-    parentStaff->FindAllDescendantByComparison(&layers, &matchType);
+    parentStaff->FindAllDescendantsByComparison(&layers, &matchType);
     const bool isTopLayer = (vrv_cast<Layer *>(*layers.begin())->GetN() == layer->GetN());
 
     ListOfObjects::iterator otherLayerIter = isTopLayer ? std::prev(layers.end()) : layers.begin();

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -96,9 +96,7 @@ int MRest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocati
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
     if (parentStaff->GetChildCount(LAYER) != 2) return defaultLocation;
 
-    ListOfObjects layers;
-    ClassIdComparison matchType(LAYER);
-    parentStaff->FindAllDescendantsByComparison(&layers, &matchType);
+    ListOfObjects layers = parentStaff->FindAllDescendantsByType(LAYER, false);
     const bool isTopLayer = (vrv_cast<Layer *>(*layers.begin())->GetN() == layer->GetN());
 
     ListOfObjects::iterator otherLayerIter = isTopLayer ? std::prev(layers.end()) : layers.begin();

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -92,7 +92,7 @@ NeumeGroup Neume::GetNeumeGroup()
 {
     ListOfObjects children;
     ClassIdComparison ac(NC);
-    this->FindAllDescendantByComparison(&children, &ac);
+    this->FindAllDescendantsByComparison(&children, &ac);
 
     auto iter = children.begin();
     Nc *previous = dynamic_cast<Nc *>(*iter);
@@ -131,7 +131,7 @@ std::vector<int> Neume::GetPitchDifferences()
     std::vector<int> pitchDifferences;
     ListOfObjects ncChildren;
     ClassIdComparison ac(NC);
-    this->FindAllDescendantByComparison(&ncChildren, &ac);
+    this->FindAllDescendantsByComparison(&ncChildren, &ac);
 
     pitchDifferences.reserve(ncChildren.size() - 1);
 
@@ -154,7 +154,7 @@ bool Neume::GenerateChildMelodic()
 {
     ListOfObjects children;
     ClassIdComparison ac(NC);
-    this->FindAllDescendantByComparison(&children, &ac);
+    this->FindAllDescendantsByComparison(&children, &ac);
 
     // Get the first neume component of the neume
     auto iter = children.begin();
@@ -190,7 +190,7 @@ PitchInterface *Neume::GetHighestPitch()
 {
     ListOfObjects pitchChildren;
     InterfaceComparison ic(INTERFACE_PITCH);
-    this->FindAllDescendantByComparison(&pitchChildren, &ic);
+    this->FindAllDescendantsByComparison(&pitchChildren, &ic);
 
     auto it = pitchChildren.begin();
     PitchInterface *max = (*it)->GetPitchInterface();
@@ -209,7 +209,7 @@ PitchInterface *Neume::GetLowestPitch()
 {
     ListOfObjects pitchChildren;
     InterfaceComparison ic(INTERFACE_PITCH);
-    this->FindAllDescendantByComparison(&pitchChildren, &ic);
+    this->FindAllDescendantsByComparison(&pitchChildren, &ic);
 
     auto it = pitchChildren.begin();
     PitchInterface *min = (*it)->GetPitchInterface();

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -90,9 +90,7 @@ bool Neume::IsLastInNeume(LayerElement *element)
 
 NeumeGroup Neume::GetNeumeGroup()
 {
-    ListOfObjects children;
-    ClassIdComparison ac(NC);
-    this->FindAllDescendantsByComparison(&children, &ac);
+    ListOfObjects children = this->FindAllDescendantsByType(NC);
 
     auto iter = children.begin();
     Nc *previous = dynamic_cast<Nc *>(*iter);
@@ -129,9 +127,7 @@ NeumeGroup Neume::GetNeumeGroup()
 std::vector<int> Neume::GetPitchDifferences()
 {
     std::vector<int> pitchDifferences;
-    ListOfObjects ncChildren;
-    ClassIdComparison ac(NC);
-    this->FindAllDescendantsByComparison(&ncChildren, &ac);
+    ListOfObjects ncChildren = this->FindAllDescendantsByType(NC);
 
     pitchDifferences.reserve(ncChildren.size() - 1);
 
@@ -152,9 +148,7 @@ std::vector<int> Neume::GetPitchDifferences()
 
 bool Neume::GenerateChildMelodic()
 {
-    ListOfObjects children;
-    ClassIdComparison ac(NC);
-    this->FindAllDescendantsByComparison(&children, &ac);
+    ListOfObjects children = this->FindAllDescendantsByType(NC);
 
     // Get the first neume component of the neume
     auto iter = children.begin();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -365,7 +365,7 @@ int Object::GetChildCount(const ClassId classId, int deepth)
 {
     ListOfObjects objects;
     ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantByComparison(&objects, &matchClassId);
+    this->FindAllDescendantsByComparison(&objects, &matchClassId);
     return (int)objects.size();
 }
 
@@ -562,7 +562,7 @@ Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int de
     return findExtremeByComparisonParams.m_element;
 }
 
-ListOfObjects Object::FindAllDescendantByType(ClassId classId, bool continueDepthSearchForMatches, int deepness)
+ListOfObjects Object::FindAllDescendantsByType(ClassId classId, bool continueDepthSearchForMatches, int deepness)
 {
     ListOfObjects objects;
     ClassIdComparison comparison(classId);
@@ -573,7 +573,7 @@ ListOfObjects Object::FindAllDescendantByType(ClassId classId, bool continueDept
     return objects;
 }
 
-void Object::FindAllDescendantByComparison(
+void Object::FindAllDescendantsByComparison(
     ListOfObjects *objects, Comparison *comparison, int deepness, bool direction, bool clear)
 {
     assert(objects);
@@ -584,7 +584,7 @@ void Object::FindAllDescendantByComparison(
     this->Process(&findAllByComparison, &findAllByComparisonParams, NULL, NULL, deepness, direction, true);
 }
 
-void Object::FindAllDescendantBetween(
+void Object::FindAllDescendantsBetween(
     ListOfObjects *objects, Comparison *comparison, Object *start, Object *end, bool clear)
 {
     assert(objects);
@@ -607,7 +607,7 @@ Object *Object::GetChild(int idx, const ClassId classId)
 {
     ListOfObjects objects;
     ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantByComparison(&objects, &matchClassId, 1);
+    this->FindAllDescendantsByComparison(&objects, &matchClassId, 1);
     if ((idx < 0) || (idx >= (int)objects.size())) {
         return NULL;
     }
@@ -721,7 +721,7 @@ int Object::GetDescendantIndex(const Object *child, const ClassId classId, int d
 {
     ListOfObjects objects;
     ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantByComparison(&objects, &matchClassId);
+    this->FindAllDescendantsByComparison(&objects, &matchClassId);
     int i = 0;
     for (auto &object : objects) {
         if (child == object) return i;
@@ -814,7 +814,7 @@ bool Object::HasEditorialContent()
 {
     ListOfObjects editorial;
     IsEditorialElementComparison editorialComparison;
-    this->FindAllDescendantByComparison(&editorial, &editorialComparison);
+    this->FindAllDescendantsByComparison(&editorial, &editorialComparison);
     return (!editorial.empty());
 }
 
@@ -823,7 +823,7 @@ bool Object::HasNonEditorialContent()
     ListOfObjects nonEditorial;
     IsEditorialElementComparison editorialComparison;
     editorialComparison.ReverseComparison();
-    this->FindAllDescendantByComparison(&nonEditorial, &editorialComparison);
+    this->FindAllDescendantsByComparison(&nonEditorial, &editorialComparison);
     return (!nonEditorial.empty());
 }
 
@@ -1015,7 +1015,7 @@ bool Object::sortByUlx(Object *a, Object *b)
         fa = a->GetFacsimileInterface();
     else {
         ListOfObjects children;
-        a->FindAllDescendantByComparison(&children, &comp);
+        a->FindAllDescendantsByComparison(&children, &comp);
         for (auto it = children.begin(); it != children.end(); ++it) {
             if ((*it)->Is(SYL)) continue;
             FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*it);
@@ -1029,7 +1029,7 @@ bool Object::sortByUlx(Object *a, Object *b)
         fb = b->GetFacsimileInterface();
     else {
         ListOfObjects children;
-        b->FindAllDescendantByComparison(&children, &comp);
+        b->FindAllDescendantsByComparison(&children, &comp);
         for (auto it = children.begin(); it != children.end(); ++it) {
             if ((*it)->Is(SYL)) continue;
             FacsimileInterface *temp = dynamic_cast<FacsimileInterface *>(*it);
@@ -1699,12 +1699,12 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
         // them)
         ListOfObjects currentObjects, previousObjects;
         AttVisibilityComparison comparison(STAFF, BOOLEAN_false);
-        measure->FindAllDescendantByComparison(&currentObjects, &comparison);
+        measure->FindAllDescendantsByComparison(&currentObjects, &comparison);
         if ((int)currentObjects.size() == measure->GetChildCount(STAFF)) {
             drawingFlags |= Measure::BarlineDrawingFlags::INVISIBLE_MEASURE_CURRENT;
         }
         if (params->m_previousMeasure) {
-            params->m_previousMeasure->FindAllDescendantByComparison(&previousObjects, &comparison);
+            params->m_previousMeasure->FindAllDescendantsByComparison(&previousObjects, &comparison);
             if ((int)previousObjects.size() == params->m_previousMeasure->GetChildCount(STAFF))
                 drawingFlags |= Measure::BarlineDrawingFlags::INVISIBLE_MEASURE_PREVIOUS;
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -361,11 +361,9 @@ int Object::GetChildCount(const ClassId classId) const
     return (int)count_if(m_children.begin(), m_children.end(), ObjectComparison(classId));
 }
 
-int Object::GetChildCount(const ClassId classId, int deepth)
+int Object::GetChildCount(const ClassId classId, int depth)
 {
-    ListOfObjects objects;
-    ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantsByComparison(&objects, &matchClassId);
+    ListOfObjects objects = this->FindAllDescendantsByType(classId, true, depth);
     return (int)objects.size();
 }
 
@@ -605,9 +603,7 @@ Object *Object::GetChild(int idx) const
 
 Object *Object::GetChild(int idx, const ClassId classId)
 {
-    ListOfObjects objects;
-    ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantsByComparison(&objects, &matchClassId, 1);
+    ListOfObjects objects = this->FindAllDescendantsByType(classId, true, 1);
     if ((idx < 0) || (idx >= (int)objects.size())) {
         return NULL;
     }
@@ -717,11 +713,9 @@ int Object::GetChildIndex(const Object *child)
     return -1;
 }
 
-int Object::GetDescendantIndex(const Object *child, const ClassId classId, int deepth)
+int Object::GetDescendantIndex(const Object *child, const ClassId classId, int depth)
 {
-    ListOfObjects objects;
-    ClassIdComparison matchClassId(classId);
-    this->FindAllDescendantsByComparison(&objects, &matchClassId);
+    ListOfObjects objects = this->FindAllDescendantsByType(classId, true, depth);
     int i = 0;
     for (auto &object : objects) {
         if (child == object) return i;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -562,6 +562,17 @@ Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int de
     return findExtremeByComparisonParams.m_element;
 }
 
+ListOfObjects Object::FindAllDescendantByType(ClassId classId, bool continueDepthSearchForMatches, int deepness)
+{
+    ListOfObjects objects;
+    ClassIdComparison comparison(classId);
+    Functor findAllByComparison(&Object::FindAllByComparison);
+    FindAllByComparisonParams findAllByComparisonParams(&comparison, &objects);
+    findAllByComparisonParams.m_continueDepthSearchForMatches = continueDepthSearchForMatches;
+    this->Process(&findAllByComparison, &findAllByComparisonParams, NULL, NULL, deepness);
+    return objects;
+}
+
 void Object::FindAllDescendantByComparison(
     ListOfObjects *objects, Comparison *comparison, int deepness, bool direction, bool clear)
 {
@@ -1392,6 +1403,9 @@ int Object::FindAllByComparison(FunctorParams *functorParams)
     // evaluate by applying the Comparison operator()
     if ((*params->m_comparison)(this)) {
         params->m_elements->push_back(this);
+        if (!params->m_continueDepthSearchForMatches) {
+            return FUNCTOR_SIBLINGS;
+        }
     }
     // continue until the end
     return FUNCTOR_CONTINUE;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -273,9 +273,7 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
 
     // find best rest location relative to elements on other layers
     Staff *realStaff = m_crossStaff ? m_crossStaff : staff;
-    ListOfObjects layers;
-    ClassIdComparison matchType(LAYER);
-    realStaff->FindAllDescendantsByComparison(&layers, &matchType);
+    ListOfObjects layers = realStaff->FindAllDescendantsByType(LAYER, false);
     const auto otherLayerRelativeLocationInfo = GetLocationRelativeToOtherLayers(layers, layer, isTopLayer);
     int currentLayerRelativeLocation = GetLocationRelativeToCurrentLayer(staff, layer, isTopLayer);
     int otherLayerRelativeLocation = otherLayerRelativeLocationInfo.first
@@ -425,9 +423,7 @@ int Rest::GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLay
     if (!previousStaff) return VRV_UNSET;
 
     // Compare number of layers in the next/previous staff and if it's the same - find layer with same N
-    ListOfObjects layers;
-    ClassIdComparison matchType(LAYER);
-    previousStaff->FindAllDescendantsByComparison(&layers, &matchType);
+    ListOfObjects layers = previousStaff->FindAllDescendantsByType(LAYER, false);
     auto layerIter = std::find_if(layers.begin(), layers.end(),
         [&](Object *foundLayer) { return vrv_cast<Layer *>(foundLayer)->GetN() == currentLayer->GetN(); });
     if (((int)layers.size() != currentStaff->GetChildCount(LAYER)) || (layerIter == layers.end())) return VRV_UNSET;
@@ -681,9 +677,7 @@ int Rest::Transpose(FunctorParams *functorParams)
     Layer *parentLayer = vrv_cast<Layer *>(GetFirstAncestor(LAYER));
     assert(parentLayer);
 
-    ListOfObjects objects;
-    ClassIdComparison matchClassId(LAYER);
-    parentStaff->FindAllDescendantsByComparison(&objects, &matchClassId);
+    ListOfObjects objects = parentStaff->FindAllDescendantsByType(LAYER, false);
     const int layerCount = (int)objects.size();
 
     Layer *firstLayer = vrv_cast<Layer *>(objects.front());

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -275,7 +275,7 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
     Staff *realStaff = m_crossStaff ? m_crossStaff : staff;
     ListOfObjects layers;
     ClassIdComparison matchType(LAYER);
-    realStaff->FindAllDescendantByComparison(&layers, &matchType);
+    realStaff->FindAllDescendantsByComparison(&layers, &matchType);
     const auto otherLayerRelativeLocationInfo = GetLocationRelativeToOtherLayers(layers, layer, isTopLayer);
     int currentLayerRelativeLocation = GetLocationRelativeToCurrentLayer(staff, layer, isTopLayer);
     int otherLayerRelativeLocation = otherLayerRelativeLocationInfo.first
@@ -427,7 +427,7 @@ int Rest::GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLay
     // Compare number of layers in the next/previous staff and if it's the same - find layer with same N
     ListOfObjects layers;
     ClassIdComparison matchType(LAYER);
-    previousStaff->FindAllDescendantByComparison(&layers, &matchType);
+    previousStaff->FindAllDescendantsByComparison(&layers, &matchType);
     auto layerIter = std::find_if(layers.begin(), layers.end(),
         [&](Object *foundLayer) { return vrv_cast<Layer *>(foundLayer)->GetN() == currentLayer->GetN(); });
     if (((int)layers.size() != currentStaff->GetChildCount(LAYER)) || (layerIter == layers.end())) return VRV_UNSET;
@@ -683,7 +683,7 @@ int Rest::Transpose(FunctorParams *functorParams)
 
     ListOfObjects objects;
     ClassIdComparison matchClassId(LAYER);
-    parentStaff->FindAllDescendantByComparison(&objects, &matchClassId);
+    parentStaff->FindAllDescendantsByComparison(&objects, &matchClassId);
     const int layerCount = (int)objects.size();
 
     Layer *firstLayer = vrv_cast<Layer *>(objects.front());

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -145,7 +145,7 @@ bool Score::ScoreDefNeedsOptimization(int optionCondense)
     if ((optionCondense == CONDENSE_auto) && !m_scoreDef.HasOptimize()) {
         ListOfObjects symbols;
         ClassIdComparison matchClassId(GRPSYM);
-        m_scoreDef.FindAllDescendantByComparison(&symbols, &matchClassId);
+        m_scoreDef.FindAllDescendantsByComparison(&symbols, &matchClassId);
         optimize = (symbols.size() > 1);
     }
 

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -143,9 +143,7 @@ bool Score::ScoreDefNeedsOptimization(int optionCondense)
     bool optimize = (m_scoreDef.HasOptimize() && m_scoreDef.GetOptimize() == BOOLEAN_true);
     // if nothing specified, do not if there is only one grpSym
     if ((optionCondense == CONDENSE_auto) && !m_scoreDef.HasOptimize()) {
-        ListOfObjects symbols;
-        ClassIdComparison matchClassId(GRPSYM);
-        m_scoreDef.FindAllDescendantsByComparison(&symbols, &matchClassId);
+        ListOfObjects symbols = m_scoreDef.FindAllDescendantsByType(GRPSYM);
         optimize = (symbols.size() > 1);
     }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -432,9 +432,7 @@ StaffDef *ScoreDef::GetStaffDef(int n)
 StaffGrp *ScoreDef::GetStaffGrp(const std::string &n)
 {
     // First get all the staffGrps
-    ClassIdComparison matchType(STAFFGRP);
-    ListOfObjects staffGrps;
-    this->FindAllDescendantsByComparison(&staffGrps, &matchType);
+    ListOfObjects staffGrps = this->FindAllDescendantsByType(STAFFGRP);
 
     // Then the @n of each first staffDef
     for (auto &item : staffGrps) {

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -434,7 +434,7 @@ StaffGrp *ScoreDef::GetStaffGrp(const std::string &n)
     // First get all the staffGrps
     ClassIdComparison matchType(STAFFGRP);
     ListOfObjects staffGrps;
-    this->FindAllDescendantByComparison(&staffGrps, &matchType);
+    this->FindAllDescendantsByComparison(&staffGrps, &matchType);
 
     // Then the @n of each first staffDef
     for (auto &item : staffGrps) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -212,13 +212,13 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
             notes.push_back(this->GetStart());
         }
         else {
-            this->GetStart()->FindAllDescendantByComparison(&notes, &cmp, 1, FORWARD, false);
+            this->GetStart()->FindAllDescendantsByComparison(&notes, &cmp, 1, FORWARD, false);
         }
         if (this->GetEnd()->Is(NOTE)) {
             notes.push_back(this->GetEnd());
         }
         else {
-            this->GetEnd()->FindAllDescendantByComparison(&notes, &cmp, 1, FORWARD, false);
+            this->GetEnd()->FindAllDescendantsByComparison(&notes, &cmp, 1, FORWARD, false);
         }
 
         // Determine the minimal and maximal diatonic pitch
@@ -1226,12 +1226,11 @@ std::pair<int, int> Slur::CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, 
 PortatoSlurType Slur::IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord, curvature_CURVEDIR curveDir) const
 {
     ListOfObjects artics;
-    ClassIdComparison cmp(ARTIC);
     if (startChord) {
-        startChord->FindAllDescendantByComparison(&artics, &cmp, 1);
+        artics = startChord->FindAllDescendantsByType(ARTIC, true, 1);
     }
     else if (startNote) {
-        startNote->FindAllDescendantByComparison(&artics, &cmp, 1);
+        artics = startNote->FindAllDescendantsByType(ARTIC, true, 1);
     }
 
     PortatoSlurType type = PortatoSlurType::None;

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -475,9 +475,7 @@ int Staff::ScoreDefOptimize(FunctorParams *functorParams)
     matchTypeLayer.ReverseComparison();
     this->FindAllDescendantsByComparison(&layers, &matchTypeLayer);
 
-    ListOfObjects mRests;
-    ClassIdComparison matchTypeMRest(MREST);
-    this->FindAllDescendantsByComparison(&mRests, &matchTypeMRest);
+    ListOfObjects mRests = this->FindAllDescendantsByType(MREST);
 
     // Show the staff only if no layer with content or only mRests
     if (layers.empty() || (mRests.size() != layers.size())) {
@@ -649,10 +647,7 @@ int Staff::CalcOnsetOffset(FunctorParams *functorParams)
 
 int Staff::CalcStem(FunctorParams *)
 {
-    ClassIdComparison isLayer(LAYER);
-    ListOfObjects layers;
-    this->FindAllDescendantsByComparison(&layers, &isLayer);
-
+    ListOfObjects layers = this->FindAllDescendantsByType(LAYER, false);
     if (layers.empty()) {
         return FUNCTOR_CONTINUE;
     }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -473,11 +473,11 @@ int Staff::ScoreDefOptimize(FunctorParams *functorParams)
     ListOfObjects layers;
     IsEmptyComparison matchTypeLayer(LAYER);
     matchTypeLayer.ReverseComparison();
-    this->FindAllDescendantByComparison(&layers, &matchTypeLayer);
+    this->FindAllDescendantsByComparison(&layers, &matchTypeLayer);
 
     ListOfObjects mRests;
     ClassIdComparison matchTypeMRest(MREST);
-    this->FindAllDescendantByComparison(&mRests, &matchTypeMRest);
+    this->FindAllDescendantsByComparison(&mRests, &matchTypeMRest);
 
     // Show the staff only if no layer with content or only mRests
     if (layers.empty() || (mRests.size() != layers.size())) {
@@ -651,7 +651,7 @@ int Staff::CalcStem(FunctorParams *)
 {
     ClassIdComparison isLayer(LAYER);
     ListOfObjects layers;
-    this->FindAllDescendantByComparison(&layers, &isLayer);
+    this->FindAllDescendantsByComparison(&layers, &isLayer);
 
     if (layers.empty()) {
         return FUNCTOR_CONTINUE;
@@ -673,7 +673,7 @@ int Staff::CalcStem(FunctorParams *)
     // Detecting empty layers (empty layers can also have @sameas) which have to be ignored for stem direction
     IsEmptyComparison isEmptyElement(LAYER);
     ListOfObjects emptyLayers;
-    this->FindAllDescendantByComparison(&emptyLayers, &isEmptyElement);
+    this->FindAllDescendantsByComparison(&emptyLayers, &isEmptyElement);
 
     // We have only one layer (or less) with content - drawing stem dir remains unset
     if ((layers.size() < 3) && (emptyLayers.size() > 0)) {

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -61,7 +61,7 @@ int Surface::GetMaxX()
     int max = 0;
     ClassIdComparison ac(ZONE);
     ListOfObjects zones;
-    FindAllDescendantByComparison(&zones, &ac);
+    FindAllDescendantsByComparison(&zones, &ac);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
         Zone *zone = vrv_cast<Zone *>(*iter);
         assert(zone);
@@ -76,7 +76,7 @@ int Surface::GetMaxY()
     int max = 0;
     ClassIdComparison ac(ZONE);
     ListOfObjects zones;
-    FindAllDescendantByComparison(&zones, &ac);
+    FindAllDescendantsByComparison(&zones, &ac);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
         Zone *zone = vrv_cast<Zone *>(*iter);
         assert(zone);

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -59,9 +59,7 @@ int Surface::GetMaxX()
 {
     if (HasLrx()) return GetLrx();
     int max = 0;
-    ClassIdComparison ac(ZONE);
-    ListOfObjects zones;
-    FindAllDescendantsByComparison(&zones, &ac);
+    ListOfObjects zones = this->FindAllDescendantsByType(ZONE);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
         Zone *zone = vrv_cast<Zone *>(*iter);
         assert(zone);
@@ -74,9 +72,7 @@ int Surface::GetMaxY()
 {
     if (HasLry()) return GetLry();
     int max = 0;
-    ClassIdComparison ac(ZONE);
-    ListOfObjects zones;
-    FindAllDescendantsByComparison(&zones, &ac);
+    ListOfObjects zones = this->FindAllDescendantsByType(ZONE);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
         Zone *zone = vrv_cast<Zone *>(*iter);
         assert(zone);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -226,7 +226,7 @@ bool System::HasMixedDrawingStemDir(LayerElement *start, LayerElement *end)
     for (auto &measure : measures) {
         Object *curStart = (measure == measureStart) ? start : measure->GetFirst();
         Object *curEnd = (measure == measureEnd) ? end : measure->GetLast();
-        measure->FindAllDescendantBetween(&children, &matchType, curStart, curEnd, false);
+        measure->FindAllDescendantsBetween(&children, &matchType, curStart, curEnd, false);
     }
 
     Layer *layerStart = vrv_cast<Layer *>(start->GetFirstAncestor(LAYER));

--- a/src/textdirinterface.cpp
+++ b/src/textdirinterface.cpp
@@ -42,7 +42,7 @@ int TextDirInterface::GetNumberOfLines(Object *object)
 
     ListOfObjects lbs;
     ClassIdComparison matches(LB);
-    object->FindAllDescendantByComparison(&lbs, &matches);
+    object->FindAllDescendantsByComparison(&lbs, &matches);
     return ((int)lbs.size() + 1);
 }
 

--- a/src/textdirinterface.cpp
+++ b/src/textdirinterface.cpp
@@ -40,9 +40,7 @@ int TextDirInterface::GetNumberOfLines(Object *object)
 {
     assert(object);
 
-    ListOfObjects lbs;
-    ClassIdComparison matches(LB);
-    object->FindAllDescendantsByComparison(&lbs, &matches);
+    ListOfObjects lbs = object->FindAllDescendantsByType(LB);
     return ((int)lbs.size() + 1);
 }
 

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -78,9 +78,7 @@ void Tie::Reset()
 bool Tie::AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote,
     Note *endNote, curvature_CURVEDIR drawingCurveDir)
 {
-    ListOfObjects objects;
-    ClassIdComparison cmp(ACCID);
-    endNote->FindAllDescendantByComparison(&objects, &cmp);
+    ListOfObjects objects = endNote->FindAllDescendantsByType(ACCID);
     if (objects.empty()) return false;
 
     int overlap = 0;

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -401,7 +401,7 @@ void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], 
 {
     ListOfObjects objects;
     ClassIdsComparison cmp({ DOT, DOTS, FLAG });
-    durElement->FindAllDescendantByComparison(&objects, &cmp);
+    durElement->FindAllDescendantsByComparison(&objects, &cmp);
 
     int adjust = 0;
     int dotsPosition = 0;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1416,7 +1416,7 @@ std::string Toolkit::GetElementsAtTime(int millisec)
     ListOfObjects notes;
     ListOfObjects chords;
 
-    measure->FindAllDescendantByComparison(&notes, &matchNoteTime);
+    measure->FindAllDescendantsByComparison(&notes, &matchNoteTime);
 
     // Fill the JSON object
     for (auto const item : notes) {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -151,7 +151,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff, int staffSize)
         // Check for possible articulations
         ListOfObjects artics;
         ClassIdsComparison comparison({ ARTIC });
-        this->FindAllDescendantByComparison(&artics, &comparison);
+        this->FindAllDescendantsByComparison(&artics, &comparison);
 
         int articPadding = 0;
         for (auto &artic : artics) {
@@ -178,7 +178,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff, int staffSize)
         // on the same level in encoding - there might be overlap of bracket with rest in that case
         ListOfObjects descendants;
         ClassIdsComparison rest({ REST });
-        this->FindAllDescendantByComparison(&descendants, &rest);
+        this->FindAllDescendantsByComparison(&descendants, &rest);
 
         int restAdjust = 0;
         const int bracketRel = tupletBracket->GetDrawingYRel() - articPadding + bracketVerticalMargin;
@@ -220,7 +220,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff, int staffSize)
         // Possible issue with beam above the tuplet - not sure this will be noticeable
         ListOfObjects descendants;
         ClassIdsComparison comparison({ ARTIC, ACCID, BEAM, DOT, FLAG, NOTE, REST, STEM });
-        this->FindAllDescendantByComparison(&descendants, &comparison);
+        this->FindAllDescendantsByComparison(&descendants, &comparison);
 
         for (auto &descendant : descendants) {
             if (!descendant->HasSelfBB()) continue;
@@ -329,7 +329,7 @@ void Tuplet::CalculateTupletNumCrossStaff(LayerElement *layerElement)
     // Find if there is a mix of cross-staff and non-cross-staff elements in the tuplet
     ListOfObjects descendants;
     ClassIdsComparison comparison({ CHORD, NOTE, REST });
-    this->FindAllDescendantByComparison(&descendants, &comparison);
+    this->FindAllDescendantsByComparison(&descendants, &comparison);
 
     Staff *crossStaff = NULL;
     Layer *crossLayer = NULL;

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -149,9 +149,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff, int staffSize)
     Beam *beam = this->GetBracketAlignedBeam();
     if (beam) {
         // Check for possible articulations
-        ListOfObjects artics;
-        ClassIdsComparison comparison({ ARTIC });
-        this->FindAllDescendantsByComparison(&artics, &comparison);
+        ListOfObjects artics = this->FindAllDescendantsByType(ARTIC);
 
         int articPadding = 0;
         for (auto &artic : artics) {
@@ -176,9 +174,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff, int staffSize)
 
         // Check for overlap with rest elements. This might happen when tuplet has rest and beam children that are
         // on the same level in encoding - there might be overlap of bracket with rest in that case
-        ListOfObjects descendants;
-        ClassIdsComparison rest({ REST });
-        this->FindAllDescendantsByComparison(&descendants, &rest);
+        ListOfObjects descendants = this->FindAllDescendantsByType(REST);
 
         int restAdjust = 0;
         const int bracketRel = tupletBracket->GetDrawingYRel() - articPadding + bracketVerticalMargin;

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -147,7 +147,7 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
 
     ListOfObjects syls;
     ClassIdComparison matchTypeSyl(SYL);
-    this->FindAllDescendantByComparison(&syls, &matchTypeSyl);
+    this->FindAllDescendantsByComparison(&syls, &matchTypeSyl);
 
     int shift = params->m_doc->GetDrawingUnit(params->m_staffSize);
     // Adjust it proportionally to the lyric size

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -145,9 +145,7 @@ int Verse::AdjustSylSpacing(FunctorParams *functorParams)
 
     /*******/
 
-    ListOfObjects syls;
-    ClassIdComparison matchTypeSyl(SYL);
-    this->FindAllDescendantsByComparison(&syls, &matchTypeSyl);
+    ListOfObjects syls = this->FindAllDescendantsByType(SYL);
 
     int shift = params->m_doc->GetDrawingUnit(params->m_staffSize);
     // Adjust it proportionally to the lyric size

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1226,9 +1226,7 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
                 fullLine.UpdateContentBBoxY(y1 + (lineWidth / 2), y1 - (lineWidth / 2));
                 fullLine.UpdateContentBBoxX(x1, x2);
                 int margin = m_doc->GetDrawingUnit(100) / 2;
-                ListOfObjects notes;
-                ClassIdComparison matchClassId(NOTE);
-                staff->FindAllDescendantsByComparison(&notes, &matchClassId);
+                ListOfObjects notes = staff->FindAllDescendantsByType(NOTE, false);
                 for (auto &note : notes) {
                     if (note->VerticalContentOverlap(&fullLine, margin / 2)) {
                         line.AddGap(note->GetContentLeft() - margin, note->GetContentRight() + margin);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1228,7 +1228,7 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
                 int margin = m_doc->GetDrawingUnit(100) / 2;
                 ListOfObjects notes;
                 ClassIdComparison matchClassId(NOTE);
-                staff->FindAllDescendantByComparison(&notes, &matchClassId);
+                staff->FindAllDescendantsByComparison(&notes, &matchClassId);
                 for (auto &note : notes) {
                     if (note->VerticalContentOverlap(&fullLine, margin / 2)) {
                         line.AddGap(note->GetContentLeft() - margin, note->GetContentRight() + margin);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -137,7 +137,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 
     // the normal case or start
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
-        start->FindAllDescendantByComparison(&artics, &matchType);
+        start->FindAllDescendantsByComparison(&artics, &matchType);
         // Then the @n of each first staffDef
         for (auto &object : artics) {
             Artic *artic = vrv_cast<Artic *>(object);
@@ -154,7 +154,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     }
     // normal case or end
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
-        end->FindAllDescendantByComparison(&artics, &matchType);
+        end->FindAllDescendantsByComparison(&artics, &matchType);
         // Then the @n of each first staffDef
         for (auto &object : artics) {
             Artic *artic = vrv_cast<Artic *>(object);


### PR DESCRIPTION
This PR adds the helper function `FindDescendantsByType` which simplifies some code. It further adds the option to skip depth search for matches which is useful when searching for all systems, measures, layers and staves.