### PR TITLE
Fix Tablature: Augmentation dots on rhythm-signs #2525

### DIFF
--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -197,10 +197,23 @@ void View::DrawTabDurSym(DeviceContext *dc, LayerElement *element, Layer *layer,
         if (tabDurSym->GetDrawingStem()) {
             y = tabDurSym->GetDrawingStem()->GetDrawingY();
         }
-        y += m_doc->GetDrawingUnit(glyphSize) * 0.5 * stemDirFactor;
-        x += m_doc->GetDrawingUnit(glyphSize);
+
+        int dotSize = 0;
+
+        if (staff->IsTabGuitar()) {
+            y += m_doc->GetDrawingUnit(glyphSize) * 0.5 * stemDirFactor;
+            x += m_doc->GetDrawingUnit(glyphSize);
+            dotSize = glyphSize * 2 / 3;
+        }
+        else {
+            // lute tablature
+            y += m_doc->GetDrawingUnit(glyphSize) * stemDirFactor * 3 / 2;
+            x += m_doc->GetDrawingUnit(glyphSize) * 3 / 2;
+            dotSize = glyphSize * 9 / 10;
+        }
+
         for (int i = 0; i < tabGrp->GetDots(); ++i) {
-            this->DrawDot(dc, x, y, glyphSize * 2 / 3);
+            this->DrawDot(dc, x, y, dotSize);
             // HARDCODED
             x += m_doc->GetDrawingUnit(glyphSize) * 0.75;
         }


### PR DESCRIPTION
An original example of augmentation dots from A Varietie of Lute Lessons
![07_fantasie_7_dowlandj_VLL](https://user-images.githubusercontent.com/76966668/153855449-f3f3dbf2-9cd1-4eb4-a02c-a3c7a2b602f5.jpg)

Verovio rendered before
![07_fantasie_7_dowlandJ ft3 mei svg crop](https://user-images.githubusercontent.com/76966668/153855696-435326ce-0480-4ee2-9fed-260d68fd6234.jpg)

Verovio rendered after
![07_fantasie_7_dowlandJ ft3 mei-2525 svg crop](https://user-images.githubusercontent.com/76966668/153855735-ee62304b-af91-45f4-8136-6f65967de236.jpg)

These changes only affect lute tablature, not guitar.
