### PR TITLE
Add members to the timemap and refactor code

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -648,6 +648,12 @@
 		4DCB7AA426D3C9600047F01D /* crc.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCB7AA226D3C9600047F01D /* crc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DD11DC42240E78B00A405D8 /* c_wrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD11DC22240E78B00A405D8 /* c_wrapper.cpp */; };
 		4DD11DC52240E78B00A405D8 /* c_wrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD11DC32240E78B00A405D8 /* c_wrapper.h */; };
+		4DD7C0FC27A55CEA00B9C017 /* timemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */; };
+		4DD7C0FD27A55CEA00B9C017 /* timemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */; };
+		4DD7C0FF27A55CFD00B9C017 /* timemap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD7C0FE27A55CFD00B9C017 /* timemap.h */; };
+		4DD7C10027A55CFD00B9C017 /* timemap.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DD7C0FE27A55CFD00B9C017 /* timemap.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DD7C10127A5650600B9C017 /* timemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */; };
+		4DD7C10227A5650600B9C017 /* timemap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */; };
 		4DDBBB571C7AE43E00054AFF /* hairpin.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DDBBB551C7AE43E00054AFF /* hairpin.h */; };
 		4DDBBB581C7AE43E00054AFF /* dynam.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DDBBB561C7AE43E00054AFF /* dynam.h */; };
 		4DDBBB5B1C7AE45900054AFF /* dynam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DDBBB591C7AE45900054AFF /* dynam.cpp */; };
@@ -1547,6 +1553,8 @@
 		4DCB7AA226D3C9600047F01D /* crc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = crc.h; path = include/crc/crc.h; sourceTree = SOURCE_ROOT; };
 		4DD11DC22240E78B00A405D8 /* c_wrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = c_wrapper.cpp; path = tools/c_wrapper.cpp; sourceTree = "<group>"; };
 		4DD11DC32240E78B00A405D8 /* c_wrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = c_wrapper.h; path = tools/c_wrapper.h; sourceTree = "<group>"; };
+		4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = timemap.cpp; path = src/timemap.cpp; sourceTree = "<group>"; };
+		4DD7C0FE27A55CFD00B9C017 /* timemap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = timemap.h; path = include/vrv/timemap.h; sourceTree = "<group>"; };
 		4DDBBB551C7AE43E00054AFF /* hairpin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hairpin.h; path = include/vrv/hairpin.h; sourceTree = "<group>"; };
 		4DDBBB561C7AE43E00054AFF /* dynam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = dynam.h; path = include/vrv/dynam.h; sourceTree = "<group>"; };
 		4DDBBB591C7AE45900054AFF /* dynam.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = dynam.cpp; path = src/dynam.cpp; sourceTree = "<group>"; };
@@ -2210,6 +2218,8 @@
 				E79ADDC326BD1AE900527E4B /* runtimeclock.h */,
 				4D98CCDA25D26E3C00DC7A2C /* smufl.cpp */,
 				4D1D733B1A1D0390001E08F6 /* smufl.h */,
+				4DD7C0FB27A55CEA00B9C017 /* timemap.cpp */,
+				4DD7C0FE27A55CFD00B9C017 /* timemap.h */,
 				8F086EBF188539540037FD8E /* toolkit.cpp */,
 				8F59291618854BF800FE51AD /* toolkit.h */,
 				4DC3B9E4239E2ABE007F185E /* transposition.cpp */,
@@ -2618,6 +2628,7 @@
 				4D1BE7821C69434C0086DC0E /* MidiFile.h in Headers */,
 				4D9C53121B52E4AE0003C6EC /* core.h in Headers */,
 				4DEC4DD221C8295700D1D273 /* supplied.h in Headers */,
+				4DD7C0FF27A55CFD00B9C017 /* timemap.h in Headers */,
 				4D1BD1B921908D78000D35B2 /* halfmrpt.h in Headers */,
 				4DF4407A1D3D085600152B7E /* functorparams.h in Headers */,
 				4DA0EADD22BB77AF00A7EBEB /* zone.h in Headers */,
@@ -2709,6 +2720,7 @@
 				4D79642726C167200026288B /* pagemilestone.h in Headers */,
 				BB4C4B1C22A932CF001F6AF0 /* arpeg.h in Headers */,
 				BB4C4B2A22A932CF001F6AF0 /* harm.h in Headers */,
+				4DD7C10027A55CFD00B9C017 /* timemap.h in Headers */,
 				BB4C4AAC22A932A0001F6AF0 /* svgdevicecontext.h in Headers */,
 				BB4C4ADE22A932BC001F6AF0 /* add.h in Headers */,
 				BB4C4B4C22A932D7001F6AF0 /* custos.h in Headers */,
@@ -3066,6 +3078,7 @@
 				4D1694071E3A44F300569BF4 /* iomusxml.cpp in Sources */,
 				4D7927D120ECCC6D0002A45D /* view_slur.cpp in Sources */,
 				4DF21D1322B3D17D009821DE /* ioabc.cpp in Sources */,
+				4DD7C10127A5650600B9C017 /* timemap.cpp in Sources */,
 				4D1694081E3A44F300569BF4 /* iopae.cpp in Sources */,
 				4D1694091E3A44F300569BF4 /* atts_critapp.cpp in Sources */,
 				4D16940A1E3A44F300569BF4 /* fermata.cpp in Sources */,
@@ -3323,6 +3336,7 @@
 				4D5FA9111E16A93F00F3B919 /* boundingbox.cpp in Sources */,
 				4DC12A841F741110000440E9 /* pgfoot2.cpp in Sources */,
 				8F086EF9188539540037FD8E /* object.cpp in Sources */,
+				4DD7C10227A5650600B9C017 /* timemap.cpp in Sources */,
 				8F086EFA188539540037FD8E /* page.cpp in Sources */,
 				8F086EFB188539540037FD8E /* pitchinterface.cpp in Sources */,
 				BDEF9EC726725234008A3A47 /* caesura.cpp in Sources */,
@@ -3495,6 +3509,7 @@
 				4D4FCD141F54570E0009C455 /* staffdef.cpp in Sources */,
 				4DEC4D7C21C8048700D1D273 /* abbr.cpp in Sources */,
 				403BEFF9206C00FF00D022D5 /* beatrpt.cpp in Sources */,
+				4DD7C0FC27A55CEA00B9C017 /* timemap.cpp in Sources */,
 				8F3DD33C18854B2E0051330C /* barline.cpp in Sources */,
 				4DB3D8D51F83D12B00B5FC2B /* tempo.cpp in Sources */,
 				4DEC4DA021C81E9400D1D273 /* orig.cpp in Sources */,
