### PR TITLE
Improve grace note slurs

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1025,13 +1025,11 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                         x2 += 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                     }
                 }
-                else if ((end->GetContentTop() >= start->GetContentTop())
-                    && (end->GetContentBottom() <= start->GetContentTop())) {
-                    y2 = end->GetDrawingY() + unit * 3;
-                }
                 else {
-                    y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
-                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    const int yMin = y1 - unit * 4;
+                    const int yTop = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                    y2 = std::max(end->GetDrawingY() + unit * 2, yMin);
+                    y2 = std::min(yTop - unit, y2);
                 }
             }
             // portato slurs
@@ -1084,7 +1082,15 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     }
                 }
                 else {
-                    x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    const int yMax = y1 + unit;
+                    const int yBottom = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                    y2 = std::min(end->GetDrawingY(), yMax);
+                    if (y2 < yBottom + unit) {
+                        y2 = yBottom + unit;
+                    }
+                    else {
+                        x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    }
                 }
             }
             // portato slurs

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1029,7 +1029,10 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     const int yMin = y1 - unit * 4;
                     const int yTop = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
                     y2 = std::max(end->GetDrawingY() + unit * 2, yMin);
-                    y2 = std::min(yTop - unit, y2);
+                    if (y2 > yTop - unit * 2) {
+                        y2 = yTop;
+                        x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    }
                 }
             }
             // portato slurs
@@ -1086,7 +1089,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     const int yBottom = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                     y2 = std::min(end->GetDrawingY(), yMax);
                     if (y2 < yBottom + unit) {
-                        y2 = yBottom + unit;
+                        y2 = yBottom + unit * 2;
                     }
                     else {
                         x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);


### PR DESCRIPTION
This PR improves grace note slurs (note to note, ending on stem side). Fixes #2592 .
<img width="333" alt="Example" src="https://user-images.githubusercontent.com/63608463/151522899-7d62ca4c-f897-43cb-b06f-5bd2d423fc90.png">

