### PR TITLE
Add support for ABC tuplets

### DIFF
--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -59,8 +59,8 @@ private:
     int SetBarLine(const std::string &musicCode, int index);
     void CalcUnitNoteLength();
     void AddAnnot(const std::string &remark);
-    void AddBeam();
-    void AddTuplet();
+    void AddLayerElement();
+    int AddTuplet(const std::string &musicCode, int i);
     void AddTie();
     void StartSlur();
     void EndSlur();
@@ -95,6 +95,11 @@ private:
 public:
     //
 private:
+    enum class ElementType {
+        Default,
+        Tuplet
+    };
+
     std::string m_filename;
     Mdiv *m_mdiv = NULL;
     Clef *m_clef = NULL;
@@ -117,6 +122,8 @@ private:
     int m_gracecount = 0;
     int m_stafflines = 5;
     int m_transpose = 0;
+    ElementType m_type = ElementType::Default;
+    std::pair<ElementType, LayerElement *> m_containerPair = { ElementType::Default, NULL };
     /*
      * ABC metadata stacks
      */

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -95,10 +95,7 @@ private:
 public:
     //
 private:
-    enum class ElementType {
-        Default,
-        Tuplet
-    };
+    enum class ElementType { Default, Tuplet };
 
     std::string m_filename;
     Mdiv *m_mdiv = NULL;

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -60,10 +60,10 @@ private:
     void CalcUnitNoteLength();
     void AddAnnot(const std::string &remark);
     void AddLayerElement();
-    int AddTuplet(const std::string &musicCode, int i);
     void AddTie();
     void StartSlur();
     void EndSlur();
+    int ParseTuplet(const std::string &musicCode, int index);
 
     // parse information fields
     void parseInstruction(const std::string &keyString); // I:

--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -96,6 +96,11 @@ public:
     //
 private:
     enum class ElementType { Default, Tuplet };
+    struct ContainerElement {
+        ElementType m_type = ElementType::Default;
+        LayerElement *m_element = NULL;
+        int m_count = 0;
+    };
 
     std::string m_filename;
     Mdiv *m_mdiv = NULL;
@@ -119,8 +124,7 @@ private:
     int m_gracecount = 0;
     int m_stafflines = 5;
     int m_transpose = 0;
-    ElementType m_type = ElementType::Default;
-    std::pair<ElementType, LayerElement *> m_containerPair = { ElementType::Default, NULL };
+    ContainerElement m_containerElement;
     /*
      * ABC metadata stacks
      */

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -347,6 +347,11 @@ void ABCInput::AddLayerElement()
             m_layer->AddChild(*iter);
         }
     }
+    // clean-up leftover data, if any
+    if (beam && !beam->GetChildCount()) delete beam;
+    if (m_containerElement.m_element && !m_containerElement.m_element->GetChildCount())
+        delete m_containerElement.m_element;
+
     m_containerElement = {};
     m_noteStack.clear();
 }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -340,11 +340,11 @@ void ABCInput::AddLayerElement()
     m_noteStack.clear();
 }
 
-int ABCInput::AddTuplet(const std::string &musicCode, int i)
+int ABCInput::ParseTuplet(const std::string &musicCode, int index)
 {
     constexpr std::string_view tupletElements = "(:0123456789 ";
-    const size_t tupletEnd = musicCode.find_first_not_of(tupletElements, ++i);
-    const std::string tupletStr = musicCode.substr(i, tupletEnd - i);
+    const size_t tupletEnd = musicCode.find_first_not_of(tupletElements, ++index);
+    const std::string tupletStr = musicCode.substr(index, tupletEnd - index);
 
     Tuplet *tuplet = new Tuplet();    
     size_t separator = tupletStr.find_first_of(":");
@@ -1138,7 +1138,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
 
         // tuplets
         else if ((i + 2 < (int)musicCode.length()) && musicCode.at(i) == '(' && isdigit(musicCode.at(i + 1))) {
-            i = AddTuplet(musicCode, i);
+            i = ParseTuplet(musicCode, i);
         }
 
         // slurs and ties

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <unordered_set>
 
 //----------------------------------------------------------------------------
 
@@ -304,44 +305,89 @@ void ABCInput::CalcUnitNoteLength()
     }
 }
 
