### PR TITLE
Add measure and rests to Toolkit::GetElementsAtTime

### DIFF
--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -60,23 +60,11 @@ class ClassIdComparison : public Comparison {
 public:
     ClassIdComparison(ClassId classId) { m_classId = classId; }
 
-    bool operator()(Object *object) override
-    {
-        if (object->Is(m_classId)) {
-            return true;
-        }
-        return false;
-    }
+    bool operator()(Object *object) override { return this->MatchesType(object); }
 
     ClassId GetType() { return m_classId; }
 
-    bool MatchesType(Object *object) override
-    {
-        if (object->Is(m_classId)) {
-            return true;
-        }
-        return false;
-    }
+    bool MatchesType(Object *object) override { return (object->Is(m_classId)); }
 
 protected:
     ClassId m_classId;
@@ -95,15 +83,9 @@ public:
         m_supportReverse = true;
     }
 
-    bool operator()(Object *object) override
-    {
-        if (object->Is(m_classIds)) {
-            return Result(true);
-        }
-        return Result(false);
-    }
+    bool operator()(Object *object) override { return Result(this->MatchesType(object)); }
 
-    bool MatchesType(Object *object) override { return true; }
+    bool MatchesType(Object *object) override { return (object->Is(m_classIds)); }
 
 protected:
     std::vector<ClassId> m_classIds;

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -454,25 +454,26 @@ private:
 };
 
 //----------------------------------------------------------------------------
-// NoteOnsetOffsetComparison
+// NoteOrRestOnsetOffsetComparison
 //----------------------------------------------------------------------------
 
 /**
  * This class evaluates if the object is a note being played at the given time.
  */
