### PR TITLE
Fix beam slope being too far impacted by the duration

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -834,8 +834,8 @@ void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *
                 break;
             }
             // Here we should look at duration too because longer values in the middle could actually be OK as they are
-            else if ((coord != m_lastNoteOrChord) || (coord != m_firstNoteOrChord)) {
-                const int durLen = len - (coord->m_dur - DUR_8) * beamInterface->m_beamWidthBlack;
+            else if (((coord != m_lastNoteOrChord) || (coord != m_firstNoteOrChord)) && (coord->m_dur > DUR_8)) {
+                const int durLen = len - unit;
                 if (durLen < refLen) {
                     lengthen = true;
                     break;


### PR DESCRIPTION
- changed code to check for another unit of margin for 16th and shorter notes in the beams. Stems are already taking duration into account, so adding extra margin based on duration led to wrong calculation of the beam slope

Fix for the issue mentioned in https://github.com/rism-digital/verovio/pull/2573#issuecomment-1016141357
![image](https://user-images.githubusercontent.com/1819669/150134074-5e4eae66-a42c-42c7-86fc-6164050c662f.png)
![image](https://user-images.githubusercontent.com/1819669/150134098-a0632d4e-dddc-4e9a-a3d2-1ac18d5a2112.png)
![image](https://user-images.githubusercontent.com/1819669/150134110-48c1092b-6797-4f69-89fc-082820bee04d.png)
