### PR TITLE
Improve chord stem direction calculation

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -228,6 +228,12 @@ protected:
     MapOfDotLocs CalcDotLocations(int layerCount, bool primary) override;
 
     /**
+     * Calculate stem direction based on the position of the notes in chord. Notes are compared in pairs starting from
+     * the top-/bottommost and moving inward towards the center of the chord
+     */
+    data_STEMDIRECTION CalcStemDirection(int verticalCenter);
+
+    /**
      * Clear the m_clusters vector and delete all the objects.
      */
     void ClearClusters() const;


### PR DESCRIPTION
- added method to Chord to allow calculation of the stem direction when extrema notes are equidistant
- notes are compared in pairs starting from the top-/bottom-most and moving inward towards the center of the chord until preferred direction is found or there are no more notes left
- in case all notes are equidistant, previous behavior is left (down direction is used)

Overall behavior is the same, save for cases with equidistant notes in chords. Previously, stem direction would always down, with the new change position of other notes in chord is taken into consideration.

`chord-007`
![image](https://user-images.githubusercontent.com/1819669/144035124-0b663b00-93e0-4bba-9324-4a0e5dd8235a.png)
