### PR TITLE
Refine cross staff beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -108,6 +108,8 @@ private:
     bool CalcBeamSlope(
         Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step);
 
+    void CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step);
+
     void CalcBeamPosition(Doc *doc, Staff *staff, Layer *layer, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
     void CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool shorten, int &step);
@@ -131,6 +133,9 @@ private:
 
     // Helper to check wheter beam fits within certain bounds
     bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset);
+
+    // Helper to find number of additional beams. Return { additional beams below main beam, additional beams above }
+    std::pair<int, int> GetAdditionalBeamCount(BeamDrawingInterface *beamInterface);
 
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly
     bool NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -140,9 +140,6 @@ private:
     // Helper to check wheter beam fits within certain bounds
     bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false);
 
-    // Helper to find number of additional beams. Return { additional beams above main beam, additional beams below }
-    std::pair<int, int> GetAdditionalBeamCount(BeamDrawingInterface *beamInterface);
-
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly
     bool NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
 
@@ -216,6 +213,7 @@ public:
     const ArrayOfBeamElementCoords *GetElementCoords();
 
     /**
+
      * Return true if the beam has a tabGrp child.
      * In that case, the ObjectList will only have tabGrp elements. See Beam::FilterList
      */
@@ -229,6 +227,12 @@ public:
     Beam *GetStemSameasBeam() const { return m_stemSameas; }
     void SetStemSameasBeam(Beam *stemSameas) { m_stemSameas = stemSameas; }
     ///@}
+	
+    /**
+     * See DrawingInterface::GetAdditionalBeamCount
+     */
+    std::pair<int, int> GetAdditionalBeamCount() const override;
+
 
     //----------//
     // Functors //

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -126,7 +126,7 @@ private:
     std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;
 
     // Calculate positioning for the horizontal beams
-    void CalcHorizontalBeam(BeamDrawingInterface *beamInterface);
+    void CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
 
     // Helper to calculate relative position of the beam to for each of the coordinates
     void CalcMixedBeamPlace(Staff *staff);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -140,7 +140,7 @@ private:
     // Helper to check wheter beam fits within certain bounds
     bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false);
 
-    // Helper to find number of additional beams. Return { additional beams below main beam, additional beams above }
+    // Helper to find number of additional beams. Return { additional beams above main beam, additional beams below }
     std::pair<int, int> GetAdditionalBeamCount(BeamDrawingInterface *beamInterface);
 
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -122,6 +122,9 @@ private:
     // Helper to calculate the longest stem length of the beam (which will be used uniformely)
     void CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal);
 
+    // Helper to calculate max/min beam points for the relative beam place
+    std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;
+
     // Calculate positioning for the horizontal beams
     void CalcHorizontalBeam(BeamDrawingInterface *beamInterface);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -122,6 +122,9 @@ private:
     // Helper to calculate the longest stem length of the beam (which will be used uniformely)
     void CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal);
 
+    // Calculate positioning for the horizontal beams
+    void CalcHorizontalBeam(BeamDrawingInterface *beamInterface);
+
     // Helper to calculate relative position of the beam to for each of the coordinates
     void CalcMixedBeamPlace(Staff *staff);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -132,7 +132,7 @@ private:
     void CalcSetValues();
 
     // Helper to check wheter beam fits within certain bounds
-    bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset);
+    bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false);
 
     // Helper to find number of additional beams. Return { additional beams below main beam, additional beams above }
     std::pair<int, int> GetAdditionalBeamCount(BeamDrawingInterface *beamInterface);

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -139,6 +139,14 @@ protected:
      */
     int GetPosition(Object *object, LayerElement *element);
 
+    //
+private:
+    /**
+     * Determines whether beam should be horizontal based on item positions and relative beam place. Should be used with
+     * mixed beams, where beam place can be different for separate elements
+     */
+    bool IsHorizontal(const std::vector<int> &items, const std::vector<data_BEAMPLACE> &directions) const;
+
 public:
     // values to be set before calling CalcBeam
     bool m_changingDur;

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -132,6 +132,16 @@ public:
      */
     void ClearCoords();
 
