### PR TITLE
Fix for tie regression

### DIFF
--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -293,7 +293,7 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
                 return defaultX;
             }
             Stem *stem = parentChord->GetDrawingStem();
-            if (stem) {
+            if (stem && !stem->IsVirtual()) {
                 return stem->GetContentRight() + 2 * radius + drawingUnit / 2;
             }
             else {
@@ -328,7 +328,7 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
                 return defaultX;
             }
             Stem *stem = parentChord->GetDrawingStem();
-            if (stem) {
+            if (stem && !stem->IsVirtual()) {
                 return stem->GetContentLeft() - 2 * radius - drawingUnit / 2;
             }
             else {
@@ -423,7 +423,13 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             r1 = startNote->GetDrawingRadius(doc);
         }
         if (!isShortTie) {
-            startPoint.x += r1 + drawingUnit / 2;
+            if (startParentChord && startParentChord->HasAdjacentNotesInStaff(staff)) {
+                startPoint.x = this->CalculateAdjacentChordXOffset(
+                    doc, staff, startParentChord, startNote, drawingCurveDir, startPoint.x, true);
+            }
+            else {
+                startPoint.x += r1 + drawingUnit / 2;
+            }
             if (startNote && startNote->GetDots() > 0) {
                 startPoint.x += drawingUnit * startNote->GetDots() * 3 / 2;
             }


### PR DESCRIPTION
- added condition to avoid using stem in stemless chord (whole and half notes)
- added missed adjustment of ties in chords with adjacent notes for the START spanning type

This fixes an issue that was caused by recent change to ties between chords with adjacent notes:
![image](https://user-images.githubusercontent.com/1819669/146933495-bbebc1c7-05a3-41af-b4ba-99da49fef82d.png)
