### PR TITLE
Fix and improve vertical positionning

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -845,16 +845,14 @@ public:
     AlignSystemsParams(Doc *doc)
     {
         m_shift = 0;
-        m_systemMargin = 0;
-        m_systemFirstMargin = 0;
+        m_systemSpacing = 0;
         m_prevBottomOverflow = 0;
         m_prevBottomClefOverflow = 0;
         m_justificationSum = 0.;
         m_doc = doc;
     }
     int m_shift;
-    int m_systemMargin;
-    int m_systemFirstMargin;
+    int m_systemSpacing;
     int m_prevBottomOverflow;
     int m_prevBottomClefOverflow;
     double m_justificationSum;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -847,12 +847,14 @@ public:
         m_shift = 0;
         m_systemMargin = 0;
         m_prevBottomOverflow = 0;
+        m_prevBottomClefOverflow = 0;
         m_justificationSum = 0.;
         m_doc = doc;
     }
     int m_shift;
     int m_systemMargin;
     int m_prevBottomOverflow;
+    int m_prevBottomClefOverflow;
     double m_justificationSum;
     Doc *m_doc;
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -846,6 +846,7 @@ public:
     {
         m_shift = 0;
         m_systemMargin = 0;
+        m_systemFirstMargin = 0;
         m_prevBottomOverflow = 0;
         m_prevBottomClefOverflow = 0;
         m_justificationSum = 0.;
@@ -853,6 +854,7 @@ public:
     }
     int m_shift;
     int m_systemMargin;
+    int m_systemFirstMargin;
     int m_prevBottomOverflow;
     int m_prevBottomClefOverflow;
     double m_justificationSum;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -686,7 +686,6 @@ public:
     OptionDbl m_spacingNonLinear;
     OptionInt m_spacingStaff;
     OptionInt m_spacingSystem;
-    OptionInt m_spacingSystemFirst;
     OptionDbl m_staffLineWidth;
     OptionDbl m_stemWidth;
     OptionDbl m_subBracketThickness;
@@ -765,6 +764,7 @@ public:
     //
     OptionDbl m_topMarginArtic;
     OptionDbl m_topMarginHarm;
+    OptionDbl m_topMarginPgFooter;
 
     /**
      * Deprecated options

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -686,6 +686,7 @@ public:
     OptionDbl m_spacingNonLinear;
     OptionInt m_spacingStaff;
     OptionInt m_spacingSystem;
+    OptionInt m_spacingSystemFirst;
     OptionDbl m_staffLineWidth;
     OptionDbl m_stemWidth;
     OptionDbl m_subBracketThickness;

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -32,6 +32,11 @@ public:
     std::string GetClassName() const override { return "PgFoot"; }
     ///@}
 
+    /**
+     * Overriden to get the appropriate margin
+     */
+    int GetTotalHeight(Doc *doc) override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/pgfoot2.h
+++ b/include/vrv/pgfoot2.h
@@ -32,6 +32,11 @@ public:
     std::string GetClassName() const override { return "PgFoot2"; }
     ///@}
 
+    /**
+     * Overriden to get the appropriate margin
+     */
+    int GetTotalHeight(Doc *doc) override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -32,6 +32,11 @@ public:
     std::string GetClassName() const override { return "PgHead"; }
     ///@}
 
+    /**
+     * Overriden to get the appropriate margin
+     */
+    int GetTotalHeight(Doc *doc) override;
+
     bool GenerateFromMEIHeader(pugi::xml_document &header);
 
     //----------//

--- a/include/vrv/pghead2.h
+++ b/include/vrv/pghead2.h
@@ -32,6 +32,11 @@ public:
     std::string GetClassName() const override { return "PgHead2"; }
     ///@}
 
+    /**
+     * Overriden to get the appropriate margin
+     */
+    int GetTotalHeight(Doc *doc) override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -90,7 +90,10 @@ public:
      * @name Get the size of row, cols or cells
      */
     ///@{