+    /**
+     * Helper to find number of additional beams. Return { additional beams above main beam, additional beams below }
+     */
+    virtual std::pair<int, int> GetAdditionalBeamCount() const { return { 0, 0 }; }
+
+    /**
+     * Helper to get number of beams represented by attributes @beam and @beam.float
+     */
+    virtual std::pair<int, int> GetFloatingBeamCount() const { return { 0, 0 }; }
+
 protected:
     /**
      * Return the position of the element in the beam.

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -47,6 +47,16 @@ public:
      */
     const ArrayOfBeamElementCoords *GetElementCoords();
 
+    /**
+     * See DrawingInterface::GetAdditionalBeamCount
+     */
+    std::pair<int, int> GetAdditionalBeamCount() const override;
+
+    /**
+     * See DrawingInterface::GetFloatingBeamCount
+     */
+    std::pair<int, int> GetFloatingBeamCount() const override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -467,6 +467,22 @@ protected:
 private:
     int GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type);
 
+    /**
+     * Template for getting above/below overflow for BeamType elements (BEAM or FTREM)
+     */
+    template <class BeamType> void GetBeamOverflow(StaffAlignment *&above, StaffAlignment *&below);
+
+    /**
+     * Template for getting above/below overflow for children of BeamType elements (BEAM or FTREM)
+     */
+    template <class BeamType>
+    void GetBeamChildOverflow(StaffAlignment *&above, StaffAlignment *&below, BeamType *parent);
+
+    /**
+     * Get above/below overflow for the chord elements
+     */
+    void GetChordOverflow(StaffAlignment *&above, StaffAlignment *&below, int staffN);
+
 public:
     /** Absolute position X. This is used for facsimile (transcription) encoding */
     int m_xAbs;

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -167,6 +167,11 @@ public:
      */
     virtual void SetFromFacsimile(Doc *doc);
 
+    /**
+     * Set beam adjustment for the corresponding staff alignment
+     */
+    void SetAlignmentBeamAdjustment(int adjust);
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -281,6 +281,14 @@ public:
     void ReAdjustFloatingPositionersGrps(AdjustFloatingPositionerGrpsParams *params,
         const ArrayOfFloatingPositioners &positioners, ArrayOfIntPairs &grpIdYRel);
 
+    /**
+     * @name Set/get for the beam adjust
+     */
+    ///@{
+    void SetBeamAdjust(int beamAdjust) { m_beamAdjust = beamAdjust; }
+    int GetBeamAdjust() const { return m_beamAdjust; }
+    ///@}
+
     //----------//
     // Functors //
     //----------//
@@ -373,6 +381,9 @@ private:
     BoundingBox *m_overflowBBoxAbove;
     BoundingBox *m_overflowBBoxBelow;
     ///@}
