### PR TITLE
Support for duration defaults

### DIFF
--- a/include/vrv/attdef.h
+++ b/include/vrv/attdef.h
@@ -38,6 +38,7 @@ typedef double data_VU;
  * These duration values are used for internal calculation and differ from the
  * MEI data.DURATION types (see below)
  */
+#define DUR_NONE -32
 #define DUR_MX -1 // maxima
 #define DUR_LG 0 // longa
 #define DUR_BR 1 // brevis
@@ -96,7 +97,7 @@ enum data_BEATRPT_REND {
  * MEI data.DURATION
  */
 enum data_DURATION {
-    DURATION_NONE = VRV_UNSET,
+    DURATION_NONE = DUR_NONE,
     DURATION_long = DUR_LG,
     DURATION_breve,
     DURATION_1,

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -408,6 +408,7 @@ public:
     Score *GetCurrentScore();
     ScoreDef *GetCurrentScoreDef();
     void SetCurrentScore(Score *score);
+    bool HasCurrentScore() const { return m_currentScore != NULL; }
     ///@}
 
     //----------//

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -45,7 +45,15 @@ public:
     virtual ~DurationInterface();
     void Reset() override;
     InterfaceId IsInterface() const override { return INTERFACE_DURATION; }
-    ///@}SetDurationGes
+    ///@}
+
+    /**
+     * @name Set and get the default duration
+     */
+    ///@{
+    void SetDurDefault(data_DURATION dur) { m_durDefault = dur; }
+    data_DURATION GetDurDefault() const { return m_durDefault; }
+    ///@}
 
     /**
      * Returns the duration (in double) for the element.
@@ -101,10 +109,18 @@ public:
     bool HasIdenticalDurationInterface(DurationInterface *otherDurationInterface);
 
 private:
-    //
+    /**
+     * Calculate the actual duration => translate mensural values
+     */
+    int CalcActualDur(data_DURATION dur) const;
+
 public:
     //
 private:
+    /**
+     * The default duration: extracted from scoreDef/staffDef and used when no duration attribute is given
+     */
+    data_DURATION m_durDefault;
 };
 
 } // namespace vrv

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1848,6 +1848,28 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// PrepareDurationParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the current scoredef default duration
+ * member 1: the current staffdef default durations
+ * member 2: the functor for redirection
+ **/
+
+class PrepareDurationParams : public FunctorParams {
+public:
+    PrepareDurationParams(Functor *functor)
+    {
+        m_durDefault = DURATION_NONE;
+        m_functor = functor;
+    }
+    data_DURATION m_durDefault;
+    std::map<int, data_DURATION> m_durDefaultForStaffN;
+    Functor *m_functor;
+};
+
+//----------------------------------------------------------------------------
 // PrepareFacsimileParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -295,48 +295,6 @@ public:
 // Use FunctorDocParams
 
 //----------------------------------------------------------------------------
-// AdjustGraceXPosParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the maximum position
- * member 1: the upcoming maximum position (i.e., the min pos for the next element)
- * member 2: the cumulated shift on the previous aligners
- * member 3: the list of staffN in the top-level scoreDef
- * member 4: the flag indicating whereas the alignment is in a Measure or in a Grace
- * member 5: the pointer to the right ALIGNMENT_DEFAULT (if any)
- * member 6: the Doc
- * member 7: the Functor to be redirected to MeasureAligner and GraceAligner
- * member 8: the end Functor for redirection
- **/
-
-class AdjustGraceXPosParams : public FunctorParams {
-public:
-    AdjustGraceXPosParams(Doc *doc, Functor *functor, Functor *functorEnd, std::vector<int> staffNs)
-    {
-        m_graceMaxPos = 0;
-        m_graceUpcomingMaxPos = -VRV_UNSET;
-        m_graceCumulatedXShift = 0;
-        m_staffNs = staffNs;
-        m_isGraceAlignment = false;
-        m_rightDefaultAlignment = NULL;
-        m_doc = doc;
-        m_functor = functor;
-        m_functorEnd = functorEnd;
-        m_staffNs = staffNs;
-    }
-    int m_graceMaxPos;
-    int m_graceUpcomingMaxPos;
-    int m_graceCumulatedXShift;
-    std::vector<int> m_staffNs;
-    bool m_isGraceAlignment;
-    Alignment *m_rightDefaultAlignment;
-    Doc *m_doc;
-    Functor *m_functor;
-    Functor *m_functorEnd;
-};
-
-//----------------------------------------------------------------------------
 // AdjustFloatingPositionersParams
 //----------------------------------------------------------------------------
 