-    int GetTotalHeight();
+    /** Height including margins */
+    virtual int GetTotalHeight(Doc *doc) = 0;
+    /** Content height */
+    int GetContentHeight();
     /** Row from 0 to 2 */
     int GetRowHeight(int row);
     /** Col from 0 to 2 */

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -90,8 +90,8 @@ public:
     /**
      * Get System Overflows
      */
-    int GetOverflowAbove(const Doc *doc) const;
-    int GetOverflowBelow(const Doc *doc) const;
+    int GetOverflowAbove(const Doc *doc, bool scoreDefClef = false) const;
+    int GetOverflowBelow(const Doc *doc, bool scoreDefClef = false) const;
 
     /**
      * Get justification sum

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1343,6 +1343,10 @@ Options::Options()
     m_spacingSystem.SetInfo("Spacing system", "The system minimal spacing in MEI units");
     m_spacingSystem.Init(12, 0, 48);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
+    
+    m_spacingSystemFirst.SetInfo("Spacing system first", "The first system minimal spacing in MEI units");
+    m_spacingSystemFirst.Init(6, 0, 48);
+    this->Register(&m_spacingSystemFirst, "spacingSystemFirst", &m_generalLayout);
 
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in unit");
     m_staffLineWidth.Init(0.15, 0.10, 0.30);
@@ -1466,7 +1470,7 @@ Options::Options()
     this->Register(&m_bottomMarginHarm, "bottomMarginHarm", &m_elementMargins);
 
     m_bottomMarginPgHead.SetInfo("Bottom margin header", "The margin for header in MEI units");
-    m_bottomMarginPgHead.Init(8.0, 0.0, 24.0);
+    m_bottomMarginPgHead.Init(2.0, 0.0, 24.0);
     this->Register(&m_bottomMarginPgHead, "bottomMarginHeader", &m_elementMargins);
 
     /// custom left

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1344,10 +1344,6 @@ Options::Options()
     m_spacingSystem.Init(12, 0, 48);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
 
-    m_spacingSystemFirst.SetInfo("Spacing system first", "The first system minimal spacing in MEI units");
-    m_spacingSystemFirst.Init(0, 0, 48);
-    this->Register(&m_spacingSystemFirst, "spacingSystemFirst", &m_generalLayout);
-
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in unit");
     m_staffLineWidth.Init(0.15, 0.10, 0.30);
     this->Register(&m_staffLineWidth, "staffLineWidth", &m_generalLayout);
@@ -1622,6 +1618,10 @@ Options::Options()
     m_topMarginHarm.SetInfo("Top margin harm", "The margin for harm in MEI units");
     m_topMarginHarm.Init(1.0, 0.0, 10.0);
     this->Register(&m_topMarginHarm, "topMarginHarm", &m_elementMargins);
+
+    m_topMarginPgFooter.SetInfo("Top margin footer", "The margin for footer in MEI units");
+    m_topMarginPgFooter.Init(2.0, 0.0, 24.0);
+    this->Register(&m_topMarginPgFooter, "topMarginPgFooter", &m_elementMargins);
 
     /********* Deprecated options *********/
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1343,7 +1343,7 @@ Options::Options()
     m_spacingSystem.SetInfo("Spacing system", "The system minimal spacing in MEI units");
     m_spacingSystem.Init(12, 0, 48);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
