### PR TITLE
Fix overlap of group symbols

### DIFF
--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -349,7 +349,7 @@ private:
     int GetMinimumStaffSpacing(const Doc *doc, const AttSpacing *attSpacing) const;
 
     /**
-     * Return whether current staff alignmnet at the start/end of bracket group
+     * Return whether current staff alignment is at the start/end of a bracket group
      */
     bool IsInBracketGroup(bool isFirst) const;
 

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -292,7 +292,7 @@ public:
     void SetBeamAdjust(int beamAdjust) { m_beamAdjust = beamAdjust; }
     int GetBeamAdjust() const { return m_beamAdjust; }
     ///@}
-    
+
     /**
      * Find overflow for the alignments taking bracket group elements into account
      */

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -250,10 +250,10 @@ public:
     BoundingBox *GetOverflowBBoxAbove() const { return m_overflowBBoxAbove; }
     void SetOverflowBBoxBelow(BoundingBox *bboxBelow, int overflowBottom);
     BoundingBox *GetOverflowBBoxBelow() const { return m_overflowBBoxBelow; }
-    void SetScoreDefClefOverflowAbove(int overflowAbove) { m_scoreDefClefOverflowAbove = overflowAbove; }
-    int GetScoreDefClefOverflowAbove() const { return m_scoreDefClefOverflowAbove; }
-    void SetScoreDefClefOverflowBelow(int overflowBelow) { m_scoreDefClefOverflowBelow = overflowBelow; }
-    int GetScoreDefClefOverflowBelow() const { return m_scoreDefClefOverflowBelow; }
+    void SetScoreDefOverflowAbove(int overflowAbove) { m_scoreDefClefOverflowAbove = overflowAbove; }
+    int GetScoreDefOverflowAbove() const { return m_scoreDefClefOverflowAbove; }
+    void SetScoreDefOverflowBelow(int overflowBelow) { m_scoreDefClefOverflowBelow = overflowBelow; }
+    int GetScoreDefOverflowBelow() const { return m_scoreDefClefOverflowBelow; }
     ///@}
 
     /**
@@ -292,6 +292,11 @@ public:
     void SetBeamAdjust(int beamAdjust) { m_beamAdjust = beamAdjust; }
     int GetBeamAdjust() const { return m_beamAdjust; }
     ///@}
+    
+    /**
+     * Find overflow for the alignments taking bracket group elements into account
+     */
+    void AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous);
 
     //----------//
     // Functors //

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -343,6 +343,11 @@ private:
      */
     int GetMinimumStaffSpacing(const Doc *doc, const AttSpacing *attSpacing) const;
 
+    /**
+     * Return whether current staff alignmnet at the start/end of bracket group
+     */
+    bool IsInBracketGroup(bool isFirst) const;
+
 public:
     //
 private:

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -250,10 +250,10 @@ public:
     BoundingBox *GetOverflowBBoxAbove() const { return m_overflowBBoxAbove; }
     void SetOverflowBBoxBelow(BoundingBox *bboxBelow, int overflowBottom);
     BoundingBox *GetOverflowBBoxBelow() const { return m_overflowBBoxBelow; }
-    void SetScoreDefOverflowAbove(int overflowAbove) { m_scoreDefClefOverflowAbove = overflowAbove; }
-    int GetScoreDefOverflowAbove() const { return m_scoreDefClefOverflowAbove; }
-    void SetScoreDefOverflowBelow(int overflowBelow) { m_scoreDefClefOverflowBelow = overflowBelow; }
-    int GetScoreDefOverflowBelow() const { return m_scoreDefClefOverflowBelow; }
+    void SetScoreDefClefOverflowAbove(int overflowAbove) { m_scoreDefClefOverflowAbove = overflowAbove; }
+    int GetScoreDefClefOverflowAbove() const { return m_scoreDefClefOverflowAbove; }
+    void SetScoreDefClefOverflowBelow(int overflowBelow) { m_scoreDefClefOverflowBelow = overflowBelow; }
+    int GetScoreDefClefOverflowBelow() const { return m_scoreDefClefOverflowBelow; }
     ///@}
 
     /**
@@ -296,7 +296,7 @@ public:
     /**
      * Find overflow for the alignments taking bracket group elements into account
      */
-    void AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous);
+    void AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous, int spacing);
 
     //----------//
     // Functors //

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1882,6 +1882,8 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
 
+        currentStaff->GetAlignment()->AdjustBracketGroupSpacing(params->m_doc, params->m_staffAlignment);
+
         params->m_staffAlignment = currentStaff->GetAlignment();
         return FUNCTOR_CONTINUE;
     }
