### PR TITLE
Filtering in the score based export

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -188,19 +188,11 @@ public:
     bool Export();
 
     /**
-     * The main method for write objects.
+     * The main method for writing objects.
      */
     ///@{
     bool WriteObject(Object *object) override;
-    bool WriteObject(Object *object, bool handleScoreBasedFilter, bool useCustomScoreDef);
-    ///@}
-
-    /**
-     * Writing object method that must be overridden in the child class.
-     */
-    ///@{
     bool WriteObjectEnd(Object *object) override;
-    bool WriteObjectEnd(Object *object, bool handleScoreBasedFilter);
     ///@}
 
     /**
@@ -265,12 +257,16 @@ private:
     bool HasValidFilter() const;
     bool IsMatchingFilter() const;
     void UpdateFilter(Object *object);
+    bool ProcessScoreBasedFilter(Object *object);
+    bool ProcessScoreBasedFilterEnd(Object *object);
     ///@}
 
     /**
-     * Writing stacked objects
+     * Writing objects
      */
     ///@{
+    bool WriteObjectInternal(Object *object, bool useCustomScoreDef);
+    bool WriteObjectInternalEnd(Object *object);
     void WriteStackedObjects();
     void WriteStackedObjectsEnd();
     ///@}
@@ -524,7 +520,7 @@ private:
     /** Boundary objects which are merged into one xml element */
     std::stack<Object *> m_boundaries;
     /** The object stack */
-    std::stack<Object *> m_objectStack;
+    std::deque<Object *> m_objectStack;
 
     /** Score based filtering */
     ///@{

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -192,7 +192,7 @@ public:
      */
     ///@{
     bool WriteObject(Object *object) override;
-    bool WriteObject(Object *object, bool handleScoreBasedFilter);
+    bool WriteObject(Object *object, bool handleScoreBasedFilter, bool useCustomScoreDef);
     ///@}
 
     /**
@@ -268,6 +268,14 @@ private:
     ///@{
     void WriteStackedObjects();
     void WriteStackedObjectsEnd();
+    ///@}
+
+    /**
+     * Scoredef manipulation
+     */
+    ///@{
+    void WriteCustomScoreDef();
+    void AdjustStaffDef(StaffDef *staffDef, Measure *measure);
     ///@}
 
     /**
@@ -516,6 +524,7 @@ private:
     ///@{
     bool m_hasFilter;
     MatchLocation m_filterMatchLocation;
+    Object *m_firstFilterMatch;
     int m_firstPage;
     int m_currentPage;
     int m_lastPage;

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -257,6 +257,9 @@ private:
     bool HasValidFilter() const;
     bool IsMatchingFilter() const;
     void UpdateFilter(Object *object);
+    void UpdatePageFilter(Object *object);
+    void UpdateMeasureFilter(Object *object);
+    void UpdateMdivFilter(Object *object);
     bool ProcessScoreBasedFilter(Object *object);
     bool ProcessScoreBasedFilterEnd(Object *object);
     ///@}

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -203,7 +203,7 @@ public:
     /**
      * Return the output as a string by writing it to the stringstream member.
      */
-    std::string GetOutput(int page = -1);
+    std::string GetOutput();
 
     /**
      * @name Setter and getter for score-based MEI output
@@ -218,12 +218,9 @@ public:
      */
     ///@{
     bool HasFilter() const;
+    void SetFirstPage(int page);
+    void SetLastPage(int page);
     ///@}
-
-    /**
-     * Return true when the MEIOutput object is currently saving single page
-     */
-    bool IsSavingSinglePage() const { return (m_page != -1); }
 
     /**
      * @name Gettersto improve code readability
@@ -245,16 +242,20 @@ public:
 
 private:
     /**
-     * Check if the filter is currently matching
+     * Filtering
      */
+    ///@{
+    bool HasValidFilter() const;
     bool IsMatchingFilter() const;
+    void UpdateFilter(Object *object);
+    ///@}
 
     /**
      * Writing stacked objects
      */
     ///@{
-    void WriteStackedObjects(bool ignoreTop);
-    void WriteStackedObjectsEnd(bool ignoreTop);
+    void WriteStackedObjects();
+    void WriteStackedObjectsEnd();
     ///@}
 
     /**
@@ -487,7 +488,6 @@ public:
 private:
     std::ostringstream m_streamStringOutput;
     int m_indent;
-    int m_page;
     bool m_scoreBasedMEI;
     pugi::xml_node m_mei;
 
@@ -502,6 +502,10 @@ private:
 
     /** Filtering */
     ///@{
+    bool m_hasFilter;
+    int m_firstPage;
+    int m_currentPage;
+    int m_lastPage;
     MatchLocation m_filterMatchLocation;
     ///@}
 

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -159,6 +159,9 @@ class Unclear;
 class Verse;
 class Zone;
 
+// Helper enums
+enum class MatchLocation { Before, Now, After };
+
 //----------------------------------------------------------------------------
 // MEIOutput
 //----------------------------------------------------------------------------
@@ -184,12 +187,18 @@ public:
     /**
      * The main method for write objects.
      */
+    ///@{
     bool WriteObject(Object *object) override;
+    bool WriteObject(Object *object, bool handleScoreBasedFilter);
+    ///@}
 
     /**
      * Writing object method that must be overridden in the child class.
      */
+    ///@{
     bool WriteObjectEnd(Object *object) override;
+    bool WriteObjectEnd(Object *object, bool handleScoreBasedFilter);
+    ///@}
 
     /**
      * Return the output as a string by writing it to the stringstream member.
@@ -202,6 +211,13 @@ public:
     ///@{
     void SetScoreBasedMEI(bool scoreBasedMEI) { m_scoreBasedMEI = scoreBasedMEI; }
     bool GetScoreBasedMEI() const { return m_scoreBasedMEI; }
+    ///@}
+
+    /**
+     * Filtering by measure, page or mdiv
+     */
+    ///@{
+    bool HasFilter() const;
     ///@}
 
     /**
@@ -228,6 +244,22 @@ public:
     void SetRemoveIds(bool removeIds) { m_removeIds = removeIds; }
 
 private:
+    /**
+     * Check if the filter is currently matching
+     */
+    bool IsMatchingFilter() const;
+
+    /**
+     * Writing stacked objects
+     */
+    ///@{
+    void WriteStackedObjects(bool ignoreTop);
+    void WriteStackedObjectsEnd(bool ignoreTop);
+    ///@}
+
+    /**
+     * Write the document
+     */
     bool WriteDoc(Doc *doc);
 
     /**
@@ -458,10 +490,21 @@ private:
     int m_page;
     bool m_scoreBasedMEI;
     pugi::xml_node m_mei;
-    /** @name Current element */
+
+    /** Current xml element */
     pugi::xml_node m_currentNode;
+    /** Xml node stack */
     std::list<pugi::xml_node> m_nodeStack;
+    /** Boundary objects which are merged into one xml element */
     std::stack<Object *> m_boundaries;
+    /** The object stack */
+    std::stack<Object *> m_objectStack;
+
+    /** Filtering */
+    ///@{
+    MatchLocation m_filterMatchLocation;
+    ///@}
+
     bool m_removeIds;
     ListOfObjects m_referredObjects;
 };

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -281,6 +281,7 @@ private:
     ///@{
     void WriteCustomScoreDef();
     void AdjustStaffDef(StaffDef *staffDef, Measure *measure);
+    bool AdjustLabel(Label *label);
     ///@}
 
     /**

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -217,7 +217,7 @@ public:
     ///@}
 
     /**
-     * Filtering by measure, page or mdiv
+     * Score based filtering by measure, page or mdiv
      */
     ///@{
     bool HasFilter() const;
@@ -225,6 +225,7 @@ public:
     void SetLastPage(int page);
     void SetFirstMeasure(const std::string &uuid);
     void SetLastMeasure(const std::string &uuid);
+    void SetMdiv(const std::string &uuid);
     void ResetFilter();
     ///@}
 
@@ -253,7 +254,7 @@ private:
     void Reset();
 
     /**
-     * Filtering
+     * Score based filtering
      */
     ///@{
     bool HasValidFilter() const;
@@ -511,7 +512,7 @@ private:
     /** The object stack */
     std::stack<Object *> m_objectStack;
 
-    /** Filtering */
+    /** Score based filtering */
     ///@{
     bool m_hasFilter;
     MatchLocation m_filterMatchLocation;
@@ -521,6 +522,8 @@ private:
     std::string m_firstMeasureUuid;
     std::string m_lastMeasureUuid;
     RangeMatchLocation m_measureFilterMatchLocation;
+    std::string m_mdivUuid;
+    MatchLocation m_mdivFilterMatchLocation;
     ///@}
 
     bool m_removeIds;

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -243,7 +243,12 @@ public:
     void SetIndent(int indent) { m_indent = indent; }
 
     /**
-     * Setter for remove Ids flag for the MEI output (default is false)
+     * Setter for ignore header flag for the MEI output (default is false)
+     */
+    void SetIgnoreHeader(bool ignoreHeader) { m_ignoreHeader = ignoreHeader; }
+
+    /**
+     * Setter for remove ids flag for the MEI output (default is false)
      */
     void SetRemoveIds(bool removeIds) { m_removeIds = removeIds; }
 
@@ -535,6 +540,7 @@ private:
     MatchLocation m_mdivFilterMatchLocation;
     ///@}
 
+    bool m_ignoreHeader;
     bool m_removeIds;
     ListOfObjects m_referredObjects;
 };

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -160,7 +160,10 @@ class Verse;
 class Zone;
 
 // Helper enums
-enum class MatchLocation { Before, Now, After };
+///@{
+enum class MatchLocation { Before, Here, After };
+enum class RangeMatchLocation { BeforeStart, AtStart, BetweenStartEnd, AtEnd, AfterEnd };
+///@}
 
 //----------------------------------------------------------------------------
 // MEIOutput
@@ -220,6 +223,9 @@ public:
     bool HasFilter() const;
     void SetFirstPage(int page);
     void SetLastPage(int page);
+    void SetFirstMeasure(const std::string &uuid);
+    void SetLastMeasure(const std::string &uuid);
+    void ResetFilter();
     ///@}
 
     /**
@@ -241,6 +247,11 @@ public:
     void SetRemoveIds(bool removeIds) { m_removeIds = removeIds; }
 
 private:
+    /**
+     * Reset
+     */
+    void Reset();
+
     /**
      * Filtering
      */
@@ -503,10 +514,13 @@ private:
     /** Filtering */
     ///@{
     bool m_hasFilter;
+    MatchLocation m_filterMatchLocation;
     int m_firstPage;
     int m_currentPage;
     int m_lastPage;