@@ -3710,6 +3725,7 @@
 				BB4C4B9922A932E5001F6AF0 /* linkinginterface.cpp in Sources */,
 				BB4C4A6A22A9321F001F6AF0 /* atts_externalsymbols.cpp in Sources */,
 				BB4C4AAD22A932A6001F6AF0 /* io.cpp in Sources */,
+				4DD7C0FD27A55CEA00B9C017 /* timemap.cpp in Sources */,
 				BB4C4B2322A932CF001F6AF0 /* dynam.cpp in Sources */,
 				BB4C4B6522A932D7001F6AF0 /* multirest.cpp in Sources */,
 				BB4C4AB322A932A6001F6AF0 /* iohumdrum.cpp in Sources */,

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -97,7 +97,7 @@ verovio.vrvToolkit.renderToPAE = Module.cwrap( 'vrvToolkit_renderToPAE', 'string
 verovio.vrvToolkit.renderToSVG = Module.cwrap( 'vrvToolkit_renderToSVG', 'string', ['number', 'number', 'string'] );
 
 // char *renderToTimemap(Toolkit *ic)
-verovio.vrvToolkit.renderToTimemap = Module.cwrap( 'vrvToolkit_renderToTimemap', 'string', ['number'] );
+verovio.vrvToolkit.renderToTimemap = Module.cwrap( 'vrvToolkit_renderToTimemap', 'string', ['number', 'string'] );
 
 // void resetXmlIdSeed(Toolkit *ic, int seed) 
 verovio.vrvToolkit.resetXmlIdSeed = Module.cwrap( 'vrvToolkit_resetXmlIdSeed', null, ['number', 'number'] );
@@ -295,9 +295,9 @@ verovio.toolkit.prototype.renderToSVG = function ( pageNo, options )
     return verovio.vrvToolkit.renderToSVG( this.ptr, pageNo, JSON.stringify( options ) );
 };
 
-verovio.toolkit.prototype.renderToTimemap = function ()
+verovio.toolkit.prototype.renderToTimemap = function ( options = {})
 {
-    return JSON.parse( verovio.vrvToolkit.renderToTimemap( this.ptr ) );
+    return JSON.parse( verovio.vrvToolkit.renderToTimemap( this.ptr, JSON.stringify( options ) ) );
 };
 
 verovio.toolkit.prototype.resetXmlIdSeed = function ( seed )

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -222,10 +222,7 @@ public:
      * Extract a timemap from the document to a JSON string.
      * Run trough all the layers and fill the timemap file content.
      */
-    bool ExportTimemap(std::string &output);
-    void PrepareJsonTimemap(std::string &output, std::map<double, double> &realTimeToScoreTime,
-        std::map<double, std::vector<std::string>> &realTimeToOnElements,
-        std::map<double, std::vector<std::string>> &realTimeToOffElements, std::map<double, double> &realTimeToTempo);
+    bool ExportTimemap(std::string &output, bool includeRests, bool includeMeasures);
 
     /**
      * Extract music features to JSON string.

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -15,6 +15,7 @@
 
 namespace vrv {
 
+class FunctorParams;
 class Mensur;
 class Object;
 
@@ -108,6 +109,39 @@ public:
      */
     bool HasIdenticalDurationInterface(DurationInterface *otherDurationInterface);
 
+    /**
+     * MIDI timing information
+     */
+    ///@{
+    void SetScoreTimeOnset(double scoreTime);
+    void SetRealTimeOnsetSeconds(double timeInSeconds);
+    void SetScoreTimeOffset(double scoreTime);
+    void SetRealTimeOffsetSeconds(double timeInSeconds);
+    void SetScoreTimeTiedDuration(double timeInSeconds);
+    double GetScoreTimeOnset() const;
+    double GetRealTimeOnsetMilliseconds() const;
+    double GetScoreTimeOffset() const;
+    double GetScoreTimeTiedDuration() const;
+    double GetRealTimeOffsetMilliseconds() const;
+    double GetScoreTimeDuration() const;
+    ///@}
+
+    //-----------------//
+    // Pseudo functors //
+    //-----------------//
+
+    /**
+     * We have functors in the interface for avoiding code duplication in each implementation class.
+     * Since we are in an interface, we need to pass the  Object (implementation) to
+     * the functor methods. These are not called by the Process/Call loop but by the implementation
+     * classes explicitely. See FloatingObject::FillStaffCurrentTimeSpanning for an example.
+     */
+
+    /**
+     * See Object::GenerateTimemap
+     */
+    virtual int InterfaceGenerateTimemap(FunctorParams *functorParams, Object *object);
+
 private:
     /**
      * Calculate the actual duration => translate mensural values
@@ -117,6 +151,42 @@ private:
 public:
     //
 private:
+    /**
+     * The score-time onset of the note in the measure (duration from the start of measure in
+     * quarter notes).
+     */
+    double m_scoreTimeOnset;
+
+    /**
+     * The score-time off-time of the note in the measure (duration from the start of the measure
+     * in quarter notes).  This is the duration of the printed note.  If the note is the start of
+     * a tied group, the score time of the tied group is this variable plus m_scoreTimeTiedDuration.
+     * If this note is a secondary note in a tied group, then this value is the score time end
+     * of the printed note, and the m_scoreTimeTiedDuration is -1.0 to indicate that it should not
+     * be exported when creating a MIDI file.
+     */
+    double m_scoreTimeOffset;
+
+    /**
+     * The time in milliseconds since the start of the measure element that contains the note.
+     */
+    double m_realTimeOnsetMilliseconds;
+
+    /**
+     * The time in milliseconds since the start of the measure element to end of printed note.
+     * The real-time duration of a tied group is not currently tracked (this gets complicated
+     * if there is a tempo change during a note sustain, which is currently not supported).
+     */
+    double m_realTimeOffsetMilliseconds;
+
+    /**
+     * If the note is the first in a tied group, then m_scoreTimeTiedDuration contains the
+     * score-time duration (in quarter notes) of all tied notes in the group after this note.
+     * If the note is a secondary note in a tied group, then this variable is set to -1.0 to
+     * indicate that it should not be written to MIDI output.
+     */
+    double m_scoreTimeTiedDuration;
+
     /**
      * The default duration: extracted from scoreDef/staffDef and used when no duration attribute is given
      */

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -137,11 +137,6 @@ public:
      * classes explicitely. See FloatingObject::FillStaffCurrentTimeSpanning for an example.
      */
 
