### PR TITLE
Fix widow measures and score based export

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run clang-format style check for C/C++ programs.
-        uses: jidicula/clang-format-action@v3.4.0
+        uses: jidicula/clang-format-action@v4.4.1
         with:
           clang-format-version: "11"
           check-path: ${{ matrix.path['check'] }}


### PR DESCRIPTION
An assertion is triggered in the MEI export of documents with widow measures (single measure on the last page). The problem is that the system end milestones are not transferred to the previous page along with the widow measure. This messes up the pairing of page/system elements and their corresponding end milestones.

The issue can be reproduced by loading an MEI with widow measure with --breaks-no-widow enabled. Next perform an MEI export. This triggers the assertion in `MEIOutput::WriteObjectEnd`.

This PR fixes the problem by moving the entire content of the system containing the widow measure.