-    MatchLocation m_filterMatchLocation;
+    std::string m_firstMeasureUuid;
+    std::string m_lastMeasureUuid;
+    RangeMatchLocation m_measureFilterMatchLocation;
     ///@}
 
     bool m_removeIds;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1128,7 +1128,7 @@ void MEIOutput::WriteStackedObjects()
 
 void MEIOutput::WriteStackedObjectsEnd()
 {
-    // Copy the stack into a list, possibly ignoring the top element
+    // Copy the stack into a list
     ListOfObjects objects;
     std::stack<Object *> tempStack = m_objectStack;
     while (!tempStack.empty()) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -259,7 +259,7 @@ std::string MEIOutput::GetOutput()
 
 bool MEIOutput::WriteObject(Object *object)
 {
-    if (this->IsScoreBasedMEI()) {
+    if (this->IsScoreBasedMEI() && this->HasFilter()) {
         if (!this->ProcessScoreBasedFilter(object)) {
             return true;
         }
@@ -863,8 +863,10 @@ bool MEIOutput::WriteObjectEnd(Object *object)
         }
     }
 
-    if (this->IsScoreBasedMEI() && !this->ProcessScoreBasedFilterEnd(object)) {
-        return true;
+    if (this->IsScoreBasedMEI() && this->HasFilter()) {
+        if (!this->ProcessScoreBasedFilterEnd(object)) {
+            return true;
+        }
     }
 
     return this->WriteObjectInternalEnd(object);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -210,7 +210,7 @@ bool MEIOutput::Export()
         if (!this->IsPageBasedMEI()) {
             decl = meiDoc.append_child(pugi::node_declaration);
             decl.set_name("xml-model");
-            decl.append_attribute("href") = "https://music-encoding.org/schema/dev/mei-all.rng";
+            decl.append_attribute("href") = schema.c_str();
             decl.append_attribute("type") = "application/xml";
             decl.append_attribute("schematypens") = "http://purl.oclc.org/dsdl/schematron";
         }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -284,7 +284,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
 
     // Main containers
     if (object->Is(DOC)) {
-        WriteDoc(dynamic_cast<Doc *>(object));
+        WriteDoc(vrv_cast<Doc *>(object));
         m_nodeStack.push_back(m_currentNode);
         return true;
     }
@@ -302,7 +302,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
     else if (object->Is(PAGES)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("pages");
-            WritePages(m_currentNode, dynamic_cast<Pages *>(object));
+            WritePages(m_currentNode, vrv_cast<Pages *>(object));
         }
         else {
             return true;
@@ -310,14 +310,14 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
     }
     else if (object->Is(SCORE)) {
         m_currentNode = m_currentNode.append_child("score");
-        WriteScore(m_currentNode, dynamic_cast<Score *>(object));
+        WriteScore(m_currentNode, vrv_cast<Score *>(object));
     }
 
     // Page and content
     else if (object->Is(PAGE)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("page");
-            WritePage(m_currentNode, dynamic_cast<Page *>(object));
+            WritePage(m_currentNode, vrv_cast<Page *>(object));
         }
         else {
             return true;
@@ -326,7 +326,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
     else if (object->Is(SYSTEM)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("system");
-            WriteSystem(m_currentNode, dynamic_cast<System *>(object));
+            WriteSystem(m_currentNode, vrv_cast<System *>(object));
         }
         else {
             return true;
@@ -336,11 +336,11 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
     // System boundaries
     else if (object->Is(ENDING)) {
         m_currentNode = m_currentNode.append_child("ending");
-        WriteEnding(m_currentNode, dynamic_cast<Ending *>(object));
+        WriteEnding(m_currentNode, vrv_cast<Ending *>(object));
     }
     else if (object->Is(EXPANSION)) {
         m_currentNode = m_currentNode.append_child("expansion");
-        WriteExpansion(m_currentNode, dynamic_cast<Expansion *>(object));
+        WriteExpansion(m_currentNode, vrv_cast<Expansion *>(object));
     }
     else if (object->Is(PB)) {
         if (this->IsScoreBasedMEI()) {
@@ -369,441 +369,441 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter)
     // ScoreDef related
     else if (object->Is(GRPSYM)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("grpSym");
-        WriteGrpSym(m_currentNode, dynamic_cast<GrpSym *>(object));
+        WriteGrpSym(m_currentNode, vrv_cast<GrpSym *>(object));
     }
     else if (object->Is(INSTRDEF)) {
         m_currentNode = m_currentNode.append_child("instrDef");
-        WriteInstrDef(m_currentNode, dynamic_cast<InstrDef *>(object));
+        WriteInstrDef(m_currentNode, vrv_cast<InstrDef *>(object));
     }
     else if (object->Is(LABEL)) {
         m_currentNode = m_currentNode.append_child("label");
-        WriteLabel(m_currentNode, dynamic_cast<Label *>(object));
+        WriteLabel(m_currentNode, vrv_cast<Label *>(object));
     }
     else if (object->Is(LABELABBR)) {
         m_currentNode = m_currentNode.append_child("labelAbbr");
-        WriteLabelAbbr(m_currentNode, dynamic_cast<LabelAbbr *>(object));
+        WriteLabelAbbr(m_currentNode, vrv_cast<LabelAbbr *>(object));
     }
     else if (object->Is(METERSIGGRP)) {
         m_currentNode = m_currentNode.append_child("meterSigGrp");
-        WriteMeterSigGrp(m_currentNode, dynamic_cast<MeterSigGrp *>(object));
+        WriteMeterSigGrp(m_currentNode, vrv_cast<MeterSigGrp *>(object));
     }
     else if (object->Is(SCOREDEF)) {
         m_currentNode = m_currentNode.append_child("scoreDef");
-        WriteScoreDef(m_currentNode, dynamic_cast<ScoreDef *>(object));
+        WriteScoreDef(m_currentNode, vrv_cast<ScoreDef *>(object));
     }
     else if (object->Is(PGFOOT)) {
         m_currentNode = m_currentNode.append_child("pgFoot");
-        WritePgFoot(m_currentNode, dynamic_cast<PgFoot *>(object));
+        WritePgFoot(m_currentNode, vrv_cast<PgFoot *>(object));
     }
     else if (object->Is(PGFOOT2)) {
         m_currentNode = m_currentNode.append_child("pgFoot2");
-        WritePgFoot2(m_currentNode, dynamic_cast<PgFoot2 *>(object));
+        WritePgFoot2(m_currentNode, vrv_cast<PgFoot2 *>(object));
     }
     else if (object->Is(PGHEAD)) {
         m_currentNode = m_currentNode.append_child("pgHead");
-        WritePgHead(m_currentNode, dynamic_cast<PgHead *>(object));
+        WritePgHead(m_currentNode, vrv_cast<PgHead *>(object));
     }
     else if (object->Is(PGHEAD2)) {
         m_currentNode = m_currentNode.append_child("pgHead2");
-        WritePgHead2(m_currentNode, dynamic_cast<PgHead2 *>(object));
+        WritePgHead2(m_currentNode, vrv_cast<PgHead2 *>(object));
     }
     else if (object->Is(STAFFGRP)) {
         m_currentNode = m_currentNode.append_child("staffGrp");
-        WriteStaffGrp(m_currentNode, dynamic_cast<StaffGrp *>(object));
+        WriteStaffGrp(m_currentNode, vrv_cast<StaffGrp *>(object));
     }
     else if (object->Is(STAFFDEF)) {
         m_currentNode = m_currentNode.append_child("staffDef");
-        WriteStaffDef(m_currentNode, dynamic_cast<StaffDef *>(object));
+        WriteStaffDef(m_currentNode, vrv_cast<StaffDef *>(object));
     }
     else if (object->Is(TUNING)) {
         m_currentNode = m_currentNode.append_child("tuning");
-        WriteTuning(m_currentNode, dynamic_cast<Tuning *>(object));
+        WriteTuning(m_currentNode, vrv_cast<Tuning *>(object));
     }
     else if (object->Is(COURSE)) {
         m_currentNode = m_currentNode.append_child("course");
-        WriteCourse(m_currentNode, dynamic_cast<Course *>(object));
+        WriteCourse(m_currentNode, vrv_cast<Course *>(object));
     }
     else if (object->Is(MEASURE)) {
         m_currentNode = m_currentNode.append_child("measure");
-        WriteMeasure(m_currentNode, dynamic_cast<Measure *>(object));
+        WriteMeasure(m_currentNode, vrv_cast<Measure *>(object));
     }
     else if (object->Is(STAFF)) {
         m_currentNode = m_currentNode.append_child("staff");
-        WriteStaff(m_currentNode, dynamic_cast<Staff *>(object));
+        WriteStaff(m_currentNode, vrv_cast<Staff *>(object));
     }
     else if (object->Is(LAYER)) {
         m_currentNode = m_currentNode.append_child("layer");
-        WriteLayer(m_currentNode, dynamic_cast<Layer *>(object));
+        WriteLayer(m_currentNode, vrv_cast<Layer *>(object));
     }
 
     // Measure elements
     else if (object->Is(ANCHOREDTEXT)) {
         m_currentNode = m_currentNode.append_child("anchoredText");
-        WriteAnchoredText(m_currentNode, dynamic_cast<AnchoredText *>(object));
+        WriteAnchoredText(m_currentNode, vrv_cast<AnchoredText *>(object));
     }
     else if (object->Is(ARPEG)) {
         m_currentNode = m_currentNode.append_child("arpeg");
-        WriteArpeg(m_currentNode, dynamic_cast<Arpeg *>(object));
+        WriteArpeg(m_currentNode, vrv_cast<Arpeg *>(object));
     }
     else if (object->Is(BRACKETSPAN)) {
         m_currentNode = m_currentNode.append_child("bracketSpan");
-        WriteBracketSpan(m_currentNode, dynamic_cast<BracketSpan *>(object));
+        WriteBracketSpan(m_currentNode, vrv_cast<BracketSpan *>(object));
     }
     else if (object->Is(BREATH)) {
         m_currentNode = m_currentNode.append_child("breath");
-        WriteBreath(m_currentNode, dynamic_cast<Breath *>(object));
+        WriteBreath(m_currentNode, vrv_cast<Breath *>(object));
     }
     else if (object->Is(CAESURA)) {
         m_currentNode = m_currentNode.append_child("caesura");
-        WriteCaesura(m_currentNode, dynamic_cast<Caesura *>(object));
+        WriteCaesura(m_currentNode, vrv_cast<Caesura *>(object));
     }
     else if (object->Is(DIR)) {
         m_currentNode = m_currentNode.append_child("dir");
-        WriteDir(m_currentNode, dynamic_cast<Dir *>(object));
+        WriteDir(m_currentNode, vrv_cast<Dir *>(object));
     }
     else if (object->Is(DYNAM)) {
         m_currentNode = m_currentNode.append_child("dynam");
-        WriteDynam(m_currentNode, dynamic_cast<Dynam *>(object));
+        WriteDynam(m_currentNode, vrv_cast<Dynam *>(object));
     }
     else if (object->Is(FERMATA)) {
         if (!object->IsAttribute()) {
             m_currentNode = m_currentNode.append_child("fermata");
-            WriteFermata(m_currentNode, dynamic_cast<Fermata *>(object));
+            WriteFermata(m_currentNode, vrv_cast<Fermata *>(object));
         }
     }
     else if (object->Is(FING)) {
         m_currentNode = m_currentNode.append_child("fing");
-        WriteFing(m_currentNode, dynamic_cast<Fing *>(object));
+        WriteFing(m_currentNode, vrv_cast<Fing *>(object));
     }
     else if (object->Is(HAIRPIN)) {
         m_currentNode = m_currentNode.append_child("hairpin");
-        WriteHairpin(m_currentNode, dynamic_cast<Hairpin *>(object));
+        WriteHairpin(m_currentNode, vrv_cast<Hairpin *>(object));
     }
     else if (object->Is(HARM)) {
         m_currentNode = m_currentNode.append_child("harm");
-        WriteHarm(m_currentNode, dynamic_cast<Harm *>(object));
+        WriteHarm(m_currentNode, vrv_cast<Harm *>(object));
     }
     else if (object->Is(LV)) {
         m_currentNode = m_currentNode.append_child("lv");
-        WriteLv(m_currentNode, dynamic_cast<Lv *>(object));
+        WriteLv(m_currentNode, vrv_cast<Lv *>(object));
     }
     else if (object->Is(MNUM)) {
         m_currentNode = m_currentNode.append_child("mNum");
-        WriteMNum(m_currentNode, dynamic_cast<MNum *>(object));
+        WriteMNum(m_currentNode, vrv_cast<MNum *>(object));
     }
     else if (object->Is(MORDENT)) {
         m_currentNode = m_currentNode.append_child("mordent");
-        WriteMordent(m_currentNode, dynamic_cast<Mordent *>(object));
+        WriteMordent(m_currentNode, vrv_cast<Mordent *>(object));
     }
     else if (object->Is(OCTAVE)) {
         m_currentNode = m_currentNode.append_child("octave");
-        WriteOctave(m_currentNode, dynamic_cast<Octave *>(object));
+        WriteOctave(m_currentNode, vrv_cast<Octave *>(object));
     }
     else if (object->Is(PEDAL)) {
         m_currentNode = m_currentNode.append_child("pedal");
-        WritePedal(m_currentNode, dynamic_cast<Pedal *>(object));
+        WritePedal(m_currentNode, vrv_cast<Pedal *>(object));
     }
     else if (object->Is(PHRASE)) {
         m_currentNode = m_currentNode.append_child("phrase");
-        WritePhrase(m_currentNode, dynamic_cast<Phrase *>(object));
+        WritePhrase(m_currentNode, vrv_cast<Phrase *>(object));
     }
 
     else if (object->Is(PITCHINFLECTION)) {
         m_currentNode = m_currentNode.append_child("pitchInfection");
-        WritePitchInflection(m_currentNode, dynamic_cast<PitchInflection *>(object));
+        WritePitchInflection(m_currentNode, vrv_cast<PitchInflection *>(object));
     }
     else if (object->Is(REH)) {
         m_currentNode = m_currentNode.append_child("reh");
-        WriteReh(m_currentNode, dynamic_cast<Reh *>(object));
+        WriteReh(m_currentNode, vrv_cast<Reh *>(object));
     }
     else if (object->Is(SLUR)) {
         m_currentNode = m_currentNode.append_child("slur");
-        WriteSlur(m_currentNode, dynamic_cast<Slur *>(object));
+        WriteSlur(m_currentNode, vrv_cast<Slur *>(object));
     }
     else if (object->Is(TEMPO)) {
         m_currentNode = m_currentNode.append_child("tempo");
-        WriteTempo(m_currentNode, dynamic_cast<Tempo *>(object));
+        WriteTempo(m_currentNode, vrv_cast<Tempo *>(object));
     }
     else if (object->Is(TIE)) {
         if (!object->IsAttribute()) {
             m_currentNode = m_currentNode.append_child("tie");
-            WriteTie(m_currentNode, dynamic_cast<Tie *>(object));
+            WriteTie(m_currentNode, vrv_cast<Tie *>(object));
         }
     }
     else if (object->Is(TRILL)) {
         m_currentNode = m_currentNode.append_child("trill");
-        WriteTrill(m_currentNode, dynamic_cast<Trill *>(object));
+        WriteTrill(m_currentNode, vrv_cast<Trill *>(object));
     }
     else if (object->Is(TURN)) {
         m_currentNode = m_currentNode.append_child("turn");
-        WriteTurn(m_currentNode, dynamic_cast<Turn *>(object));
+        WriteTurn(m_currentNode, vrv_cast<Turn *>(object));
     }
 
     // Layer elements
     else if (object->Is(ACCID)) {
         // Do not add a node for object representing an attribute
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("accid");
-        WriteAccid(m_currentNode, dynamic_cast<Accid *>(object));
+        WriteAccid(m_currentNode, vrv_cast<Accid *>(object));
     }
     else if (object->Is(ARTIC)) {
         // Do not add a node for object representing an attribute
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("artic");
-        WriteArtic(m_currentNode, dynamic_cast<Artic *>(object));
+        WriteArtic(m_currentNode, vrv_cast<Artic *>(object));
     }
     else if (object->Is(BARLINE)) {
         m_currentNode = m_currentNode.append_child("barLine");
-        WriteBarLine(m_currentNode, dynamic_cast<BarLine *>(object));
+        WriteBarLine(m_currentNode, vrv_cast<BarLine *>(object));
     }
     else if (object->Is(BEAM)) {
         m_currentNode = m_currentNode.append_child("beam");
-        WriteBeam(m_currentNode, dynamic_cast<Beam *>(object));
+        WriteBeam(m_currentNode, vrv_cast<Beam *>(object));
     }
     else if (object->Is(BEATRPT)) {
         m_currentNode = m_currentNode.append_child("beatRpt");
-        WriteBeatRpt(m_currentNode, dynamic_cast<BeatRpt *>(object));
+        WriteBeatRpt(m_currentNode, vrv_cast<BeatRpt *>(object));
     }
     else if (object->Is(BTREM)) {
         m_currentNode = m_currentNode.append_child("bTrem");
-        WriteBTrem(m_currentNode, dynamic_cast<BTrem *>(object));
+        WriteBTrem(m_currentNode, vrv_cast<BTrem *>(object));
     }
     else if (object->Is(CHORD)) {
         m_currentNode = m_currentNode.append_child("chord");
-        WriteChord(m_currentNode, dynamic_cast<Chord *>(object));
+        WriteChord(m_currentNode, vrv_cast<Chord *>(object));
     }
     else if (object->Is(CLEF)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("clef");
-        WriteClef(m_currentNode, dynamic_cast<Clef *>(object));
+        WriteClef(m_currentNode, vrv_cast<Clef *>(object));
     }
     else if (object->Is(CUSTOS)) {
         m_currentNode = m_currentNode.append_child("custos");
-        WriteCustos(m_currentNode, dynamic_cast<Custos *>(object));
+        WriteCustos(m_currentNode, vrv_cast<Custos *>(object));
     }
     else if (object->Is(DOT)) {
         m_currentNode = m_currentNode.append_child("dot");
-        WriteDot(m_currentNode, dynamic_cast<Dot *>(object));
+        WriteDot(m_currentNode, vrv_cast<Dot *>(object));
     }
     else if (object->Is(FTREM)) {
         m_currentNode = m_currentNode.append_child("fTrem");
-        WriteFTrem(m_currentNode, dynamic_cast<FTrem *>(object));
+        WriteFTrem(m_currentNode, vrv_cast<FTrem *>(object));
     }
     else if (object->Is(GLISS)) {
         m_currentNode = m_currentNode.append_child("gliss");
-        WriteGliss(m_currentNode, dynamic_cast<Gliss *>(object));
+        WriteGliss(m_currentNode, vrv_cast<Gliss *>(object));
     }
     else if (object->Is(GRACEGRP)) {
         m_currentNode = m_currentNode.append_child("graceGrp");
-        WriteGraceGrp(m_currentNode, dynamic_cast<GraceGrp *>(object));
+        WriteGraceGrp(m_currentNode, vrv_cast<GraceGrp *>(object));
     }
     else if (object->Is(HALFMRPT)) {
         m_currentNode = m_currentNode.append_child("halfmRpt");
-        WriteHalfmRpt(m_currentNode, dynamic_cast<HalfmRpt *>(object));
+        WriteHalfmRpt(m_currentNode, vrv_cast<HalfmRpt *>(object));
     }
     else if (object->Is(KEYACCID)) {
         m_currentNode = m_currentNode.append_child("keyAccid");
-        WriteKeyAccid(m_currentNode, dynamic_cast<KeyAccid *>(object));
+        WriteKeyAccid(m_currentNode, vrv_cast<KeyAccid *>(object));
     }
     else if (object->Is(KEYSIG)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("keySig");
-        WriteKeySig(m_currentNode, dynamic_cast<KeySig *>(object));
+        WriteKeySig(m_currentNode, vrv_cast<KeySig *>(object));
     }
     else if (object->Is(LIGATURE)) {
         m_currentNode = m_currentNode.append_child("ligature");
-        WriteLigature(m_currentNode, dynamic_cast<Ligature *>(object));
+        WriteLigature(m_currentNode, vrv_cast<Ligature *>(object));
     }
     else if (object->Is(MENSUR)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("mensur");
-        WriteMensur(m_currentNode, dynamic_cast<Mensur *>(object));
+        WriteMensur(m_currentNode, vrv_cast<Mensur *>(object));
     }
     else if (object->Is(METERSIG)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("meterSig");
-        WriteMeterSig(m_currentNode, dynamic_cast<MeterSig *>(object));
+        WriteMeterSig(m_currentNode, vrv_cast<MeterSig *>(object));
     }
     else if (object->Is(MREST)) {
         m_currentNode = m_currentNode.append_child("mRest");
-        WriteMRest(m_currentNode, dynamic_cast<MRest *>(object));
+        WriteMRest(m_currentNode, vrv_cast<MRest *>(object));
     }
     else if (object->Is(MRPT)) {
         m_currentNode = m_currentNode.append_child("mRpt");
-        WriteMRpt(m_currentNode, dynamic_cast<MRpt *>(object));
+        WriteMRpt(m_currentNode, vrv_cast<MRpt *>(object));
     }
     else if (object->Is(MRPT2)) {
         m_currentNode = m_currentNode.append_child("mRpt2");
-        WriteMRpt2(m_currentNode, dynamic_cast<MRpt2 *>(object));
+        WriteMRpt2(m_currentNode, vrv_cast<MRpt2 *>(object));
     }
     else if (object->Is(MSPACE)) {
         m_currentNode = m_currentNode.append_child("mSpace");
-        WriteMSpace(m_currentNode, dynamic_cast<MSpace *>(object));
+        WriteMSpace(m_currentNode, vrv_cast<MSpace *>(object));
     }
     else if (object->Is(MULTIREST)) {
         m_currentNode = m_currentNode.append_child("multiRest");
-        WriteMultiRest(m_currentNode, dynamic_cast<MultiRest *>(object));
+        WriteMultiRest(m_currentNode, vrv_cast<MultiRest *>(object));
     }
     else if (object->Is(MULTIRPT)) {
         m_currentNode = m_currentNode.append_child("multiRpt");
-        WriteMultiRpt(m_currentNode, dynamic_cast<MultiRpt *>(object));
+        WriteMultiRpt(m_currentNode, vrv_cast<MultiRpt *>(object));
     }
     else if (object->Is(NC)) {
         m_currentNode = m_currentNode.append_child("nc");
-        WriteNc(m_currentNode, dynamic_cast<Nc *>(object));
+        WriteNc(m_currentNode, vrv_cast<Nc *>(object));
     }
     else if (object->Is(NEUME)) {
         m_currentNode = m_currentNode.append_child("neume");
-        WriteNeume(m_currentNode, dynamic_cast<Neume *>(object));
+        WriteNeume(m_currentNode, vrv_cast<Neume *>(object));
     }
     else if (object->Is(NOTE)) {
         m_currentNode = m_currentNode.append_child("note");
-        WriteNote(m_currentNode, dynamic_cast<Note *>(object));
+        WriteNote(m_currentNode, vrv_cast<Note *>(object));
     }
     else if (object->Is(PLICA)) {
         m_currentNode = m_currentNode.append_child("plica");
-        WritePlica(m_currentNode, dynamic_cast<Plica *>(object));
+        WritePlica(m_currentNode, vrv_cast<Plica *>(object));
     }
     else if (object->Is(PROPORT)) {
         m_currentNode = m_currentNode.append_child("proport");
-        WriteProport(m_currentNode, dynamic_cast<Proport *>(object));
+        WriteProport(m_currentNode, vrv_cast<Proport *>(object));
     }
     else if (object->Is(REST)) {
         m_currentNode = m_currentNode.append_child("rest");
-        WriteRest(m_currentNode, dynamic_cast<Rest *>(object));
+        WriteRest(m_currentNode, vrv_cast<Rest *>(object));
     }
     else if (object->Is(SPACE)) {
         m_currentNode = m_currentNode.append_child("space");
-        WriteSpace(m_currentNode, dynamic_cast<Space *>(object));
+        WriteSpace(m_currentNode, vrv_cast<Space *>(object));
     }
     else if (object->Is(SYL)) {
         m_currentNode = m_currentNode.append_child("syl");
-        WriteSyl(m_currentNode, dynamic_cast<Syl *>(object));
+        WriteSyl(m_currentNode, vrv_cast<Syl *>(object));
     }
     else if (object->Is(SYLLABLE)) {
         m_currentNode = m_currentNode.append_child("syllable");
-        WriteSyllable(m_currentNode, dynamic_cast<Syllable *>(object));
+        WriteSyllable(m_currentNode, vrv_cast<Syllable *>(object));
     }
     else if (object->Is(TABDURSYM)) {
         m_currentNode = m_currentNode.append_child("tabDurSym");
-        WriteTabDurSym(m_currentNode, dynamic_cast<TabDurSym *>(object));
+        WriteTabDurSym(m_currentNode, vrv_cast<TabDurSym *>(object));
     }
     else if (object->Is(TABGRP)) {
         m_currentNode = m_currentNode.append_child("tabGrp");
-        WriteTabGrp(m_currentNode, dynamic_cast<TabGrp *>(object));
+        WriteTabGrp(m_currentNode, vrv_cast<TabGrp *>(object));
     }
     else if (object->Is(TUPLET)) {
         m_currentNode = m_currentNode.append_child("tuplet");
-        WriteTuplet(m_currentNode, dynamic_cast<Tuplet *>(object));
+        WriteTuplet(m_currentNode, vrv_cast<Tuplet *>(object));
     }
     else if (object->Is(VERSE)) {
         m_currentNode = m_currentNode.append_child("verse");
-        WriteVerse(m_currentNode, dynamic_cast<Verse *>(object));
+        WriteVerse(m_currentNode, vrv_cast<Verse *>(object));
     }
 
     // Text elements
     else if (object->Is(FIG)) {
         m_currentNode = m_currentNode.append_child("fig");
-        WriteFig(m_currentNode, dynamic_cast<Fig *>(object));
+        WriteFig(m_currentNode, vrv_cast<Fig *>(object));
     }
     else if (object->Is(FIGURE)) {
         m_currentNode = m_currentNode.append_child("f");
-        WriteF(m_currentNode, dynamic_cast<F *>(object));
+        WriteF(m_currentNode, vrv_cast<F *>(object));
     }
     else if (object->Is(FB)) {
         m_currentNode = m_currentNode.append_child("fb");
-        WriteFb(m_currentNode, dynamic_cast<Fb *>(object));
+        WriteFb(m_currentNode, vrv_cast<Fb *>(object));
     }
     else if (object->Is(LB)) {
         m_currentNode = m_currentNode.append_child("lb");
-        WriteLb(m_currentNode, dynamic_cast<Lb *>(object));
+        WriteLb(m_currentNode, vrv_cast<Lb *>(object));
     }
     else if (object->Is(NUM)) {
         m_currentNode = m_currentNode.append_child("num");
-        WriteNum(m_currentNode, dynamic_cast<Num *>(object));
+        WriteNum(m_currentNode, vrv_cast<Num *>(object));
     }
     else if (object->Is(REND)) {
         m_currentNode = m_currentNode.append_child("rend");
-        WriteRend(m_currentNode, dynamic_cast<Rend *>(object));
+        WriteRend(m_currentNode, vrv_cast<Rend *>(object));
     }
     else if (object->Is(SVG)) {
         m_currentNode = m_currentNode.append_child("svg");
-        WriteSvg(m_currentNode, dynamic_cast<Svg *>(object));
+        WriteSvg(m_currentNode, vrv_cast<Svg *>(object));
     }
     else if (object->Is(TEXT)) {
-        WriteText(m_currentNode, dynamic_cast<Text *>(object));
+        WriteText(m_currentNode, vrv_cast<Text *>(object));
     }
 
     // Editorial markup
     else if (object->Is(ABBR)) {
         m_currentNode = m_currentNode.append_child("abbr");
-        WriteAbbr(m_currentNode, dynamic_cast<Abbr *>(object));
+        WriteAbbr(m_currentNode, vrv_cast<Abbr *>(object));
     }
     else if (object->Is(ADD)) {
         m_currentNode = m_currentNode.append_child("add");
-        WriteAdd(m_currentNode, dynamic_cast<Add *>(object));
+        WriteAdd(m_currentNode, vrv_cast<Add *>(object));
     }
     else if (object->Is(ANNOT)) {
         m_currentNode = m_currentNode.append_child("annot");
-        WriteAnnot(m_currentNode, dynamic_cast<Annot *>(object));
+        WriteAnnot(m_currentNode, vrv_cast<Annot *>(object));
     }
     else if (object->Is(APP)) {
         m_currentNode = m_currentNode.append_child("app");
-        WriteApp(m_currentNode, dynamic_cast<App *>(object));
+        WriteApp(m_currentNode, vrv_cast<App *>(object));
     }
     else if (object->Is(CHOICE)) {
         m_currentNode = m_currentNode.append_child("choice");
-        WriteChoice(m_currentNode, dynamic_cast<Choice *>(object));
+        WriteChoice(m_currentNode, vrv_cast<Choice *>(object));
     }
     else if (object->Is(CORR)) {
         m_currentNode = m_currentNode.append_child("corr");
-        WriteCorr(m_currentNode, dynamic_cast<Corr *>(object));
+        WriteCorr(m_currentNode, vrv_cast<Corr *>(object));
     }
     else if (object->Is(DAMAGE)) {
         m_currentNode = m_currentNode.append_child("damage");
-        WriteDamage(m_currentNode, dynamic_cast<Damage *>(object));
+        WriteDamage(m_currentNode, vrv_cast<Damage *>(object));
     }
     else if (object->Is(DEL)) {
         m_currentNode = m_currentNode.append_child("del");
-        WriteDel(m_currentNode, dynamic_cast<Del *>(object));
+        WriteDel(m_currentNode, vrv_cast<Del *>(object));
     }
     else if (object->Is(EXPAN)) {
         m_currentNode = m_currentNode.append_child("epxan");
-        WriteExpan(m_currentNode, dynamic_cast<Expan *>(object));
+        WriteExpan(m_currentNode, vrv_cast<Expan *>(object));
     }
     else if (object->Is(LEM)) {
         m_currentNode = m_currentNode.append_child("lem");
-        WriteLem(m_currentNode, dynamic_cast<Lem *>(object));
+        WriteLem(m_currentNode, vrv_cast<Lem *>(object));
     }
     else if (object->Is(ORIG)) {
         m_currentNode = m_currentNode.append_child("orig");
-        WriteOrig(m_currentNode, dynamic_cast<Orig *>(object));
+        WriteOrig(m_currentNode, vrv_cast<Orig *>(object));
     }
     else if (object->Is(RDG)) {
         m_currentNode = m_currentNode.append_child("rdg");
-        WriteRdg(m_currentNode, dynamic_cast<Rdg *>(object));
+        WriteRdg(m_currentNode, vrv_cast<Rdg *>(object));
     }
     else if (object->Is(REF)) {
         m_currentNode = m_currentNode.append_child("ref");
-        WriteRef(m_currentNode, dynamic_cast<Ref *>(object));
+        WriteRef(m_currentNode, vrv_cast<Ref *>(object));
     }
     else if (object->Is(REG)) {
         m_currentNode = m_currentNode.append_child("reg");
-        WriteReg(m_currentNode, dynamic_cast<Reg *>(object));
+        WriteReg(m_currentNode, vrv_cast<Reg *>(object));
     }
     else if (object->Is(RESTORE)) {
         m_currentNode = m_currentNode.append_child("restore");
-        WriteRestore(m_currentNode, dynamic_cast<Restore *>(object));
+        WriteRestore(m_currentNode, vrv_cast<Restore *>(object));
     }
     else if (object->Is(SIC)) {
         m_currentNode = m_currentNode.append_child("sic");
-        WriteSic(m_currentNode, dynamic_cast<Sic *>(object));
+        WriteSic(m_currentNode, vrv_cast<Sic *>(object));
     }
     else if (object->Is(SUBST)) {
         m_currentNode = m_currentNode.append_child("subst");
-        WriteSubst(m_currentNode, dynamic_cast<Subst *>(object));
+        WriteSubst(m_currentNode, vrv_cast<Subst *>(object));
     }
     else if (object->Is(SUPPLIED)) {
         m_currentNode = m_currentNode.append_child("supplied");
-        WriteSupplied(m_currentNode, dynamic_cast<Supplied *>(object));
+        WriteSupplied(m_currentNode, vrv_cast<Supplied *>(object));
     }
     else if (object->Is(UNCLEAR)) {
         m_currentNode = m_currentNode.append_child("unclear");
-        WriteUnclear(m_currentNode, dynamic_cast<Unclear *>(object));
+        WriteUnclear(m_currentNode, vrv_cast<Unclear *>(object));
     }
 
     // SystemMilestoneEnd - nothing to add - only

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -299,7 +299,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
 
     // Main containers
     if (object->Is(DOC)) {
-        WriteDoc(vrv_cast<Doc *>(object));
+        this->WriteDoc(vrv_cast<Doc *>(object));
         m_nodeStack.push_back(m_currentNode);
         return true;
     }
@@ -317,7 +317,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
     else if (object->Is(PAGES)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("pages");
-            WritePages(m_currentNode, vrv_cast<Pages *>(object));
+            this->WritePages(m_currentNode, vrv_cast<Pages *>(object));
         }
         else {
             return true;
@@ -325,14 +325,14 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
     }
     else if (object->Is(SCORE)) {
         m_currentNode = m_currentNode.append_child("score");
-        WriteScore(m_currentNode, vrv_cast<Score *>(object));
+        this->WriteScore(m_currentNode, vrv_cast<Score *>(object));
     }
 
     // Page and content
     else if (object->Is(PAGE)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("page");
-            WritePage(m_currentNode, vrv_cast<Page *>(object));
+            this->WritePage(m_currentNode, vrv_cast<Page *>(object));
         }
         else {
             return true;
@@ -341,7 +341,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
     else if (object->Is(SYSTEM)) {
         if (this->IsPageBasedMEI()) {
             m_currentNode = m_currentNode.append_child("system");
-            WriteSystem(m_currentNode, vrv_cast<System *>(object));
+            this->WriteSystem(m_currentNode, vrv_cast<System *>(object));
         }
         else {
             return true;
@@ -351,11 +351,11 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
     // System boundaries
     else if (object->Is(ENDING)) {
         m_currentNode = m_currentNode.append_child("ending");
-        WriteEnding(m_currentNode, vrv_cast<Ending *>(object));
+        this->WriteEnding(m_currentNode, vrv_cast<Ending *>(object));
     }
     else if (object->Is(EXPANSION)) {
         m_currentNode = m_currentNode.append_child("expansion");
-        WriteExpansion(m_currentNode, vrv_cast<Expansion *>(object));
+        this->WriteExpansion(m_currentNode, vrv_cast<Expansion *>(object));
     }
     else if (object->Is(PB)) {
         if (this->IsScoreBasedMEI()) {
@@ -384,441 +384,441 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
     // ScoreDef related
     else if (object->Is(GRPSYM)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("grpSym");
-        WriteGrpSym(m_currentNode, vrv_cast<GrpSym *>(object));
+        this->WriteGrpSym(m_currentNode, vrv_cast<GrpSym *>(object));
     }
     else if (object->Is(INSTRDEF)) {
         m_currentNode = m_currentNode.append_child("instrDef");
-        WriteInstrDef(m_currentNode, vrv_cast<InstrDef *>(object));
+        this->WriteInstrDef(m_currentNode, vrv_cast<InstrDef *>(object));
     }
     else if (object->Is(LABEL)) {
         m_currentNode = m_currentNode.append_child("label");
-        WriteLabel(m_currentNode, vrv_cast<Label *>(object));
+        this->WriteLabel(m_currentNode, vrv_cast<Label *>(object));
     }
     else if (object->Is(LABELABBR)) {
         m_currentNode = m_currentNode.append_child("labelAbbr");
-        WriteLabelAbbr(m_currentNode, vrv_cast<LabelAbbr *>(object));
+        this->WriteLabelAbbr(m_currentNode, vrv_cast<LabelAbbr *>(object));
     }
     else if (object->Is(METERSIGGRP)) {
         m_currentNode = m_currentNode.append_child("meterSigGrp");
-        WriteMeterSigGrp(m_currentNode, vrv_cast<MeterSigGrp *>(object));
+        this->WriteMeterSigGrp(m_currentNode, vrv_cast<MeterSigGrp *>(object));
     }
     else if (object->Is(SCOREDEF)) {
         m_currentNode = m_currentNode.append_child("scoreDef");
-        WriteScoreDef(m_currentNode, vrv_cast<ScoreDef *>(object));
+        this->WriteScoreDef(m_currentNode, vrv_cast<ScoreDef *>(object));
     }
     else if (object->Is(PGFOOT)) {
         m_currentNode = m_currentNode.append_child("pgFoot");
-        WritePgFoot(m_currentNode, vrv_cast<PgFoot *>(object));
+        this->WritePgFoot(m_currentNode, vrv_cast<PgFoot *>(object));
     }
     else if (object->Is(PGFOOT2)) {
         m_currentNode = m_currentNode.append_child("pgFoot2");
-        WritePgFoot2(m_currentNode, vrv_cast<PgFoot2 *>(object));
+        this->WritePgFoot2(m_currentNode, vrv_cast<PgFoot2 *>(object));
     }
     else if (object->Is(PGHEAD)) {
         m_currentNode = m_currentNode.append_child("pgHead");
-        WritePgHead(m_currentNode, vrv_cast<PgHead *>(object));
+        this->WritePgHead(m_currentNode, vrv_cast<PgHead *>(object));
     }
     else if (object->Is(PGHEAD2)) {
         m_currentNode = m_currentNode.append_child("pgHead2");
-        WritePgHead2(m_currentNode, vrv_cast<PgHead2 *>(object));
+        this->WritePgHead2(m_currentNode, vrv_cast<PgHead2 *>(object));
     }
     else if (object->Is(STAFFGRP)) {
         m_currentNode = m_currentNode.append_child("staffGrp");
-        WriteStaffGrp(m_currentNode, vrv_cast<StaffGrp *>(object));
+        this->WriteStaffGrp(m_currentNode, vrv_cast<StaffGrp *>(object));
     }
     else if (object->Is(STAFFDEF)) {
         m_currentNode = m_currentNode.append_child("staffDef");
-        WriteStaffDef(m_currentNode, vrv_cast<StaffDef *>(object));
+        this->WriteStaffDef(m_currentNode, vrv_cast<StaffDef *>(object));
     }
     else if (object->Is(TUNING)) {
         m_currentNode = m_currentNode.append_child("tuning");
-        WriteTuning(m_currentNode, vrv_cast<Tuning *>(object));
+        this->WriteTuning(m_currentNode, vrv_cast<Tuning *>(object));
     }
     else if (object->Is(COURSE)) {
         m_currentNode = m_currentNode.append_child("course");
-        WriteCourse(m_currentNode, vrv_cast<Course *>(object));
+        this->WriteCourse(m_currentNode, vrv_cast<Course *>(object));
     }
     else if (object->Is(MEASURE)) {
         m_currentNode = m_currentNode.append_child("measure");
-        WriteMeasure(m_currentNode, vrv_cast<Measure *>(object));
+        this->WriteMeasure(m_currentNode, vrv_cast<Measure *>(object));
     }
     else if (object->Is(STAFF)) {
         m_currentNode = m_currentNode.append_child("staff");
-        WriteStaff(m_currentNode, vrv_cast<Staff *>(object));
+        this->WriteStaff(m_currentNode, vrv_cast<Staff *>(object));
     }
     else if (object->Is(LAYER)) {
         m_currentNode = m_currentNode.append_child("layer");
-        WriteLayer(m_currentNode, vrv_cast<Layer *>(object));
+        this->WriteLayer(m_currentNode, vrv_cast<Layer *>(object));
     }
 
     // Measure elements
     else if (object->Is(ANCHOREDTEXT)) {
         m_currentNode = m_currentNode.append_child("anchoredText");
-        WriteAnchoredText(m_currentNode, vrv_cast<AnchoredText *>(object));
+        this->WriteAnchoredText(m_currentNode, vrv_cast<AnchoredText *>(object));
     }
     else if (object->Is(ARPEG)) {
         m_currentNode = m_currentNode.append_child("arpeg");
-        WriteArpeg(m_currentNode, vrv_cast<Arpeg *>(object));
+        this->WriteArpeg(m_currentNode, vrv_cast<Arpeg *>(object));
     }
     else if (object->Is(BRACKETSPAN)) {
         m_currentNode = m_currentNode.append_child("bracketSpan");
-        WriteBracketSpan(m_currentNode, vrv_cast<BracketSpan *>(object));
+        this->WriteBracketSpan(m_currentNode, vrv_cast<BracketSpan *>(object));
     }
     else if (object->Is(BREATH)) {
         m_currentNode = m_currentNode.append_child("breath");
-        WriteBreath(m_currentNode, vrv_cast<Breath *>(object));
+        this->WriteBreath(m_currentNode, vrv_cast<Breath *>(object));
     }
     else if (object->Is(CAESURA)) {
         m_currentNode = m_currentNode.append_child("caesura");
-        WriteCaesura(m_currentNode, vrv_cast<Caesura *>(object));
+        this->WriteCaesura(m_currentNode, vrv_cast<Caesura *>(object));
     }
     else if (object->Is(DIR)) {
         m_currentNode = m_currentNode.append_child("dir");
-        WriteDir(m_currentNode, vrv_cast<Dir *>(object));
+        this->WriteDir(m_currentNode, vrv_cast<Dir *>(object));
     }
     else if (object->Is(DYNAM)) {
         m_currentNode = m_currentNode.append_child("dynam");
-        WriteDynam(m_currentNode, vrv_cast<Dynam *>(object));
+        this->WriteDynam(m_currentNode, vrv_cast<Dynam *>(object));
     }
     else if (object->Is(FERMATA)) {
         if (!object->IsAttribute()) {
             m_currentNode = m_currentNode.append_child("fermata");
-            WriteFermata(m_currentNode, vrv_cast<Fermata *>(object));
+            this->WriteFermata(m_currentNode, vrv_cast<Fermata *>(object));
         }
     }
     else if (object->Is(FING)) {
         m_currentNode = m_currentNode.append_child("fing");
-        WriteFing(m_currentNode, vrv_cast<Fing *>(object));
+        this->WriteFing(m_currentNode, vrv_cast<Fing *>(object));
     }
     else if (object->Is(HAIRPIN)) {
         m_currentNode = m_currentNode.append_child("hairpin");
-        WriteHairpin(m_currentNode, vrv_cast<Hairpin *>(object));
+        this->WriteHairpin(m_currentNode, vrv_cast<Hairpin *>(object));
     }
     else if (object->Is(HARM)) {
         m_currentNode = m_currentNode.append_child("harm");
-        WriteHarm(m_currentNode, vrv_cast<Harm *>(object));
+        this->WriteHarm(m_currentNode, vrv_cast<Harm *>(object));
     }
     else if (object->Is(LV)) {
         m_currentNode = m_currentNode.append_child("lv");
-        WriteLv(m_currentNode, vrv_cast<Lv *>(object));
+        this->WriteLv(m_currentNode, vrv_cast<Lv *>(object));
     }
     else if (object->Is(MNUM)) {
         m_currentNode = m_currentNode.append_child("mNum");
-        WriteMNum(m_currentNode, vrv_cast<MNum *>(object));
+        this->WriteMNum(m_currentNode, vrv_cast<MNum *>(object));
     }
     else if (object->Is(MORDENT)) {
         m_currentNode = m_currentNode.append_child("mordent");
-        WriteMordent(m_currentNode, vrv_cast<Mordent *>(object));
+        this->WriteMordent(m_currentNode, vrv_cast<Mordent *>(object));
     }
     else if (object->Is(OCTAVE)) {
         m_currentNode = m_currentNode.append_child("octave");
-        WriteOctave(m_currentNode, vrv_cast<Octave *>(object));
+        this->WriteOctave(m_currentNode, vrv_cast<Octave *>(object));
     }
     else if (object->Is(PEDAL)) {
         m_currentNode = m_currentNode.append_child("pedal");
-        WritePedal(m_currentNode, vrv_cast<Pedal *>(object));
+        this->WritePedal(m_currentNode, vrv_cast<Pedal *>(object));
     }
     else if (object->Is(PHRASE)) {
         m_currentNode = m_currentNode.append_child("phrase");
-        WritePhrase(m_currentNode, vrv_cast<Phrase *>(object));
+        this->WritePhrase(m_currentNode, vrv_cast<Phrase *>(object));
     }
 
     else if (object->Is(PITCHINFLECTION)) {
         m_currentNode = m_currentNode.append_child("pitchInfection");
-        WritePitchInflection(m_currentNode, vrv_cast<PitchInflection *>(object));
+        this->WritePitchInflection(m_currentNode, vrv_cast<PitchInflection *>(object));
     }
     else if (object->Is(REH)) {
         m_currentNode = m_currentNode.append_child("reh");
-        WriteReh(m_currentNode, vrv_cast<Reh *>(object));
+        this->WriteReh(m_currentNode, vrv_cast<Reh *>(object));
     }
     else if (object->Is(SLUR)) {
         m_currentNode = m_currentNode.append_child("slur");
-        WriteSlur(m_currentNode, vrv_cast<Slur *>(object));
+        this->WriteSlur(m_currentNode, vrv_cast<Slur *>(object));
     }
     else if (object->Is(TEMPO)) {
         m_currentNode = m_currentNode.append_child("tempo");
-        WriteTempo(m_currentNode, vrv_cast<Tempo *>(object));
+        this->WriteTempo(m_currentNode, vrv_cast<Tempo *>(object));
     }
     else if (object->Is(TIE)) {
         if (!object->IsAttribute()) {
             m_currentNode = m_currentNode.append_child("tie");
-            WriteTie(m_currentNode, vrv_cast<Tie *>(object));
+            this->WriteTie(m_currentNode, vrv_cast<Tie *>(object));
         }
     }
     else if (object->Is(TRILL)) {
         m_currentNode = m_currentNode.append_child("trill");
-        WriteTrill(m_currentNode, vrv_cast<Trill *>(object));
+        this->WriteTrill(m_currentNode, vrv_cast<Trill *>(object));
     }
     else if (object->Is(TURN)) {
         m_currentNode = m_currentNode.append_child("turn");
-        WriteTurn(m_currentNode, vrv_cast<Turn *>(object));
+        this->WriteTurn(m_currentNode, vrv_cast<Turn *>(object));
     }
 
     // Layer elements
     else if (object->Is(ACCID)) {
         // Do not add a node for object representing an attribute
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("accid");
-        WriteAccid(m_currentNode, vrv_cast<Accid *>(object));
+        this->WriteAccid(m_currentNode, vrv_cast<Accid *>(object));
     }
     else if (object->Is(ARTIC)) {
         // Do not add a node for object representing an attribute
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("artic");
-        WriteArtic(m_currentNode, vrv_cast<Artic *>(object));
+        this->WriteArtic(m_currentNode, vrv_cast<Artic *>(object));
     }
     else if (object->Is(BARLINE)) {
         m_currentNode = m_currentNode.append_child("barLine");
-        WriteBarLine(m_currentNode, vrv_cast<BarLine *>(object));
+        this->WriteBarLine(m_currentNode, vrv_cast<BarLine *>(object));
     }
     else if (object->Is(BEAM)) {
         m_currentNode = m_currentNode.append_child("beam");
-        WriteBeam(m_currentNode, vrv_cast<Beam *>(object));
+        this->WriteBeam(m_currentNode, vrv_cast<Beam *>(object));
     }
     else if (object->Is(BEATRPT)) {
         m_currentNode = m_currentNode.append_child("beatRpt");
-        WriteBeatRpt(m_currentNode, vrv_cast<BeatRpt *>(object));
+        this->WriteBeatRpt(m_currentNode, vrv_cast<BeatRpt *>(object));
     }
     else if (object->Is(BTREM)) {
         m_currentNode = m_currentNode.append_child("bTrem");
-        WriteBTrem(m_currentNode, vrv_cast<BTrem *>(object));
+        this->WriteBTrem(m_currentNode, vrv_cast<BTrem *>(object));
     }
     else if (object->Is(CHORD)) {
         m_currentNode = m_currentNode.append_child("chord");
-        WriteChord(m_currentNode, vrv_cast<Chord *>(object));
+        this->WriteChord(m_currentNode, vrv_cast<Chord *>(object));
     }
     else if (object->Is(CLEF)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("clef");
-        WriteClef(m_currentNode, vrv_cast<Clef *>(object));
+        this->WriteClef(m_currentNode, vrv_cast<Clef *>(object));
     }
     else if (object->Is(CUSTOS)) {
         m_currentNode = m_currentNode.append_child("custos");
-        WriteCustos(m_currentNode, vrv_cast<Custos *>(object));
+        this->WriteCustos(m_currentNode, vrv_cast<Custos *>(object));
     }
     else if (object->Is(DOT)) {
         m_currentNode = m_currentNode.append_child("dot");
-        WriteDot(m_currentNode, vrv_cast<Dot *>(object));
+        this->WriteDot(m_currentNode, vrv_cast<Dot *>(object));
     }
     else if (object->Is(FTREM)) {
         m_currentNode = m_currentNode.append_child("fTrem");
-        WriteFTrem(m_currentNode, vrv_cast<FTrem *>(object));
+        this->WriteFTrem(m_currentNode, vrv_cast<FTrem *>(object));
     }
     else if (object->Is(GLISS)) {
         m_currentNode = m_currentNode.append_child("gliss");
-        WriteGliss(m_currentNode, vrv_cast<Gliss *>(object));
+        this->WriteGliss(m_currentNode, vrv_cast<Gliss *>(object));
     }
     else if (object->Is(GRACEGRP)) {
         m_currentNode = m_currentNode.append_child("graceGrp");
-        WriteGraceGrp(m_currentNode, vrv_cast<GraceGrp *>(object));
+        this->WriteGraceGrp(m_currentNode, vrv_cast<GraceGrp *>(object));
     }
     else if (object->Is(HALFMRPT)) {
         m_currentNode = m_currentNode.append_child("halfmRpt");
-        WriteHalfmRpt(m_currentNode, vrv_cast<HalfmRpt *>(object));
+        this->WriteHalfmRpt(m_currentNode, vrv_cast<HalfmRpt *>(object));
     }
     else if (object->Is(KEYACCID)) {
         m_currentNode = m_currentNode.append_child("keyAccid");
-        WriteKeyAccid(m_currentNode, vrv_cast<KeyAccid *>(object));
+        this->WriteKeyAccid(m_currentNode, vrv_cast<KeyAccid *>(object));
     }
     else if (object->Is(KEYSIG)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("keySig");
-        WriteKeySig(m_currentNode, vrv_cast<KeySig *>(object));
+        this->WriteKeySig(m_currentNode, vrv_cast<KeySig *>(object));
     }
     else if (object->Is(LIGATURE)) {
         m_currentNode = m_currentNode.append_child("ligature");
-        WriteLigature(m_currentNode, vrv_cast<Ligature *>(object));
+        this->WriteLigature(m_currentNode, vrv_cast<Ligature *>(object));
     }
     else if (object->Is(MENSUR)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("mensur");
-        WriteMensur(m_currentNode, vrv_cast<Mensur *>(object));
+        this->WriteMensur(m_currentNode, vrv_cast<Mensur *>(object));
     }
     else if (object->Is(METERSIG)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("meterSig");
-        WriteMeterSig(m_currentNode, vrv_cast<MeterSig *>(object));
+        this->WriteMeterSig(m_currentNode, vrv_cast<MeterSig *>(object));
     }
     else if (object->Is(MREST)) {
         m_currentNode = m_currentNode.append_child("mRest");
-        WriteMRest(m_currentNode, vrv_cast<MRest *>(object));
+        this->WriteMRest(m_currentNode, vrv_cast<MRest *>(object));
     }
     else if (object->Is(MRPT)) {
         m_currentNode = m_currentNode.append_child("mRpt");
-        WriteMRpt(m_currentNode, vrv_cast<MRpt *>(object));
+        this->WriteMRpt(m_currentNode, vrv_cast<MRpt *>(object));
     }
     else if (object->Is(MRPT2)) {
         m_currentNode = m_currentNode.append_child("mRpt2");
-        WriteMRpt2(m_currentNode, vrv_cast<MRpt2 *>(object));
+        this->WriteMRpt2(m_currentNode, vrv_cast<MRpt2 *>(object));
     }
     else if (object->Is(MSPACE)) {
         m_currentNode = m_currentNode.append_child("mSpace");
-        WriteMSpace(m_currentNode, vrv_cast<MSpace *>(object));
+        this->WriteMSpace(m_currentNode, vrv_cast<MSpace *>(object));
     }
     else if (object->Is(MULTIREST)) {
         m_currentNode = m_currentNode.append_child("multiRest");
-        WriteMultiRest(m_currentNode, vrv_cast<MultiRest *>(object));
+        this->WriteMultiRest(m_currentNode, vrv_cast<MultiRest *>(object));
     }
     else if (object->Is(MULTIRPT)) {
         m_currentNode = m_currentNode.append_child("multiRpt");
-        WriteMultiRpt(m_currentNode, vrv_cast<MultiRpt *>(object));
+        this->WriteMultiRpt(m_currentNode, vrv_cast<MultiRpt *>(object));
     }
     else if (object->Is(NC)) {
         m_currentNode = m_currentNode.append_child("nc");
-        WriteNc(m_currentNode, vrv_cast<Nc *>(object));
+        this->WriteNc(m_currentNode, vrv_cast<Nc *>(object));
     }
     else if (object->Is(NEUME)) {
         m_currentNode = m_currentNode.append_child("neume");
-        WriteNeume(m_currentNode, vrv_cast<Neume *>(object));
+        this->WriteNeume(m_currentNode, vrv_cast<Neume *>(object));
     }
     else if (object->Is(NOTE)) {
         m_currentNode = m_currentNode.append_child("note");
-        WriteNote(m_currentNode, vrv_cast<Note *>(object));
+        this->WriteNote(m_currentNode, vrv_cast<Note *>(object));
     }
     else if (object->Is(PLICA)) {
         m_currentNode = m_currentNode.append_child("plica");
-        WritePlica(m_currentNode, vrv_cast<Plica *>(object));
+        this->WritePlica(m_currentNode, vrv_cast<Plica *>(object));
     }
     else if (object->Is(PROPORT)) {
         m_currentNode = m_currentNode.append_child("proport");
-        WriteProport(m_currentNode, vrv_cast<Proport *>(object));
+        this->WriteProport(m_currentNode, vrv_cast<Proport *>(object));
     }
     else if (object->Is(REST)) {
         m_currentNode = m_currentNode.append_child("rest");
-        WriteRest(m_currentNode, vrv_cast<Rest *>(object));
+        this->WriteRest(m_currentNode, vrv_cast<Rest *>(object));
     }
     else if (object->Is(SPACE)) {
         m_currentNode = m_currentNode.append_child("space");
-        WriteSpace(m_currentNode, vrv_cast<Space *>(object));
+        this->WriteSpace(m_currentNode, vrv_cast<Space *>(object));
     }
     else if (object->Is(SYL)) {
         m_currentNode = m_currentNode.append_child("syl");
-        WriteSyl(m_currentNode, vrv_cast<Syl *>(object));
+        this->WriteSyl(m_currentNode, vrv_cast<Syl *>(object));
     }
     else if (object->Is(SYLLABLE)) {
         m_currentNode = m_currentNode.append_child("syllable");
-        WriteSyllable(m_currentNode, vrv_cast<Syllable *>(object));
+        this->WriteSyllable(m_currentNode, vrv_cast<Syllable *>(object));
     }
     else if (object->Is(TABDURSYM)) {
         m_currentNode = m_currentNode.append_child("tabDurSym");
-        WriteTabDurSym(m_currentNode, vrv_cast<TabDurSym *>(object));
+        this->WriteTabDurSym(m_currentNode, vrv_cast<TabDurSym *>(object));
     }
     else if (object->Is(TABGRP)) {
         m_currentNode = m_currentNode.append_child("tabGrp");
-        WriteTabGrp(m_currentNode, vrv_cast<TabGrp *>(object));
+        this->WriteTabGrp(m_currentNode, vrv_cast<TabGrp *>(object));
     }
     else if (object->Is(TUPLET)) {
         m_currentNode = m_currentNode.append_child("tuplet");
-        WriteTuplet(m_currentNode, vrv_cast<Tuplet *>(object));
+        this->WriteTuplet(m_currentNode, vrv_cast<Tuplet *>(object));
     }
     else if (object->Is(VERSE)) {
         m_currentNode = m_currentNode.append_child("verse");
-        WriteVerse(m_currentNode, vrv_cast<Verse *>(object));
+        this->WriteVerse(m_currentNode, vrv_cast<Verse *>(object));
     }
 
     // Text elements
     else if (object->Is(FIG)) {
         m_currentNode = m_currentNode.append_child("fig");
-        WriteFig(m_currentNode, vrv_cast<Fig *>(object));
+        this->WriteFig(m_currentNode, vrv_cast<Fig *>(object));
     }
     else if (object->Is(FIGURE)) {
         m_currentNode = m_currentNode.append_child("f");
-        WriteF(m_currentNode, vrv_cast<F *>(object));
+        this->WriteF(m_currentNode, vrv_cast<F *>(object));
     }
     else if (object->Is(FB)) {
         m_currentNode = m_currentNode.append_child("fb");
-        WriteFb(m_currentNode, vrv_cast<Fb *>(object));
+        this->WriteFb(m_currentNode, vrv_cast<Fb *>(object));
     }
     else if (object->Is(LB)) {
         m_currentNode = m_currentNode.append_child("lb");
-        WriteLb(m_currentNode, vrv_cast<Lb *>(object));
+        this->WriteLb(m_currentNode, vrv_cast<Lb *>(object));
     }
     else if (object->Is(NUM)) {
         m_currentNode = m_currentNode.append_child("num");
-        WriteNum(m_currentNode, vrv_cast<Num *>(object));
+        this->WriteNum(m_currentNode, vrv_cast<Num *>(object));
     }
     else if (object->Is(REND)) {
         m_currentNode = m_currentNode.append_child("rend");
-        WriteRend(m_currentNode, vrv_cast<Rend *>(object));
+        this->WriteRend(m_currentNode, vrv_cast<Rend *>(object));
     }
     else if (object->Is(SVG)) {
         m_currentNode = m_currentNode.append_child("svg");
-        WriteSvg(m_currentNode, vrv_cast<Svg *>(object));
+        this->WriteSvg(m_currentNode, vrv_cast<Svg *>(object));
     }
     else if (object->Is(TEXT)) {
-        WriteText(m_currentNode, vrv_cast<Text *>(object));
+        this->WriteText(m_currentNode, vrv_cast<Text *>(object));
     }
 
     // Editorial markup
     else if (object->Is(ABBR)) {
         m_currentNode = m_currentNode.append_child("abbr");
-        WriteAbbr(m_currentNode, vrv_cast<Abbr *>(object));
+        this->WriteAbbr(m_currentNode, vrv_cast<Abbr *>(object));
     }
     else if (object->Is(ADD)) {
         m_currentNode = m_currentNode.append_child("add");
-        WriteAdd(m_currentNode, vrv_cast<Add *>(object));
+        this->WriteAdd(m_currentNode, vrv_cast<Add *>(object));
     }
     else if (object->Is(ANNOT)) {
         m_currentNode = m_currentNode.append_child("annot");
-        WriteAnnot(m_currentNode, vrv_cast<Annot *>(object));
+        this->WriteAnnot(m_currentNode, vrv_cast<Annot *>(object));
     }
     else if (object->Is(APP)) {
         m_currentNode = m_currentNode.append_child("app");
-        WriteApp(m_currentNode, vrv_cast<App *>(object));
+        this->WriteApp(m_currentNode, vrv_cast<App *>(object));
     }
     else if (object->Is(CHOICE)) {
         m_currentNode = m_currentNode.append_child("choice");
-        WriteChoice(m_currentNode, vrv_cast<Choice *>(object));
+        this->WriteChoice(m_currentNode, vrv_cast<Choice *>(object));
     }
     else if (object->Is(CORR)) {
         m_currentNode = m_currentNode.append_child("corr");
-        WriteCorr(m_currentNode, vrv_cast<Corr *>(object));
+        this->WriteCorr(m_currentNode, vrv_cast<Corr *>(object));
     }
     else if (object->Is(DAMAGE)) {
         m_currentNode = m_currentNode.append_child("damage");
-        WriteDamage(m_currentNode, vrv_cast<Damage *>(object));
+        this->WriteDamage(m_currentNode, vrv_cast<Damage *>(object));
     }
     else if (object->Is(DEL)) {
         m_currentNode = m_currentNode.append_child("del");
-        WriteDel(m_currentNode, vrv_cast<Del *>(object));
+        this->WriteDel(m_currentNode, vrv_cast<Del *>(object));
     }
     else if (object->Is(EXPAN)) {
         m_currentNode = m_currentNode.append_child("epxan");
-        WriteExpan(m_currentNode, vrv_cast<Expan *>(object));
+        this->WriteExpan(m_currentNode, vrv_cast<Expan *>(object));
     }
     else if (object->Is(LEM)) {
         m_currentNode = m_currentNode.append_child("lem");
-        WriteLem(m_currentNode, vrv_cast<Lem *>(object));
+        this->WriteLem(m_currentNode, vrv_cast<Lem *>(object));
     }
     else if (object->Is(ORIG)) {
         m_currentNode = m_currentNode.append_child("orig");
-        WriteOrig(m_currentNode, vrv_cast<Orig *>(object));
+        this->WriteOrig(m_currentNode, vrv_cast<Orig *>(object));
     }
     else if (object->Is(RDG)) {
         m_currentNode = m_currentNode.append_child("rdg");
-        WriteRdg(m_currentNode, vrv_cast<Rdg *>(object));
+        this->WriteRdg(m_currentNode, vrv_cast<Rdg *>(object));
     }
     else if (object->Is(REF)) {
         m_currentNode = m_currentNode.append_child("ref");
-        WriteRef(m_currentNode, vrv_cast<Ref *>(object));
+        this->WriteRef(m_currentNode, vrv_cast<Ref *>(object));
     }
     else if (object->Is(REG)) {
         m_currentNode = m_currentNode.append_child("reg");
-        WriteReg(m_currentNode, vrv_cast<Reg *>(object));
+        this->WriteReg(m_currentNode, vrv_cast<Reg *>(object));
     }
     else if (object->Is(RESTORE)) {
         m_currentNode = m_currentNode.append_child("restore");
-        WriteRestore(m_currentNode, vrv_cast<Restore *>(object));
+        this->WriteRestore(m_currentNode, vrv_cast<Restore *>(object));
     }
     else if (object->Is(SIC)) {
         m_currentNode = m_currentNode.append_child("sic");
-        WriteSic(m_currentNode, vrv_cast<Sic *>(object));
+        this->WriteSic(m_currentNode, vrv_cast<Sic *>(object));
     }
     else if (object->Is(SUBST)) {
         m_currentNode = m_currentNode.append_child("subst");
-        WriteSubst(m_currentNode, vrv_cast<Subst *>(object));
+        this->WriteSubst(m_currentNode, vrv_cast<Subst *>(object));
     }
     else if (object->Is(SUPPLIED)) {
         m_currentNode = m_currentNode.append_child("supplied");
-        WriteSupplied(m_currentNode, vrv_cast<Supplied *>(object));
+        this->WriteSupplied(m_currentNode, vrv_cast<Supplied *>(object));
     }
     else if (object->Is(UNCLEAR)) {
         m_currentNode = m_currentNode.append_child("unclear");
-        WriteUnclear(m_currentNode, vrv_cast<Unclear *>(object));
+        this->WriteUnclear(m_currentNode, vrv_cast<Unclear *>(object));
     }
 
     // SystemMilestoneEnd - nothing to add - only
@@ -861,7 +861,7 @@ bool MEIOutput::WriteObject(Object *object, bool handleScoreBasedFilter, bool us
         }
     }
 
-    WriteUnsupportedAttr(m_currentNode, object);
+    this->WriteUnsupportedAttr(m_currentNode, object);
 
     return true;
 }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -980,11 +980,21 @@ bool MEIOutput::IsMatchingFilter() const
 
 void MEIOutput::UpdateFilter(Object *object)
 {
+    this->UpdatePageFilter(object);
+    this->UpdateMeasureFilter(object);
+    this->UpdateMdivFilter(object);
+}
+
+void MEIOutput::UpdatePageFilter(Object *object)
+{
     // Update page
     if (object->Is(PAGE)) {
         ++m_currentPage;
     }
+}
 
+void MEIOutput::UpdateMeasureFilter(Object *object)
+{
     // Update measure range
     if (m_firstMeasureUuid.empty() && (m_measureFilterMatchLocation == RangeMatchLocation::BeforeStart)) {
         m_measureFilterMatchLocation = RangeMatchLocation::BetweenStartEnd;
@@ -1019,7 +1029,10 @@ void MEIOutput::UpdateFilter(Object *object)
             default: break;
         }
     }
+}
 
+void MEIOutput::UpdateMdivFilter(Object *object)
+{
     // Update mdiv
     if (m_mdivUuid.empty() && (m_mdivFilterMatchLocation == MatchLocation::Before)) {
         m_mdivFilterMatchLocation = MatchLocation::Here;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1153,11 +1153,21 @@ void MEIOutput::WriteCustomScoreDef()
         }
     }
 
+    // Detect the scoredef which is used as reference
+    ScoreDef *refScoreDef = NULL;
     if (measure) {
-        // Create a copy of the measure scoredef and adjust it to keep track of clef changes, key signature changes,
+        refScoreDef = measure->GetDrawingScoreDef();
+        if (!refScoreDef) {
+            // Use the system scoredef as fallback
+            System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
+            if (system) refScoreDef = system->GetDrawingScoreDef();
+        }
+    }
+
+    if (measure && refScoreDef) {
+        // Create a copy of the reference scoredef and adjust it to keep track of clef changes, key signature changes,
         // etc.
-        ScoreDef *measureScoreDef = measure->GetDrawingScoreDef();
-        ScoreDef *scoreDef = vrv_cast<ScoreDef *>(measureScoreDef->Clone());
+        ScoreDef *scoreDef = vrv_cast<ScoreDef *>(refScoreDef->Clone());
         ListOfObjects staffDefs = scoreDef->FindAllDescendantsByType(STAFFDEF);
         for (Object *staffDef : staffDefs) {
             this->AdjustStaffDef(vrv_cast<StaffDef *>(staffDef), measure);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1066,18 +1066,9 @@ void MEIOutput::UpdateMdivFilter(Object *object)
                 // Mdivs can contain mdivs as children
                 // => have to check whether we are still in the subtree of the filtered mdiv
                 if (!m_mdivUuid.empty()) {
-                    // Copy the start elements of the boundary stack
-                    ListOfObjects startElements;
-                    std::stack<Object *> tempStack = m_boundaries;
-                    while (!tempStack.empty()) {
-                        PageMilestoneEnd *end = dynamic_cast<PageMilestoneEnd *>(tempStack.top());
-                        if (end) startElements.push_front(end->GetStart());
-                        tempStack.pop();
-                    }
-                    // Check that none of those matches the filtered mdiv
-                    const bool noneMatchingStartElements = std::none_of(startElements.cbegin(), startElements.cend(),
+                    const bool noneMatchingStackElements = std::none_of(m_objectStack.cbegin(), m_objectStack.cend(),
                         [this](Object *object) { return (object->GetUuid() == m_mdivUuid); });
-                    if (noneMatchingStartElements) {
+                    if (noneMatchingStackElements) {
                         m_mdivFilterMatchLocation = MatchLocation::After;
                     }
                 }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -151,6 +151,7 @@ MEIOutput::MEIOutput(Doc *doc) : Output(doc)
 {
     m_indent = 5;
     m_scoreBasedMEI = false;
+    m_ignoreHeader = false;
     m_removeIds = false;
 
     this->Reset();
@@ -1246,7 +1247,7 @@ bool MEIOutput::WriteDoc(Doc *doc)
 
     // ---- header ----
 
-    if (m_doc->m_header.first_child()) {
+    if (!m_ignoreHeader && m_doc->m_header.first_child()) {
         m_mei.append_copy(m_doc->m_header.first_child());
     }
     else {

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -82,8 +82,8 @@ int Mdiv::Save(FunctorParams *functorParams)
 
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
     if (m_visibility == Hidden && meiOutput) {
-        // Do not output hidden mdivs in page-based MEI or when saving a single score-based MEI page
-        if (!meiOutput->GetScoreBasedMEI() || meiOutput->IsSavingSinglePage()) return FUNCTOR_SIBLINGS;
+        // Do not output hidden mdivs in page-based MEI or when saving score-based MEI with filter
+        if (!meiOutput->GetScoreBasedMEI() || meiOutput->HasFilter()) return FUNCTOR_SIBLINGS;
     }
     return Object::Save(functorParams);
 }
@@ -95,8 +95,8 @@ int Mdiv::SaveEnd(FunctorParams *functorParams)
 
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(params->m_output);
     if (m_visibility == Hidden && meiOutput) {
-        // Do not output hidden mdivs in page-based MEI or when saving a single score-based MEI page
-        if (!meiOutput->GetScoreBasedMEI() || meiOutput->IsSavingSinglePage()) return FUNCTOR_SIBLINGS;
+        // Do not output hidden mdivs in page-based MEI or when saving score-based MEI with filter
+        if (!meiOutput->GetScoreBasedMEI() || meiOutput->HasFilter()) return FUNCTOR_SIBLINGS;
     }
     return Object::SaveEnd(functorParams);
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -767,6 +767,8 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
     bool removeIds = m_options->m_removeIds.GetValue();
     int firstPage = 0;
     int lastPage = 0;
+    std::string firstMeasure;
+    std::string lastMeasure;
 
     jsonxx::Object json;
 
@@ -784,6 +786,8 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
                 firstPage = json.get<jsonxx::Number>("pageNo");
                 lastPage = firstPage;
             }
+            if (json.has<jsonxx::String>("firstMeasure")) firstMeasure = json.get<jsonxx::String>("firstMeasure");
+            if (json.has<jsonxx::String>("lastMeasure")) lastMeasure = json.get<jsonxx::String>("lastMeasure");
         }
     }
 
@@ -803,6 +807,8 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
 
     if (firstPage > 0) meioutput.SetFirstPage(firstPage);
     if (lastPage > 0) meioutput.SetLastPage(lastPage);
+    if (!firstMeasure.empty()) meioutput.SetFirstMeasure(firstMeasure);
+    if (!lastMeasure.empty()) meioutput.SetLastMeasure(lastMeasure);
 
     std::string output = meioutput.GetOutput();
     if (initialPageNo >= 0) m_doc.SetDrawingPage(initialPageNo);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -769,6 +769,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
     int lastPage = 0;
     std::string firstMeasure;
     std::string lastMeasure;
+    std::string mdiv;
 
     jsonxx::Object json;
 
@@ -788,6 +789,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
             }
             if (json.has<jsonxx::String>("firstMeasure")) firstMeasure = json.get<jsonxx::String>("firstMeasure");
             if (json.has<jsonxx::String>("lastMeasure")) lastMeasure = json.get<jsonxx::String>("lastMeasure");
+            if (json.has<jsonxx::String>("mdiv")) mdiv = json.get<jsonxx::String>("mdiv");
         }
     }
 
@@ -809,6 +811,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
     if (lastPage > 0) meioutput.SetLastPage(lastPage);
     if (!firstMeasure.empty()) meioutput.SetFirstMeasure(firstMeasure);
     if (!lastMeasure.empty()) meioutput.SetLastMeasure(lastMeasure);
+    if (!mdiv.empty()) meioutput.SetMdiv(mdiv);
 
     std::string output = meioutput.GetOutput();
     if (initialPageNo >= 0) m_doc.SetDrawingPage(initialPageNo);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -764,6 +764,7 @@ bool Toolkit::LoadData(const std::string &data)
 std::string Toolkit::GetMEI(const std::string &jsonOptions)
 {
     bool scoreBased = true;
+    bool ignoreHeader = false;
     bool removeIds = m_options->m_removeIds.GetValue();
     int firstPage = 0;
     int lastPage = 0;
@@ -780,6 +781,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
         }
         else {
             if (json.has<jsonxx::Boolean>("scoreBased")) scoreBased = json.get<jsonxx::Boolean>("scoreBased");
+            if (json.has<jsonxx::Boolean>("ignoreHeader")) ignoreHeader = json.get<jsonxx::Boolean>("ignoreHeader");
             if (json.has<jsonxx::Boolean>("removeIds")) removeIds = json.get<jsonxx::Boolean>("removeIds");
             if (json.has<jsonxx::Number>("firstPage")) firstPage = json.get<jsonxx::Number>("firstPage");
             if (json.has<jsonxx::Number>("lastPage")) lastPage = json.get<jsonxx::Number>("lastPage");
@@ -805,6 +807,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
 
     int indent = (m_options->m_outputIndentTab.GetValue()) ? -1 : m_options->m_outputIndent.GetValue();
     meioutput.SetIndent(indent);
+    meioutput.SetIgnoreHeader(ignoreHeader);
     meioutput.SetRemoveIds(removeIds);
 
     if (firstPage > 0) meioutput.SetFirstPage(firstPage);

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -646,7 +646,6 @@ int main(int argc, char **argv)
                 std::cout << toolkit.GetMEI(params);
             }
             else if (!toolkit.SaveFile(outfile, params)) {
-                std::cerr << "Unable to write MEI to " << outfile << "." << std::endl;
                 exit(1);
             }
             else {


### PR DESCRIPTION
This PR enhances the filtered score based export:
- The (filtered) score based export now always generates a valid MEI which can be loaded back in Verovio. In particular, this is compatible with multiple mdivs.
- New filtering options: it is now possible to filter a page range (provide `firstPage` and `lastPage` in the json as int), by measure range (provide `firstMeasure` and `lastMeasure` in the json as string containing the measures uuids), by mdiv (provide `mdiv` in the json as string containing the mdiv uuid), or by a combination of those. For backward compatibility I kept the possibility to provide `pageNo` to filter a single page.
- Adapted scoredef: when exporting a part in the middle of a score, the scoredef is adjusted to reflect changes in clef, key signature, etc. Also the instrument labels are removed or replaced by abbreviations. The following example shows the rendered export of single measures:

| After clef change | After key signature change |
| ----------------- | --------------------------- |
| <img width="289" alt="M77" src="https://user-images.githubusercontent.com/63608463/146380469-93b1b20d-e7bb-437c-8f9f-38d65ab3eb85.png"> | <img width="295" alt="M99" src="https://user-images.githubusercontent.com/63608463/146380521-61046b26-05ee-43df-a158-92b5634103ca.png"> |

- It is possible to ignore the MEI header, which likely makes sense when exporting a part in the middle of a score. For this provide `ignoreHeader` in the json with true.