-    /**
-     * See Object::GenerateTimemap
-     */
-    virtual int InterfaceGenerateTimemap(FunctorParams *functorParams, Object *object);
-
 private:
     /**
      * Calculate the actual duration => translate mensural values

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1626,13 +1626,24 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: mapping of real times to score times
- * member 1: mapping of real times to elements which should be highlighted at time
- * member 2: mapping of real times to elements which should be unhighlighted at time
- * member 3: mapping of real times to tempos
- * member 4: Score time from the start of the piece to previous barline in quarter notes
- * member 5: Real time from the start of the piece to previous barline in ms
- * member 6: Currently active tempo
+ * Helper struct to store timemap entries
+ */
+struct TimemapEntry {
+    double tempo = -1000.0;
+    double qstamp;
+    std::vector<std::string> notesOn;
+    std::vector<std::string> notesOff;
+    std::vector<std::string> restsOn;
+    std::vector<std::string> restsOff;
+    std::string measureOn;
+};
+
+/**
+ * member 0: mapping of real times with TimemapEntry
+ * member 1: Score time from the start of the piece to previous barline in quarter notes
+ * member 2: Real time from the start of the piece to previous barline in ms
+ * member 3: Currently active tempo
+ * member 4: The functor for redirection
  **/
 
 class GenerateTimemapParams : public FunctorParams {
@@ -1644,10 +1655,7 @@ public:
         m_currentTempo = 120.0;
         m_functor = functor;
     }
-    std::map<double, double> realTimeToScoreTime;
-    std::map<double, std::vector<std::string>> realTimeToOnElements;
-    std::map<double, std::vector<std::string>> realTimeToOffElements;
-    std::map<double, double> realTimeToTempo;
+    std::map<double, TimemapEntry> m_timemap;
     double m_scoreTimeOffset;
     double m_realTimeOffsetMilliseconds;
     double m_currentTempo;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -57,6 +57,7 @@ class StemmedDrawingInterface;
 class Syl;
 class System;
 class SystemAligner;
+class Timemap;
 class Transposer;
 class TupletNum;
 class Turn;
@@ -1632,19 +1633,6 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * Helper struct to store timemap entries
- */
-struct TimemapEntry {
-    double tempo = -1000.0;
-    double qstamp;
-    std::vector<std::string> notesOn;
-    std::vector<std::string> notesOff;
-    std::vector<std::string> restsOn;
-    std::vector<std::string> restsOff;
-    std::string measureOn;
-};
-
-/**
  * member 0: mapping of real times with TimemapEntry
  * member 1: Score time from the start of the piece to previous barline in quarter notes
  * member 2: Real time from the start of the piece to previous barline in ms
@@ -1654,17 +1642,18 @@ struct TimemapEntry {
 
 class GenerateTimemapParams : public FunctorParams {
 public:
-    GenerateTimemapParams(Functor *functor)
+    GenerateTimemapParams(Timemap *timemap, Functor *functor)
     {
         m_scoreTimeOffset = 0.0;
         m_realTimeOffsetMilliseconds = 0;
         m_currentTempo = 120.0;
+        m_timemap = timemap;
         m_functor = functor;
     }
-    std::map<double, TimemapEntry> m_timemap;
     double m_scoreTimeOffset;
     double m_realTimeOffsetMilliseconds;
     double m_currentTempo;
+    Timemap *m_timemap;
     Functor *m_functor;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1633,10 +1633,10 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: mapping of real times with TimemapEntry
- * member 1: Score time from the start of the piece to previous barline in quarter notes
- * member 2: Real time from the start of the piece to previous barline in ms
- * member 3: Currently active tempo
+ * member 0: Score time from the start of the piece to previous barline in quarter notes
+ * member 1: Real time from the start of the piece to previous barline in ms
+ * member 2: Currently active tempo
+ * member 3: A pointer to the Timemap
  * member 4: The functor for redirection
  **/
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -211,23 +211,6 @@ public:
     bool IsVisible() const;
 
     /**
-     * MIDI timing information
-     */
-    ///@{
-    void SetScoreTimeOnset(double scoreTime);
-    void SetRealTimeOnsetSeconds(double timeInSeconds);
-    void SetScoreTimeOffset(double scoreTime);
-    void SetRealTimeOffsetSeconds(double timeInSeconds);
-    void SetScoreTimeTiedDuration(double timeInSeconds);
-    double GetScoreTimeOnset() const;
-    double GetRealTimeOnsetMilliseconds() const;
-    double GetScoreTimeOffset() const;
-    double GetScoreTimeTiedDuration() const;
-    double GetRealTimeOffsetMilliseconds() const;
-    double GetScoreTimeDuration() const;
-    ///@}
-
-    /**
      * MIDI pitch
      */
     int GetMIDIPitch(int shift = 0);
@@ -378,42 +361,6 @@ private:
      * Position in the cluster (1-indexed position in said cluster; 0 if does not have position)
      */
     int m_clusterPosition;
-
-    /**
-     * The score-time onset of the note in the measure (duration from the start of measure in
-     * quarter notes).
-     */
-    double m_scoreTimeOnset;
-
-    /**
-     * The score-time off-time of the note in the measure (duration from the start of the measure
-     * in quarter notes).  This is the duration of the printed note.  If the note is the start of
-     * a tied group, the score time of the tied group is this variable plus m_scoreTimeTiedDuration.
-     * If this note is a secondary note in a tied group, then this value is the score time end
-     * of the printed note, and the m_scoreTimeTiedDuration is -1.0 to indicate that it should not
-     * be exported when creating a MIDI file.
-     */
-    double m_scoreTimeOffset;
-
-    /**
-     * The time in milliseconds since the start of the measure element that contains the note.
-     */
-    double m_realTimeOnsetMilliseconds;
-
-    /**
-     * The time in milliseconds since the start of the measure element to end of printed note.
-     * The real-time duration of a tied group is not currently tracked (this gets complicated
-     * if there is a tempo change during a note sustain, which is currently not supported).
-     */
-    double m_realTimeOffsetMilliseconds;
-
-    /**
-     * If the note is the first in a tied group, then m_scoreTimeTiedDuration contains the
-     * score-time duration (in quarter notes) of all tied notes in the group after this note.
-     * If the note is a secondary note in a tied group, then this variable is set to -1.0 to
-     * indicate that it should not be written to MIDI output.
-     */
-    double m_scoreTimeTiedDuration;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -84,6 +84,11 @@ public:
     wchar_t GetRestGlyph(int duration) const;
     ///@}
 
+    /**
+     * Get the vertical location for the rests that are located on other layers
+     */
+    int GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation);
+
     //----------//
     // Functors //
     //----------//