-    
+
     m_spacingSystemFirst.SetInfo("Spacing system first", "The first system minimal spacing in MEI units");
     m_spacingSystemFirst.Init(0, 0, 48);
     this->Register(&m_spacingSystemFirst, "spacingSystemFirst", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1345,7 +1345,7 @@ Options::Options()
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
     
     m_spacingSystemFirst.SetInfo("Spacing system first", "The first system minimal spacing in MEI units");
-    m_spacingSystemFirst.Init(6, 0, 48);
+    m_spacingSystemFirst.Init(0, 0, 48);
     this->Register(&m_spacingSystemFirst, "spacingSystemFirst", &m_generalLayout);
 
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in unit");

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -680,7 +680,7 @@ int Page::GetContentHeight() const
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();
 
     if (this->GetFooter()) {
-        height += this->GetFooter()->GetTotalHeight();
+        height += this->GetFooter()->GetTotalHeight(doc);
     }
 
     return height;
@@ -842,11 +842,9 @@ int Page::AlignSystems(FunctorParams *functorParams)
     RunningElement *header = this->GetHeader();
     if (header) {
         header->SetDrawingYRel(params->m_shift);
-        const int headerHeight = header->GetTotalHeight();
+        const int headerHeight = header->GetTotalHeight(params->m_doc);
         if (headerHeight > 0) {
-            const int bottomMarginPgHead
-                = params->m_doc->GetOptions()->m_bottomMarginPgHead.GetValue() * params->m_doc->GetDrawingUnit(100);
-            params->m_shift -= header->GetTotalHeight() + bottomMarginPgHead;
+            params->m_shift -= headerHeight;
         }
     }
     return FUNCTOR_CONTINUE;
@@ -862,18 +860,20 @@ int Page::AlignSystemsEnd(FunctorParams *functorParams)
 
     RunningElement *footer = this->GetFooter();
     if (footer) {
-        m_drawingJustifiableHeight -= footer->GetTotalHeight();
+        m_drawingJustifiableHeight -= footer->GetTotalHeight(params->m_doc);
 
         // Move it up below the last system
         if (params->m_doc->GetOptions()->m_adjustPageHeight.GetValue()) {
             if (this->GetChildCount()) {
                 System *last = dynamic_cast<System *>(this->GetLast(SYSTEM));
                 assert(last);
-                footer->SetDrawingYRel(last->GetDrawingYRel() - last->GetHeight());
+                const int unit = params->m_doc->GetDrawingUnit(100);
+                const int topMargin = params->m_doc->GetOptions()->m_topMarginPgFooter.GetValue() * unit;
+                footer->SetDrawingYRel(last->GetDrawingYRel() - last->GetHeight() - topMargin);
             }
         }
         else {
-            footer->SetDrawingYRel(footer->GetTotalHeight());
+            footer->SetDrawingYRel(footer->GetContentHeight());
         }
     }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -841,11 +841,13 @@ int Page::AlignSystems(FunctorParams *functorParams)
 
     RunningElement *header = this->GetHeader();
     if (header) {
-        const int bottomMarginPgHead
-            = params->m_doc->GetOptions()->m_bottomMarginPgHead.GetValue() * params->m_doc->GetDrawingUnit(100);
-
         header->SetDrawingYRel(params->m_shift);
-        params->m_shift -= header->GetTotalHeight() + bottomMarginPgHead;
+        const int headerHeight = header->GetTotalHeight();
+        if (headerHeight > 0) {
+            const int bottomMarginPgHead
+                = params->m_doc->GetOptions()->m_bottomMarginPgHead.GetValue() * params->m_doc->GetDrawingUnit(100);
+            params->m_shift -= header->GetTotalHeight() + bottomMarginPgHead;
+        }
     }
     return FUNCTOR_CONTINUE;
 }

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -551,6 +551,7 @@ void Page::LayOutVertically()
     AlignSystemsParams alignSystemsParams(doc);
     alignSystemsParams.m_shift = doc->m_drawingPageContentHeight;
     alignSystemsParams.m_systemMargin = (doc->GetOptions()->m_spacingSystem.GetValue()) * doc->GetDrawingUnit(100);
+    alignSystemsParams.m_systemFirstMargin = (doc->GetOptions()->m_spacingSystemFirst.GetValue()) * doc->GetDrawingUnit(100);
     Functor alignSystems(&Object::AlignSystems);
     Functor alignSystemsEnd(&Object::AlignSystemsEnd);
     this->Process(&alignSystems, &alignSystemsParams, &alignSystemsEnd);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -551,7 +551,8 @@ void Page::LayOutVertically()
     AlignSystemsParams alignSystemsParams(doc);
     alignSystemsParams.m_shift = doc->m_drawingPageContentHeight;
     alignSystemsParams.m_systemMargin = (doc->GetOptions()->m_spacingSystem.GetValue()) * doc->GetDrawingUnit(100);
