### PR TITLE
Fix Xcode warning

### DIFF
--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -547,11 +547,10 @@ int Stem::CalcStem(FunctorParams *functorParams)
     // There is never a flag with stem sameas notes or with a duration longer than 8th notes
     if (!params->m_stemSameas && params->m_dur > DUR_4) {
         flag = vrv_cast<Flag *>(this->GetFirst(FLAG));
-        if (flag) {
-            flag->m_drawingNbFlags = params->m_dur - DUR_4;
-            if (!this->HasStemLen() && !this->IsGraceNote() && this->HasStemMod()) {
-                slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
-            }
+        assert(flag);
+        flag->m_drawingNbFlags = params->m_dur - DUR_4;
+        if (!this->HasStemLen() && !this->IsGraceNote() && this->HasStemMod()) {
+            slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
         }
     }
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -547,10 +547,11 @@ int Stem::CalcStem(FunctorParams *functorParams)
     // There is never a flag with stem sameas notes or with a duration longer than 8th notes
     if (!params->m_stemSameas && params->m_dur > DUR_4) {
         flag = vrv_cast<Flag *>(this->GetFirst(FLAG));
-        assert(flag);
-        flag->m_drawingNbFlags = params->m_dur - DUR_4;
-        if (!this->HasStemLen() && !this->IsGraceNote() && this->HasStemMod()) {
-            slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
+        if (flag) {
+            flag->m_drawingNbFlags = params->m_dur - DUR_4;
+            if (!this->HasStemLen() && !this->IsGraceNote() && this->HasStemMod()) {
+                slashFactor += (params->m_dur > DUR_8) ? 2 : 1;
+            }
         }
     }
 

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1110,7 +1110,7 @@ void ABCInput::parseLyrics()
         i += syllables.at(j).second;
     }
     // clean up syllables that were not added to any of the layer elements
-    for (const auto syl : syllables) {
+    for (const auto &syl : syllables) {
         if (!syl.first->GetParent()) delete syl.first;
     }
 


### PR DESCRIPTION
This PR fixes the warning regarding copying the container in the loop. Additionally fixes a wrong assertion which was triggered when running the test suite.