-class NoteOnsetOffsetComparison : public ClassIdComparison {
+class NoteOrRestOnsetOffsetComparison : public ClassIdsComparison {
 
 public:
-    NoteOnsetOffsetComparison(const int time) : ClassIdComparison(NOTE) { m_time = time; }
+    NoteOrRestOnsetOffsetComparison(const int time) : ClassIdsComparison({ NOTE, REST }) { m_time = time; }
 
     void SetTime(int time) { m_time = time; }
 
     bool operator()(Object *object) override
     {
         if (!MatchesType(object)) return false;
-        Note *note = vrv_cast<Note *>(object);
-        assert(note);
-        return ((m_time >= note->GetRealTimeOnsetMilliseconds()) && (m_time <= note->GetRealTimeOffsetMilliseconds()));
+        DurationInterface *interface = object->GetDurationInterface();
+        assert(interface);
+        return ((m_time >= interface->GetRealTimeOnsetMilliseconds())
+            && (m_time <= interface->GetRealTimeOffsetMilliseconds()));
     }
 
 private:

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1432,6 +1432,7 @@ std::string Toolkit::GetElementsAtTime(int millisec)
     jsonxx::Object o;
     jsonxx::Array noteArray;
     jsonxx::Array chordArray;
+    jsonxx::Array restArray;
 
     // Here we need to check that the midi timemap is done
     if (!m_doc.HasMidiTimemap()) {
@@ -1454,19 +1455,24 @@ std::string Toolkit::GetElementsAtTime(int millisec)
     Page *page = dynamic_cast<Page *>(measure->GetFirstAncestor(PAGE));
     if (page) pageNo = page->GetIdx() + 1;
 
-    NoteOnsetOffsetComparison matchNoteTime(millisec - measureTimeOffset);
-    ListOfObjects notes;
+    NoteOrRestOnsetOffsetComparison matchTime(millisec - measureTimeOffset);
+    ListOfObjects notesOrRests;
     ListOfObjects chords;
 
-    measure->FindAllDescendantsByComparison(&notes, &matchNoteTime);
+    measure->FindAllDescendantsByComparison(&notesOrRests, &matchTime);
 
     // Fill the JSON object
-    for (auto const item : notes) {
-        noteArray << item->GetUuid();
-        Note *note = vrv_cast<Note *>(item);
-        assert(note);
-        Chord *chord = note->IsChordTone();
-        if (chord) chords.push_back(chord);
+    for (auto const item : notesOrRests) {
+        if (item->Is(NOTE)) {
+            noteArray << item->GetUuid();
+            Note *note = vrv_cast<Note *>(item);
+            assert(note);
+            Chord *chord = note->IsChordTone();
+            if (chord) chords.push_back(chord);
+        }
+        else if (item->Is(REST)) {
+            restArray << item->GetUuid();
+        }
     }
     chords.unique();
     for (auto const item : chords) {
@@ -1475,7 +1481,9 @@ std::string Toolkit::GetElementsAtTime(int millisec)
 
     o << "notes" << noteArray;
     o << "chords" << chordArray;
+    o << "rests" << restArray;
     o << "page" << pageNo;
+    o << "measure" << measure->GetUuid();
 
     return o.json();
 }


### PR DESCRIPTION
This PR add "measure" and "rests" keys to the method.

Example
![image](https://user-images.githubusercontent.com/689412/151446431-cc04d836-0a03-4aff-ad50-9c054c288b75.png)

At time 0
```json
{
	"chords": [
	],
	"measure": "mn06yxr",
	"notes": [
		"n3p7qje" 
	],
	"page": 1,
	"rests": [
		"r8rwqlv" 
	] 
} 
```

At time 2000
```json
{
	"chords": [
	],
	"measure": "mkdu9lf",
	"notes": [
		"nvu10s0" 
	],
	"page": 1,
	"rests": [
		"r8ncdeq",
		"rp0rxwq" 
	] 
} 
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Note and rest collision between different layers</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2017-05-09">2017-05-09</date>
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>When a rest occurs at the same time as a note in two different layers, Verovio moves the rest vertically to avoid the note.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.0.0" label="2">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv xml:id="mo6mcsf">
                <score xml:id="sk8b4r1">
                    <scoreDef xml:id="sttgisg">
                        <staffGrp xml:id="sx6tkou">
                            <staffDef xml:id="s9zrpqk" n="1" lines="5" clef.shape="G" clef.line="2" meter.count="6" meter.unit="8" />
                        </staffGrp>
                    </scoreDef>
                    <section xml:id="sp1a8fc">
                        <measure xml:id="mn06yxr" n="0">
                            <staff xml:id="s3pxqm3" n="1">
                                <layer xml:id="lmvfixp" n="1">
                                    <rest xml:id="r8rwqlv" dots="1" dur="4" />
                                    <note xml:id="npns2kd" dots="1" dur="4" oct="5" pname="e">
                                        <accid xml:id="acp0w3e" accid.ges="n" />
                                    </note>
                                </layer>
                                <layer xml:id="lpretxp" n="2">
                                    <note xml:id="n3p7qje" dots="1" dur="4" oct="4" pname="f">
                                        <accid xml:id="a5b2tvx" accid.ges="n" />
                                    </note>
                                    <note xml:id="nrve1l6" dots="1" dur="4" oct="4" pname="e">
                                        <accid xml:id="auidswb" accid.ges="n" />
                                    </note>
                                </layer>
                            </staff>
                        </measure>
                        <measure xml:id="mkdu9lf">
                            <staff xml:id="spwv28w" n="1">
                                <layer xml:id="lqw9upy" n="1">
                                    <rest xml:id="r8ncdeq" dur="4" />
                                    <rest xml:id="rp0rxwq" dur="8" />
                                    <note xml:id="nye771i" dots="1" dur="4" oct="5" pname="e">
                                        <accid xml:id="ahuqase" accid.ges="n" />
                                    </note>
                                </layer>
                                <layer xml:id="lvcj6he" n="2">
                                    <note xml:id="nvu10s0" dots="1" dur="4" oct="5" pname="f">
                                        <accid xml:id="aval5pk" accid.ges="n" />
                                    </note>
                                    <note xml:id="nbnmr5d" dots="1" dur="4" oct="4" pname="e">
                                        <accid xml:id="a6ndk8z" accid.ges="n" />
                                    </note>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```