### PR TITLE
Return path member variable to track font-specific glyph location

### DIFF
--- a/include/vrv/glyph.h
+++ b/include/vrv/glyph.h
@@ -67,6 +67,14 @@ public:
     ///@}
 
     /**
+     * @name Setter and getter for the path
+     */
+    ///@{
+    std::string GetPath() { return m_path; }
+    void SetPath(const std::string &path) { m_path = path; }
+    ///@}
+
+    /**
      * @name Setter and getter for the horizAdvX
      */
     ///@{
@@ -106,6 +114,8 @@ private:
     int m_unitsPerEm;
     /** The Unicode code in hexa as string */
     std::string m_codeStr;
+    /** Path to the glyph XML file */
+    std::string m_path;
     /** A map of the available anchors */
     std::map<SMuFLGlyphAnchor, Point> m_anchors;
 };

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -23,6 +23,8 @@
 
 //----------------------------------------------------------------------------
 
+class Glyph;
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
@@ -284,7 +286,7 @@ private:
 
     // holds the list of glyphs from the smufl font used so far
     // they will be added at the end of the file as <defs>
-    std::set<std::string> m_smuflGlyphs;
+    std::set<Glyph *> m_smuflGlyphs;
 
     // pugixml data
     pugi::xml_document m_svgDoc;

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -151,8 +151,6 @@ public:
     /** Resource path */
     static std::string GetPath() { return s_path; }
     static void SetPath(const std::string &path) { s_path = path; }
-    /** Font name */
-    static std::string GetSmuflFontName() { return s_smuflFontName; }
     /** Init the SMufL music and text fonts */
     static bool InitFonts();
     /** Init the text font (bounding boxes and ASCII only) */
@@ -181,8 +179,6 @@ private:
 
     /** The path to the resources directory (e.g., for the svg/ subdirectory with fonts as XML */
     static thread_local std::string s_path;
-    /** Name of the font used for SMUFL glyphs*/
-    static thread_local std::string s_smuflFontName;
     /** The loaded SMuFL font */
     static thread_local GlyphTable s_fontGlyphTable;
     /** A text font used for bounding box calculations */

--- a/src/glyph.cpp
+++ b/src/glyph.cpp
@@ -35,6 +35,7 @@ Glyph::Glyph()
     m_horizAdvX = 0;
     m_unitsPerEm = 20480;
     m_codeStr = "[unset]";
+    m_path = "[unset]";
 }
 
 Glyph::Glyph(std::string path, std::string codeStr)
@@ -81,6 +82,7 @@ Glyph::Glyph(int unitsPerEm)
     m_horizAdvX = 0;
     m_unitsPerEm = unitsPerEm * 10;
     m_codeStr = "[unset]";
+    m_path = "[unset]";
 }
 
 Glyph::~Glyph() {}

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -124,11 +124,9 @@ void SvgDeviceContext::Commit(bool xml_declaration)
         pugi::xml_document sourceDoc;
 
         // for each needed glyph
-        std::set<std::string>::const_iterator it;
-        for (it = m_smuflGlyphs.begin(); it != m_smuflGlyphs.end(); ++it) {
+        for (auto it = m_smuflGlyphs.begin(); it != m_smuflGlyphs.end(); ++it) {
             // load the XML file that contains it as a pugi::xml_document
-            const std::string path = Resources::GetPath() + "/" + Resources::GetSmuflFontName() + "/" + *it + ".xml";
-            std::ifstream source(path);
+            std::ifstream source((*it)->GetPath());
             sourceDoc.load(source);
 
             // copy all the nodes inside into the master document
@@ -906,7 +904,7 @@ void SvgDeviceContext::DrawMusicText(const std::wstring &text, int x, int y, boo
         }
 
         // Add the glyph to the array for the <defs>
-        m_smuflGlyphs.insert(glyph->GetCodeStr());
+        m_smuflGlyphs.insert(glyph);
 
         // Write the char in the SVG
         pugi::xml_node useChild = AppendChild("use");

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -66,7 +66,6 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 thread_local std::string Resources::s_path = "/usr/local/share/verovio";
-thread_local std::string Resources::s_smuflFontName = "";
 thread_local Resources::GlyphTextMap Resources::s_textFont;
 thread_local Resources::GlyphTable Resources::s_fontGlyphTable;
 thread_local Resources::GlyphNameTable Resources::s_glyphNameTable;
@@ -167,9 +166,6 @@ Glyph *Resources::GetTextGlyph(wchar_t code)
 
 bool Resources::LoadFont(const std::string &fontName)
 {
-    // set font name
-    s_smuflFontName = fontName;
-
     pugi::xml_document doc;
     const std::string filename = Resources::GetPath() + "/" + fontName + ".xml";
     pugi::xml_parse_result parseResult = doc.load_file(filename.c_str());
@@ -200,6 +196,7 @@ bool Resources::LoadFont(const std::string &fontName)
         if (current.attribute("w")) width = current.attribute("w").as_float();
         if (current.attribute("h")) height = current.attribute("h").as_float();
         glyph.SetBoundingBox(x, y, width, height);
+        glyph.SetPath(Resources::GetPath() + "/" + fontName + "/" + c_attribute.value() + ".xml");
         if (current.attribute("h-a-x")) glyph.SetHorizAdvX(current.attribute("h-a-x").as_float());
 
         // load anchors


### PR DESCRIPTION
closes #2652

So far this is a simple fix to fix the regression mentioned in the issue. 
![image](https://user-images.githubusercontent.com/1819669/154696403-9d871dee-9901-4a78-aafc-1542e793a9de.png)
