### PR TITLE
Develop beamlet fixes

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -250,7 +250,6 @@ public:
     int m_overlapMargin;
     int m_maxShortening; // maximum allowed shortening in half units
     bool m_centered; // beam is centered on the line
-    bool m_shortened; // stem is shortened because pointing oustide the staff
     data_BEAMPLACE m_beamRelativePlace;
     char m_partialFlags[MAX_DURATION_PARTIALS];
     data_BEAMPLACE m_partialFlagPlace;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -68,6 +68,9 @@ public:
     int GetAdjacentElementsDuration(int elementX) const;
 
 private:
+    // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
+    void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
+
     void CalcBeamInit(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
     bool CalcBeamSlope(
@@ -79,8 +82,6 @@ private:
 
     // Helper to adjust position of starting point to make sure that beam start-/endpoints touch the staff lines
     void CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
-
-    void CalcStemLenInHalfUnitsgth(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
 
     void CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -122,17 +122,17 @@ public:
     bool HasOneStepHeight();
 
     /**
+     * Get total beam width with regards to the shortest duration of the beam (counting both beams and whitespace
+     * between them)
+     */
+    int GetTotalBeamWidth() const;
+
+    /**
      * Clear the m_beamElementCoords vector and delete all the objects.
      */
     void ClearCoords();
 
 protected:
-    /**
-     * Set higher ledger number for the interface. Either top or bottom ledger lines are taken into account, based on
-     * the m_notesStemDir
-     */
-    void AdjustLedgerLineNumber(LayerElement *element);
-
     /**
      * Return the position of the element in the beam.
      * For notes, lookup the position of the parent chord.
@@ -148,7 +148,6 @@ public:
     Staff *m_crossStaffContent;
     data_STAFFREL_basic m_crossStaffRel;
     int m_shortestDur;
-    int m_ledgerLines;
     data_STEMDIRECTION m_notesStemDir;
     data_BEAMPLACE m_drawingPlace;
     Staff *m_beamStaff;

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -128,6 +128,12 @@ public:
 
 protected:
     /**
+     * Set higher ledger number for the interface. Either top or bottom ledger lines are taken into account, based on
+     * the m_notesStemDir
+     */
+    void AdjustLedgerLineNumber(LayerElement *element);
+
+    /**
      * Return the position of the element in the beam.
      * For notes, lookup the position of the parent chord.
      */
@@ -142,6 +148,7 @@ public:
     Staff *m_crossStaffContent;
     data_STAFFREL_basic m_crossStaffRel;
     int m_shortestDur;
+    int m_ledgerLines;
     data_STEMDIRECTION m_notesStemDir;
     data_BEAMPLACE m_drawingPlace;
     Staff *m_beamStaff;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -300,7 +300,7 @@ void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInt
         if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
             const int topPosition = coord->m_yBeam + beamInterface->GetTotalBeamWidth();
             const int topMargin = staffTop - doubleUnit / 2;
-            if (topPosition > topMargin) {
+            if (topPosition >= topMargin) {
                 adjust = ((topPosition - topMargin) / doubleUnit + 1) * doubleUnit;
                 break;
             }
@@ -308,7 +308,7 @@ void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInt
         else if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
             const int bottomPosition = coord->m_yBeam - beamInterface->GetTotalBeamWidth();
             const int bottomMargin = staffTop - staffHeight + doubleUnit / 2;
-            if (bottomPosition < bottomMargin) {
+            if (bottomPosition <= bottomMargin) {
                 adjust = ((bottomPosition - bottomMargin) / doubleUnit - 1) * doubleUnit;
                 break;
             }
@@ -691,8 +691,6 @@ void BeamSegment::CalcBeamPosition(
         }
     }
 
-    this->AdjustBeamToLedgerLines(doc, staff, beamInterface);
-
     /******************************************************************/
     // Calculate the slope is necessary
 
@@ -737,6 +735,8 @@ void BeamSegment::CalcBeamPosition(
 
         this->CalcAdjustPosition(staff, doc, beamInterface);
     }
+
+    this->AdjustBeamToLedgerLines(doc, staff, beamInterface);
 }
 
 void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool shorten, int &step)

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -969,7 +969,7 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool is
         // if location matches, or if current elements duration is shorter than 8th. This ensures that beams with
         // partial beams will not be shorted when lowest/highest note is 8th and can be shortened
         if ((coord->m_closestNote->GetDrawingLoc() == relevantNoteLoc)
-            || (!isHorizontal && (coord->m_dur > DUR_8) && (m_uniformStemLength < 13)))
+            || (!isHorizontal && (coord->m_dur > DUR_8) && (std::abs(m_uniformStemLength) < 13)))
             m_uniformStemLength = coordStemLength;
     }
     // make adjustments for the grace notes length