@@ -124,9 +129,9 @@ public:
     int Transpose(FunctorParams *functorParams) override;
 
     /**
-     * Get the vertical location for the rests that are located on other layers
+     * See Object::GenerateTimemap
      */
-    int GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation);
+    int GenerateTimemap(FunctorParams *functorParams) override;
 
 private:
     /**

--- a/include/vrv/timemap.h
+++ b/include/vrv/timemap.h
@@ -42,7 +42,7 @@ struct TimemapEntry {
 //----------------------------------------------------------------------------
 
 /**
- * This class represents a clock to measure runtime.
+ * This class holds a timemap for exporting onset / offset values.
  */
 class Timemap {
 public:
@@ -54,26 +54,30 @@ public:
     virtual ~Timemap();
     ///@}
 
-    /** Resets the clock */
+    /** Resets the timemap */
     void Reset();
 
+    /**
+     * Add an entry to the timemap.
+     * Currently support note and rest (duration interfaces) and measure.
+     */
     void AddEntry(Object *object, GenerateTimemapParams *params);
 
     /**
      * Write the current timemap to a JSON string
      */
-    void ToJson(std::string &output);
+    void ToJson(std::string &output, bool includetRests, bool includetMeasures);
 
 private:
     //
 public:
     //
 private:
-    /** The time point at which the clock was started */
+    /** The map with time values as keys */
     std::map<double, TimemapEntry> m_map;
 
 }; // class Timemap
 
 } // namespace vrv
 
-#endif // __VRV_RUNTIMECLOCK_H__
+#endif // __VRV_TIMEMAP_H__

--- a/include/vrv/timemap.h
+++ b/include/vrv/timemap.h
@@ -1,0 +1,79 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        timemap.h
+// Author:      Laurent Pugin
+// Created:     29/01/2022
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_TIMEMAP_H__
+#define __VRV_TIMEMAP_H__
+
+#include <assert.h>
+#include <map>
+#include <string>
+#include <vector>
+
+//----------------------------------------------------------------------------
+
+namespace vrv {
+
+class Object;
+class GenerateTimemapParams;
+
+//----------------------------------------------------------------------------
+// TimemapEntry
+//----------------------------------------------------------------------------
+
+/**
+ * Helper struct to store timemap entries
+ */
+struct TimemapEntry {
+    double tempo = -1000.0;
+    double qstamp;
+    std::vector<std::string> notesOn;
+    std::vector<std::string> notesOff;
+    std::vector<std::string> restsOn;
+    std::vector<std::string> restsOff;
+    std::string measureOn;
+};
+
+//----------------------------------------------------------------------------
+// Timemap
+//----------------------------------------------------------------------------
+
+/**
+ * This class represents a clock to measure runtime.
+ */
+class Timemap {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     */
+    ///@{
+    Timemap();
+    virtual ~Timemap();
+    ///@}
+
+    /** Resets the clock */
+    void Reset();
+
+    void AddEntry(Object *object, GenerateTimemapParams *params);
+
+    /**
+     * Write the current timemap to a JSON string
+     */
+    void ToJson(std::string &output);
+
+private:
+    //
+public:
+    //
+private:
+    /** The time point at which the clock was started */
+    std::map<double, TimemapEntry> m_map;
+
+}; // class Timemap
+
+} // namespace vrv
+
+#endif // __VRV_RUNTIMECLOCK_H__

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -380,9 +380,10 @@ public:
     /**
      * Render a document to a timemap
      *
+     * @param jsonOptions A stringified JSON objects with the timemap options
      * @return The timemap as a string
      */
-    std::string RenderToTimemap();
+    std::string RenderToTimemap(const std::string &jsonOptions = "");
 
     /**
      * Render a document to timemap and save it to the file
@@ -390,9 +391,10 @@ public:
      * This methods is not available in the JavaScript version of the toolkit.
      *
      * @param @filename The output filename
+     * @param jsonOptions A stringified JSON objects with the timemap options
      * @return True if the file was successfully written
      */
-    bool RenderToTimemapFile(const std::string &filename);
+    bool RenderToTimemapFile(const std::string &filename, const std::string &jsonOptions = "");
 
     //@}
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -55,6 +55,7 @@
 #include "syllable.h"
 #include "system.h"
 #include "text.h"
+#include "timemap.h"
 #include "timestamp.h"
 #include "transposition.h"
 #include "verse.h"
@@ -406,63 +407,12 @@ bool Doc::ExportTimemap(std::string &output, bool includeRests, bool includeMeas
         output = "";
         return false;
     }
+    Timemap timemap;
     Functor generateTimemap(&Object::GenerateTimemap);
-    GenerateTimemapParams generateTimemapParams(&generateTimemap);
+    GenerateTimemapParams generateTimemapParams(&timemap, &generateTimemap);
     this->Process(&generateTimemap, &generateTimemapParams);
 
