### PR TITLE
Slurs with common start or end

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -189,9 +189,14 @@ public:
         const Point bezier[4], bool isMaxExtrema, int approximationSteps = BEZIER_APPROXIMATION);
 
     /**
+     * @return true if the distance between the points does not exceed margin
+     */
+    static bool ArePointsClose(const Point &p1, const Point &p2, int margin);
+
+    /**
      * Calculate the slope represented by two points
      */
-    static double CalcSlope(Point const &p1, Point const &p2);
+    static double CalcSlope(const Point &p1, const Point &p2);
 
     /**
      * Calculate the position of a point after a rotation of alpha (in radian) around the center

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -290,10 +290,14 @@ public:
     ///@}
 
     /**
-     * Moves bounding points vertically by a specified distance downward
+     * Moves bounding points horizontally or vertically by a specified distance
      */
+    ///@{
+    void MoveFrontHorizontal(int distance);
+    void MoveBackHorizontal(int distance);
     void MoveFrontVertical(int distance);
     void MoveBackVertical(int distance);
+    ///@}
 
     /**
      * Calculate the min or max Y for a set of points

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -760,7 +760,12 @@ Point BoundingBox::CalcPositionAfterRotation(Point point, float alpha, Point cen
     return point;
 }
 
-double BoundingBox::CalcSlope(Point const &p1, Point const &p2)
+bool BoundingBox::ArePointsClose(const Point &p1, const Point &p2, int margin)
+{
+    return (hypot(p1.x - p2.x, p1.y - p2.y) <= margin);
+}
+
+double BoundingBox::CalcSlope(const Point &p1, const Point &p2)
 {
     if ((p1.y == p2.y) || (p1.x == p2.x)) return 0.0;
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -544,6 +544,18 @@ void FloatingCurvePositioner::UpdatePoints(const BezierCurve &bezier)
     this->UpdateCurveParams(points, m_angle, m_thickness, m_dir);
 }
 
+void FloatingCurvePositioner::MoveFrontHorizontal(int distance)
+{
+    m_points[0].x += distance;
+    m_points[1].x += distance;
+}
+
+void FloatingCurvePositioner::MoveBackHorizontal(int distance)
+{
+    m_points[2].x += distance;
+    m_points[3].x += distance;
+}
+
 void FloatingCurvePositioner::MoveFrontVertical(int distance)
 {
     m_points[0].y += distance;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -934,25 +934,36 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
         }
     }
 
+    // Adjust positioning of slurs with common start/end
     Staff *staff = GetStaff();
     if (staff) {
-        const int slurShift = staff->m_drawingStaffSize / 2;
-        for (size_t i = 0; i + 1 < positioners.size(); i++) {
+        const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        for (size_t i = 0; i + 1 < positioners.size(); ++i) {
             Slur *firstSlur = vrv_cast<Slur *>(positioners[i]->GetObject());
-            for (auto j = i + 1; j < positioners.size(); j++) {
+            for (size_t j = i + 1; j < positioners.size(); ++j) {
                 Slur *secondSlur = vrv_cast<Slur *>(positioners[j]->GetObject());
                 Point points1[4], points2[4];
                 positioners[i]->GetPoints(points1);
                 positioners[j]->GetPoints(points2);
-                if (firstSlur->GetStart() == secondSlur->GetStart()) {
-                    FloatingCurvePositioner *positioner = positioners[points1[2].x > points2[2].x ? i : j];
-                    positioner->MoveFrontVertical(
-                        positioner->GetDir() == curvature_CURVEDIR_below ? -slurShift : slurShift);
+                if ((firstSlur->GetStart() == secondSlur->GetStart())
+                    && BoundingBox::ArePointsClose(points1[0], points2[0], unit)) {
+                    FloatingCurvePositioner *positioner = positioners[points1[3].x > points2[3].x ? i : j];
+                    positioner->MoveFrontVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -unit : unit);
                 }
-                else if (firstSlur->GetEnd() == secondSlur->GetEnd()) {
+                else if ((firstSlur->GetEnd() == secondSlur->GetEnd())
+                    && BoundingBox::ArePointsClose(points1[3], points2[3], unit)) {
                     FloatingCurvePositioner *positioner = positioners[points1[0].x < points2[0].x ? i : j];
-                    positioner->MoveBackVertical(
-                        positioner->GetDir() == curvature_CURVEDIR_below ? -slurShift : slurShift);
+                    positioner->MoveBackVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -unit : unit);
+                }
+                else if ((firstSlur->GetStart() == secondSlur->GetEnd())
+                    && BoundingBox::ArePointsClose(points1[0], points2[3], unit)) {
+                    positioners[i]->MoveFrontHorizontal(unit / 2);
+                    positioners[j]->MoveBackHorizontal(-unit / 2);
+                }
+                else if ((firstSlur->GetEnd() == secondSlur->GetStart())
+                    && BoundingBox::ArePointsClose(points1[3], points2[0], unit)) {
+                    positioners[i]->MoveBackHorizontal(-unit / 2);
+                    positioners[j]->MoveFrontHorizontal(unit / 2);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes #2496 and introduces horizontal space for slurs starting and ending at the same element.

| Before | After |
| ------ | ----- |
| <img width="339" alt="Before1" src="https://user-images.githubusercontent.com/63608463/144045531-b9c3b63b-d10a-4fff-b87a-86dd7d5fb8fa.png"> | <img width="341" alt="After1" src="https://user-images.githubusercontent.com/63608463/144045573-bb66c95f-481e-4665-b00f-8d3ce1bb806c.png"> |
| <img width="744" alt="Before2" src="https://user-images.githubusercontent.com/63608463/144045659-500eb007-c497-42da-8515-4755b4387f83.png"> | <img width="721" alt="After2" src="https://user-images.githubusercontent.com/63608463/144045688-d2177c2d-9554-4428-af4a-a3520c10988e.png"> |
| <img width="631" alt="Before3" src="https://user-images.githubusercontent.com/63608463/144045745-23566a8d-bb9c-4131-bb81-8f00f56bcc8a.png"> | <img width="623" alt="After3" src="https://user-images.githubusercontent.com/63608463/144045776-c1f94b81-e2dc-475d-ae5d-2af24df6e469.png"> |
 
<details>
<summary>Show MEI of example 2</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>slur slur interaction</title>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
         </titleStmt>
         <pubStmt></pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-3exvht">
         <appInfo xml:id="appinfo-3duax3">
            <application xml:id="application-mxrrbm" isodate="2021-11-25T08:47:12" version="3.8.0-dev-7b45cdf">
               <name xml:id="name-5r95x">Verovio</name>
               <p xml:id="p-o3df8u">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="muzbxhn">
            <score xml:id="scsm982">
               <scoreDef xml:id="sy6m98k">
                  <staffGrp xml:id="suetw1i">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="lusji29">Violin</label>
                        <clef xml:id="cj4vay4" shape="G" line="2" />
                        <keySig xml:id="kdz7qxf" sig="0" />
                        <meterSig xml:id="mwerfp7" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="sttr9fw">
                  <measure xml:id="mfcm7hi" n="1">
                     <staff xml:id="swm1e55" n="1">
                        <layer xml:id="l30mml4" n="1">
                           <note xml:id="nxvzlob" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="nkhgkwh" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="s42knoi" startid="#nxvzlob" endid="#nkhgkwh" curvedir="below" />
                     <slur xml:id="squuqd0" startid="#nxvzlob" endid="#nn6twj2" curvedir="above" />
                  </measure>
                  <measure xml:id="m4uwl6d" right="dbl" n="2">
                     <staff xml:id="sv2m8wz" n="1">
                        <layer xml:id="lk0hebp" n="1">
                           <note xml:id="nya33wh" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="nn6twj2" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="sf8lzt1" startid="#nya33wh" endid="#nn6twj2" curvedir="below" />
                  </measure>
                  <measure xml:id="m3dsu8w" n="3">
                     <staff xml:id="s207eqi" n="1">
                        <layer xml:id="l5x6p9n" n="1">
                           <note xml:id="ne11prz" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="ne15jbv" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="sra88" startid="#ne11prz" endid="#ne15jbv" curvedir="above" />
                     <slur xml:id="sy6vzr5" startid="#ne11prz" endid="#ne1xq5n" curvedir="below" />
                  </measure>
                  <measure xml:id="me215l9" right="dbl" n="4">
                     <staff xml:id="sexefp4" n="1">
                        <layer xml:id="lagsx28" n="1">
                           <note xml:id="n6rfgft" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="ne1xq5n" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="sxrg1ym" startid="#n6rfgft" endid="#ne1xq5n" curvedir="above" />
                  </measure>
                  <measure xml:id="moh47t3" n="5">
                     <staff xml:id="sgrnyoj" n="1">
                        <layer xml:id="lcw6u5g" n="1">
                           <note xml:id="nwg36tt" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="na6vlcx" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="suvfsgh" startid="#nwg36tt" endid="#na6vlcx" curvedir="above" />
                     <slur xml:id="s6p67vt" startid="#nwg36tt" endid="#najtehm" curvedir="above" />
                  </measure>
                  <measure xml:id="mpd4ejh" right="dbl" n="6">
                     <staff xml:id="sl66ggw" n="1">
                        <layer xml:id="l2l056r" n="1">
                           <note xml:id="nk2gccb" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="najtehm" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="sux1ljp" startid="#nk2gccb" endid="#najtehm" curvedir="above" />
                  </measure>
                  <measure xml:id="msiqlfa" n="7">
                     <staff xml:id="st777kk" n="1">
                        <layer xml:id="lc00sue" n="1">
                           <note xml:id="n24qivt" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="ng0ih9c" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="spuibzz" startid="#n24qivt" endid="#ng0ih9c" curvedir="below" />
                     <slur xml:id="st2sogw" startid="#n24qivt" endid="#ncu6g2s" curvedir="below" />
                  </measure>
                  <measure xml:id="mfjjxru" right="end" n="8">
                     <staff xml:id="s7k1m1s" n="1">
                        <layer xml:id="l3veyvs" n="1">
                           <note xml:id="nni95u8" dur.ppq="2" dur="2" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="ncu6g2s" dur.ppq="2" dur="2" oct="4" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                     <slur xml:id="s9f0ahw" startid="#nni95u8" endid="#ncu6g2s" curvedir="below" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
<summary>Show MEI of example 3</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-07-30" type="encoding-date">2021-07-30</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-xwopln">
         <appInfo xml:id="appinfo-a209u3">
            <application xml:id="application-oqlg5f" isodate="2021-10-07T15:48:50" version="3.7.0-dev-ab9a2ad">
               <name xml:id="name-54q3e8">Verovio</name>
               <p xml:id="p-9bogng">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mlj4v68">
            <score xml:id="sdie2kd">
               <scoreDef xml:id="sqosio4">
                  <staffGrp xml:id="s2kukk6">
                     <staffGrp xml:id="S1-ty9q8jPDVsCWNSEmZ4EMBA" bar.thru="true">
                        <staffDef xml:id="sbx4ten" n="1" lines="5" ppq="4">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <keySig xml:id="key-1" sig="2f" />
                           <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                        </staffDef>
                        <staffDef xml:id="spk2jp7" n="2" lines="5" ppq="4">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <keySig xml:id="key-2" sig="2f" />
                           <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                        </staffDef>
                        <grpSym xml:id="gn2ijqh" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="svuhz75">
                  <measure xml:id="measure-0015-10290-11510-1-mdiv-1" n="168">
                     <staff xml:id="svesutk" n="1">
                        <layer xml:id="l1arzun" n="1">
                           <chord xml:id="c2fmprc" dots="1" dur.ppq="12" dur="2" stem.dir="up">
                              <note xml:id="note-0015-10330-11670-1" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0015-10330-11630-1" oct="4" pname="b" accid.ges="f" />
                              <note xml:id="note-0015-10350-11620-1" oct="5" pname="c" />
                           </chord>
                           <chord xml:id="cymb7vz" dur.ppq="8" dur="2" stem.dir="up">
                              <note xml:id="note-0015-10560-11660-1" oct="4" pname="f" />
                              <note xml:id="note-0015-10560-11640-1" oct="4" pname="a">
                                 <accid xml:id="a2pm6lk" accid="n" accid.ges="n" />
                              </note>
                              <note xml:id="note-0015-10560-11610-1" oct="5" pname="d" />
                           </chord>
                           <chord xml:id="c8qvbpx" dur.ppq="4" dur="4" stem.dir="up">
                              <note xml:id="note-0015-10700-11670-1" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-0015-10700-11610-1" oct="5" pname="d" />
                              <note xml:id="note-0015-10700-11640-1" oct="4" pname="a" accid.ges="n" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="spkpnbc" n="2">
                        <layer xml:id="lzt9si" n="5">
                           <beam xml:id="brhhgpg">
                              <note xml:id="note-0015-10330-11890-2" dur.ppq="2" dur="8" oct="2" pname="f" stem.dir="down" />
                              <note xml:id="note-0015-10360-11850-2" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                              <note xml:id="note-0015-10400-11830-2" dur.ppq="2" dur="8" oct="3" pname="e" stem.dir="down" accid.ges="f" />
                              <note xml:id="note-0015-10440-11790-2" dur.ppq="2" dur="8" oct="3" pname="b" stem.dir="down" accid.ges="f" />
                              <note xml:id="note-0015-10480-11830-2" dur.ppq="2" dur="8" oct="3" pname="e" stem.dir="down" accid.ges="f" />
                              <note xml:id="note-0015-10520-11850-2" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                           </beam>
                           <beam xml:id="b6j2isf">
                              <note xml:id="note-0015-10560-11890-2" dur.ppq="2" dur="8" oct="2" pname="f" stem.dir="down" />
                              <note xml:id="note-0015-10590-11850-2" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                              <note xml:id="note-0015-10630-11830-2" dur.ppq="2" dur="8" oct="3" pname="e" stem.dir="down" accid.ges="f" />
                              <note xml:id="note-0015-10670-11800-2" dur.ppq="2" dur="8" oct="3" pname="a" stem.dir="down" />
                              <note xml:id="note-0015-10700-11830-2" dur.ppq="2" dur="8" oct="3" pname="e" stem.dir="down" accid.ges="f" />
                              <note xml:id="note-0015-10740-11850-2" dur.ppq="2" dur="8" oct="3" pname="c" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <slur xml:id="bow-0015-10420-11810" startid="#note-0015-10330-11890-2" endid="#note-0015-10520-11850-2" curvedir="above" />
                     <slur xml:id="bow-0015-10650-11820" startid="#note-0015-10520-11850-2" endid="#note-0015-10740-11850-2" curvedir="above" />
                     <pedal xml:id="pd4lf4e" staff="2" tstamp="1.000000" dir="down" place="below" vgrp="60" />
                     <pedal xml:id="pe8cjhi" staff="2" tstamp="3.400000" dir="up" place="below" vgrp="60" />
                     <pedal xml:id="pygspeg" staff="2" tstamp="4.000000" dir="down" place="below" vgrp="60" />
                     <pedal xml:id="pmzzqhq" staff="2" tstamp="6.900000" dir="up" place="below" vgrp="60" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>