### PR TITLE
Support for stem.sameas

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -220,8 +220,12 @@ protected:
     int CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, int y2);
 
 private:
-    /** A flag indicating that we have notes with stem shared and that it should not be drawn */
-    bool m_stemSameAsNotes;
+    /**
+     * A pointer to the beam with which stem are shared.
+     * The pointer is bi-directional (each beam points to the other one.
+     * It is the in Note::ResovleStemSameas()
+     */
+    Beam *m_stemSameas;
 
 public:
     /** */

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -174,6 +174,14 @@ public:
      */
     bool IsTabBeam();
 
+    /**
+     * @name Setter and getter for the stemSameasNote flag
+     */
+    ///@{
+    void SetStemSameasNotes(bool stemSameasNotes) { m_stemSameAsNotes = stemSameasNotes; }
+    bool GetStemSameasNotes() const { return m_stemSameAsNotes; }
+    ///@}
+
     //----------//
     // Functors //
     //----------//
@@ -212,7 +220,9 @@ protected:
     int CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, int y2);
 
 private:
-    //
+    /** A flag indicating that we have notes with stem shared and that it should not be drawn */
+    bool m_stemSameAsNotes;
+
 public:
     /** */
     BeamSegment m_beamSegment;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -157,10 +157,10 @@ public:
      * @name The role in a stem.sameas situation.
      * Set in BeamSegment::InitSameasRoles and then in UpdateSameasRoles
      * Used to determine if the beam is the primary one (normal stems and beams)
-     * or the secondary one (linking both notes). This depends on the drawing stem direction,
+     * or the secondary one (linking both notes). This depends on the drawing beam place,
      * which can be encoded but otherwise calculated by CalcBeamPlace.
      * The pointer to the other beam m_stemSameasReverseRole is set only for the first of the
-     * two beam and is not bi-directional. Is is set in InitSameasRoles.
+     * two beams and is not bi-directional. Is is set in InitSameasRoles.
      */
     ///@{
     StemSameasDrawingRole m_stemSameasRole;
@@ -263,9 +263,9 @@ protected:
 
 private:
     /**
-     * A pointer to the beam with which stem are shared.
-     * The pointer is bi-directional (each beam points to the other one.
-     * It is the in Note::ResovleStemSameas()
+     * A pointer to the beam with which stems are shared.
+     * The pointer is bi-directional – each beam points to the other one.
+     * It is set in Note::ResovleStemSameas()
      */
     Beam *m_stemSameas;
 

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -154,8 +154,8 @@ public:
      * Helper to adjust overlapping layers for chords
      * Returns the shift of the adjustment
      */
-    int AdjustOverlappingLayers(
-        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison) override;
+    int AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted,
+        bool &isUnison, bool &stemSameas) override;
 
     /**
      * Helper to get list of notes that are adjacent to the specified location.

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -132,6 +132,14 @@ public:
      */
     void ClearCoords();
 
+    /**
+     * @name Setter and getter for the stemSameasNote flag
+     */
+    ///@{
+    void SetStemSameasNotes(bool stemSameasNotes) { m_stemSameAsNotes = stemSameasNotes; }
+    bool GetStemSameasNotes() const { return m_stemSameAsNotes; }
+    ///@}
+
 protected:
     /**
      * Return the position of the element in the beam.
@@ -166,6 +174,10 @@ public:
      * An array of coordinates for each element
      **/
     ArrayOfBeamElementCoords m_beamElementCoords;
+
+private:
+    /** A flag indicating that we have notes with stem shared and that it should not be drawn */
+    bool m_stemSameAsNotes;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -132,14 +132,6 @@ public:
      */
     void ClearCoords();
 
-    /**
-     * @name Setter and getter for the stemSameasNote flag
-     */
-    ///@{
-    void SetStemSameasNotes(bool stemSameasNotes) { m_stemSameAsNotes = stemSameasNotes; }
-    bool GetStemSameasNotes() const { return m_stemSameAsNotes; }
-    ///@}
-
 protected:
     /**
      * Return the position of the element in the beam.
@@ -176,8 +168,7 @@ public:
     ArrayOfBeamElementCoords m_beamElementCoords;
 
 private:
-    /** A flag indicating that we have notes with stem shared and that it should not be drawn */
-    bool m_stemSameAsNotes;
+    //
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -462,7 +462,8 @@ public:
  * member 5: a pointer to the functor for passing it to the system aligner
  * member 6: a pointer to the end functor for passing it to the system aligner
  * member 7: flag whether element is in unison