-    double currentTempo = -1000.0;
-    double newTempo;
-
-    jsonxx::Array timemap;
-
-    for (auto &[tstamp, entry] : generateTimemapParams.m_timemap) {
-        jsonxx::Object o;
-        o << "tstamp" << tstamp;
-        o << "qstamp" << entry.qstamp;
-
-        // on / off
-        if (!entry.notesOn.empty()) {
-            jsonxx::Array notesOn;
-            for (auto note : entry.notesOn) notesOn << note;
-            o << "on" << notesOn;
-        }
-        if (!entry.notesOff.empty()) {
-            jsonxx::Array notesOff;
-            for (auto note : entry.notesOff) notesOff << note;
-            o << "off" << notesOff;
-        }
-
-        // restsOn / restsOff
-        if (includeRests) {
-            if (!entry.restsOn.empty()) {
-                jsonxx::Array restsOn;
-                for (auto rest : entry.restsOn) restsOn << rest;
-                o << "restsOn" << restsOn;
-            }
-            if (!entry.restsOff.empty()) {
-                jsonxx::Array restsOff;
-                for (auto rest : entry.restsOff) restsOff << rest;
-                o << "restsOff" << restsOff;
-            }
-        }
-
-        // tempo
-        if (entry.tempo != -1000.0) {
-            newTempo = entry.tempo;
-            if (newTempo != currentTempo) {
-                currentTempo = newTempo;
-                o << "tempo" << std::to_string(currentTempo);
-            }
-        }
-
-        // measureOn
-        if (includeMeasures && !entry.measureOn.empty()) {
-            o << "measureOn" << entry.measureOn;
-        }
-
-        timemap << o;
-    }
-    output = timemap.json();
+    timemap.ToJson(output);
 
     return true;
 }

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -410,9 +410,6 @@ bool Doc::ExportTimemap(std::string &output, bool includeRests, bool includeMeas
     GenerateTimemapParams generateTimemapParams(&generateTimemap);
     this->Process(&generateTimemap, &generateTimemapParams);
 
-    includeRests = true;
-    includeMeasures = true;
-
     double currentTempo = -1000.0;
     double newTempo;
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -412,7 +412,7 @@ bool Doc::ExportTimemap(std::string &output, bool includeRests, bool includeMeas
     GenerateTimemapParams generateTimemapParams(&timemap, &generateTimemap);
     this->Process(&generateTimemap, &generateTimemapParams);
 
-    timemap.ToJson(output);
+    timemap.ToJson(output, includeRests, includeMeasures);
 
     return true;
 }

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -303,48 +303,4 @@ double DurationInterface::GetScoreTimeDuration() const
 // Interface pseudo functor (redirected)
 //----------------------------------------------------------------------------
 
-int DurationInterface::InterfaceGenerateTimemap(FunctorParams *functorParams, Object *object)
-{
-    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
-    assert(params);
-
-    double realTimeStart = params->m_realTimeOffsetMilliseconds + this->GetRealTimeOnsetMilliseconds();
-    double scoreTimeStart = params->m_scoreTimeOffset + this->GetScoreTimeOnset();
-
-    double realTimeEnd = params->m_realTimeOffsetMilliseconds + this->GetRealTimeOffsetMilliseconds();
-    double scoreTimeEnd = params->m_scoreTimeOffset + this->GetScoreTimeOffset();
-
-    bool isRest = (object->Is(REST));
-
-    TimemapEntry startEntry;
-    if (params->m_timemap.count(realTimeStart) > 0) startEntry = params->m_timemap.at(realTimeStart);
-
-    // Should check if value for realTimeStart already exists and if so, then
-    // ensure that it is equal to scoreTimeStart:
-    startEntry.qstamp = scoreTimeStart;
-
-    // Store the element ID in list to turn on at given time - note or rest
-    if (!isRest) startEntry.notesOn.push_back(object->GetUuid());
-    if (isRest) startEntry.restsOn.push_back(object->GetUuid());
-
-    TimemapEntry endEntry;
-    if (params->m_timemap.count(realTimeEnd) > 0) endEntry = params->m_timemap.at(realTimeEnd);
-
-    // Should check if value for realTimeEnd already exists and if so, then
-    // ensure that it is equal to scoreTimeEnd:
-    endEntry.qstamp = scoreTimeEnd;
-
-    // Store the element ID in list to turn off at given time - notes or rest
-    if (!isRest) endEntry.notesOff.push_back(object->GetUuid());
-    if (isRest) endEntry.restsOff.push_back(object->GetUuid());
-
-    startEntry.tempo = params->m_currentTempo;
-
-    // Update the timemap
-    params->m_timemap[realTimeStart] = startEntry;
-    params->m_timemap[realTimeEnd] = endEntry;
-
-    return FUNCTOR_SIBLINGS;
-}
-
 } // namespace vrv

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2406,6 +2406,15 @@ int LayerElement::CalcOnsetOffset(FunctorParams *functorParams)
         incrementScoreTime = incrementScoreTime / (DUR_MAX / DURATION_4);
         params->m_currentScoreTime += incrementScoreTime;
         params->m_currentRealTimeSeconds += incrementScoreTime * 60.0 / params->m_currentTempo;
+        // For rests to be possibly added to the timemap
+        if (element->Is(REST)) {
+            Rest *rest = vrv_cast<Rest *>(element);
+            double realTimeIncrementSeconds = incrementScoreTime * 60.0 / params->m_currentTempo;
+            rest->SetScoreTimeOnset(params->m_currentScoreTime);
+            rest->SetRealTimeOnsetSeconds(params->m_currentRealTimeSeconds);
+            rest->SetScoreTimeOffset(params->m_currentScoreTime + incrementScoreTime);
+            rest->SetRealTimeOffsetSeconds(params->m_currentRealTimeSeconds + realTimeIncrementSeconds);
+        }
     }
     else if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2404,8 +2404,6 @@ int LayerElement::CalcOnsetOffset(FunctorParams *functorParams)
         incrementScoreTime = element->GetAlignmentDuration(
             params->m_currentMensur, params->m_currentMeterSig, true, params->m_notationType);
         incrementScoreTime = incrementScoreTime / (DUR_MAX / DURATION_4);
-        params->m_currentScoreTime += incrementScoreTime;
-        params->m_currentRealTimeSeconds += incrementScoreTime * 60.0 / params->m_currentTempo;
         // For rests to be possibly added to the timemap
         if (element->Is(REST)) {
             Rest *rest = vrv_cast<Rest *>(element);
@@ -2415,6 +2413,8 @@ int LayerElement::CalcOnsetOffset(FunctorParams *functorParams)
             rest->SetScoreTimeOffset(params->m_currentScoreTime + incrementScoreTime);
             rest->SetRealTimeOffsetSeconds(params->m_currentRealTimeSeconds + realTimeIncrementSeconds);
         }
+        params->m_currentScoreTime += incrementScoreTime;
+        params->m_currentRealTimeSeconds += incrementScoreTime * 60.0 / params->m_currentTempo;
     }
     else if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1553,6 +1553,22 @@ int Measure::GenerateTimemap(FunctorParams *functorParams)
     params->m_realTimeOffsetMilliseconds = m_realTimeOffsetMilliseconds.back();
     params->m_currentTempo = m_currentTempo;
 
+    double scoreTimeStart = params->m_scoreTimeOffset;
+    double realTimeStart = params->m_realTimeOffsetMilliseconds;
+
+    TimemapEntry startEntry;
+    if (params->m_timemap.count(realTimeStart) > 0) startEntry = params->m_timemap.at(realTimeStart);
+
+    // Should check if value for realTimeStart already exists and if so, then
+    // ensure that it is equal to scoreTimeStart:
+    startEntry.qstamp = scoreTimeStart;
+
+    // Add the measureOn
+    startEntry.measureOn = this->GetUuid();
+
+    // Update the timemap
+    params->m_timemap[realTimeStart] = startEntry;
+
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -36,6 +36,7 @@
 #include "tempo.h"
 #include "tie.h"
 #include "timeinterface.h"
+#include "timemap.h"
 #include "timestamp.h"
 #include "vrv.h"
 
@@ -1548,26 +1549,11 @@ int Measure::GenerateTimemap(FunctorParams *functorParams)
     GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
     assert(params);
 