-void ABCInput::AddBeam()
+void ABCInput::AddLayerElement() 
 {
-    if (!m_noteStack.size()) {
-        return;
-    }
-    else if (m_noteStack.size() == 1) {
+    // exit if there is nothing to add
+    if (!m_noteStack.size()) return;
+    // if just one note in the stack - add it do the layer directly
+    if (m_noteStack.size() == 1) {
         m_layer->AddChild(m_noteStack.back());
+        m_noteStack.clear();
+    }
+    // otherwise we can have beam or tuplet (for now)
+    LayerElement *element = NULL;
+    // if container pair key is set to Tuplet - proceed with it
+    if (m_containerPair.second && (ElementType::Tuplet == m_containerPair.first)) {
+        element = m_containerPair.second;
+    }
+    // otherwise default to it being beam
+    else {
+        element = new Beam();
+    }
+    // add stacked notes to the current element
+    for (auto iter = m_noteStack.begin(); iter != m_noteStack.end(); ++iter) {
+        element->AddChild(*iter);
+    }
+    if (element->FindDescendantByType(NOTE)) {
+        m_layer->AddChild(element);
     }
     else {
-        Beam *beam = new Beam();
         for (auto iter = m_noteStack.begin(); iter != m_noteStack.end(); ++iter) {
-            beam->AddChild(*iter);
-        }
-        if (beam->FindDescendantByType(NOTE)) {
-            m_layer->AddChild(beam);
-        }
-        else {
-            for (auto iter = m_noteStack.begin(); iter != m_noteStack.end(); ++iter) {
-                m_layer->AddChild(*iter);
-            }
+            m_layer->AddChild(*iter);
         }
     }
+    m_containerPair = { ElementType::Default, NULL };
     m_noteStack.clear();
 }
 
-void ABCInput::AddTuplet()
+int ABCInput::AddTuplet(const std::string &musicCode, int i)
 {
-    if (!m_noteStack.size()) {
-        return;
+    constexpr std::string_view tupletElements = "(:0123456789 ";
+    const size_t tupletEnd = musicCode.find_first_not_of(tupletElements, ++i);
+    const std::string tupletStr = musicCode.substr(i, tupletEnd - i);
+
+    Tuplet *tuplet = new Tuplet();    
+    size_t separator = tupletStr.find_first_of(":");
+    // Get tuplet number first 9:_:_
+    int tupletNum = 0;
+    if (separator != std::string::npos) {
+        const std::string tupletNumStr = tupletStr.substr(0, separator);
+        tupletNum = atoi(tupletNumStr.data());
+        ++separator;
     }
     else {
-        Tuplet *tuplet = new Tuplet();
-        for (auto iter = m_noteStack.begin(); iter != m_noteStack.end(); ++iter) {
-            tuplet->AddChild(*iter);
-        }
-        m_layer->AddChild(tuplet);
+        tupletNum = atoi(tupletStr.c_str());
     }
-    m_noteStack.clear();
+    // Get tuplet number base _:3:_
+    int tupletNumbase = 0;
+    if (separator != std::string::npos) {
+        size_t secondSeparator = tupletStr.find_first_of(":", separator);
+        if (secondSeparator != std::string::npos) {
+            if (secondSeparator != separator) {
+                std::string tupletNumbaseStr = tupletStr.substr(separator, secondSeparator - separator);
+                tupletNumbase = atoi(tupletNumbaseStr.data());
+                separator = secondSeparator + 1;
+            }
+        }
+        else {
+            std::string tupletNumbaseStr = tupletStr.substr(separator);
+            tupletNumbase = atoi(tupletNumbaseStr.data());
+            separator = secondSeparator + 1;
+        }
+    }
+    // List of tuplets with default base of 3
+    const std::unordered_set<int> threeBase = { 2, 4, 8, 9 };
+    if (!tupletNumbase) {
+        tupletNumbase = threeBase.count(tupletNum) ? 3 : 2;
+    }
+    // Get number of elements supposed to be in the tuplet _:_:9
+    // Ignore this for the time being
+    tuplet->SetNum(tupletNum);
+    tuplet->SetNumbase(tupletNumbase);
+    m_containerPair = { ElementType::Tuplet, tuplet };
+
+    // return index of the last element in tuplet, so that we point to the actual notes when incrementing 'i'
+    return tupletEnd - 1;
 }
 
 void ABCInput::AddAnnot(const std::string &remark)
@@ -1032,7 +1078,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
         }
         if (isspace(musicCode.at(i))) {
             // always ends a beam
-            AddBeam();
+            AddLayerElement();
         }
 
         // comments
@@ -1067,7 +1113,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
 
         // linebreaks
         else if (musicCode.at(i) == m_linebreak) {
-            AddBeam();
+            AddLayerElement();
             Sb *sb = new Sb();
             section->AddChild(sb);
         }
@@ -1092,8 +1138,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
 
         // tuplets
         else if ((i + 2 < (int)musicCode.length()) && musicCode.at(i) == '(' && isdigit(musicCode.at(i + 1))) {
-            LogWarning("ABC import: Tuplets not supported yet");
-            // AddTuplet();
+            i = AddTuplet(musicCode, i);
         }
 
         // slurs and ties
@@ -1136,7 +1181,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             // end chord
             if (chord->GetDur() < DURATION_8) {
                 // if chord cannot be beamed, write it directly to the layer
-                if (m_noteStack.size() > 0) AddBeam();
+                if (m_noteStack.size() > 0) AddLayerElement();
                 m_layer->AddChild(chord);
             }
             else
@@ -1157,7 +1202,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             }
             // end grace group
             else {
-                if ((m_gracecount > 1) || (grace == GRACE_unacc)) AddBeam();
+                if ((m_gracecount > 1) || (grace == GRACE_unacc)) AddLayerElement();
                 grace = GRACE_NONE;
                 m_gracecount = 0;
             }
