### PR TITLE
Fix Misplaced repetition dots in tablature #2648

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -950,22 +950,26 @@ void View::DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine)
     const int x1 = x - barLineWidth / 2 - (dotSeparation + dotWidth);
     const int x2 = x + xShift;
 
-    const int yBottom = staff->GetDrawingY() - staff->m_drawingLines * m_doc->GetDrawingUnit(staffSize);
-    const int yTop = yBottom + m_doc->GetDrawingDoubleUnit(staffSize);
+    const int numDots = 3 - staff->m_drawingLines % 2; // odd => 2 dots, even => 3 dots
+    const int yInc = m_doc->GetDrawingDoubleUnit(staffSize); // vertical distance between dots
+    const int yBottom = staff->GetDrawingY() - (staff->m_drawingLines + numDots % 2) * m_doc->GetDrawingUnit(staffSize);
+    const int yTop = yBottom + (numDots - 1) * yInc;
 
     if (barLine->GetForm() == BARRENDITION_rptstart) {
-        this->DrawSmuflCode(dc, x2 - thickBarLineWidth / 2, yTop, SMUFL_E044_repeatDot, staffSize, false);
-        this->DrawSmuflCode(dc, x2 - thickBarLineWidth / 2, yBottom, SMUFL_E044_repeatDot, staffSize, false);
+        for (int y = yTop; y >= yBottom; y -= yInc) {
+            this->DrawSmuflCode(dc, x2 - thickBarLineWidth / 2, y, SMUFL_E044_repeatDot, staffSize, false);
+        }
     }
     if (barLine->GetForm() == BARRENDITION_rptboth) {
-        this->DrawSmuflCode(
-            dc, x2 + barLineSeparation + barLineWidth / 2, yTop, SMUFL_E044_repeatDot, staffSize, false);
-        this->DrawSmuflCode(
-            dc, x2 + barLineSeparation + barLineWidth / 2, yBottom, SMUFL_E044_repeatDot, staffSize, false);
+        for (int y = yTop; y >= yBottom; y -= yInc) {
+            this->DrawSmuflCode(
+                dc, x2 + barLineSeparation + barLineWidth / 2, y, SMUFL_E044_repeatDot, staffSize, false);
+        }
     }
     if ((barLine->GetForm() == BARRENDITION_rptend) || (barLine->GetForm() == BARRENDITION_rptboth)) {
-        this->DrawSmuflCode(dc, x1, yTop, SMUFL_E044_repeatDot, staffSize, false);
-        this->DrawSmuflCode(dc, x1, yBottom, SMUFL_E044_repeatDot, staffSize, false);
+        for (int y = yTop; y >= yBottom; y -= yInc) {
+            this->DrawSmuflCode(dc, x1, y, SMUFL_E044_repeatDot, staffSize, false);
+        }
     }
 
     return;


### PR DESCRIPTION
Fix issue #2648 

Odd number of staff lines use 2 dots, even number of staff lines use 3 dots.

4 line staff
![test4 mei svg](https://user-images.githubusercontent.com/76966668/154690594-c0ec1c18-b19e-4843-a3ec-ee725c004a64.jpg)


5 line staff
![test5 mei svg](https://user-images.githubusercontent.com/76966668/154690740-99c88e37-8178-4f22-b3f2-aeb682da946c.jpg)


6 line staff
![test6 mei svg](https://user-images.githubusercontent.com/76966668/154690902-ebc3d965-1c33-4be0-9bce-e3ceb4e12dd9.jpg)

