### PR TITLE
allow more accidentals in keySig

### DIFF
--- a/src/att.cpp
+++ b/src/att.cpp
@@ -312,7 +312,7 @@ data_KEYSIGNATURE Att::StrToKeysignature(const std::string &value, bool logWarni
     int alterationNumber = 0;
     data_ACCIDENTAL_WRITTEN alterationType = ACCIDENTAL_WRITTEN_NONE;
 
-    std::regex test("mixed|0|[1-7][s|f]");
+    std::regex test("mixed|0|([1-9]|1[0-2])[f|s]");
     if (!std::regex_match(value, test)) {
         if (logWarning) LogWarning("Unsupported data.KEYSIGNATURE '%s'", value.c_str());
         return { -1, ACCIDENTAL_WRITTEN_NONE };
@@ -322,7 +322,7 @@ data_KEYSIGNATURE Att::StrToKeysignature(const std::string &value, bool logWarni
         return { VRV_UNSET, ACCIDENTAL_WRITTEN_NONE };
     }
     else if (value != "0") {
-        alterationNumber = atoi(value.substr(0, 1).c_str());
+        alterationNumber = std::stoi(value);
         alterationType = (value.at(1) == 's') ? ACCIDENTAL_WRITTEN_s : ACCIDENTAL_WRITTEN_f;
     }
     else {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -179,7 +179,7 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid)
 
     int i;
     data_ACCIDENTAL_WRITTEN accidType = this->GetAccidType();
-    for (i = 0; i < this->GetAccidCount(); i++) {
+    for (i = 0; i < this->GetAccidCount(); ++i) {
         mapOfPitchAccid[KeySig::GetAccidPnameAt(accidType, i)] = accidType;
     }
 }
@@ -200,17 +200,17 @@ std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, d
         return keyAccid->GetSymbolStr();
     }
 
-    if (pos > 6) return symbolStr;
+    if (pos > 12) return symbolStr;
 
     int symb;
     accid = this->GetAccidType();
     if (accid == ACCIDENTAL_WRITTEN_f) {
-        symb = SMUFL_E260_accidentalFlat;
-        pname = s_pnameForFlats[pos];
+        symb = (pos < 7) ? SMUFL_E260_accidentalFlat : SMUFL_E264_accidentalDoubleFlat;
+        pname = s_pnameForFlats[pos % 7];
     }
     else {
-        symb = SMUFL_E262_accidentalSharp;
-        pname = s_pnameForSharps[pos];
+        symb = (pos < 7) ? SMUFL_E262_accidentalSharp : SMUFL_E263_accidentalDoubleSharp;
+        pname = s_pnameForSharps[pos % 7];
     }
 
     symbolStr.push_back(symb);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -719,7 +719,7 @@ int Object::GetDescendantIndex(const Object *child, const ClassId classId, int d
     int i = 0;
     for (auto &object : objects) {
         if (child == object) return i;
-        i++;
+        ++i;
     }
     return -1;
 }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -316,12 +316,12 @@ std::ostream &operator<<(std::ostream &out, const TransPitch &pitch)
         default: out << "X";
     }
     if (pitch.m_accid > 0) {
-        for (int i = 0; i < pitch.m_accid; i++) {
+        for (int i = 0; i < pitch.m_accid; ++i) {
             out << "#";
         }
     }
     else if (pitch.m_accid < 0) {
-        for (int i = 0; i < abs(pitch.m_accid); i++) {
+        for (int i = 0; i < abs(pitch.m_accid); ++i) {
             out << "b";
         }
     }
@@ -693,7 +693,7 @@ bool Transposer::GetKeyTonic(const std::string &keyTonic, TransPitch &tonic)
     int pitch = 0;
     int accid = 0;
     int state = 0;
-    for (unsigned int i = 0; i < (unsigned int)keyTonic.size(); i++) {
+    for (unsigned int i = 0; i < (unsigned int)keyTonic.size(); ++i) {
         switch (state) {
             case 0:
                 switch (keyTonic[i]) {
@@ -760,7 +760,7 @@ int Transposer::GetInterval(const std::string &intervalName)
     std::string number;
     int state = 0;
 
-    for (int i = 0; i < (int)intervalName.size(); i++) {
+    for (int i = 0; i < (int)intervalName.size(); ++i) {
         switch (state) {
             case 0: // direction or quality expected
                 switch (intervalName[i]) {
@@ -1142,7 +1142,7 @@ TransPitch Transposer::IntegerPitchToTransPitch(int ipitch)
         // search from C upwards
         mindiff = chroma - m_diatonicMapping[0];
         mini = 0;
-        for (int i = 1; i < (int)m_diatonicMapping.size(); i++) {
+        for (int i = 1; i < (int)m_diatonicMapping.size(); ++i) {
             int diff = chroma - m_diatonicMapping[i];
             if (abs(diff) < abs(mindiff)) {
                 mindiff = diff;
@@ -1212,7 +1212,7 @@ std::string Transposer::GetIntervalName(int intervalClass)
 
     int mindiff = chroma;
     int mini = 0;
-    for (int i = 1; i < (int)m_diatonicMapping.size(); i++) {
+    for (int i = 1; i < (int)m_diatonicMapping.size(); ++i) {
         int diff = chroma - (m_diatonicMapping[i] - m_diatonicMapping[0]);
         if (abs(diff) < abs(mindiff)) {
             mindiff = diff;
@@ -1329,12 +1329,12 @@ std::string Transposer::GetIntervalName(int intervalClass)
 
     if (quality.empty()) {
         if (augmented) {
-            for (int i = 0; i < augmented; i++) {
+            for (int i = 0; i < augmented; ++i) {
                 quality += "A";
             }
         }
         else if (diminished) {
-            for (int i = 0; i < diminished; i++) {
+            for (int i = 0; i < diminished; ++i) {
                 quality += "d";
             }
         }
@@ -1391,7 +1391,7 @@ int Transposer::IntervalToCircleOfFifths(int transval)
 
     int p5 = this->PerfectFifthClass();
     int p4 = this->PerfectFourthClass();
-    for (int i = 1; i < m_base; i++) {
+    for (int i = 1; i < m_base; ++i) {
         if ((p5 * i) % m_base == transval) {
             return i;
         }
@@ -1549,12 +1549,12 @@ std::string Transposer::DiatonicChromaticToIntervalName(int diatonic, int chroma
             output += "P";
         }
         else if (chromatic > 0) {
-            for (int i = 0; i < chromatic; i++) {
+            for (int i = 0; i < chromatic; ++i) {
                 output += "A";
             }
         }
         else {
-            for (int i = 0; i < -chromatic; i++) {
+            for (int i = 0; i < -chromatic; ++i) {
                 output += "d";
             }
         }
@@ -1676,12 +1676,12 @@ std::string Transposer::DiatonicChromaticToIntervalName(int diatonic, int chroma
 
     if (quality.empty()) {
         if (augmented) {
-            for (int i = 0; i < augmented; i++) {
+            for (int i = 0; i < augmented; ++i) {
                 quality += "A";
             }
         }
         else if (diminished) {
-            for (int i = 0; i < diminished; i++) {
+            for (int i = 0; i < diminished; ++i) {
                 quality += "d";
             }
         }
@@ -1719,7 +1719,7 @@ void Transposer::IntervalToDiatonicChromatic(int &diatonic, int &chromatic, cons
     std::string number;
     int state = 0;
 
-    for (int i = 0; i < (int)intervalName.size(); i++) {
+    for (int i = 0; i < (int)intervalName.size(); ++i) {
         switch (state) {
             case 0: // direction or quality expected
                 switch (intervalName[i]) {


### PR DESCRIPTION
This PR updates the regex for keySig and allows moving further in the circle of fifths. 

![keysig](https://user-images.githubusercontent.com/7693447/152136021-927a085f-cd5b-4b2e-8b89-aa3bf1d9998a.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Key signatures with more than seven accidentals</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">Enote GmbH</corpName>
            </respStmt>
            <date isodate="2022-02-02">2 Feb 2022</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>When using more than seven accidentals in keySig Verovio uses double accidentals.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.9.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="11s" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="invis">
                     <staff n="1">
                        <layer n="1">
                           <space dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

There are different ways to draw these key signatures. This implementation takes the easiest way, others are documented here: https://en.wikipedia.org/wiki/Theoretical_key
For allowing different renderings we should think about something on MEI side first.