-    // Deal with repeated music later, for now get the last times.
-    params->m_scoreTimeOffset = m_scoreTimeOffset.back();
-    params->m_realTimeOffsetMilliseconds = m_realTimeOffsetMilliseconds.back();
-    params->m_currentTempo = m_currentTempo;
+    params->m_scoreTimeOffset = this->m_scoreTimeOffset.back();
+    params->m_realTimeOffsetMilliseconds = this->m_realTimeOffsetMilliseconds.back();
+    params->m_currentTempo = this->m_currentTempo;
 
-    double scoreTimeStart = params->m_scoreTimeOffset;
-    double realTimeStart = params->m_realTimeOffsetMilliseconds;
-
-    TimemapEntry startEntry;
-    if (params->m_timemap.count(realTimeStart) > 0) startEntry = params->m_timemap.at(realTimeStart);
-
-    // Should check if value for realTimeStart already exists and if so, then
-    // ensure that it is equal to scoreTimeStart:
-    startEntry.qstamp = scoreTimeStart;
-
-    // Add the measureOn
-    startEntry.measureOn = this->GetUuid();
-
-    // Update the timemap
-    params->m_timemap[realTimeStart] = startEntry;
+    params->m_timemap->AddEntry(this, params);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -32,6 +32,7 @@
 #include "syl.h"
 #include "tabgrp.h"
 #include "tie.h"
+#include "timemap.h"
 #include "transposition.h"
 #include "tuning.h"
 #include "verse.h"
@@ -1486,10 +1487,15 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
 
 int Note::GenerateTimemap(FunctorParams *functorParams)
 {
+    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
+    assert(params);
+
     Note *note = vrv_cast<Note *>(this->ThisOrSameasAsLink());
     assert(note);
 
-    return note->InterfaceGenerateTimemap(functorParams, note);
+    params->m_timemap->AddEntry(note, params);
+
+    return FUNCTOR_SIBLINGS;
 }
 
 int Note::Transpose(FunctorParams *functorParams)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -117,12 +117,6 @@ void Note::Reset()
 
     m_drawingLoc = 0;
     m_flippedNotehead = false;
-
-    m_scoreTimeOnset = 0.0;
-    m_scoreTimeOffset = 0.0;
-    m_realTimeOnsetMilliseconds = 0;
-    m_realTimeOffsetMilliseconds = 0;
-    m_scoreTimeTiedDuration = 0.0;
 }
 
 bool Note::IsSupportedChild(Object *child)
@@ -554,33 +548,6 @@ bool Note::IsEnharmonicWith(Note *note)
     return (this->GetMIDIPitch() == note->GetMIDIPitch());
 }
 
-void Note::SetScoreTimeOnset(double scoreTime)
-{
-    m_scoreTimeOnset = scoreTime;
-}
-
-void Note::SetRealTimeOnsetSeconds(double timeInSeconds)
-{
-    // m_realTimeOnsetMilliseconds = int(timeInSeconds * 1000.0 + 0.5);
-    m_realTimeOnsetMilliseconds = timeInSeconds * 1000.0;
-}
-
-void Note::SetScoreTimeOffset(double scoreTime)
-{
-    m_scoreTimeOffset = scoreTime;
-}
-
-void Note::SetRealTimeOffsetSeconds(double timeInSeconds)
-{
-    // m_realTimeOffsetMilliseconds = int(timeInSeconds * 1000.0 + 0.5);
-    m_realTimeOffsetMilliseconds = timeInSeconds * 1000.0;
-}
-
-void Note::SetScoreTimeTiedDuration(double scoreTime)
-{
-    m_scoreTimeTiedDuration = scoreTime;
-}
-
 int Note::GetMIDIPitch(const int shift)
 {
     int pitch = 0;
@@ -622,36 +589,6 @@ int Note::GetMIDIPitch(const int shift)
 
     // Apply shift, i.e. from transposition instruments
     return pitch + shift;
-}
-
-double Note::GetScoreTimeOnset() const
-{
-    return m_scoreTimeOnset;
-}
-
-double Note::GetRealTimeOnsetMilliseconds() const
-{
-    return m_realTimeOnsetMilliseconds;
-}
-
-double Note::GetScoreTimeOffset() const
-{
-    return m_scoreTimeOffset;
-}
-
-double Note::GetRealTimeOffsetMilliseconds() const
-{
-    return m_realTimeOffsetMilliseconds;
-}
-
-double Note::GetScoreTimeTiedDuration() const
-{
-    return m_scoreTimeTiedDuration;
-}
-
-double Note::GetScoreTimeDuration() const
-{
-    return this->GetScoreTimeOffset() - this->GetScoreTimeOnset();
 }
 
 int Note::GetChromaticAlteration()
@@ -1457,35 +1394,10 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
 
 int Note::GenerateTimemap(FunctorParams *functorParams)
 {
-    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
-    assert(params);
-
     Note *note = vrv_cast<Note *>(this->ThisOrSameasAsLink());
     assert(note);
 
-    double realTimeStart = params->m_realTimeOffsetMilliseconds + note->GetRealTimeOnsetMilliseconds();
-    double scoreTimeStart = params->m_scoreTimeOffset + note->GetScoreTimeOnset();
-
-    double realTimeEnd = params->m_realTimeOffsetMilliseconds + note->GetRealTimeOffsetMilliseconds();
-    double scoreTimeEnd = params->m_scoreTimeOffset + note->GetScoreTimeOffset();
-
-    // Should check if value for realTimeStart already exists and if so, then
-    // ensure that it is equal to scoreTimeStart:
-    params->realTimeToScoreTime[realTimeStart] = scoreTimeStart;
-
-    // Store the element ID in list to turn on at given time.
-    params->realTimeToOnElements[realTimeStart].push_back(this->GetUuid());
-
-    // Should check if value for realTimeEnd already exists and if so, then
-    // ensure that it is equal to scoreTimeEnd:
-    params->realTimeToScoreTime[realTimeEnd] = scoreTimeEnd;
-
-    // Store the element ID in list to turn off at given time.
-    params->realTimeToOffElements[realTimeEnd].push_back(this->GetUuid());
-
-    params->realTimeToTempo[realTimeStart] = params->m_currentTempo;
-
-    return FUNCTOR_SIBLINGS;
+    return note->InterfaceGenerateTimemap(functorParams, note);
 }
 
 int Note::Transpose(FunctorParams *functorParams)

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -734,9 +734,6 @@ int Rest::Transpose(FunctorParams *functorParams)
 
 int Rest::GenerateTimemap(FunctorParams *functorParams)
 {
-    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
-    assert(params);
-
     return this->InterfaceGenerateTimemap(functorParams, this);
 }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -23,6 +23,7 @@
 #include "smufl.h"
 #include "staff.h"
 #include "system.h"
+#include "timemap.h"
 #include "transposition.h"
 #include "vrv.h"
 
