### PR TITLE
Simplify staff search

### DIFF
--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -185,7 +185,7 @@ public:
     /**
      * Find the ancestor or cross staff
      */
-    Staff *FindStaff(StaffSearch strategy);
+    Staff *FindStaff(StaffSearch strategy, bool assertExistence = true) const;
 
     /**
      * Look for a cross or a a parent LayerElement (note, chord, rest) with a cross staff.

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -183,9 +183,9 @@ public:
     Alignment *GetAlignment() const { return m_alignment; }
 
     /**
-     * Find the ancestor or cross staff
+     * Get the ancestor or cross staff
      */
-    Staff *FindStaff(StaffSearch strategy, bool assertExistence = true) const;
+    Staff *GetAncestorStaff(StaffSearch strategy = ANCESTOR_ONLY, bool assertExistence = true) const;
 
     /**
      * Look for a cross or a a parent LayerElement (note, chord, rest) with a cross staff.

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -29,6 +29,9 @@ class MeterSig;
 class Staff;
 class StaffAlignment;
 
+// Helper enums
+enum StaffSearch { ANCESTOR_ONLY = 0, RESOLVE_CROSSSTAFF };
+
 //----------------------------------------------------------------------------
 // LayerElement
 //----------------------------------------------------------------------------
@@ -178,6 +181,11 @@ public:
      * Alignment getter
      */
     Alignment *GetAlignment() const { return m_alignment; }
