### PR TITLE
Change floating objects order (place fingerings before hairpins)

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -874,6 +874,9 @@ int System::AdjustFloatingPositioners(FunctorParams *functorParams)
     params->m_classId = TRILL;
     m_systemAligner.Process(params->m_functor, params);
 
+    params->m_classId = FING;
+    m_systemAligner.Process(params->m_functor, params);
+
     params->m_classId = DYNAM;
     m_systemAligner.Process(params->m_functor, params);
 
@@ -898,9 +901,6 @@ int System::AdjustFloatingPositioners(FunctorParams *functorParams)
     m_systemAligner.Process(params->m_functor, params);
 
     params->m_classId = FERMATA;
-    m_systemAligner.Process(params->m_functor, params);
-
-    params->m_classId = FING;
     m_systemAligner.Process(params->m_functor, params);
 
     params->m_classId = DIR;


### PR DESCRIPTION
Changed from:
![image](https://user-images.githubusercontent.com/1819669/146193320-54965036-0285-41a3-81ee-d76d2e08a8eb.png)
To:
![image](https://user-images.githubusercontent.com/1819669/146193403-343326d7-c5bf-4ad2-a59f-197a060e5e4d.png)