@@ -734,7 +735,12 @@ int Rest::Transpose(FunctorParams *functorParams)
 
 int Rest::GenerateTimemap(FunctorParams *functorParams)
 {
-    return this->InterfaceGenerateTimemap(functorParams, this);
+    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
+    assert(params);
+
+    params->m_timemap->AddEntry(this, params);
+
+    return FUNCTOR_SIBLINGS;
 }
 
 } // namespace vrv

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -732,4 +732,12 @@ int Rest::Transpose(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int Rest::GenerateTimemap(FunctorParams *functorParams)
+{
+    GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
+    assert(params);
+
+    return this->InterfaceGenerateTimemap(functorParams, this);
+}
+
 } // namespace vrv

--- a/src/timemap.cpp
+++ b/src/timemap.cpp
@@ -1,0 +1,177 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        timemap.cpp
+// Author:      Laurent Pugin
+// Created:     29/01/2022
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "timemap.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+#include "functorparams.h"
+#include "measure.h"
+#include "note.h"
+#include "rest.h"
+#include "vrv.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Timemap
+//----------------------------------------------------------------------------
+
+Timemap::Timemap()
+{
+    this->Reset();
+}
+
+Timemap::~Timemap() {}
+
+void Timemap::Reset() {}
+
+void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
+{
+    assert(object);
+    assert(params);
+
+    // It is a bit weird to have a timemap parameter, but we need it to call this method from the functor.
+    // Just make sure they are the same because below we use m_map (and not params->m_timemap)
+    assert(params->m_timemap == this);
+
+    TimemapEntry emptyEntry;
+
+    if (object->Is({ NOTE, REST })) {
+        DurationInterface *interface = object->GetDurationInterface();
+        assert(interface);
+
+        double realTimeStart = params->m_realTimeOffsetMilliseconds + interface->GetRealTimeOnsetMilliseconds();
+        double scoreTimeStart = params->m_scoreTimeOffset + interface->GetScoreTimeOnset();
+
+        double realTimeEnd = params->m_realTimeOffsetMilliseconds + interface->GetRealTimeOffsetMilliseconds();
+        double scoreTimeEnd = params->m_scoreTimeOffset + interface->GetScoreTimeOffset();
+
+        bool isRest = (object->Is(REST));
+
+        /*********** start values ***********/
+
+        if (m_map.count(realTimeStart) == 0) {
+            m_map[realTimeStart] = emptyEntry;
+        }
+        TimemapEntry *startEntry = &m_map.at(realTimeStart);
+
+        // Should check if value for realTimeStart already exists and if so, then
+        // ensure that it is equal to scoreTimeStart:
+        startEntry->qstamp = scoreTimeStart;
+
+        // Store the element ID in list to turn on at given time - note or rest
+        if (!isRest) startEntry->notesOn.push_back(object->GetUuid());
+        if (isRest) startEntry->restsOn.push_back(object->GetUuid());
+
+        // Also add the tempo the
+        startEntry->tempo = params->m_currentTempo;
+
+        /*********** end values ***********/
+
+        if (m_map.count(realTimeEnd) == 0) {
+            m_map[realTimeEnd] = emptyEntry;
+        }
+        TimemapEntry *endEntry = &m_map.at(realTimeEnd);
+
+        // Should check if value for realTimeEnd already exists and if so, then
+        // ensure that it is equal to scoreTimeEnd:
+        endEntry->qstamp = scoreTimeEnd;
+
+        // Store the element ID in list to turn off at given time - notes or rest
+        if (!isRest) endEntry->notesOff.push_back(object->GetUuid());
+        if (isRest) endEntry->restsOff.push_back(object->GetUuid());
+    }
+    else if (object->Is(MEASURE)) {
+
+        Measure *measure = vrv_cast<Measure *>(object);
+        assert(measure);
+
+        // Deal with repeated music later, for now get the last times.
+        double scoreTimeStart = params->m_scoreTimeOffset;
+        double realTimeStart = params->m_realTimeOffsetMilliseconds;
+
+        if (m_map.count(realTimeStart) == 0) {
+            m_map[realTimeStart] = emptyEntry;
+        }
+        TimemapEntry *startEntry = &m_map.at(realTimeStart);
+
+        // Should check if value for realTimeStart already exists and if so, then
+        // ensure that it is equal to scoreTimeStart:
+        startEntry->qstamp = scoreTimeStart;
+
+        // Add the measureOn
+        startEntry->measureOn = measure->GetUuid();
+    }
+}
+
+void Timemap::ToJson(std::string &output)
+{
+
+    bool includeRests = true;
+    bool includeMeasures = true;
+
+    double currentTempo = -1000.0;
+    double newTempo;
+
+    jsonxx::Array timemap;
+
+    for (auto &[tstamp, entry] : m_map) {
+        jsonxx::Object o;
+        o << "tstamp" << tstamp;
+        o << "qstamp" << entry.qstamp;
+
+        // on / off
+        if (!entry.notesOn.empty()) {
+            jsonxx::Array notesOn;
+            for (auto note : entry.notesOn) notesOn << note;
+            o << "on" << notesOn;
+        }
+        if (!entry.notesOff.empty()) {
+            jsonxx::Array notesOff;
+            for (auto note : entry.notesOff) notesOff << note;
+            o << "off" << notesOff;
+        }
+
+        // restsOn / restsOff
+        if (includeRests) {
+            if (!entry.restsOn.empty()) {
+                jsonxx::Array restsOn;
+                for (auto rest : entry.restsOn) restsOn << rest;
+                o << "restsOn" << restsOn;
+            }
+            if (!entry.restsOff.empty()) {
+                jsonxx::Array restsOff;
+                for (auto rest : entry.restsOff) restsOff << rest;
+                o << "restsOff" << restsOff;
+            }
+        }
+
+        // tempo
+        if (entry.tempo != -1000.0) {
+            newTempo = entry.tempo;
+            if (newTempo != currentTempo) {
+                currentTempo = newTempo;
+                o << "tempo" << std::to_string(currentTempo);
+            }
+        }
+
+        // measureOn
+        if (includeMeasures && !entry.measureOn.empty()) {
+            o << "measureOn" << entry.measureOn;
+        }
+
+        timemap << o;
+    }
+    output = timemap.json();
+}
+
+} // namespace vrv

--- a/src/timemap.cpp
+++ b/src/timemap.cpp
@@ -113,12 +113,8 @@ void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
     }
 }
 
