### PR TITLE
Add option to include an additional CSS to the SVG

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -616,6 +616,7 @@ public:
     OptionBool m_shrinkToFit;
     OptionBool m_staccatoCenter;
     OptionBool m_svgBoundingBoxes;
+    OptionString m_svgCss;
     OptionBool m_svgViewBox;
     OptionBool m_svgHtml5;
     OptionBool m_svgFormatRaw;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -218,6 +218,11 @@ public:
     void SetRemoveXlink(bool removeXlink) { m_removeXlink = removeXlink; }
 
     /**
+     * Setter for an additional CSS
+     */
+    void SetCss(std::string css) { m_css = css; }
+
+    /**
      *  Copies additional attributes of defined elements to the SVG, each string in the form "elementName@attribute"
      * (e.g., "note@pname")
      */
@@ -304,6 +309,8 @@ private:
     bool m_svgViewBox;
     // output HTML5 data-* attributes
     bool m_html5;
+    // additional CSS
+    std::string m_css;
     // copy additional attributes of given elements to the SVG, in the form "note@pname; layer@n"
     std::multimap<ClassId, std::string> m_svgAdditionalAttributes;
     // format output as raw, stripping extraneous whitespace and non-content newlines

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1262,7 +1262,7 @@ Options::Options()
     this->Register(&m_lyricVerseCollapse, "lyricVerseCollapse", &m_generalLayout);
 
     m_measureMinWidth.SetInfo("Measure min width", "The minimal measure width in MEI units");
-    m_measureMinWidth.Init(1, 1, 30);
+    m_measureMinWidth.Init(15, 1, 30);
     this->Register(&m_measureMinWidth, "minMeasureWidth", &m_generalLayout);
 
     m_mnumInterval.SetInfo("Measure Number Interval", "How frequently to place measure numbers");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1066,6 +1066,10 @@ Options::Options()
     m_svgBoundingBoxes.Init(false);
     this->Register(&m_svgBoundingBoxes, "svgBoundingBoxes", &m_general);
 
+    m_svgCss.SetInfo("SVG additional CSS", "CSS (as a string) to be added to the SVG output");
+    m_svgCss.Init("");
+    this->Register(&m_svgCss, "svgCss", &m_general);
+
     m_svgViewBox.SetInfo("Use viewbox on svg root", "Use viewBox on svg root element for easy scaling of document");
     m_svgViewBox.Init(false);
     this->Register(&m_svgViewBox, "svgViewBox", &m_general);
@@ -1258,7 +1262,7 @@ Options::Options()
     this->Register(&m_lyricVerseCollapse, "lyricVerseCollapse", &m_generalLayout);
 
     m_measureMinWidth.SetInfo("Measure min width", "The minimal measure width in MEI units");
-    m_measureMinWidth.Init(15, 1, 30);
+    m_measureMinWidth.Init(1, 1, 30);
     this->Register(&m_measureMinWidth, "minMeasureWidth", &m_generalLayout);
 
     m_mnumInterval.SetInfo("Measure Number Interval", "How frequently to place measure numbers");

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -405,6 +405,13 @@ void SvgDeviceContext::StartPage()
         m_currentNode = m_svgNodeStack.back();
     }
 
+    if (!m_css.empty()) {
+        m_currentNode = m_currentNode.append_child("style");
+        m_currentNode.append_attribute("type") = "text/css";
+        m_currentNode.append_child(pugi::node_pcdata).set_value(m_css.c_str());
+        m_currentNode = m_svgNodeStack.back();
+    }
+
     // a graphic for definition scaling
     m_currentNode = m_currentNode.append_child("svg");
     m_svgNodeStack.push_back(m_currentNode);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1303,6 +1303,11 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xmlDeclaration)
         svg.SetSvgBoundingBoxes(true);
     }
 
+    // set the additional CSS if any
+    if (!m_options->m_svgCss.GetValue().empty()) {
+        svg.SetCss(m_options->m_svgCss.GetValue());
+    }
+
     if (m_options->m_svgViewBox.GetValue()) {
         svg.SetSvgViewBox(true);
     }


### PR DESCRIPTION
This PR add the `--svg-css` option to pass and additional CSS to be included in the SVG output.

For example, setting `--svg-css 'g.clef{ fill: grey; }'` will add

```xml
<style type="text/css">g.clef{ fill: grey; }</style>
```
 
to the SVG and produce

![image](https://user-images.githubusercontent.com/689412/154999403-29a47d3f-31b6-4cf5-b56b-e4b37802cc3f.png)

