### PR TITLE
Develop fix gracenotes

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1065,8 +1065,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     }
                 }
                 else {
-                    y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-                    x2 -= endRadius;
+                    x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
             // portato slurs

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -994,7 +994,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             else if (isGraceToNoteSlur) {
-                if (start->IsInBeam()) {
+                if (end->IsInBeam()) {
                     x2 += 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
                 else if (parentBeam || parentFTrem) {
@@ -1051,7 +1051,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             else if (isGraceToNoteSlur) {
-                if (start->IsInBeam()) {
+                if (end->IsInBeam()) {
                     x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
                 else if (parentBeam || parentFTrem) {


### PR DESCRIPTION

| Before | After |
| ----------------- | --------------------------- |
| ![image](https://user-images.githubusercontent.com/689412/146929880-48309bb0-47f5-49cf-bb6f-69d69203f6a7.png) | ![image](https://user-images.githubusercontent.com/689412/146929726-8099f6f3-c764-41c6-ab35-7c4eabaf3d32.png) |

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Layers with altered unisons</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2020">2020</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Place accidentals before both parts, except for altered unisons.</annot>
         </notesStmt>
         <sourceDesc>
            <source>
               <bibl>Behind Bars, p. 91, example 1</bibl>
            </source>
         </sourceDesc>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.0.0" label="0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1" xml:id="layer_22908">
                           <beam xml:id="beam_22998">
                              <note dur="32" grace="unknown" oct="5" pname="a" stem.dir="up" xml:id="note_23004"/>
                              <note dur="32" grace="unknown" oct="5" pname="b" stem.dir="up" xml:id="note_23010"/>
                           </beam>
                           <beam xml:id="beam_23016">
                              <note dur="8" oct="6" pname="c" tstamp="1" xml:id="note_23022"/>
                              <note dots="1" dur="16" oct="6" pname="c" tstamp="1.5" xml:id="note_23028"/>
                              <note dur="32" oct="6" pname="c" tstamp="1.875" xml:id="note_23034"/>
                           </beam>
                           <beam xml:id="beam_23040">
                              <note dur="8" oct="6" pname="c" tstamp="2" xml:id="note_23046"/>
                              <note dur="32" oct="5" pname="b" tstamp="2.5" xml:id="note_23052"/>
                              <note dur="32" oct="5" pname="a" tstamp="2.625" xml:id="note_23058"/>
                              <note dur="32" oct="5" pname="g" tstamp="2.75" xml:id="note_23064"/>
                              <note dur="32" oct="5" pname="f" tstamp="2.875" xml:id="note_23070"/>
                           </beam>
                        </layer>
                     </staff>
                     <slur curvedir="below" endid="#note_23022" staff="1" startid="#note_23004" xml:id="slur_23226"/>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1" xml:id="layer_26094">
                           <beam xml:id="beam_26184">
                              <note dur="16" oct="4" pname="a" tstamp="1" xml:id="note_26190"/>
                              <note dur="16" oct="5" pname="a" tstamp="1.25" xml:id="note_26196"/>
                           </beam>
                           <note dur="32" grace="unknown" oct="5" pname="g" stem.dir="up" xml:id="note_26202"/>
                           <beam xml:id="beam_26208">
                              <note dur="16" oct="5" pname="f" tstamp="1.5" xml:id="note_26214"/>
                              <note dur="32" oct="5" pname="e" tstamp="1.75" xml:id="note_26220"/>
                              <note dur="32" oct="5" pname="d" tstamp="1.875" xml:id="note_26226"/>
                           </beam>
                           <beam xml:id="beam_26232">
                              <note dur="8" oct="5" pname="c" tstamp="2" xml:id="note_26238"/>
                              <note dur="8" oct="4" pname="b" tstamp="2.5" xml:id="note_26244"/>
                           </beam>
                        </layer>
                     </staff>
                     <slur curvedir="below" endid="#note_26214" staff="1" startid="#note_26202" xml:id="slur_26394"/>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```