@@ -405,6 +363,48 @@ public:
     std::vector<ClassId> m_classIds;
     data_STAFFREL m_place;
     Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
+// AdjustGraceXPosParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the maximum position
+ * member 1: the upcoming maximum position (i.e., the min pos for the next element)
+ * member 2: the cumulated shift on the previous aligners
+ * member 3: the list of staffN in the top-level scoreDef
+ * member 4: the flag indicating whereas the alignment is in a Measure or in a Grace
+ * member 5: the pointer to the right ALIGNMENT_DEFAULT (if any)
+ * member 6: the Doc
+ * member 7: the Functor to be redirected to MeasureAligner and GraceAligner
+ * member 8: the end Functor for redirection
+ **/
+
+class AdjustGraceXPosParams : public FunctorParams {
+public:
+    AdjustGraceXPosParams(Doc *doc, Functor *functor, Functor *functorEnd, std::vector<int> staffNs)
+    {
+        m_graceMaxPos = 0;
+        m_graceUpcomingMaxPos = -VRV_UNSET;
+        m_graceCumulatedXShift = 0;
+        m_staffNs = staffNs;
+        m_isGraceAlignment = false;
+        m_rightDefaultAlignment = NULL;
+        m_doc = doc;
+        m_functor = functor;
+        m_functorEnd = functorEnd;
+        m_staffNs = staffNs;
+    }
+    int m_graceMaxPos;
+    int m_graceUpcomingMaxPos;
+    int m_graceCumulatedXShift;
+    std::vector<int> m_staffNs;
+    bool m_isGraceAlignment;
+    Alignment *m_rightDefaultAlignment;
+    Doc *m_doc;
+    Functor *m_functor;
+    Functor *m_functorEnd;
 };
 
 //----------------------------------------------------------------------------
@@ -1521,6 +1521,26 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// GenerateFeaturesParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a pointer to the Doc
+ * member 1: a pointer to the FeatureExtractor to which extraction is delegated
+ **/
+
+class GenerateFeaturesParams : public FunctorParams {
+public:
+    GenerateFeaturesParams(Doc *doc, FeatureExtractor *extractor)
+    {
+        m_doc = doc;
+        m_extractor = extractor;
+    }
+    Doc *m_doc;
+    FeatureExtractor *m_extractor;
+};
+
+//----------------------------------------------------------------------------
 // GenerateMIDIParams
 //----------------------------------------------------------------------------
 
@@ -1596,26 +1616,6 @@ public:
     double m_realTimeOffsetMilliseconds;
     double m_currentTempo;
     Functor *m_functor;
-};
-
-//----------------------------------------------------------------------------
-// GenerateFeaturesParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: a pointer to the Doc
- * member 1: a pointer to the FeatureExtractor to which extraction is delegated
- **/
-
-class GenerateFeaturesParams : public FunctorParams {
-public:
-    GenerateFeaturesParams(Doc *doc, FeatureExtractor *extractor)
-    {
-        m_doc = doc;
-        m_extractor = extractor;
-    }
-    Doc *m_doc;
-    FeatureExtractor *m_extractor;
 };
 
 //----------------------------------------------------------------------------
