### PR TITLE
Adds arm64 compat to Python builds

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -88,6 +88,7 @@ jobs:
         env:
           CIBW_SKIP: cp27-* # manylinux2014 not compatible with python 2.7
           CIBW_BUILD: ${{ env.CIBW_BUILD_IDENTIFIER }}
+          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS: brew update && brew install swig


### PR DESCRIPTION
From: https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon

This commit adds specific builds for x86_64 and arm64. It does not add a universal2 option, to try and keep down the library size when installing. 

Refs #2663