-    alignSystemsParams.m_systemFirstMargin = (doc->GetOptions()->m_spacingSystemFirst.GetValue()) * doc->GetDrawingUnit(100);
+    alignSystemsParams.m_systemFirstMargin
+        = (doc->GetOptions()->m_spacingSystemFirst.GetValue()) * doc->GetDrawingUnit(100);
     Functor alignSystems(&Object::AlignSystems);
     Functor alignSystemsEnd(&Object::AlignSystemsEnd);
     this->Process(&alignSystems, &alignSystemsParams, &alignSystemsEnd);

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -550,9 +550,7 @@ void Page::LayOutVertically()
     // Adjust system Y position
     AlignSystemsParams alignSystemsParams(doc);
     alignSystemsParams.m_shift = doc->m_drawingPageContentHeight;
-    alignSystemsParams.m_systemMargin = (doc->GetOptions()->m_spacingSystem.GetValue()) * doc->GetDrawingUnit(100);
-    alignSystemsParams.m_systemFirstMargin
-        = (doc->GetOptions()->m_spacingSystemFirst.GetValue()) * doc->GetDrawingUnit(100);
+    alignSystemsParams.m_systemSpacing = (doc->GetOptions()->m_spacingSystem.GetValue()) * doc->GetDrawingUnit(100);
     Functor alignSystems(&Object::AlignSystems);
     Functor alignSystemsEnd(&Object::AlignSystemsEnd);
     this->Process(&alignSystems, &alignSystemsParams, &alignSystemsEnd);

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -13,6 +13,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -33,6 +34,18 @@ PgFoot::~PgFoot() {}
 void PgFoot::Reset()
 {
     RunningElement::Reset();
+}
+
+int PgFoot::GetTotalHeight(Doc *doc)
+{
+    assert(doc);
+
+    int height = this->GetContentHeight();
+    if (height > 0) {
+        const int unit = doc->GetDrawingUnit(100);
+        height += doc->GetOptions()->m_topMarginPgFooter.GetValue() * unit;
+    }
+    return height;
 }
 
 //----------------------------------------------------------------------------

--- a/src/pgfoot2.cpp
+++ b/src/pgfoot2.cpp
@@ -13,6 +13,8 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
@@ -31,6 +33,18 @@ PgFoot2::~PgFoot2() {}
 void PgFoot2::Reset()
 {
     RunningElement::Reset();
+}
+
+int PgFoot2::GetTotalHeight(Doc *doc)
+{
+    assert(doc);
+
+    int height = this->GetContentHeight();
+    if (height > 0) {
+        const int unit = doc->GetDrawingUnit(100);
+        height += doc->GetOptions()->m_topMarginPgFooter.GetValue() * unit;
+    }
+    return height;
 }
 
 //----------------------------------------------------------------------------

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -13,6 +13,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
 #include "lb.h"
 #include "rend.h"
 #include "text.h"
@@ -36,6 +37,18 @@ PgHead::~PgHead() {}
 void PgHead::Reset()
 {
     RunningElement::Reset();
+}
+
+int PgHead::GetTotalHeight(Doc *doc)
+{
+    assert(doc);
+
+    int height = this->GetContentHeight();
+    if (height > 0) {
+        const int unit = doc->GetDrawingUnit(100);
+        height += doc->GetOptions()->m_bottomMarginPgHead.GetValue() * unit;
+    }
+    return height;
 }
 
 bool PgHead::GenerateFromMEIHeader(pugi::xml_document &header)

--- a/src/pghead2.cpp
+++ b/src/pghead2.cpp
@@ -13,6 +13,8 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
@@ -31,6 +33,18 @@ PgHead2::~PgHead2() {}
 void PgHead2::Reset()
 {
     RunningElement::Reset();
+}
+
+int PgHead2::GetTotalHeight(Doc *doc)
+{
+    assert(doc);
+
+    int height = this->GetContentHeight();
+    if (height > 0) {
+        const int unit = doc->GetDrawingUnit(100);
+        height += doc->GetOptions()->m_bottomMarginPgHead.GetValue() * unit;
+    }
+    return height;
 }
 
 //----------------------------------------------------------------------------

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -185,7 +185,7 @@ void RunningElement::SetDrawingPage(Page *page)
     }
 }
 