- * member 8: the total shift of the current note or chord
+ * member 8: flag whether element (note) has as stem same as note
+ * member 9: the total shift of the current note or chord
  **/
 
 class AdjustLayersParams : public FunctorParams {
@@ -476,6 +477,7 @@ public:
         m_staffNs = staffNs;
         m_unison = false;
         m_ignoreDots = true;
+        m_stemSameas = false;
         m_accumulatedShift = 0;
     }
     std::vector<int> m_staffNs;
@@ -487,6 +489,7 @@ public:
     Functor *m_functorEnd;
     bool m_unison;
     bool m_ignoreDots;
+    bool m_stemSameas;
     int m_accumulatedShift;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1052,10 +1052,11 @@ public:
  * member 1: the vertical center of the staff
  * member 2: the actual duration of the chord / note
  * member 3: the flag for grace notes (stem is not extended)
- * member 4: the current staff (to avoid additional lookup)
- * member 5: the current layer (ditto)
- * member 6: the chord or note to which the stem belongs
- * member 7: the doc
+ * member 4: the flag for stem.sameas notes
+ * member 5: the current staff (to avoid additional lookup)
+ * member 6: the current layer (ditto)
+ * member 7: the chord or note to which the stem belongs
+ * member 8: the doc
  **/
 
 class CalcStemParams : public FunctorParams {
@@ -1066,6 +1067,7 @@ public:
         m_verticalCenter = 0;
         m_dur = DUR_1;
         m_isGraceNote = false;
+        m_stemSameas = false;
         m_staff = NULL;
         m_layer = NULL;
         m_interface = NULL;
@@ -1075,6 +1077,7 @@ public:
     int m_verticalCenter;
     int m_dur;
     bool m_isGraceNote;
+    bool m_stemSameas;
     Staff *m_staff;
     Layer *m_layer;
     StemmedDrawingInterface *m_interface;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1972,8 +1972,11 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: ArrayOfInterfaceUuidPairs holds the interface / uuid pairs to match
- * member 1: bool* fillList for indicating whether the pairs have to be stacked or not
+ * member 0: MapOfLinkingInterfaceUuidPairs holds the interface / uuid pairs to match for links
+ * member 1: MapOfLinkingInterfaceUuidPairs holds the interface / uuid pairs to match for sameas
+ * member 2: MapOfNoteUuidPairs holds the note / uuid pairs to match for stem.sameas
+ * member 3: bool* fillList for indicating whether the pairs have to be stacked or not
+ *
  **/
 
 class PrepareLinkingParams : public FunctorParams {
@@ -1981,6 +1984,7 @@ public:
     PrepareLinkingParams() { m_fillList = true; }
     MapOfLinkingInterfaceUuidPairs m_nextUuidPairs;
     MapOfLinkingInterfaceUuidPairs m_sameasUuidPairs;
+    MapOfNoteUuidPairs m_stemSameasUuidPairs;
     bool m_fillList;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -461,8 +461,8 @@ public:
  * member 4: the doc
  * member 5: a pointer to the functor for passing it to the system aligner
  * member 6: a pointer to the end functor for passing it to the system aligner
- * member 7: flag whether element is in unison
- * member 8: flag whether element (note) has as stem same as note
+ * member 7: flag whether the element is in unison
+ * member 8: flag whether the element (note) has as stem.sameas note
  * member 9: the total shift of the current note or chord
  **/
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -241,8 +241,8 @@ public:
      * Helper to adjust overlapping layers for notes, chords, stems, etc.
      * Returns the shift of the adjustment
      */
-    virtual int AdjustOverlappingLayers(
-        Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison);
+    virtual int AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements,
+        bool areDotsAdjusted, bool &isUnison, bool &stemSameAs);
 
     /**
      * Calculate note horizontal overlap with elemenents from another layers. Returns overlapMargin and index of other

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -232,6 +232,14 @@ public:
      */
     int GetMIDIPitch(int shift = 0);
 
+    /**
+     * @name Checker and getter for a note with which the stem is shared
+     */
+    ///@{
+    bool HasStemSameasNote() const { return (m_stemSameas); }
+    Note *GetStemSameasNote() const { return m_stemSameas; }
+    ///@}
+
 public:
     //----------------//
     // Static methods //
@@ -414,6 +422,17 @@ private:
      * indicate that it should not be written to MIDI output.
      */
     double m_scoreTimeTiedDuration;
+
+    /**
+     * A pointer to a note with which the note shares its stem and implementing @stem.sameas.
+     * The other note is always the one with the stem going outward (up or down). This means
+     * that the note pointing to it will have a stem linking the two notes.
+     * The current implementation requires the notes with the @stem.sameas to be in a lower layer.
+     * The note in the upper layer has no attribute. By default, stems go up but the @stem.dir
+     * value is supported. If the stem is going down, the upper note will have a m_stemSameas Note.
+     * It means that the pointing note is not necessary the note carrying the @stem.sameas.
+     */
+    Note *m_stemSameas;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -250,6 +250,14 @@ public:
      */
     void ResolveStemSameas(PrepareLinkingParams *params);
 
+    /**
+     * Calculate the stem direction of the pair of notes.
+     * The presence of a StemSameasNote() needs to be check before calling it.
+     * Encoded stem direction on the calling note is taken into account.
+     * Called from Note::CalcStem
+     */
+    data_STEMDIRECTION CalcStemDirForSameasNote(int verticalCenter);
+
 public:
     //----------------//
     // Static methods //

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -443,12 +443,8 @@ private:
 
     /**
      * A pointer to a note with which the note shares its stem and implementing @stem.sameas.
-     * The other note is always the one with the stem going outward (up or down). This means
-     * that the note pointing to it will have a stem linking the two notes.
-     * The current implementation requires the notes with the @stem.sameas to be in a lower layer.
-     * The note in the upper layer has no attribute. By default, stems go up but the @stem.dir
-     * value is supported. If the stem is going down, the upper note will have a m_stemSameas Note.
-     * It means that the pointing note is not necessary the note carrying the @stem.sameas.
+     * The pointer is bi-directional (both notes point to each other).
+     * It is set in Note::ResolveStemSameas
      */
     Note *m_stemSameas;
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -30,6 +30,7 @@ namespace vrv {
 class Accid;
 class Chord;
 class Note;
+class PrepareLinkingParams;
 class Slur;
 class TabGrp;
 class Tie;
@@ -239,6 +240,11 @@ public:
     bool HasStemSameasNote() const { return (m_stemSameas); }
     Note *GetStemSameasNote() const { return m_stemSameas; }
     ///@}
+
+    /**
+     *
+     */
+    void ResolveStemSameas(PrepareLinkingParams *params);
 
 public:
     //----------------//

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -245,8 +245,8 @@ public:
     /**
      * Resovle @stem.sameas links by instanciating Note::m_stemSameas (*Note).
      * Called twice from Object::PrepareLinks. Once to fill uuid / note pairs,
-     * and once to resolve the link. The direction of the link depends on the
-     * stem direction and not on the presence of the @stem.sameas
+     * and once to resolve the link. The link is bi-directional, which means
+     * that both notes have their m_stemSameas pointer instanciated.
      */
     void ResolveStemSameas(PrepareLinkingParams *params);
 
@@ -443,6 +443,15 @@ private:
      * It means that the pointing note is not necessary the note carrying the @stem.sameas.
      */
     Note *m_stemSameas;
+
+    /**
+     * The role in a stem.sameas situation.
+     * Set in Note::ResolveStemSameas and then in Note::CalcStemDirForSameasNote
+     * Used to determine if the note is the primary one (normal stem, e.g., with flag)
+     * or the secondary one (linking both notes). This depends on the drawing stem direction,
+     * which can be encoded but otherwise calculated by CalcStemDirForSameasNote
+     */
+    StemSameasDrawingRole m_stemSameasRole;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -243,7 +243,10 @@ public:
     ///@}
 
     /**
-     *
+     * Resovle @stem.sameas links by instanciating Note::m_stemSameas (*Note).
+     * Called twice from Object::PrepareLinks. Once to fill uuid / note pairs,
+     * and once to resolve the link. The direction of the link depends on the
+     * stem direction and not on the presence of the @stem.sameas
      */
     void ResolveStemSameas(PrepareLinkingParams *params);
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -234,11 +234,12 @@ public:
     int GetMIDIPitch(int shift = 0);
 
     /**
-     * @name Checker and getter for a note with which the stem is shared
+     * @name Checker, getter and setter for a note with which the stem is shared
      */
     ///@{
     bool HasStemSameasNote() const { return (m_stemSameas); }
     Note *GetStemSameasNote() const { return m_stemSameas; }
+    void SetStemSameasNote(Note *stemSameas) { m_stemSameas = stemSameas; }
     ///@}
 
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -325,6 +325,8 @@ typedef std::vector<std::pair<int, int>> ArrayOfIntPairs;
 
 typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceUuidPairs;
 
+typedef std::map<std::string, Note *> MapOfNoteUuidPairs;
+
 typedef std::vector<std::pair<PlistInterface *, std::string>> ArrayOfPlistInterfaceUuidPairs;
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -604,6 +604,12 @@ enum Accessor { SELF = 0, CONTENT };
 enum { KEY_LEFT = 37, KEY_UP = 38, KEY_RIGHT = 39, KEY_DOWN = 40 };
 
 //----------------------------------------------------------------------------
+// Stem sameas drawing role
+//----------------------------------------------------------------------------
+
+enum StemSameasDrawingRole { SAMEAS_NONE = 0, SAMEAS_UNSET, SAMEAS_PRIMARY, SAMEAS_SECONDARY };
+
+//----------------------------------------------------------------------------
 // Legacy Wolfgang defines
 //----------------------------------------------------------------------------
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1214,6 +1214,8 @@ void Beam::Reset()
     ResetBeamRend();
     ResetColor();
     ResetCue();
+
+    m_stemSameAsNotes = false;
 }
 
 bool Beam::IsSupportedChild(Object *child)

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1215,7 +1215,7 @@ void Beam::Reset()
     ResetColor();
     ResetCue();
 
-    m_stemSameAsNotes = false;
+    m_stemSameas = NULL;
 }
 
 bool Beam::IsSupportedChild(Object *child)