@@ -1802,6 +1802,27 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// PrepareCrossStaffParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a pointer to the current measure
+ **/
+
+class PrepareCrossStaffParams : public FunctorParams {
+public:
+    PrepareCrossStaffParams()
+    {
+        m_currentMeasure = NULL;
+        m_currentCrossStaff = NULL;
+        m_currentCrossLayer = NULL;
+    }
+    Measure *m_currentMeasure;
+    Staff *m_currentCrossStaff;
+    Layer *m_currentCrossLayer;
+};
+
+//----------------------------------------------------------------------------
 // PrepareDelayedTurnsParams
 //----------------------------------------------------------------------------
 
@@ -1867,27 +1888,6 @@ public:
     std::vector<Hairpin *> m_hairpins;
     std::map<std::string, Harm *> m_harms;
     Doc *m_doc;
-};
-
-//----------------------------------------------------------------------------
-// PrepareCrossStaffParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: a pointer to the current measure
- **/
-
-class PrepareCrossStaffParams : public FunctorParams {
-public:
-    PrepareCrossStaffParams()
-    {
-        m_currentMeasure = NULL;
-        m_currentCrossStaff = NULL;
-        m_currentCrossLayer = NULL;
-    }
-    Measure *m_currentMeasure;
-    Staff *m_currentCrossStaff;
-    Layer *m_currentCrossLayer;
 };
 
 //----------------------------------------------------------------------------
@@ -2026,6 +2026,20 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// PrepareSlursParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the doc
+ **/
+
+class PrepareSlursParams : public FunctorParams {
+public:
+    PrepareSlursParams(Doc *doc) { m_doc = doc; }
+    Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
 // PrepareTimePointingParams
 //----------------------------------------------------------------------------
 
@@ -2069,6 +2083,18 @@ public:
     PrepareTimestampsParams() {}
     ListOfSpanningInterClassIdPairs m_timeSpanningInterfaces;
     ListOfObjectBeatPairs m_tstamps;
+};
+
+//----------------------------------------------------------------------------
+// ReorderByXPosParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a pointer to the current object whose children we (may) reorder
+ **/
+class ReorderByXPosParams : public FunctorParams {
+public:
+    int modifications = 0;
 };
 
 //----------------------------------------------------------------------------
@@ -2382,32 +2408,6 @@ public:
     }
     Page *m_page;
     System *m_currentSystem;
-};
-
-//----------------------------------------------------------------------------
-// ReorderByXPosParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: a pointer to the current object whose children we (may) reorder
- **/
-class ReorderByXPosParams : public FunctorParams {
-public:
-    int modifications = 0;
-};
-
-//----------------------------------------------------------------------------
-// PrepareSlursParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the doc
- **/
-
-class PrepareSlursParams : public FunctorParams {
-public:
-    PrepareSlursParams(Doc *doc) { m_doc = doc; }
-    Doc *m_doc;
 };
 
 } // namespace vrv

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -102,7 +102,7 @@ private:
     MeterSig *m_meter = NULL;
     Layer *m_layer = NULL;
 
