### PR TITLE
Fix issues with timestamp slurs

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2359,7 +2359,7 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         }
 
         // Skip elements aligned at start/end, but on a different staff
-        if (this->GetAlignment() == start->GetAlignment()) {
+        if ((this->GetAlignment() == start->GetAlignment()) && !start->Is(TIMESTAMP_ATTR)) {
             Layer *layer = NULL;
             Staff *staff = this->GetCrossStaff(layer);
             if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
@@ -2369,7 +2369,7 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
                 return FUNCTOR_CONTINUE;
             }
         }
-        if (this->GetAlignment() == end->GetAlignment()) {
+        if ((this->GetAlignment() == end->GetAlignment()) && !end->Is(TIMESTAMP_ATTR)) {
             Layer *layer = NULL;
             Staff *staff = this->GetCrossStaff(layer);
             if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -881,24 +881,14 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     bool isShortSlur = false;
     if (x2 - x1 < doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize)) isShortSlur = true;
 
-    /************** calculate the radius for adjusting the x position **************/
-
-    int startRadius = 0;
-    if (!start->Is(TIMESTAMP_ATTR)) {
-        startRadius = start->GetDrawingRadius(doc);
-    }
-
-    int endRadius = 0;
-    if (!end->Is(TIMESTAMP_ATTR)) {
-        endRadius = end->GetDrawingRadius(doc);
-    }
-
     Beam *parentBeam = NULL;
     FTrem *parentFTrem = NULL;
     int yChordMax = 0, yChordMin = 0;
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
-        // first get the min max of the chord (if any)
+    if (((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) && !start->Is(TIMESTAMP_ATTR)) {
+        // get the radius for adjusting the x position
+        const int startRadius = start->GetDrawingRadius(doc);
+        // get the min max of the chord (if any)
         if (startChord) {
             startChord->GetYExtremes(yChordMax, yChordMin);
         }
@@ -930,8 +920,8 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
             // d(^)
             else {
-                // put it on the side, move it left, but not if we have a @tstamp
-                if (!start->Is(TIMESTAMP_ATTR) && (startStemLen != 0)) x1 += unit * 2;
+                // put it on the side, move it right
+                if (startStemLen != 0) x1 += unit * 2;
                 if (startChord)
                     y1 = yChordMax + unit * 3;
                 else
@@ -975,7 +965,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
             // P(_)
             else {
-                // put it on the side, but no need to move it left
+                // put it on the side, but no need to move it right
                 if (startChord) {
                     y1 = yChordMin - unit * 3;
                 }
@@ -985,7 +975,9 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
         }
     }
-    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
+    if (((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) && !end->Is(TIMESTAMP_ATTR)) {
+        // get the radius for adjusting the x position
+        const int endRadius = end->GetDrawingRadius(doc);
         // get the min max of the chord if any
         if (endChord) {
             endChord->GetYExtremes(yChordMax, yChordMin);
@@ -1040,7 +1032,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
             // (^)d
             else {
-                // put it on the side, no need to move it right
+                // put it on the side, no need to move it left
                 if (endChord) {
                     y2 = yChordMax + unit * 3;
                 }
@@ -1095,8 +1087,8 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
             // (_)P
             else {
-                // put it on the side, move it right, but not if we have a @tstamp2
-                if (!end->Is(TIMESTAMP_ATTR)) x2 -= unit * 2;
+                // put it on the side, move it left
+                if (endStemLen != 0) x2 -= unit * 2;
                 if (endChord) {
                     y2 = yChordMin - unit * 3;
                 }


### PR DESCRIPTION
This PR fixes some issues with slurs defined between timestamps:
- There was a crash in the following example.
- After fixing the crash, there were still rendering issues, since slurs were positioned with respect to the wrong staves.

| Before rendering fix | After |
| ----- | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/144234987-7aeb1326-e7de-489a-9341-fc6fc48eefd3.png) | ![After](https://user-images.githubusercontent.com/63608463/144235014-2bbd0685-0727-464b-9aa0-cf0928c5d743.png) |

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-16" ?>
<mei xml:id="m-1" meiversion="3.0.0" xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink">
<meiHead xml:id="m-2">
    <fileDesc xml:id="m-3">
        <titleStmt xml:id="m-4">
            <title xml:id="m-10">bjsbw431</title>
            <respStmt xml:id="m-11">
                <persName xml:id="m-12"/>
            </respStmt>
        </titleStmt>
        <pubStmt xml:id="m-13">
            <availability xml:id="m-14">
                <useRestrict xml:id="m-15"/>
            </availability>
        </pubStmt>
    </fileDesc>
    <encodingDesc xml:id="m-16">
        <appInfo xml:id="m-17">
            <application xml:id="sibelius" isodate="2016-8-10T14:37:49Z" version="7500">
                <name xml:id="m-19" type="operating-system">Windows 7</name>
            </application>
            <application xml:id="sibmei" type="plugin" version="2.0.1">
                <name xml:id="m-21">Sibelius to MEI Exporter (2.0.1)</name>
            </application>
        </appInfo>
    </encodingDesc>
    <workDesc xml:id="m-5">
        <work xml:id="m-6">
            <titleStmt xml:id="m-7">
                <title xml:id="m-8">bjsbw431</title>
                <respStmt xml:id="m-9"/>
            </titleStmt>
        </work>
    </workDesc>
</meiHead>
<music xml:id="m-22">
    <body xml:id="m-23">
        <mdiv xml:id="m-24">
            <score xml:id="m-25">
                <scoreDef xml:id="m-26" lyric.weight="normal" meter.sym="common" meter.count="4" meter.unit="4" music.name="Opus Std" page.botmar="15mm" page.height="297mm" page.leftmar="15mm" page.rightmar="15mm" page.topmar="15mm" page.width="210mm" ppq="256" text.name="Times New Roman">
                    <staffGrp xml:id="m-27">
                        <staffGrp xml:id="m-40" n="1" symbol="bracket">
                            <staffDef xml:id="m-28" clef.line="2" clef.shape="G" key.mode="major" key.sig="1s" lines="5" n="1">
                                <instrDef xml:id="m-30" midi.channel="1" midi.pan="13" midi.volume="127"/>
                            </staffDef>
                            <staffDef xml:id="m-31" clef.line="2" clef.shape="G" key.mode="major" key.sig="1s" lines="5" n="2">
                                <instrDef xml:id="m-33" midi.channel="1" midi.pan="89" midi.volume="127"/>
                            </staffDef>
                            <staffDef xml:id="m-34" clef.dis="8" clef.dis.place="below" clef.line="2" clef.shape="G" key.mode="major" key.sig="1s" lines="5" n="3">
                                <instrDef xml:id="m-36" midi.channel="1" midi.pan="38" midi.volume="127"/>
                            </staffDef>
                            <staffDef xml:id="m-37" clef.line="4" clef.shape="F" key.mode="major" key.sig="1s" lines="5" n="4">
                                <instrDef xml:id="m-39" midi.channel="1" midi.pan="113" midi.volume="127"/>
                            </staffDef>
                        </staffGrp>
                    </staffGrp>
                </scoreDef>
                <section xml:id="m-41">
                    <measure xml:id="m-42" label="1" metcon="false" n="1">
                        <staff xml:id="m-43" n="1">
                            <layer xml:id="m-44" n="1">
                                <note xml:id="m-45" dur="4" dur.ges="256p" oct="4" pname="g" pnum="67" stem.dir="up">
                                    <verse xml:id="m-46" n="1">
                                        <syl xml:id="m-47">Wenn</syl>
                                    </verse>
                                </note>
                            </layer>
                        </staff>
                        <staff xml:id="m-48" n="2">
                            <layer xml:id="m-49" n="1">
                                <note xml:id="m-50" dur="4" dur.ges="256p" oct="4" pname="d" pnum="62" stem.dir="up">
                                    <verse xml:id="m-51" n="1">
                                        <syl xml:id="m-52">Wenn</syl>
                                    </verse>
                                </note>
                            </layer>
                        </staff>
                        <staff xml:id="m-53" n="3">
                            <layer xml:id="m-54" n="1">
                                <beam xml:id="m-56">
                                    <note xml:id="m-55" dur="8" dur.ges="128p" oct="3" pname="b" pnum="59" stem.dir="up"/>
                                    <note xml:id="m-57" dur="8" dur.ges="128p" oct="3" pname="a" pnum="57" stem.dir="up"/>
                                </beam>
                            </layer>
                        </staff>
                        <staff xml:id="m-58" n="4">
                            <layer xml:id="m-59" n="1">
                                <beam xml:id="m-61">
                                    <note xml:id="m-60" dur="8" dur.ges="128p" oct="3" pname="g" pnum="55" stem.dir="down"/>
                                    <note xml:id="m-62" dur="8" dur.ges="128p" oct="3" pname="f" pnum="54" stem.dir="down">
                                        <accid xml:id="m-63" accid.ges="s"/>
                                    </note>
                                </beam>
                            </layer>
                        </staff>
                        <anchoredText xml:id="m-64">
                            <title xml:id="m-65">Wenn wir in höchsten Nöten</title>
                        </anchoredText>
                    </measure>
                    <measure xml:id="m-66" n="2">
                        <staff xml:id="m-67" n="1">
                            <layer xml:id="m-68" n="1">
                                <note xml:id="m-69" dur="4" dur.ges="256p" oct="4" pname="g" pnum="67" stem.dir="up">
                                    <verse xml:id="m-75" n="1">
                                        <syl xml:id="m-76">wir</syl>
                                    </verse>
                                </note>
                                <note xml:id="m-70" dur="4" dur.ges="256p" oct="4" pname="a" pnum="69" stem.dir="up">
                                    <verse xml:id="m-77" n="1">
                                        <syl xml:id="m-78">in</syl>
                                    </verse>
                                </note>
                                <note xml:id="m-71" dur="4" dur.ges="256p" oct="4" pname="b" pnum="71" stem.dir="down">
                                    <verse xml:id="m-79" n="1">
                                        <syl xml:id="m-80" con="d" wordpos="i">höchs</syl>
                                    </verse>
                                </note>
                                <beam xml:id="m-73">
                                    <note xml:id="m-72" dur="8" dur.ges="128p" oct="4" pname="a" pnum="69" stem.dir="up">
                                        <verse xml:id="m-81" n="1">
                                            <syl xml:id="m-82" con="u" wordpos="t">ten</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="m-74" dur="8" dur.ges="128p" oct="4" pname="b" pnum="71" stem.dir="up"/>
                                </beam>
                            </layer>
                        </staff>
                        <staff xml:id="m-83" n="2">
                            <layer xml:id="m-84" n="1">
                                <beam xml:id="m-86">
                                    <note xml:id="m-85" dur="8" dur.ges="128p" oct="4" pname="d" pnum="62" stem.dir="up">
                                        <verse xml:id="m-95" n="1">
                                            <syl xml:id="m-96">wir</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="m-87" dur="8" dur.ges="128p" oct="4" pname="c" pnum="61" stem.dir="up">
                                        <accid xml:id="m-88" accid="s"/>
                                    </note>
                                </beam>
                                <note xml:id="m-89" dur="4" dur.ges="256p" oct="4" pname="d" pnum="62" stem.dir="up">
                                    <verse xml:id="m-97" n="1">
                                        <syl xml:id="m-98">in</syl>
                                    </verse>
                                </note>
                                <beam xml:id="m-91">
                                    <note xml:id="m-90" dur="8" dur.ges="128p" oct="4" pname="d" pnum="62" stem.dir="up">
                                        <verse xml:id="m-99" n="1">
                                            <syl xml:id="m-100" con="d" wordpos="i">höchs</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="m-92" dur="8" dur.ges="128p" oct="4" pname="e" pnum="64" stem.dir="up"/>
                                </beam>
                                <note xml:id="m-93" dur="4" dur.ges="256p" oct="4" pname="f" pnum="66" stem.dir="up">
                                    <accid xml:id="m-94" accid.ges="s"/>
                                    <verse xml:id="m-101" n="1">
                                        <syl xml:id="m-102" wordpos="t">ten</syl>
                                    </verse>
                                </note>
                            </layer>
                        </staff>
                        <staff xml:id="m-103" n="3">
                            <layer xml:id="m-104" n="1">
                                <note xml:id="m-105" dur="4" dur.ges="256p" oct="3" pname="g" pnum="55" stem.dir="up"/>
                                <beam xml:id="m-107">
                                    <note xml:id="m-106" dur="8" dur.ges="128p" oct="4" pname="d" pnum="62" stem.dir="down"/>
                                    <note xml:id="m-108" dur="8" dur.ges="128p" oct="4" pname="c" pnum="60" stem.dir="down"/>
                                </beam>
                                <beam xml:id="m-110">
                                    <note xml:id="m-109" dur="8" dur.ges="128p" oct="3" pname="b" pnum="59" stem.dir="down"/>
                                    <note xml:id="m-111" dur="8" dur.ges="128p" oct="4" pname="c" pnum="60" stem.dir="down"/>
                                </beam>
                                <note xml:id="m-112" dur="4" dur.ges="256p" oct="4" pname="d" pnum="62" stem.dir="down"/>
                            </layer>
                        </staff>
                        <staff xml:id="m-113" n="4">
                            <layer xml:id="m-114" n="1">
                                <note xml:id="m-115" dur="4" dur.ges="256p" oct="3" pname="e" pnum="52" stem.dir="down"/>
                                <beam xml:id="m-118">
                                    <note xml:id="m-116" dur="8" dur.ges="128p" oct="3" pname="f" pnum="54" stem.dir="down">
                                        <accid xml:id="m-117" accid.ges="s"/>
                                    </note>
                                    <note xml:id="m-119" dur="8" dur.ges="128p" oct="3" pname="d" pnum="50" stem.dir="down"/>
                                </beam>
                                <note xml:id="m-120" dur="4" dur.ges="256p" oct="3" pname="g" pnum="55" stem.dir="down"/>
                                <note xml:id="m-121" dur="4" dur.ges="256p" oct="3" pname="d" pnum="50" stem.dir="down"/>
                            </layer>
                        </staff>
                    </measure>
                    <measure xml:id="m-122" n="3">
                        <staff xml:id="m-123" n="1">
                            <layer xml:id="m-124" n="1">
                                <note xml:id="m-126" dur="4" dur.ges="256p" oct="5" pname="c" pnum="72" stem.dir="down">
                                    <verse xml:id="m-130" n="1">
                                        <syl xml:id="m-131" con="d" wordpos="i">Nö</syl>
                                    </verse>
                                </note>
                                <note xml:id="m-127" dur="4" dur.ges="256p" oct="4" pname="b" pnum="71" stem.dir="down"/>
                                <note xml:id="m-128" dots="1" dur="4" dur.ges="384p" oct="4" pname="a" pnum="69" stem.dir="up"/>
                                <note xml:id="m-129" dur="8" dur.ges="128p" oct="4" pname="a" pnum="69" stem.dir="up">
                                    <verse xml:id="m-132" n="1">
                                        <syl xml:id="m-133" wordpos="t">ten</syl>
                                    </verse>
                                </note>
                            </layer>
                        </staff>
                        <staff xml:id="m-134" n="2">
                            <layer xml:id="m-135" n="1">
                                <beam xml:id="m-138">
                                    <note xml:id="m-137" dur="8" dur.ges="128p" oct="4" pname="g" pnum="67" stem.dir="up">
                                        <verse xml:id="m-149" n="1">
                                            <syl xml:id="m-150" con="d" wordpos="i">Nö</syl>
                                        </verse>
                                    </note>
                                    <note xml:id="m-139" dur="8" dur.ges="128p" oct="4" pname="a" pnum="69" stem.dir="up"/>
                                </beam>
                                <note xml:id="m-140" dur="4" dur.ges="256p" oct="4" pname="g" pnum="67" stem.dir="up"/>
                                <beam xml:id="m-143">
                                    <note xml:id="m-142" dur="8" dur.ges="128p" oct="4" pname="g" pnum="67" stem.dir="up"/>
                                    <note xml:id="m-144" dur="16" dur.ges="64p" oct="4" pname="f" pnum="66" stem.dir="up">
                                        <accid xml:id="m-145" accid.ges="s"/>
                                    </note>
                                    <note xml:id="m-146" dur="16" dur.ges="64p" oct="4" pname="e" pnum="64" stem.dir="up"/>
                                </beam>
                                <note xml:id="m-147" dur="4" dur.ges="256p" oct="4" pname="f" pnum="66" stem.dir="up">
                                    <accid xml:id="m-148" accid.ges="s"/>
                                    <verse xml:id="m-151" n="1">
                                        <syl xml:id="m-152" wordpos="t">ten</syl>
                                    </verse>
                                </note>
                            </layer>
                        </staff>
                        <staff xml:id="m-153" n="3">
                            <layer xml:id="m-154" n="1">
                                <beam xml:id="m-157">
                                    <note xml:id="m-156" dur="8" dur.ges="128p" oct="3" pname="g" pnum="55" stem.dir="up"/>
                                </beam>
                                <note xml:id="m-158" dots="1" dur="4" dur.ges="384p" oct="4" pname="d" pnum="62" stem.dir="down"/>
                                <beam xml:id="m-160">
                                    <note xml:id="m-159" dur="8" dur.ges="128p" oct="4" pname="e" pnum="64" stem.dir="down"/>
                                    <note xml:id="m-161" dur="8" dur.ges="128p" oct="4" pname="c" pnum="60" stem.dir="down"/>
                                </beam>
                                <beam xml:id="m-163">
                                    <note xml:id="m-162" dur="8" dur.ges="128p" oct="3" pname="a" pnum="57" stem.dir="down"/>
                                    <note xml:id="m-164" dur="16" dur.ges="64p" oct="4" pname="d" pnum="62" stem.dir="down"/>
                                    <note xml:id="m-165" dur="16" dur.ges="64p" oct="4" pname="c" pnum="60" stem.dir="down"/>
                                </beam>
                            </layer>
                        </staff>
                        <staff xml:id="m-166" n="4">
                            <layer xml:id="m-167" n="1">
                                <beam xml:id="m-169">
                                    <note xml:id="m-168" dur="8" dur.ges="128p" oct="3" pname="e" pnum="52" stem.dir="down"/>
                                    <note xml:id="m-170" dur="8" dur.ges="128p" oct="3" pname="f" pnum="54" stem.dir="down">
                                        <accid xml:id="m-171" accid.ges="s"/>
                                    </note>
                                </beam>
                                <note xml:id="m-172" dur="4" dur.ges="256p" oct="3" pname="g" pnum="55" stem.dir="down"/>
                                <note xml:id="m-173" dur="4" dur.ges="256p" oct="3" pname="c" pnum="48" stem.dir="up"/>
                                <note xml:id="m-174" dur="4" dur.ges="256p" oct="3" pname="d" pnum="50" stem.dir="down"/>
                            </layer>
                        </staff>
                        <tie xml:id="m-141" endid="#m-142" startid="#m-140"/>
                        <slur xml:id="m-125" layer="1" staff="1" tstamp="1" tstamp2="3"/>
                        <slur xml:id="m-136" layer="1" staff="2" tstamp="1" tstamp2="3.75"/>
                        <slur xml:id="m-155" layer="1" staff="3" tstamp="1" tstamp2="3.5"/>
                    </measure>
                </section>
            </score>
        </mdiv>
    </body>
</music>
</mei>
```
</details>



