### PR TITLE
Add support for lyrics in ABC importer

### DIFF
--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -73,6 +73,7 @@ private:
     void parseMeter(const std::string &meterString); // M:
     void parseTempo(const std::string &tempoString); // Q:
     void parseReferenceNumber(const std::string &referenceNumberString); // X:
+    void parseLyrics(); // w:
 
     // input functions
     void readInformationField(const char &dataKey, std::string dataValue);
@@ -145,6 +146,9 @@ private:
 
     std::vector<LayerElement *> m_layerElements;
     std::vector<LayerElement *> m_noteStack;
+    // Array of added notes in one line of ABC file. Used to track elements that might require adding verse to
+    std::vector<LayerElement *> m_lineNoteArray;
+    int m_verseNumber = 1;
     /*
      * ABC decoration stacks
      */

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1041,12 +1041,15 @@ void ABCInput::parseLyrics()
                 ++counter;
                 ++found;
             }
+            --found;
         }
         // separate syllable from delimeters to form syl that we want to add
         syl = abcLine.substr(start, found - start);
         syl.erase(std::remove_if(syl.begin(), syl.end(), [](unsigned char x) { return x == '_'; }), syl.end());
         std::replace(syl.begin(), syl.end(), '~', ' ');
-        syllables.push_back({ syl, counter });
+        if (!syl.empty()) {
+            syllables.push_back({ syl, counter });
+        }
 
         // find next delimeter in the string
         start = found + 1;
@@ -1062,10 +1065,10 @@ void ABCInput::parseLyrics()
     // Iterate over notes and syllables simultaneously. Move through note array using counters for each syllable, moving
     // for several notes if syllable needs to be held
     for (int i = 0, j = 0; (i < m_lineNoteArray.size()) && (j < syllables.size()); ++j) {
-        if (m_lineNoteArray.at(i)->IsGraceNote()) {
+        while (m_lineNoteArray.at(i)->IsGraceNote() && (i < m_lineNoteArray.size())) {
             ++i;
-            continue;
         }
+        if (i >= m_lineNoteArray.size()) break;
         Text *sylText = new Text();
         sylText->SetText(UTF8to16(syllables.at(j).first));
         Syl *syl = new Syl();

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1028,10 +1028,10 @@ void ABCInput::InitScoreAndSection(Score *&score, Section *&section)
 void ABCInput::parseLyrics()
 {
     std::vector<std::pair<Syl *, int>> syllables;
-    constexpr std::string_view delimeters = "~\\-_ ";
+    constexpr std::string_view delimiters = "~\\-_ ";
     // skipping w:, so start from third element
     std::size_t start = 2;
-    std::size_t found = abcLine.find_first_of(delimeters, 2);
+    std::size_t found = abcLine.find_first_of(delimiters, 2);
     while (found != std::string::npos) {
         // Counter indicates for how many notes verse should be held. This defaults to 1, unless '_' is found
         int counter = 1;
@@ -1059,7 +1059,7 @@ void ABCInput::parseLyrics()
                 sylType = sylLog_CON_d;
             }
         }
-        // separate syllable from delimeters to form syl that we want to add
+        // separate syllable from delimiters to form syl that we want to add
         syllable = abcLine.substr(start, found - start);
         syllable.erase(
             std::remove_if(syllable.begin(), syllable.end(), [](unsigned char x) { return (x == '_') || (x == '\\'); }),
@@ -1078,8 +1078,8 @@ void ABCInput::parseLyrics()
 
         // find next delimeter in the string
         start = found + 1;
-        found = abcLine.find_first_of(delimeters, start);
-        // if none found, the rest of the string is going to server as last syl
+        found = abcLine.find_first_of(delimiters, start);
+        // if none found, the rest of the string is going to serve as last syl
         if ((found == std::string::npos) && (start < abcLine.size())) {
             std::string syllable = abcLine.substr(start);
             if (!syllable.empty() && syllable[syllable.size() - 1] == '\r') syllable.erase(syllable.size() - 1);
@@ -1109,6 +1109,11 @@ void ABCInput::parseLyrics()
         verse->AddChild(syllables.at(j).first);
         i += syllables.at(j).second;
     }
+    // clean up syllables that were not added to any of the layer elements
+    for (const auto syl : syllables) {
+        if (!syl.first->GetParent()) delete syl.first;
+    }
+
     // increment verse number, in case next line in file is also w:
     ++m_verseNumber;
 }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1050,13 +1050,13 @@ void ABCInput::parseLyrics()
             sylType = sylLog_CON_s;
         }
         else if (abcLine.at(found) == '-') {
-            sylType = sylLog_CON_b;
+            sylType = sylLog_CON_d;
         }
         else if (abcLine.at(found) == '\\') {
             if ((found + 1 < abcLine.size()) && (abcLine.at(found + 1) == '-')) {
                 counter = 0;
                 ++found;
-                sylType = sylLog_CON_b;
+                sylType = sylLog_CON_d;
             }
         }
         // separate syllable from delimeters to form syl that we want to add
@@ -1070,7 +1070,7 @@ void ABCInput::parseLyrics()
             Syl *syl = new Syl();
             syl->AddChild(sylText);
             syl->SetCon(sylType);
-            if (sylType == sylLog_CON_b) {
+            if (sylType == sylLog_CON_d) {
                 syl->SetWordpos(sylLog_WORDPOS_m);
             }
             syllables.push_back({ syl, counter });
@@ -1082,6 +1082,7 @@ void ABCInput::parseLyrics()
         // if none found, the rest of the string is going to server as last syl
         if ((found == std::string::npos) && (start < abcLine.size())) {
             std::string syllable = abcLine.substr(start);
+            if (!syllable.empty() && syllable[syllable.size() - 1] == '\r') syllable.erase(syllable.size() - 1);
             Text *sylText = new Text();
             sylText->SetText(UTF8to16(syllable));
             Syl *syl = new Syl();
@@ -1093,7 +1094,7 @@ void ABCInput::parseLyrics()
 
     // Iterate over notes and syllables simultaneously. Move through note array using counters for each syllable, moving
     // for several notes if syllable needs to be held
-    for (int i = 0, j = 0; (i < m_lineNoteArray.size()) && (j < syllables.size()); ++j) {
+    for (size_t i = 0, j = 0; (i < m_lineNoteArray.size()) && (j < syllables.size()); ++j) {
         while (m_lineNoteArray.at(i)->IsGraceNote() && (i < m_lineNoteArray.size())) {
             ++i;
         }


### PR DESCRIPTION
closes #2558 

This adds support for the `w:` element to the ABC importer.
![image](https://user-images.githubusercontent.com/1819669/153577372-be1258ae-695a-4a21-8d74-e7b49baf8015.png)

