### PR TITLE
Add breaks='encoded' option to tk.redoLayout()

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1187,6 +1187,9 @@ void Toolkit::RedoLayout()
     if (m_options->m_breaks.GetValue() == BREAKS_line) {
         m_doc.CastOffLineDoc();
     }
+    else if (m_options->m_breaks.GetValue() == BREAKS_encoded) {
+        m_doc.CastOffEncodingDoc();
+    }
     else if (m_options->m_breaks.GetValue() == BREAKS_smart) {
         m_doc.CastOffSmartDoc();
     }


### PR DESCRIPTION
`Toolkit.redoLayout()` now supports `breaks='encoded'` which was left out for unknown reasons.