### PR TITLE
Update transcription page-based MEI

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -745,6 +745,9 @@ private:
     ///@{
     // to MEI 5.0.0
     void UpgradePageTo_5_0_0(Page *page);
+    void UpgradeMeasureTo_5_0_0(pugi::xml_node measure);
+    void UpgradeStaffTo_5_0_0(pugi::xml_node staff);
+    void UpgradeLayerElementTo_5_0_0(pugi::xml_node element);
     // to MEI 4.0.0
     void UpgradeBeatRptTo_4_0_0(pugi::xml_node beatRpt, BeatRpt *vrvBeatRpt);
     void UpgradeDurGesTo_4_0_0(pugi::xml_node element, DurationInterface *interface);

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -40,6 +40,7 @@ class StaffAlignment;
 class LayerElement : public Object,
                      public FacsimileInterface,
                      public LinkingInterface,
+                     public AttCoordX1,
                      public AttLabelled,
                      public AttTyped {
 public:

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -35,6 +35,8 @@ class TimestampAttr;
  */
 class Measure : public Object,
                 public AttBarring,
+                public AttCoordX1,
+                public AttCoordX2,
                 public AttMeasureLog,
                 public AttMeterConformanceBar,
                 public AttNNumberLike,

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -33,7 +33,12 @@ class Tuning;
  * It contains Measure objects.
  * For unmeasured music, one single Measure is added for simplifying internal processing
  */
-class Staff : public Object, public FacsimileInterface, public AttNInteger, public AttTyped, public AttVisibility {
+class Staff : public Object,
+              public FacsimileInterface,
+              public AttCoordY1,
+              public AttNInteger,
+              public AttTyped,
+              public AttVisibility {
 
 public:
     /**

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4353,6 +4353,10 @@ bool MEIInput::ReadMeasure(Object *parent, pugi::xml_node measure)
     vrvMeasure->ReadPointing(measure);
     vrvMeasure->ReadTyped(measure);
 
+    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+        UpgradeMeasureTo_5_0_0(measure);
+    }
+
     if (measure.attribute("coord.x1") && measure.attribute("coord.x2") && (m_doc->GetType() == Transcription)) {
         vrvMeasure->ReadCoordX1(measure);
         vrvMeasure->ReadCoordX2(measure);
@@ -4980,6 +4984,10 @@ bool MEIInput::ReadStaff(Object *parent, pugi::xml_node staff)
     vrvStaff->ReadTyped(staff);
     vrvStaff->ReadVisibility(staff);
 
+    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+        UpgradeStaffTo_5_0_0(staff);
+    }
+
     if (staff.attribute("coord.y1") && (m_doc->GetType() == Transcription)) {
         vrvStaff->ReadCoordY1(staff);
         vrvStaff->m_yAbs = vrvStaff->GetCoordY1() * DEFINITION_FACTOR;
@@ -5199,15 +5207,19 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
 
 bool MEIInput::ReadLayerElement(pugi::xml_node element, LayerElement *object)
 {
-    if (element.attribute("coord.x1") && (m_doc->GetType() == Transcription)) {
-        object->ReadCoordX1(element);
-        object->m_xAbs = object->GetCoordX1() * DEFINITION_FACTOR;
-    }
-
     SetMeiUuid(element, object);
     ReadLinkingInterface(element, object);
     object->ReadLabelled(element);
     object->ReadTyped(element);
+
+    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+        UpgradeLayerElementTo_5_0_0(element);
+    }
+
+    if (element.attribute("coord.x1") && (m_doc->GetType() == Transcription)) {
+        object->ReadCoordX1(element);
+        object->m_xAbs = object->GetCoordX1() * DEFINITION_FACTOR;
+    }
 
     return true;
 }
@@ -6949,6 +6961,30 @@ void MEIInput::UpgradePageTo_5_0_0(Page *page)
 
     PageMilestoneEnd *mdivEnd = new PageMilestoneEnd(mdiv);
     page->AddChild(mdivEnd);
+}
+
+void MEIInput::UpgradeMeasureTo_5_0_0(pugi::xml_node measure)
+{
+    if (measure.attribute("ulx")) {
+        measure.attribute("ulx").set_name("coord.x1");
+    }
+    if (measure.attribute("lrx")) {
+        measure.attribute("lrx").set_name("coord.x2");
+    }
+}
+
+void MEIInput::UpgradeStaffTo_5_0_0(pugi::xml_node staff)
+{
+    if (staff.attribute("uly")) {
+        staff.attribute("uly").set_name("coord.y1");
+    }
+}
+
+void MEIInput::UpgradeLayerElementTo_5_0_0(pugi::xml_node element)
+{
+    if (element.attribute("ulx")) {
+        element.attribute("ulx").set_name("coord.x1");
+    }
 }
 
 void MEIInput::UpgradeBeatRptTo_4_0_0(pugi::xml_node beatRpt, BeatRpt *vrvBeatRpt)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1285,9 +1285,12 @@ void MEIOutput::WriteMeasure(pugi::xml_node currentNode, Measure *measure)
     measure->WriteNNumberLike(currentNode);
     measure->WritePointing(currentNode);
     measure->WriteTyped(currentNode);
+    // For now we copy the adjusted value of coord.x1 and coord.x2 to xAbs and xAbs2 respectively
     if ((measure->m_xAbs != VRV_UNSET) && (measure->m_xAbs2 != VRV_UNSET)) {
-        currentNode.append_attribute("ulx") = StringFormat("%d", measure->m_xAbs / DEFINITION_FACTOR).c_str();
-        currentNode.append_attribute("lrx") = StringFormat("%d", measure->m_xAbs2 / DEFINITION_FACTOR).c_str();
+        measure->SetCoordX1(measure->m_xAbs / DEFINITION_FACTOR);
+        measure->SetCoordX2(measure->m_xAbs2 / DEFINITION_FACTOR);
+        measure->WriteCoordX1(currentNode);
+        measure->WriteCoordX2(currentNode);
     }
 }
 
@@ -4348,11 +4351,11 @@ bool MEIInput::ReadMeasure(Object *parent, pugi::xml_node measure)
     vrvMeasure->ReadPointing(measure);
     vrvMeasure->ReadTyped(measure);
 
-    if (measure.attribute("ulx") && measure.attribute("lrx") && (m_doc->GetType() == Transcription)) {
-        vrvMeasure->m_xAbs = atoi(measure.attribute("ulx").value()) * DEFINITION_FACTOR;
-        vrvMeasure->m_xAbs2 = atoi(measure.attribute("lrx").value()) * DEFINITION_FACTOR;
-        measure.remove_attribute("ulx");
-        measure.remove_attribute("lrx");
+    if (measure.attribute("coord.x1") && measure.attribute("coord.x2") && (m_doc->GetType() == Transcription)) {
+        vrvMeasure->ReadCoordX1(measure);
+        vrvMeasure->ReadCoordX2(measure);
+        vrvMeasure->m_xAbs = vrvMeasure->GetCoordX1() * DEFINITION_FACTOR;
+        vrvMeasure->m_xAbs2 = vrvMeasure->GetCoordX2() * DEFINITION_FACTOR;
     }
 
     parent->AddChild(vrvMeasure);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1652,7 +1652,8 @@ void MEIOutput::WriteLayerElement(pugi::xml_node currentNode, LayerElement *elem
     element->WriteLabelled(currentNode);
     element->WriteTyped(currentNode);
     if (element->m_xAbs != VRV_UNSET) {
-        currentNode.attribute("ulx") = StringFormat("%d", element->m_xAbs / DEFINITION_FACTOR).c_str();
+        element->SetCoordX1(element->m_xAbs / DEFINITION_FACTOR);
+        element->WriteCoordX1(currentNode);
     }
 }
 
@@ -5197,9 +5198,9 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
 
 bool MEIInput::ReadLayerElement(pugi::xml_node element, LayerElement *object)
 {
-    if (element.attribute("ulx") && (m_doc->GetType() == Transcription)) {
-        object->m_xAbs = atoi(element.attribute("ulx").value()) * DEFINITION_FACTOR;
-        element.remove_attribute("ulx");
+    if (element.attribute("coord.x1") && (m_doc->GetType() == Transcription)) {
+        object->ReadCoordX1(element);
+        object->m_xAbs = object->GetCoordX1() * DEFINITION_FACTOR;
     }
 
     SetMeiUuid(element, object);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1578,7 +1578,8 @@ void MEIOutput::WriteStaff(pugi::xml_node currentNode, Staff *staff)
 
     // y position
     if (staff->m_yAbs != VRV_UNSET) {
-        currentNode.append_attribute("uly") = StringFormat("%d", staff->m_yAbs / DEFINITION_FACTOR).c_str();
+        staff->SetCoordY1(staff->m_yAbs / DEFINITION_FACTOR);
+        staff->WriteCoordY1(currentNode);
     }
 }
 
@@ -4979,9 +4980,9 @@ bool MEIInput::ReadStaff(Object *parent, pugi::xml_node staff)
     vrvStaff->ReadTyped(staff);
     vrvStaff->ReadVisibility(staff);
 
-    if (staff.attribute("uly") && (m_doc->GetType() == Transcription)) {
-        vrvStaff->m_yAbs = atoi(staff.attribute("uly").value()) * DEFINITION_FACTOR;
-        staff.remove_attribute("uly");
+    if (staff.attribute("coord.y1") && (m_doc->GetType() == Transcription)) {
+        vrvStaff->ReadCoordY1(staff);
+        vrvStaff->m_yAbs = vrvStaff->GetCoordY1() * DEFINITION_FACTOR;
     }
 
     if (!vrvStaff->HasN() || (vrvStaff->GetN() == 0)) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -70,10 +70,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 LayerElement::LayerElement()
-    : Object(LAYER_ELEMENT, "le-"), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+    : Object(LAYER_ELEMENT, "le-"), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
 {
     RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
+    RegisterAttClass(ATT_COORDX1);
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);
 
@@ -81,10 +82,11 @@ LayerElement::LayerElement()
 }
 
 LayerElement::LayerElement(ClassId classId)
-    : Object(classId, "le-"), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+    : Object(classId, "le-"), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
 {
     RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
+    RegisterAttClass(ATT_COORDX1);
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);
 
@@ -92,10 +94,11 @@ LayerElement::LayerElement(ClassId classId)
 }
 
 LayerElement::LayerElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), FacsimileInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+    : Object(classId, classIdStr), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
 {
     RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
+    RegisterAttClass(ATT_COORDX1);
     RegisterAttClass(ATT_LABELLED);
     RegisterAttClass(ATT_TYPED);
 
@@ -107,6 +110,7 @@ void LayerElement::Reset()
     Object::Reset();
     FacsimileInterface::Reset();
     LinkingInterface::Reset();
+    ResetCoordX1();
     ResetLabelled();
     ResetTyped();
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -52,6 +52,8 @@ static const ClassRegistrar<Measure> s_factory("measure", MEASURE);
 Measure::Measure(bool measureMusic, int logMeasureNb)
     : Object(MEASURE, "measure-")
     , AttBarring()
+    , AttCoordX1()
+    , AttCoordX2()
     , AttMeasureLog()
     , AttMeterConformanceBar()
     , AttNNumberLike()
@@ -59,6 +61,8 @@ Measure::Measure(bool measureMusic, int logMeasureNb)
     , AttTyped()
 {
     RegisterAttClass(ATT_BARRING);
+    RegisterAttClass(ATT_COORDX1);
+    RegisterAttClass(ATT_COORDX2);
     RegisterAttClass(ATT_MEASURELOG);
     RegisterAttClass(ATT_METERCONFORMANCEBAR);
     RegisterAttClass(ATT_NNUMBERLIKE);
@@ -111,6 +115,8 @@ void Measure::CloneReset()
 void Measure::Reset()
 {
     Object::Reset();
+    ResetCoordX1();
+    ResetCoordX2();
     ResetMeasureLog();
     ResetMeterConformanceBar();
     ResetNNumberLike();

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -41,8 +41,10 @@ namespace vrv {
 
 static const ClassRegistrar<Staff> s_factory("staff", STAFF);
 
-Staff::Staff(int n) : Object(STAFF, "staff-"), FacsimileInterface(), AttNInteger(), AttTyped(), AttVisibility()
+Staff::Staff(int n)
+    : Object(STAFF, "staff-"), FacsimileInterface(), AttCoordY1(), AttNInteger(), AttTyped(), AttVisibility()
 {
+    RegisterAttClass(ATT_COORDY1);
     RegisterAttClass(ATT_NINTEGER);
     RegisterAttClass(ATT_TYPED);
     RegisterAttClass(ATT_VISIBILITY);
@@ -58,6 +60,7 @@ void Staff::Reset()
 {
     Object::Reset();
     FacsimileInterface::Reset();
+    ResetCoordY1();
     ResetNInteger();
     ResetTyped();
     ResetVisibility();


### PR DESCRIPTION
The PR does not introduces a new feature but simply updates the code to match the current page-based customization
* Use `att.coord.x1`, `att.coord.x2` and `att.coord.y1` as appropriate on `Measure`, `Staff` and `LayerElement`
* Add methods to upgrade old files (MEI 2013)