### PR TITLE
Improve adjacent note ties overlap

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -157,6 +157,13 @@ public:
     int AdjustOverlappingLayers(
         Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison) override;
 
+    /**
+     * Helper to get list of notes that are adjacent to the specified location.
+     * Diatonic step difference is take up to 2 points, so HasAdjacentNotesInStaff() needs to be called first, to make
+     * sure there actually are adjacent notes.
+     */
+    std::list<Note *> GetAdjacentNotesList(Staff *staff, int loc);
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -57,7 +57,7 @@ public:
     /**
     * Calculate starting/ending point for the ties in the chords with adjacent notes
     */
-    int CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
+    int CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
         curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint);
 
     //----------//

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -55,8 +55,8 @@ public:
     virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
 
     /**
-    * Calculate starting/ending point for the ties in the chords with adjacent notes
-    */
+     * Calculate starting/ending point for the ties in the chords with adjacent notes
+     */
     int CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
         curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint);
 

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -54,6 +54,12 @@ public:
 
     virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
 
+    /**
+    * Calculate starting/ending point for the ties in the chords with adjacent notes
+    */
+    int CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
+        curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint);
+
     //----------//
     // Functors //
     //----------//
@@ -72,7 +78,7 @@ private:
 
     // Calculate initial position X position and return stem direction of the startNote
     void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
-        bool isOuterChordNote, Point &startPoint, Point &endPoint);
+        bool isOuterChordNote, Point &startPoint, Point &endPoint, curvature_CURVEDIR drawingCurveDir);
 
     // Helper function to get preferred curve direction based on the number of conditions (like note direction, position
     // on the staff, etc.)

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -545,7 +545,6 @@ std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
         if ((std::abs(locDiff) <= 2) && (locDiff != 0)) {
             adjacentNotes.push_back(note);
         }
-
     }
     return adjacentNotes;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -525,6 +525,31 @@ int Chord::AdjustOverlappingLayers(
     return 0;
 }
 
+std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
+{
+    const ArrayOfObjects *notes = this->GetList(this);
+    assert(notes);
+
+    std::list<Note *> adjacentNotes;
+    for (Object *obj : *notes) {
+        Note *note = vrv_cast<Note *>(obj);
+        assert(note);
+
+        Layer *layer = NULL;
+        Staff *noteStaff = note->GetCrossStaff(layer);
+        if (!noteStaff) noteStaff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+        assert(noteStaff);
+        if (noteStaff != staff) continue;
+
+        const int locDiff = note->GetDrawingLoc() - loc;
+        if ((std::abs(locDiff) <= 2) && (locDiff != 0)) {
+            adjacentNotes.push_back(note);
+        }
+
+    }
+    return adjacentNotes;
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -276,9 +276,10 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     return true;
 }
 
