### PR TITLE
Fixed: Deprecate Python 3.6, add 3.10

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -24,7 +24,7 @@ jobs:
       # Build the wheels for Linux, Windows and macOS for Python 3.9
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         architecture: [x86, x64]
         include:
           - os: macos-latest

--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -24,7 +24,7 @@ jobs:
       # Build the wheels for Linux, Windows and macOS for Python 3.9
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         architecture: [x86, x64]
         include:
           - os: macos-latest

--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -88,8 +88,8 @@ jobs:
         env:
           CIBW_SKIP: cp27-* # manylinux2014 not compatible with python 2.7
           CIBW_BUILD: ${{ env.CIBW_BUILD_IDENTIFIER }}
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS: brew update && brew install swig
           CIBW_BEFORE_ALL_WINDOWS: choco install swig -f -y
           CIBW_BEFORE_BUILD: swig -version && bash -c 'cd tools; ./get_git_commit.sh' && swig -c++ -python -py3 ./bindings/python/verovio.i


### PR DESCRIPTION
Can wait a bit to see if anyone has any objections to the change, but this will be ready to go if/when approved.

Fixes #2635