### PR TITLE
MIDI for grace notes

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -226,6 +226,11 @@ public:
      */
     int AdjustCrossStaffContent(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::GenerateMIDI
+     */
+    int GenerateMIDI(FunctorParams *functorParams) override;
+
 protected:
     /**
      * The note locations w.r.t. each staff

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1571,7 +1571,9 @@ using MIDIChordSequence = std::list<MIDIChord>;
  * member 4: int: the semi tone transposition for the current track
  * member 5: double with the current tempo
  * member 6: expanded notes due to ornaments and tremolandi
- * member 7: grace note sequence
+ * member 7: deferred notes which start slightly later
+ * member 8: grace note sequence
+ * member 9: the functor
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1593,6 +1595,7 @@ public:
     int m_transSemi;
     double m_currentTempo;
     std::map<Note *, MIDINoteSequence> m_expandedNotes;
+    std::map<Note *, double> m_deferredNotes;
     MIDIChordSequence m_graceNotes;
     Functor *m_functor;
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1548,7 +1548,7 @@ public:
  * Helper struct to store note sequences which replace notes in MIDI output due to expanded ornaments and tremolandi
  */
 struct MIDINote {
-    char pitch;
+    int pitch;
     double duration;
 };
 
@@ -1558,7 +1558,7 @@ using MIDINoteSequence = std::list<MIDINote>;
  * Helper struct to store chord sequences in MIDI output due to grace notes
  */
 struct MIDIChord {
-    std::set<char> pitches;
+    std::set<int> pitches;
     double duration;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1555,12 +1555,23 @@ struct MIDINote {
 using MIDINoteSequence = std::list<MIDINote>;
 
 /**
+ * Helper struct to store chord sequences in MIDI output due to grace notes
+ */
+struct MIDIChord {
+    std::set<char> pitches;
+    double duration;
+};
+
+using MIDIChordSequence = std::list<MIDIChord>;
+
+/**
  * member 0: MidiFile*: the MidiFile we are writing to
  * member 1: int: the midi track number
  * member 3: double: the score time from the start of the music to the start of the current measure
  * member 4: int: the semi tone transposition for the current track
  * member 5: double with the current tempo
  * member 6: expanded notes due to ornaments and tremolandi
+ * member 7: grace note sequence
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1582,6 +1593,7 @@ public:
     int m_transSemi;
     double m_currentTempo;
     std::map<Note *, MIDINoteSequence> m_expandedNotes;
+    MIDIChordSequence m_graceNotes;
     Functor *m_functor;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1570,11 +1570,12 @@ using MIDIChordSequence = std::list<MIDIChord>;
  * member 3: double: the score time from the start of the music to the start of the current measure
  * member 4: int: the semi tone transposition for the current track
  * member 5: double with the current tempo
- * member 6: expanded notes due to ornaments and tremolandi
- * member 7: deferred notes which start slightly later
- * member 8: grace note sequence
- * member 9: flag indicating whether the last grace note/chord was accented
- * member 10: the functor
+ * member 6: the last (non grace) note that was performed
+ * member 7: expanded notes due to ornaments and tremolandi
+ * member 8: deferred notes which start slightly later
+ * member 9: grace note sequence
+ * member 10: flag indicating whether the last grace note/chord was accented
+ * member 11: the functor
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1587,6 +1588,7 @@ public:
         m_totalTime = 0.0;
         m_transSemi = 0;
         m_currentTempo = 120.0;
+        m_lastNote = NULL;
         m_accentedGraceNote = false;
         m_functor = functor;
     }
@@ -1596,6 +1598,7 @@ public:
     double m_totalTime;
     int m_transSemi;
     double m_currentTempo;
+    Note *m_lastNote;
     std::map<Note *, MIDINoteSequence> m_expandedNotes;
     std::map<Note *, double> m_deferredNotes;
     MIDIChordSequence m_graceNotes;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1573,7 +1573,8 @@ using MIDIChordSequence = std::list<MIDIChord>;
  * member 6: expanded notes due to ornaments and tremolandi
  * member 7: deferred notes which start slightly later
  * member 8: grace note sequence
- * member 9: the functor
+ * member 9: flag indicating whether the last grace note/chord was accented
+ * member 10: the functor
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1586,6 +1587,7 @@ public:
         m_totalTime = 0.0;
         m_transSemi = 0;
         m_currentTempo = 120.0;
+        m_accentedGraceNote = false;
         m_functor = functor;
     }
     smf::MidiFile *m_midiFile;
@@ -1597,6 +1599,7 @@ public:
     std::map<Note *, MIDINoteSequence> m_expandedNotes;
     std::map<Note *, double> m_deferredNotes;
     MIDIChordSequence m_graceNotes;
+    bool m_accentedGraceNote;
     Functor *m_functor;
 };
 

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -36,6 +36,17 @@ public:
      */
     bool IsSupportedChild(Object *object) override;
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * @name See Object::GenerateMIDIEnd
+     */
+    ///@{
+    int GenerateMIDIEnd(FunctorParams *functorParams) override;
+    ///@}
+
 protected:
     //
 private:

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -219,15 +219,18 @@ public:
     void SetScoreTimeOffset(double scoreTime);
     void SetRealTimeOffsetSeconds(double timeInSeconds);
     void SetScoreTimeTiedDuration(double timeInSeconds);
-    void CalcMIDIPitch(int shift);
     double GetScoreTimeOnset() const;
     double GetRealTimeOnsetMilliseconds() const;
     double GetScoreTimeOffset() const;
     double GetScoreTimeTiedDuration() const;
     double GetRealTimeOffsetMilliseconds() const;
     double GetScoreTimeDuration() const;
-    char GetMIDIPitch() const;
     ///@}
+
+    /**
+     * MIDI pitch
+     */
+    int GetMIDIPitch(int shift);
 
 public:
     //----------------//
@@ -411,11 +414,6 @@ private:
      * indicate that it should not be written to MIDI output.
      */
     double m_scoreTimeTiedDuration;
-
-    /**
-     * The MIDI pitch of the note.
-     */
-    char m_MIDIPitch;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -343,6 +343,16 @@ private:
      */
     bool IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShifted);
 
+    /**
+     * Register deferred notes for MIDI
+     */
+    void DeferMIDINote(FunctorParams *functorParams, double shift, bool includeChordSiblings);
+
+    /**
+     * Create the MIDI output of the grace note sequence stored in params
+     */
+    void GenerateGraceNoteMIDI(FunctorParams *functorParams, double startTime, int tpq, int channel, int velocity);
+
 public:
     //
 private:

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -230,7 +230,7 @@ public:
     /**
      * MIDI pitch
      */
-    int GetMIDIPitch(int shift);
+    int GetMIDIPitch(int shift = 0);
 
 public:
     //----------------//

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1269,6 +1269,7 @@ public:
      */
     ///@{
     virtual int GenerateMIDI(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int GenerateMIDIEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
     ///@}
 
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -65,6 +65,8 @@ enum MEIVersion { MEI_UNDEFINED = 0, MEI_2013, MEI_3_0_0, MEI_4_0_0, MEI_4_0_1, 
 #define MIDI_VELOCITY 90
 #define MIDI_TEMPO 120
 
+#define UNACC_GRACENOTE_DUR 27 // in milliseconds
+
 //----------------------------------------------------------------------------
 // Object defines
 //----------------------------------------------------------------------------

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -86,8 +86,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     auto expandNote = [params, noteInQuarterDur](Object *obj) {
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
-        note->CalcMIDIPitch(params->m_transSemi);
-        const char pitch = note->GetMIDIPitch();
+        const int pitch = note->GetMIDIPitch(params->m_transSemi);
         const double totalInQuarterDur = note->GetScoreTimeDuration() + note->GetScoreTimeTiedDuration();
         const int multiplicity = totalInQuarterDur / noteInQuarterDur;
         (params->m_expandedNotes)[note] = MIDINoteSequence(multiplicity, { pitch, noteInQuarterDur });

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -24,6 +24,7 @@
 #include "elementpart.h"
 #include "fermata.h"
 #include "functorparams.h"
+#include "gracegrp.h"
 #include "horizontalaligner.h"
 #include "layer.h"
 #include "note.h"
@@ -993,6 +994,12 @@ int Chord::GenerateMIDI(FunctorParams *functorParams)
         }
 
         params->m_graceNotes.push_back({ pitches, quarterDuration });
+
+        bool accented = (this->GetGrace() == GRACE_acc);
+        GraceGrp *graceGrp = vrv_cast<GraceGrp *>(this->GetFirstAncestor(GRACEGRP));
+        if (graceGrp && (graceGrp->GetGrace() == GRACE_acc)) accented = true;
+        params->m_accentedGraceNote = accented;
+
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -970,4 +970,33 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Chord::GenerateMIDI(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    // Handle grace chords
+    if (this->IsGraceNote()) {
+        std::set<int> pitches;
+        const ArrayOfObjects *notes = this->GetList(this);
+        assert(notes);
+        for (Object *obj : *notes) {
+            Note *note = vrv_cast<Note *>(obj);
+            assert(note);
+            pitches.insert(note->GetMIDIPitch(params->m_transSemi));
+        }
+
+        double quarterDuration = 0.0;
+        const data_DURATION dur = this->GetDur();
+        if ((dur >= DURATION_long) && (dur <= DURATION_1024)) {
+            quarterDuration = pow(2.0, (DURATION_4 - dur));
+        }
+
+        params->m_graceNotes.push_back({ pitches, quarterDuration });
+        return FUNCTOR_SIBLINGS;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -57,9 +57,9 @@ void Clef::Reset()
 
 int Clef::GetClefLocOffset() const
 {
-    if (this->HasSameasLink() && this->GetSameasLink()->Is(CLEF)) {
-        Clef *sameas = vrv_cast<Clef *>(this->GetSameasLink());
-        assert(sameas);
+    // Only resolve simple sameas links to avoid infinite recursion
+    Clef *sameas = dynamic_cast<Clef *>(this->GetSameasLink());
+    if (sameas && !sameas->HasSameasLink()) {
         return sameas->GetClefLocOffset();
     }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -382,6 +382,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             filters.push_back(&matchLayer);
 
             Functor generateMIDI(&Object::GenerateMIDI);
+            Functor generateMIDIEnd(&Object::GenerateMIDIEnd);
             GenerateMIDIParams generateMIDIParams(midiFile, &generateMIDI);
             generateMIDIParams.m_midiChannel = midiChannel;
             generateMIDIParams.m_midiTrack = midiTrack;
@@ -389,7 +390,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             generateMIDIParams.m_currentTempo = tempo;
 
             // LogDebug("Exporting track %d ----------------", midiTrack);
-            this->Process(&generateMIDI, &generateMIDIParams, NULL, &filters);
+            this->Process(&generateMIDI, &generateMIDIParams, &generateMIDIEnd, &filters);
         }
     }
 }

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -60,10 +60,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
         // Check if the note is tied to a previous one and skip it if yes
         if (note->GetScoreTimeTiedDuration() == -1.0) return;
 
-        note->CalcMIDIPitch(0);
-
         std::stringstream pitch;
-
         data_OCTAVE oct = note->GetOct();
         char octSign = (oct > 3) ? '\'' : ',';
         int signCount = (oct > 3) ? (oct - 3) : (4 - oct);
@@ -105,7 +102,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
 
         // We have a previous note, so we can calculate an interval
         if (m_previousNote) {
-            std::string interval = StringFormat("%d", note->GetMIDIPitch() - m_previousNote->GetMIDIPitch());
+            std::string interval = StringFormat("%d", note->GetMIDIPitch(0) - m_previousNote->GetMIDIPitch(0));
             m_intervals << interval;
             jsonxx::Array intervalsIds;
             intervalsIds << m_previousNote->GetUuid();

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -102,7 +102,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
 
         // We have a previous note, so we can calculate an interval
         if (m_previousNote) {
-            std::string interval = StringFormat("%d", note->GetMIDIPitch(0) - m_previousNote->GetMIDIPitch(0));
+            std::string interval = StringFormat("%d", note->GetMIDIPitch() - m_previousNote->GetMIDIPitch());
             m_intervals << interval;
             jsonxx::Array intervalsIds;
             intervalsIds << m_previousNote->GetUuid();

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -84,6 +84,7 @@ int GraceGrp::GenerateMIDIEnd(FunctorParams *functorParams)
     GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
     assert(params);
 
+    // Handling of Nachschlag
     if (!params->m_graceNotes.empty() && (this->GetAttach() == graceGrpLog_ATTACH_pre) && !params->m_accentedGraceNote
         && params->m_lastNote) {
         double startTime = params->m_totalTime + params->m_lastNote->GetScoreTimeOffset();

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -100,7 +100,7 @@ int GraceGrp::GenerateMIDIEnd(FunctorParams *functorParams)
 
         for (const MIDIChord &chord : params->m_graceNotes) {
             const double stopTime = startTime + graceNoteDur;
-            for (char pitch : chord.pitches) {
+            for (int pitch : chord.pitches) {
                 params->m_midiFile->addNoteOn(params->m_midiTrack, startTime * tpq, channel, pitch, velocity);
                 params->m_midiFile->addNoteOff(params->m_midiTrack, stopTime * tpq, channel, pitch);
             }

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -16,10 +16,15 @@
 #include "beam.h"
 #include "chord.h"
 #include "editorial.h"
+#include "functorparams.h"
 #include "note.h"
 #include "rest.h"
 #include "space.h"
 #include "vrv.h"
+
+//----------------------------------------------------------------------------
+
+#include "MidiFile.h"
 
 namespace vrv {
 
@@ -72,6 +77,38 @@ bool GraceGrp::IsSupportedChild(Object *child)
         return false;
     }
     return true;
+}
+
+int GraceGrp::GenerateMIDIEnd(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    if (!params->m_graceNotes.empty() && (this->GetAttach() == graceGrpLog_ATTACH_pre) && !params->m_accentedGraceNote
+        && params->m_lastNote) {
+        double startTime = params->m_totalTime + params->m_lastNote->GetScoreTimeOffset();
+        const double graceNoteDur = UNACC_GRACENOTE_DUR * params->m_currentTempo / 60000.0;
+        const double totalDur = graceNoteDur * params->m_graceNotes.size();
+        startTime -= totalDur;
+        startTime = std::max(startTime, 0.0);
+
+        const int channel = params->m_midiChannel;
+        int velocity = MIDI_VELOCITY;
+        if (params->m_lastNote->HasVel()) velocity = params->m_lastNote->GetVel();
+        const int tpq = params->m_midiFile->getTPQ();
+
+        for (const MIDIChord &chord : params->m_graceNotes) {
+            const double stopTime = startTime + graceNoteDur;
+            for (char pitch : chord.pitches) {
+                params->m_midiFile->addNoteOn(params->m_midiTrack, startTime * tpq, channel, pitch, velocity);
+                params->m_midiFile->addNoteOff(params->m_midiTrack, stopTime * tpq, channel, pitch);
+            }
+            startTime = stopTime;
+        }
+
+        params->m_graceNotes.clear();
+    }
+    return FUNCTOR_CONTINUE;
 }
 
 } // namespace vrv

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -625,12 +625,13 @@ double LayerElement::GetAlignmentDuration(
         return 0.0;
     }
 
-    if (this->HasSameasLink() && this->GetSameasLink()->IsLayerElement()) {
-        LayerElement *sameas = vrv_cast<LayerElement *>(this->GetSameasLink());
-        assert(sameas);
+    // Only resolve simple sameas links to avoid infinite recursion
+    LayerElement *sameas = dynamic_cast<LayerElement *>(this->GetSameasLink());
+    if (sameas && !sameas->HasSameasLink()) {
         return sameas->GetAlignmentDuration(mensur, meterSig, notGraceOnly, notationType);
     }
-    else if (this->HasInterface(INTERFACE_DURATION)) {
+
+    if (this->HasInterface(INTERFACE_DURATION)) {
         int num = 1;
         int numbase = 1;
         Tuplet *tuplet = dynamic_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
@@ -2489,9 +2490,10 @@ int LayerElement::GenerateMIDI(FunctorParams *functorParams)
 
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
-    if (this->HasSameasLink()) {
-        assert(this->GetSameasLink());
-        this->GetSameasLink()->Process(params->m_functor, functorParams);
+    // Only resolve simple sameas links to avoid infinite recursion
+    LayerElement *sameas = dynamic_cast<LayerElement *>(this->GetSameasLink());
+    if (sameas && !sameas->HasSameasLink()) {
+        sameas->Process(params->m_functor, functorParams);
     }
 
     return FUNCTOR_CONTINUE;
@@ -2504,9 +2506,10 @@ int LayerElement::GenerateTimemap(FunctorParams *functorParams)
 
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
-    if (this->HasSameasLink()) {
-        assert(this->GetSameasLink());
-        this->GetSameasLink()->Process(params->m_functor, functorParams);
+    // Only resolve simple sameas links to avoid infinite recursion
+    LayerElement *sameas = dynamic_cast<LayerElement *>(this->GetSameasLink());
+    if (sameas && !sameas->HasSameasLink()) {
+        sameas->Process(params->m_functor, functorParams);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -779,7 +779,7 @@ void Note::GenerateGraceNoteMIDI(FunctorParams *functorParams, double startTime,
 
     for (const MIDIChord &chord : params->m_graceNotes) {
         const double stopTime = startTime + graceNoteDur;
-        for (char pitch : chord.pitches) {
+        for (int pitch : chord.pitches) {
             params->m_midiFile->addNoteOn(params->m_midiTrack, startTime * tpq, channel, pitch, velocity);
             params->m_midiFile->addNoteOff(params->m_midiTrack, stopTime * tpq, channel, pitch);
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1329,8 +1329,18 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    // For now just ignore grace notes
+    // Handle grace notes
     if (this->IsGraceNote()) {
+        this->CalcMIDIPitch(params->m_transSemi);
+        const char pitch = this->GetMIDIPitch();
+
+        double quarterDuration = 0.0;
+        const data_DURATION dur = this->GetDur();
+        if ((dur >= DURATION_long) && (dur <= DURATION_1024)) {
+            quarterDuration = pow(2.0, (DURATION_4 - dur));
+        }
+
+        params->m_graceNotes.push_back({ { pitch }, quarterDuration });
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -553,7 +553,7 @@ bool Note::IsVisible() const
 
 bool Note::IsEnharmonicWith(Note *note)
 {
-    return (this->GetMIDIPitch(0) == note->GetMIDIPitch(0));
+    return (this->GetMIDIPitch() == note->GetMIDIPitch());
 }
 
 void Note::SetScoreTimeOnset(double scoreTime)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -768,9 +768,7 @@ void Note::GenerateGraceNoteMIDI(FunctorParams *functorParams, double startTime,
         graceNoteDur = totalDur / params->m_graceNotes.size();
     }
     else {
-        // Unaccented grace notes obtain a fixed duration of 27 ms
-        constexpr int ms = 27;
-        graceNoteDur = ms * params->m_currentTempo / 60000.0;
+        graceNoteDur = UNACC_GRACENOTE_DUR * params->m_currentTempo / 60000.0;
         const double totalDur = graceNoteDur * params->m_graceNotes.size();
         if (startTime >= totalDur) {
             startTime -= totalDur;
@@ -1437,6 +1435,9 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
         params->m_midiFile->addNoteOn(params->m_midiTrack, startTime * tpq, channel, pitch, velocity);
         params->m_midiFile->addNoteOff(params->m_midiTrack, stopTime * tpq, channel, pitch);
     }
+
+    // Store reference, i.e. for Nachschlag
+    params->m_lastNote = this;
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -583,10 +583,12 @@ void Note::SetScoreTimeTiedDuration(double scoreTime)
     m_scoreTimeTiedDuration = scoreTime;
 }
 
-int Note::GetMIDIPitch(int shift)
+int Note::GetMIDIPitch(const int shift)
 {
+    int pitch = 0;
+
     if (this->HasPnum()) {
-        return this->GetPnum();
+        pitch = this->GetPnum();
     }
     else if (this->HasPname() || this->HasPnameGes()) {
         int midiBase = 0;
@@ -606,26 +608,23 @@ int Note::GetMIDIPitch(int shift)
         // Check for accidentals
         midiBase += this->GetChromaticAlteration();
 
-        // Apply shift, i.e. from transposition instruments
-        midiBase += shift;
-
         int oct = this->GetOct();
         if (this->HasOctGes()) oct = this->GetOctGes();
 
-        return midiBase + (oct + 1) * 12;
+        pitch = midiBase + (oct + 1) * 12;
     }
     else if (this->HasTabCourse()) {
         // tablature
         Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
         assert(staff);
         if (staff->m_drawingTuning) {
-            m_MIDIPitch = staff->m_drawingTuning->CalcPitchNumber(
+            pitch = staff->m_drawingTuning->CalcPitchNumber(
                 this->GetTabCourse(), this->GetTabFret(), staff->m_drawingNotationType);
         }
     }
-    else {
-        m_MIDIPitch = 0;
-    }
+
+    // Apply shift, i.e. from transposition instruments
+    return pitch + shift;
 }
 
 double Note::GetScoreTimeOnset() const

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1644,7 +1644,7 @@ std::string Toolkit::GetMIDIValuesForElement(const std::string &xmlId)
         Note *note = vrv_cast<Note *>(element);
         assert(note);
         const int timeOfElement = this->GetTimeForElement(xmlId);
-        const int pitchOfElement = note->GetMIDIPitch(0);
+        const int pitchOfElement = note->GetMIDIPitch();
         const int durationOfElement = note->GetRealTimeOffsetMilliseconds() - note->GetRealTimeOnsetMilliseconds();
         o << "time" << timeOfElement;
         o << "pitch" << pitchOfElement;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1643,10 +1643,9 @@ std::string Toolkit::GetMIDIValuesForElement(const std::string &xmlId)
         }
         Note *note = vrv_cast<Note *>(element);
         assert(note);
-        int timeOfElement = this->GetTimeForElement(xmlId);
-        note->CalcMIDIPitch(0);
-        int pitchOfElement = note->GetMIDIPitch();
-        int durationOfElement = note->GetRealTimeOffsetMilliseconds() - note->GetRealTimeOnsetMilliseconds();
+        const int timeOfElement = this->GetTimeForElement(xmlId);
+        const int pitchOfElement = note->GetMIDIPitch(0);
+        const int durationOfElement = note->GetRealTimeOffsetMilliseconds() - note->GetRealTimeOnsetMilliseconds();
         o << "time" << timeOfElement;
         o << "pitch" << pitchOfElement;
         o << "duration" << durationOfElement;


### PR DESCRIPTION
This PR implements MIDI for grace notes. It distinguishes between accented grace notes (appoggiatura), unaccented grace notes (acciaccatura) and Nachschlag.

[MIDI-examples.zip](https://github.com/rism-digital/verovio/files/7881635/MIDI-examples.zip)

**Unaccented example**
![Unaccented](https://user-images.githubusercontent.com/63608463/149764517-fcba6ec9-c67f-47e8-a741-10f425aeabce.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-09-21" type="encoding-date">2021-09-21</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-3v65bx">
         <appInfo xml:id="appinfo-fnspf4">
            <application xml:id="application-a1wc03" isodate="2021-12-15T12:50:34" version="3.8.0-dev-f7e50d5-dirty">
               <name xml:id="name-95t0ay">Verovio</name>
               <p xml:id="p-e0a3ed">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mwhf4l3">
            <score xml:id="sd9ogml">
               <scoreDef xml:id="s8g6in6">
                  <staffGrp xml:id="sv3sh0z">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="lyvhqys">Piano</label>
                        <labelAbbr xml:id="l9ogzms">Pno.</labelAbbr>
                        <instrDef xml:id="in35fe9" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef xml:id="cf6wuny" shape="G" line="2" />
                        <keySig xml:id="kblva13" sig="0" />
                        <meterSig xml:id="mbx2ti" count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="sjisc24">
                  <pb xml:id="pc78gru" />
                  <measure xml:id="mo170g6" n="1">
                     <staff xml:id="sz5mguv" n="1">
                        <layer xml:id="l33x32" n="1">
                           <note xml:id="nusdy1m" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                           <note xml:id="n2t5ra8" dur="8" oct="5" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           <note xml:id="nmssbxa" dur.ppq="1" dur="4" oct="6" pname="d" stem.dir="down" />
                           <note xml:id="nhan9mf" dur="8" oct="6" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           <note xml:id="nkymmzo" dur.ppq="1" dur="4" oct="5" pname="e" stem.dir="down" />
                           <note xml:id="nt2zkhn" dur="8" oct="5" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           <note xml:id="nybtpfj" dur.ppq="1" dur="4" oct="6" pname="f" stem.dir="down" accid="s" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mhngoj6" n="2">
                     <staff xml:id="sp8je0t" n="1">
                        <layer xml:id="la43qq" n="1">
                           <beam xml:id="bxsjiaq">
                              <note xml:id="nshl6jp" dur="8" oct="6" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="nnia0ek" dur="8" oct="6" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           </beam>
                           <note xml:id="ntpbhve" dur.ppq="1" dur="4" oct="5" pname="a" stem.dir="down" />
                           <beam xml:id="biendmm">
                              <note xml:id="npn0ni0" dur="8" oct="5" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="npke3gs" dur="8" oct="5" pname="b" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="nt2oil2" dur.ppq="1" dur="4" oct="7" pname="c" stem.dir="down" />
                           <beam xml:id="bx1vehk">
                              <note xml:id="n7w7y69" dur="8" oct="7" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="ncsli9y" dur="8" oct="7" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="noh5i34" dur.ppq="1" dur="4" oct="6" pname="d" stem.dir="down" accid="s" />
                           <beam xml:id="b3es1xy">
                              <note xml:id="nyfyuhz" dur="8" oct="6" pname="e" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="nqge3bw" dur="8" oct="6" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="ngkpkob" dur.ppq="1" dur="4" oct="7" pname="f" stem.dir="down" accid="s" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mh04put" n="3">
                     <staff xml:id="s389j1j" n="1">
                        <layer xml:id="lbunaax" n="1">
                           <beam xml:id="be5lg4n">
                              <note xml:id="nry1bkr" dur="8" oct="7" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="nn291tx" dur="8" oct="7" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="nfto572" dur="8" oct="7" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="nhdcj6q" dur.ppq="1" dur="4" oct="6" pname="a" stem.dir="down" accid="s" />
                           <beam xml:id="bm68u55">
                              <note xml:id="n64ctsc" dur="8" oct="6" pname="b" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="nn1j0pw" dur="8" oct="7" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="ne0ltjo" dur="8" oct="7" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           </beam>
                           <note xml:id="n39rvcp" dur.ppq="1" dur="4" oct="4" pname="d" stem.dir="up" />
                           <beam xml:id="b69nvuj">
                              <note xml:id="nensa4z" dur="8" oct="4" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="n3odu8t" dur="8" oct="4" pname="e" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="n89fbsn" dur="8" oct="4" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="nqm8pnq" dur.ppq="1" dur="4" oct="7" pname="f" stem.dir="down" accid="s" />
                           <beam xml:id="b1wwlxd">
                              <note xml:id="nryfwvk" dur="8" oct="7" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" accid.ges="s" />
                              <note xml:id="ndgloaf" dur="8" oct="7" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" accid="n" />
                              <note xml:id="ng45zuw" dur="8" oct="7" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" accid="f" />
                           </beam>
                           <note xml:id="nmda1je" dur.ppq="1" dur="4" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                  </measure>
                  <sb xml:id="sut5paw" />
                  <measure xml:id="mmcy4rj" right="end" n="4">
                     <staff xml:id="sakfhkg" n="1">
                        <layer xml:id="l7mc1uk" n="1">
                           <beam xml:id="b7i89i2">
                              <note xml:id="n8s2j12" dur="8" oct="4" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="noehrnb" dur="8" oct="4" pname="b" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="n20twxp" dur="8" oct="5" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="ndnpa6g" dur="8" oct="5" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           </beam>
                           <note xml:id="nxkqu3u" dur.ppq="1" dur="4" oct="7" pname="d" stem.dir="down" />
                           <beam xml:id="bb7hz1z">
                              <note xml:id="n45jbbt" dur="8" oct="7" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="no7zg50" dur="8" oct="7" pname="e" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="nhlxenm" dur="8" oct="7" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="n61otez" dur="8" oct="7" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                           </beam>
                           <note xml:id="nis3wpt" dur.ppq="1" dur="4" oct="5" pname="g" stem.dir="down" />
                           <beam xml:id="bmyvl6m">
                              <note xml:id="njgsv1j" dur="8" oct="5" pname="g" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="n5fh261" dur="8" oct="5" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" />
                              <note xml:id="njykgu0" dur="8" oct="5" pname="a" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="n6u10lx" dur="8" oct="5" pname="b" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="n41mkgl" dur.ppq="1" dur="4" oct="7" pname="c" stem.dir="down" />
                           <beam xml:id="bayht7x">
                              <note xml:id="nqn2hzw" dur="8" oct="7" pname="c" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="noojvxn" dur="8" oct="7" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" accid="n" />
                              <note xml:id="nzgedoa" dur="8" oct="7" pname="d" grace="unacc" stem.dir="up" stem.mod="1slash" accid="s" />
                              <note xml:id="nr7y4yl" dur="8" oct="7" pname="e" grace="unacc" stem.dir="up" stem.mod="1slash" />
                           </beam>
                           <note xml:id="np6otks" dur.ppq="1" dur="4" oct="6" pname="f" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

**Accented example**
![Accented](https://user-images.githubusercontent.com/63608463/149765734-a4aa74ff-0fb4-402c-a75f-b805296ef831.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Grace notes example</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-09</date>
         </pubStmt>
         <notesStmt>
            <annot>Verovio supports the "grace" attribute in the "note" element for grace notes.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" key.sig="2s" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="b" grace="acc" />
                           <note dur="2" oct="4" pname="d" />
                           <note dur="8" oct="4" pname="a" grace="acc" />
                           <note dur="4" oct="4" pname="d" />
                           <note dur="8" oct="4" pname="g" grace="acc" />
                           <note dur="4" oct="4" pname="d" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="f" grace="acc" />
                           <note dur="4" oct="4" pname="d" />
                           <note dur="8" oct="4" pname="e" grace="acc" />
                           <note dur="4" oct="4" pname="d" />
                           <note dur="8" oct="4" pname="e" grace="acc" />
                           <note dur="2" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="f" grace="acc" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="8" oct="4" pname="g" grace="acc" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="8" oct="4" pname="a" grace="acc" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="8" oct="4" pname="b" grace="acc" />
                           <note dur="4" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end" n="4" label="feature-example">
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="a" grace="acc" />
                           <note dur="4" oct="5" pname="c" />
                           <beam>
                              <note dur="8" oct="5" pname="g" grace="acc" />
                              <note dur="8" oct="5" pname="c" grace="acc" />
                              <note dur="8" oct="5" pname="d" grace="acc" />
                           </beam>
                           <note dur="4" oct="5" pname="c" />
                           <beam>
                              <note dur="8" oct="6" pname="d" grace="acc" />
                              <note dur="8" oct="6" pname="c" grace="acc" />
                              <note dur="8" oct="5" pname="b" grace="acc" />
                              <note dur="8" oct="5" pname="a" grace="acc" />
                              <note dur="8" oct="5" pname="g" grace="acc" />
                              <note dur="8" oct="5" pname="f" grace="acc" />
                              <note dur="8" oct="5" pname="e" grace="acc" />
                              <note dur="8" oct="5" pname="d" grace="acc" />
                              <note dur="16" oct="5" pname="c" grace="acc" />
                              <note dur="16" oct="4" pname="b" grace="acc" />
                              <note dur="16" oct="4" pname="a" grace="acc" accid="f" />
                              <note dur="16" oct="5" pname="c" grace="acc" />
                              <note dur="32" oct="4" pname="b" grace="acc" />
                              <note dur="32" oct="4" pname="f" grace="acc" />
                              <note dur="64" oct="4" pname="g" grace="acc" />
                              <note dur="64" oct="4" pname="c" grace="acc" />
                           </beam>
                           <note dur="2" oct="4" pname="d" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

**Nachschlag example**
![Nachschlag](https://user-images.githubusercontent.com/63608463/149766084-d4caf9b4-ba82-44a9-b440-3b8c39e3d24a.png)
<details>
<summary>Show MEI</summary>
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.2.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="e" accid.ges="n" />
                           <graceGrp grace="unacc" attach="pre">
                             <note dur="8" oct="5" pname="d" accid.ges="n" />
                           </graceGrp>
                           <note dur="4" oct="5" pname="c" accid.ges="n" />
                           <graceGrp grace="unacc" attach="pre">
                             <note dur="8" oct="4" pname="b" accid.ges="n" />
                           </graceGrp>
                           <note dur="2" oct="4" pname="a" accid.ges="n" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