-int RunningElement::GetTotalHeight()
+int RunningElement::GetContentHeight()
 {
     int height = 0;
     int i;

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -114,8 +114,8 @@ void Score::CalcRunningElementHeight(Doc *doc)
     RunningElement *page1Header = page1->GetHeader();
     RunningElement *page1Footer = page1->GetFooter();
 
-    m_drawingPgHeadHeight = (page1Header) ? page1Header->GetTotalHeight() : 0;
-    m_drawingPgFootHeight = (page1Footer) ? page1Footer->GetTotalHeight() : 0;
+    m_drawingPgHeadHeight = (page1Header) ? page1Header->GetTotalHeight(doc) : 0;
+    m_drawingPgFootHeight = (page1Footer) ? page1Footer->GetTotalHeight(doc) : 0;
 
     Page *page2 = new Page();
     page2->m_score = this;
@@ -127,8 +127,8 @@ void Score::CalcRunningElementHeight(Doc *doc)
     RunningElement *page2Header = page2->GetHeader();
     RunningElement *page2Footer = page2->GetFooter();
 
-    m_drawingPgHead2Height = (page2Header) ? page2Header->GetTotalHeight() : 0;
-    m_drawingPgFoot2Height = (page2Footer) ? page2Footer->GetTotalHeight() : 0;
+    m_drawingPgHead2Height = (page2Header) ? page2Header->GetTotalHeight(doc) : 0;
+    m_drawingPgFoot2Height = (page2Footer) ? page2Footer->GetTotalHeight(doc) : 0;
 
     pages->DeleteChild(page1);
     pages->DeleteChild(page2);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -753,13 +753,16 @@ int System::AlignSystems(FunctorParams *functorParams)
     assert(params);
     assert(m_systemAligner.GetBottomAlignment());
 
-    int systemMargin = this->IsFirstInPage() ? 0 : params->m_systemMargin;
+    int systemMargin = this->IsFirstInPage() ? params->m_systemFirstMargin : params->m_systemMargin;
     if (systemMargin) {
+        const int contentOverflow = params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove(params->m_doc);
+        const int clefOverflow = params->m_prevBottomClefOverflow + m_systemAligner.GetOverflowAbove(params->m_doc, true);
         const int margin
-            = systemMargin - (params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove(params->m_doc));
+            = systemMargin - std::max(contentOverflow, clefOverflow);
         // Ensure minimal white space between consecutive systems by adding one staff space
         const int unit = params->m_doc->GetDrawingUnit(100);
-        params->m_shift -= std::max(margin, 2 * unit);
+        if (margin > 0) params->m_shift -= margin;
+        //params->m_shift -= std::max(margin, 2 * unit);
     }
 
     this->SetDrawingYRel(params->m_shift);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -756,13 +756,13 @@ int System::AlignSystems(FunctorParams *functorParams)
     int systemMargin = this->IsFirstInPage() ? params->m_systemFirstMargin : params->m_systemMargin;
     if (systemMargin) {
         const int contentOverflow = params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove(params->m_doc);
-        const int clefOverflow = params->m_prevBottomClefOverflow + m_systemAligner.GetOverflowAbove(params->m_doc, true);
-        const int margin
-            = systemMargin - std::max(contentOverflow, clefOverflow);
-        // Ensure minimal white space between consecutive systems by adding one staff space
-        const int unit = params->m_doc->GetDrawingUnit(100);
-        if (margin > 0) params->m_shift -= margin;
-        //params->m_shift -= std::max(margin, 2 * unit);
+        const int clefOverflow
+            = params->m_prevBottomClefOverflow + m_systemAligner.GetOverflowAbove(params->m_doc, true);
+        // Alignment is already pre-determined with staff alignment overflow
+        // We need to subtract them from the desired margin
+        const int actualMargin = systemMargin - std::max(contentOverflow, clefOverflow);
+        // Set the margin if it exsits (greater than 0)
+        if (actualMargin > 0) params->m_shift -= actualMargin;
     }
 
     this->SetDrawingYRel(params->m_shift);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -753,16 +753,17 @@ int System::AlignSystems(FunctorParams *functorParams)
     assert(params);
     assert(m_systemAligner.GetBottomAlignment());
 
-    int systemMargin = this->IsFirstInPage() ? params->m_systemFirstMargin : params->m_systemMargin;
-    if (systemMargin) {
+    // No spacing for the first system
+    int systemSpacing = this->IsFirstInPage() ? 0 : params->m_systemSpacing;
+    if (systemSpacing) {
         const int contentOverflow = params->m_prevBottomOverflow + m_systemAligner.GetOverflowAbove(params->m_doc);
         const int clefOverflow
             = params->m_prevBottomClefOverflow + m_systemAligner.GetOverflowAbove(params->m_doc, true);
         // Alignment is already pre-determined with staff alignment overflow
-        // We need to subtract them from the desired margin
-        const int actualMargin = systemMargin - std::max(contentOverflow, clefOverflow);
-        // Set the margin if it exsits (greater than 0)
-        if (actualMargin > 0) params->m_shift -= actualMargin;
+        // We need to subtract them from the desired spacing
+        const int actualSpacing = systemSpacing - std::max(contentOverflow, clefOverflow);
+        // Set the spacing if it exsits (greater than 0)
+        if (actualSpacing > 0) params->m_shift -= actualSpacing;
     }
 
     this->SetDrawingYRel(params->m_shift);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -773,6 +773,7 @@ int System::AlignSystems(FunctorParams *functorParams)
     }
 
     params->m_prevBottomOverflow = m_systemAligner.GetOverflowBelow(params->m_doc);
+    params->m_prevBottomClefOverflow = m_systemAligner.GetOverflowBelow(params->m_doc, true);
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -493,7 +493,8 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
     StaffAlignment *prevAlignment = dynamic_cast<StaffAlignment *>(parent->GetPrevious(this));
 
     if (!prevAlignment) {
-        return this->GetOverflowAbove() + this->GetOverlap();
+        const int maxOverflow = std::max(this->GetOverflowAbove(), this->GetScoreDefClefOverflowAbove());
+        return maxOverflow + this->GetOverlap();
     }
 
     int overflowSum = 0;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -515,8 +515,9 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
         overflowSum += this->GetOverlap();
     }
 