@@ -1315,7 +1360,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
                 note->SetDur(meiDur);
                 if (note->GetDur() < DURATION_8) {
                     // if note cannot be beamed, write it directly to the layer
-                    if (m_noteStack.size() > 0) AddBeam();
+                    if (m_noteStack.size() > 0) AddLayerElement();
                     m_layer->AddChild(note);
                 }
                 else
@@ -1395,7 +1440,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             space->SetDur(meiDur);
 
             // spaces cannot be beamed
-            AddBeam();
+            AddLayerElement();
             m_layer->AddChild(space);
         }
 
@@ -1472,7 +1517,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             rest->SetDur(meiDur);
 
             // rests cannot be beamed
-            AddBeam();
+            AddLayerElement();
             m_layer->AddChild(rest);
         }
 
@@ -1517,7 +1562,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
         // barLine
         else if (musicCode.at(i) == '|') {
             // add stacked elements to layer
-            AddBeam();
+            AddLayerElement();
             i = SetBarLine(musicCode, i);
 
             if (m_barLines.second != BARRENDITION_NONE) {
@@ -1569,7 +1614,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
     // Verovio does not support line-breaks within a layer
     // has to be refined later
     if (sysBreak && (m_linebreak != '\0') && !(section->GetLast())->Is(SB)) {
-        AddBeam();
+        AddLayerElement();
         Sb *sb = new Sb();
         sb->SetUuid(StringFormat("abcLine%02d", m_lineNum + 1));
         section->AddChild(sb);

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -305,7 +305,7 @@ void ABCInput::CalcUnitNoteLength()
     }
 }
 
-void ABCInput::AddLayerElement() 
+void ABCInput::AddLayerElement()
 {
     // exit if there is nothing to add
     if (!m_noteStack.size()) return;
@@ -346,7 +346,7 @@ int ABCInput::ParseTuplet(const std::string &musicCode, int index)
     const size_t tupletEnd = musicCode.find_first_not_of(tupletElements, ++index);
     const std::string tupletStr = musicCode.substr(index, tupletEnd - index);
 
-    Tuplet *tuplet = new Tuplet();    
+    Tuplet *tuplet = new Tuplet();
     size_t separator = tupletStr.find_first_of(":");
     // Get tuplet number first 9:_:_
     int tupletNum = 0;

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -335,12 +335,14 @@ void ABCInput::AddLayerElement()
         if (m_containerElement.m_element && (ElementType::Tuplet == m_containerElement.m_type)) {
             element = m_containerElement.m_element;
             element->AddChild(beam);
+            m_containerElement.m_element = NULL;
         }
         // otherwise default to it being beam
         else {
             element = beam;
         }
         m_layer->AddChild(element);
+        beam = NULL;
     }
     else {
         for (auto iter = m_noteStack.begin(); iter != m_noteStack.end(); ++iter) {
@@ -348,9 +350,8 @@ void ABCInput::AddLayerElement()
         }
     }
     // clean-up leftover data, if any
-    if (beam && !beam->GetChildCount()) delete beam;
-    if (m_containerElement.m_element && !m_containerElement.m_element->GetChildCount())
-        delete m_containerElement.m_element;
+    if (beam) delete beam;
+    if (m_containerElement.m_element) delete m_containerElement.m_element;
 
     m_containerElement = {};
     m_noteStack.clear();


### PR DESCRIPTION
Added logic to parse and import tuplets from the ABC format.

![image](https://user-images.githubusercontent.com/1819669/152124632-bfacd1c1-0359-401c-8d77-a6c7481340c9.png)

<details><summary>Example ABC</summary>

```
X:6
T:Farewell Manchester
%%VWML:Yarkers1797-5234-p6-0
F:http://www.vwml.org/record/Yarkers1797/5234/p6
Z:Transcribed by David Jacobs Sept 2015
L:1/8
M:2/4
K:G
B2A2|GcB2|AGFG|A/G/F/E/D2|B2A2|GcB2|AGFG|A4:|
d2c2|Bge2|dGc2|Bge2|dG cB/A/|BA/G/ Dc|B2A2|G4:|
B/A/G/B/ A/G/F/A/|G/e/d/c/B2|AB/G/ FG|A/G/F/E/D2|B/A/G/A/ A/G/F/G/|G/e/d/c/ B2|AB/G/ FG|A4:|
d/c/B/d/ c/B/A/c/|B/A/G/g/ e2|d/c/B/d/ c/B/A/c/|B/A/G/g/ e2|d/c/A/d/ c/B/A/c/|B/A/G/B/ D/G/A/"C"c/|B2A2|G4:|
(3BDB (3ADA|(3GDcB2|(3ABA FG|(3ABG (3FED|(3BDB (3ADA|(3GDcB2|(3ABG FG|A4:|
"Cont"(3dBd (3cAc|(3BGge2|(3dBd (3cAc|(3BGge2|(3dBd (3cAc|(3BAG (3DGc|G2A2|G3:|
```

</details>

