### PR TITLE
Adjust short slurs

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -150,7 +150,8 @@ private:
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical shift of the slur end points
-    std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+    std::pair<int, int> CalcEndPointShift(
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin, int unit);
 
     // Calculate the horizontal control point offset
     std::tuple<bool, int, int> CalcControlPointOffset(
@@ -176,6 +177,9 @@ private:
     ///@{
     // Shift end points for collisions nearby
     void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection) const;
+
+    // Rebalance shifts to avoid awkward tilting of short slurs
+    void RebalanceShifts(int &shiftLeft, int &shiftRight, double distance, int unit) const;
 
     // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis
     // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -313,7 +313,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     bezier.UpdateControlPointParams(curve->GetDir());
 
     const int unit = doc->GetDrawingUnit(100);
-    const int margin = doc->GetOptions()->m_slurMargin.GetValue() * doc->GetDrawingUnit(100);
+    const int margin = doc->GetOptions()->m_slurMargin.GetValue() * unit;
 
     // STEP 1: Filter spanned elements and discard certain bounding boxes even though they collide
     this->FilterSpannedElements(curve, bezier, margin);
@@ -369,7 +369,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     // STEP 5: Adjust the slur shape
     // Through the control point adjustments in step 3 and 4 it can happen that the slur looses its desired shape.
     // We correct the shape if the slur is too flat or not convex.
-    this->AdjustSlurShape(bezier, curve->GetDir(), doc->GetDrawingUnit(100));
+    this->AdjustSlurShape(bezier, curve->GetDir(), unit);
     curve->UpdatePoints(bezier);
 
     // Since we are going to redraw it, reset its bounding box

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -312,6 +312,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     BezierCurve bezier(points[0], points[1], points[2], points[3]);
     bezier.UpdateControlPointParams(curve->GetDir());
 
+    const int unit = doc->GetDrawingUnit(100);
     const int margin = doc->GetOptions()->m_slurMargin.GetValue() * doc->GetDrawingUnit(100);
 
     // STEP 1: Filter spanned elements and discard certain bounding boxes even though they collide
@@ -321,7 +322,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     // Only collisions near the endpoints are taken into account.
     int endPointShiftLeft = 0;
     int endPointShiftRight = 0;
-    std::tie(endPointShiftLeft, endPointShiftRight) = this->CalcEndPointShift(curve, bezier, margin);
+    std::tie(endPointShiftLeft, endPointShiftRight) = this->CalcEndPointShift(curve, bezier, margin, unit);
     if ((endPointShiftLeft != 0) || (endPointShiftRight != 0)) {
         const int sign = (curve->GetDir() == curvature_CURVEDIR_above) ? 1 : -1;
         bezier.p1.y += sign * endPointShiftLeft;
@@ -406,7 +407,8 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
     }
 }
 
-std::pair<int, int> Slur::CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin)
+std::pair<int, int> Slur::CalcEndPointShift(
+    FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, const int margin, const int unit)
 {
     if (bezierCurve.p1.x >= bezierCurve.p2.x) return { 0, 0 };
 
@@ -443,6 +445,9 @@ std::pair<int, int> Slur::CalcEndPointShift(FloatingCurvePositioner *curve, cons
             this->ShiftEndPoints(shiftLeft, shiftRight, distanceRatioRight, intersectionRight);
         }
     }
+
+    this->RebalanceShifts(shiftLeft, shiftRight, dist, unit);
+
     return { shiftLeft, shiftRight };
 }
 
@@ -466,6 +471,26 @@ void Slur::ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int int
             intersection *= pow(10.0 * ratio - 8.5, 2.0);
         }
         shiftRight = std::max(shiftRight, intersection);
+    }
+}
+
+void Slur::RebalanceShifts(int &shiftLeft, int &shiftRight, const double distance, const int unit) const
+{
+    // alpha is 1 for dist <= 4U, 0 for dist >= 8U, interpolated between 4U and 8U
+    double alpha = 0.0;
+    if (distance <= 4.0 * unit) {
+        alpha = 1.0;
+    }
+    else if (distance <= 8.0 * unit) {
+        alpha = 2.0 - distance / (4.0 * unit);
+    }
+
+    const int difference = std::abs(shiftLeft - shiftRight);
+    if (shiftLeft < shiftRight) {
+        shiftLeft += alpha * difference;
+    }
+    else {
+        shiftRight += alpha * difference;
     }
 }
 


### PR DESCRIPTION
This PR fixes #2418 . It introduces some extra handling such that short slurs are adjusted as a whole (rather than shifting endpoints individually) in order to avoid awkward slur shapes.
![After](https://user-images.githubusercontent.com/63608463/150136609-e5a3f528-be47-4a9a-ab77-d73e1ac9be2e.png)

