### PR TITLE
Fix missing hyphens

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -207,6 +207,11 @@ public:
     int PrepareLayerElementParts(FunctorParams *functorParams) override;
 
     /**
+     * See Object::PrepareLyrics
+     */
+    int PrepareLyrics(FunctorParams *functorParams) override;
+
+    /**
      * See Object::CalcOnsetOffsetEnd
      */
     int CalcOnsetOffsetEnd(FunctorParams *functorParams) override;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1896,7 +1896,8 @@ public:
 
 /**
  * member 0: the current Syl
- * member 1: the last Note
+ * member 1: the last Note or Chord
+ * member 2: the penultimate Note or Chord
  **/
 
 class PrepareLyricsParams : public FunctorParams {
@@ -1904,12 +1905,12 @@ public:
     PrepareLyricsParams()
     {
         m_currentSyl = NULL;
-        m_lastNote = NULL;
-        m_lastButOneNote = NULL;
+        m_lastNoteOrChord = NULL;
+        m_penultimateNoteOrChord = NULL;
     }
     Syl *m_currentSyl;
-    Note *m_lastNote;
-    Note *m_lastButOneNote;
+    LayerElement *m_lastNoteOrChord;
+    LayerElement *m_penultimateNoteOrChord;
 };
 
 //----------------------------------------------------------------------------

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -871,6 +871,17 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Chord::PrepareLyrics(FunctorParams *functorParams)
+{
+    PrepareLyricsParams *params = vrv_params_cast<PrepareLyricsParams *>(functorParams);
+    assert(params);
+
+    params->m_penultimateNoteOrChord = params->m_lastNoteOrChord;
+    params->m_lastNoteOrChord = this;
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Chord::CalcOnsetOffsetEnd(FunctorParams *functorParams)
 {
     CalcOnsetOffsetParams *params = vrv_params_cast<CalcOnsetOffsetParams *>(functorParams);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1865,8 +1865,8 @@ int Doc::PrepareLyricsEnd(FunctorParams *functorParams)
     if (!params->m_currentSyl) {
         return FUNCTOR_STOP; // early return
     }
-    if (params->m_lastNote && (params->m_currentSyl->GetStart() != params->m_lastNote)) {
-        params->m_currentSyl->SetEnd(params->m_lastNote);
+    if (params->m_lastNoteOrChord && (params->m_currentSyl->GetStart() != params->m_lastNoteOrChord)) {
+        params->m_currentSyl->SetEnd(params->m_lastNoteOrChord);
     }
     else if (m_options->m_openControlEvents.GetValue()) {
         sylLog_WORDPOS wordpos = params->m_currentSyl->GetWordpos();

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2785,7 +2785,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     // const std::string textColor = textNode.attribute("color").as_string();
                     const std::string textStyle = childNode.attribute("font-style").as_string();
                     const std::string textWeight = childNode.attribute("font-weight").as_string();
-                    const int lineThrough = childNode.attribute("line-through").as_int();
+                    const short int lineThrough = childNode.attribute("line-through").as_int();
                     const std::string lang = childNode.attribute("xml:lang").as_string();
                     std::string textStr = childNode.text().as_string();
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2785,7 +2785,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     // const std::string textColor = textNode.attribute("color").as_string();
                     const std::string textStyle = childNode.attribute("font-style").as_string();
                     const std::string textWeight = childNode.attribute("font-weight").as_string();
-                    int lineThrough = childNode.attribute("line-through").as_int();
+                    const int lineThrough = childNode.attribute("line-through").as_int();
                     const std::string lang = childNode.attribute("xml:lang").as_string();
                     std::string textStr = childNode.text().as_string();
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1273,8 +1273,10 @@ int Note::PrepareLyrics(FunctorParams *functorParams)
     PrepareLyricsParams *params = vrv_params_cast<PrepareLyricsParams *>(functorParams);
     assert(params);
 
-    params->m_lastButOneNote = params->m_lastNote;
-    params->m_lastNote = this;
+    if (!this->IsChordTone()) {
+        params->m_penultimateNoteOrChord = params->m_lastNoteOrChord;
+        params->m_lastNoteOrChord = this;
+    }
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -150,16 +150,16 @@ int Syl::PrepareLyrics(FunctorParams *functorParams)
         // The previous syl was an initial or median -> The note we just parsed is the end
         if ((params->m_currentSyl->GetWordpos() == sylLog_WORDPOS_i)
             || (params->m_currentSyl->GetWordpos() == sylLog_WORDPOS_m)) {
-            params->m_currentSyl->SetEnd(params->m_lastNote);
+            params->m_currentSyl->SetEnd(params->m_lastNoteOrChord);
             params->m_currentSyl->m_nextWordSyl = this;
         }
         // The previous syl was a underscore -> the previous but one was the end
         else if (params->m_currentSyl->GetCon() == sylLog_CON_u) {
-            if (params->m_currentSyl->GetStart() == params->m_lastButOneNote)
+            if (params->m_currentSyl->GetStart() == params->m_penultimateNoteOrChord)
                 LogWarning("Syllable with underline extender under one single note '%s'",
                     params->m_currentSyl->GetStart()->GetUuid().c_str());
             else
-                params->m_currentSyl->SetEnd(params->m_lastButOneNote);
+                params->m_currentSyl->SetEnd(params->m_penultimateNoteOrChord);
         }
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -187,7 +187,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
         }
     }
     if (!start || !end) return;
-    if (!interface->IsOrdered(start, end)) {
+    if (!interface->IsOrdered(start, end) && !element->Is(SYL)) {
         // To avoid showing the same warning multiple times, display a warning only during actual drawing
         if (!dc->Is(BBOX_DEVICE_CONTEXT) && (m_currentPage == vrv_cast<Page *>(start->GetFirstAncestor(PAGE)))) {
             LogWarning("%s '%s' is ignored, since start '%s' does not occur temporally before end '%s'.",


### PR DESCRIPTION
This PR fixes three problems causing missing syllable hyphens and closes #2565 .

1. The time spanning order check is skipped for syllables (red).
2. The musicxml importer can now deal with multiple `syllabic` elements within lyrics (blue).
3. The start and end of the time spanning interface is properly set for syllables between chords (green).
![After](https://user-images.githubusercontent.com/63608463/149130489-8d4d113e-013b-4158-af0e-4fbf53a01b96.png)

