### PR TITLE
Enforce minimal white space between systems

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -757,7 +757,9 @@ int System::AlignSystems(FunctorParams *functorParams)
     if (systemMargin) {
         const int margin
             = systemMargin - (params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove(params->m_doc));
-        params->m_shift -= margin > 0 ? margin : 0;
+        // Ensure minimal white space between consecutive systems by adding one staff space
+        const int unit = params->m_doc->GetDrawingUnit(100);
+        params->m_shift -= std::max(margin, 2 * unit);
     }
 
     SetDrawingYRel(params->m_shift);


### PR DESCRIPTION
This PR adds minimal white space between consecutive systems as proposed in https://github.com/rism-digital/verovio/pull/2478 .
Additionally, the following should work:
- Minimal white space is never added before the first system of a page.
- Minimal white space is not added when there is already enough whitespace between consecutive systems.