-    // Add a margin
-    overflowSum += doc->GetBottomMargin(STAFF) * doc->GetDrawingUnit(this->GetStaffSize());
+    // Add a margin but not for the bottom aligner
+    if (m_staff) overflowSum += doc->GetBottomMargin(STAFF) * doc->GetDrawingUnit(this->GetStaffSize());
+
     if (const int adjust = prevAlignment->GetBeamAdjust()) {
         overflowSum += adjust;
     }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -445,6 +445,8 @@ int StaffAlignment::GetMinimumSpacing(const Doc *doc) const
 {
     assert(doc);
 
+    const AttSpacing *scoreDefSpacing = this->GetAttSpacing();
+
     int spacing = 0;
     if (m_staff && m_staff->m_drawingStaffDef) {
         // Default or staffDef spacing
@@ -452,10 +454,10 @@ int StaffAlignment::GetMinimumSpacing(const Doc *doc) const
             spacing = m_staff->m_drawingStaffDef->GetSpacing() * doc->GetDrawingUnit(100);
         }
         else {
-            const AttSpacing *scoreDefSpacing = this->GetAttSpacing();
             switch (m_spacingType) {
                 case SystemAligner::SpacingType::System: {
-                    spacing = this->GetParentSystem()->GetMinimumSystemSpacing(doc);
+                    // Top staff spacing (above) is half of a staff spacing
+                    spacing = this->GetMinimumStaffSpacing(doc, scoreDefSpacing) / 2;
                     break;
                 }
                 case SystemAligner::SpacingType::Staff: {
@@ -478,6 +480,10 @@ int StaffAlignment::GetMinimumSpacing(const Doc *doc) const
                 default: assert(false);
             }
         }
+    }
+    // This is the bottom aligner - spacing is half of a staff spacing
+    else {
+        spacing = this->GetMinimumStaffSpacing(doc, scoreDefSpacing) / 2;
     }
 
     return spacing;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1055,9 +1055,7 @@ int StaffAlignment::AlignVerticallyEnd(FunctorParams *functorParams)
     AlignVerticallyParams *params = vrv_params_cast<AlignVerticallyParams *>(functorParams);
     assert(params);
 
-    if (m_spacingType != SystemAligner::SpacingType::System) {
-        params->m_cumulatedShift += this->GetMinimumSpacing(params->m_doc);
-    }
+    params->m_cumulatedShift += this->GetMinimumSpacing(params->m_doc);
 
     this->SetYRel(-params->m_cumulatedShift);
 
@@ -1075,10 +1073,7 @@ int StaffAlignment::AdjustYPos(FunctorParams *functorParams)
     const int defaultSpacing = this->GetMinimumSpacing(params->m_doc);
     const int minSpacing = this->CalcMinimumRequiredSpacing(params->m_doc);
 
-    if (m_spacingType == SystemAligner::SpacingType::System) {
-        params->m_cumulatedShift += minSpacing;
-    }
-    else if (minSpacing > defaultSpacing) {
+    if (minSpacing > defaultSpacing) {
         params->m_cumulatedShift += minSpacing - defaultSpacing;
     }
 

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -132,22 +132,26 @@ void SystemAligner::FindAllIntersectionPoints(
     }
 }
 
-int SystemAligner::GetOverflowAbove(const Doc *) const
+int SystemAligner::GetOverflowAbove(const Doc *, bool scoreDefClef) const
 {
     if (!this->GetChildCount() || this->GetChild(0) == m_bottomAlignment) return 0;
 
     StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(0));
     assert(alignment);
     return alignment->GetOverflowAbove();
+    int overflowAbove = scoreDefClef ? alignment->GetScoreDefClefOverflowAbove() : alignment->GetOverflowAbove();
+    return overflowAbove;
 }
 