Here is a more comprehensive test set:
![Above](https://user-images.githubusercontent.com/63608463/151522995-55af25e7-df37-4383-a39d-873c16dc7dd7.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2022-01-24T10:58:49" version="3.9.0-dev-a25f001">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mm80yeh">
    <score xml:id="so4igsv">
     <scoreDef xml:id="s9qx8ud">
      <staffGrp xml:id="sf69jkv">
       <staffDef xml:id="sxh5rm6" n="1" lines="5">
        <clef xml:id="ctxeno7" shape="G" line="2" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <measure xml:id="measure-L1" n="1">
       <staff xml:id="sxqdctl" n="1">
        <layer xml:id="layer-L1F1N1" n="1">
         <note xml:id="N1" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N2" dur="4" oct="4" pname="g" accid.ges="n" stem.dir="up"/>
         <note xml:id="N3" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N4" dur="4" oct="4" pname="a" accid.ges="n" stem.dir="up"/>
         <note xml:id="N5" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N6" dur="4" oct="4" pname="b" accid.ges="n" stem.dir="up"/>
         <note xml:id="N7" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N8" dur="4" oct="5" pname="c" accid.ges="n" stem.dir="up"/>
         <note xml:id="N9" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N10" dur="4" oct="5" pname="d" accid.ges="n" stem.dir="up"/>
         <note xml:id="N11" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N12" dur="4" oct="5" pname="e" accid.ges="n" stem.dir="up"/>
         <note xml:id="N13" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N14" dur="4" oct="5" pname="f" accid.ges="n" stem.dir="up"/>
         <note xml:id="N15" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N16" dur="4" oct="5" pname="a" accid.ges="n" stem.dir="up"/>
         <note xml:id="N17" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N18" dur="4" oct="6" pname="c" accid.ges="n" stem.dir="up"/>
         <note xml:id="N19" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N20" dur="4" oct="4" pname="e" accid.ges="n" stem.dir="up"/>
         <note xml:id="N21" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N22" dur="4" oct="4" pname="c" accid.ges="n" stem.dir="up"/>
         <note xml:id="N23" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N24" dur="4" oct="3" pname="a" accid.ges="n" stem.dir="up"/>
        </layer>
       </staff>
       <slur staff="1" startid="#N1" endid="#N2" curvedir="above" />
       <slur staff="1" startid="#N3" endid="#N4" curvedir="above" />
       <slur staff="1" startid="#N5" endid="#N6" curvedir="above" />
       <slur staff="1" startid="#N7" endid="#N8" curvedir="above" />
       <slur staff="1" startid="#N9" endid="#N10" curvedir="above" />
       <slur staff="1" startid="#N11" endid="#N12" curvedir="above" />
       <slur staff="1" startid="#N13" endid="#N14" curvedir="above" />
       <slur staff="1" startid="#N15" endid="#N16" curvedir="above" />
       <slur staff="1" startid="#N17" endid="#N18" curvedir="above" />
       <slur staff="1" startid="#N19" endid="#N20" curvedir="above" />
       <slur staff="1" startid="#N21" endid="#N22" curvedir="above" />
       <slur staff="1" startid="#N23" endid="#N24" curvedir="above" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>

![Below](https://user-images.githubusercontent.com/63608463/151523173-917bd1ef-a40e-4ac6-97cd-062e3b29ce6a.png)

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2022-01-24T10:58:49" version="3.9.0-dev-a25f001">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mm80yeh">
    <score xml:id="so4igsv">
     <scoreDef xml:id="s9qx8ud">
      <staffGrp xml:id="sf69jkv">
       <staffDef xml:id="sxh5rm6" n="1" lines="5">
        <clef xml:id="ctxeno7" shape="G" line="2" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <measure xml:id="measure-L1" n="1">
       <staff xml:id="sxqdctl" n="1">
        <layer xml:id="layer-L1F1N1" n="1">
         <note xml:id="N1" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N2" dur="4" oct="4" pname="g" accid.ges="n" stem.dir="down"/>
         <note xml:id="N3" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N4" dur="4" oct="4" pname="a" accid.ges="n" stem.dir="down"/>
         <note xml:id="N5" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N6" dur="4" oct="4" pname="b" accid.ges="n" stem.dir="down"/>
         <note xml:id="N7" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N8" dur="4" oct="5" pname="c" accid.ges="n" stem.dir="down"/>
         <note xml:id="N9" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N10" dur="4" oct="5" pname="d" accid.ges="n" stem.dir="down"/>
         <note xml:id="N11" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N12" dur="4" oct="5" pname="e" accid.ges="n" stem.dir="down"/>
         <note xml:id="N13" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N14" dur="4" oct="5" pname="f" accid.ges="n" stem.dir="down"/>
         <note xml:id="N15" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N16" dur="4" oct="5" pname="a" accid.ges="n" stem.dir="down"/>
         <note xml:id="N17" dur="8" oct="5" pname="c" grace="acc" accid.ges="n" />
         <note xml:id="N18" dur="4" oct="6" pname="c" accid.ges="n" stem.dir="down"/>
         <note xml:id="N19" dur="8" oct="4" pname="a" grace="acc" accid.ges="n" />
         <note xml:id="N20" dur="4" oct="6" pname="c" accid.ges="n" stem.dir="down"/>
         <note xml:id="N21" dur="8" oct="4" pname="f" grace="acc" accid.ges="n" />
         <note xml:id="N22" dur="4" oct="6" pname="c" accid.ges="n" stem.dir="down"/>
         <note xml:id="N23" dur="8" oct="4" pname="d" grace="acc" accid.ges="n" />
         <note xml:id="N24" dur="4" oct="6" pname="c" accid.ges="n" stem.dir="down"/>
        </layer>
       </staff>
       <slur staff="1" startid="#N1" endid="#N2" curvedir="below" />
       <slur staff="1" startid="#N3" endid="#N4" curvedir="below" />
       <slur staff="1" startid="#N5" endid="#N6" curvedir="below" />
       <slur staff="1" startid="#N7" endid="#N8" curvedir="below" />
       <slur staff="1" startid="#N9" endid="#N10" curvedir="below" />
       <slur staff="1" startid="#N11" endid="#N12" curvedir="below" />
       <slur staff="1" startid="#N13" endid="#N14" curvedir="below" />
       <slur staff="1" startid="#N15" endid="#N16" curvedir="below" />
       <slur staff="1" startid="#N17" endid="#N18" curvedir="below" />
       <slur staff="1" startid="#N19" endid="#N20" curvedir="below" />
       <slur staff="1" startid="#N21" endid="#N22" curvedir="below" />
       <slur staff="1" startid="#N23" endid="#N24" curvedir="below" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>