-int Tie::CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
+int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
     curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint)
 {
+    assert(parentChord);
     const int drawingUnit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int radius = note ? note->GetDrawingRadius(doc) : drawingUnit;
 
@@ -385,7 +386,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             if (endNote) r2 = endNote->GetDrawingRadius(doc);
             // startPoint
             if (startParentChord && startParentChord->HasAdjacentNotesInStaff(staff)) {
-                startPoint.x = this->CaclulateAdjacentChordXOffset(
+                startPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, staff, startParentChord, startNote, drawingCurveDir, startPoint.x, true);
             }
             else {
@@ -395,7 +396,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             Staff *endStaff = staff;
             if (endParentChord) endStaff = vrv_cast<Staff *>(endParentChord->GetFirstAncestor(STAFF));
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
-                endPoint.x = this->CaclulateAdjacentChordXOffset(
+                endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);
             }
             else {
@@ -449,7 +450,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             Staff *endStaff = staff;
             if (endParentChord) endStaff = vrv_cast<Staff *>(endParentChord->GetFirstAncestor(STAFF));
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
-                endPoint.x = this->CaclulateAdjacentChordXOffset(
+                endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);
             }
             else {

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -284,13 +284,23 @@ int Tie::CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
 
     // adjust starting point for the ties in chords with adjacent notes
     if (isStartPoint) {
+        const int defaultX = initialX + (radius + drawingUnit / 2);
         // if stem is down adjacent notes are going to be on the left side of the stem, hence always take right side of
         // the chord
         if (parentChord->GetDrawingStemDir() == STEMDIRECTION_down) {
-            return parentChord->GetContentRight() + drawingUnit / 2;
+            if ((curvature_CURVEDIR_below == drawingCurveDir) && (note == parentChord->GetBottomNote())) {
+                return defaultX;
+            }
+            Stem *stem = parentChord->GetDrawingStem();
+            if (stem) {
+                return stem->GetContentRight() + 2 * radius + drawingUnit / 2;
+            }
+            else {
+                return parentChord->GetContentRight() + drawingUnit / 2;
+            }
         }
         else {
-            if (!note) return initialX + (radius + drawingUnit / 2);
+            if (!note) return defaultX;
             const std::list<Note *> adjacentNotes = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
             for (const auto adjacentNote : adjacentNotes) {
                 if (adjacentNote->GetDrawingX() > note->GetDrawingX()) {
@@ -304,18 +314,28 @@ int Tie::CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
                     }
                 }
             }
-            return initialX + (radius + drawingUnit / 2);
+            return defaultX;
         }
     }
     // adjust ending point for the ties in chords with adjacent notes
     else {
+        const int defaultX = initialX - (radius + drawingUnit / 2);
         // similar to the starting point - when stem direction is up, all adjacent notes are on the right, so take left
         // side of the chord
         if (parentChord->GetDrawingStemDir() == STEMDIRECTION_up) {
-            return parentChord->GetContentLeft() - drawingUnit / 2;
+            if ((curvature_CURVEDIR_above == drawingCurveDir) && (note == parentChord->GetTopNote())) {
+                return defaultX;
+            }
+            Stem *stem = parentChord->GetDrawingStem();
+            if (stem) {
+                return stem->GetContentLeft() - 2 * radius - drawingUnit / 2;
+            }
+            else {
+                return parentChord->GetContentLeft() - drawingUnit / 2;
+            }
         }
         else {
-            if (!note) return initialX - (radius + drawingUnit / 2);
+            if (!note) return defaultX;
             const std::list<Note *> adjacentNotes = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
             for (const auto adjacentNote : adjacentNotes) {
                 if (adjacentNote->GetDrawingX() < note->GetDrawingX()) {
@@ -329,7 +349,7 @@ int Tie::CaclulateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
                     }
                 }
             }
-            return initialX - (radius + drawingUnit / 2);
+            return defaultX;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue with overlap of ties and notes in chords with clustered notes.
Before:
![image](https://user-images.githubusercontent.com/1819669/144611204-4b1653bb-add4-447f-8be4-0c4d733e7fdf.png)
![image](https://user-images.githubusercontent.com/1819669/144611370-004ae2c4-8b75-4e90-8be6-09e0aa46a0fe.png)

After:
![image](https://user-images.githubusercontent.com/1819669/144611254-66fd1c14-5172-4ace-9618-3d0de6e12187.png)
![image](https://user-images.githubusercontent.com/1819669/144611290-4347e7bf-9bae-4c7f-bfc2-76e4d1072ec8.png)

<details><summary>Example MEI (1):</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc/>
      <encodingDesc>
         <appInfo>
            <application version="0.9.13">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef meter.count="4" meter.unit="4">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section label="feature-example">
                  <pb/>
                  <measure n="1" label="1">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4" tie="i">
                              <note xml:id="note-0000000221777088" dur="4" oct="4" pname="f" tie="i" />
                              <note xml:id="note-0000001523390471" dur="4" oct="4" pname="a" tie="i" />
                              <note xml:id="note-0000001323606563" dur="4" oct="4" pname="b" tie="i" />
                              <note xml:id="note-0000000072405068" dur="4" oct="5" pname="d" tie="i" />
                              <note xml:id="note-0000001436233674" dur="4" oct="5" pname="f" tie="i" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="2" tie="t">
                              <note xml:id="note-0000000569453428" dur="4" oct="4" pname="f" tie="t" />
                              <note xml:id="note-0000001616633364" dur="4" oct="4" pname="a" tie="t" />
                              <note xml:id="note-0000000793846904" dur="4" oct="4" pname="b" tie="t" />
                              <note xml:id="note-0000002016500364" dur="4" oct="5" pname="d" tie="t" />
                              <note xml:id="note-0000001882184441" dur="4" oct="5" pname="f" tie="t" />
                           </chord>
                           <chord dur="2">
                              <note xml:id="n01" dur="4" oct="4" pname="a" />
                              <note xml:id="n02" dur="4" oct="4" pname="f" />
                              <note xml:id="n03" dur="4" oct="4" pname="d" />
                              <note xml:id="n04" dur="4" oct="3" pname="b" />
                              <note xml:id="n05" dur="4" oct="3" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie startid="#n01" endid="#n06" />
                     <tie startid="#n02" endid="#n07" />
                     <tie startid="#n03" endid="#n08" />
                     <tie startid="#n04" endid="#n09" />
                     <tie startid="#n05" endid="#n10" />
                  </measure>
                  <sb/>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="2">
                              <note xml:id="n06" dur="4" oct="4" pname="a" />
                              <note xml:id="n07" dur="4" oct="4" pname="f" />
                              <note xml:id="n08" dur="4" oct="4" pname="d" />
                              <note xml:id="n09" dur="4" oct="3" pname="b" />
                              <note xml:id="n10" dur="4" oct="3" pname="a" />
                           </chord>
                           <chord dur="4" tie="i">
                              <note dur="4" oct="4" pname="g" tie="i" />
                              <note dur="4" oct="4" pname="a" tie="i" />
                              <note dur="4" oct="4" pname="b" tie="i" />
                              <note dur="4" oct="5" pname="d" tie="i" />
                              <note dur="4" oct="5" pname="c" tie="i" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure n="4">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4" tie="t">
                              <note dur="4" oct="4" pname="g" tie="t" />
                              <note dur="4" oct="4" pname="a" tie="t" />
                              <note dur="4" oct="4" pname="b" tie="t" />
                              <note dur="4" oct="5" pname="d" tie="t" />
                              <note dur="4" oct="5" pname="c" tie="t" />
                           </chord>
                           <chord dur="4" tie="i">
                              <note dur="4" oct="4" pname="a" tie="i" />
                              <note dur="4" oct="4" pname="f" tie="i" />
                              <note dur="4" oct="4" pname="c" tie="i" />
                              <note dur="4" oct="3" pname="a" tie="i" />
                              <note dur="4" oct="3" pname="b" tie="i" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure right="end" n="5">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4" tie="t">
                              <note dur="4" oct="4" pname="a" tie="t" />
                              <note dur="4" oct="4" pname="f" tie="t" />
                              <note dur="4" oct="4" pname="c" tie="t" />
                              <note dur="4" oct="3" pname="a" tie="t" />
                              <note dur="4" oct="3" pname="b" tie="t" />
                           </chord>
                           <chord xml:id="chord-0000000233621824" dur.ppq="4" dur="4" stem.dir="down">
                              <note xml:id="note-0000001041748545" oct="5" pname="a" />
                              <note xml:id="note-0000002128010417" oct="5" pname="d" accid.ges="s" />
                              <note xml:id="note-0000000854262232" oct="4" pname="b" accid.ges="s" />
                              <note xml:id="note-0000000106103353" oct="4" pname="a" />
                           </chord>
                           <chord xml:id="chord-0000000492929843" dur.ppq="8" dur="2" stem.dir="down">
                              <note xml:id="note-0000000790689697" oct="5" pname="a" />
                              <note xml:id="note-0000001827444822" oct="5" pname="d" accid.ges="s" />
                              <note xml:id="note-0000001802945975" oct="4" pname="b" accid.ges="s" />
                              <note xml:id="note-0000001488473100" oct="4" pname="a" />
                           </chord>
                           <chord xml:id="chord-0000000233621824a" dur.ppq="4" dur="4" stem.dir="up">
                              <note xml:id="note-0000001041748545a" oct="4" pname="a" />
                              <note xml:id="note-0000002128010417a" oct="4" pname="d" accid.ges="s" />
                              <note xml:id="note-0000000854262232a" oct="4" pname="b" accid.ges="s" />
                              <note xml:id="note-0000000106103353a" oct="3" pname="a" />
                           </chord>
                           <chord xml:id="chord-0000000492929843a" dur.ppq="8" dur="2" stem.dir="up">
                              <note xml:id="note-0000000790689697a" oct="4" pname="a" />
                              <note xml:id="note-0000001827444822a" oct="4" pname="d" accid.ges="s" />
                              <note xml:id="note-0000001802945975a" oct="4" pname="b" accid.ges="s" />
                              <note xml:id="note-0000001488473100a" oct="3" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="tie-0000000881889252" startid="#note-0000001041748545" endid="#note-0000000790689697" />
                     <tie xml:id="tie-0000001055540460" startid="#note-0000000854262232" endid="#note-0000001802945975" />
                     <tie xml:id="tie-0000000867626861" startid="#note-0000000106103353" endid="#note-0000001488473100" />
                     <tie xml:id="tie-0000000881889252a" startid="#note-0000001041748545a" endid="#note-0000000790689697a" />
                     <tie xml:id="tie-0000001055540460a" startid="#note-0000000854262232a" endid="#note-0000001802945975a" />
                     <tie xml:id="tie-0000000867626861a" startid="#note-0000000106103353a" endid="#note-0000001488473100a" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>

<details><summary>Example MEI (2)</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-11-09" type="encoding-date">2021-11-09</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-3tk">
         <appInfo xml:id="appinfo-mms">
            <application xml:id="application-5jv" isodate="2021-12-03T15:36:48" version="3.8.0-dev-[undefined]">
               <name xml:id="name-eiq">Verovio</name>
               <p xml:id="p-uj">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m1ly">
            <score xml:id="s7z4">
               <scoreDef xml:id="s8hw">
                  <staffGrp xml:id="slki">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="lc4u">Piano</label>
                        <labelAbbr xml:id="lmp8">Pno.</labelAbbr>
                        <instrDef xml:id="i19j" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="ce6p" shape="G" line="2" />
                        <keySig xml:id="kfs8" sig="0" />
                        <meterSig xml:id="mama" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s100">
                  <measure xml:id="mec" n="1">
                     <staff xml:id="siue" n="1">
                        <layer xml:id="lj5g" n="1">
                           <chord xml:id="cm18" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="n2d2" oct="4" pname="c" accid="s" />
                              <note xml:id="nj7c" oct="4" pname="d" />
                              <note xml:id="nbo2" oct="4" pname="e" />
                              <note xml:id="nkig" oct="4" pname="f" />
                              <note xml:id="n16r" oct="4" pname="g" />
                              <note xml:id="n44f" oct="4" pname="a" />
                              <note xml:id="nmy" oct="4" pname="b" />
                           </chord>
                           <chord xml:id="cnxg" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="nn17" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="nfgp" oct="4" pname="d" />
                              <note xml:id="n496" oct="4" pname="e" />
                              <note xml:id="n5ik" oct="4" pname="f" />
                              <note xml:id="n72g" oct="4" pname="g" />
                              <note xml:id="nlia" oct="4" pname="a" />
                              <note xml:id="n58a" oct="4" pname="b" />
                           </chord>
                           <chord xml:id="c8r8" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="napc" oct="5" pname="d" accid="s" />
                              <note xml:id="n52s" oct="5" pname="e" />
                              <note xml:id="nc4x" oct="5" pname="f" accid="s" />
                              <note xml:id="n86i" oct="5" pname="g" accid="s" />
                              <note xml:id="ndkb" oct="5" pname="a" />
                           </chord>
                           <chord xml:id="cdj3" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="nonm" oct="5" pname="d" accid.ges="s" />
                              <note xml:id="n382" oct="5" pname="e" />
                              <note xml:id="n4hk" oct="5" pname="f" accid.ges="s" />
                              <note xml:id="n6nv" oct="5" pname="g" accid.ges="s" />
                              <note xml:id="nhf8" oct="5" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="t1tn" startid="#n2d2" endid="#nn17" />
                     <tie xml:id="tcbf" startid="#nj7c" endid="#nfgp" />
                     <tie xml:id="toxj" startid="#nbo2" endid="#n496" />
                     <tie xml:id="tagn" startid="#nkig" endid="#n5ik" />
                     <tie xml:id="t7kn" startid="#n16r" endid="#n72g" />
                     <tie xml:id="tooe" startid="#n44f" endid="#nlia" />
                     <tie xml:id="tknv" startid="#nmy" endid="#n58a" />
                     <tie xml:id="tb1p" startid="#napc" endid="#nonm" />
                     <tie xml:id="t8pl" startid="#n52s" endid="#n382" />
                     <tie xml:id="t5wy" startid="#nc4x" endid="#n4hk" />
                     <tie xml:id="t7iq" startid="#n86i" endid="#n6nv" />
                     <tie xml:id="teww" startid="#ndkb" endid="#nhf8" />
                  </measure>
                  <measure xml:id="mhtg" n="2">
                     <staff xml:id="seqx" n="1">
                        <layer xml:id="ljha" n="1">
                           <chord xml:id="cllk" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="n969" oct="4" pname="e" accid="s" />
                              <note xml:id="ni5c" oct="4" pname="f" accid="s" />
                              <note xml:id="n1vj" oct="4" pname="g" accid="s" />
                              <note xml:id="nma3" oct="4" pname="a" />
                              <note xml:id="njei" oct="4" pname="b" accid="f" />
                           </chord>
                           <chord xml:id="ccpl" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="ngyj" oct="4" pname="e" accid.ges="s" />
                              <note xml:id="n2ld" oct="4" pname="f" accid.ges="s" />
                              <note xml:id="nk36" oct="4" pname="g" accid.ges="s" />
                              <note xml:id="nkrc" oct="4" pname="a" />
                              <note xml:id="nl69" oct="4" pname="b" accid.ges="f" />
                           </chord>
                           <chord xml:id="clvs" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="n6jr" oct="4" pname="d" accid="s" />
                              <note xml:id="nddv" oct="4" pname="e" accid.ges="s" />
                              <note xml:id="nnv7" oct="4" pname="f" accid.ges="s" />
                              <note xml:id="nhqs" oct="4" pname="g" accid="n" />
                              <note xml:id="n4p4" oct="4" pname="a" />
                           </chord>
                           <chord xml:id="caxu" dur.ppq="1" dur="4" stem.dir="up">
                              <note xml:id="n8t4" oct="4" pname="d" accid.ges="s" />
                              <note xml:id="nfyv" oct="4" pname="e" accid.ges="s" />
                              <note xml:id="noqc" oct="4" pname="f" accid.ges="s" />
                              <note xml:id="nbom" oct="4" pname="g" />
                              <note xml:id="n5na" oct="4" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="tjln" startid="#n969" endid="#ngyj" />
                     <tie xml:id="tmo7" startid="#ni5c" endid="#n2ld" />
                     <tie xml:id="tjmw" startid="#n1vj" endid="#nk36" />
                     <tie xml:id="tbzz" startid="#nma3" endid="#nkrc" />
                     <tie xml:id="t4oj" startid="#njei" endid="#nl69" />
                     <tie xml:id="t17v" startid="#n6jr" endid="#n8t4" />
                     <tie xml:id="tabb" startid="#nddv" endid="#nfyv" />
                     <tie xml:id="t54a" startid="#nnv7" endid="#noqc" />
                     <tie xml:id="t8gx" startid="#nhqs" endid="#nbom" />
                     <tie xml:id="tnkl" startid="#n4p4" endid="#n5na" />
                  </measure>
                  <measure xml:id="mkdu" n="3">
                     <staff xml:id="sduv" n="1">
                        <layer xml:id="l47k" n="1">
                           <chord xml:id="ccc0" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="n49j" oct="5" pname="d" />
                              <note xml:id="n8k6" oct="5" pname="e" accid="f" />
                              <note xml:id="nkcx" oct="5" pname="f" />
                              <note xml:id="n183" oct="5" pname="g" accid="f" />
                              <note xml:id="n2ur" oct="5" pname="a" accid="f" />
                           </chord>
                           <chord xml:id="cc7l" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="n3dl" oct="5" pname="d" />
                              <note xml:id="nljh" oct="5" pname="e" accid.ges="f" />
                              <note xml:id="nmgy" oct="5" pname="f" />
                              <note xml:id="nhiz" oct="5" pname="g" accid.ges="f" />
                              <note xml:id="nnxj" oct="5" pname="a" accid.ges="f" />
                           </chord>
                           <chord xml:id="cl80" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="ntv" oct="5" pname="g" accid="s" />
                              <note xml:id="n7db" oct="5" pname="a" accid="s" />
                              <note xml:id="ngkt" oct="5" pname="b" accid="s" />
                              <note xml:id="n2el" oct="6" pname="c" accid="s" />
                              <note xml:id="ni6e" oct="6" pname="d" />
                           </chord>
                           <chord xml:id="ccmg" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="n6eu" oct="5" pname="g" accid.ges="s" />
                              <note xml:id="nicm" oct="5" pname="a" accid.ges="s" />
                              <note xml:id="n601" oct="5" pname="b" accid.ges="s" />
                              <note xml:id="nnq1" oct="6" pname="c" accid.ges="s" />
                              <note xml:id="n910" oct="6" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="t939" startid="#n49j" endid="#n3dl" />
                     <tie xml:id="ter8" startid="#n8k6" endid="#nljh" />
                     <tie xml:id="thkd" startid="#nkcx" endid="#nmgy" />
                     <tie xml:id="tba2" startid="#n183" endid="#nhiz" />
                     <tie xml:id="t8f7" startid="#n2ur" endid="#nnxj" />
                     <tie xml:id="tix3" startid="#ntv" endid="#n6eu" />
                     <tie xml:id="taxr" startid="#n7db" endid="#nicm" />
                     <tie xml:id="t9hw" startid="#ngkt" endid="#n601" />
                     <tie xml:id="tbk4" startid="#n2el" endid="#nnq1" />
                     <tie xml:id="t283" startid="#ni6e" endid="#n910" />
                  </measure>
                  <measure xml:id="m9xl" right="end" n="4">
                     <staff xml:id="s4j3" n="1">
                        <layer xml:id="l4kh" n="1">
                           <chord xml:id="cp62" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="ngjd" oct="4" pname="g" accid="s" />
                              <note xml:id="n42f" oct="4" pname="a" />
                              <note xml:id="nmdd" oct="4" pname="b" accid="f" />
                              <note xml:id="nkvb" oct="5" pname="c" />
                              <note xml:id="n4ao" oct="5" pname="d" />
                           </chord>
                           <chord xml:id="cn6g" dur.ppq="1" dur="4" stem.dir="down">
                              <note xml:id="n4kv" oct="4" pname="g" accid.ges="s" />
                              <note xml:id="n8fc" oct="4" pname="a" />
                              <note xml:id="n5n8" oct="4" pname="b" accid.ges="f" />
                              <note xml:id="nn0m" oct="5" pname="c" />
                              <note xml:id="ncco" oct="5" pname="d" />
                           </chord>
                           <rest xml:id="r5wx" dur.ppq="2" dur="2" />
                        </layer>
                     </staff>
                     <tie xml:id="tmdq" startid="#ngjd" endid="#n4kv" />
                     <tie xml:id="teix" startid="#n42f" endid="#n8fc" />
                     <tie xml:id="t1mw" startid="#nmdd" endid="#n5n8" />
                     <tie xml:id="tfq2" startid="#nkvb" endid="#nn0m" />
                     <tie xml:id="thj0" startid="#n4ao" endid="#ncco" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>
