### PR TITLE
Refined beam intersection

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -167,7 +167,7 @@ public:
      * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
      * intersection.
      */
-    int Intersects(BeamDrawingInterface *beamInterface, Accessor type, int additionalOffset = 0) const;
+    int Intersects(BeamDrawingInterface *beamInterface, Accessor type, int margin = 0) const;
 
     //----------------//
     // Static methods //


### PR DESCRIPTION
This PR refines the intersection calculation of beams with control elements.

| Before | After |
| ------ | ----- |
| <img width="787" alt="Before" src="https://user-images.githubusercontent.com/63608463/149770460-af0407cd-dc6b-4fc2-aa79-c6769706effb.png"> | <img width="778" alt="After" src="https://user-images.githubusercontent.com/63608463/149770491-68760ab6-9299-4bfa-8703-afb8d5a8ca72.png"> |

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp bar.thru="true" symbol="brace">
                    <staffDef n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="3f" meter.sym="common" />
                    <staffDef n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="3f" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="17">
                     <staff n="1">
                       <layer n="1">
                         <space dur="2" />
                         <space dur="4" />
                         <note dur="4" xml:id="note-m17-l1-1" oct="5" pname="c" />
                       </layer>
                       <layer n="2">
                         <chord dur="2" stem.dir="down" dots="1" artic="acc">
                           <note xml:id="note-m17-l2-1" oct="4" pname="e" accid="n" />
                           <note xml:id="note-m17-l2-2" oct="5" pname="c" />
                           <note xml:id="note-m17-l2-3" oct="5" pname="e" accid="n" />
                         </chord>
                         <beam>
                           <chord dur="8" dots="1">
                             <note xml:id="note-m17-l2-4" oct="4" pname="e" />
                             <note xml:id="note-m17-l2-5" oct="5" pname="e" />
                           </chord>
                           <chord dur="16">
                             <note oct="4" pname="e" accid="f" />
                             <note oct="5" pname="e" accid="f" />
                           </chord>
                         </beam>
                       </layer>
                     </staff>
                     <staff n="2">
                       <layer n="3">
                          <beam>
                             <note xml:id="note-m17-l3-1" dur="16" oct="1" pname="g" />
                             <note xml:id="note-m17-l3-2" dur="16" oct="2" pname="g" />
                             <note xml:id="note-m17-l3-3" dur="16" oct="3" pname="c" />
                             <note xml:id="note-m17-l3-4" dur="16" oct="2" pname="b" accid="n" />
                          </beam>
                          <beam>
                             <note xml:id="note-m17-l3-5" dur="16" oct="3" pname="d" stem.dir="down" accid="f" />
                             <note xml:id="note-m17-l3-6" dur="16" oct="3" pname="c" />
                             <note xml:id="note-m17-l3-7" dur="16" oct="3" pname="d" accid="n" />
                             <note xml:id="note-m17-l3-8" dur="16" oct="3" pname="c" accid="s" />
                          </beam>
                          <beam>
                             <note xml:id="note-m17-l3-9" dur="16" oct="3" pname="e" accid="f" />
                             <note xml:id="note-m17-l3-10" dur="16" oct="3" pname="d" />
                             <note xml:id="note-m17-l3-11" dur="16" oct="3" pname="e" accid="n" />
                             <note xml:id="note-m17-l3-12" dur="16" oct="3" pname="d" accid="s" />
                          </beam>
                          <beam>
                             <note xml:id="note-m17-l3-13" dur="16" oct="3" pname="f" />
                             <note xml:id="note-m17-l3-14" dur="16" oct="3" pname="e" />
                             <note xml:id="note-m17-l3-15" dur="16" oct="3" pname="g" accid="f" />
                             <note dur="16" oct="3" pname="f" />
                          </beam>
                        </layer>
                     </staff>
                     <slur startid="#note-m17-l3-1" endid="#note-m19-l3-1" curvedir="above" />
                     <tie startid="#note-m17-l2-1" endid="#note-m17-l2-4" curvedir="below" />
                     <tie startid="#note-m17-l2-2" endid="#note-m17-l1-1" curvedir="above" />
                     <tie startid="#note-m17-l2-3" endid="#note-m17-l2-5" curvedir="above" />
                     <hairpin staff="2" tstamp="2.0" tstamp2="0m+5.0" form="cres" />
                     <fing staff="2" place="below" startid="#note-m17-l3-1">5</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-2">1</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-3">3</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-4">4</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-5">2</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-6">4</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-7">1</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-8">3</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-9">2</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-10">4</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-11">1</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-12">3</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-13">1</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-14">4</fing>
                     <fing staff="2" place="below" startid="#note-m17-l3-15">2</fing>
                  </measure>
                  <measure n="18">
                     <staff n="1">
                       <layer n="1">
                         <note dur="2" oct="4" pname="b" accid="n" />
                       </layer>
                       <layer n="2">
                         <chord xml:id="chord-m18-l2-1" dur="4">
                           <note oct="4" pname="e" accid.ges="f" />
                           <note oct="5" pname="e" accid.ges="f" />
                           <artic artic="acc" place="above" />
                         </chord>
                         <chord xml:id="chord-m18-l2-2" dur="4">
                           <note oct="4" pname="d" />
                           <note oct="5" pname="d" />
                         </chord>
                         <rest dur="2" />
                       </layer>
                     </staff>
                     <staff n="2">
                       <layer n="3">
                          <beam>
                             <note xml:id="note-m18-l3-1" dur="16" oct="3" pname="g" accid="n" />
                             <note xml:id="note-m18-l3-2" dur="16" oct="3" pname="f" accid="s" />
                             <note dur="16" oct="3" pname="a" accid.ges="f" />
                             <note dur="16" oct="3" pname="g" />
                          </beam>
                          <beam>
                             <note xml:id="note-m18-l3-3" dur="16" oct="3" pname="b" accid="f" />
                             <note dur="16" oct="3" pname="a" accid.ges="f" />
                             <note xml:id="note-m18-l3-4" dur="16" oct="3" pname="g" />
                             <note dur="16" oct="3" pname="f" accid="n" />
                          </beam>
                          <beam>
                             <note dur="16" oct="3" pname="e" stem.dir="down" accid.ges="f" />
                             <note dur="16" oct="3" pname="d" />
                             <note xml:id="note-m18-l3-5" dur="16" oct="3" pname="c" />
                             <note dur="16" oct="2" pname="b" accid="n" />
                          </beam>
                          <beam>
                             <note dur="16" oct="2" pname="a" accid.ges="f" />
                             <note xml:id="note-m18-l3-6" dur="16" oct="2" pname="g" />
                             <note dur="16" oct="2" pname="f" />
                             <note dur="16" oct="2" pname="d" />
                          </beam>
                        </layer>
                     </staff>
                     <slur startid="#chord-m18-l2-1" endid="#chord-m18-l2-2" curvedir="above" />
                     <slur startid="#chord-m18-l2-1" endid="#chord-m18-l2-2" curvedir="below" />
                     <hairpin staff="2" tstamp="1.0" tstamp2="0m+5.0" form="dim" />
                     <fing staff="2" place="below" startid="#note-m18-l3-1">1</fing>
                     <fing staff="2" place="below" startid="#note-m18-l3-2">4</fing>
                     <fing staff="2" place="below" startid="#note-m18-l3-3">1</fing>
                     <fing staff="2" place="below" startid="#note-m18-l3-4">1</fing>
                     <fing staff="2" place="below" startid="#note-m18-l3-5">1</fing>
                     <fing staff="2" place="below" startid="#note-m18-l3-6">1</fing>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>