-void Timemap::ToJson(std::string &output)
+void Timemap::ToJson(std::string &output, bool includeRests, bool includeMeasures)
 {
-
-    bool includeRests = true;
-    bool includeMeasures = true;
-
     double currentTempo = -1000.0;
     double newTempo;
 

--- a/src/timemap.cpp
+++ b/src/timemap.cpp
@@ -32,7 +32,10 @@ Timemap::Timemap()
 
 Timemap::~Timemap() {}
 
-void Timemap::Reset() {}
+void Timemap::Reset()
+{
+    m_map.clear();
+}
 
 void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
 {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1399,12 +1399,29 @@ bool Toolkit::RenderToPAEFile(const std::string &filename)
     return true;
 }
 
-std::string Toolkit::RenderToTimemap()
+std::string Toolkit::RenderToTimemap(const std::string &jsonOptions)
 {
+    bool includeMeasures = true;
+    bool includeRests = true;
+
+    jsonxx::Object json;
+
+    // Read JSON options if not empty
+    if (!jsonOptions.empty()) {
+        if (!json.parse(jsonOptions)) {
+            LogWarning("Cannot parse JSON std::string. Using default options.");
+        }
+        else {
+            if (json.has<jsonxx::Boolean>("includeMeasures"))
+                includeMeasures = json.get<jsonxx::Boolean>("includeMeasures");
+            if (json.has<jsonxx::Boolean>("includeRests")) includeRests = json.get<jsonxx::Boolean>("includeRests");
+        }
+    }
+
     this->ResetLogBuffer();
 
     std::string output;
-    m_doc.ExportTimemap(output);
+    m_doc.ExportTimemap(output, includeRests, includeMeasures);
     return output;
 }
 
@@ -1476,12 +1493,9 @@ bool Toolkit::RenderToMIDIFile(const std::string &filename)
     return true;
 }
 
-bool Toolkit::RenderToTimemapFile(const std::string &filename)
+bool Toolkit::RenderToTimemapFile(const std::string &filename, const std::string &jsonOptions)
 {
-    this->ResetLogBuffer();
-
-    std::string outputString;
-    m_doc.ExportTimemap(outputString);
+    std::string outputString = this->RenderToTimemap(jsonOptions);
 
     std::ofstream output(filename.c_str());
     if (!output.is_open()) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1401,8 +1401,8 @@ bool Toolkit::RenderToPAEFile(const std::string &filename)
 
 std::string Toolkit::RenderToTimemap(const std::string &jsonOptions)
 {
-    bool includeMeasures = true;
-    bool includeRests = true;
+    bool includeMeasures = false;
+    bool includeRests = false;
 
     jsonxx::Object json;
 


### PR DESCRIPTION
The PR and an option to the `Toolkit::RenderToTimemap` method in order to include rests or measure IDs. The parameter is a stringyfied JSON object with keys `{"includeRests": true, "includeMeasures": true }`.

Rests and measures in the timemap have their own keys `restsOn`, `restsOff` and `measureOn`.

Example
![image](https://user-images.githubusercontent.com/689412/151446431-cc04d836-0a03-4aff-ad50-9c054c288b75.png)
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Note and rest collision between different layers</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2017-05-09">2017-05-09</date>
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>When a rest occurs at the same time as a note in two different layers, Verovio moves the rest vertically to avoid the note.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.0.0" label="2">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mo6mcsf">
                <score xml:id="sk8b4r1">
                    <scoreDef xml:id="sttgisg">
                        <staffGrp xml:id="sx6tkou">
                            <staffDef xml:id="s9zrpqk" n="1" lines="5" clef.shape="G" clef.line="2" meter.count="6" meter.unit="8" />
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="sp1a8fc">
                        <measure xml:id="mn06yxr" n="0">
                            <staff xml:id="s3pxqm3" n="1">
                                <layer xml:id="lmvfixp" n="1">
                                    <rest xml:id="r8rwqlv" dots="1" dur="4" />
                                    <note xml:id="npns2kd" dots="1" dur="4" oct="5" pname="e">
                                        <accid xml:id="acp0w3e" accid.ges="n" />
                                    </note>
                                </layer>
                                <layer xml:id="lpretxp" n="2">
                                    <note xml:id="n3p7qje" dots="1" dur="4" oct="4" pname="f">
                                        <accid xml:id="a5b2tvx" accid.ges="n" />
                                    </note>
                                    <note xml:id="nrve1l6" dots="1" dur="4" oct="4" pname="e">
                                        <accid xml:id="auidswb" accid.ges="n" />
                                    </note>
                                </layer>
                            </staff>
                        </measure>
                        <measure xml:id="mkdu9lf">
                            <staff xml:id="spwv28w" n="1">
                                <layer xml:id="lqw9upy" n="1">
                                    <rest xml:id="r8ncdeq" dur="4" />
                                    <rest xml:id="rp0rxwq" dur="8" />
                                    <note xml:id="nye771i" dots="1" dur="4" oct="5" pname="e">
                                        <accid xml:id="ahuqase" accid.ges="n" />
                                    </note>
                                </layer>
                                <layer xml:id="lvcj6he" n="2">
                                    <note xml:id="nvu10s0" dots="1" dur="4" oct="5" pname="f">
                                        <accid xml:id="aval5pk" accid.ges="n" />
                                    </note>
                                    <note xml:id="nbnmr5d" dots="1" dur="4" oct="4" pname="e">
                                        <accid xml:id="a6ndk8z" accid.ges="n" />
                                    </note>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>

```
```json
[
   {
      "measureOn": "mn06yxr",
      "on": ["n3p7qje"],
      "qstamp": 0,
      "restsOn": ["r8rwqlv"],
      "tempo": "120.000000",
      "tstamp": 0
   },
   {
      "off": ["n3p7qje"],
      "on": [
         "npns2kd",
         "nrve1l6"
      ],
      "qstamp": 1.5,
      "restsOff": ["r8rwqlv"],
      "tstamp": 750
   },
   {
      "measureOn": "mkdu9lf",
      "off": [
         "npns2kd",
         "nrve1l6"
      ],
      "on": ["nvu10s0"],
      "qstamp": 3,
      "restsOn": ["r8ncdeq"],
      "tstamp": 1500
   },
   {
      "qstamp": 4,
      "restsOff": ["r8ncdeq"],
      "restsOn": ["rp0rxwq"],
      "tstamp": 2000
   },
   {
      "off": ["nvu10s0"],
      "on": [
         "nye771i",
         "nbnmr5d"
      ],
      "qstamp": 4.5,
      "restsOff": ["rp0rxwq"],
      "tstamp": 2250
   },
   {
      "off": [
         "nye771i",
         "nbnmr5d"
      ],
      "qstamp": 6,
      "tstamp": 3000
   }
]
```