### PR TITLE
Fix section restart shift

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -804,6 +804,8 @@ public:
 /**
  * member 0: the cumulated shift
  * member 1: the cumulated justifiable width
+ * member 2: shift next measure due to section restart
+ * member 3: the doc
  **/
 
 class AlignMeasuresParams : public FunctorParams {
@@ -812,11 +814,13 @@ public:
     {
         m_shift = 0;
         m_justifiableWidth = 0;
+        m_applySectionRestartShift = false;
         m_doc = doc;
     }
 
     int m_shift;
     int m_justifiableWidth;
+    bool m_applySectionRestartShift;
     Doc *m_doc;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1708,12 +1708,14 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the justification ratio
- * member 1: the justification ratio for the measure (depends on the margin)
- * member 2: the non justifiable margin
- * member 3: the system full width (without system margins)
- * member 4: the functor to be redirected to the MeasureAligner
- * member 5: the doc
+ * member 0: the relative X position of the next measure
+ * member 1: the justification ratio
+ * member 2: the left barline X position
+ * member 3: the right barline X position
+ * member 4: the system full width (without system margins)
+ * member 5: shift next measure due to section restart
+ * member 6: the functor to be redirected to the MeasureAligner
+ * member 7: the doc
  **/
 
 class JustifyXParams : public FunctorParams {
@@ -1725,6 +1727,7 @@ public:
         m_leftBarLineX = 0;
         m_rightBarLineX = 0;
         m_systemFullWidth = 0;
+        m_applySectionRestartShift = false;
         m_functor = functor;
         m_doc = doc;
     }
@@ -1733,6 +1736,7 @@ public:
     int m_leftBarLineX;
     int m_rightBarLineX;
     int m_systemFullWidth;
+    bool m_applySectionRestartShift;
     Functor *m_functor;
     Doc *m_doc;
 };

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -204,6 +204,11 @@ public:
     int GetDrawingOverflow();
 
     /**
+     * Calculates the section restart shift
+     */
+    int GetSectionRestartShift(Doc *doc) const;
+
+    /**
      * @name Setter and getter of the drawing scoreDef
      */
     ///@{

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -76,6 +76,11 @@ public:
      */
     int AlignMeasures(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::JustifyX
+     */
+    int JustifyX(FunctorParams *functorParams) override;
+
 private:
     //
 public:

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -71,6 +71,11 @@ public:
      */
     int ResetDrawing(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::AlignMeasures
+     */
+    int AlignMeasures(FunctorParams *functorParams) override;
+
 private:
     //
 public:

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1157,8 +1157,13 @@ int Measure::JustifyX(FunctorParams *functorParams)
     JustifyXParams *params = vrv_params_cast<JustifyXParams *>(functorParams);
     assert(params);
 
+    if (params->m_applySectionRestartShift) {
+        params->m_measureXRel += this->GetSectionRestartShift(params->m_doc);
+        params->m_applySectionRestartShift = false;
+    }
+
     if (params->m_measureXRel > 0) {
-        SetDrawingXRel(params->m_measureXRel);
+        this->SetDrawingXRel(params->m_measureXRel);
     }
     else {
         params->m_measureXRel = GetDrawingXRel();

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -362,6 +362,11 @@ int Measure::GetDrawingOverflow()
     return std::max(0, overflow);
 }
 
+int Measure::GetSectionRestartShift(Doc *doc) const
+{
+    return 5 * doc->GetDrawingDoubleUnit(100);
+}
+
 void Measure::SetDrawingScoreDef(ScoreDef *drawingScoreDef)
 {
     assert(!m_drawingScoreDef); // We should always call UnscoreDefSetCurrent before
@@ -1169,16 +1174,12 @@ int Measure::AlignMeasures(FunctorParams *functorParams)
     AlignMeasuresParams *params = vrv_params_cast<AlignMeasuresParams *>(functorParams);
     assert(params);
 
-    assert(this->GetParent());
-    Object *object = this->GetParent()->GetPrevious(this);
-    if (object && object->Is(SECTION)) {
-        Section *section = vrv_cast<Section *>(object);
-        if (section && (section->GetRestart() == BOOLEAN_true)) {
-            params->m_shift += 5 * params->m_doc->GetDrawingDoubleUnit(100);
-        }
+    if (params->m_applySectionRestartShift) {
+        params->m_shift += this->GetSectionRestartShift(params->m_doc);
+        params->m_applySectionRestartShift = false;
     }
 
-    SetDrawingXRel(params->m_shift);
+    this->SetDrawingXRel(params->m_shift);
 
     params->m_shift += this->GetWidth();
     params->m_justifiableWidth += this->GetRightBarLineXRel() - this->GetLeftBarLineXRel();

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -608,7 +608,10 @@ int ScoreDef::JustifyX(FunctorParams *functorParams)
     JustifyXParams *params = vrv_params_cast<JustifyXParams *>(functorParams);
     assert(params);
 
-    params->m_measureXRel += m_drawingLabelsWidth;
+    if (m_drawingLabelsWidth > 0) {
+        params->m_measureXRel += m_drawingLabelsWidth;
+        params->m_applySectionRestartShift = false;
+    }
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -591,13 +591,13 @@ int ScoreDef::AlignMeasures(FunctorParams *functorParams)
     AlignMeasuresParams *params = vrv_params_cast<AlignMeasuresParams *>(functorParams);
     assert(params);
 
-    // SetDrawingXRel(m_systemLeftMar + this->GetDrawingWidth());
     params->m_shift += m_drawingLabelsWidth;
-    if (this->IsSectionRestart()) {
-        const bool hasLabel
-            = (NULL != this->FindDescendantByType(LABEL)) || (NULL != this->FindDescendantByType(LABELABBR));
-        // Add space if we have no label/labelAbbr and no grpSym
-        if (!hasLabel) params->m_shift += 5 * params->m_doc->GetDrawingDoubleUnit(100);
+
+    if (params->m_applySectionRestartShift) {
+        ClassIdsComparison comparison({ LABEL, LABELABBR });
+        if (this->FindDescendantByComparison(&comparison)) {
+            params->m_applySectionRestartShift = false;
+        }
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -126,4 +126,16 @@ int Section::ResetDrawing(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Section::AlignMeasures(FunctorParams *functorParams)
+{
+    AlignMeasuresParams *params = vrv_params_cast<AlignMeasuresParams *>(functorParams);
+    assert(params);
+
+    if (this->GetRestart() == BOOLEAN_true) {
+        params->m_applySectionRestartShift = true;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -138,4 +138,16 @@ int Section::AlignMeasures(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Section::JustifyX(FunctorParams *functorParams)
+{
+    JustifyXParams *params = vrv_params_cast<JustifyXParams *>(functorParams);
+    assert(params);
+
+    if (this->GetRestart() == BOOLEAN_true) {
+        params->m_applySectionRestartShift = true;
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv


### PR DESCRIPTION
This PR fixes #2468 by considering the section restart also in the JustifyX functor.

<img width="1031" alt="SectionRestartShift" src="https://user-images.githubusercontent.com/63608463/151117014-2f694bc2-03b1-4e5f-8d11-969fb9e77537.png">