-    data_DURATION m_durDefault; // todo: switch to MEI
+    data_DURATION m_durDefault;
     std::string m_ID;
     int m_unitDur;
     std::pair<data_BARRENDITION, data_BARRENDITION> m_barLines

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -398,6 +398,11 @@ public:
      */
     int PrepareSlurs(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::PrepareDuration
+     */
+    int PrepareDuration(FunctorParams *functorParams) override;
+
 protected:
     /**
      * Helper to figure whether two chords are in fully in unison based on the locations of the notes.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1072,6 +1072,11 @@ public:
     ///@}
 
     /**
+     * Extract default duration from scoredef/staffdef
+     */
+    virtual int PrepareDuration(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Match start for TimePointingInterface elements (such as fermata or harm).
      */
     ///@{

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -79,7 +79,10 @@ public:
      * Get the SMuFL glyph or a rest considering its actual duration.
      * This is valid only for CMN and for duration shorter than half notes.
      */
+    ///@{
     wchar_t GetRestGlyph() const;
+    wchar_t GetRestGlyph(int duration) const;
+    ///@}
 
     //----------//
     // Functors //

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -116,6 +116,11 @@ public:
      */
     int ScoreDefOptimize(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::PrepareDuration
+     */
+    int PrepareDuration(FunctorParams *functorParams) override;
+
 private:
     /**
      * The score/scoreDef (first child of the score)

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -234,7 +234,6 @@ public:
     int CastOffSystems(FunctorParams *functorParams) override;
 
     /**
-
      * See Object::CastOffEncoding
      */
     int CastOffEncoding(FunctorParams *functorParams) override;
@@ -248,6 +247,11 @@ public:
      * See Object::JustifyX
      */
     int JustifyX(FunctorParams *functorParams) override;
+
+    /**
+     * See Object::PrepareDuration
+     */
+    int PrepareDuration(FunctorParams *functorParams) override;
 
 protected:
     /**

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -28,6 +28,7 @@ namespace vrv {
  * It is not an abstract class but should not be instanciated directly.
  */
 class ScoreDefInterface : public Interface,
+                          public AttDurationDefault,
                           public AttLyricStyle,
                           public AttMeasureNumbers,
                           public AttMidiTempo,

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -74,6 +74,11 @@ public:
      */
     int SetStaffDefRedrawFlags(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::PrepareDuration
+     */
+    int PrepareDuration(FunctorParams *functorParams) override;
+
 private:
     //
 public:

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -512,6 +512,12 @@ void Doc::PrepareDrawing()
         this->Process(&resetDrawing, NULL);
     }
 
+    /************ Store default durations ************/
+
+    Functor prepareDuration(&Object::PrepareDuration);
+    PrepareDurationParams prepareDurationParams(&prepareDuration);
+    this->Process(&prepareDuration, &prepareDurationParams);
+
     /************ Resolve @startid / @endid ************/
 
     // Try to match all spanning elements (slur, tie, etc) by processing backwards

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -62,6 +62,8 @@ void DurationInterface::Reset()
     ResetDurationRatio();
     ResetFermataPresent();
     ResetStaffIdent();
+
+    m_durDefault = DURATION_NONE;
 }
 
 double DurationInterface::GetInterfaceAlignmentDuration(int num, int numBase)
@@ -176,17 +178,22 @@ bool DurationInterface::IsLastInBeam(LayerElement *noteOrRest)
 
 int DurationInterface::GetActualDur() const
 {
-    if (!this->HasDur()) return DURATION_NONE;
-    // maxima (-1) is a mensural only value
-    if (this->GetDur() == DURATION_maxima) return DUR_MX;
-    return (this->GetDur() & DUR_MENSURAL_MASK);
+    const data_DURATION dur = this->HasDur() ? this->GetDur() : this->GetDurDefault();
+    return this->CalcActualDur(dur);
 }
 
 int DurationInterface::GetActualDurGes() const
 {
+    const data_DURATION dur = this->HasDurGes() ? this->GetDurGes() : DURATION_NONE;
+    return this->CalcActualDur(dur);
+}
+
+int DurationInterface::CalcActualDur(data_DURATION dur) const
+{
+    if (dur == DURATION_NONE) return dur;
     // maxima (-1) is a mensural only value
-    if (this->GetDurGes() == DURATION_maxima) return DUR_MX;
-    return (this->GetDurGes() & DUR_MENSURAL_MASK);
+    if (dur == DURATION_maxima) return DUR_MX;
+    return (dur & DUR_MENSURAL_MASK);
 }
 
 int DurationInterface::GetNoteOrChordDur(LayerElement *element)

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -176,6 +176,7 @@ bool DurationInterface::IsLastInBeam(LayerElement *noteOrRest)
 
 int DurationInterface::GetActualDur() const
 {
+    if (!this->HasDur()) return DURATION_NONE;
     // maxima (-1) is a mensural only value
     if (this->GetDur() == DURATION_maxima) return DUR_MX;
     return (this->GetDur() & DUR_MENSURAL_MASK);

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -69,6 +69,7 @@ void DurationInterface::Reset()
 double DurationInterface::GetInterfaceAlignmentDuration(int num, int numBase)
 {
     int noteDur = this->GetDurGes() != DURATION_NONE ? this->GetActualDurGes() : this->GetActualDur();
+    if (noteDur == DUR_NONE) noteDur = DUR_4;
 
     if (this->HasNum()) num *= this->GetNum();
     if (this->HasNumbase()) numBase *= this->GetNumbase();
@@ -86,6 +87,7 @@ double DurationInterface::GetInterfaceAlignmentDuration(int num, int numBase)
 double DurationInterface::GetInterfaceAlignmentMensuralDuration(int num, int numBase, Mensur *currentMensur)
 {
     int noteDur = this->GetDurGes() != DURATION_NONE ? this->GetActualDurGes() : this->GetActualDur();
+    if (noteDur == DUR_NONE) noteDur = DUR_4;
 
     if (!currentMensur) {
         LogWarning("No current mensur for calculating duration");
@@ -190,7 +192,7 @@ int DurationInterface::GetActualDurGes() const
 
 int DurationInterface::CalcActualDur(data_DURATION dur) const
 {
-    if (dur == DURATION_NONE) return dur;
+    if (dur == DURATION_NONE) return DUR_NONE;
     // maxima (-1) is a mensural only value
     if (dur == DURATION_maxima) return DUR_MX;
     return (dur & DUR_MENSURAL_MASK);

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1556,7 +1556,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             section->AddChild(scoreDef);
             m_meter = NULL;
         }
-        
+
         if (m_durDefault != DURATION_NONE) {
             ScoreDef *scoreDef = new ScoreDef();
             scoreDef->SetDurDefault(m_durDefault);

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -161,15 +161,15 @@ void ABCInput::parseABC(std::istream &infile)
                 staffDef->AddChild(m_clef);
                 m_clef = NULL;
             }
+            if (m_meter) {
+                staffDef->AddChild(m_meter);
+                m_meter = NULL;
+            }
             staffGrp->AddChild(staffDef);
             m_doc->GetCurrentScoreDef()->AddChild(staffGrp);
             if (m_key) {
                 m_doc->GetCurrentScoreDef()->AddChild(m_key);
                 m_key = NULL;
-            }
-            if (m_meter) {
-                m_doc->GetCurrentScoreDef()->AddChild(m_meter);
-                m_meter = NULL;
             }
         }
 
@@ -577,7 +577,6 @@ void ABCInput::parseKey(std::string &keyString)
     m_key = new KeySig();
     m_key->IsAttribute(true);
     m_clef = new Clef();
-    m_clef->IsAttribute(true);
     while (isspace(keyString[i])) ++i;
 
     // set key.pname
@@ -767,7 +766,6 @@ void ABCInput::parseMeter(const std::string &meterString)
         // this is a little "hack", until libMEI is fixed
         m_meter->SetCount({ atoi(meterCount.c_str()) });
         m_meter->SetUnit(atoi(&meterString[meterString.find('/') + 1]));
-        m_meter->IsAttribute(true);
     }
 }
 

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -146,7 +146,7 @@ void ABCInput::parseABC(std::istream &infile)
         // create score
         assert(m_mdiv != NULL);
         Score *score = new Score();
-        if (!m_doc->GetCurrentScoreDef()->GetFirst(STAFFGRP)) {
+        if (!m_doc->HasCurrentScore() || !m_doc->GetCurrentScoreDef()->GetFirst(STAFFGRP)) {
             m_mdiv->AddChild(score);
 
             // create page head
@@ -185,6 +185,7 @@ void ABCInput::parseABC(std::istream &infile)
         if (m_durDefault == DURATION_NONE) {
             CalcUnitNoteLength();
         }
+        m_doc->GetCurrentScoreDef()->SetDurDefault(m_durDefault);
 
         // read music code
         m_layer = new Layer();
@@ -295,12 +296,10 @@ void ABCInput::CalcUnitNoteLength()
     if (!meterSig || !meterSig->HasUnit() || double(meterSig->GetTotalCount()) / double(meterSig->GetUnit()) >= 0.75) {
         m_unitDur = 8;
         m_durDefault = DURATION_8;
-        // m_doc->m_scoreDef.SetDurDefault(DURATION_8);
     }
     else {
         m_unitDur = 16;
         m_durDefault = DURATION_16;
-        // m_doc->m_scoreDef.SetDurDefault(DURATION_16);
     }
 }
 
@@ -744,7 +743,6 @@ void ABCInput::parseUnitNoteLength(const std::string &unitNoteLength)
         case 256: m_durDefault = DURATION_256; break;
         default: break;
     }
-    // m_doc->m_scoreDef.SetDurDefault(m_durDefault);
 }
 
 void ABCInput::parseMeter(const std::string &meterString)

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -186,6 +186,7 @@ void ABCInput::parseABC(std::istream &infile)
             CalcUnitNoteLength();
         }
         m_doc->GetCurrentScoreDef()->SetDurDefault(m_durDefault);
+        m_durDefault = DURATION_NONE;
 
         // read music code
         m_layer = new Layer();
@@ -1554,6 +1555,13 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             scoreDef->AddChild(m_meter);
             section->AddChild(scoreDef);
             m_meter = NULL;
+        }
+        
+        if (m_durDefault != DURATION_NONE) {
+            ScoreDef *scoreDef = new ScoreDef();
+            scoreDef->SetDurDefault(m_durDefault);
+            section->AddChild(scoreDef);
+            m_durDefault = DURATION_NONE;
         }
     }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2684,6 +2684,7 @@ void MEIOutput::WriteScoreDefInterface(pugi::xml_node element, ScoreDefInterface
 {
     assert(interface);
 
+    interface->WriteDurationDefault(element);
     interface->WriteLyricStyle(element);
     interface->WriteMidiTempo(element);
     interface->WriteMultinumMeasures(element);
@@ -6472,6 +6473,7 @@ bool MEIInput::ReadPositionInterface(pugi::xml_node element, PositionInterface *
 
 bool MEIInput::ReadScoreDefInterface(pugi::xml_node element, ScoreDefInterface *interface)
 {
+    interface->ReadDurationDefault(element);
     interface->ReadLyricStyle(element);
     interface->ReadMidiTempo(element);
     interface->ReadMultinumMeasures(element);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2546,4 +2546,28 @@ int LayerElement::PrepareSlurs(FunctorParams *)
     return FUNCTOR_SIBLINGS;
 }
 
+int LayerElement::PrepareDuration(FunctorParams *functorParams)
+{
+    PrepareDurationParams *params = vrv_params_cast<PrepareDurationParams *>(functorParams);
+    assert(params);
+
+    DurationInterface *durInterface = this->GetDurationInterface();
+    if (durInterface) {
+        durInterface->SetDurDefault(params->m_durDefault);
+        // Check if there is a duration default for the staff
+        if (!params->m_durDefaultForStaffN.empty()) {
+            Layer *layer = NULL;
+            Staff *staff = this->GetCrossStaff(layer);
+            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+            assert(staff);
+
+            if (params->m_durDefaultForStaffN.count(staff->GetN()) > 0) {
+                durInterface->SetDurDefault(params->m_durDefaultForStaffN.at(staff->GetN()));
+            }
+        }
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -220,6 +220,11 @@ void Rest::AddChild(Object *child)
 
 wchar_t Rest::GetRestGlyph() const
 {
+    return this->GetRestGlyph(this->GetActualDur());
+}
+
+wchar_t Rest::GetRestGlyph(const int duration) const
+{
     // If there is glyph.num, prioritize it
     if (HasGlyphNum()) {
         wchar_t code = GetGlyphNum();
@@ -231,7 +236,7 @@ wchar_t Rest::GetRestGlyph() const
         if (NULL != Resources::GetGlyph(code)) return code;
     }
 
-    switch (this->GetActualDur()) {
+    switch (duration) {
         case DUR_LG: return SMUFL_E4E1_restLonga; break;
         case DUR_BR: return SMUFL_E4E2_restDoubleWhole; break;
         case DUR_1: return SMUFL_E4E3_restWhole; break;

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -263,4 +263,17 @@ int Score::ScoreDefOptimize(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Score::PrepareDuration(FunctorParams *functorParams)
+{
+    PrepareDurationParams *params = vrv_params_cast<PrepareDurationParams *>(functorParams);
+    assert(params);
+
+    ScoreDef *scoreDef = this->GetScoreDef();
+    if (scoreDef) {
+        scoreDef->Process(params->m_functor, params);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -610,4 +610,15 @@ int ScoreDef::JustifyX(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int ScoreDef::PrepareDuration(FunctorParams *functorParams)
+{
+    PrepareDurationParams *params = vrv_params_cast<PrepareDurationParams *>(functorParams);
+    assert(params);
+
+    params->m_durDefaultForStaffN.clear();
+    params->m_durDefault = this->GetDurDefault();
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/scoredefinterface.cpp
+++ b/src/scoredefinterface.cpp
@@ -25,6 +25,7 @@ namespace vrv {
 
 ScoreDefInterface::ScoreDefInterface()
     : Interface()
+    , AttDurationDefault()
     , AttLyricStyle()
     , AttMeasureNumbers()
     , AttMidiTempo()
@@ -33,6 +34,7 @@ ScoreDefInterface::ScoreDefInterface()
     , AttSpacing()
     , AttSystems()
 {
+    RegisterInterfaceAttClass(ATT_DURATIONDEFAULT);
     RegisterInterfaceAttClass(ATT_LYRICSTYLE);
     RegisterInterfaceAttClass(ATT_MEASURENUMBERS);
     RegisterInterfaceAttClass(ATT_METERSIGDEFAULTLOG);
@@ -50,6 +52,7 @@ ScoreDefInterface::~ScoreDefInterface() {}
 
 void ScoreDefInterface::Reset()
 {
+    ResetDurationDefault();
     ResetLyricStyle();
     ResetMeasureNumbers();
     ResetMidiTempo();

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -168,4 +168,16 @@ int StaffDef::SetStaffDefRedrawFlags(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int StaffDef::PrepareDuration(FunctorParams *functorParams)
+{
+    PrepareDurationParams *params = vrv_params_cast<PrepareDurationParams *>(functorParams);
+    assert(params);
+
+    if (this->HasDurDefault() && this->HasN()) {
+        params->m_durDefaultForStaffN[this->GetN()] = this->GetDurDefault();
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1356,7 +1356,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         int drawingDur = note->GetDrawingDur();
         if (drawingDur == DUR_NONE) {
             if (note->IsInBeam() && !dc->Is(BBOX_DEVICE_CONTEXT)) {
-                LogWarning("Missing duration for note '%s'", note->GetUuid().c_str());
+                LogWarning("Missing duration for note '%s' in beam", note->GetUuid().c_str());
             }
             drawingDur = DUR_4;
         }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1432,17 +1432,17 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     if (rest->m_crossStaff) staff = rest->m_crossStaff;
 
     const bool drawingCueSize = rest->GetDrawingCueSize();
-    const int drawingDur = rest->GetActualDur();
+    int drawingDur = rest->GetActualDur();
     if (drawingDur == DUR_NONE) {
         if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
             LogWarning("Missing duration for rest '%s'", rest->GetUuid().c_str());
         }
-        return;
+        drawingDur = DUR_4;
     }
-    const wchar_t drawingGlyph = rest->GetRestGlyph();
+    const wchar_t drawingGlyph = rest->GetRestGlyph(drawingDur);
 
-    int x = element->GetDrawingX();
-    int y = element->GetDrawingY();
+    const int x = element->GetDrawingX();
+    const int y = element->GetDrawingY();
 
     DrawSmuflCode(dc, x, y, drawingGlyph, staff->m_drawingStaffSize, drawingCueSize);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1354,6 +1354,12 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     if (!(note->GetHeadVisible() == BOOLEAN_false)) {
         /************** Noteheads: **************/
         int drawingDur = note->GetDrawingDur();
+        if (drawingDur == DUR_NONE) {
+            if (note->IsInBeam() && !dc->Is(BBOX_DEVICE_CONTEXT)) {
+                LogWarning("Missing duration for note '%s'", note->GetUuid().c_str());
+            }
+            drawingDur = DUR_4;
+        }
         drawingDur = ((note->GetColored() == BOOLEAN_true) && drawingDur > DUR_1) ? (drawingDur + 1) : drawingDur;
 
         if (drawingDur < DUR_BR) {
@@ -1427,6 +1433,12 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     const bool drawingCueSize = rest->GetDrawingCueSize();
     const int drawingDur = rest->GetActualDur();
+    if (drawingDur == DUR_NONE) {
+        if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
+            LogWarning("Missing duration for rest '%s'", rest->GetUuid().c_str());
+        }
+        return;
+    }
     const wchar_t drawingGlyph = rest->GetRestGlyph();
 
     int x = element->GetDrawingX();


### PR DESCRIPTION
This PR adds support for @dur.default on scoreDef and staffDef. Support is also added on the ABC importer.

**MEI example and rendering**
<img width="391" alt="After" src="https://user-images.githubusercontent.com/63608463/149324534-e1de2524-725d-4456-bad5-48690dec7461.png">

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef dur.default="2">
                  <staffGrp bar.thru="true" symbol="brace">
                    <staffDef n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="3f" meter.sym="common" />
                    <staffDef n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="3f" meter.sym="common" dur.default="16" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <chord stem.dir="up" artic="acc">
                             <note oct="4" pname="b" accid="n" />
                             <note oct="5" pname="d" />
                             <note oct="5" pname="f" />
                             <note oct="5" pname="g" />
                             <note oct="5" pname="b" accid="n" />
                          </chord>
                          <rest dur="2"/>
                        </layer>
                        <layer n="2">
                           <rest dur="8"/>
                           <beam>
                              <note xml:id="note-m1-l2-1" dur="16" oct="4" pname="a" accid.ges="f">
                                <artic artic="acc" place="above"/>
                              </note>
                              <note xml:id="note-m1-l2-2" dur="16" oct="4" pname="g" />
                           </beam>
                           <beam>
                              <note xml:id="note-m1-l2-3" dur="16" oct="4" pname="f">
                                <artic artic="acc" place="above"/>
                              </note>
                              <note xml:id="note-m1-l2-4" dur="16" oct="4" pname="d" />
                              <note xml:id="note-m1-l2-5" dur="16" oct="4" pname="e" accid.ges="f" />
                              <note xml:id="note-m1-l2-6" dur="16" oct="4" pname="d" />
                           </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="3">
                           <space dur="2"/>
                           <beam>
                              <note xml:id="note-m1-l3-1" oct="3" pname="b" stem.dir="up" accid="n">
                                <artic artic="acc" place="above"/>
                              </note>
                              <note xml:id="note-m1-l3-2" oct="3" pname="g" />
                              <note xml:id="note-m1-l3-3" oct="3" pname="a" accid.ges="f" />
                              <note xml:id="note-m1-l3-4" oct="3" pname="g" />
                           </beam>
                           <beam>
                              <note oct="3" pname="f" stem.dir="up">
                                <artic artic="acc" place="above"/>
                              </note>
                              <note oct="3" pname="d" />
                              <note oct="3" pname="e" accid.ges="f" />
                              <note oct="3" pname="d" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```