### PR TITLE
Avoid accid code being set to 0

### DIFF
--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -82,7 +82,8 @@ std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const
         wchar_t code = Resources::GetGlyphCode(GetGlyphName());
         if (NULL == Resources::GetGlyph(code)) code = 0;
     }
-    else {
+
+    if (!code) {
         switch (notationType) {
             case NOTATIONTYPE_mensural:
             case NOTATIONTYPE_mensural_black:


### PR DESCRIPTION
Small fix for the cases, where getting code of GlyphNum/GlyphName results in 0 (e.g. glyph outside of supported range), which ends up being used for bounding box calculation and might lead to some extreme margins:
![image](https://user-images.githubusercontent.com/1819669/144423422-97054ad9-4421-4b1a-b904-c9bf8995c4a2.png)
Even worse with multiple staves:
![image](https://user-images.githubusercontent.com/1819669/144423564-943b44b0-f40f-4332-8ca6-faa9dc072141.png)

After the fix:
![image](https://user-images.githubusercontent.com/1819669/144423468-260f3fb2-8f1e-4f37-9648-cb746e048b57.png)
![image](https://user-images.githubusercontent.com/1819669/144423700-f9bf4121-1326-414e-aae5-77d3a0b5e577.png)

