### PR TITLE
Extend barlines for staves with single line

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -789,9 +789,15 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         }
 
         int yTop = first->GetDrawingY();
+        if (firstDef->GetLines() <= 1) {
+            yTop += m_doc->GetDrawingDoubleUnit(first->m_drawingStaffSize);
+        }
         // for the bottom position we need to take into account the number of lines and the staff size
         int yBottom
             = last->GetDrawingY() - (lastDef->GetLines() - 1) * m_doc->GetDrawingDoubleUnit(last->m_drawingStaffSize);
+        if (lastDef->GetLines() <= 1) {
+            yBottom -= m_doc->GetDrawingDoubleUnit(last->m_drawingStaffSize);
+        }
 
         // erase intersections only if we have more than one staff
         bool eraseIntersections = (first != last) ? true : false;


### PR DESCRIPTION
- addeed code to extend barlines above/below staffline for staff groups with sinlge line staves

closes #2404 

![image](https://user-images.githubusercontent.com/1819669/146166569-fe178ed4-f825-47aa-a00b-33c652b842c0.png)
![image](https://user-images.githubusercontent.com/1819669/146166627-778897af-6089-4086-a255-4c5f199b825f.png)
