### PR TITLE
Resolve stem collisions

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -283,7 +283,7 @@ public:
     }
     std::vector<int> m_staffNs;
     std::vector<LayerElement *> m_elements;
-    std::vector<LayerElement *> m_dots;
+    std::vector<Dots *> m_dots;
     Doc *m_doc;
     Functor *m_functor;
     Functor *m_functorEnd;

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -358,7 +358,7 @@ private:
      * Return whether dots are overlapping with flag. Take into account flag height, its position as well
      * as position of the note and position of the dots
      */
-    bool IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShifted);
+    bool IsDotOverlappingWithFlag(Doc *doc, const int staffSize, int dotLocShift);
 
     /**
      * Register deferred notes for MIDI

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1197,7 +1197,7 @@ int Alignment::AdjustDotsEnd(FunctorParams *functorParams)
                     if (diff > max) max = diff;
                 }
                 if (max) dot->SetDrawingXRel(dot->GetDrawingXRel() + max);
-                vrv_cast<Dots *>(dot)->IsAdjusted(true);
+                dot->IsAdjusted(true);
             }
         }
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1711,11 +1711,13 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
         else if (this->Is(NOTE)) {
             Note *currentNote = vrv_cast<Note *>(this);
             assert(currentNote);
-            if ((currentNote->GetDrawingDur() == DUR_1) && otherElements.at(i)->Is(STEM) && (shift == 0)) {
+            if (otherElements.at(i)->Is(STEM) && (shift == 0)) {
                 const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
-                data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
-                if (this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0) != 0) {
+                const data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
+                const int leftOverlap = this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0);
+                const int rightOverlap = this->HorizontalRightOverlap(otherElements.at(i), doc, 0, 0);
+                if ((leftOverlap != 0) && (rightOverlap != 0)) {
                     shift = 3 * horizontalMargin;
                     if (stemDir == STEMDIRECTION_up) {
                         shift *= -1;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1495,7 +1495,7 @@ int LayerElement::AdjustDots(FunctorParams *functorParams)
 
     if (this->Is(NOTE) && this->GetParent()->Is(CHORD)) return FUNCTOR_SIBLINGS;
     if (this->Is(DOTS)) {
-        params->m_dots.push_back(this);
+        params->m_dots.push_back(vrv_cast<Dots *>(this));
     }
     else {
         params->m_elements.push_back(this);
@@ -1711,7 +1711,7 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
         else if (this->Is(NOTE)) {
             Note *currentNote = vrv_cast<Note *>(this);
             assert(currentNote);
-            if (otherElements.at(i)->Is(STEM) && (shift == 0)) {
+            if (otherElements.at(i)->Is(STEM) && (shift == 0) && areDotsAdjusted) {
                 const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
                 const data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1713,19 +1713,10 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             assert(currentNote);
             if (otherElements.at(i)->Is(STEM) && (shift == 0) && areDotsAdjusted) {
                 Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
-                const data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
                 // Nothing to do if note has same stem
                 if (currentNote->HasStemSameasNote()) continue;
 
-                const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-                const int leftOverlap = this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0);
-                const int rightOverlap = this->HorizontalRightOverlap(otherElements.at(i), doc, 0, 0);
-                if ((leftOverlap != 0) && (rightOverlap != 0)) {
-                    shift = 3 * horizontalMargin;
-                    if (stemDir == STEMDIRECTION_up) {
-                        shift *= -1;
-                    }
-                }
+                shift -= stem->CompareToElementPosition(doc, currentNote, 0);
             }
         }
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1712,9 +1712,12 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             Note *currentNote = vrv_cast<Note *>(this);
             assert(currentNote);
             if (otherElements.at(i)->Is(STEM) && (shift == 0) && areDotsAdjusted) {
-                const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 Stem *stem = vrv_cast<Stem *>(otherElements.at(i));
                 const data_STEMDIRECTION stemDir = stem->GetDrawingStemDir();
+                // Nothing to do if note has same stem
+                if (currentNote->HasStemSameasNote()) continue;
+
+                const int horizontalMargin = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 const int leftOverlap = this->HorizontalLeftOverlap(otherElements.at(i), doc, 0, 0);
                 const int rightOverlap = this->HorizontalRightOverlap(otherElements.at(i), doc, 0, 0);
                 if ((leftOverlap != 0) && (rightOverlap != 0)) {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1207,7 +1207,7 @@ int Note::CalcDots(FunctorParams *functorParams)
             flagShift += shift;
         }
         else if ((this->GetDrawingStemDir() == STEMDIRECTION_up) && !this->IsInBeam() && (this->GetDrawingStemLen() < 3)
-            && !this->IsInBeamSpan() && (this->IsDotOverlappingWithFlag(params->m_doc, staffSize, isDotShifted))) {
+            && !this->IsInBeamSpan() && (this->IsDotOverlappingWithFlag(params->m_doc, staffSize, dotLocShift))) {
             // HARDCODED
             const int shift = params->m_doc->GetGlyphWidth(SMUFL_E240_flag8thUp, staffSize, drawingCueSize) * 0.8;
             flagShift += shift;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -724,7 +724,7 @@ void Note::UpdateFromTransPitch(const TransPitch &tp)
     }
 }
 
-bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShifted)
+bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, int dotLocShift)
 {
     Object *stem = this->GetFirst(STEM);
     if (!stem) return false;
@@ -739,7 +739,7 @@ bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShi
     const int flagHeight = doc->GetGlyphHeight(flagGlyph, staffSize, this->GetDrawingCueSize());
 
     const int dotMargin = flag->GetDrawingY() - this->GetDrawingY() - flagHeight - this->GetDrawingRadius(doc) / 2
-        - (isDotShifted ? doc->GetDrawingUnit(staffSize) : 0);
+        - dotLocShift * doc->GetDrawingUnit(staffSize);
 
     return dotMargin < 0;
 }
@@ -1197,8 +1197,10 @@ int Note::CalcDots(FunctorParams *functorParams)
         dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
         assert(dots);
 
-        dots->SetMapOfDotLocs(this->CalcOptimalDotLocations());
-        const bool isDotShifted = (this->GetDrawingLoc() % 2 == 0);
+        MapOfDotLocs dotLocs = this->CalcOptimalDotLocations();
+        dots->SetMapOfDotLocs(dotLocs);
+
+        const int dotLocShift = *(dotLocs.cbegin()->second.rbegin()) - this->GetDrawingLoc();
 
         // Stem up, shorter than 4th and not in beam
         if (const int shift = dots->GetFlagShift(); shift) {


### PR DESCRIPTION
This PR resolves stem collisions between notes on different layers.

| Before | After |
| ------ | ----- |
| ![Before1](https://user-images.githubusercontent.com/63608463/154266249-0f70b8ba-5427-43ea-9944-7b09439906b9.png) | ![After1](https://user-images.githubusercontent.com/63608463/154266275-a17f417f-0fe1-4c05-8819-c0501423495c.png) |
| ![Before2](https://user-images.githubusercontent.com/63608463/154266304-c545dd80-a264-477a-90a9-10da14e1b7c7.png) | ![After2](https://user-images.githubusercontent.com/63608463/154266319-d976c02e-14dc-42a2-af75-05d254d1d397.png) |
| ![Before3](https://user-images.githubusercontent.com/63608463/154266354-b90e29f1-8db2-4053-9102-9f96223c9017.png) | ![After3](https://user-images.githubusercontent.com/63608463/154266381-1e6b5cb6-ad62-4c20-b0c7-4c2593d396aa.png) |

<details>
<summary> Show MEI of Example 1 </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-fjb4d2">
         <appInfo xml:id="appinfo-9z07ki">
            <application xml:id="application-8fwijx" isodate="2022-02-14T10:56:58" version="3.9.0-dev-1f738f4">
               <name xml:id="name-vv8aph">Verovio</name>
               <p xml:id="p-o9hjsr">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m8wrfvb">
            <score xml:id="si9mbnd">
               <scoreDef xml:id="slo7gs3">
                  <staffGrp xml:id="s4h7ezq">
                     <staffGrp xml:id="s3km841" bar.thru="true">
                        <grpSym xml:id="gpbyskx" symbol="brace" />
                        <staffGrp xml:id="P1-NULL" bar.thru="true">
                           <staffDef xml:id="s4puokv" n="1" lines="5" ppq="16">
                              <clef xml:id="clef-1" shape="G" line="2" />
                              <keySig xml:id="key-1" sig="3f" />
                              <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                           </staffDef>
                           <staffDef xml:id="shytwk9" n="2" lines="5" ppq="16">
                              <clef xml:id="clef-2" shape="F" line="4" />
                              <keySig xml:id="key-2" sig="3f" />
                              <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                           </staffDef>
                        </staffGrp>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s201tjp">
                  <measure xml:id="measure-35-mdiv-1" n="35">
                     <staff xml:id="svffjuw" n="1">
                        <layer xml:id="lrc3k41" n="2">
                           <note xml:id="note-1039" dots="1" dur.ppq="48" dur="2" staff="2" oct="2" pname="b" stem.dir="up" accid.ges="n" />
                        </layer>
                     </staff>
                     <staff xml:id="s9c7wx" n="2">
                        <layer xml:id="ltahnnq" n="1">
                           <beam xml:id="b6n2q4u">
                              <note xml:id="note-1042" dur.ppq="4" dur="16" oct="3" pname="f" stem.dir="up" />
                              <note xml:id="note-1043" dur.ppq="4" dur="16" oct="3" pname="a" stem.dir="up" accid.ges="f" />
                              <note xml:id="note-1044" dur.ppq="4" dur="16" oct="3" pname="g" stem.dir="up" />
                              <note xml:id="note-1045" dur.ppq="4" dur="16" oct="3" pname="f" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer xml:id="laurtn7" n="3">
                           <note xml:id="note-1056" dots="1" dur.ppq="48" dur="2" oct="2" pname="c" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
<summary> Show MEI of Example 2 </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-fjb4d2">
         <appInfo xml:id="appinfo-9z07ki">
            <application xml:id="application-8fwijx" isodate="2022-02-14T10:56:58" version="3.9.0-dev-1f738f4">
               <name xml:id="name-vv8aph">Verovio</name>
               <p xml:id="p-o9hjsr">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m8wrfvb">
            <score xml:id="si9mbnd">
               <scoreDef xml:id="slo7gs3">
                  <staffGrp xml:id="s4h7ezq">
                     <staffGrp xml:id="s3km841" bar.thru="true">
                        <grpSym xml:id="gpbyskx" symbol="brace" />
                        <staffGrp xml:id="P1-NULL" bar.thru="true">
                           <staffDef xml:id="s4puokv" n="1" lines="5" ppq="16">
                              <clef xml:id="clef-1" shape="G" line="2" />
                              <keySig xml:id="key-1" sig="3f" />
                              <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                           </staffDef>
                           <staffDef xml:id="shytwk9" n="2" lines="5" ppq="16">
                              <clef xml:id="clef-2" shape="F" line="4" />
                              <keySig xml:id="key-2" sig="3f" />
                              <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                           </staffDef>
                        </staffGrp>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s201tjp">
                  <measure xml:id="measure-35-mdiv-1" n="35">
                     <staff xml:id="svffjuw" n="1">
                        <layer n="1">
                          <rest dur="4"></rest>
                        </layer>
                     </staff>
                     <staff xml:id="s9c7wx" n="2">
                        <layer xml:id="lrc3k41" n="2">
                          <note xml:id="note-1039" dur.ppq="48" dur="4" oct="2" pname="b" stem.dir="up" accid.ges="n" />
                        </layer>
                        <layer xml:id="ltahnnq" n="3">
                          <note xml:id="note-1042" dur.ppq="4" dur="2" oct="3" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
<summary> Show MEI of Example 3 </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-fjb4d2">
         <appInfo xml:id="appinfo-9z07ki">
            <application xml:id="application-8fwijx" isodate="2022-02-14T10:56:58" version="3.9.0-dev-1f738f4">
               <name xml:id="name-vv8aph">Verovio</name>
               <p xml:id="p-o9hjsr">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m8wrfvb">
            <score xml:id="si9mbnd">
               <scoreDef xml:id="slo7gs3">
                  <staffGrp xml:id="s4h7ezq">
                     <staffGrp xml:id="s3km841" bar.thru="true">
                        <grpSym xml:id="gpbyskx" symbol="brace" />
                        <staffGrp xml:id="P1-NULL" bar.thru="true">
                           <staffDef xml:id="s4puokv" n="1" lines="5" ppq="16">
                              <clef xml:id="clef-1" shape="G" line="2" />
                              <keySig xml:id="key-1" sig="3f" />
                              <meterSig xml:id="time-1" count="4" sym="common" unit="4" />
                           </staffDef>
                           <staffDef xml:id="shytwk9" n="2" lines="5" ppq="16">
                              <clef xml:id="clef-2" shape="F" line="4" />
                              <keySig xml:id="key-2" sig="3f" />
                              <meterSig xml:id="time-2" count="4" sym="common" unit="4" />
                           </staffDef>
                        </staffGrp>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s201tjp">
                  <measure xml:id="measure-35-mdiv-1" n="35">
                     <staff xml:id="svffjuw" n="1">
                        <layer n="1">
                          <rest dur="4"></rest>
                        </layer>
                     </staff>
                     <staff xml:id="s9c7wx" n="2">
                        <layer xml:id="ltahnnq" n="2">
                          <note xml:id="note-1042" dur.ppq="4" dur="2" oct="3" pname="f" stem.dir="down" />
                        </layer>
                        <layer xml:id="lrc3k41" n="3">
                          <note xml:id="note-1039" dur.ppq="48" dur="4" oct="2" pname="b" stem.dir="down" accid.ges="n" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>


 