### PR TITLE
Fix for --mdiv-all weird justification

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -800,7 +800,7 @@ int System::JustifyX(FunctorParams *functorParams)
     if (this->IsLastOfMdiv()) {
         double minLastJust = params->m_doc->GetOptions()->m_minLastJustification.GetValue();
         if ((minLastJust > 0) && (params->m_justifiableRatio > (1 / minLastJust))) {
-            return FUNCTOR_STOP;
+            return FUNCTOR_SIBLINGS;
         }
     }
 


### PR DESCRIPTION
- continue processing system siblings instead of stopping to avoid weird rendering for executions with --mdiv-all option

Previously, with `--mdiv-all` option, if one `mdiv` ended and another `mdiv` started on the same page, Verovio would not justify systems of the second `mdiv`.