### PR TITLE
Fix for cue beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -126,7 +126,7 @@ private:
         Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
     // Helper to calculate the longest stem length of the beam (which will be used uniformely)
-    void CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal);
+    void CalcBeamStemLength(Doc *doc, Staff *staff, data_BEAMPLACE place, bool isHorizontal);
 
     // Helper to set the stem values
     void CalcSetStemValues(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -121,14 +121,14 @@ void BeamSegment::CalcBeam(
         CalcMixedBeamPlace(staff);
         CalcPartialFlagPlace();
     }
-    CalcBeamStemLength(staff, beamInterface->m_drawingPlace, horizontal);
+    CalcBeamStemLength(doc, staff, beamInterface->m_drawingPlace, horizontal);
 
     // Set drawing stem positions
     CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
     if (BEAMPLACE_mixed == beamInterface->m_drawingPlace) {
         if (NeedToResetPosition(staff, doc, beamInterface)) {
             CalcBeamInit(layer, staff, doc, beamInterface, place);
-            CalcBeamStemLength(staff, beamInterface->m_drawingPlace, horizontal);
+            CalcBeamStemLength(doc, staff, beamInterface->m_drawingPlace, horizontal);
             CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
         }
     }
@@ -1206,7 +1206,7 @@ void BeamSegment::CalcBeamPlaceTab(
     }
 }
 
-void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal)
+void BeamSegment::CalcBeamStemLength(Doc *doc, Staff *staff, data_BEAMPLACE place, bool isHorizontal)
 {
     int relevantNoteLoc = VRV_UNSET;
     const data_STEMDIRECTION globalStemDir = (place == BEAMPLACE_below) ? STEMDIRECTION_down : STEMDIRECTION_up;
@@ -1251,12 +1251,8 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool is
     // make adjustments for the grace notes length
     for (auto coord : m_beamElementCoordRefs) {
         if (coord->m_element) {
-            if (coord->m_element->IsGraceNote()) {
-                m_uniformStemLength *= 0.75;
-                break;
-            }
-            if (coord->m_element->GetDrawingCueSize()) {
-                m_uniformStemLength *= 0.75;
+            if (coord->m_element->IsGraceNote() || coord->m_element->GetDrawingCueSize()) {
+                m_uniformStemLength *= doc->GetOptions()->m_graceFactor.GetValue();
                 break;
             }
         }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1255,6 +1255,10 @@ void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool is
                 m_uniformStemLength *= 0.75;
                 break;
             }
+            if (coord->m_element->GetDrawingCueSize()) {
+                m_uniformStemLength *= 0.75;
+                break;
+            }
         }
     }
 }

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -254,11 +254,6 @@ void BeamDrawingInterface::InitCue(bool beamCue)
             return false;
         });
     }
-
-    // Always set stem direction to up for grace note beam unless stem direction is provided
-    if (m_cueSize && (m_notesStemDir == STEMDIRECTION_NONE)) {
-        m_notesStemDir = STEMDIRECTION_up;
-    }
 }
 
 bool BeamDrawingInterface::IsHorizontal()

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -244,15 +244,26 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
 
 void BeamDrawingInterface::InitCue(bool beamCue)
 {
+    bool hasGraceNotes = false;
     if (beamCue) {
         m_cueSize = beamCue;
     }
     else {
-        m_cueSize = std::all_of(m_beamElementCoords.begin(), m_beamElementCoords.end(), [](BeamElementCoord *coord) {
-            if (!coord->m_element) return false;
-            if (coord->m_element->IsGraceNote() || coord->m_element->GetDrawingCueSize()) return true;
-            return false;
-        });
+        m_cueSize = std::all_of(
+            m_beamElementCoords.begin(), m_beamElementCoords.end(), [&hasGraceNotes](BeamElementCoord *coord) {
+                if (!coord->m_element) return false;
+                if (coord->m_element->IsGraceNote()) {
+                    hasGraceNotes = true;
+                    return true;
+                }
+                if (coord->m_element->GetDrawingCueSize()) return true;
+                return false;
+            });
+    }
+
+    // Always set stem direction to up for grace note beam unless stem direction is provided
+    if (hasGraceNotes && (m_notesStemDir == STEMDIRECTION_NONE)) {
+        m_notesStemDir = STEMDIRECTION_up;
     }
 }
 


### PR DESCRIPTION
Fix for the stem length and direction of the cue beams.
![image](https://user-images.githubusercontent.com/1819669/153864819-d260a7c1-1233-4626-a309-be060021fd91.png)

After fix:
![image](https://user-images.githubusercontent.com/1819669/153862790-f4242fc3-f17e-4280-bafa-d6fd4aeeea30.png)

<details><summary>MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Beamed cue notes</title>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2022-02-09" type="encoding-date">2022-02-09</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="f" grace="acc" />
                              <note dur="8" oct="4" pname="d" grace="acc" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="f" />
                              <note dur="8" oct="4" pname="d" />
                           </beam>
                           <beam>
                              <note dur="8" oct="4" pname="f" cue="true" />
                              <note dur="8" oct="4" pname="d" cue="true" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="f" grace="acc" />
                              <note dur="8" oct="5" pname="d" grace="acc" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="f" />
                              <note dur="8" oct="5" pname="d" />
                           </beam>
                           <beam>
                              <note dur="8" oct="5" pname="f" cue="true" />
                              <note dur="8" oct="5" pname="d" cue="true" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="f" />
                           <note dur="8" oct="4" pname="d" />
                           <note dur="8" oct="4" pname="f" cue="true" />
                           <note dur="8" oct="4" pname="d" cue="true" />
                           <note dur="8" oct="5" pname="f" />
                           <note dur="8" oct="5" pname="d" />
                           <note dur="8" oct="5" pname="f" cue="true" />
                           <note dur="8" oct="5" pname="d" cue="true" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>