+
+    // Value to store required beam adjustment for cross-staff beams
+    int m_beamAdjust;
 
     /**
      * The list of overflowing bounding boxes (e.g, LayerElement or FloatingPositioner)

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -383,7 +383,7 @@ private:
     ///@}
 
     // Value to store required beam adjustment for cross-staff beams
-    int m_beamAdjust;
+    int m_beamAdjust = 0;
 
     /**
      * The list of overflowing bounding boxes (e.g, LayerElement or FloatingPositioner)

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -323,7 +323,7 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterfa
     if (!this->DoesBeamOverlap(staffTop, topOffset, staffBottom, bottomOffset, beamInterface->m_crossStaffContent)) {
         return false;
     }
-        
+
     if (!beamInterface->m_crossStaffContent) {
         // Calculate midpoint for the beam with mixed placement
         int min = m_beamElementCoordRefs.at(0)->m_element->GetDrawingY();
@@ -589,7 +589,6 @@ bool BeamSegment::CalcBeamSlope(
     m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
         Point(m_lastNoteOrChord->m_x, m_lastNoteOrChord->m_yBeam));
 
-
     int noteStep = 0;
     double noteSlope = 0.0;
     if (m_firstNoteOrChord->m_closestNote && m_lastNoteOrChord->m_closestNote) {
@@ -776,10 +775,10 @@ bool BeamSegment::CalcBeamSlope(
     else if (place == BEAMPLACE_mixed) {
         if (step <= unit) {
             step = 0;
-        }            
+        }
         else if (step > unit * 2) {
             step = unit * 2;
-        } 
+        }
         this->CalcMixedBeamStem(beamInterface, step);
     }
 
@@ -797,12 +796,12 @@ bool BeamSegment::CalcBeamSlope(
     return true;
 }
 
-
 void BeamSegment::CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step)
 {
     // In cases, when both first and last notes/chords of the beam have same relative places (i.e. they have same stem
     // direction and/or same staff), - we don't need additional calculations
-    if ((m_firstNoteOrChord->m_beamRelativePlace == m_lastNoteOrChord->m_beamRelativePlace) && (!beamInterface->m_crossStaffContent)) {
+    if ((m_firstNoteOrChord->m_beamRelativePlace == m_lastNoteOrChord->m_beamRelativePlace)
+        && (!beamInterface->m_crossStaffContent)) {
         if (m_beamSlope < 0.0) {
             m_firstNoteOrChord->m_yBeam = m_lastNoteOrChord->m_yBeam + step;
         }
@@ -1194,8 +1193,7 @@ std::pair<int, int> BeamSegment::CalcBeamRelativeMinMax(data_BEAMPLACE place) co
     int lowestPoint = VRV_UNSET;
     std::for_each(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
         if (coord->m_beamRelativePlace == place) {
-            if ((highestPoint == VRV_UNSET) || (coord->m_yBeam > highestPoint))
-                highestPoint = coord->m_yBeam;
+            if ((highestPoint == VRV_UNSET) || (coord->m_yBeam > highestPoint)) highestPoint = coord->m_yBeam;
             if ((lowestPoint == VRV_UNSET) || (coord->m_yBeam < lowestPoint)) {
                 lowestPoint = coord->m_yBeam;
             }
@@ -1205,8 +1203,9 @@ std::pair<int, int> BeamSegment::CalcBeamRelativeMinMax(data_BEAMPLACE place) co
     return { highestPoint, lowestPoint };
 }
 
-void BeamSegment::CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterface* beamInterface) {
-    
+void BeamSegment::CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface)
+{
+
     if (beamInterface->m_drawingPlace == BEAMPLACE_mixed) {
         this->CalcMixedBeamStem(beamInterface, 0);
     }
@@ -1776,7 +1775,7 @@ int Beam::CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, in
     return overlap;
 }
 
-std::pair<int, int> Beam::GetAdditionalBeamCount() const 
+std::pair<int, int> Beam::GetAdditionalBeamCount() const
 {
     int topShortestDur = DUR_8;
     int bottomShortestDur = DUR_8;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -232,7 +232,7 @@ void BeamSegment::CalcBeam(
                 if (FTrem *fTrem = dynamic_cast<FTrem *>(beamInterface);
                     fTrem && (coord->GetStemDir() == STEMDIRECTION_down)) {
                     const int beamsCount = fTrem->GetBeams();
-                    stemOffset = (beamsCount - 1) * beamInterface->m_beamWidth;
+                    stemOffset = beamsCount * beamInterface->m_beamWidth;
                 }
 
                 if (coord->m_beamRelativePlace == BEAMPLACE_below) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -231,7 +231,8 @@ void BeamSegment::CalcBeam(
                 // handle cross-staff fTrem cases
                 if (FTrem *fTrem = dynamic_cast<FTrem *>(beamInterface);
                     fTrem && (coord->GetStemDir() == STEMDIRECTION_down)) {
-                    const int beamsCount = fTrem->GetBeams();
+                    int beamsCount = std::max(fTrem->GetBeams(), fTrem->GetBeamsFloat());
+                    if (!fTrem->HasBeamsFloat()) beamsCount--;
                     stemOffset = beamsCount * beamInterface->m_beamWidth;
                 }
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1169,7 +1169,6 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool is
         const data_STEMDIRECTION stemDir = (place != BEAMPLACE_mixed) ? globalStemDir
             : (coord->m_beamRelativePlace == BEAMPLACE_below)         ? STEMDIRECTION_down
                                                                       : STEMDIRECTION_up;
-        const int stemDirBias = (stemDir == STEMDIRECTION_up) ? 1 : -1;
         coord->SetClosestNote(stemDir);
         if (!coord->m_closestNote) continue;
         if (relevantNoteLoc == VRV_UNSET) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -229,8 +229,8 @@ void BeamSegment::CalcBeam(
                     stemOffset = (coord->m_dur - DUR_8) * beamInterface->m_beamWidth;
                 }
                 // handle cross-staff fTrem cases
-                if (FTrem *fTrem = vrv_cast<FTrem *>(beamInterface);
-                    fTrem->Is(FTREM) && (coord->GetStemDir() == STEMDIRECTION_down)) {
+                if (FTrem *fTrem = dynamic_cast<FTrem *>(beamInterface);
+                    fTrem && (coord->GetStemDir() == STEMDIRECTION_down)) {
                     const int beamsCount = fTrem->GetBeams();
                     stemOffset = (beamsCount - 1) * beamInterface->m_beamWidth;
                 }
@@ -274,14 +274,14 @@ void BeamSegment::CalcBeam(
 bool BeamSegment::DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff)
 {
     // find if current beam fits within the staff
-    auto withinBounds
+    auto outsideBounds
         = std::find_if(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
               if ((coord->m_yBeam > staffTop - topOffset) || (coord->m_yBeam < staffBottom + bottomOffset)) {
                   return true;
               }
               return false;
           });
-    if (!isCrossStaff && (withinBounds != m_beamElementCoordRefs.end())) return true;
+    if (!isCrossStaff && (outsideBounds != m_beamElementCoordRefs.end())) return true;
     auto overlapping
         = std::find_if(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
               assert(coord->m_element);
@@ -301,8 +301,7 @@ bool BeamSegment::DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, 
 std::pair<int, int> BeamSegment::GetAdditionalBeamCount(BeamDrawingInterface *beamInterface)
 {
     // In case we're dealing with fTrem - take @beams attribute into consideration
-    FTrem *fTrem = vrv_cast<FTrem *>(beamInterface);
-    if (fTrem->Is(FTREM)) {
+    if (FTrem *fTrem = dynamic_cast<FTrem *>(beamInterface); fTrem) {
         return { fTrem->GetBeams() / 2, 0 };
     }
 

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -290,10 +290,10 @@ bool BeamDrawingInterface::IsHorizontal()
     // Detect concave shapes
     for (i = 1; i < itemCount - 1; ++i) {
         if (m_drawingPlace == BEAMPLACE_above) {
-            if ((items.at(i) > first) && (items.at(i) > last)) return true;
+            if ((items.at(i) >= first) && (items.at(i) >= last)) return true;
         }
         else {
-            if ((items.at(i) < first) && (items.at(i) < last)) return true;
+            if ((items.at(i) <= first) && (items.at(i) <= last)) return true;
         }
     }
 

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -302,70 +302,25 @@ bool BeamDrawingInterface::IsHorizontal()
     // First note and last note have the same postion
     if (first == last) return true;
 
-    // Detect concave shapes
-    for (int i = 1; i < itemCount - 1; ++i) {
-        if (m_drawingPlace == BEAMPLACE_above) {
-            if ((items.at(i) >= first) && (items.at(i) >= last)) return true;
-        }
-        else if (m_drawingPlace == BEAMPLACE_below) {
-            if ((items.at(i) <= first) && (items.at(i) <= last)) return true;
-        }
-    }
-    if (m_drawingPlace == BEAMPLACE_mixed) {
-        if ((itemCount == 3) && (directions.front() == directions.back())) return true;
-        int directionChanges = 0;
-        data_BEAMPLACE previous = directions.front();
-        std::for_each(directions.begin(), directions.end(), [&previous, &directionChanges](data_BEAMPLACE current) {
-            if (current != previous) {
-                ++directionChanges;
-                previous = current;
-            }
-        });
-        // if we have a mix of cross-staff elements, going from one staff to another repeatedly, we need to check note
-        // directions. Otherwise we can use direction of the outside pitches for beam
-        if (directionChanges > 1) {
-            int previousTop = VRV_UNSET;
-            int previousBottom = VRV_UNSET;
-            NoteDirection outsidePitchDirection = GetNoteDirection(first, last);
-            std::map<NoteDirection, int> beamDirections{ { NoteDirection::none, 0 }, { NoteDirection::upward, 0 },
-                { NoteDirection::downward, 0 } };
-            for (int i = 0; i < itemCount; ++i) {
-                if (directions[i] == BEAMPLACE_above) {
-                    if (previousTop == VRV_UNSET) {
-                        previousTop = items[i];
-                    }
-                    else {
-                        ++beamDirections[GetNoteDirection(previousTop, items[i])];
-                    }
-                }
-                else if (directions[i] == BEAMPLACE_below) {
-                    if (previousBottom == VRV_UNSET) {
-                        previousBottom = items[i];
-                    }
-                    else {
-                        ++beamDirections[GetNoteDirection(previousBottom, items[i])];
-                    }
-                }
-            }
-            // if direction of beam outside pitches corresponds to majority of the note directions within the beam, beam
-            // can be drawn in that direction. Otherwise horizontal beam should be used
-            bool result = std::all_of(beamDirections.begin(), beamDirections.end(),
-                [&beamDirections, &outsidePitchDirection](const auto &pair) {
-                    return (pair.first == outsidePitchDirection) ? true
-                                                                 : pair.second <= beamDirections[outsidePitchDirection];
-                });
-            if (!result) return true;
-        }
-    }
+    // If drawing place is mixed and is should be drawn horizontal based on mixed rules
+    if ((m_drawingPlace == BEAMPLACE_mixed) && (IsHorizontal(items, directions))) return true;
 
     // Detect beam with two pitches only and as step at the beginning or at the end
     const bool firstStep = (first != items.at(1));
     const bool lastStep = (last != items.at(items.size() - 2));
     if ((items.size() > 2) && (firstStep || lastStep)) {
+        // Detect concave shapes
+        for (int i = 1; i < itemCount - 1; ++i) {
+            if (m_drawingPlace == BEAMPLACE_above) {
+                if ((items.at(i) >= first) && (items.at(i) >= last)) return true;
+            }
+            else if (m_drawingPlace == BEAMPLACE_below) {
+                if ((items.at(i) <= first) && (items.at(i) <= last)) return true;
+            }
+        }
         std::vector<int> pitches;
         std::unique_copy(items.begin(), items.end(), std::back_inserter(pitches));
         if (pitches.size() == 2) {
-            // if (firstStep)
             if (m_drawingPlace == BEAMPLACE_above) {
                 // Single note at the beginning as lower first
                 if (firstStep && (std::is_sorted(items.begin(), items.end()))) return true;
@@ -382,6 +337,57 @@ bool BeamDrawingInterface::IsHorizontal()
     }
 
     return false;
+}
+
+bool BeamDrawingInterface::IsHorizontal(const std::vector<int>& items, const std::vector<data_BEAMPLACE>& directions) const
+{
+    // items and directions should be of the same size, otherwise something is not wrong
+    if (items.size() != directions.size()) return false;
+    if ((items.size() == 3) && (directions.front() == directions.back())) return true;
+
+    // calculate how many times stem direction is changed withing the beam
+    int directionChanges = 0;
+    data_BEAMPLACE previous = directions.front();
+    std::for_each(directions.begin(), directions.end(), [&previous, &directionChanges](data_BEAMPLACE current) {
+        if (current != previous) {
+            ++directionChanges;
+            previous = current;
+        }
+    });
+    // if we have a mix of cross-staff elements, going from one staff to another repeatedly, we need to check note
+    // directions. Otherwise we can use direction of the outside pitches for beam
+    if (directionChanges <= 1) return false;
+
+    int previousTop = VRV_UNSET;
+    int previousBottom = VRV_UNSET;
+    NoteDirection outsidePitchDirection = GetNoteDirection(items.front(), items.back());
+    std::map<NoteDirection, int> beamDirections{ { NoteDirection::none, 0 }, { NoteDirection::upward, 0 },
+        { NoteDirection::downward, 0 } };
+    for (int i = 0; i < items.size(); ++i) {
+        if (directions[i] == BEAMPLACE_above) {
+            if (previousTop == VRV_UNSET) {
+                previousTop = items[i];
+            }
+            else {
+                ++beamDirections[GetNoteDirection(previousTop, items[i])];
+            }
+        }
+        else if (directions[i] == BEAMPLACE_below) {
+            if (previousBottom == VRV_UNSET) {
+                previousBottom = items[i];
+            }
+            else {
+                ++beamDirections[GetNoteDirection(previousBottom, items[i])];
+            }
+        }
+    }
+    // if direction of beam outside pitches corresponds to majority of the note directions within the beam, beam
+    // can be drawn in that direction. Otherwise horizontal beam should be used
+    bool result = std::any_of(
+        beamDirections.begin(), beamDirections.end(), [&beamDirections, &outsidePitchDirection](const auto &pair) {
+            return (pair.first == outsidePitchDirection) ? false : pair.second > beamDirections[outsidePitchDirection];
+        });
+    return result;
 }
 
 bool BeamDrawingInterface::IsRepeatedPattern()

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -341,9 +341,11 @@ bool BeamDrawingInterface::IsHorizontal()
 
 bool BeamDrawingInterface::IsHorizontal(const std::vector<int>& items, const std::vector<data_BEAMPLACE>& directions) const
 {
-    // items and directions should be of the same size, otherwise something is not wrong
+    // items and directions should be of the same size, otherwise something is wrong
     if (items.size() != directions.size()) return false;
-    if ((items.size() == 3) && (directions.front() == directions.back()) && m_crossStaffContent) return true;
+    if ((items.size() == 3) && m_crossStaffContent) {
+        if ((directions.at(0) == directions.at(2)) && (directions.at(0) != directions.at(1))) return true;        
+    }
 
     // calculate how many times stem direction is changed withing the beam
     int directionChanges = 0;

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -21,11 +21,7 @@
 
 namespace vrv {
 
-enum class NoteDirection {
-    none,
-    upward,
-    downward
-};
+enum class NoteDirection { none, upward, downward };
 
 // helper for determining note direction
 NoteDirection GetNoteDirection(int leftNoteX, int rightNoteX)
@@ -339,12 +335,13 @@ bool BeamDrawingInterface::IsHorizontal()
     return false;
 }
 
-bool BeamDrawingInterface::IsHorizontal(const std::vector<int>& items, const std::vector<data_BEAMPLACE>& directions) const
+bool BeamDrawingInterface::IsHorizontal(
+    const std::vector<int> &items, const std::vector<data_BEAMPLACE> &directions) const
 {
     // items and directions should be of the same size, otherwise something is wrong
     if (items.size() != directions.size()) return false;
     if ((items.size() == 3) && m_crossStaffContent) {
-        if ((directions.at(0) == directions.at(2)) && (directions.at(0) != directions.at(1))) return true;        
+        if ((directions.at(0) == directions.at(2)) && (directions.at(0) != directions.at(1))) return true;
     }
 
     // calculate how many times stem direction is changed withing the beam

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -343,7 +343,7 @@ bool BeamDrawingInterface::IsHorizontal(const std::vector<int>& items, const std
 {
     // items and directions should be of the same size, otherwise something is not wrong
     if (items.size() != directions.size()) return false;
-    if ((items.size() == 3) && (directions.front() == directions.back())) return true;
+    if ((items.size() == 3) && (directions.front() == directions.back()) && m_crossStaffContent) return true;
 
     // calculate how many times stem direction is changed withing the beam
     int directionChanges = 0;

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -107,6 +107,16 @@ void FTrem::FilterList(ArrayOfObjects *childList)
     this->InitCue(false);
 }
 
+std::pair<int, int> FTrem::GetAdditionalBeamCount() const
+{
+    return { std::max(this->GetBeams(), this->GetBeamsFloat()), 0 };
+}
+
+std::pair<int, int> FTrem::GetFloatingBeamCount() const
+{
+    return { this->GetBeams(), this->GetBeamsFloat() };
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -313,8 +313,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
     }
 }
 
-template <class BeamType>
-void LayerElement::GetBeamOverflow(StaffAlignment *&above, StaffAlignment *&below)
+template <class BeamType> void LayerElement::GetBeamOverflow(StaffAlignment *&above, StaffAlignment *&below)
 {
     if (!this->Is({ BEAM, FTREM })) return;
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -300,7 +300,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
             this->GetBeamChildOverflow<Beam>(above, below, beam);
         }
         else if (this->GetFirstAncestor(FTREM)) {
-            FTrem *fTrem = vrv_cast<FTrem *>(this->GetFirstAncestor(BEAM));
+            FTrem *fTrem = vrv_cast<FTrem *>(this->GetFirstAncestor(FTREM));
             this->GetBeamChildOverflow<FTrem>(above, below, fTrem);
         }
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -290,65 +290,95 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
     above = staff->GetAlignment();
     below = above;
 
-    // Chord and beam parent (if any)
-    Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
-    Beam *beam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
+    // Dots, flags and stems with cross-staff chords need special treatment
+    this->GetChordOverflow(above, below, staff->GetN());
 
+    // Stems cross-staff beam need special treatment but only if the beam itself is not cross-staff
+    if (this->Is({ ARTIC, STEM })) {
+        if (this->GetFirstAncestor(BEAM)) {
+            Beam *beam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
+            this->GetBeamChildOverflow<Beam>(above, below, beam);
+        }
+        else if (this->GetFirstAncestor(FTREM)) {
+            FTrem *fTrem = vrv_cast<FTrem *>(this->GetFirstAncestor(BEAM));
+            this->GetBeamChildOverflow<FTrem>(above, below, fTrem);
+        }
+    }
+    // Beams in cross-staff situation need special treatment
+    else if (this->Is(BEAM)) {
+        this->GetBeamOverflow<Beam>(above, below);
+    }
+    else if (this->Is(FTREM)) {
+        this->GetBeamOverflow<FTrem>(above, below);
+    }
+}
+
+template <class BeamType>
+void LayerElement::GetBeamOverflow(StaffAlignment *&above, StaffAlignment *&below)
+{
+    if (!this->Is({ BEAM, FTREM })) return;
+
+    BeamType *beam = vrv_cast<BeamType *>(this);
+    assert(beam);
+    // Beam between the staves - ignore both above and below
+    if (!beam->m_crossStaffContent || beam->m_crossStaff) return;
+
+    data_STAFFREL_basic direction = beam->m_crossStaffRel;
+    if (beam->m_drawingPlace == BEAMPLACE_mixed) {
+        above = NULL;
+        below = NULL;
+    }
+    // Beam below - ignore above and find the appropriate below staff
+    else if (beam->m_drawingPlace == BEAMPLACE_below) {
+        above = NULL;
+        if (direction == STAFFREL_basic_above) {
+            below = beam->m_beamStaff->GetAlignment();
+        }
+        else {
+            below = beam->m_crossStaffContent->GetAlignment();
+        }
+    }
+    // Beam above - ignore below and find the appropriate above staff
+    else if (beam->m_drawingPlace == BEAMPLACE_above) {
+        below = NULL;
+        if (direction == STAFFREL_basic_below) {
+            above = beam->m_beamStaff->GetAlignment();
+        }
+        else {
+            above = beam->m_crossStaffContent->GetAlignment();
+        }
+    }
+}
+
+template <class BeamType>
+void LayerElement::GetBeamChildOverflow(StaffAlignment *&above, StaffAlignment *&below, BeamType *parent)
+{
+    if (parent && parent->m_crossStaffContent && !parent->m_crossStaff) {
+        data_STAFFREL_basic direction = parent->m_crossStaffRel;
+        if (direction == STAFFREL_basic_above) {
+            above = parent->m_crossStaffContent->GetAlignment();
+            below = parent->m_beamStaff->GetAlignment();
+        }
+        else {
+            above = parent->m_beamStaff->GetAlignment();
+            below = parent->m_crossStaffContent->GetAlignment();
+        }
+    }
+}
+
+void LayerElement::GetChordOverflow(StaffAlignment *&above, StaffAlignment *&below, int staffN)
+{
+    Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
     // Dots, flags and stems with cross-staff chords need special treatment
     if (this->Is({ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
         Staff *staffAbove = NULL;
         Staff *staffBelow = NULL;
         chord->GetCrossStaffExtremes(staffAbove, staffBelow);
-        if (staffAbove && (staffAbove->GetN() < staff->GetN())) {
+        if (staffAbove && (staffAbove->GetN() < staffN)) {
             above = staffAbove->GetAlignment();
         }
-        if (staffBelow && (staffBelow->GetN() > staff->GetN())) {
+        if (staffBelow && (staffBelow->GetN() > staffN)) {
             below = staffBelow->GetAlignment();
-        }
-    }
-    // Stems cross-staff beam need special treatment but only if the beam itself is not cross-staff
-    if (this->Is({ ARTIC, STEM }) && beam && beam->m_crossStaffContent && !beam->m_crossStaff) {
-        data_STAFFREL_basic direction = beam->m_crossStaffRel;
-        if (direction == STAFFREL_basic_above) {
-            above = beam->m_crossStaffContent->GetAlignment();
-            below = beam->m_beamStaff->GetAlignment();
-        }
-        else {
-            above = beam->m_beamStaff->GetAlignment();
-            below = beam->m_crossStaffContent->GetAlignment();
-        }
-    }
-    // Beams in cross-staff situation need special treatment
-    if (this->Is(BEAM)) {
-        beam = vrv_cast<Beam *>(this);
-        assert(beam);
-        // Beam between the staves - ignore both above and below
-        if (beam->m_crossStaffContent && !beam->m_crossStaff) {
-            data_STAFFREL_basic direction = beam->m_crossStaffRel;
-            if (beam->m_drawingPlace == BEAMPLACE_mixed) {
-                above = NULL;
-                below = NULL;
-            }
-            // Beam below - ignore above and find the appropriate below staff
-            else if (beam->m_drawingPlace == BEAMPLACE_below) {
-                above = NULL;
-                if (direction == STAFFREL_basic_above) {
-                    below = beam->m_beamStaff->GetAlignment();
-                }
-                else {
-                    below = beam->m_crossStaffContent->GetAlignment();
-                }
-            }
-            // Beam above - ignore below and find the appropriate above staff
-            else if (beam->m_drawingPlace == BEAMPLACE_above) {
-                below = NULL;
-                if (direction == STAFFREL_basic_below) {
-                    above = beam->m_beamStaff->GetAlignment();
-                }
-                else {
-                    above = beam->m_crossStaffContent->GetAlignment();
-                }
-            }
         }
     }
 }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -377,6 +377,11 @@ int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
     }
 }
 
+void Staff::SetAlignmentBeamAdjustment(int adjust)
+{
+    m_staffAlignment->SetBeamAdjust(adjust);
+}
+
 //----------------------------------------------------------------------------
 // LedgerLine
 //----------------------------------------------------------------------------

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -506,6 +506,10 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
 
     // Add a margin
     overflowSum += doc->GetBottomMargin(STAFF) * doc->GetDrawingUnit(this->GetStaffSize());
+    if (const int adjust = prevAlignment->GetBeamAdjust()) {
+        overflowSum += adjust;
+    }
+
 
     BoundingBox *previous = prevAlignment->GetOverflowBBoxBelow();
     BoundingBox *current = this->GetOverflowBBoxAbove();


### PR DESCRIPTION
closes #2159
closes #2188 
closes #1939 
closes #1847
closes #1957
closes #2004

This PR improves several of the cross-staff beam cases, as well as introduces some general beam improvements (horizontal beam placement from #1939).
![image](https://user-images.githubusercontent.com/1819669/146936262-38b32a0f-e6b0-4f18-985b-19bc4e59c8e3.png)
![image](https://user-images.githubusercontent.com/1819669/147080973-c1827f85-bae4-4e6b-8a6e-469159d1ce9d.png)
![image](https://user-images.githubusercontent.com/1819669/147081545-64c63fe3-213e-47b5-a823-4ab7fecc87e2.png)

For this case, since mixed beam cannot be placed within the staff without overlapping with notes/stems or falling outside of the staff, it is converted to ordinary beam.
![image](https://user-images.githubusercontent.com/1819669/146936362-cc0ad074-cf7c-41d5-a4d0-a562a4aa6834.png)
cross-staff-001 before and after:
![image](https://user-images.githubusercontent.com/1819669/146936910-ab240288-561a-4561-976d-6c01cdba3394.png)
![image](https://user-images.githubusercontent.com/1819669/146936955-5cffaa69-82f1-4242-aaf5-b60621363cfb.png)
cross-staff-004:
![image](https://user-images.githubusercontent.com/1819669/146936598-519b8864-37f2-408f-9009-09e7e25188c2.png)
![image](https://user-images.githubusercontent.com/1819669/146936685-7a8b5069-33bf-4adc-a654-0a8964fd9f94.png)
cross-staff-007:
![image](https://user-images.githubusercontent.com/1819669/146936723-c02e9ad9-d005-409b-8197-69e406f866fe.png)
![image](https://user-images.githubusercontent.com/1819669/146936729-dafaeb8d-88c7-4032-86fa-7d58df9c6adc.png)
cross-staff-023:
![image](https://user-images.githubusercontent.com/1819669/146937004-7fefea18-9dcb-4685-83b3-3c808f842387.png)
![image](https://user-images.githubusercontent.com/1819669/146937017-68614030-1b7a-46f4-aff3-63eea40b88d5.png)