@@ -1295,10 +1295,6 @@ void BeamElementCoord::SetDrawingStemDir(
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     m_stem->SetDrawingStemDir(stemDir);
-    int ledgerLines = 0;
-    int ledgerLinesOpposite = 0;
-    m_shortened = false;
-
     m_yBeam = m_element->GetDrawingY();
     m_x += (STEMDIRECTION_up == stemDir) ? interface->m_stemXAbove[interface->m_cueSize]
                                          : interface->m_stemXBelow[interface->m_cueSize];
@@ -1313,13 +1309,6 @@ void BeamElementCoord::SetDrawingStemDir(
     }
 
     m_yBeam = m_closestNote->GetDrawingY();
-    if (stemDir == STEMDIRECTION_up) {
-        m_closestNote->HasLedgerLines(ledgerLinesOpposite, ledgerLines);
-    }
-    else {
-        m_closestNote->HasLedgerLines(ledgerLines, ledgerLinesOpposite);
-    }
-
     m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
 
     if (m_element->IsGraceNote()) return;
@@ -1340,10 +1329,10 @@ void BeamElementCoord::SetDrawingStemDir(
     }
 
     // Make sure there is a at least one staff space before the ledger lines
-    if ((ledgerLines > 2) && (interface->m_shortestDur > DUR_32)) {
+    if ((interface->m_ledgerLines > 2) && (interface->m_shortestDur > DUR_32)) {
         m_yBeam += (stemDir == STEMDIRECTION_up) ? 4 * unit : -4 * unit;
     }
-    else if ((ledgerLines > 1) && (interface->m_shortestDur > DUR_16)) {
+    else if ((interface->m_ledgerLines > 1) && (interface->m_shortestDur > DUR_16)) {
         m_yBeam += (stemDir == STEMDIRECTION_up) ? 2 * unit : -2 * unit;
     }
 
@@ -1366,7 +1355,6 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
         if ((m_maxShortening > 0) && ((stemLenInHalfUnits - standardStemLen) > m_maxShortening)) {
             stemLenInHalfUnits = standardStemLen - m_maxShortening;
         }
-        m_shortened = true;
         extend = false;
     }
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -736,7 +736,7 @@ void BeamSegment::CalcBeamPosition(
         this->CalcAdjustPosition(staff, doc, beamInterface);
     }
 
-    this->AdjustBeamToLedgerLines(doc, staff, beamInterface);
+    if (!beamInterface->m_crossStaffContent) this->AdjustBeamToLedgerLines(doc, staff, beamInterface);
 }
 
 void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool shorten, int &step)

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -84,7 +84,6 @@ void BeamDrawingInterface::Reset()
     m_crossStaffContent = NULL;
     m_crossStaffRel = STAFFREL_basic_NONE;
     m_shortestDur = 0;
-    m_ledgerLines = 0;
     m_notesStemDir = STEMDIRECTION_NONE;
     m_drawingPlace = BEAMPLACE_NONE;
     m_beamStaff = NULL;
@@ -94,25 +93,9 @@ void BeamDrawingInterface::Reset()
     m_beamWidthWhite = 0;
 }
 
-void BeamDrawingInterface::AdjustLedgerLineNumber(LayerElement *element)
+int BeamDrawingInterface::GetTotalBeamWidth() const
 {
-    Note *note = NULL;
-    if (element->Is(NOTE)) {
-        note = vrv_cast<Note *>(element);
-    }
-    else if (element->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(element);
-        note = (STEMDIRECTION_up == m_notesStemDir) ? chord->GetTopNote() : chord->GetBottomNote();
-    }
-    if (!note) return;
-
-    int ledgerLines = 0;
-    int ignore = 0;
-    if (m_notesStemDir == STEMDIRECTION_up)
-        note->HasLedgerLines(ignore, ledgerLines);
-    else
-        note->HasLedgerLines(ledgerLines, ignore);
-    m_ledgerLines = std::max(m_ledgerLines, ledgerLines);
+    return m_beamWidthBlack + (m_shortestDur - DUR_8) * m_beamWidth;
 }
 
 void BeamDrawingInterface::ClearCoords()