+
+    /**
+     * Find the ancestor or cross staff
+     */
+    Staff *FindStaff(StaffSearch strategy);
 
     /**
      * Look for a cross or a a parent LayerElement (note, chord, rest) with a cross staff.

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -121,11 +121,9 @@ std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const
 
 void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
 {
-    Layer *layer = NULL;
-    Staff *staff = element->GetCrossStaff(layer);
-    if (!staff) staff = vrv_cast<Staff *>(element->GetFirstAncestor(STAFF));
-
+    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
+
     if (element->Is(NOTE) && chord && chord->HasAdjacentNotesInStaff(staff)) {
         const int horizontalMargin = 4 * doc->GetDrawingStemWidth(staffSize);
         const int drawingUnit = doc->GetDrawingUnit(staffSize);

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -121,7 +121,7 @@ std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const
 
 void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
 {
-    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = element->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
 
     if (element->Is(NOTE) && chord && chord->HasAdjacentNotesInStaff(staff)) {

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -226,13 +226,10 @@ int Arpeg::AdjustArpeg(FunctorParams *functorParams)
     // We should have call DrawArpeg before
     assert(this->GetCurrentFloatingPositioner());
 
-    Staff *topStaff = vrv_cast<Staff *>(topNote->GetFirstAncestor(STAFF));
-    assert(topStaff);
+    Staff *topStaff = topNote->FindStaff(ANCESTOR_ONLY);
+    Staff *bottomStaff = bottomNote->FindStaff(ANCESTOR_ONLY);
 
-    Staff *bottomStaff = vrv_cast<Staff *>(bottomNote->GetFirstAncestor(STAFF));
-    assert(bottomStaff);
-
-    Staff *crossStaff = GetCrossStaff();
+    Staff *crossStaff = this->GetCrossStaff();
     const int staffN = (crossStaff != NULL) ? crossStaff->GetN() : topStaff->GetN();
 
     int minTopLeft, maxTopRight;

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -226,8 +226,8 @@ int Arpeg::AdjustArpeg(FunctorParams *functorParams)
     // We should have call DrawArpeg before
     assert(this->GetCurrentFloatingPositioner());
 
-    Staff *topStaff = topNote->FindStaff(ANCESTOR_ONLY);
-    Staff *bottomStaff = bottomNote->FindStaff(ANCESTOR_ONLY);
+    Staff *topStaff = topNote->GetAncestorStaff();
+    Staff *bottomStaff = bottomNote->GetAncestorStaff();
 
     Staff *crossStaff = this->GetCrossStaff();
     const int staffN = (crossStaff != NULL) ? crossStaff->GetN() : topStaff->GetN();

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -399,17 +399,10 @@ int Artic::AdjustArtic(FunctorParams *functorParams)
 
     int yIn, yOut, yRel;
 
-    // Get the parent or cross-staff / layer
-
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
-
-    if (m_crossStaff) {
-        staff = m_crossStaff;
-    }
-
+    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
     Beam *beam = dynamic_cast<Beam *>(GetFirstAncestor(BEAM));
     int staffYBottom = -params->m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
+
     // Avoid in artic to be in legder lines
     if (this->GetDrawingPlace() == STAFFREL_above) {
         yIn = std::max(
@@ -550,8 +543,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
     switch (artic) {
         case ARTICULATION_stacc:
         case ARTICULATION_stacciss: {
-            Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-            assert(staff);
+            Staff *staff = this->FindStaff(ANCESTOR_ONLY);
             const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
                 shift += shift - stemWidth / 2;

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -399,7 +399,7 @@ int Artic::AdjustArtic(FunctorParams *functorParams)
 
     int yIn, yOut, yRel;
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     Beam *beam = dynamic_cast<Beam *>(GetFirstAncestor(BEAM));
     int staffYBottom = -params->m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
 
@@ -543,7 +543,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
     switch (artic) {
         case ARTICULATION_stacc:
         case ARTICULATION_stacciss: {
-            Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+            Staff *staff = this->GetAncestorStaff();
             const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
                 shift += shift - stemWidth / 2;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1292,7 +1292,7 @@ void Beam::FilterList(ArrayOfObjects *childList)
         }
     }
 
-    Staff *beamStaff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *beamStaff = this->GetAncestorStaff();
     /*
     if (this->HasBeamWith()) {
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
@@ -1516,7 +1516,7 @@ int Beam::CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, in
     auto collidingElementsList = parentLayer->GetLayerElementsForTimeSpanOf(this, true);
     if (collidingElementsList.empty()) return 0;
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     int leftMargin = 0;
     int rightMargin = 0;
@@ -1593,7 +1593,7 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
 
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_overlapMargin) {
-        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = this->GetAncestorStaff();
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin = (overlapMargin + staffOffset) * params->m_directionBias;
     }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1292,9 +1292,7 @@ void Beam::FilterList(ArrayOfObjects *childList)
         }
     }
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
-    Staff *beamStaff = staff;
+    Staff *beamStaff = this->FindStaff(ANCESTOR_ONLY);
     /*
     if (this->HasBeamWith()) {
         Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
@@ -1518,8 +1516,7 @@ int Beam::CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, in
     auto collidingElementsList = parentLayer->GetLayerElementsForTimeSpanOf(this, true);
     if (collidingElementsList.empty()) return 0;
 
-    Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     int leftMargin = 0;
     int rightMargin = 0;
@@ -1596,8 +1593,7 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
 
     const int overlapMargin = std::max(leftMargin * params->m_directionBias, rightMargin * params->m_directionBias);
     if (overlapMargin >= params->m_overlapMargin) {
-        Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
         const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params->m_overlapMargin = (overlapMargin + staffOffset) * params->m_directionBias;
     }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -535,7 +535,7 @@ std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
 
-        Staff *noteStaff = note->FindStaff(RESOLVE_CROSSSTAFF);
+        Staff *noteStaff = note->GetAncestorStaff(RESOLVE_CROSSSTAFF);
         if (noteStaff != staff) continue;
 
         const int locDiff = note->GetDrawingLoc() - loc;
@@ -610,7 +610,7 @@ int Chord::CalcArtic(FunctorParams *functorParams)
     params->m_parent = this;
     params->m_stemDir = this->GetDrawingStemDir();
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -680,7 +680,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
 
     Stem *stem = this->GetDrawingStem();
     assert(stem);
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -742,7 +742,7 @@ MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate)
 
         if (predicate && !predicate(note)) continue;
 
-        Staff *staff = note->FindStaff(RESOLVE_CROSSSTAFF);
+        Staff *staff = note->GetAncestorStaff(RESOLVE_CROSSSTAFF);
 
         noteLocations[staff].insert(note->GetDrawingLoc());
     }
@@ -910,7 +910,7 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
     // Check if chord spreads across several staves
     std::list<Staff *> extremalStaves;
     for (Note *note : { this->GetTopNote(), this->GetBottomNote() }) {
-        Staff *staff = note->FindStaff(RESOLVE_CROSSSTAFF);
+        Staff *staff = note->GetAncestorStaff(RESOLVE_CROSSSTAFF);
         extremalStaves.push_back(staff);
     }
     assert(extremalStaves.size() == 2);
@@ -942,7 +942,7 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
         }
 
         // Reposition the stem
-        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = this->GetAncestorStaff();
         Staff *rootStaff
             = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? extremalStaves.back() : extremalStaves.front();
         stem->SetDrawingYRel(stem->GetDrawingYRel() + getShift(staff) - getShift(rootStaff));

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -535,10 +535,7 @@ std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
 
-        Layer *layer = NULL;
-        Staff *noteStaff = note->GetCrossStaff(layer);
-        if (!noteStaff) noteStaff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-        assert(noteStaff);
+        Staff *noteStaff = note->FindStaff(RESOLVE_CROSSSTAFF);
         if (noteStaff != staff) continue;
 
         const int locDiff = note->GetDrawingLoc() - loc;
@@ -747,10 +744,7 @@ MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate)
 
         if (predicate && !predicate(note)) continue;
 
-        Layer *layer = NULL;
-        Staff *staff = note->GetCrossStaff(layer);
-        if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = note->FindStaff(RESOLVE_CROSSSTAFF);
 
         noteLocations[staff].insert(note->GetDrawingLoc());
     }
@@ -918,10 +912,7 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
     // Check if chord spreads across several staves
     std::list<Staff *> extremalStaves;
     for (Note *note : { this->GetTopNote(), this->GetBottomNote() }) {
-        Layer *layer = NULL;
-        Staff *staff = note->GetCrossStaff(layer);
-        if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = note->FindStaff(RESOLVE_CROSSSTAFF);
         extremalStaves.push_back(staff);
     }
     assert(extremalStaves.size() == 2);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -610,8 +610,7 @@ int Chord::CalcArtic(FunctorParams *functorParams)
     params->m_parent = this;
     params->m_stemDir = this->GetDrawingStemDir();
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -681,8 +680,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
 
     Stem *stem = this->GetDrawingStem();
     assert(stem);
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -944,8 +942,7 @@ int Chord::AdjustCrossStaffContent(FunctorParams *functorParams)
         }
 
         // Reposition the stem
-        Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
         Staff *rootStaff
             = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? extremalStaves.back() : extremalStaves.front();
         stem->SetDrawingYRel(stem->GetDrawingYRel() + getShift(staff) - getShift(rootStaff));

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -184,7 +184,7 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     assert(params);
     if (!params->m_beam) return FUNCTOR_SIBLINGS;
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     auto currentShapeIter = topToMiddleProportions.find(GetShape());
     if (currentShapeIter == topToMiddleProportions.end()) return FUNCTOR_CONTINUE;
@@ -234,7 +234,7 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
 
     assert(params->m_aligner);
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     // Create ad comparison object for each type / @n
     std::vector<int> ns;

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -184,8 +184,7 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     assert(params);
     if (!params->m_beam) return FUNCTOR_SIBLINGS;
 
-    Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     auto currentShapeIter = topToMiddleProportions.find(GetShape());
     if (currentShapeIter == topToMiddleProportions.end()) return FUNCTOR_CONTINUE;
@@ -235,8 +234,7 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
 
     assert(params->m_aligner);
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     // Create ad comparison object for each type / @n
     std::vector<int> ns;

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -2194,7 +2194,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
     int initialLrx = firstChild->GetZone()->GetLrx();
     int initialLry = firstChild->GetZone()->GetLry();
 
-    Staff *staff = el->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = el->GetAncestorStaff();
     Facsimile *facsimile = m_doc->GetFacsimile();
 
     const int noteHeight = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);
@@ -2293,7 +2293,7 @@ bool EditorToolkitNeume::ToggleLigature(std::vector<std::string> elementIds, std
         int ligLrx = firstNc->GetZone()->GetLrx();
         int ligLry = firstNc->GetZone()->GetLry();
 
-        Staff *staff = firstNc->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = firstNc->GetAncestorStaff();
 
         const int noteHeight = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);
         const int noteWidth = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 1.4);
@@ -2780,7 +2780,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
 
     if (obj->Is(CUSTOS)) {
         Custos *custos = dynamic_cast<Custos *>(obj);
-        Staff *staff = custos->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = custos->GetAncestorStaff();
 
         // Check interfaces
         if ((custos->GetPitchInterface() == NULL) || (custos->GetFacsimileInterface() == NULL)) {
@@ -2840,7 +2840,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
 
     else if (obj->Is(SYLLABLE)) {
         Syllable *syl = dynamic_cast<Syllable *>(obj);
-        Staff *staff = syl->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = syl->GetAncestorStaff();
 
         ListOfObjects pitchedChildren;
         InterfaceComparison ic(INTERFACE_PITCH);
@@ -2917,7 +2917,7 @@ bool EditorToolkitNeume::AdjustClefLineFromPosition(Clef *clef, Staff *staff)
     assert(clef);
 
     if (staff == NULL) {
-        staff = clef->FindStaff(ANCESTOR_ONLY);
+        staff = clef->GetAncestorStaff();
     }
 
     if (!clef->HasFacs() || !staff->HasFacs()) {

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -2194,8 +2194,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
     int initialLrx = firstChild->GetZone()->GetLrx();
     int initialLry = firstChild->GetZone()->GetLry();
 
-    Staff *staff = vrv_cast<Staff *>(el->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = el->FindStaff(ANCESTOR_ONLY);
     Facsimile *facsimile = m_doc->GetFacsimile();
 
     const int noteHeight = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);
@@ -2294,8 +2293,7 @@ bool EditorToolkitNeume::ToggleLigature(std::vector<std::string> elementIds, std
         int ligLrx = firstNc->GetZone()->GetLrx();
         int ligLry = firstNc->GetZone()->GetLry();
 
-        Staff *staff = vrv_cast<Staff *>(firstNc->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = firstNc->FindStaff(ANCESTOR_ONLY);
 
         const int noteHeight = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 2);
         const int noteWidth = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / 1.4);
@@ -2782,8 +2780,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
 
     if (obj->Is(CUSTOS)) {
         Custos *custos = dynamic_cast<Custos *>(obj);
-        Staff *staff = vrv_cast<Staff *>(custos->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = custos->FindStaff(ANCESTOR_ONLY);
 
         // Check interfaces
         if ((custos->GetPitchInterface() == NULL) || (custos->GetFacsimileInterface() == NULL)) {
@@ -2843,8 +2840,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
 
     else if (obj->Is(SYLLABLE)) {
         Syllable *syl = dynamic_cast<Syllable *>(obj);
-        Staff *staff = vrv_cast<Staff *>(syl->GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = syl->FindStaff(ANCESTOR_ONLY);
 
         ListOfObjects pitchedChildren;
         InterfaceComparison ic(INTERFACE_PITCH);
@@ -2921,9 +2917,8 @@ bool EditorToolkitNeume::AdjustClefLineFromPosition(Clef *clef, Staff *staff)
     assert(clef);
 
     if (staff == NULL) {
-        staff = dynamic_cast<Staff *>(clef->GetFirstAncestor(STAFF));
+        staff = clef->FindStaff(ANCESTOR_ONLY);
     }
-    assert(staff);
 
     if (!clef->HasFacs() || !staff->HasFacs()) {
         return false;

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -307,7 +307,7 @@ bool Stem::IsSupportedChild(Object *child)
 
 int Stem::CompareToElementPosition(Doc *doc, LayerElement *otherElement, int margin)
 {
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     // check if there is an overlap on the left or on the right and displace stem's parent correspondingly
     const int right = HorizontalLeftOverlap(otherElement, doc, margin, 0);

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -307,8 +307,7 @@ bool Stem::IsSupportedChild(Object *child)
 
 int Stem::CompareToElementPosition(Doc *doc, LayerElement *otherElement, int margin)
 {
-    Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     // check if there is an overlap on the left or on the right and displace stem's parent correspondingly
     const int right = HorizontalLeftOverlap(otherElement, doc, margin, 0);

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -101,8 +101,7 @@ void FTrem::FilterList(ArrayOfObjects *childList)
         ++iter;
     }
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     this->InitCoords(childList, staff, BEAMPLACE_NONE);
     this->InitCue(false);

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -101,7 +101,7 @@ void FTrem::FilterList(ArrayOfObjects *childList)
         ++iter;
     }
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     this->InitCoords(childList, staff, BEAMPLACE_NONE);
     this->InitCue(false);

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1339,12 +1339,7 @@ int AlignmentReference::AdjustLayersEnd(FunctorParams *functorParams)
     // Determine staff
     if (params->m_current.empty()) return FUNCTOR_CONTINUE;
     LayerElement *firstElem = params->m_current.at(0);
-    Layer *layer = NULL;
-    Staff *staff = firstElem->GetCrossStaff(layer);
-    if (!staff) {
-        staff = vrv_cast<Staff *>(firstElem->GetFirstAncestor(STAFF));
-    }
-    assert(staff);
+    Staff *staff = firstElem->FindStaff(RESOLVE_CROSSSTAFF);
 
     const int extension
         = params->m_doc->GetDrawingLedgerLineExtension(staff->m_drawingStaffSize, firstElem->GetDrawingCueSize());

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1163,7 +1163,7 @@ int Alignment::AdjustDotsEnd(FunctorParams *functorParams)
         // otherwise they should be kept separate
         for (auto dot : params->m_dots) {
             // A third staff size will be used as required margin
-            const Staff *staff = dot->FindStaff(RESOLVE_CROSSSTAFF);
+            const Staff *staff = dot->GetAncestorStaff(RESOLVE_CROSSSTAFF);
             const int staffSize = staff->m_drawingStaffSize;
             const int thirdUnit = params->m_doc->GetDrawingUnit(staffSize) / 3;
 
@@ -1337,7 +1337,7 @@ int AlignmentReference::AdjustLayersEnd(FunctorParams *functorParams)
     // Determine staff
     if (params->m_current.empty()) return FUNCTOR_CONTINUE;
     LayerElement *firstElem = params->m_current.at(0);
-    Staff *staff = firstElem->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = firstElem->GetAncestorStaff(RESOLVE_CROSSSTAFF);
 
     const int extension
         = params->m_doc->GetDrawingLedgerLineExtension(staff->m_drawingStaffSize, firstElem->GetDrawingCueSize());

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1163,9 +1163,7 @@ int Alignment::AdjustDotsEnd(FunctorParams *functorParams)
         // otherwise they should be kept separate
         for (auto dot : params->m_dots) {
             // A third staff size will be used as required margin
-            const Staff *staff
-                = vrv_cast<Staff *>(dot->m_crossStaff ? dot->m_crossStaff : dot->GetFirstAncestor(STAFF));
-            assert(staff);
+            const Staff *staff = dot->FindStaff(RESOLVE_CROSSSTAFF);
             const int staffSize = staff->m_drawingStaffSize;
             const int thirdUnit = params->m_doc->GetDrawingUnit(staffSize) / 3;
 

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -498,7 +498,7 @@ void PAEOutput::WriteTuplet(Tuplet *tuplet)
 {
     assert(tuplet);
 
-    Staff *staff = tuplet->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = tuplet->GetAncestorStaff();
 
     double content = tuplet->GetContentAlignmentDuration(NULL, NULL, true, staff->m_drawingNotationType);
     // content = DUR_MAX / 2^(dur - 2)

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -498,8 +498,7 @@ void PAEOutput::WriteTuplet(Tuplet *tuplet)
 {
     assert(tuplet);
 
-    Staff *staff = vrv_cast<Staff *>(tuplet->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = tuplet->FindStaff(ANCESTOR_ONLY);
 
     double content = tuplet->GetContentAlignmentDuration(NULL, NULL, true, staff->m_drawingNotationType);
     // content = DUR_MAX / 2^(dur - 2)

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -282,7 +282,7 @@ data_STEMDIRECTION Layer::GetDrawingStemDir(const ArrayOfBeamElementCoords *coor
     assert(alignmentLast);
 
     // We are ignoring cross-staff situation here because this should not be called if we have one
-    Staff *staff = first->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = first->GetAncestorStaff();
 
     double time = alignmentFirst->GetTime();
     double duration = alignmentLast->GetTime() - time + last->GetAlignmentDuration();
@@ -306,7 +306,7 @@ std::set<int> Layer::GetLayersNForTimeSpanOf(LayerElement *element)
     Alignment *alignment = element->GetAlignment();
     assert(alignment);
 
-    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = element->GetAncestorStaff(RESOLVE_CROSSSTAFF);
 
     return this->GetLayersNInTimeSpan(alignment->GetTime(), element->GetAlignmentDuration(), measure, staff->GetN());
 }
@@ -374,7 +374,7 @@ ListOfObjects Layer::GetLayerElementsForTimeSpanOf(LayerElement *element, bool e
         return {};
     }
 
-    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = element->GetAncestorStaff(RESOLVE_CROSSSTAFF);
 
     return GetLayerElementsInTimeSpan(time, duration, measure, staff->GetN(), excludeCurrent);
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -282,8 +282,7 @@ data_STEMDIRECTION Layer::GetDrawingStemDir(const ArrayOfBeamElementCoords *coor
     assert(alignmentLast);
 
     // We are ignoring cross-staff situation here because this should not be called if we have one
-    Staff *staff = vrv_cast<Staff *>(first->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = first->FindStaff(ANCESTOR_ONLY);
 
     double time = alignmentFirst->GetTime();
     double duration = alignmentLast->GetTime() - time + last->GetAlignmentDuration();

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -307,13 +307,7 @@ std::set<int> Layer::GetLayersNForTimeSpanOf(LayerElement *element)
     Alignment *alignment = element->GetAlignment();
     assert(alignment);
 
-    Layer *layer = NULL;
-    Staff *staff = element->GetCrossStaff(layer);
-    if (!staff) {
-        staff = dynamic_cast<Staff *>(element->GetFirstAncestor(STAFF));
-    }
-    // At this stage we have the parent or the cross-staff
-    assert(staff);
+    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
 
     return this->GetLayersNInTimeSpan(alignment->GetTime(), element->GetAlignmentDuration(), measure, staff->GetN());
 }
@@ -381,13 +375,7 @@ ListOfObjects Layer::GetLayerElementsForTimeSpanOf(LayerElement *element, bool e
         return {};
     }
 
-    Layer *layer = NULL;
-    Staff *staff = element->GetCrossStaff(layer);
-    if (!staff) {
-        staff = static_cast<Staff *>(element->GetFirstAncestor(STAFF));
-    }
-    // At this stage we have the parent or the cross-staff
-    assert(staff);
+    Staff *staff = element->FindStaff(RESOLVE_CROSSSTAFF);
 
     return GetLayerElementsInTimeSpan(time, duration, measure, staff->GetN(), excludeCurrent);
 }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -242,6 +242,18 @@ int LayerElement::GetOriginalLayerN()
     return layerN;
 }
 
+Staff *LayerElement::FindStaff(const StaffSearch strategy)
+{
+    Staff *staff = NULL;
+    if (strategy == RESOLVE_CROSSSTAFF) {
+        Layer *layer = NULL;
+        staff = this->GetCrossStaff(layer);
+    }
+    if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+    assert(staff);
+    return staff;
+}
+
 Staff *LayerElement::GetCrossStaff(Layer *&layer) const
 {
     if (m_crossStaff) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -282,11 +282,7 @@ data_STAFFREL_basic LayerElement::GetCrossStaffRel()
 
 void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlignment *&below)
 {
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    Layer *crossLayer = NULL;
-    Staff *crossStaff = this->GetCrossStaff(crossLayer);
-    if (crossStaff) staff = crossStaff;
-    assert(staff);
+    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
 
     // By default use the alignment of the staff
     above = staff->GetAlignment();
@@ -2375,21 +2371,15 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
 
         // Skip elements aligned at start/end, but on a different staff
         if ((this->GetAlignment() == start->GetAlignment()) && !start->Is(TIMESTAMP_ATTR)) {
-            Layer *layer = NULL;
-            Staff *staff = this->GetCrossStaff(layer);
-            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-            Staff *startStaff = start->GetCrossStaff(layer);
-            if (!startStaff) startStaff = vrv_cast<Staff *>(start->GetFirstAncestor(STAFF));
+            Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+            Staff *startStaff = start->FindStaff(RESOLVE_CROSSSTAFF);
             if (staff->GetN() != startStaff->GetN()) {
                 return FUNCTOR_CONTINUE;
             }
         }
         if ((this->GetAlignment() == end->GetAlignment()) && !end->Is(TIMESTAMP_ATTR)) {
-            Layer *layer = NULL;
-            Staff *staff = this->GetCrossStaff(layer);
-            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-            Staff *endStaff = end->GetCrossStaff(layer);
-            if (!endStaff) endStaff = vrv_cast<Staff *>(end->GetFirstAncestor(STAFF));
+            Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+            Staff *endStaff = end->FindStaff(RESOLVE_CROSSSTAFF);
             if (staff->GetN() != endStaff->GetN()) {
                 return FUNCTOR_CONTINUE;
             }
@@ -2576,11 +2566,7 @@ int LayerElement::PrepareDuration(FunctorParams *functorParams)
         durInterface->SetDurDefault(params->m_durDefault);
         // Check if there is a duration default for the staff
         if (!params->m_durDefaultForStaffN.empty()) {
-            Layer *layer = NULL;
-            Staff *staff = this->GetCrossStaff(layer);
-            if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-            assert(staff);
-
+            Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
             if (params->m_durDefaultForStaffN.count(staff->GetN()) > 0) {
                 durInterface->SetDurDefault(params->m_durDefaultForStaffN.at(staff->GetN()));
             }

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -136,7 +136,7 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
     m_drawingShapes.clear();
 
     Note *lastNote = dynamic_cast<Note *>(this->GetList(this)->back());
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
 
     const ArrayOfObjects *notes = this->GetList(this);
     assert(notes);

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -136,8 +136,7 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
     m_drawingShapes.clear();
 
     Note *lastNote = dynamic_cast<Note *>(this->GetList(this)->back());
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
 
     const ArrayOfObjects *notes = this->GetList(this);
     assert(notes);

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -90,8 +90,7 @@ int MRest::ResetHorizontalAlignment(FunctorParams *functorParams)
 int MRest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation)
 {
     if (!layer) return defaultLocation;
-    Staff *parentStaff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-    assert(parentStaff);
+    Staff *parentStaff = this->FindStaff(ANCESTOR_ONLY);
 
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
     if (parentStaff->GetChildCount(LAYER) != 2) return defaultLocation;

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -90,7 +90,7 @@ int MRest::ResetHorizontalAlignment(FunctorParams *functorParams)
 int MRest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation)
 {
     if (!layer) return defaultLocation;
-    Staff *parentStaff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *parentStaff = this->GetAncestorStaff();
 
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
     if (parentStaff->GetChildCount(LAYER) != 2) return defaultLocation;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1062,10 +1062,7 @@ MapOfNoteLocs Note::CalcNoteLocations(NotePredicate predicate)
 {
     if (predicate && !predicate(this)) return {};
 
-    Layer *layer = NULL;
-    Staff *staff = this->GetCrossStaff(layer);
-    if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
 
     MapOfNoteLocs noteLocations;
     noteLocations[staff] = { this->GetDrawingLoc() };

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -211,7 +211,7 @@ Accid *Note::GetDrawingAccid()
 bool Note::HasLedgerLines(int &linesAbove, int &linesBelow, Staff *staff)
 {
     if (!staff) {
-        staff = this->FindStaff(ANCESTOR_ONLY);
+        staff = this->GetAncestorStaff();
     }
 
     linesAbove = (this->GetDrawingLoc() - staff->m_drawingLines * 2 + 2) / 2;
@@ -455,7 +455,7 @@ wchar_t Note::GetMensuralNoteheadGlyph() const
         return 0;
     }
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
 
     wchar_t code = 0;
@@ -618,7 +618,7 @@ void Note::CalcMIDIPitch(int shift)
     }
     else if (this->HasTabCourse()) {
         // tablature
-        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = this->GetAncestorStaff();
         if (staff->m_drawingTuning) {
             m_MIDIPitch = staff->m_drawingTuning->CalcPitchNumber(
                 this->GetTabCourse(), this->GetTabFret(), staff->m_drawingNotationType);
@@ -862,7 +862,7 @@ int Note::CalcArtic(FunctorParams *functorParams)
     params->m_parent = this;
     params->m_stemDir = this->GetDrawingStemDir();
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -930,7 +930,7 @@ int Note::CalcStem(FunctorParams *functorParams)
 
     Stem *stem = this->GetDrawingStem();
     assert(stem);
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 
@@ -982,7 +982,7 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
     FunctorDocParams *params = vrv_params_cast<FunctorDocParams *>(functorParams);
     assert(params);
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     const int staffSize = staff->m_drawingStaffSize;
 
     bool mixedCue = false;
@@ -1053,7 +1053,7 @@ MapOfNoteLocs Note::CalcNoteLocations(NotePredicate predicate)
 {
     if (predicate && !predicate(this)) return {};
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
 
     MapOfNoteLocs noteLocations;
     noteLocations[staff] = { this->GetDrawingLoc() };
@@ -1088,7 +1088,7 @@ int Note::CalcDots(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     const int staffSize = staff->m_drawingStaffSize;
     const bool drawingCueSize = this->GetDrawingCueSize();
 
@@ -1156,7 +1156,7 @@ int Note::CalcLedgerLines(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     const int staffSize = staff->m_drawingStaffSize;
     const int staffX = staff->GetDrawingX();
     const bool drawingCueSize = this->GetDrawingCueSize();

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -521,8 +521,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
     // Adjustment should be an even number, so that the rest is positioned properly
     const int overlapMargin = std::min(leftMargin, rightMargin);
     if (overlapMargin < 0) {
-        Staff *staff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-        assert(staff);
+        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
         if ((!HasOloc() || !HasPloc()) && !HasLoc()) {
             const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
             const int locAdjust = (params->m_directionBias * (overlapMargin - 2 * unit + 1) / unit);
@@ -608,11 +607,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
-
-    if (m_crossStaff) staff = m_crossStaff;
-
+    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
     const bool drawingCueSize = this->GetDrawingCueSize();
     const int staffSize = staff->m_drawingStaffSize;
 
@@ -676,9 +671,7 @@ int Rest::Transpose(FunctorParams *functorParams)
     if ((!HasOloc() || !HasPloc()) && !HasLoc()) return FUNCTOR_SIBLINGS;
 
     // Find whether current layer is top, middle (either one if multiple) or bottom
-    Staff *parentStaff = vrv_cast<Staff *>(GetFirstAncestor(STAFF));
-    assert(parentStaff);
-
+    Staff *parentStaff = this->FindStaff(ANCESTOR_ONLY);
     Layer *parentLayer = vrv_cast<Layer *>(GetFirstAncestor(LAYER));
     assert(parentLayer);
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -521,7 +521,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
     // Adjustment should be an even number, so that the rest is positioned properly
     const int overlapMargin = std::min(leftMargin, rightMargin);
     if (overlapMargin < 0) {
-        Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = this->GetAncestorStaff();
         if ((!HasOloc() || !HasPloc()) && !HasLoc()) {
             const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
             const int locAdjust = (params->m_directionBias * (overlapMargin - 2 * unit + 1) / unit);
@@ -607,7 +607,7 @@ int Rest::CalcDots(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = this->FindStaff(RESOLVE_CROSSSTAFF);
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSSSTAFF);
     const bool drawingCueSize = this->GetDrawingCueSize();
     const int staffSize = staff->m_drawingStaffSize;
 
@@ -671,7 +671,7 @@ int Rest::Transpose(FunctorParams *functorParams)
     if ((!HasOloc() || !HasPloc()) && !HasLoc()) return FUNCTOR_SIBLINGS;
 
     // Find whether current layer is top, middle (either one if multiple) or bottom
-    Staff *parentStaff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *parentStaff = this->GetAncestorStaff();
     Layer *parentLayer = vrv_cast<Layer *>(GetFirstAncestor(LAYER));
     assert(parentLayer);
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -137,8 +137,8 @@ Staff *Slur::GetBoundaryCrossStaff()
     }
     else {
         // Check if the two elements are in different staves (but themselves not cross-staff)
-        Staff *startStaff = start->FindStaff(ANCESTOR_ONLY, false);
-        Staff *endStaff = end->FindStaff(ANCESTOR_ONLY, false);
+        Staff *startStaff = start->GetAncestorStaff(ANCESTOR_ONLY, false);
+        Staff *endStaff = end->GetAncestorStaff(ANCESTOR_ONLY, false);
         if (startStaff && endStaff && (startStaff->GetN() != endStaff->GetN())) {
             return endStaff;
         }
@@ -163,8 +163,8 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
 
     std::set<int> staffNumbers;
     staffNumbers.emplace(staff->GetN());
-    Staff *startStaff = this->GetStart()->FindStaff(RESOLVE_CROSSSTAFF, false);
-    Staff *endStaff = this->GetEnd()->FindStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *startStaff = this->GetStart()->GetAncestorStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *endStaff = this->GetEnd()->GetAncestorStaff(RESOLVE_CROSSSTAFF, false);
     if (startStaff && (startStaff != staff)) {
         staffNumbers.emplace(startStaff->GetN());
     }
@@ -273,7 +273,7 @@ Staff *Slur::CalculateExtremalStaff(Staff *staff, int xMin, int xMax, char spann
     // The floating curve positioner of cross staff slurs should live in the upper/lower staff alignment
     // corresponding to whether the slur is curved above/below
     auto adaptStaff = [&extremalStaff, curveDir](LayerElement *element) {
-        Staff *elementStaff = element->FindStaff(RESOLVE_CROSSSTAFF);
+        Staff *elementStaff = element->GetAncestorStaff(RESOLVE_CROSSSTAFF);
         if ((curveDir == curvature_CURVEDIR_above) && (elementStaff->GetN() < extremalStaff->GetN())) {
             extremalStaff = elementStaff;
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -137,8 +137,8 @@ Staff *Slur::GetBoundaryCrossStaff()
     }
     else {
         // Check if the two elements are in different staves (but themselves not cross-staff)
-        Staff *startStaff = vrv_cast<Staff *>(start->GetFirstAncestor(STAFF));
-        Staff *endStaff = vrv_cast<Staff *>(end->GetFirstAncestor(STAFF));
+        Staff *startStaff = start->FindStaff(ANCESTOR_ONLY, false);
+        Staff *endStaff = end->FindStaff(ANCESTOR_ONLY, false);
         if (startStaff && endStaff && (startStaff->GetN() != endStaff->GetN())) {
             return endStaff;
         }
@@ -163,10 +163,8 @@ std::vector<LayerElement *> Slur::CollectSpannedElements(Staff *staff, int xMin,
 
     std::set<int> staffNumbers;
     staffNumbers.emplace(staff->GetN());
-    Staff *startStaff = this->GetStart()->m_crossStaff ? this->GetStart()->m_crossStaff
-                                                       : vrv_cast<Staff *>(this->GetStart()->GetFirstAncestor(STAFF));
-    Staff *endStaff = this->GetEnd()->m_crossStaff ? this->GetEnd()->m_crossStaff
-                                                   : vrv_cast<Staff *>(this->GetEnd()->GetFirstAncestor(STAFF));
+    Staff *startStaff = this->GetStart()->FindStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *endStaff = this->GetEnd()->FindStaff(RESOLVE_CROSSSTAFF, false);
     if (startStaff && (startStaff != staff)) {
         staffNumbers.emplace(startStaff->GetN());
     }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -275,11 +275,7 @@ Staff *Slur::CalculateExtremalStaff(Staff *staff, int xMin, int xMax, char spann
     // The floating curve positioner of cross staff slurs should live in the upper/lower staff alignment
     // corresponding to whether the slur is curved above/below
     auto adaptStaff = [&extremalStaff, curveDir](LayerElement *element) {
-        Layer *elementLayer = NULL;
-        Staff *elementStaff = element->GetCrossStaff(elementLayer);
-        if (!elementStaff) elementStaff = vrv_cast<Staff *>(element->GetFirstAncestor(STAFF));
-        assert(elementStaff);
-
+        Staff *elementStaff = element->FindStaff(RESOLVE_CROSSSTAFF);
         if ((curveDir == curvature_CURVEDIR_above) && (elementStaff->GetN() < extremalStaff->GetN())) {
             extremalStaff = elementStaff;
         }

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -394,7 +394,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             }
             // endPoint
             Staff *endStaff = staff;
-            if (endParentChord) endStaff = vrv_cast<Staff *>(endParentChord->GetFirstAncestor(STAFF));
+            if (endParentChord) endStaff = endParentChord->FindStaff(ANCESTOR_ONLY);
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);
@@ -454,7 +454,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
         if (!isShortTie) {
             // endPoint
             Staff *endStaff = staff;
-            if (endParentChord) endStaff = vrv_cast<Staff *>(endParentChord->GetFirstAncestor(STAFF));
+            if (endParentChord) endStaff = endParentChord->FindStaff(ANCESTOR_ONLY);
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -394,7 +394,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             }
             // endPoint
             Staff *endStaff = staff;
-            if (endParentChord) endStaff = endParentChord->FindStaff(ANCESTOR_ONLY);
+            if (endParentChord) endStaff = endParentChord->GetAncestorStaff();
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);
@@ -454,7 +454,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
         if (!isShortTie) {
             // endPoint
             Staff *endStaff = staff;
-            if (endParentChord) endStaff = endParentChord->FindStaff(ANCESTOR_ONLY);
+            if (endParentChord) endStaff = endParentChord->GetAncestorStaff();
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(
                     doc, endStaff, endParentChord, endNote, drawingCurveDir, endPoint.x, false);

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -97,7 +97,7 @@ bool TimePointInterface::IsOnStaff(int n)
         return false;
     }
     else if (m_start) {
-        Staff *staff = dynamic_cast<Staff *>(m_start->GetFirstAncestor(STAFF));
+        Staff *staff = m_start->FindStaff(ANCESTOR_ONLY, false);
         if (staff && (staff->GetN() == n)) return true;
     }
     return false;
@@ -129,8 +129,8 @@ std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Objec
         }
     }
     else if (m_start && !m_start->Is(TIMESTAMP_ATTR)) {
-        Staff *staff = dynamic_cast<Staff *>(m_start->GetFirstAncestor(STAFF));
-        if (staff) staffList.push_back(staff->GetN());
+        Staff *staff = m_start->FindStaff(ANCESTOR_ONLY);
+        staffList.push_back(staff->GetN());
     }
     else if (measure->GetChildCount(STAFF) == 1) {
         // If we have no @staff or startid but only one staff child assume it is the first one (@n1 is assumed)
@@ -285,10 +285,10 @@ void TimeSpanningInterface::GetCrossStaffOverflows(
 
     // No cross-staff endpoints, check if the slur itself crosses staves
     if (!startStaff) {
-        startStaff = dynamic_cast<Staff *>(this->GetStart()->GetFirstAncestor(STAFF));
+        startStaff = this->GetStart()->FindStaff(ANCESTOR_ONLY, false);
     }
     if (!endStaff) {
-        endStaff = dynamic_cast<Staff *>(this->GetEnd()->GetFirstAncestor(STAFF));
+        endStaff = this->GetEnd()->FindStaff(ANCESTOR_ONLY, false);
     }
 
     // This happens with slurs starting or ending with a timestamp

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -97,7 +97,7 @@ bool TimePointInterface::IsOnStaff(int n)
         return false;
     }
     else if (m_start) {
-        Staff *staff = m_start->FindStaff(ANCESTOR_ONLY, false);
+        Staff *staff = m_start->GetAncestorStaff(ANCESTOR_ONLY, false);
         if (staff && (staff->GetN() == n)) return true;
     }
     return false;
@@ -129,7 +129,7 @@ std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Objec
         }
     }
     else if (m_start && !m_start->Is(TIMESTAMP_ATTR)) {
-        Staff *staff = m_start->FindStaff(ANCESTOR_ONLY);
+        Staff *staff = m_start->GetAncestorStaff();
         staffList.push_back(staff->GetN());
     }
     else if (measure->GetChildCount(STAFF) == 1) {
@@ -285,10 +285,10 @@ void TimeSpanningInterface::GetCrossStaffOverflows(
 
     // No cross-staff endpoints, check if the slur itself crosses staves
     if (!startStaff) {
-        startStaff = this->GetStart()->FindStaff(ANCESTOR_ONLY, false);
+        startStaff = this->GetStart()->GetAncestorStaff(ANCESTOR_ONLY, false);
     }
     if (!endStaff) {
-        endStaff = this->GetEnd()->FindStaff(ANCESTOR_ONLY, false);
+        endStaff = this->GetEnd()->GetAncestorStaff(ANCESTOR_ONLY, false);
     }
 
     // This happens with slurs starting or ending with a timestamp

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -320,7 +320,7 @@ void Tuplet::CalculateTupletNumCrossStaff(LayerElement *layerElement)
         return;
     };
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     // Find if there is a mix of cross-staff and non-cross-staff elements in the tuplet
     ListOfObjects descendants;
     ClassIdsComparison comparison({ CHORD, NOTE, REST });
@@ -643,7 +643,7 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     const int staffSize = staff->m_drawingStaffSize;
 
     assert(m_drawingBracketPos != STAFFREL_basic_NONE);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -320,8 +320,7 @@ void Tuplet::CalculateTupletNumCrossStaff(LayerElement *layerElement)
         return;
     };
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
     // Find if there is a mix of cross-staff and non-cross-staff elements in the tuplet
     ListOfObjects descendants;
     ClassIdsComparison comparison({ CHORD, NOTE, REST });
@@ -644,9 +643,8 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
-    int staffSize = staff->m_drawingStaffSize;
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    const int staffSize = staff->m_drawingStaffSize;
 
     assert(m_drawingBracketPos != STAFFREL_basic_NONE);
 

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -238,9 +238,9 @@ int Verse::PrepareProcessingLists(FunctorParams *functorParams)
     assert(params);
     // StaffN_LayerN_VerseN_t *tree = vrv_cast<StaffN_LayerN_VerseN_t*>((*params).at(0));
 
-    Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
-    assert(staff && layer);
+    assert(layer);
 
     params->m_verseTree.child[staff->GetN()].child[layer->GetN()].child[this->GetN()];
     // Alternate solution with StaffN_LayerN_VerseN_t

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -238,7 +238,7 @@ int Verse::PrepareProcessingLists(FunctorParams *functorParams)
     assert(params);
     // StaffN_LayerN_VerseN_t *tree = vrv_cast<StaffN_LayerN_VerseN_t*>((*params).at(0));
 
-    Staff *staff = this->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = this->GetAncestorStaff();
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1336,7 +1336,7 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
     const int bottom = bottomNote->GetDrawingY();
 
     // We arbitrarily look at the top note
-    Staff *staff = topNote->FindStaff(ANCESTOR_ONLY);
+    Staff *staff = topNote->GetAncestorStaff();
     const bool drawingCueSize = topNote->GetDrawingCueSize();
 
     // We are going to have only one FloatingPositioner - staff will be the top note one

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1336,8 +1336,7 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
     const int bottom = bottomNote->GetDrawingY();
 
     // We arbitrarily look at the top note
-    Staff *staff = vrv_cast<Staff *>(topNote->GetFirstAncestor(STAFF));
-    assert(staff);
+    Staff *staff = topNote->FindStaff(ANCESTOR_ONLY);
     const bool drawingCueSize = topNote->GetDrawingCueSize();
 
     // We are going to have only one FloatingPositioner - staff will be the top note one

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -834,7 +834,7 @@ void View::DrawBarLine(
     assert(dc);
     assert(barLine);
 
-    Staff *staff = barLine->FindStaff(ANCESTOR_ONLY, false);
+    Staff *staff = barLine->GetAncestorStaff(ANCESTOR_ONLY, false);
     const int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
 
     const int x = barLine->GetDrawingX();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -834,7 +834,7 @@ void View::DrawBarLine(
     assert(dc);
     assert(barLine);
 
-    Staff *staff = dynamic_cast<Staff *>(barLine->GetFirstAncestor(STAFF));
+    Staff *staff = barLine->FindStaff(ANCESTOR_ONLY, false);
     const int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
 
     const int x = barLine->GetDrawingX();

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -182,8 +182,8 @@ float View::CalcInitialSlur(
     const std::vector<LayerElement *> elements
         = slur->CollectSpannedElements(staff, bezier.p1.x, bezier.p2.x, curve->GetSpanningType());
 
-    Staff *startStaff = slur->GetStart()->FindStaff(RESOLVE_CROSSSTAFF, false);
-    Staff *endStaff = slur->GetEnd()->FindStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *startStaff = slur->GetStart()->GetAncestorStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *endStaff = slur->GetEnd()->GetAncestorStaff(RESOLVE_CROSSSTAFF, false);
 
     curve->ClearSpannedElements();
     for (auto element : elements) {

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -182,10 +182,9 @@ float View::CalcInitialSlur(
     const std::vector<LayerElement *> elements
         = slur->CollectSpannedElements(staff, bezier.p1.x, bezier.p2.x, curve->GetSpanningType());
 
-    Staff *startStaff = slur->GetStart()->m_crossStaff ? slur->GetStart()->m_crossStaff
-                                                       : vrv_cast<Staff *>(slur->GetStart()->GetFirstAncestor(STAFF));
-    Staff *endStaff = slur->GetEnd()->m_crossStaff ? slur->GetEnd()->m_crossStaff
-                                                   : vrv_cast<Staff *>(slur->GetEnd()->GetFirstAncestor(STAFF));
+    Staff *startStaff = slur->GetStart()->FindStaff(RESOLVE_CROSSSTAFF, false);
+    Staff *endStaff = slur->GetEnd()->FindStaff(RESOLVE_CROSSSTAFF, false);
+
     curve->ClearSpannedElements();
     for (auto element : elements) {
 


### PR DESCRIPTION
This PR simplifies staff search by introducing a helper function for layer elements. This can operate in two modes: looking for the ancestor staff only or resolving cross staff additionally.