@@ -1692,9 +1692,10 @@ int Beam::ResetDrawing(FunctorParams *functorParams)
 {
     // Call parent one too
     LayerElement::ResetDrawing(functorParams);
+    BeamDrawingInterface::Reset();
 
     m_beamSegment.Reset();
-    m_stemSameAsNotes = false;
+    m_stemSameas = NULL;
 
     // We want the list of the ObjectListInterface to be re-generated
     this->Modify();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1250,7 +1250,7 @@ void BeamSegment::InitSameasRoles(Beam *sameasBeam, data_BEAMPLACE &initialPlace
 
     // This is the first time and the first beam for which we are calling it.
     // All we need to do is setting the pointer to the role of the other beam
-    // and make both of them as unset
+    // and mark both of them as unset
     if (m_stemSameasRole == SAMEAS_NONE) {
         m_stemSameasReverseRole = &sameasBeam->m_beamSegment.m_stemSameasRole;
         m_stemSameasRole = SAMEAS_UNSET;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1694,6 +1694,7 @@ int Beam::ResetDrawing(FunctorParams *functorParams)
     LayerElement::ResetDrawing(functorParams);
 
     m_beamSegment.Reset();
+    m_stemSameAsNotes = false;
 
     // We want the list of the ObjectListInterface to be re-generated
     this->Modify();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1667,7 +1667,7 @@ int Beam::CalcStem(FunctorParams *functorParams)
     CalcStemParams *params = vrv_params_cast<CalcStemParams *>(functorParams);
     assert(params);
 
-    if (this->IsTabBeam()) return FUNCTOR_CONTINUE;
+    if (this->IsTabBeam() || this->GetStemSameasNotes()) return FUNCTOR_CONTINUE;
 
     const ArrayOfObjects *beamChildren = this->GetList(this);
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -696,6 +696,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
     params->m_interface = this;
     params->m_dur = this->GetActualDur();
     params->m_isGraceNote = this->IsGraceNote();
+    params->m_stemSameas = false;
 
     /************ Set the direction ************/
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -478,7 +478,7 @@ bool Chord::HasNoteWithDots()
 }
 
 int Chord::AdjustOverlappingLayers(
-    Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison)
+    Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison, bool &stemSameas)
 {
     int margin = 0;
     // get positions of other elements

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -578,7 +578,7 @@ void Doc::PrepareDrawing()
 
     /************ Resolve linking (@next) ************/
 
-    // Try to match all pointing elements using @next and @sameas
+    // Try to match all pointing elements using @next, @sameas and @stem.sameas
     PrepareLinkingParams prepareLinkingParams;
     Functor prepareLinking(&Object::PrepareLinking);
     this->Process(&prepareLinking, &prepareLinkingParams);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -584,7 +584,7 @@ void Doc::PrepareDrawing()
     this->Process(&prepareLinking, &prepareLinkingParams);
 
     // If we have some left process again backward
-    if (!prepareLinkingParams.m_sameasUuidPairs.empty()) {
+    if (!prepareLinkingParams.m_sameasUuidPairs.empty() || !prepareLinkingParams.m_stemSameasUuidPairs.empty()) {
         prepareLinkingParams.m_fillList = false;
         this->Process(&prepareLinking, &prepareLinkingParams, NULL, NULL, UNLIMITED_DEPTH, BACKWARD);
     }
@@ -596,6 +596,10 @@ void Doc::PrepareDrawing()
     if (!prepareLinkingParams.m_sameasUuidPairs.empty()) {
         LogWarning(
             "%d element(s) with a @sameas could match the target", prepareLinkingParams.m_sameasUuidPairs.size());
+    }
+    if (!prepareLinkingParams.m_stemSameasUuidPairs.empty()) {
+        LogWarning("%d element(s) with a @stem.sameas could match the target",
+            prepareLinkingParams.m_stemSameasUuidPairs.size());
     }
 
     /************ Resolve @plist ************/

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -92,8 +92,6 @@ void BeamDrawingInterface::Reset()
     m_beamWidth = 0;
     m_beamWidthBlack = 0;
     m_beamWidthWhite = 0;
-
-    m_stemSameAsNotes = false;
 }
 
 int BeamDrawingInterface::GetTotalBeamWidth() const

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -92,6 +92,8 @@ void BeamDrawingInterface::Reset()
     m_beamWidth = 0;
     m_beamWidthBlack = 0;
     m_beamWidthWhite = 0;
+
+    m_stemSameAsNotes = false;
 }
 
 int BeamDrawingInterface::GetTotalBeamWidth() const

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -487,7 +487,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
     if (this->HasStemLen()) {
         baseStem = this->GetStemLen() * -params->m_doc->GetDrawingUnit(staffSize);
     }
-    else {
+    // Do not adjust the baseStem for stem sameas notes (its length is in m_chordStemLength)
+    else if (!params->m_stemSameas) {
         int thirdUnit = params->m_doc->GetDrawingUnit(staffSize) / 3;
         const data_STEMDIRECTION stemDir = params->m_interface->GetDrawingStemDir();
         baseStem = -(params->m_interface->CalcStemLenInThirdUnits(params->m_staff, stemDir) * thirdUnit);
@@ -496,7 +497,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
     // Even if a stem length is given we add the length of the chord content (however only if not 0)
     // Also, the given stem length is understood as being measured from the center of the note.
     // This means that it will be adjusted according to the note head (see below
-    if (!this->HasStemLen() || (this->GetStemLen() != 0)) {
+    if (!params->m_staff || !this->HasStemLen() || (this->GetStemLen() != 0)) {
         Point p;
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
             if (this->GetStemPos() == STEMPOSITION_left) {
@@ -507,7 +508,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
                 p = params->m_interface->GetStemUpSE(params->m_doc, staffSize, drawingCueSize);
                 p.x -= stemShift;
             }
-            this->SetDrawingStemLen(baseStem + params->m_chordStemLength + p.y);
+            const int stemShotening = (params->m_stemSameas) ? 0 : p.y;
+            this->SetDrawingStemLen(baseStem + params->m_chordStemLength + stemShotening);
         }
         else {
             if (this->GetStemPos() == STEMPOSITION_right) {
@@ -518,7 +520,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
                 p = params->m_interface->GetStemDownNW(params->m_doc, staffSize, drawingCueSize);
                 p.x += stemShift;
             }
-            this->SetDrawingStemLen(-(baseStem + params->m_chordStemLength - p.y));
+            const int stemShotening = (params->m_stemSameas) ? 0 : p.y;
+            this->SetDrawingStemLen(-(baseStem + params->m_chordStemLength - stemShotening));
         }
         this->SetDrawingYRel(this->GetDrawingYRel() + p.y);
         this->SetDrawingXRel(p.x);
@@ -541,7 +544,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
     }
 
     Flag *flag = NULL;
-    if (params->m_dur > DUR_4) {
+    // There is never a flag with stem sameas notes or with a duration longer than 8th notes
+    if (!params->m_stemSameas && params->m_dur > DUR_4) {
         flag = vrv_cast<Flag *>(this->GetFirst(FLAG));
         assert(flag);
         flag->m_drawingNbFlags = params->m_dur - DUR_4;
@@ -570,9 +574,9 @@ int Stem::CalcStem(FunctorParams *functorParams)
         flag->SetDrawingYRel(-this->GetDrawingStemLen());
     }
 
-    // Do not adjust the length if given in the encoding - however, the stem will be extend with the SMuFL
-    // extension from 32th - this can be improved
-    if (this->HasStemLen()) {
+    // Do not adjust the length with stem sameas notes or if given in the encoding
+    // however, the stem will be extend with the SMuFL extension from 32th - this can be improved
+    if (params->m_stemSameas || this->HasStemLen()) {
         if ((this->GetStemLen() == 0) && flag) flag->m_drawingNbFlags = 0;
         return FUNCTOR_CONTINUE;
     }

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -107,58 +107,6 @@ void FTrem::FilterList(ArrayOfObjects *childList)
     this->InitCue(false);
 }
 
-/*
-void FTrem::InitCoords(ArrayOfObjects *childList)
-{
-    ClearCoords();
-
-    if (childList->empty()) {
-        return;
-    }
-
-    BeamElementCoord *firstElement = new BeamElementCoord;
-    BeamElementCoord *secondElement = new BeamElementCoord;
-
-    m_beamElementCoords.push_back(firstElement);
-    m_beamElementCoords.push_back(secondElement);
-
-    // current point to the first Note in the layed out layer
-    firstElement->m_element = dynamic_cast<LayerElement *>(childList->front());
-    // fTrem list should contain only DurationInterface objects
-    assert(firstElement->m_element->GetDurationInterface());
-    // current point to the first Note in the layed out layer
-    secondElement->m_element = dynamic_cast<LayerElement *>(childList->back());
-    // fTrem list should contain only DurationInterface objects
-    assert(secondElement->m_element->GetDurationInterface());
-    // Should we assert this at the beginning?
-    if (firstElement->m_element == secondElement->m_element) {
-        return;
-    }
-
-    m_changingDur = false;
-    m_beamHasChord = false;
-    m_hasMultipleStemDir = false;
-    m_cueSize = false;
-    // adjust beam->m_drawingParams.m_shortestDur depending on the number of slashes
-    m_shortestDur = std::max(DUR_8, DUR_1 + this->GetBeams());
-    m_stemDir = STEMDIRECTION_NONE;
-
-    if (firstElement->m_element->Is(CHORD)) {
-        m_beamHasChord = true;
-    }
-    if (secondElement->m_element->Is(CHORD)) {
-        m_beamHasChord = true;
-    }
-
-    // For now look at the stemDir only on the first note
-    assert(dynamic_cast<AttStems *>(firstElement->m_element));
-    m_stemDir = (dynamic_cast<AttStems *>(firstElement->m_element))->GetStemDir();
-
-    // We look only at the first note for checking if cue-sized. Somehow arbitrarily
-    m_cueSize = firstElement->m_element->GetDrawingCueSize();
- }
- */
-
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1062,7 +1062,7 @@ int Note::CalcStem(FunctorParams *functorParams)
 
     // Use the params->m_chordStemLength for the length of the stem beetween the notes
     if (this->HasStemSameasNote()) {
-        params->m_chordStemLength = this->GetDrawingY() - this->GetStemSameasNote()->GetDrawingY();
+        params->m_chordStemLength = -std::abs(this->GetDrawingY() - this->GetStemSameasNote()->GetDrawingY());
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -551,6 +551,11 @@ bool Note::IsVisible() const
     return true;
 }
 
+void Note::ResolveStemSameas(PrepareLinkingParams *params)
+{
+    assert(params);
+}
+
 bool Note::IsEnharmonicWith(Note *note)
 {
     return (this->GetMIDIPitch() == note->GetMIDIPitch());

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1034,7 +1034,7 @@ int Note::CalcStem(FunctorParams *functorParams)
 
     // Stems have been calculated previously in Beam or fTrem - siblings because flags do not need to
     // be processed either - except when there is a stemSameasNote
-    if ((this->IsInBeam() || this->IsInFTrem()) && !this->HasStemSameasNote()) {
+    if ((this->IsInBeam() || this->IsInFTrem())) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -1069,7 +1069,7 @@ int Note::CalcStem(FunctorParams *functorParams)
     params->m_interface = this;
     params->m_dur = this->GetActualDur();
     params->m_isGraceNote = this->IsGraceNote();
-    params->m_stemSameas = this->HasStemSameasNote();
+    params->m_stemSameas = false;
 
     int staffSize = staff->m_drawingStaffSize;
 
@@ -1082,8 +1082,7 @@ int Note::CalcStem(FunctorParams *functorParams)
     data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
 
     if (this->HasStemSameasNote()) {
-        // for stem same as notes, the direction is up if the note also carries the @stem.sameas attribute (default)
-        stemDir = (this->HasStemSameas()) ? STEMDIRECTION_up : STEMDIRECTION_down;
+        stemDir = this->CalcStemDirForSameasNote(params->m_verticalCenter);
     }
     else if (stem->HasStemDir()) {
         stemDir = stem->GetStemDir();
@@ -1104,8 +1103,10 @@ int Note::CalcStem(FunctorParams *functorParams)
     stem->SetDrawingYRel(0);
 
     // Use the params->m_chordStemLength for the length of the stem beetween the notes
-    if (this->HasStemSameasNote()) {
+    // The value of m_stemSameasRole is set by Note::CalcStemDirForSameasNote
+    if (this->HasStemSameasNote() && m_stemSameasRole == SAMEAS_SECONDARY) {
         params->m_chordStemLength = -std::abs(this->GetDrawingY() - this->GetStemSameasNote()->GetDrawingY());
+        params->m_stemSameas = true;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -123,6 +123,8 @@ void Note::Reset()
     m_realTimeOnsetMilliseconds = 0;
     m_realTimeOffsetMilliseconds = 0;
     m_scoreTimeTiedDuration = 0.0;
+
+    m_stemSameas = NULL;
 }
 
 bool Note::IsSupportedChild(Object *child)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1370,6 +1370,7 @@ int Note::ResetDrawing(FunctorParams *functorParams)
 
     m_drawingLoc = 0;
     m_flippedNotehead = false;
+    m_stemSameas = NULL;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1467,14 +1467,9 @@ int Object::FindAllReferencedObjects(FunctorParams *functorParams)
     if (this->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(this);
         assert(note);
-        if (note->HasStemSameasNote()) {
-            // We need to check where the @stem.sameas attribute actually is because of the handling
-            // of share stem pointers depending on the stem direction.
-            // If it is on this note, then the reference we want to keep is the other note.
-            // Otherwise it means that the @stem.sameas is on the other note that we already have
-            // the one that is actually referenced
-            if (note->HasStemSameas()) note = note->GetStemSameasNote();
-            params->m_elements->push_back(note);
+        // The note has a stem.sameas that was resolved the a note, then that one is referenced
+        if (note->HasStemSameas() && note->HasStemSameasNote()) {
+            params->m_elements->push_back(note->GetStemSameasNote());
         }
     }
     // These will also be referred to as milestones in page-based MEI

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1464,6 +1464,19 @@ int Object::FindAllReferencedObjects(FunctorParams *functorParams)
         if (interface->GetEnd() && !interface->GetEnd()->Is(TIMESTAMP_ATTR))
             params->m_elements->push_back(interface->GetEnd());
     }
+    if (this->Is(NOTE)) {
+        Note *note = vrv_cast<Note *>(this);
+        assert(note);
+        if (note->HasStemSameasNote()) {
+            // We need to check where the @stem.sameas attribute actually is because of the handling
+            // of share stem pointers depending on the stem direction.
+            // If it is on this note, then the reference we want to keep is the other note.
+            // Otherwise it means that the @stem.sameas is on the other note that we already have
+            // the one that is actually referenced
+            if (note->HasStemSameas()) note = note->GetStemSameasNote();
+            params->m_elements->push_back(note);
+        }
+    }
     // These will also be referred to as milestones in page-based MEI
     if (params->m_milestoneReferences && this->IsMilestoneElement()) {
         params->m_elements->push_back(this);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1526,7 +1526,7 @@ int Object::PrepareLinking(FunctorParams *functorParams)
         interface->InterfacePrepareLinking(functorParams, this);
     }
 
-    if (params->m_fillList && this->Is(NOTE)) {
+    if (this->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(this);
         assert(note);
         PrepareLinkingParams *params = vrv_params_cast<PrepareLinkingParams *>(functorParams);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1526,6 +1526,14 @@ int Object::PrepareLinking(FunctorParams *functorParams)
         interface->InterfacePrepareLinking(functorParams, this);
     }
 
+    if (params->m_fillList && this->Is(NOTE)) {
+        Note *note = vrv_cast<Note *>(this);
+        assert(note);
+        PrepareLinkingParams *params = vrv_params_cast<PrepareLinkingParams *>(functorParams);
+        assert(params);
+        note->ResolveStemSameas(params);
+    }
+
     // @next
     std::string uuid = this->GetUuid();
     auto r1 = params->m_nextUuidPairs.equal_range(uuid);

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -42,7 +42,6 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     assert(beam);
 
     const bool isTabBeam = beam->IsTabBeam();
-    const bool hasStemSameas = beam->GetStemSameasNotes();
 
     /******************************************************************/
     // initialization
@@ -56,14 +55,17 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     beam->m_beamSegment.InitCoordRefs(beam->GetElementCoords());
 
+    data_BEAMPLACE initialPlace = beam->GetPlace();
+    if (beam->HasStemSameasBeam()) beam->m_beamSegment.InitSameasRoles(beam->GetStemSameasBeam(), initialPlace);
+
     /******************************************************************/
     // Calculate the beam slope and position
 
     if (isTabBeam) {
-        beam->m_beamSegment.CalcTabBeam(layer, beam->m_beamStaff, m_doc, beam, beam->GetPlace());
+        beam->m_beamSegment.CalcTabBeam(layer, beam->m_beamStaff, m_doc, beam, initialPlace);
     }
-    else if (!hasStemSameas) {
-        beam->m_beamSegment.CalcBeam(layer, beam->m_beamStaff, m_doc, beam, beam->GetPlace());
+    else if (!beam->m_beamSegment.StemSameasIsSecondary()) {
+        beam->m_beamSegment.CalcBeam(layer, beam->m_beamStaff, m_doc, beam, initialPlace);
     }
 
     /******************************************************************/
@@ -77,9 +79,10 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     DrawLayerChildren(dc, beam, layer, staff, measure);
 
     /******************************************************************/
-    // Draw the beamSegment
+    // Draw the beamSegment - but not if it is a secondary beam in a stem.sameas
 
-    if (!hasStemSameas) DrawBeamSegment(dc, &beam->m_beamSegment, beam, layer, staff, measure);
+    if (!beam->m_beamSegment.StemSameasIsSecondary())
+        DrawBeamSegment(dc, &beam->m_beamSegment, beam, layer, staff, measure);
 
     dc->EndGraphic(element, this);
 }

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -42,6 +42,7 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     assert(beam);
 
     const bool isTabBeam = beam->IsTabBeam();
+    const bool hasStemSameas = beam->GetStemSameasNotes();
 
     /******************************************************************/
     // initialization
@@ -61,7 +62,7 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     if (isTabBeam) {
         beam->m_beamSegment.CalcTabBeam(layer, beam->m_beamStaff, m_doc, beam, beam->GetPlace());
     }
-    else {
+    else if (!hasStemSameas) {
         beam->m_beamSegment.CalcBeam(layer, beam->m_beamStaff, m_doc, beam, beam->GetPlace());
     }
 
@@ -78,7 +79,7 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     /******************************************************************/
     // Draw the beamSegment
 
-    DrawBeamSegment(dc, &beam->m_beamSegment, beam, layer, staff, measure);
+    if (!hasStemSameas) DrawBeamSegment(dc, &beam->m_beamSegment, beam, layer, staff, measure);
 
     dc->EndGraphic(element, this);
 }


### PR DESCRIPTION
This PR adds support for the `@stem.sameas` for orchestral notation as requested here https://github.com/rism-digital/verovio/issues/2554

This is the result for the test file https://github.com/rism-digital/verovio.org/blob/gh-pages/_tests/stem/stem-014.mei
![image](https://user-images.githubusercontent.com/689412/151043188-64b1d979-58b8-4f9d-84fb-716b60c36e04.png)

There are a few encoding requirements with the current implementation:
* `@stem.sameas` is expected to be given on the notes of the second layer
* the stem direction is up by default but `@stem.dir="down"` can be given on the notes of the first layer
* when the stem direction is indicated and the notes are in a beam, is has to be given on each note

Treatment of articulations needs to be clarified. The current implementation does not properly handle unison or second intervals. However, these are pretty rare.