@@ -220,7 +203,6 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
             }
             // keep the shortest dur in the beam
             m_shortestDur = std::max(currentDur, m_shortestDur);
-            this->AdjustLedgerLineNumber(current);
         }
         // check if we have more than duration in the beam
         if (!m_changingDur && currentDur != lastDur) m_changingDur = true;

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -94,8 +94,7 @@ void BeamDrawingInterface::Reset()
     m_beamWidthWhite = 0;
 }
 
-
-void BeamDrawingInterface::AdjustLedgerLineNumber(LayerElement *element) 
+void BeamDrawingInterface::AdjustLedgerLineNumber(LayerElement *element)
 {
     Note *note = NULL;
     if (element->Is(NOTE)) {

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -84,6 +84,7 @@ void BeamDrawingInterface::Reset()
     m_crossStaffContent = NULL;
     m_crossStaffRel = STAFFREL_basic_NONE;
     m_shortestDur = 0;
+    m_ledgerLines = 0;
     m_notesStemDir = STEMDIRECTION_NONE;
     m_drawingPlace = BEAMPLACE_NONE;
     m_beamStaff = NULL;

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -93,6 +93,28 @@ void BeamDrawingInterface::Reset()
     m_beamWidthWhite = 0;
 }
 
+
+void BeamDrawingInterface::AdjustLedgerLineNumber(LayerElement *element) 
+{
+    Note *note = NULL;
+    if (element->Is(NOTE)) {
+        note = vrv_cast<Note *>(element);
+    }
+    else if (element->Is(CHORD)) {
+        Chord *chord = vrv_cast<Chord *>(element);
+        note = (STEMDIRECTION_up == m_notesStemDir) ? chord->GetTopNote() : chord->GetBottomNote();
+    }
+    if (!note) return;
+
+    int ledgerLines = 0;
+    int ignore = 0;
+    if (m_notesStemDir == STEMDIRECTION_up)
+        note->HasLedgerLines(ignore, ledgerLines);
+    else
+        note->HasLedgerLines(ledgerLines, ignore);
+    m_ledgerLines = std::max(m_ledgerLines, ledgerLines);
+}
+
 void BeamDrawingInterface::ClearCoords()
 {
     ArrayOfBeamElementCoords::iterator iter;
@@ -198,6 +220,7 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
             }
             // keep the shortest dur in the beam
             m_shortestDur = std::max(currentDur, m_shortestDur);
+            this->AdjustLedgerLineNumber(current);
         }
         // check if we have more than duration in the beam
         if (!m_changingDur && currentDur != lastDur) m_changingDur = true;

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -308,10 +308,15 @@ void View::DrawBeamSegment(DeviceContext *dc, BeamSegment *beamSegment, BeamDraw
                         beamElementCoords->at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_THROUGH;
                     }
                     // not needed for the next one or break
-                    else if (!beamElementCoords->at(idx)->m_element->Is(REST)) {
+                    else {
                         // we are starting a beam or after a beam break - put it right
                         if (start) {
-                            beamElementCoords->at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_RIGHT;
+                            if ((idx != 0) && (beamElementCoords->at(idx - 1)->m_element->Is(REST))) {
+                                beamElementCoords->at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_LEFT;
+                            }
+                            else {
+                                beamElementCoords->at(idx)->m_partialFlags[testDur - DUR_8] = PARTIAL_RIGHT;
+                            }
                         }
                         // or the previous one had no partial
                         else if (beamElementCoords->at(noteIndexes.at(i - 1))->m_dur < (char)testDur) {


### PR DESCRIPTION
closes #2518

![image](https://user-images.githubusercontent.com/1819669/144868793-1ef99d0d-3482-4199-967e-07ac7baff5be.png)

Fixes an issue with invalid beam slope when first notes of the beam have shorter duration but are have only 1 ledger line, and last notes have 2 or more:
![image](https://user-images.githubusercontent.com/1819669/144868998-4405c12d-5027-47a2-8a95-18bc33bdadaf.png)
After the fix:
![image](https://user-images.githubusercontent.com/1819669/144869039-4af885c3-9f89-468a-b9c4-1aa82c64a447.png)
