### PR TITLE
Fix for the stem length on beams with mixed duration

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -259,7 +259,7 @@ public:
 
     int m_x;
     int m_yBeam; // y value of stem top position
-    int m_dur; // drawing duration
+    short m_dur; // drawing duration
     int m_breaksec;
     int m_overlapMargin;
     int m_maxShortening; // maximum allowed shortening in half units

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -267,8 +267,8 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterfa
 {
     const int unit = doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     // find shortest duration for above/below beams for the sake of calculating overlap with additional beams
-    int topShortestDur = DUR_8;
-    int bottomShortestDur = DUR_8;
+    short topShortestDur = DUR_8;
+    short bottomShortestDur = DUR_8;
     std::for_each(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
         if (coord->m_partialFlagPlace == BEAMPLACE_above) {
             topShortestDur = std::max(topShortestDur, coord->m_dur);
@@ -1058,14 +1058,17 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool is
         }
     }
 
+    short minDuration = DUR_4;
     for (auto coord : m_beamElementCoordRefs) {
-        const int coordStemLength = coord->CalculateStemLength(staff, stemDir, isHorizontal);
         if (!coord->m_closestNote) continue;
         // if location matches, or if current elements duration is shorter than 8th. This ensures that beams with
         // partial beams will not be shorted when lowest/highest note is 8th and can be shortened
-        if ((coord->m_closestNote->GetDrawingLoc() == relevantNoteLoc)
-            || (!isHorizontal && (coord->m_dur > DUR_8) && (std::abs(m_uniformStemLength) < 13)))
-            m_uniformStemLength = coordStemLength;
+        if ((coord->m_dur > minDuration)
+            && ((coord->m_closestNote->GetDrawingLoc() == relevantNoteLoc)
+                || (!isHorizontal && (std::abs(m_uniformStemLength) < 13)))) {
+            m_uniformStemLength = coord->CalculateStemLength(staff, stemDir, isHorizontal);
+            minDuration = coord->m_dur;
+        }
     }
     // make adjustments for the grace notes length
     for (auto coord : m_beamElementCoordRefs) {


### PR DESCRIPTION
- changed code to take the shortest note stem length as uniform in beams with multiple notes on the same location (e.g. horizontal beams)
closes #2561
![image](https://user-images.githubusercontent.com/1819669/150510271-75e4d868-f25a-4ade-82f5-8a5974032463.png)

This problem also occurred for 128th notes, but since beam overlapped with staff top it was adjusted then (which was not the case for 64th notes). This change makes rendering of beams with notes of different duration consistent with rendering of beams with notes of same duration, as well as beams with beamlets.

Before:
![image](https://user-images.githubusercontent.com/1819669/150511563-1ef3da56-567d-42b1-a7c5-19e89d337fa4.png)

After:
![image](https://user-images.githubusercontent.com/1819669/150512055-e543a473-346d-4f19-90e7-9529b93b52d2.png)