-int SystemAligner::GetOverflowBelow(const Doc *doc) const
+int SystemAligner::GetOverflowBelow(const Doc *doc, bool scoreDefClef) const
 {
     if (!this->GetChildCount() || this->GetChild(0) == m_bottomAlignment) return 0;
 
     StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(this->GetChildCount() - 2));
     assert(alignment);
     return alignment->GetOverflowBelow() + doc->GetBottomMargin(STAFF) * doc->GetDrawingUnit(alignment->GetStaffSize());
+    int overflowBelow = scoreDefClef ? alignment->GetScoreDefClefOverflowBelow() : alignment->GetOverflowBelow();
+    return overflowBelow;
 }
 
 double SystemAligner::GetJustificationSum(const Doc *doc) const

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -138,7 +138,6 @@ int SystemAligner::GetOverflowAbove(const Doc *, bool scoreDefClef) const
 
     StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(0));
     assert(alignment);
-    return alignment->GetOverflowAbove();
     int overflowAbove = scoreDefClef ? alignment->GetScoreDefClefOverflowAbove() : alignment->GetOverflowAbove();
     return overflowAbove;
 }
@@ -149,7 +148,6 @@ int SystemAligner::GetOverflowBelow(const Doc *doc, bool scoreDefClef) const
 
     StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(this->GetChildCount() - 2));
     assert(alignment);
-    return alignment->GetOverflowBelow() + doc->GetBottomMargin(STAFF) * doc->GetDrawingUnit(alignment->GetStaffSize());
     int overflowBelow = scoreDefClef ? alignment->GetScoreDefClefOverflowBelow() : alignment->GetOverflowBelow();
     return overflowBelow;
 }


### PR DESCRIPTION
This PR addresses #1843 and brings improvements to the vertical positioning. By default, half of a staff spacing is now set above the first staff of a system and below the last one. This is the illustrated result with the default spacing options for an empty staff.

```bash
verovio --adjust-page-height --page-width 1300 example-01.mei --footer none --header none
```

