### PR TITLE
Fixes outstanding issues in PAE importer

### DIFF
--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -3995,7 +3995,16 @@ bool PAEInput::ConvertDuration()
             assert(interface);
             interface->SetDur(currentDur->first);
             if (currentDur->second) {
-                interface->SetDots(currentDur->second);
+                if (interface->GetDur() == DURATION_128 && token.Is(NOTE)) {
+                    Note *note = vrv_cast<Note *>(token.m_object);
+                    assert(note);
+                    note->SetDur(DURATION_4);
+                    note->SetStemLen(0);
+                    note->SetStemVisible(BOOLEAN_false);
+                }
+                else {
+                    interface->SetDots(currentDur->second);
+                }
             }
             // Move to the next on the stack - but this is meanless if we have a single value
             if (durations.size() > 1) {

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2256,7 +2256,8 @@ enum {
     ERR_055_KEYSIG_CHANGE,
     ERR_056_TIMESIG_CHANGE,
     ERR_057_MENSUR_CHANGE,
-    ERR_058_FERMATA_MREST
+    ERR_058_FERMATA_MREST,
+    ERR_059_DOUBLE_DOTS_MENS
 };
 
 // clang-format off
@@ -2318,7 +2319,8 @@ const std::map<int, std::string> PAEInput::s_errCodes{
     { ERR_055_KEYSIG_CHANGE, "The key signature cannot be changed more than once in a measure." },
     { ERR_056_TIMESIG_CHANGE, "The time signature cannot be changed more than once in a measure." },
     { ERR_057_MENSUR_CHANGE, "The mensur sign cannot be changed more than once in a measure." },
-    { ERR_058_FERMATA_MREST, "A fermata on measure with extra '%s' is invalid." }
+    { ERR_058_FERMATA_MREST, "A fermata on measure with extra '%s' is invalid." },
+    { ERR_059_DOUBLE_DOTS_MENS, "Double-dotted notes are invalid with mensural notation." }
 };
 // clang-format on
 
@@ -4013,6 +4015,16 @@ bool PAEInput::ConvertDuration()
                     note->SetDur(DURATION_4);
                     note->SetStemLen(0);
                     note->SetStemVisible(BOOLEAN_false);
+                }
+                else if (m_isMensural) {
+                    if (currentDur->second > 1) {
+                        LogPAE(ERR_059_DOUBLE_DOTS_MENS, *token);
+                        if (m_pedanticMode) return false;
+                    }
+                    Dot *dot = new Dot();
+                    // We need to insert it before the next one
+                    ++token;
+                    token = m_pae.insert(token, pae::Token(0, pae::UNKOWN_POS, dot));
                 }
                 else {
                     interface->SetDots(currentDur->second);


### PR DESCRIPTION
### Pseudo neumatic notation

Pseudo neumatic notation coded with dotted 128th notes is supported again
```
7.EDCDEEE
```
![image](https://user-images.githubusercontent.com/689412/151965387-dab9652e-5b03-4ece-ada0-57a0826a6d3c.png)

### Dots with mensural notation

With a `G+2` clef
```
1.2'GGBA''DC'BB
```
![image](https://user-images.githubusercontent.com/689412/151965726-02a3f56b-4fe9-4cae-8b60-cfb6ce88adf2.png)


### Nested beams

Nested beams are now supported when the second one is within a grace group
```
6{''D'Bqq{3''C'BA}r8B}''gD{8C'6AF}
```
![image](https://user-images.githubusercontent.com/689412/151964674-10763c99-fc9f-486e-98b8-a870db555924.png)

However, they will not be converted when the second one is place outside the grace group
```
6{''D'B{qq3''C'BAr}8B}''gD{8C'6AF}

[Warning] PAE: A beam cannot be started with '{' before closing the previous one. (character 7)
[Warning] PAE: An extra '}' to close a beam is present. (character 21)
```
![image](https://user-images.githubusercontent.com/689412/151964994-14d9e5d3-1324-46f2-b5a0-64f785f396ac.png)

Note that if there is no nesting of the beams, a beam outside a grace group remains valid
```
6''D'B{qq3''C'BAr}8B''gD{8C'6AF}
```
![image](https://user-images.githubusercontent.com/689412/151965988-dff0d830-6600-4315-9ac4-a24e72d91abd.png)