@@ -1955,7 +1957,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         if (overflowAbove > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
             // LogMessage("%s top overflow: %d", current->GetUuid().c_str(), overflowAbove);
             if (isScoreDefClef) {
-                above->SetScoreDefClefOverflowAbove(overflowAbove);
+                above->SetScoreDefOverflowAbove(overflowAbove);
             }
             else {
                 above->SetOverflowBBoxAbove(current, overflowAbove);
@@ -1971,7 +1973,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         if (overflowBelow > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
             // LogMessage("%s bottom overflow: %d", current->GetUuid().c_str(), overflowBelow);
             if (isScoreDefClef) {
-                below->SetScoreDefClefOverflowBelow(overflowBelow);
+                below->SetScoreDefOverflowBelow(overflowBelow);
             }
             else {
                 below->SetOverflowBBoxBelow(current, overflowBelow);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1882,8 +1882,6 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
 
-        currentStaff->GetAlignment()->AdjustBracketGroupSpacing(params->m_doc, params->m_staffAlignment);
-
         params->m_staffAlignment = currentStaff->GetAlignment();
         return FUNCTOR_CONTINUE;
     }
@@ -1957,7 +1955,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         if (overflowAbove > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
             // LogMessage("%s top overflow: %d", current->GetUuid().c_str(), overflowAbove);
             if (isScoreDefClef) {
-                above->SetScoreDefOverflowAbove(overflowAbove);
+                above->SetScoreDefClefOverflowAbove(overflowAbove);
             }
             else {
                 above->SetOverflowBBoxAbove(current, overflowAbove);
@@ -1973,7 +1971,7 @@ int Object::SetOverflowBBoxes(FunctorParams *functorParams)
         if (overflowBelow > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
             // LogMessage("%s bottom overflow: %d", current->GetUuid().c_str(), overflowBelow);
             if (isScoreDefClef) {
-                below->SetScoreDefOverflowBelow(overflowBelow);
+                below->SetScoreDefClefOverflowBelow(overflowBelow);
             }
             else {
                 below->SetOverflowBBoxBelow(current, overflowBelow);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -541,9 +541,10 @@ void StaffAlignment::AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previou
     if (!previous) return;
 
     const int unit = doc->GetDrawingUnit(this->GetStaffSize());
+    const int offset = (doc->GetOptions()->m_bracketThickness.GetValue() - 1) * unit / 2;
     if (this->IsInBracketGroup(true) && previous->IsInBracketGroup(false)) {
-        const int overflowAbove = doc->GetGlyphHeight(SMUFL_E003_bracketTop, this->GetStaffSize(), false);
-        const int overflowBelow = doc->GetGlyphHeight(SMUFL_E004_bracketBottom, this->GetStaffSize(), false);
+        const int overflowAbove = doc->GetGlyphHeight(SMUFL_E003_bracketTop, this->GetStaffSize(), false) + offset;
+        const int overflowBelow = doc->GetGlyphHeight(SMUFL_E004_bracketBottom, this->GetStaffSize(), false) + offset;
         if (spacing < (overflowAbove + overflowBelow)) {
             const int bracketOverlap = (overflowAbove + overflowBelow) - spacing / 2;
             if (this->GetOverlap() < bracketOverlap) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -540,9 +540,9 @@ void StaffAlignment::AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previou
 {
     if (!previous) return;
 
-    const int unit = doc->GetDrawingUnit(this->GetStaffSize());
-    const int offset = (doc->GetOptions()->m_bracketThickness.GetValue() - 1) * unit / 2;
     if (this->IsInBracketGroup(true) && previous->IsInBracketGroup(false)) {
+        const int unit = doc->GetDrawingUnit(this->GetStaffSize());
+        const int offset = (doc->GetOptions()->m_bracketThickness.GetValue() - 1) * unit / 2;
         const int overflowAbove = doc->GetGlyphHeight(SMUFL_E003_bracketTop, this->GetStaffSize(), false) + offset;
         const int overflowBelow = doc->GetGlyphHeight(SMUFL_E004_bracketBottom, this->GetStaffSize(), false) + offset;
         if (spacing < (overflowAbove + overflowBelow)) {


### PR DESCRIPTION
Fix for the overlap of grouping symbols (brackets) between groups:
![image](https://user-images.githubusercontent.com/1819669/155497570-7da52d87-f2b1-454f-ac2a-1e49c3494153.png)

After the fix:
![image](https://user-images.githubusercontent.com/1819669/155498458-322b1afb-1050-4cb6-b34b-78829e47e667.png)