![image](https://user-images.githubusercontent.com/689412/153362120-d449e753-e17a-4422-83b9-171cc6ee09a1.png)

<details>
<summary>Show MEI for example-01.mei</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Text example</title>
         </titleStmt>
         <pubStmt/>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <pgHead xml:id="pghead-0000000012068167">
                     <rend xml:id="rend-0000000149363456" halign="center" valign="middle">
                        <rend xml:id="rend-0000000742427957" fontsize="x-large">Text example</rend>
                     </rend>
                  </pgHead>
                  <pgFoot>
                     <rend fontsize="smaller" halign="left" valign="bottom">https://www.verovio.org – © 2022</rend>
                  </pgFoot>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="C" clef.line="3" key.mode="major" key.sig="0" meter.count="4" meter.unit="4" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

By removing the top and bottom page margins, we get
```bash
verovio --adjust-page-height --page-width 1300 example-01.mei --footer none --header none --page-margin-top 0 --page-margin-bottom 0
```
![image](https://user-images.githubusercontent.com/689412/153364191-1f3c876e-05a2-43ba-a7e1-faf8cf3691f3.png)

By setting the staff spacing to 0, we get
```bash
verovio --adjust-page-height --page-width 1300 example-01.mei --footer none --header none --page-margin-top 0 --page-margin-bottom 0 --spacing-staff 0
```
![image](https://user-images.githubusercontent.com/689412/153364756-45b18400-cde7-4f0b-a20f-ce34ba9fde69.png)

The half staff-space above the staff means that having content above the staff line does not change vertical positioning (issue #1843). Because the default value for `--spacing-staff` is 12.0 MEI units, it means can fit up to 3 staff spaces (i.e., up to a D6 with a G-2 clef).

![image](https://user-images.githubusercontent.com/689412/153366539-5ce66290-6e25-480d-8ae1-887c4c51dbd2.png)

<details>
<summary>Show MEI for example-02.mei</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Text example</title>
         </titleStmt>
         <pubStmt/>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <pgHead xml:id="pghead-0000000012068167">
                     <rend xml:id="rend-0000000149363456" halign="center" valign="middle">
                        <rend xml:id="rend-0000000742427957" fontsize="x-large">Text example</rend>
                     </rend>
                  </pgHead>
                  <pgFoot>
                     <rend fontsize="smaller" halign="left" valign="bottom">https://www.verovio.org – © 2022</rend>
                  </pgFoot>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" key.sig="0" meter.count="4" meter.unit="4" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note pname="e" oct="5" dur="4"/>
                           <note pname="f" oct="5" dur="4"/>
                           <note pname="g" oct="5" dur="4"/>
                           <note pname="a" oct="5" dur="4"/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

If the content takes more space than half a staff spacing, then space is added (same a before)

<details>
<summary>Show MEI for example-03.mei</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Text example</title>
         </titleStmt>
         <pubStmt/>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <pgHead xml:id="pghead-0000000012068167">
                     <rend xml:id="rend-0000000149363456" halign="center" valign="middle">
                        <rend xml:id="rend-0000000742427957" fontsize="x-large">Text example</rend>
                     </rend>
                  </pgHead>
                  <pgFoot>
                     <rend fontsize="smaller" halign="left" valign="bottom">https://www.verovio.org – © 2022</rend>
                  </pgFoot>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="major" key.sig="0" meter.count="4" meter.unit="4" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note pname="d" oct="6" dur="4"/>
                           <note pname="e" oct="6" dur="4"/>
                           <note pname="f" oct="6" dur="4"/>
                           <note pname="g" oct="6" dur="4"/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest/>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

![image](https://user-images.githubusercontent.com/689412/153375645-af73360a-53b8-42aa-95f0-6cde476e33ce.png)

One issue resolved with this PR was the adding of the header bottom margin even when the header was empty. This used to cause a lot of confusion. It is now added only if the header is not empty, and the default value was changed from 8.0 to 2.0 MEI units. It means that the behaviour remains as similar as possible because half a staff spacing is 6.0, so the sum remains 8.0.

The PR also adds a `--top-margin-pg-footer` (default 2.0 MEI unit)
```bash
verovio --adjust-page-height --page-width 1300 example-02.mei
```
![image](https://user-images.githubusercontent.com/689412/153381834-8ab58437-324a-4f0a-8928-5360a05b9d4a.png)
