### PR TITLE
Const correctness for tree search

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -287,7 +287,7 @@ public:
      * Return true if the beam has a tabGrp child.
      * In that case, the ObjectList will only have tabGrp elements. See Beam::FilterList
      */
-    bool IsTabBeam();
+    bool IsTabBeam() const;
 
     /**
      * @name Checker, getter and setter for a beam with which the stems are shared

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -53,7 +53,7 @@ private:
     /**
      * Calculate the duration of an individual note in a measured tremolo
      */
-    data_DURATION CalcIndividualNoteDuration();
+    data_DURATION CalcIndividualNoteDuration() const;
 
 public:
     //

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -241,7 +241,7 @@ public:
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
         if (!object->HasAttClass(ATT_NINTEGER)) return false;
-        const AttNInteger *element = vrv_cast<const AttNInteger *>(object);
+        const AttNInteger *element = dynamic_cast<const AttNInteger *>(object);
         assert(element);
         return (element->GetN() == m_n);
     }
@@ -270,7 +270,7 @@ public:
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
         if (!object->HasAttClass(ATT_NINTEGER)) return false;
-        const AttNInteger *element = vrv_cast<const AttNInteger *>(object);
+        const AttNInteger *element = dynamic_cast<const AttNInteger *>(object);
         assert(element);
         return (std::find(m_ns.begin(), m_ns.end(), element->GetN()) != m_ns.end());
     }
@@ -298,7 +298,7 @@ public:
         if (!MatchesType(object)) return false;
         // This should not happen, but just in case
         if (!object->HasAttClass(ATT_NNUMBERLIKE)) return false;
-        const AttNNumberLike *element = vrv_cast<const AttNNumberLike *>(object);
+        const AttNNumberLike *element = dynamic_cast<const AttNNumberLike *>(object);
         assert(element);
         return (element->GetN() == m_n);
     }
@@ -369,7 +369,7 @@ public:
     {
         if (!MatchesType(object)) return false;
         if (!object->HasAttClass(ATT_VISIBILITY)) return false;
-        const AttVisibility *visibility = vrv_cast<const AttVisibility *>(object);
+        const AttVisibility *visibility = dynamic_cast<const AttVisibility *>(object);
         assert(visibility);
         return (visibility->GetVisible() == m_isVisible);
     }

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -47,7 +47,7 @@ public:
     /**
      * Check if the ControlElement has a Rend child and return its @halign equivalent (if any)
      */
-    data_HORIZONTALALIGNMENT GetChildRendAlignment();
+    data_HORIZONTALALIGNMENT GetChildRendAlignment() const;
 
     /**
      * Check if the ControlElement applies at a point where there is more than on layer.

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -112,12 +112,15 @@ public:
      * Will find it only when having read a pages-based MEI file,
      * or when a file was converted to page-based MEI.
      */
+    ///@{
     Pages *GetPages();
+    const Pages *GetPages() const;
+    ///@}
 
     /**
      * Get the total page count
      */
-    int GetPageCount();
+    int GetPageCount() const;
 
     /**
      * Return true if the MIDI generation is already done

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -213,7 +213,7 @@ public:
      * true before ExportMIDI() or ExportTimemap() can export anything (These two functions
      * will automatically run CalculateMidiTimemap() if HasMidiTimemap() return false.
      */
-    bool HasMidiTimemap();
+    bool HasMidiTimemap() const;
 
     /**
      * Export the document to a MIDI file.

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1440,7 +1440,7 @@ public:
         m_element = NULL;
     }
     Comparison *m_comparison;
-    Object *m_element;
+    const Object *m_element;
 };
 
 //----------------------------------------------------------------------------
@@ -1456,7 +1456,7 @@ class FindByUuidParams : public FunctorParams {
 public:
     FindByUuidParams() { m_element = NULL; }
     std::string m_uuid;
-    Object *m_element;
+    const Object *m_element;
 };
 
 //----------------------------------------------------------------------------
@@ -1498,7 +1498,7 @@ public:
         m_element = NULL;
     }
     Comparison *m_comparison;
-    Object *m_element;
+    const Object *m_element;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1359,7 +1359,7 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the attComparision text
+ * member 0: the comparison object
  * member 1: an array of all matching objects
  * member 2: the start object range
  * member 3: the end object range
@@ -1367,7 +1367,7 @@ public:
 
 class FindAllBetweenParams : public FunctorParams {
 public:
-    FindAllBetweenParams(Comparison *comparison, ListOfObjects *elements, Object *start, Object *end)
+    FindAllBetweenParams(Comparison *comparison, ListOfObjects *elements, const Object *start, const Object *end)
     {
         m_comparison = comparison;
         m_elements = elements;
@@ -1376,8 +1376,35 @@ public:
     }
     Comparison *m_comparison;
     ListOfObjects *m_elements;
-    Object *m_start;
-    Object *m_end;
+    const Object *m_start;
+    const Object *m_end;
+};
+
+//----------------------------------------------------------------------------
+// FindAllConstBetweenParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the comparison object
+ * member 1: an array of all matching objects
+ * member 2: the start object range
+ * member 3: the end object range
+ **/
+
+class FindAllConstBetweenParams : public FunctorParams {
+public:
+    FindAllConstBetweenParams(
+        Comparison *comparison, ListOfConstObjects *elements, const Object *start, const Object *end)
+    {
+        m_comparison = comparison;
+        m_elements = elements;
+        m_start = start;
+        m_end = end;
+    }
+    Comparison *m_comparison;
+    ListOfConstObjects *m_elements;
+    const Object *m_start;
+    const Object *m_end;
 };
 
 //----------------------------------------------------------------------------
@@ -1405,7 +1432,7 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the attComparision text
+ * member 0: the comparison object
  * member 1: an array of all matching objects
  * member 2: flag indicating whether descendants of matches should be searched as well
  **/
@@ -1420,6 +1447,29 @@ public:
     }
     Comparison *m_comparison;
     ListOfObjects *m_elements;
+    bool m_continueDepthSearchForMatches;
+};
+
+//----------------------------------------------------------------------------
+// FindAllConstByComparisonParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the comparison object
+ * member 1: an array of all matching objects
+ * member 2: flag indicating whether descendants of matches should be searched as well
+ **/
+
+class FindAllConstByComparisonParams : public FunctorParams {
+public:
+    FindAllConstByComparisonParams(Comparison *comparison, ListOfConstObjects *elements)
+    {
+        m_comparison = comparison;
+        m_elements = elements;
+        m_continueDepthSearchForMatches = true;
+    }
+    Comparison *m_comparison;
+    ListOfConstObjects *m_elements;
     bool m_continueDepthSearchForMatches;
 };
 

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -61,9 +61,9 @@ public:
     /**
      * Transposition related. The int tracks where we have iterated through the string.
      */
-    bool GetRootPitch(TransPitch &pitch, unsigned int &pos);
+    bool GetRootPitch(TransPitch &pitch, unsigned int &pos) const;
     void SetRootPitch(const TransPitch &pitch, unsigned int endPos);
-    bool GetBassPitch(TransPitch &pitch);
+    bool GetBassPitch(TransPitch &pitch) const;
     void SetBassPitch(const TransPitch &pitch);
 
     //----------//

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -192,12 +192,12 @@ public:
     /**
      * Return true if the alignment contains at least one reference with staffN
      */
-    bool HasAlignmentReference(int staffN);
+    bool HasAlignmentReference(int staffN) const;
 
     /**
      * Return true if the alignment contains only references to timestamp attributes.
      */
-    bool HasTimestampOnly();
+    bool HasTimestampOnly() const;
 
     //----------//
     // Functors //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -158,7 +158,7 @@ public:
     /**
      * Return pair of max and min Y value within alignment. Elements will be counted by alignment references.
      */
-    std::pair<int, int> GetAlignmentTopBottom();
+    std::pair<int, int> GetAlignmentTopBottom() const;
 
     /**
      * Add an accidental to the accidSpace of the AlignmentReference holding it.
@@ -408,7 +408,7 @@ public:
      */
     bool CopyChildren() const override { return false; }
 
-    int GetAlignmentCount() const { return (int)GetChildren().size(); }
+    int GetAlignmentCount() const { return this->GetChildCount(); }
 
     //----------//
     // Functors //
@@ -419,7 +419,10 @@ protected:
      * Search if an alignment of the type is already there at the time.
      * If not, return in idx the position where it needs to be inserted (-1 if it is the end)
      */
+    ///@{
     Alignment *SearchAlignmentAtTime(double time, AlignmentType type, int &idx);
+    const Alignment *SearchAlignmentAtTime(double time, AlignmentType type, int &idx) const;
+    ///@}
 
     /**
      * Add an alignment at the appropriate position (at the end if -1)
@@ -447,7 +450,7 @@ public:
      * @name Constructors, destructors, reset and class name methods
      * Reset method resets all attribute classes
      */
-    ///@(
+    ///@{
     MeasureAligner();
     virtual ~MeasureAligner();
     void Reset() override;

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -408,7 +408,7 @@ public:
      */
     bool CopyChildren() const override { return false; }
 
-    int GetAlignmentCount() const { return (int)GetChildren()->size(); }
+    int GetAlignmentCount() const { return (int)GetChildren().size(); }
 
     //----------//
     // Functors //

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -135,10 +135,10 @@ public:
     ListOfObjects GetLayerElementsInTimeSpan(
         double time, double duration, Measure *measure, int staff, bool excludeCurrent);
 
-    Clef *GetCurrentClef() const;
-    KeySig *GetCurrentKeySig() const;
-    Mensur *GetCurrentMensur() const;
-    MeterSig *GetCurrentMeterSig() const;
+    Clef *GetCurrentClef();
+    KeySig *GetCurrentKeySig();
+    Mensur *GetCurrentMensur();
+    MeterSig *GetCurrentMeterSig();
 
     void ResetStaffDefObjects();
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -110,7 +110,7 @@ public:
      */
     ///@{
     /** Return true if the element is a grace note */
-    bool IsGraceNote();
+    bool IsGraceNote() const;
     /** Return true if the element is has to be rederred as cue sized */
     bool GetDrawingCueSize() const;
     /** Return true if the element is a note within a ligature */

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -233,10 +233,10 @@ public:
      * Used only on beam, tuplet or ftrem have.
      */
     double GetSameAsContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
 
     double GetContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
 
     /**
      * Get zone bounds using child elements with facsimile information.

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -186,14 +186,20 @@ public:
     /**
      * Get the ancestor or cross staff
      */
-    Staff *GetAncestorStaff(StaffSearch strategy = ANCESTOR_ONLY, bool assertExistence = true) const;
+    ///@{
+    Staff *GetAncestorStaff(StaffSearch strategy = ANCESTOR_ONLY, bool assertExistence = true);
+    const Staff *GetAncestorStaff(StaffSearch strategy = ANCESTOR_ONLY, bool assertExistence = true) const;
+    ///@}
 
     /**
      * Look for a cross or a a parent LayerElement (note, chord, rest) with a cross staff.
      * Also set the corresponding m_crossLayer to layer if a cross staff is found.
      * Return NULL if there is no cross-staff in the element or a parent.
      */
-    Staff *GetCrossStaff(Layer *&layer) const;
+    ///@{
+    Staff *GetCrossStaff(Layer *&layer);
+    const Staff *GetCrossStaff(Layer *&layer) const;
+    ///@}
 
     /**
      * Retrieve the direction of a cross-staff situation

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -81,9 +81,9 @@ public:
 
     bool GenerateChildMelodic();
 
-    NeumeGroup GetNeumeGroup();
+    NeumeGroup GetNeumeGroup() const;
 
-    std::vector<int> GetPitchDifferences();
+    std::vector<int> GetPitchDifferences() const;
 
     PitchInterface *GetHighestPitch();
     PitchInterface *GetLowestPitch();

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -213,7 +213,7 @@ public:
     /**
      * Check if a note or its parent chord are visible
      */
-    bool IsVisible() const;
+    bool IsVisible();
 
     /**
      * MIDI pitch

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -114,6 +114,7 @@ public:
      */
     ///@{
     Accid *GetDrawingAccid();
+    const Accid *GetDrawingAccid() const;
     ///@}
 
     /**
@@ -131,7 +132,7 @@ public:
      * Otherwise, it will look for the Staff ancestor.
      * Set the value of ledger lines above or below.
      */
-    bool HasLedgerLines(int &linesAbove, int &linesBelow, Staff *staff = NULL);
+    bool HasLedgerLines(int &linesAbove, int &linesBelow, const Staff *staff = NULL) const;
 
     /**
      * Overriding functions to return information from chord parent if any

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -137,7 +137,8 @@ public:
      * Overriding functions to return information from chord parent if any
      */
     ///@{
-    Chord *IsChordTone() const;
+    Chord *IsChordTone();
+    const Chord *IsChordTone() const;
     int GetDrawingDur() const;
     bool IsClusterExtreme() const; // used to find if it is the highest or lowest note in a cluster
     ///@}
@@ -145,7 +146,10 @@ public:
     /**
      * Return the parent TabGrp is the note is part of one.
      */
-    TabGrp *IsTabGrpNote() const;
+    ///@{
+    TabGrp *IsTabGrpNote();
+    const TabGrp *IsTabGrpNote() const;
+    ///@}
 
     /**
      * @name Return the smufl string to use for a note give the notation type

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -453,10 +453,10 @@ public:
      * The start and end objects are included in the result set.
      */
     ///@{
-    void FindAllDescendantsBetween(
-        ListOfObjects *objects, Comparison *comparison, const Object *start, const Object *end, bool clear = true);
+    void FindAllDescendantsBetween(ListOfObjects *objects, Comparison *comparison, const Object *start,
+        const Object *end, bool clear = true, int depth = UNLIMITED_DEPTH);
     void FindAllDescendantsBetween(ListOfConstObjects *objects, Comparison *comparison, const Object *start,
-        const Object *end, bool clear = true) const;
+        const Object *end, bool clear = true, int depth = UNLIMITED_DEPTH) const;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -372,27 +372,42 @@ public:
      * Look for a descendant with the specified uuid (returns NULL if not found)
      * This method is a wrapper for the Object::FindByUuid functor.
      */
-    Object *FindDescendantByUuid(std::string uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    ///@{
+    Object *FindDescendantByUuid(const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    const Object *FindDescendantByUuid(
+        const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
+    ///@}
 
     /**
      * Look for a descendant with the specified type (returns NULL if not found)
      * This method is a wrapper for the Object::FindByType functor.
      */
+    ///@{
     Object *FindDescendantByType(ClassId classId, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    const Object *FindDescendantByType(ClassId classId, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
+    ///@}
 
     /**
      * Return the first element matching the Comparison functor
      * Deepness allow to limit the depth search (EditorialElements are not count)
      */
+    ///@{
     Object *FindDescendantByComparison(
         Comparison *comparison, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    const Object *FindDescendantByComparison(
+        Comparison *comparison, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
+    ///@}
 
     /**
      * Return the element matching the extreme value with an Comparison functor
      * Deepness allow to limit the depth search (EditorialElements are not count)
      */
+    ///@{
     Object *FindDescendantExtremeByComparison(
         Comparison *comparison, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    const Object *FindDescendantExtremeByComparison(
+        Comparison *comparison, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
+    ///@}
 
     /**
      * Return all the objects with specified type
@@ -588,16 +603,16 @@ public:
     /**
      * Find a Object with a specified uuid.
      */
-    virtual int FindByUuid(FunctorParams *functorParams);
+    virtual int FindByUuid(FunctorParams *functorParams) const;
 
     /**
      * Find a Object with a Comparison functor .     */
-    virtual int FindByComparison(FunctorParams *functorParams);
+    virtual int FindByComparison(FunctorParams *functorParams) const;
 
     /**
      * Find a Object with the extreme value with a Comparison functor .
      */
-    virtual int FindExtremeByComparison(FunctorParams *functorParams);
+    virtual int FindExtremeByComparison(FunctorParams *functorParams) const;
 
     /**
      * Find a all Object with an Comparison functor.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -273,7 +273,9 @@ public:
      */
     ///@{
     Object *GetFirst(const ClassId classId = UNSPECIFIED);
+    const Object *GetFirst(const ClassId classId = UNSPECIFIED) const;
     Object *GetNext();
+    const Object *GetNext() const;
     ///@}
 
     /**
@@ -282,13 +284,18 @@ public:
      */
     ///@{
     Object *GetNext(const Object *child, const ClassId classId = UNSPECIFIED);
+    const Object *GetNext(const Object *child, const ClassId classId = UNSPECIFIED) const;
     Object *GetPrevious(const Object *child, const ClassId classId = UNSPECIFIED);
+    const Object *GetPrevious(const Object *child, const ClassId classId = UNSPECIFIED) const;
     ///@}
 
     /**
      * Return the last child of the object (if any, NULL otherwise)
      */
-    Object *GetLast(const ClassId classId = UNSPECIFIED) const;
+    ///@{
+    Object *GetLast(const ClassId classId = UNSPECIFIED);
+    const Object *GetLast(const ClassId classId = UNSPECIFIED) const;
+    ///@}
 
     /**
      * Get the parent of the Object
@@ -1451,8 +1458,8 @@ private:
      * Values are set when GetFirst is called (which is mandatory)
      */
     ///@{
-    ArrayOfObjects::iterator m_iteratorEnd, m_iteratorCurrent;
-    ClassId m_iteratorElementType;
+    mutable ArrayOfObjects::const_iterator m_iteratorEnd, m_iteratorCurrent;
+    mutable ClassId m_iteratorElementType;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -422,22 +422,34 @@ public:
     /**
      * Return all the objects with specified type
      */
+    ///@{
     ListOfObjects FindAllDescendantsByType(
         ClassId classId, bool continueDepthSearchForMatches = true, int deepness = UNLIMITED_DEPTH);
+    ListOfConstObjects FindAllDescendantsByType(
+        ClassId classId, bool continueDepthSearchForMatches = true, int deepness = UNLIMITED_DEPTH) const;
+    ///@}
 
     /**
      * Return all the objects matching the Comparison functor
      * Deepness allow to limit the depth search (EditorialElements are not count)
      */
+    ///@{
     void FindAllDescendantsByComparison(ListOfObjects *objects, Comparison *comparison, int deepness = UNLIMITED_DEPTH,
         bool direction = FORWARD, bool clear = true);
+    void FindAllDescendantsByComparison(ListOfConstObjects *objects, Comparison *comparison,
+        int deepness = UNLIMITED_DEPTH, bool direction = FORWARD, bool clear = true) const;
+    ///@}
 
     /**
      * Return all the objects matching the Comparison functor and being between start and end in the tree.
      * The start and end objects are included in the result set.
      */
-    void FindAllDescendantsBetween(ListOfObjects *objects, Comparison *comparison, Object *start, Object *end,
-        bool clear = true, int depth = UNLIMITED_DEPTH);
+    ///@{
+    void FindAllDescendantsBetween(
+        ListOfObjects *objects, Comparison *comparison, const Object *start, const Object *end, bool clear = true);
+    void FindAllDescendantsBetween(ListOfConstObjects *objects, Comparison *comparison, const Object *start,
+        const Object *end, bool clear = true) const;
+    ///@}
 
     /**
      * Give up ownership of the child at the idx position (NULL if not found)
@@ -627,12 +639,18 @@ public:
     /**
      * Find a all Object with an Comparison functor.
      */
+    ///@{
     virtual int FindAllByComparison(FunctorParams *functorParams);
+    virtual int FindAllConstByComparison(FunctorParams *functorParams) const;
+    ///@}
 
     /**
      * Find a all Object between a start and end Object and with an Comparison functor.
      */
+    ///@{
     virtual int FindAllBetween(FunctorParams *functorParams);
+    virtual int FindAllConstBetween(FunctorParams *functorParams) const;
+    ///@}
 
     /**
      * Find a all Object to which another object points to in the data.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -234,6 +234,7 @@ public:
     int GetChildCount() const { return (int)m_children.size(); }
     int GetChildCount(const ClassId classId) const;
     int GetChildCount(const ClassId classId, int depth) const;
+    int GetDescendantCount(const ClassId classId) const;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1359,6 +1359,15 @@ private:
      */
     void Init(ClassId classId, const std::string &classIdStr);
 
+    /**
+     * Helper methods for functor processing
+     */
+    ///@{
+    void UpdateDocumentScore(bool direction) const;
+    bool SkipChildren(Functor *functor) const;
+    bool FiltersApply(const ArrayOfComparisons *filters, Object *object) const;
+    ///@}
+
 public:
     /**
      * Keep an array of unsupported attributes as pairs.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -300,7 +300,10 @@ public:
     /**
      * Get the parent of the Object
      */
-    Object *GetParent() const { return m_parent; }
+    ///@{
+    Object *GetParent() { return m_parent; }
+    const Object *GetParent() const { return m_parent; }
+    ///@}
 
     /**
      * Set the parent of the Object.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -344,7 +344,7 @@ public:
     /**
      * Look for the Object in the children and return its position (-1 if not found)
      */
-    int GetChildIndex(const Object *child);
+    int GetChildIndex(const Object *child) const;
 
     /**
      * Look for all Objects of a class and return its position (-1 if not found)
@@ -445,15 +445,24 @@ public:
     /**
      * Returns all ancestors
      */
-    ListOfObjects GetAncestors() const;
+    ///@{
+    ListOfObjects GetAncestors();
+    ListOfConstObjects GetAncestors() const;
+    ///@}
 
     /**
      * Return the first ancestor of the specified type.
      * The maxSteps parameter limits the search to a certain number of level if not -1.
      */
-    Object *GetFirstAncestor(const ClassId classId, int maxSteps = -1) const;
+    ///@{
+    Object *GetFirstAncestor(const ClassId classId, int maxSteps = -1);
+    const Object *GetFirstAncestor(const ClassId classId, int maxSteps = -1) const;
+    ///@}
 
-    Object *GetFirstAncestorInRange(const ClassId classIdMin, const ClassId classIdMax, int maxDepth = -1) const;
+    ///@{
+    Object *GetFirstAncestorInRange(const ClassId classIdMin, const ClassId classIdMax, int maxDepth = -1);
+    const Object *GetFirstAncestorInRange(const ClassId classIdMin, const ClassId classIdMax, int maxDepth = -1) const;
+    ///@}
 
     /**
      * Return the last ancestor that is NOT of the specified type.
@@ -560,7 +569,7 @@ public:
     /**
      * @Return true if left appears before right in preorder traversal
      */
-    static bool IsPreOrdered(Object *left, Object *right);
+    static bool IsPreOrdered(const Object *left, const Object *right);
 
     //----------//
     // Functors //
@@ -1368,7 +1377,7 @@ private:
      * Helper methods for functor processing
      */
     ///@{
-    void UpdateDocumentScore(bool direction) const;
+    void UpdateDocumentScore(bool direction);
     bool SkipChildren(Functor *functor) const;
     bool FiltersApply(const ArrayOfComparisons *filters, Object *object) const;
     ///@}

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -233,25 +233,32 @@ public:
     ///@{
     int GetChildCount() const { return (int)m_children.size(); }
     int GetChildCount(const ClassId classId) const;
-    int GetChildCount(const ClassId classId, int depth);
+    int GetChildCount(const ClassId classId, int depth) const;
     ///@}
 
     /**
      * Child access (generic)
      */
-    Object *GetChild(int idx) const;
+    ///@{
+    Object *GetChild(int idx);
+    const Object *GetChild(int idx) const;
     Object *GetChild(int idx, const ClassId classId);
+    const Object *GetChild(int idx, const ClassId classId) const;
+    ///@}
 
     /**
-     * Return a const pointer to the children
+     * Return the children as const reference or copy
      */
-    virtual const ArrayOfObjects *GetChildren(bool docChildren = true) const { return &m_children; }
+    ///@{
+    ArrayOfConstObjects GetChildren() const;
+    const ArrayOfObjects &GetChildren() { return m_children; }
+    ///@}
 
     /**
-     * Return a pointer to the children that allows modification.
+     * Return a reference to the children that allows modification.
      * This method should be all only in AddChild overrides methods
      */
-    ArrayOfObjects *GetChildrenForModification() { return &m_children; }
+    ArrayOfObjects &GetChildrenForModification() { return m_children; }
 
     /**
      * Fill an array of pairs with all attributes and their values.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -538,9 +538,14 @@ public:
      * limit (EditorialElement objects do not count).
      * skipFirst does not call the functor or endFunctor on the first (calling) level
      */
+    ///@{
     void Process(Functor *functor, FunctorParams *functorParams, Functor *endFunctor = NULL,
         ArrayOfComparisons *filters = NULL, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD,
         bool skipFirst = false);
+    void Process(Functor *functor, FunctorParams *functorParams, Functor *endFunctor = NULL,
+        ArrayOfComparisons *filters = NULL, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD,
+        bool skipFirst = false) const;
+    ///@}
 
     //----------------//
     // Static methods //
@@ -1579,15 +1584,18 @@ private:
 class Functor {
 private:
     int (Object::*obj_fpt)(FunctorParams *functorParams); // pointer to member function
+    int (Object::*const_obj_fpt)(FunctorParams *functorParams) const;
 
 public:
     // constructor - takes pointer to a functor method and stores it
     Functor();
     Functor(int (Object::*_obj_fpt)(FunctorParams *));
+    Functor(int (Object::*_const_obj_fpt)(FunctorParams *) const);
     virtual ~Functor(){};
 
     // Call the internal functor method
     void Call(Object *ptr, FunctorParams *functorParams);
+    void Call(const Object *ptr, FunctorParams *functorParams);
 
 private:
     //

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -67,8 +67,10 @@ public:
      * Looks if the page is the first one or not
      */
     ///@{
-    RunningElement *GetHeader() const;
-    RunningElement *GetFooter() const;
+    RunningElement *GetHeader();
+    const RunningElement *GetHeader() const;
+    RunningElement *GetFooter();
+    const RunningElement *GetFooter() const;
     ///@}
 
     /**

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -52,7 +52,7 @@ public:
     /**
      * Return the number of system (children are System object only)
      */
-    int GetSystemCount() const { return (int)GetChildren()->size(); }
+    int GetSystemCount() const { return (int)GetChildren().size(); }
 
     /**
      * @name Get and set the pixel per unit factor.

--- a/include/vrv/pagemilestone.h
+++ b/include/vrv/pagemilestone.h
@@ -43,7 +43,7 @@ public:
      * @name Get the corresponding milestone start
      */
     ///@{
-    Object *GetStart() { return m_start; }
+    Object *GetStart() const { return m_start; }
     std::string GetStartClassName() const { return m_startClassName; }
     ///@}
 

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -35,7 +35,7 @@ public:
     /**
      * Overriden to get the appropriate margin
      */
-    int GetTotalHeight(Doc *doc) override;
+    int GetTotalHeight(const Doc *doc) const override;
 
     //----------//
     // Functors //

--- a/include/vrv/pgfoot2.h
+++ b/include/vrv/pgfoot2.h
@@ -35,7 +35,7 @@ public:
     /**
      * Overriden to get the appropriate margin
      */
-    int GetTotalHeight(Doc *doc) override;
+    int GetTotalHeight(const Doc *doc) const override;
 
     //----------//
     // Functors //

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -35,7 +35,7 @@ public:
     /**
      * Overriden to get the appropriate margin
      */
-    int GetTotalHeight(Doc *doc) override;
+    int GetTotalHeight(const Doc *doc) const override;
 
     bool GenerateFromMEIHeader(pugi::xml_document &header);
 

--- a/include/vrv/pghead2.h
+++ b/include/vrv/pghead2.h
@@ -35,7 +35,7 @@ public:
     /**
      * Overriden to get the appropriate margin
      */
-    int GetTotalHeight(Doc *doc) override;
+    int GetTotalHeight(const Doc *doc) const override;
 
     //----------//
     // Functors //

--- a/include/vrv/pitchinterface.h
+++ b/include/vrv/pitchinterface.h
@@ -52,7 +52,7 @@ public:
      * Get steps between calling object and parameter.
      * Returns calling pitch minus parameter pitch.
      */
-    int PitchDifferenceTo(PitchInterface *pi);
+    int PitchDifferenceTo(const PitchInterface *pi) const;
 
     /**
      * adjust the pitch value so that it stays in the same x,y position

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -91,9 +91,9 @@ public:
      */
     ///@{
     /** Height including margins */
-    virtual int GetTotalHeight(Doc *doc) = 0;
+    virtual int GetTotalHeight(const Doc *doc) const = 0;
     /** Content height */
-    int GetContentHeight();
+    int GetContentHeight() const;
     /** Row from 0 to 2 */
     int GetRowHeight(int row) const;
     /** Col from 0 to 2 */

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -95,11 +95,11 @@ public:
     /** Content height */
     int GetContentHeight();
     /** Row from 0 to 2 */
-    int GetRowHeight(int row);
+    int GetRowHeight(int row) const;
     /** Col from 0 to 2 */
-    int GetColHeight(int col);
+    int GetColHeight(int col) const;
     /** Row from 0 to 8 */
-    int GetCellHeight(int cell);
+    int GetCellHeight(int cell) const;
     ///@}
 
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -55,7 +55,7 @@ public:
      * Helper looking at the parent Doc and set its scoreDef as current one.
      * Called from Object::Process
      */
-    void SetAsCurrent() const;
+    void SetAsCurrent();
 
     /**
      * Calculate the height of the pgHead/pgHead2 and pgFoot/pgFoot2 (if any)

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -55,7 +55,7 @@ public:
      * Helper looking at the parent Doc and set its scoreDef as current one.
      * Called from Object::Process
      */
-    void SetAsCurrent();
+    void SetAsCurrent() const;
 
     /**
      * Calculate the height of the pgHead/pgHead2 and pgFoot/pgFoot2 (if any)

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -67,7 +67,7 @@ public:
     /**
      * Check whether we need to optimize score based on the condense option
      */
-    bool ScoreDefNeedsOptimization(int optionCondense);
+    bool ScoreDefNeedsOptimization(int optionCondense) const;
 
     //----------//
     // Functors //

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -64,11 +64,11 @@ public:
      * @name Methods for checking the presence of clef, key signature, etc. information and getting them.
      */
     ///@{
-    bool HasClefInfo(int depth = 1);
-    bool HasKeySigInfo(int depth = 1);
-    bool HasMensurInfo(int depth = 1);
-    bool HasMeterSigInfo(int depth = 1);
-    bool HasMeterSigGrpInfo(int depth = 1);
+    bool HasClefInfo(int depth = 1) const;
+    bool HasKeySigInfo(int depth = 1) const;
+    bool HasMensurInfo(int depth = 1) const;
+    bool HasMeterSigInfo(int depth = 1) const;
+    bool HasMeterSigGrpInfo(int depth = 1) const;
     ///@}
 
     /**
@@ -81,15 +81,20 @@ public:
      */
     ///@{
     Clef *GetClef();
-    Clef *GetClefCopy();
+    const Clef *GetClef() const;
+    Clef *GetClefCopy() const;
     KeySig *GetKeySig();
-    KeySig *GetKeySigCopy();
+    const KeySig *GetKeySig() const;
+    KeySig *GetKeySigCopy() const;
     Mensur *GetMensur();
-    Mensur *GetMensurCopy();
+    const Mensur *GetMensur() const;
+    Mensur *GetMensurCopy() const;
     MeterSig *GetMeterSig();
-    MeterSig *GetMeterSigCopy();
+    const MeterSig *GetMeterSig() const;
+    MeterSig *GetMeterSigCopy() const;
     MeterSigGrp *GetMeterSigGrp();
-    MeterSigGrp *GetMeterSigGrpCopy();
+    const MeterSigGrp *GetMeterSigGrp() const;
+    MeterSigGrp *GetMeterSigGrpCopy() const;
     ///@}
 
     //----------//
@@ -197,9 +202,13 @@ public:
      */
     ///@{
     PgFoot *GetPgFoot();
+    const PgFoot *GetPgFoot() const;
     PgFoot2 *GetPgFoot2();
+    const PgFoot2 *GetPgFoot2() const;
     PgHead *GetPgHead();
+    const PgHead *GetPgHead() const;
     PgHead2 *GetPgHead2();
+    const PgHead2 *GetPgHead2() const;
     ///@}
 
     /**
@@ -207,7 +216,7 @@ public:
      */
     int GetMaxStaffSize();
 
-    bool IsSectionRestart();
+    bool IsSectionRestart() const;
 
     //----------//
     // Functors //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -61,11 +61,6 @@ public:
     FacsimileInterface *GetFacsimileInterface() override { return dynamic_cast<FacsimileInterface *>(this); }
 
     /**
-     * Return a const pointer to the children
-     */
-    const ArrayOfObjects *GetChildren(bool docChildren = true) const override;
-
-    /**
      * Delete all the legder line arrays.
      */
     void ClearLedgerLines();

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -86,8 +86,8 @@ public:
      * @name Methods for checking the presence of label and labelAbbr information and getting them.
      */
     ///@{
-    bool HasLabelInfo();
-    bool HasLabelAbbrInfo();
+    bool HasLabelInfo() const;
+    bool HasLabelAbbrInfo() const;
 
     ///@}
 
@@ -97,9 +97,11 @@ public:
      */
     ///@{
     Label *GetLabel();
-    Label *GetLabelCopy();
+    const Label *GetLabel() const;
+    Label *GetLabelCopy() const;
     LabelAbbr *GetLabelAbbr();
-    LabelAbbr *GetLabelAbbrCopy();
+    const LabelAbbr *GetLabelAbbr() const;
+    LabelAbbr *GetLabelAbbrCopy() const;
     ///@}
 
     //----------//

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -40,8 +40,8 @@ public:
     ///@}
     bool IsSupportedChild(Object *object) override;
 
-    int GetMaxX();
-    int GetMaxY();
+    int GetMaxX() const;
+    int GetMaxY() const;
 
 protected:
     //

--- a/include/vrv/textdirinterface.h
+++ b/include/vrv/textdirinterface.h
@@ -38,7 +38,7 @@ public:
     /**
      * Return the number of lines in the text object by counting <lb> children
      */
-    int GetNumberOfLines(Object *object);
+    int GetNumberOfLines(const Object *object) const;
 
 private:
     //

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -47,6 +47,7 @@ public:
     ///@{
     void SetStart(LayerElement *start);
     LayerElement *GetStart() { return m_start; }
+    const LayerElement *GetStart() const { return m_start; }
     ///@}
 
     /**
@@ -62,7 +63,7 @@ public:
     /**
      * Return true if a start is given (@startid or @tstamp)
      */
-    bool HasStart() { return (m_start); }
+    bool HasStart() const { return (m_start); }
 
     /**
      * Return the start measure of the TimePointInterface
@@ -151,6 +152,7 @@ public:
     ///@{
     void SetEnd(LayerElement *end);
     LayerElement *GetEnd() { return m_end; }
+    const LayerElement *GetEnd() const { return m_end; }
     ///@}
 
     /**
@@ -161,7 +163,7 @@ public:
     /**
      *
      */
-    bool HasStartAndEnd() { return (m_start && m_end); }
+    bool HasStartAndEnd() const { return (m_start && m_end); }
 
     /**
      * Return the end measure of the TimePointInterface

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -42,7 +42,7 @@ public:
     /**
      * Return the line for a the tuning and a given course and a notation type
      */
-    int CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines);
+    int CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines) const;
 
     /**
      * Calclate the MIDI pitch number for course/fret
@@ -53,7 +53,7 @@ public:
      *
      * @return MIDI pitch
      */
-    int CalcPitchNumber(int course, int fret, data_NOTATIONTYPE notationType);
+    int CalcPitchNumber(int course, int fret, data_NOTATIONTYPE notationType) const;
 
     //----------//
     // Functors //

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -69,7 +69,7 @@ public:
      * Get the StaffAlignment for the staffN.
      * Return NULL if not found.
      */
-    StaffAlignment *GetStaffAlignmentForStaffN(int staffN) const;
+    StaffAlignment *GetStaffAlignmentForStaffN(int staffN);
 
     /**
      * Get pointer to the parent system.

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -311,7 +311,11 @@ class TimeSpanningInterface;
 
 typedef std::vector<Object *> ArrayOfObjects;
 
+typedef std::vector<const Object *> ArrayOfConstObjects;
+
 typedef std::list<Object *> ListOfObjects;
+
+typedef std::list<const Object *> ListOfConstObjects;
 
 typedef std::vector<Comparison *> ArrayOfComparisons;
 

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -69,7 +69,7 @@ int Arpeg::GetDrawingX() const
 
     // Otherwise get the measure - no cast to Measure is necessary
     LogDebug("Accessing an arpeg x without positioner");
-    Object *measure = this->GetFirstAncestor(MEASURE);
+    const Object *measure = this->GetFirstAncestor(MEASURE);
     assert(measure);
 
     // This will be very arbitrary positionned...

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -544,7 +544,7 @@ int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIR
     switch (artic) {
         case ARTICULATION_stacc:
         case ARTICULATION_stacciss: {
-            Staff *staff = this->GetAncestorStaff();
+            const Staff *staff = this->GetAncestorStaff();
             const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             if ((stemDir == STEMDIRECTION_up) && (m_drawingPlace == STAFFREL_above)) {
                 shift += shift - stemWidth / 2;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1619,7 +1619,7 @@ const ArrayOfBeamElementCoords *Beam::GetElementCoords()
     return &m_beamElementCoords;
 }
 
-bool Beam::IsTabBeam()
+bool Beam::IsTabBeam() const
 {
     return (this->FindDescendantByType(TABGRP));
 }

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -108,7 +108,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-data_DURATION BTrem::CalcIndividualNoteDuration()
+data_DURATION BTrem::CalcIndividualNoteDuration() const
 {
     // Check if duration is given by attribute
     if (this->HasUnitdur()) {
@@ -118,13 +118,13 @@ data_DURATION BTrem::CalcIndividualNoteDuration()
     // Otherwise consider duration and stem modifier of first child chord/note
     data_DURATION childDur = DURATION_NONE;
     data_STEMMODIFIER stemMod = STEMMODIFIER_NONE;
-    Chord *chord = vrv_cast<Chord *>(this->FindDescendantByType(CHORD));
+    const Chord *chord = vrv_cast<const Chord *>(this->FindDescendantByType(CHORD));
     if (chord) {
         childDur = chord->GetDur();
         stemMod = chord->GetStemMod();
     }
     else {
-        Note *note = vrv_cast<Note *>(this->FindDescendantByType(NOTE));
+        const Note *note = vrv_cast<const Note *>(this->FindDescendantByType(NOTE));
         if (note) {
             childDur = note->GetDur();
             stemMod = note->GetStemMod();

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -157,16 +157,16 @@ void Chord::AddChild(Object *child)
         return;
     }
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     child->SetParent(this);
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ DOTS, STEM })) {
-        children->insert(children->begin(), child);
+        children.insert(children.begin(), child);
     }
     else {
-        children->push_back(child);
+        children.push_back(child);
     }
     Modify();
 }

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -66,9 +66,9 @@ void ControlElement::Reset()
     this->ResetTyped();
 }
 
-data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment()
+data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment() const
 {
-    Rend *rend = dynamic_cast<Rend *>(this->FindDescendantByType(REND));
+    const Rend *rend = dynamic_cast<const Rend *>(this->FindDescendantByType(REND));
     if (!rend || !rend->HasHalign()) return HORIZONTALALIGNMENT_NONE;
 
     return rend->GetHalign();

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -76,9 +76,9 @@ bool Dir::IsSupportedChild(Object *child)
 
 bool Dir::AreChildrenAlignedTo(data_HORIZONTALALIGNMENT alignment) const
 {
-    const ArrayOfObjects *children = this->GetChildren();
-    bool hasHalign = std::any_of(children->begin(), children->end(), [&alignment](Object *child) {
-        AttHorizontalAlign *hAlign = dynamic_cast<AttHorizontalAlign *>(child);
+    ArrayOfConstObjects children = this->GetChildren();
+    bool hasHalign = std::any_of(children.begin(), children.end(), [&alignment](const Object *child) {
+        const AttHorizontalAlign *hAlign = dynamic_cast<const AttHorizontalAlign *>(child);
         return (hAlign && (hAlign->GetHalign() == alignment));
     });
     return hasHalign;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1297,9 +1297,14 @@ Pages *Doc::GetPages()
     return dynamic_cast<Pages *>(this->FindDescendantByType(PAGES));
 }
 
-int Doc::GetPageCount()
+const Pages *Doc::GetPages() const
 {
-    Pages *pages = this->GetPages();
+    return dynamic_cast<const Pages *>(this->FindDescendantByType(PAGES));
+}
+
+int Doc::GetPageCount() const
+{
+    const Pages *pages = this->GetPages();
     return ((pages) ? pages->GetChildCount() : 0);
 }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -244,7 +244,7 @@ bool Doc::GenerateMeasureNumbers()
     return true;
 }
 
-bool Doc::HasMidiTimemap()
+bool Doc::HasMidiTimemap() const
 {
     return (m_MIDITimemapTempo == m_options->m_midiTempoAdjustment.GetValue());
 }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -40,10 +40,9 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
 {
     assert(prevSect);
     // find all siblings of expansion element to know what in MEI file
-    const vrv::ArrayOfObjects *expansionSiblings = prevSect->GetParent()->GetChildren();
-    assert(expansionSiblings);
+    const vrv::ArrayOfObjects &expansionSiblings = prevSect->GetParent()->GetChildren();
     std::vector<std::string> reductionList;
-    for (auto o : *expansionSiblings) {
+    for (auto o : expansionSiblings) {
         if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetUuid());
     }
 
@@ -123,7 +122,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
 
 bool ExpansionMap::UpdateIds(Object *object)
 {
-    for (Object *o : *object->GetChildren()) {
+    for (Object *o : object->GetChildren()) {
         o->IsExpansion(true);
         if (o->HasInterface(INTERFACE_TIME_POINT)) {
             TimePointInterface *interface = o->GetTimePointInterface();
@@ -239,7 +238,7 @@ bool ExpansionMap::HasExpansionMap()
 
 void ExpansionMap::GetUuidList(Object *object, std::vector<std::string> &idList)
 {
-    for (Object *o : *object->GetChildren()) {
+    for (Object *o : object->GetChildren()) {
         idList.push_back(o->GetUuid());
         this->GetUuidList(o, idList);
     }
@@ -250,8 +249,8 @@ void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
     target->SetUuid(
         source->GetUuid() + "-rend" + std::to_string(this->GetExpansionIdsForElement(source->GetUuid()).size() + 1));
 
-    ArrayOfObjects sourceObjects = *source->GetChildren();
-    ArrayOfObjects targetObjects = *target->GetChildren();
+    ArrayOfObjects sourceObjects = source->GetChildren();
+    ArrayOfObjects targetObjects = target->GetChildren();
     if (sourceObjects.size() <= 0 || sourceObjects.size() != targetObjects.size()) return;
 
     unsigned i = 0;

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -77,9 +77,9 @@ bool Harm::IsSupportedChild(Object *child)
     return true;
 }
 
-bool Harm::GetRootPitch(TransPitch &pitch, unsigned int &pos)
+bool Harm::GetRootPitch(TransPitch &pitch, unsigned int &pos) const
 {
-    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    const Text *textObject = dynamic_cast<const Text *>(this->FindDescendantByType(TEXT, 1));
     if (!textObject) return false;
     std::wstring text = textObject->GetText();
 
@@ -119,9 +119,9 @@ void Harm::SetRootPitch(const TransPitch &pitch, unsigned int endPos)
     }
 }
 
-bool Harm::GetBassPitch(TransPitch &pitch)
+bool Harm::GetBassPitch(TransPitch &pitch) const
 {
-    Text *textObject = dynamic_cast<Text *>(this->FindDescendantByType(TEXT, 1));
+    const Text *textObject = dynamic_cast<const Text *>(this->FindDescendantByType(TEXT, 1));
     if (!textObject) return false;
     std::wstring text = textObject->GetText();
     if (!text.length()) return false;

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -491,13 +491,13 @@ bool Alignment::HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN)
     return otherRef->HasAccidVerticalOverlap(currentRef->GetChildren());
 }
 
-bool Alignment::HasAlignmentReference(int staffN)
+bool Alignment::HasAlignmentReference(int staffN) const
 {
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
     return (this->FindDescendantByComparison(&matchStaff, 1) != NULL);
 }
 
-bool Alignment::HasTimestampOnly()
+bool Alignment::HasTimestampOnly() const
 {
     // If no child, then not timestamp
     if (!this->GetChildCount()) return false;

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -55,7 +55,7 @@ Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType t
     Alignment *alignment = NULL;
     // First try to see if we already have something at the time position
     for (i = 0; i < this->GetAlignmentCount(); ++i) {
-        alignment = vrv_cast<Alignment *>(this->GetChildren()->at(i));
+        alignment = vrv_cast<Alignment *>(this->GetChildren().at(i));
         assert(alignment);
 
         double alignment_time = alignment->GetTime();
@@ -80,9 +80,9 @@ Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType t
 void HorizontalAligner::AddAlignment(Alignment *alignment, int idx)
 {
     alignment->SetParent(this);
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
     if (idx == -1) {
-        children->push_back(alignment);
+        children.push_back(alignment);
     }
     else {
         InsertChild(alignment, idx);
@@ -159,7 +159,7 @@ void MeasureAligner::SetMaxTime(double time)
     Alignment *alignment = NULL;
     // Increase the time position for all alignment from the right barline
     for (i = idx; i < this->GetAlignmentCount(); ++i) {
-        alignment = vrv_cast<Alignment *>(this->GetChildren()->at(i));
+        alignment = vrv_cast<Alignment *>(this->GetChildren().at(i));
         assert(alignment);
         // Change it only if higher than before
         if (time > alignment->GetTime()) alignment->SetTime(time);
@@ -198,7 +198,7 @@ void MeasureAligner::AdjustProportionally(const ArrayOfAdjustmentTuples &adjustm
         int startX = start->GetXRel();
         int endX = end->GetXRel();
         // We use a reverse iterator
-        for (auto child : *this->GetChildren()) {
+        for (auto child : this->GetChildren()) {
             Alignment *current = vrv_cast<Alignment *>(child);
             assert(current);
             // Nothing to do once we passed the start alignment
@@ -221,7 +221,7 @@ void MeasureAligner::PushAlignmentsRight()
 {
     Alignment *previous = NULL;
     ArrayOfObjects::const_reverse_iterator riter;
-    for (riter = this->GetChildren()->rbegin(); riter != this->GetChildren()->rend(); ++riter) {
+    for (riter = this->GetChildren().rbegin(); riter != this->GetChildren().rend(); ++riter) {
         Alignment *current = vrv_cast<Alignment *>(*riter);
         assert(current);
         if (current->IsOfType({ ALIGNMENT_GRACENOTE })) {
@@ -255,7 +255,7 @@ void MeasureAligner::AdjustGraceNoteSpacing(Doc *doc, Alignment *alignment, int 
 
     bool found = false;
     ArrayOfObjects::const_reverse_iterator riter;
-    for (riter = this->GetChildren()->rbegin(); riter != this->GetChildren()->rend(); ++riter) {
+    for (riter = this->GetChildren().rbegin(); riter != this->GetChildren().rend(); ++riter) {
         if (!found) {
             if ((*riter) == alignment) found = true;
             continue;
@@ -420,7 +420,7 @@ void GraceAligner::SetGraceAligmentXPos(Doc *doc)
 
     int i = 0;
     // Then the @n of each first staffDef
-    for (childrenIter = this->GetChildren()->rbegin(); childrenIter != this->GetChildren()->rend(); ++childrenIter) {
+    for (childrenIter = this->GetChildren().rbegin(); childrenIter != this->GetChildren().rend(); ++childrenIter) {
         Alignment *alignment = vrv_cast<Alignment *>(*childrenIter);
         assert(alignment);
         // We space with a notehead (non grace size) which seems to be a reasonable default spacing with margin
@@ -488,7 +488,7 @@ bool Alignment::HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN)
         = vrv_cast<AlignmentReference *>(otherAlignment->FindDescendantByComparison(&matchStaff, 1));
     if (!currentRef || !otherRef) return false;
 
-    return otherRef->HasAccidVerticalOverlap(currentRef->GetChildren());
+    return otherRef->HasAccidVerticalOverlap(&currentRef->GetChildren());
 }
 
 bool Alignment::HasAlignmentReference(int staffN) const
@@ -633,7 +633,7 @@ AlignmentReference *Alignment::GetReferenceWithElement(LayerElement *element, in
 {
     AlignmentReference *reference = NULL;
 
-    for (auto child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         reference = dynamic_cast<AlignmentReference *>(child);
         if (reference->GetN() == staffN) {
             return reference;
@@ -650,9 +650,9 @@ std::pair<int, int> Alignment::GetAlignmentTopBottom()
     int max = VRV_UNSET, min = VRV_UNSET;
     // Iterate over each element in each alignment reference and find max/min Y value - these will serve as top/bottom
     // values for the Alignment
-    for (auto child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         AlignmentReference *reference = dynamic_cast<AlignmentReference *>(child);
-        for (auto element : *reference->GetChildren()) {
+        for (auto element : reference->GetChildren()) {
             const int top = element->GetSelfTop();
             if ((VRV_UNSET == max) || (top > max)) {
                 max = top;
@@ -723,25 +723,25 @@ void AlignmentReference::AddChild(Object *child)
     LayerElement *childElement = vrv_cast<LayerElement *>(child);
     assert(childElement);
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     if (!childElement->HasSameas()) {
         ArrayOfObjects::iterator childrenIter;
         // Check if the we will have a reference with multiple layers
-        for (childrenIter = children->begin(); childrenIter != children->end(); ++childrenIter) {
+        for (childrenIter = children.begin(); childrenIter != children.end(); ++childrenIter) {
             LayerElement *element = dynamic_cast<LayerElement *>(*childrenIter);
             if (childElement->GetAlignmentLayerN() == element->GetAlignmentLayerN()) {
                 break;
             }
         }
-        if (childrenIter == children->end()) m_layerCount++;
+        if (childrenIter == children.end()) m_layerCount++;
     }
 
     // Special case where we do not set the parent because the reference will not have ownership
     // Children will be treated as relinquished objects in the desctructor
     // However, we need to make sure the child has a parent (somewhere else)
     assert(child->GetParent() && this->IsReferenceObject());
-    children->push_back(child);
+    children.push_back(child);
     Modify();
 }
 
@@ -760,7 +760,7 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
     std::vector<Accid *> leftAccids;
 
     // bottom one
-    for (auto child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         accid->AdjustX(dynamic_cast<LayerElement *>(child), doc, staffSize, leftAccids, adjustedAccids);
     }
 
@@ -773,7 +773,7 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
 
 bool AlignmentReference::HasAccidVerticalOverlap(const ArrayOfObjects *objects)
 {
-    for (const auto child : *this->GetChildren()) {
+    for (const auto child : this->GetChildren()) {
         if (!child->Is(ACCID)) continue;
         Accid *accid = vrv_cast<Accid *>(child);
         if (!accid->HasAccid()) continue;
@@ -808,11 +808,11 @@ TimestampAttr *TimestampAligner::GetTimestampAtTime(double time)
     time = time - 1.0;
     TimestampAttr *timestampAttr = NULL;
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // First try to see if we already have something at the time position
     for (i = 0; i < this->GetChildCount(); ++i) {
-        timestampAttr = vrv_cast<TimestampAttr *>(children->at(i));
+        timestampAttr = vrv_cast<TimestampAttr *>(children.at(i));
         assert(timestampAttr);
 
         double alignmentTime = timestampAttr->GetActualDurPos();
@@ -830,7 +830,7 @@ TimestampAttr *TimestampAligner::GetTimestampAtTime(double time)
     timestampAttr->SetDrawingPos(time);
     timestampAttr->SetParent(this);
     if (idx == -1) {
-        children->push_back(timestampAttr);
+        children.push_back(timestampAttr);
     }
     else {
         InsertChild(timestampAttr, idx);
@@ -1385,7 +1385,7 @@ int AlignmentReference::AdjustGraceXPos(FunctorParams *functorParams)
     // Because we are processing grace notes alignment backward (see Alignment::AdjustGraceXPos) we need
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
-    for (auto child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         child->Process(params->m_functor, params, params->m_functorEnd, NULL, UNLIMITED_DEPTH, FORWARD);
     }
 

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -50,12 +50,17 @@ void HorizontalAligner::Reset()
 
 Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType type, int &idx)
 {
+    return const_cast<Alignment *>(std::as_const(*this).SearchAlignmentAtTime(time, type, idx));
+}
+
+const Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType type, int &idx) const
+{
     int i;
     idx = -1; // the index if we reach the end.
-    Alignment *alignment = NULL;
+    const Alignment *alignment = NULL;
     // First try to see if we already have something at the time position
     for (i = 0; i < this->GetAlignmentCount(); ++i) {
-        alignment = vrv_cast<Alignment *>(this->GetChildren().at(i));
+        alignment = vrv_cast<const Alignment *>(this->GetChild(i));
         assert(alignment);
 
         double alignment_time = alignment->GetTime();
@@ -159,7 +164,7 @@ void MeasureAligner::SetMaxTime(double time)
     Alignment *alignment = NULL;
     // Increase the time position for all alignment from the right barline
     for (i = idx; i < this->GetAlignmentCount(); ++i) {
-        alignment = vrv_cast<Alignment *>(this->GetChildren().at(i));
+        alignment = vrv_cast<Alignment *>(this->GetChild(i));
         assert(alignment);
         // Change it only if higher than before
         if (time > alignment->GetTime()) alignment->SetTime(time);
@@ -645,13 +650,13 @@ AlignmentReference *Alignment::GetReferenceWithElement(LayerElement *element, in
     return reference;
 }
 
-std::pair<int, int> Alignment::GetAlignmentTopBottom()
+std::pair<int, int> Alignment::GetAlignmentTopBottom() const
 {
     int max = VRV_UNSET, min = VRV_UNSET;
     // Iterate over each element in each alignment reference and find max/min Y value - these will serve as top/bottom
     // values for the Alignment
     for (auto child : this->GetChildren()) {
-        AlignmentReference *reference = dynamic_cast<AlignmentReference *>(child);
+        const AlignmentReference *reference = dynamic_cast<const AlignmentReference *>(child);
         for (auto element : reference->GetChildren()) {
             const int top = element->GetSelfTop();
             if ((VRV_UNSET == max) || (top > max)) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -353,7 +353,7 @@ void MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
         AttNNumberLikeComparison comparisonMeasure(MEASURE, measure->GetN());
         Measure *existingMeasure = vrv_cast<Measure *>(section->FindDescendantByComparison(&comparisonMeasure, 1));
         if (existingMeasure) {
-            for (auto current : *measure->GetChildren()) {
+            for (auto current : measure->GetChildren()) {
                 if (!current->Is(STAFF)) {
                     continue;
                 }
@@ -384,7 +384,7 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
 
     int currTime = 0;
     if (m_layerEndTimes.count(layer) > 0) currTime = m_layerEndTimes.at(layer);
-    if ((layer->GetChildren()->size() == 0 && m_durTotal > 0) || currTime < m_durTotal) {
+    if ((layer->GetChildren().size() == 0 && m_durTotal > 0) || currTime < m_durTotal) {
         FillSpace(layer, m_durTotal - currTime);
     }
 
@@ -1684,7 +1684,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
         m_tieStopStack.clear();
     }
 
-    for (auto staff : *measure->GetChildren()) {
+    for (auto staff : measure->GetChildren()) {
         if (!staff->Is(STAFF)) {
             continue;
         }
@@ -4572,26 +4572,26 @@ void MusicXmlInput::SetChordStaff(Layer *layer)
     Chord *chord = vrv_cast<Chord *>(m_elementStackMap.at(layer).back());
     if (!chord) return;
 
-    const ArrayOfObjects *children = chord->GetChildren();
-    auto it = find_if(children->begin(), children->end(), [](Object *object) {
+    const ArrayOfObjects &children = chord->GetChildren();
+    auto it = find_if(children.begin(), children.end(), [](Object *object) {
         if (!object->Is(NOTE)) return false;
         Note *note = vrv_cast<Note *>(object);
         return !note->HasStaff();
     });
-    if (it != chord->GetChildren()->end()) return;
+    if (it != chord->GetChildren().end()) return;
 
     // if all notes have @staff attribute, but it's not the same staff at least of one note - leave it as is
     const auto chordStaff = vrv_cast<Note *>(chord->GetFirst(NOTE))->GetStaff();
-    it = find_if(children->begin(), children->end(), [&chordStaff](Object *object) {
+    it = find_if(children.begin(), children.end(), [&chordStaff](Object *object) {
         if (!object->Is(NOTE)) return false;
         Note *note = vrv_cast<Note *>(object);
         return (chordStaff != note->GetStaff());
     });
-    if (it != chord->GetChildren()->end()) return;
+    if (it != chord->GetChildren().end()) return;
 
     // Now that we're sure that cross-staff is the same for all notes, we can set it to chord and clear of notes
     chord->SetStaff(chordStaff);
-    for_each(children->begin(), children->end(), [](Object *object) {
+    for_each(children.begin(), children.end(), [](Object *object) {
         if (!object->Is(NOTE)) return;
         Note *note = vrv_cast<Note *>(object);
         note->ResetStaffIdent();

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -402,28 +402,28 @@ ListOfObjects Layer::GetLayerElementsInTimeSpan(
     return layerElementsInTimeSpanParams.m_elements;
 }
 
-Clef *Layer::GetCurrentClef() const
+Clef *Layer::GetCurrentClef()
 {
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff && staff->m_drawingStaffDef && staff->m_drawingStaffDef->GetCurrentClef());
     return staff->m_drawingStaffDef->GetCurrentClef();
 }
 
-KeySig *Layer::GetCurrentKeySig() const
+KeySig *Layer::GetCurrentKeySig()
 {
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff && staff->m_drawingStaffDef);
     return staff->m_drawingStaffDef->GetCurrentKeySig();
 }
 
-Mensur *Layer::GetCurrentMensur() const
+Mensur *Layer::GetCurrentMensur()
 {
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff && staff->m_drawingStaffDef);
     return staff->m_drawingStaffDef->GetCurrentMensur();
 }
 
-MeterSig *Layer::GetCurrentMeterSig() const
+MeterSig *Layer::GetCurrentMeterSig()
 {
     Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
     assert(staff && staff->m_drawingStaffDef);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -262,7 +262,7 @@ Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool ass
         Layer *layer = NULL;
         staff = this->GetCrossStaff(layer);
     }
-    if (!staff) staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+    if (!staff) staff = vrv_cast<Staff *>(const_cast<LayerElement *>(this)->GetFirstAncestor(STAFF));
     if (assertExistence) assert(staff);
     return staff;
 }
@@ -275,8 +275,8 @@ Staff *LayerElement::GetCrossStaff(Layer *&layer) const
         return m_crossStaff;
     }
 
-    LayerElement *parent
-        = dynamic_cast<LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
+    LayerElement *parent = dynamic_cast<LayerElement *>(
+        const_cast<LayerElement *>(this)->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
 
     if (parent) return parent->GetCrossStaff(layer);
 
@@ -355,7 +355,7 @@ int LayerElement::GetDrawingX() const
 {
     // If this element has a facsimile and we are in facsimile mode, use Facsimile::GetDrawingX
     if (this->HasFacs()) {
-        Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+        const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
         assert(doc);
         if (doc->GetType() == Facs) {
             return FacsimileInterface::GetDrawingX();
@@ -370,22 +370,22 @@ int LayerElement::GetDrawingX() const
     if (!m_alignment) {
         // assert(this->Is({ BEAM, FTREM, TUPLET }));
         // Here we just get the measure position - no cast to Measure is necessary
-        Object *measure = this->GetFirstAncestor(MEASURE);
+        const Object *measure = this->GetFirstAncestor(MEASURE);
         assert(measure);
         m_cachedDrawingX = measure->GetDrawingX();
         return m_cachedDrawingX;
     }
 
     // First get the first layerElement parent (if any) and use its position if they share the same alignment
-    LayerElement *parent
-        = dynamic_cast<LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
+    const LayerElement *parent
+        = dynamic_cast<const LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
     if (parent && (parent->GetAlignment() == this->GetAlignment())) {
         m_cachedDrawingX = (parent->GetDrawingX() + this->GetDrawingXRel());
         return m_cachedDrawingX;
     }
 
     // Otherwise get the measure - no cast to Measure is necessary
-    Object *measure = this->GetFirstAncestor(MEASURE);
+    const Object *measure = this->GetFirstAncestor(MEASURE);
     assert(measure);
 
     int graceNoteShift = 0;
@@ -403,7 +403,7 @@ int LayerElement::GetDrawingY() const
 {
     // If this element has a facsimile and we are in facsimile mode, use Facsimile::GetDrawingY
     if (this->HasFacs()) {
-        Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+        const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
         assert(doc);
         if (doc->GetType() == Facs) {
             return FacsimileInterface::GetDrawingY();
@@ -413,7 +413,7 @@ int LayerElement::GetDrawingY() const
     if (m_cachedDrawingY != VRV_UNSET) return m_cachedDrawingY;
 
     // Look if we have a crossStaff situation
-    Object *object = m_crossStaff; // GetCrossStaff();
+    const Object *object = m_crossStaff; // GetCrossStaff();
     // First get the first layerElement parent (if any) but only if the element is not directly relative to staff
     // (e.g. artic, syl)
     if (!object && !this->IsRelativeToStaff()) object = this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -160,38 +160,39 @@ LayerElement *LayerElement::ThisOrSameasAsLink()
     return dynamic_cast<LayerElement *>(this->GetSameasLink());
 }
 
-bool LayerElement::IsGraceNote()
+bool LayerElement::IsGraceNote() const
 {
     // First, regardless of the type, check whether it's part of GRACEGRP
     if (this->GetFirstAncestor(GRACEGRP)) return true;
     // For note, we need to look at it or at the parent chord
     if (this->Is(NOTE)) {
-        Note const *note = vrv_cast<Note const *>(this);
+        const Note *note = vrv_cast<const Note *>(this);
         assert(note);
-        Chord *chord = note->IsChordTone();
+        const Chord *chord = note->IsChordTone();
         if (chord)
             return chord->HasGrace();
         else
             return (note->HasGrace());
     }
     else if (this->Is(CHORD)) {
-        Chord const *chord = vrv_cast<Chord const *>(this);
+        const Chord *chord = vrv_cast<const Chord *>(this);
         assert(chord);
         return (chord->HasGrace());
     }
     else if (this->Is(TUPLET)) {
         ClassIdsComparison matchType({ NOTE, CHORD });
         ArrayOfObjects children;
-        LayerElement *child = dynamic_cast<LayerElement *>(this->FindDescendantByComparison(&matchType));
+        LayerElement *child
+            = dynamic_cast<LayerElement *>(const_cast<LayerElement *>(this)->FindDescendantByComparison(&matchType));
         if (child) return child->IsGraceNote();
     }
     // For accid, artic, etc.. look at the parent note / chord
     else {
         // For an accid we expect to be the child of a note - the note will lookup at the chord parent in necessary
-        Note *note = dynamic_cast<Note *>(this->GetFirstAncestor(NOTE, MAX_ACCID_DEPTH));
+        const Note *note = dynamic_cast<const Note *>(this->GetFirstAncestor(NOTE, MAX_ACCID_DEPTH));
         if (note) return note->IsGraceNote();
         // For an artic we can be direct child of a chord
-        Chord *chord = dynamic_cast<Chord *>(this->GetFirstAncestor(CHORD, MAX_ACCID_DEPTH));
+        const Chord *chord = dynamic_cast<const Chord *>(this->GetFirstAncestor(CHORD, MAX_ACCID_DEPTH));
         if (chord) return chord->IsGraceNote();
     }
     return false;
@@ -2006,7 +2007,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
     }
     // For note, we also need to look at the parent chord
     else if (this->Is(NOTE)) {
-        Note const *note = vrv_cast<Note const *>(this);
+        Note *note = vrv_cast<Note *>(this);
         assert(note);
         Chord *chord = note->IsChordTone();
         if (chord) m_drawingCueSize = chord->GetDrawingCueSize();
@@ -2020,7 +2021,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
     }
     // For accid, look at the parent if @func="edit" or otherwise to the parent note
     else if (this->Is(ACCID)) {
-        Accid const *accid = vrv_cast<Accid *>(this);
+        Accid *accid = vrv_cast<Accid *>(this);
         assert(accid);
         if (accid->GetFunc() == accidLog_FUNC_edit)
             m_drawingCueSize = true;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -257,17 +257,27 @@ bool LayerElement::IsInBeamSpan() const
 
 Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool assertExistence) const
 {
-    Staff *staff = NULL;
+    return const_cast<Staff *>(std::as_const(*this).GetAncestorStaff(strategy, assertExistence));
+}
+
+const Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool assertExistence) const
+{
+    const Staff *staff = NULL;
     if (strategy == RESOLVE_CROSS_STAFF) {
         Layer *layer = NULL;
         staff = this->GetCrossStaff(layer);
     }
-    if (!staff) staff = vrv_cast<Staff *>(const_cast<LayerElement *>(this)->GetFirstAncestor(STAFF));
+    if (!staff) staff = vrv_cast<const Staff *>(this->GetFirstAncestor(STAFF));
     if (assertExistence) assert(staff);
     return staff;
 }
 
-Staff *LayerElement::GetCrossStaff(Layer *&layer) const
+Staff *LayerElement::GetCrossStaff(Layer *&layer)
+{
+    return const_cast<Staff *>(std::as_const(*this).GetCrossStaff(layer));
+}
+
+const Staff *LayerElement::GetCrossStaff(Layer *&layer) const
 {
     if (m_crossStaff) {
         assert(m_crossLayer);
@@ -275,8 +285,8 @@ Staff *LayerElement::GetCrossStaff(Layer *&layer) const
         return m_crossStaff;
     }
 
-    LayerElement *parent = dynamic_cast<LayerElement *>(
-        const_cast<LayerElement *>(this)->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
+    const LayerElement *parent
+        = dynamic_cast<const LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
 
     if (parent) return parent->GetCrossStaff(layer);
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -703,7 +703,7 @@ double LayerElement::GetAlignmentDuration(
 }
 
 double LayerElement::GetSameAsContentAlignmentDuration(
-    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType) const
+    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType)
 {
     if (!this->HasSameasLink() || !this->GetSameasLink()->Is({ BEAM, FTREM, TUPLET })) {
         return 0.0;
@@ -716,7 +716,7 @@ double LayerElement::GetSameAsContentAlignmentDuration(
 }
 
 double LayerElement::GetContentAlignmentDuration(
-    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType) const
+    Mensur *mensur, MeterSig *meterSig, bool notGraceOnly, data_NOTATIONTYPE notationType)
 {
     if (!this->Is({ BEAM, FTREM, TUPLET })) {
         return 0.0;
@@ -724,7 +724,7 @@ double LayerElement::GetContentAlignmentDuration(
 
     double duration = 0.0;
 
-    for (auto child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         // Skip everything that does not have a duration interface and notes in chords
         if (!child->HasInterface(INTERFACE_DURATION) || (child->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH) != NULL)) {
             continue;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -255,7 +255,7 @@ bool LayerElement::IsInBeamSpan() const
     return m_isInBeamspan;
 }
 
-Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool assertExistence) const
+Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool assertExistence)
 {
     return const_cast<Staff *>(std::as_const(*this).GetAncestorStaff(strategy, assertExistence));
 }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -182,8 +182,7 @@ bool LayerElement::IsGraceNote() const
     else if (this->Is(TUPLET)) {
         ClassIdsComparison matchType({ NOTE, CHORD });
         ArrayOfObjects children;
-        LayerElement *child
-            = dynamic_cast<LayerElement *>(const_cast<LayerElement *>(this)->FindDescendantByComparison(&matchType));
+        const LayerElement *child = dynamic_cast<const LayerElement *>(this->FindDescendantByComparison(&matchType));
         if (child) return child->IsGraceNote();
     }
     // For accid, artic, etc.. look at the parent note / chord

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -188,17 +188,17 @@ void Measure::AddChildBack(Object *child)
     }
 
     child->SetParent(this);
-    ArrayOfObjects *children = this->GetChildrenForModification();
-    if (children->empty()) {
-        children->push_back(child);
+    ArrayOfObjects &children = this->GetChildrenForModification();
+    if (children.empty()) {
+        children.push_back(child);
     }
-    else if (children->back()->Is(STAFF)) {
-        children->push_back(child);
+    else if (children.back()->Is(STAFF)) {
+        children.push_back(child);
     }
     else {
-        for (auto it = children->begin(); it != children->end(); ++it) {
+        for (auto it = children.begin(); it != children.end(); ++it) {
             if (!(*it)->Is(STAFF)) {
-                children->insert(it, child);
+                children.insert(it, child);
                 break;
             }
         }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -209,7 +209,7 @@ void Measure::AddChildBack(Object *child)
 int Measure::GetDrawingX() const
 {
     if (!this->IsMeasuredMusic()) {
-        System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+        const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
         assert(system);
         if (system->m_yAbs != VRV_UNSET) {
             return (system->m_systemLeftMar);
@@ -220,7 +220,7 @@ int Measure::GetDrawingX() const
 
     if (m_cachedDrawingX != VRV_UNSET) return m_cachedDrawingX;
 
-    System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+    const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     m_cachedDrawingX = system->GetDrawingX() + this->GetDrawingXRel();
     return m_cachedDrawingX;
@@ -325,10 +325,10 @@ int Measure::GetRightBarLineRight() const
 int Measure::GetWidth() const
 {
     if (!this->IsMeasuredMusic()) {
-        System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+        const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
         assert(system);
         if (system->m_yAbs != VRV_UNSET) {
-            Page *page = vrv_cast<Page *>(system->GetFirstAncestor(PAGE));
+            const Page *page = vrv_cast<const Page *>(system->GetFirstAncestor(PAGE));
             assert(page);
             // xAbs2 =  page->m_pageWidth - system->m_systemRightMar;
             return page->m_pageWidth - system->m_systemLeftMar - system->m_systemRightMar;

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -88,19 +88,19 @@ bool Neume::IsLastInNeume(LayerElement *element)
     return false;
 }
 
-NeumeGroup Neume::GetNeumeGroup()
+NeumeGroup Neume::GetNeumeGroup() const
 {
-    ListOfObjects children = this->FindAllDescendantsByType(NC);
+    ListOfConstObjects children = this->FindAllDescendantsByType(NC);
 
     auto iter = children.begin();
-    Nc *previous = dynamic_cast<Nc *>(*iter);
+    const Nc *previous = dynamic_cast<const Nc *>(*iter);
     if (previous == NULL) return NEUME_ERROR;
     ++iter;
 
     std::string key = "";
 
     for (; iter != children.end(); ++iter) {
-        Nc *current = vrv_cast<Nc *>(*iter);
+        const Nc *current = vrv_cast<const Nc *>(*iter);
         assert(current);
 
         int pitchDifference = current->PitchDifferenceTo(previous);
@@ -124,21 +124,21 @@ NeumeGroup Neume::GetNeumeGroup()
     }
 }
 
-std::vector<int> Neume::GetPitchDifferences()
+std::vector<int> Neume::GetPitchDifferences() const
 {
     std::vector<int> pitchDifferences;
-    ListOfObjects ncChildren = this->FindAllDescendantsByType(NC);
+    ListOfConstObjects ncChildren = this->FindAllDescendantsByType(NC);
 
     pitchDifferences.reserve(ncChildren.size() - 1);
 
     // Iterate through children and calculate pitch differences
     auto iter = ncChildren.begin();
-    Nc *previous = dynamic_cast<Nc *>(*iter);
+    const Nc *previous = dynamic_cast<const Nc *>(*iter);
     if (previous == NULL) return pitchDifferences;
     ++iter;
 
     for (; iter != ncChildren.end(); ++iter) {
-        Nc *current = vrv_cast<Nc *>(*iter);
+        const Nc *current = vrv_cast<const Nc *>(*iter);
         assert(current);
         pitchDifferences.push_back(current->PitchDifferenceTo(previous));
         previous = current;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -545,7 +545,7 @@ wchar_t Note::GetNoteheadGlyph(const int duration) const
     return SMUFL_E0A4_noteheadBlack;
 }
 
-bool Note::IsVisible() const
+bool Note::IsVisible()
 {
     if (this->HasVisible()) {
         return this->GetVisible() == BOOLEAN_true;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -454,7 +454,7 @@ wchar_t Note::GetMensuralNoteheadGlyph() const
         return 0;
     }
 
-    Staff *staff = this->GetAncestorStaff();
+    const Staff *staff = this->GetAncestorStaff();
     bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
 
     wchar_t code = 0;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -222,12 +222,12 @@ bool Note::HasLedgerLines(int &linesAbove, int &linesBelow, Staff *staff)
 
 Chord *Note::IsChordTone() const
 {
-    return dynamic_cast<Chord *>(this->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
+    return dynamic_cast<Chord *>(const_cast<Note *>(this)->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
 }
 
 int Note::GetDrawingDur() const
 {
-    Chord *chordParent = dynamic_cast<Chord *>(this->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
+    const Chord *chordParent = dynamic_cast<const Chord *>(this->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
     if (chordParent && !this->HasDur()) {
         return chordParent->GetActualDur();
     }
@@ -248,7 +248,7 @@ bool Note::IsClusterExtreme() const
 
 TabGrp *Note::IsTabGrpNote() const
 {
-    return dynamic_cast<TabGrp *>(this->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
+    return dynamic_cast<TabGrp *>(const_cast<Note *>(this)->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
 }
 
 std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -220,9 +220,14 @@ bool Note::HasLedgerLines(int &linesAbove, int &linesBelow, Staff *staff)
     return ((linesAbove > 0) || (linesBelow > 0));
 }
 
-Chord *Note::IsChordTone() const
+Chord *Note::IsChordTone()
 {
-    return dynamic_cast<Chord *>(const_cast<Note *>(this)->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
+    return dynamic_cast<Chord *>(this->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
+}
+
+const Chord *Note::IsChordTone() const
+{
+    return dynamic_cast<const Chord *>(this->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH));
 }
 
 int Note::GetDrawingDur() const
@@ -246,9 +251,14 @@ bool Note::IsClusterExtreme() const
         return false;
 }
 
-TabGrp *Note::IsTabGrpNote() const
+TabGrp *Note::IsTabGrpNote()
 {
-    return dynamic_cast<TabGrp *>(const_cast<Note *>(this)->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
+    return dynamic_cast<TabGrp *>(this->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
+}
+
+const TabGrp *Note::IsTabGrpNote() const
+{
+    return dynamic_cast<const TabGrp *>(this->GetFirstAncestor(TABGRP, MAX_TABGRP_DEPTH));
 }
 
 std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -201,11 +201,15 @@ void Note::AlignDotsShift(Note *otherNote)
 
 Accid *Note::GetDrawingAccid()
 {
-    Accid *accid = dynamic_cast<Accid *>(this->FindDescendantByType(ACCID));
-    return accid;
+    return dynamic_cast<Accid *>(this->FindDescendantByType(ACCID));
 }
 
-bool Note::HasLedgerLines(int &linesAbove, int &linesBelow, Staff *staff)
+const Accid *Note::GetDrawingAccid() const
+{
+    return dynamic_cast<const Accid *>(this->FindDescendantByType(ACCID));
+}
+
+bool Note::HasLedgerLines(int &linesAbove, int &linesBelow, const Staff *staff) const
 {
     if (!staff) {
         staff = this->GetAncestorStaff();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -176,15 +176,15 @@ void Note::AddChild(Object *child)
 
     child->SetParent(this);
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ DOTS, STEM })) {
-        children->insert(children->begin(), child);
+        children.insert(children.begin(), child);
     }
     else {
-        children->push_back(child);
+        children.push_back(child);
     }
     Modify();
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -658,7 +658,7 @@ void Object::FindAllDescendantsByComparison(
 }
 
 void Object::FindAllDescendantsBetween(
-    ListOfObjects *objects, Comparison *comparison, const Object *start, const Object *end, bool clear)
+    ListOfObjects *objects, Comparison *comparison, const Object *start, const Object *end, bool clear, int depth)
 {
     assert(objects);
     if (clear) objects->clear();
@@ -668,15 +668,15 @@ void Object::FindAllDescendantsBetween(
     this->Process(&findAllBetween, &findAllBetweenParams, NULL, NULL, depth, FORWARD, true);
 }
 
-void Object::FindAllDescendantsBetween(
-    ListOfConstObjects *objects, Comparison *comparison, const Object *start, const Object *end, bool clear) const
+void Object::FindAllDescendantsBetween(ListOfConstObjects *objects, Comparison *comparison, const Object *start,
+    const Object *end, bool clear, int depth) const
 {
     assert(objects);
     if (clear) objects->clear();
 
     Functor findAllConstBetween(&Object::FindAllConstBetween);
     FindAllConstBetweenParams findAllConstBetweenParams(comparison, objects, start, end);
-    this->Process(&findAllConstBetween, &findAllConstBetweenParams, NULL, NULL, UNLIMITED_DEPTH, FORWARD, true);
+    this->Process(&findAllConstBetween, &findAllConstBetweenParams, NULL, NULL, depth, FORWARD, true);
 }
 
 Object *Object::GetChild(int idx)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -529,7 +529,12 @@ void Object::ClearRelinquishedChildren()
     }
 }
 
-Object *Object::FindDescendantByUuid(std::string uuid, int deepness, bool direction)
+Object *Object::FindDescendantByUuid(const std::string &uuid, int deepness, bool direction)
+{
+    return const_cast<Object *>(std::as_const(*this).FindDescendantByUuid(uuid, deepness, direction));
+}
+
+const Object *Object::FindDescendantByUuid(const std::string &uuid, int deepness, bool direction) const
 {
     Functor findByUuid(&Object::FindByUuid);
     FindByUuidParams findbyUuidParams;
@@ -540,11 +545,21 @@ Object *Object::FindDescendantByUuid(std::string uuid, int deepness, bool direct
 
 Object *Object::FindDescendantByType(ClassId classId, int deepness, bool direction)
 {
+    return const_cast<Object *>(std::as_const(*this).FindDescendantByType(classId, deepness, direction));
+}
+
+const Object *Object::FindDescendantByType(ClassId classId, int deepness, bool direction) const
+{
     ClassIdComparison comparison(classId);
     return this->FindDescendantByComparison(&comparison, deepness, direction);
 }
 
 Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness, bool direction)
+{
+    return const_cast<Object *>(std::as_const(*this).FindDescendantByComparison(comparison, deepness, direction));
+}
+
+const Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     Functor findByComparison(&Object::FindByComparison);
     FindByComparisonParams findByComparisonParams(comparison);
@@ -553,6 +568,12 @@ Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness,
 }
 
 Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int deepness, bool direction)
+{
+    return const_cast<Object *>(
+        std::as_const(*this).FindDescendantExtremeByComparison(comparison, deepness, direction));
+}
+
+const Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     Functor findExtremeByComparison(&Object::FindExtremeByComparison);
     FindExtremeByComparisonParams findExtremeByComparisonParams(comparison);
@@ -1436,7 +1457,7 @@ int Object::AddLayerElementToFlatList(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Object::FindByUuid(FunctorParams *functorParams)
+int Object::FindByUuid(FunctorParams *functorParams) const
 {
     FindByUuidParams *params = vrv_params_cast<FindByUuidParams *>(functorParams);
     assert(params);
@@ -1455,7 +1476,7 @@ int Object::FindByUuid(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Object::FindByComparison(FunctorParams *functorParams)
+int Object::FindByComparison(FunctorParams *functorParams) const
 {
     FindByComparisonParams *params = vrv_params_cast<FindByComparisonParams *>(functorParams);
     assert(params);
@@ -1475,7 +1496,7 @@ int Object::FindByComparison(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Object::FindExtremeByComparison(FunctorParams *functorParams)
+int Object::FindExtremeByComparison(FunctorParams *functorParams) const
 {
     FindExtremeByComparisonParams *params = vrv_params_cast<FindExtremeByComparisonParams *>(functorParams);
     assert(params);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -367,6 +367,12 @@ int Object::GetChildCount(const ClassId classId, int depth) const
     return (int)objects.size();
 }
 
+int Object::GetDescendantCount(const ClassId classId) const
+{
+    ListOfConstObjects objects = this->FindAllDescendantsByType(classId);
+    return (int)objects.size();
+}
+
 int Object::GetAttributes(ArrayOfStrAttr *attributes) const
 {
     assert(attributes);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -361,9 +361,9 @@ int Object::GetChildCount(const ClassId classId) const
     return (int)count_if(m_children.begin(), m_children.end(), ObjectComparison(classId));
 }
 
-int Object::GetChildCount(const ClassId classId, int depth)
+int Object::GetChildCount(const ClassId classId, int depth) const
 {
-    ListOfObjects objects = this->FindAllDescendantsByType(classId, true, depth);
+    ListOfConstObjects objects = this->FindAllDescendantsByType(classId, true, depth);
     return (int)objects.size();
 }
 
@@ -673,7 +673,12 @@ void Object::FindAllDescendantsBetween(
     this->Process(&findAllConstBetween, &findAllConstBetweenParams, NULL, NULL, UNLIMITED_DEPTH, FORWARD, true);
 }
 
-Object *Object::GetChild(int idx) const
+Object *Object::GetChild(int idx)
+{
+    return const_cast<Object *>(std::as_const(*this).GetChild(idx));
+}
+
+const Object *Object::GetChild(int idx) const
 {
     if ((idx < 0) || (idx >= (int)m_children.size())) {
         return NULL;
@@ -683,13 +688,23 @@ Object *Object::GetChild(int idx) const
 
 Object *Object::GetChild(int idx, const ClassId classId)
 {
-    ListOfObjects objects = this->FindAllDescendantsByType(classId, true, 1);
+    return const_cast<Object *>(std::as_const(*this).GetChild(idx, classId));
+}
+
+const Object *Object::GetChild(int idx, const ClassId classId) const
+{
+    ListOfConstObjects objects = this->FindAllDescendantsByType(classId, true, 1);
     if ((idx < 0) || (idx >= (int)objects.size())) {
         return NULL;
     }
-    ListOfObjects::iterator it = objects.begin();
+    ListOfConstObjects::iterator it = objects.begin();
     std::advance(it, idx);
     return *it;
+}
+
+ArrayOfConstObjects Object::GetChildren() const
+{
+    return ArrayOfConstObjects(m_children.begin(), m_children.end());
 }
 
 bool Object::DeleteChild(Object *child)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -415,6 +415,11 @@ bool Object::HasAttribute(std::string attribute, std::string value) const
 
 Object *Object::GetFirst(const ClassId classId)
 {
+    return const_cast<Object *>(std::as_const(*this).GetFirst(classId));
+}
+
+const Object *Object::GetFirst(const ClassId classId) const
+{
     m_iteratorElementType = classId;
     m_iteratorEnd = m_children.end();
     m_iteratorCurrent = std::find_if(m_children.begin(), m_iteratorEnd, ObjectComparison(m_iteratorElementType));
@@ -423,14 +428,24 @@ Object *Object::GetFirst(const ClassId classId)
 
 Object *Object::GetNext()
 {
-    m_iteratorCurrent++;
+    return const_cast<Object *>(std::as_const(*this).GetNext());
+}
+
+const Object *Object::GetNext() const
+{
+    ++m_iteratorCurrent;
     m_iteratorCurrent = std::find_if(m_iteratorCurrent, m_iteratorEnd, ObjectComparison(m_iteratorElementType));
     return (m_iteratorCurrent == m_iteratorEnd) ? NULL : *m_iteratorCurrent;
 }
 
 Object *Object::GetNext(const Object *child, const ClassId classId)
 {
-    ArrayOfObjects::iterator iteratorEnd, iteratorCurrent;
+    return const_cast<Object *>(std::as_const(*this).GetNext(child, classId));
+}
+
+const Object *Object::GetNext(const Object *child, const ClassId classId) const
+{
+    ArrayOfObjects::const_iterator iteratorEnd, iteratorCurrent;
     iteratorEnd = m_children.end();
     iteratorCurrent = std::find(m_children.begin(), iteratorEnd, child);
     if (iteratorCurrent != iteratorEnd) {
@@ -442,7 +457,12 @@ Object *Object::GetNext(const Object *child, const ClassId classId)
 
 Object *Object::GetPrevious(const Object *child, const ClassId classId)
 {
-    ArrayOfObjects::reverse_iterator riteratorEnd, riteratorCurrent;
+    return const_cast<Object *>(std::as_const(*this).GetPrevious(child, classId));
+}
+
+const Object *Object::GetPrevious(const Object *child, const ClassId classId) const
+{
+    ArrayOfObjects::const_reverse_iterator riteratorEnd, riteratorCurrent;
     riteratorEnd = m_children.rend();
     riteratorCurrent = std::find(m_children.rbegin(), riteratorEnd, child);
     if (riteratorCurrent != riteratorEnd) {
@@ -452,7 +472,12 @@ Object *Object::GetPrevious(const Object *child, const ClassId classId)
     return (riteratorCurrent == riteratorEnd) ? NULL : *riteratorCurrent;
 }
 
-Object *Object::GetLast(const ClassId classId) const
+Object *Object::GetLast(const ClassId classId)
+{
+    return const_cast<Object *>(std::as_const(*this).GetLast(classId));
+}
+
+const Object *Object::GetLast(const ClassId classId) const
 {
     ArrayOfObjects::const_reverse_iterator riter
         = std::find_if(m_children.rbegin(), m_children.rend(), ObjectComparison(classId));

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -79,16 +79,21 @@ bool Page::IsSupportedChild(Object *child)
     return true;
 }
 
-RunningElement *Page::GetHeader() const
+RunningElement *Page::GetHeader()
+{
+    return const_cast<RunningElement *>(std::as_const(*this).GetHeader());
+}
+
+const RunningElement *Page::GetHeader() const
 {
     assert(m_score);
 
-    Doc *doc = dynamic_cast<Doc *>(const_cast<Page *>(this)->GetFirstAncestor(DOC));
+    const Doc *doc = dynamic_cast<const Doc *>(this->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_header.GetValue() == HEADER_none)) {
         return NULL;
     }
 
-    Pages *pages = doc->GetPages();
+    Pages *pages = const_cast<Doc *>(doc)->GetPages();
     assert(pages);
 
     // first page or use the pgHeader for all pages?
@@ -100,16 +105,21 @@ RunningElement *Page::GetHeader() const
     }
 }
 
-RunningElement *Page::GetFooter() const
+RunningElement *Page::GetFooter()
+{
+    return const_cast<RunningElement *>(std::as_const(*this).GetFooter());
+}
+
+const RunningElement *Page::GetFooter() const
 {
     assert(m_scoreEnd);
 
-    Doc *doc = dynamic_cast<Doc *>(const_cast<Page *>(this)->GetFirstAncestor(DOC));
+    const Doc *doc = dynamic_cast<const Doc *>(this->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_footer.GetValue() == FOOTER_none)) {
         return NULL;
     }
 
-    Pages *pages = doc->GetPages();
+    Pages *pages = const_cast<Doc *>(doc)->GetPages();
     assert(pages);
 
     // first page or use the pgFooter for all pages?

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -712,8 +712,8 @@ int Page::GetContentWidth() const
     assert(this == doc->GetDrawingPage());
 
     int maxWidth = 0;
-    for (auto &child : *this->GetChildren()) {
-        System *system = dynamic_cast<System *>(child);
+    for (auto child : this->GetChildren()) {
+        const System *system = dynamic_cast<const System *>(child);
         if (system) {
             // we include the left margin and the right margin
             int systemWidth = system->m_drawingTotalWidth + system->m_systemLeftMar + system->m_systemRightMar;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -93,7 +93,7 @@ const RunningElement *Page::GetHeader() const
         return NULL;
     }
 
-    Pages *pages = const_cast<Doc *>(doc)->GetPages();
+    const Pages *pages = doc->GetPages();
     assert(pages);
 
     // first page or use the pgHeader for all pages?
@@ -119,7 +119,7 @@ const RunningElement *Page::GetFooter() const
         return NULL;
     }
 
-    Pages *pages = const_cast<Doc *>(doc)->GetPages();
+    const Pages *pages = doc->GetPages();
     assert(pages);
 
     // first page or use the pgFooter for all pages?
@@ -689,7 +689,7 @@ int Page::GetContentHeight() const
         return 0;
     }
 
-    System *last = dynamic_cast<System *>(this->GetLast(SYSTEM));
+    const System *last = dynamic_cast<const System *>(this->GetLast(SYSTEM));
     assert(last);
     int height = doc->m_drawingPageContentHeight - last->GetDrawingYRel() + last->GetHeight();
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -83,7 +83,7 @@ RunningElement *Page::GetHeader() const
 {
     assert(m_score);
 
-    Doc *doc = dynamic_cast<Doc *>(this->GetFirstAncestor(DOC));
+    Doc *doc = dynamic_cast<Doc *>(const_cast<Page *>(this)->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_header.GetValue() == HEADER_none)) {
         return NULL;
     }
@@ -104,7 +104,7 @@ RunningElement *Page::GetFooter() const
 {
     assert(m_scoreEnd);
 
-    Doc *doc = dynamic_cast<Doc *>(this->GetFirstAncestor(DOC));
+    Doc *doc = dynamic_cast<Doc *>(const_cast<Page *>(this)->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_footer.GetValue() == FOOTER_none)) {
         return NULL;
     }
@@ -668,7 +668,7 @@ void Page::LayOutPitchPos()
 
 int Page::GetContentHeight() const
 {
-    Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+    const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
     assert(doc);
 
     // Doc::SetDrawingPage should have been called before
@@ -692,7 +692,7 @@ int Page::GetContentHeight() const
 
 int Page::GetContentWidth() const
 {
-    Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+    const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
     assert(doc);
     // in non debug
     if (!doc) return 0;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -636,7 +636,7 @@ void Page::JustifyVertically()
             }
         }
         else {
-            const int stavesPerSystem = m_drawingScoreDef.GetChildCount(STAFFDEF, UNLIMITED_DEPTH);
+            const int stavesPerSystem = m_drawingScoreDef.GetDescendantCount(STAFFDEF);
             if (childSystems * stavesPerSystem < 8) return;
         }
     }

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -36,7 +36,7 @@ void PgFoot::Reset()
     RunningElement::Reset();
 }
 
-int PgFoot::GetTotalHeight(Doc *doc)
+int PgFoot::GetTotalHeight(const Doc *doc) const
 {
     assert(doc);
 

--- a/src/pgfoot2.cpp
+++ b/src/pgfoot2.cpp
@@ -35,7 +35,7 @@ void PgFoot2::Reset()
     RunningElement::Reset();
 }
 
-int PgFoot2::GetTotalHeight(Doc *doc)
+int PgFoot2::GetTotalHeight(const Doc *doc) const
 {
     assert(doc);
 

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -39,7 +39,7 @@ void PgHead::Reset()
     RunningElement::Reset();
 }
 
-int PgHead::GetTotalHeight(Doc *doc)
+int PgHead::GetTotalHeight(const Doc *doc) const
 {
     assert(doc);
 

--- a/src/pghead2.cpp
+++ b/src/pghead2.cpp
@@ -35,7 +35,7 @@ void PgHead2::Reset()
     RunningElement::Reset();
 }
 
-int PgHead2::GetTotalHeight(Doc *doc)
+int PgHead2::GetTotalHeight(const Doc *doc) const
 {
     assert(doc);
 

--- a/src/pitchinterface.cpp
+++ b/src/pitchinterface.cpp
@@ -87,7 +87,7 @@ void PitchInterface::AdjustPitchByOffset(int pitchOffset)
     this->SetOct(oct);
 }
 
-int PitchInterface::PitchDifferenceTo(PitchInterface *pi)
+int PitchInterface::PitchDifferenceTo(const PitchInterface *pi) const
 {
     assert(pi);
     int pitchDifference = 0;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -206,15 +206,15 @@ void Rest::AddChild(Object *child)
 
     child->SetParent(this);
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // Dots are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is(DOTS)) {
-        children->insert(children->begin(), child);
+        children.insert(children.begin(), child);
     }
     else {
-        children->push_back(child);
+        children.push_back(child);
     }
     Modify();
 }

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -185,7 +185,7 @@ void RunningElement::SetDrawingPage(Page *page)
     }
 }
 
-int RunningElement::GetContentHeight()
+int RunningElement::GetContentHeight() const
 {
     int height = 0;
     int i;

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -195,7 +195,7 @@ int RunningElement::GetContentHeight()
     return height;
 }
 
-int RunningElement::GetRowHeight(int row)
+int RunningElement::GetRowHeight(int row) const
 {
     assert((row >= 0) && (row < 3));
 
@@ -207,7 +207,7 @@ int RunningElement::GetRowHeight(int row)
     return height;
 }
 
-int RunningElement::GetColHeight(int col)
+int RunningElement::GetColHeight(int col) const
 {
     assert((col >= 0) && (col < 3));
 
@@ -219,13 +219,13 @@ int RunningElement::GetColHeight(int col)
     return height;
 }
 
-int RunningElement::GetCellHeight(int cell)
+int RunningElement::GetCellHeight(int cell) const
 {
     assert((cell >= 0) && (cell < 9));
 
     int columnHeight = 0;
-    ArrayOfTextElements *textElements = &m_cells[cell];
-    ArrayOfTextElements::iterator iter;
+    const ArrayOfTextElements *textElements = &m_cells[cell];
+    ArrayOfTextElements::const_iterator iter;
     for (iter = textElements->begin(); iter != textElements->end(); ++iter) {
         if ((*iter)->HasContentBB()) {
             columnHeight += (*iter)->GetContentY2() - (*iter)->GetContentY1();

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -86,13 +86,13 @@ bool Score::IsSupportedChild(Object *child)
     return true;
 }
 
-void Score::SetAsCurrent()
+void Score::SetAsCurrent() const
 {
     Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
     // The doc can be NULL when doing the castoff and the pages are no attached to the doc
     // If such cases, it will not matter not to have the current scoreDef in the doc
     if (doc) {
-        doc->SetCurrentScore(this);
+        doc->SetCurrentScore(const_cast<Score *>(this));
     }
 }
 

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -136,14 +136,14 @@ void Score::CalcRunningElementHeight(Doc *doc)
     doc->ResetDrawingPage();
 }
 
-bool Score::ScoreDefNeedsOptimization(int optionCondense)
+bool Score::ScoreDefNeedsOptimization(int optionCondense) const
 {
     if (optionCondense == CONDENSE_none) return false;
     // optimize scores only if encoded
     bool optimize = (m_scoreDef.HasOptimize() && m_scoreDef.GetOptimize() == BOOLEAN_true);
     // if nothing specified, do not if there is only one grpSym
     if ((optionCondense == CONDENSE_auto) && !m_scoreDef.HasOptimize()) {
-        ListOfObjects symbols = m_scoreDef.FindAllDescendantsByType(GRPSYM);
+        ListOfConstObjects symbols = m_scoreDef.FindAllDescendantsByType(GRPSYM);
         optimize = (symbols.size() > 1);
     }
 

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -86,7 +86,7 @@ bool Score::IsSupportedChild(Object *child)
     return true;
 }
 
-void Score::SetAsCurrent() const
+void Score::SetAsCurrent()
 {
     Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
     // The doc can be NULL when doing the castoff and the pages are no attached to the doc

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -92,7 +92,7 @@ void Score::SetAsCurrent()
     // The doc can be NULL when doing the castoff and the pages are no attached to the doc
     // If such cases, it will not matter not to have the current scoreDef in the doc
     if (doc) {
-        doc->SetCurrentScore(const_cast<Score *>(this));
+        doc->SetCurrentScore(this);
     }
 }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -74,40 +74,45 @@ void ScoreDefElement::Reset()
     this->ResetTyped();
 }
 
-bool ScoreDefElement::HasClefInfo(int depth)
+bool ScoreDefElement::HasClefInfo(int depth) const
 {
     return (this->FindDescendantByType(CLEF, depth));
 }
 
-bool ScoreDefElement::HasKeySigInfo(int depth)
+bool ScoreDefElement::HasKeySigInfo(int depth) const
 {
     return (this->FindDescendantByType(KEYSIG, depth));
 }
 
-bool ScoreDefElement::HasMensurInfo(int depth)
+bool ScoreDefElement::HasMensurInfo(int depth) const
 {
     return (this->FindDescendantByType(MENSUR, depth));
 }
 
-bool ScoreDefElement::HasMeterSigInfo(int depth)
+bool ScoreDefElement::HasMeterSigInfo(int depth) const
 {
     return (this->FindDescendantByType(METERSIG, depth));
 }
 
-bool ScoreDefElement::HasMeterSigGrpInfo(int depth)
+bool ScoreDefElement::HasMeterSigGrpInfo(int depth) const
 {
     return (this->FindDescendantByType(METERSIGGRP, depth));
 }
 
 Clef *ScoreDefElement::GetClef()
 {
+    return const_cast<Clef *>(std::as_const(*this).GetClef());
+}
+
+const Clef *ScoreDefElement::GetClef() const
+{
     // Always check if HasClefInfo() is true before asking for it
-    Clef *clef = vrv_cast<Clef *>(this->FindDescendantByType(CLEF, 1));
+    const Clef *clef = vrv_cast<const Clef *>(this->FindDescendantByType(CLEF, 1));
     assert(clef);
     return clef;
 }
 
-Clef *ScoreDefElement::GetClefCopy()
+Clef *ScoreDefElement::GetClefCopy() const
 {
     // Always check if HasClefInfo() is true before asking for a clone
     Clef *clone = dynamic_cast<Clef *>(this->GetClef()->Clone());
@@ -118,13 +123,18 @@ Clef *ScoreDefElement::GetClefCopy()
 
 KeySig *ScoreDefElement::GetKeySig()
 {
+    return const_cast<KeySig *>(std::as_const(*this).GetKeySig());
+}
+
+const KeySig *ScoreDefElement::GetKeySig() const
+{
     // Always check if HasKeySigInfo() is true before asking for it
-    KeySig *keySig = vrv_cast<KeySig *>(this->FindDescendantByType(KEYSIG, 1));
+    const KeySig *keySig = vrv_cast<const KeySig *>(this->FindDescendantByType(KEYSIG, 1));
     assert(keySig);
     return keySig;
 }
 
-KeySig *ScoreDefElement::GetKeySigCopy()
+KeySig *ScoreDefElement::GetKeySigCopy() const
 {
     // Always check if HasKeySigInfo() is true before asking for a clone
     KeySig *clone = dynamic_cast<KeySig *>(this->GetKeySig()->Clone());
@@ -135,13 +145,18 @@ KeySig *ScoreDefElement::GetKeySigCopy()
 
 Mensur *ScoreDefElement::GetMensur()
 {
+    return const_cast<Mensur *>(std::as_const(*this).GetMensur());
+}
+
+const Mensur *ScoreDefElement::GetMensur() const
+{
     // Always check if HasMensurInfo() is true before asking for it
-    Mensur *mensur = vrv_cast<Mensur *>(this->FindDescendantByType(MENSUR, 1));
+    const Mensur *mensur = vrv_cast<const Mensur *>(this->FindDescendantByType(MENSUR, 1));
     assert(mensur);
     return mensur;
 }
 
-Mensur *ScoreDefElement::GetMensurCopy()
+Mensur *ScoreDefElement::GetMensurCopy() const
 {
     // Always check if HasMensurInfo() is true before asking for a clone
     Mensur *clone = dynamic_cast<Mensur *>(this->GetMensur()->Clone());
@@ -152,13 +167,18 @@ Mensur *ScoreDefElement::GetMensurCopy()
 
 MeterSig *ScoreDefElement::GetMeterSig()
 {
+    return const_cast<MeterSig *>(std::as_const(*this).GetMeterSig());
+}
+
+const MeterSig *ScoreDefElement::GetMeterSig() const
+{
     // Always check if HasMeterSigInfo() is true before asking for it
-    MeterSig *meterSig = vrv_cast<MeterSig *>(this->FindDescendantByType(METERSIG, 1));
+    const MeterSig *meterSig = vrv_cast<const MeterSig *>(this->FindDescendantByType(METERSIG, 1));
     assert(meterSig);
     return meterSig;
 }
 
-MeterSig *ScoreDefElement::GetMeterSigCopy()
+MeterSig *ScoreDefElement::GetMeterSigCopy() const
 {
     // Always check if HasMeterSigInfo() is true before asking for a clone
     MeterSig *clone = dynamic_cast<MeterSig *>(this->GetMeterSig()->Clone());
@@ -169,13 +189,18 @@ MeterSig *ScoreDefElement::GetMeterSigCopy()
 
 MeterSigGrp *ScoreDefElement::GetMeterSigGrp()
 {
+    return const_cast<MeterSigGrp *>(std::as_const(*this).GetMeterSigGrp());
+}
+
+const MeterSigGrp *ScoreDefElement::GetMeterSigGrp() const
+{
     // Always check if HasMeterSigGrpInfo() is true before asking for it
-    MeterSigGrp *meterSigGrp = vrv_cast<MeterSigGrp *>(this->FindDescendantByType(METERSIGGRP, 1));
+    const MeterSigGrp *meterSigGrp = vrv_cast<const MeterSigGrp *>(this->FindDescendantByType(METERSIGGRP, 1));
     assert(meterSigGrp);
     return meterSigGrp;
 }
 
-MeterSigGrp *ScoreDefElement::GetMeterSigGrpCopy()
+MeterSigGrp *ScoreDefElement::GetMeterSigGrpCopy() const
 {
     // Always check if HasMeterSigGrpInfo() is true before asking for a clone
     MeterSigGrp *clone = dynamic_cast<MeterSigGrp *>(this->GetMeterSigGrp()->Clone());
@@ -507,9 +532,19 @@ PgFoot *ScoreDef::GetPgFoot()
     return dynamic_cast<PgFoot *>(this->FindDescendantByType(PGFOOT));
 }
 
+const PgFoot *ScoreDef::GetPgFoot() const
+{
+    return dynamic_cast<const PgFoot *>(this->FindDescendantByType(PGFOOT));
+}
+
 PgFoot2 *ScoreDef::GetPgFoot2()
 {
     return dynamic_cast<PgFoot2 *>(this->FindDescendantByType(PGFOOT2));
+}
+
+const PgFoot2 *ScoreDef::GetPgFoot2() const
+{
+    return dynamic_cast<const PgFoot2 *>(this->FindDescendantByType(PGFOOT2));
 }
 
 PgHead *ScoreDef::GetPgHead()
@@ -517,9 +552,19 @@ PgHead *ScoreDef::GetPgHead()
     return dynamic_cast<PgHead *>(this->FindDescendantByType(PGHEAD));
 }
 
+const PgHead *ScoreDef::GetPgHead() const
+{
+    return dynamic_cast<const PgHead *>(this->FindDescendantByType(PGHEAD));
+}
+
 PgHead2 *ScoreDef::GetPgHead2()
 {
     return dynamic_cast<PgHead2 *>(this->FindDescendantByType(PGHEAD2));
+}
+
+const PgHead2 *ScoreDef::GetPgHead2() const
+{
+    return dynamic_cast<const PgHead2 *>(this->FindDescendantByType(PGHEAD2));
 }
 
 int ScoreDef::GetMaxStaffSize()
@@ -528,13 +573,13 @@ int ScoreDef::GetMaxStaffSize()
     return (staffGrp) ? staffGrp->GetMaxStaffSize() : 100;
 }
 
-bool ScoreDef::IsSectionRestart()
+bool ScoreDef::IsSectionRestart() const
 {
     if (!this->GetParent()) return false;
     // In page-based structure, Section is a sibling to scoreDef
     // This has limitations: will not work with editorial markup, additional nested sections, and
     // if the section milestone is in the previous system.
-    Section *section = dynamic_cast<Section *>(this->GetParent()->GetPrevious(this, SECTION));
+    const Section *section = dynamic_cast<const Section *>(this->GetParent()->GetPrevious(this, SECTION));
     return (section && (section->GetRestart() == BOOLEAN_true));
 }
 

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -127,7 +127,7 @@ bool Staff::IsSupportedChild(Object *child)
 int Staff::GetDrawingX() const
 {
     if (this->HasFacs()) {
-        Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+        const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
         assert(doc);
         if (doc->GetType() == Facs) {
             return FacsimileInterface::GetDrawingX();
@@ -139,7 +139,7 @@ int Staff::GetDrawingX() const
 int Staff::GetDrawingY() const
 {
     if (this->HasFacs()) {
-        Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+        const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
         assert(DOC);
         if (doc->GetType() == Facs) {
             return FacsimileInterface::GetDrawingY();
@@ -152,7 +152,7 @@ int Staff::GetDrawingY() const
 
     if (m_cachedDrawingY != VRV_UNSET) return m_cachedDrawingY;
 
-    System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+    const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
 
     m_cachedDrawingY = system->GetDrawingY() + m_staffAlignment->GetYRel();
@@ -162,7 +162,7 @@ int Staff::GetDrawingY() const
 double Staff::GetDrawingRotate() const
 {
     if (this->HasFacs()) {
-        Doc *doc = vrv_cast<Doc *>(this->GetFirstAncestor(DOC));
+        const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
         assert(doc);
         if (doc->GetType() == Facs) {
             return FacsimileInterface::GetDrawingRotate();

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -91,11 +91,6 @@ void Staff::CloneReset()
     m_drawingTuning = NULL;
 }
 
-const ArrayOfObjects *Staff::GetChildren(bool docChildren) const
-{
-    return Object::GetChildren(true);
-}
-
 void Staff::ClearLedgerLines()
 {
     m_ledgerLinesAbove.clear();

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -172,25 +172,30 @@ void StaffGrp::SetGroupSymbol(GrpSym *grpSym)
     }
 }
 
-bool StaffGrp::HasLabelInfo()
+bool StaffGrp::HasLabelInfo() const
 {
     return (this->FindDescendantByType(LABEL, 1));
 }
 
-bool StaffGrp::HasLabelAbbrInfo()
+bool StaffGrp::HasLabelAbbrInfo() const
 {
     return (this->FindDescendantByType(LABELABBR, 1));
 }
 
 Label *StaffGrp::GetLabel()
 {
+    return const_cast<Label *>(std::as_const(*this).GetLabel());
+}
+
+const Label *StaffGrp::GetLabel() const
+{
     // Always check if HasLabelInfo() is true before asking for it
-    Label *label = vrv_cast<Label *>(this->FindDescendantByType(LABEL, 1));
+    const Label *label = vrv_cast<const Label *>(this->FindDescendantByType(LABEL, 1));
     assert(label);
     return label;
 }
 
-Label *StaffGrp::GetLabelCopy()
+Label *StaffGrp::GetLabelCopy() const
 {
     // Always check if HasClefInfo() is true before asking for a clone
     Label *clone = dynamic_cast<Label *>(this->GetLabel()->Clone());
@@ -201,13 +206,18 @@ Label *StaffGrp::GetLabelCopy()
 
 LabelAbbr *StaffGrp::GetLabelAbbr()
 {
+    return const_cast<LabelAbbr *>(std::as_const(*this).GetLabelAbbr());
+}
+
+const LabelAbbr *StaffGrp::GetLabelAbbr() const
+{
     // Always check if HasLabelAbbrInfo() is true before asking for it
-    LabelAbbr *labelAbbr = vrv_cast<LabelAbbr *>(this->FindDescendantByType(LABELABBR, 1));
+    const LabelAbbr *labelAbbr = vrv_cast<const LabelAbbr *>(this->FindDescendantByType(LABELABBR, 1));
     assert(labelAbbr);
     return labelAbbr;
 }
 
-LabelAbbr *StaffGrp::GetLabelAbbrCopy()
+LabelAbbr *StaffGrp::GetLabelAbbrCopy() const
 {
     // Always check if HasClefInfo() is true before asking for a clone
     LabelAbbr *clone = dynamic_cast<LabelAbbr *>(this->GetLabelAbbr()->Clone());

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -234,7 +234,7 @@ int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *)
 {
     this->SetDrawingVisibility(OPTIMIZATION_HIDDEN);
 
-    for (auto &child : *this->GetChildren()) {
+    for (auto child : this->GetChildren()) {
         if (child->Is(STAFFDEF)) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(child);
             assert(staffDef);
@@ -254,7 +254,7 @@ int StaffGrp::ScoreDefOptimizeEnd(FunctorParams *)
     }
 
     if ((this->GetSymbol() == staffGroupingSym_SYMBOL_brace) && (this->GetDrawingVisibility() != OPTIMIZATION_HIDDEN)) {
-        for (auto &child : *this->GetChildren()) {
+        for (auto child : this->GetChildren()) {
             if (child->Is(STAFFDEF)) {
                 StaffDef *staffDef = vrv_cast<StaffDef *>(child);
                 assert(staffDef);

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -55,26 +55,26 @@ bool Surface::IsSupportedChild(Object *object)
     return true;
 }
 
-int Surface::GetMaxX()
+int Surface::GetMaxX() const
 {
     if (this->HasLrx()) return this->GetLrx();
     int max = 0;
-    ListOfObjects zones = this->FindAllDescendantsByType(ZONE);
+    ListOfConstObjects zones = this->FindAllDescendantsByType(ZONE);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
-        Zone *zone = vrv_cast<Zone *>(*iter);
+        const Zone *zone = vrv_cast<const Zone *>(*iter);
         assert(zone);
         max = (zone->GetLrx() > max) ? zone->GetLrx() : max;
     }
     return max;
 }
 
-int Surface::GetMaxY()
+int Surface::GetMaxY() const
 {
     if (this->HasLry()) return this->GetLry();
     int max = 0;
-    ListOfObjects zones = this->FindAllDescendantsByType(ZONE);
+    ListOfConstObjects zones = this->FindAllDescendantsByType(ZONE);
     for (auto iter = zones.begin(); iter != zones.end(); ++iter) {
-        Zone *zone = vrv_cast<Zone *>(*iter);
+        const Zone *zone = vrv_cast<const Zone *>(*iter);
         assert(zone);
         max = (zone->GetLry() > max) ? zone->GetLry() : max;
     }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1060,8 +1060,8 @@ int System::CastOffPages(FunctorParams *functorParams)
         Object *nextSystem = params->m_contentPage->GetNext(this, SYSTEM);
         Object *lastSystem = params->m_currentPage->GetLast(SYSTEM);
         if (!nextSystem && lastSystem && (this == params->m_leftoverSystem)) {
-            ArrayOfObjects *children = this->GetChildrenForModification();
-            for (Object *child : *children) {
+            ArrayOfObjects &children = this->GetChildrenForModification();
+            for (Object *child : children) {
                 child->MoveItselfTo(lastSystem);
             }
             return FUNCTOR_SIBLINGS;

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -64,15 +64,15 @@ void TabDurSym::AddChild(Object *child)
 
     child->SetParent(this);
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is(STEM)) {
-        children->insert(children->begin(), child);
+        children.insert(children.begin(), child);
     }
     else {
-        children->push_back(child);
+        children.push_back(child);
     }
     Modify();
 }

--- a/src/textdirinterface.cpp
+++ b/src/textdirinterface.cpp
@@ -36,12 +36,11 @@ void TextDirInterface::Reset()
     this->ResetPlacementRelStaff();
 }
 
-int TextDirInterface::GetNumberOfLines(Object *object)
+int TextDirInterface::GetNumberOfLines(const Object *object) const
 {
     assert(object);
 
-    ListOfObjects lbs = object->FindAllDescendantsByType(LB);
-    return ((int)lbs.size() + 1);
+    return object->GetDescendantCount(LB) + 1;
 }
 
 } // namespace vrv

--- a/src/textelement.cpp
+++ b/src/textelement.cpp
@@ -61,13 +61,13 @@ int TextElement::GetDrawingX() const
     // No cache for text elements
 
     // First get the first layerElement parent (if any) and use its position if they share the same alignment
-    Object *textElement = this->GetFirstAncestorInRange(TEXT_ELEMENT, TEXT_ELEMENT_max);
+    const Object *textElement = this->GetFirstAncestorInRange(TEXT_ELEMENT, TEXT_ELEMENT_max);
     if (textElement) {
         return (textElement->GetDrawingX() + this->GetDrawingXRel());
     }
 
     // Otherwise get the running element parent - no cast to RunningElement is necessary
-    Object *runningElement = this->GetFirstAncestorInRange(RUNNING_ELEMENT, RUNNING_ELEMENT_max);
+    const Object *runningElement = this->GetFirstAncestorInRange(RUNNING_ELEMENT, RUNNING_ELEMENT_max);
     if (runningElement) {
         return (runningElement->GetDrawingX() + this->GetDrawingXRel());
     }
@@ -80,13 +80,13 @@ int TextElement::GetDrawingY() const
     // No cache for text elements
 
     // First get the first layerElement parent (if any) and use its position if they share the same alignment
-    Object *textElement = this->GetFirstAncestorInRange(TEXT_ELEMENT, TEXT_ELEMENT_max);
+    const Object *textElement = this->GetFirstAncestorInRange(TEXT_ELEMENT, TEXT_ELEMENT_max);
     if (textElement) {
         return (textElement->GetDrawingY() + this->GetDrawingYRel());
     }
 
     // Otherwise get the running element parent - no cast to RunningElement is necessary
-    Object *runningElement = this->GetFirstAncestorInRange(RUNNING_ELEMENT, RUNNING_ELEMENT_max);
+    const Object *runningElement = this->GetFirstAncestorInRange(RUNNING_ELEMENT, RUNNING_ELEMENT_max);
     if (runningElement) {
         return (runningElement->GetDrawingY() + this->GetDrawingYRel());
     }

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -55,7 +55,7 @@ bool Tuning::IsSupportedChild(Object *child)
     return true;
 }
 
-int Tuning::CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines)
+int Tuning::CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines) const
 {
     switch (notationType) {
         case NOTATIONTYPE_tab_lute_french:
@@ -67,7 +67,7 @@ int Tuning::CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines)
     }
 }
 
-int Tuning::CalcPitchNumber(int course, int fret, data_NOTATIONTYPE notationType)
+int Tuning::CalcPitchNumber(int course, int fret, data_NOTATIONTYPE notationType) const
 {
     // Use <tuning><course>s, if available
     // else use @tuning.standard, if available
@@ -75,7 +75,7 @@ int Tuning::CalcPitchNumber(int course, int fret, data_NOTATIONTYPE notationType
 
     // Do we have the tuning for this course?
     AttNNumberLikeComparison cnc(COURSE, std::to_string(course));
-    Course *courseTuning = vrv_cast<Course *>(this->FindDescendantByComparison(&cnc));
+    const Course *courseTuning = vrv_cast<const Course *>(this->FindDescendantByComparison(&cnc));
 
     if (courseTuning && courseTuning->HasPname() && courseTuning->HasOct()) {
 

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -126,15 +126,15 @@ void Tuplet::AddChild(Object *child)
 
     child->SetParent(this);
 
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // Num and bracket are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
     if (child->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
-        children->insert(children->begin(), child);
+        children.insert(children.begin(), child);
     }
     else {
-        children->push_back(child);
+        children.push_back(child);
     }
 
     Modify();

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -62,7 +62,7 @@ StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc
 
     if (idx < this->GetChildCount()) {
         children.push_back(m_bottomAlignment);
-        return dynamic_cast<StaffAlignment *>(this->GetChildren().at(idx));
+        return dynamic_cast<StaffAlignment *>(this->GetChild(idx));
     }
     // check that we are searching for the next one (not a gap)
     assert(idx == this->GetChildCount());
@@ -87,7 +87,7 @@ StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN)
 {
     StaffAlignment *alignment = NULL;
     for (int i = 0; i < this->GetChildCount(); ++i) {
-        alignment = vrv_cast<StaffAlignment *>(this->GetChildren().at(i));
+        alignment = vrv_cast<StaffAlignment *>(this->GetChild(i));
         assert(alignment);
 
         if ((alignment->GetStaff()) && (alignment->GetStaff()->GetN() == staffN)) return alignment;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -493,10 +493,10 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
 {
     assert(doc);
 
-    Object *parent = this->GetParent();
+    const Object *parent = this->GetParent();
     assert(parent);
 
-    StaffAlignment *prevAlignment = dynamic_cast<StaffAlignment *>(parent->GetPrevious(this));
+    const StaffAlignment *prevAlignment = dynamic_cast<const StaffAlignment *>(parent->GetPrevious(this));
 
     if (!prevAlignment) {
         const int maxOverflow = std::max(this->GetOverflowAbove(), this->GetScoreDefClefOverflowAbove());

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -52,17 +52,17 @@ void SystemAligner::Reset()
 
 StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc)
 {
-    ArrayOfObjects *children = this->GetChildrenForModification();
+    ArrayOfObjects &children = this->GetChildrenForModification();
 
     // The last one is always the bottomAlignment (unless if not created)
     if (m_bottomAlignment) {
         // remove it temporarily
-        children->pop_back();
+        children.pop_back();
     }
 
     if (idx < this->GetChildCount()) {
-        children->push_back(m_bottomAlignment);
-        return dynamic_cast<StaffAlignment *>(this->GetChildren()->at(idx));
+        children.push_back(m_bottomAlignment);
+        return dynamic_cast<StaffAlignment *>(this->GetChildren().at(idx));
     }
     // check that we are searching for the next one (not a gap)
     assert(idx == this->GetChildCount());
@@ -74,20 +74,20 @@ StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc
     alignment->SetStaff(staff, doc, this->GetAboveSpacingType(staff));
     alignment->SetParent(this);
     alignment->SetParentSystem(this->GetSystem());
-    children->push_back(alignment);
+    children.push_back(alignment);
 
     if (m_bottomAlignment) {
-        children->push_back(m_bottomAlignment);
+        children.push_back(m_bottomAlignment);
     }
 
     return alignment;
 }
 
-StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN) const
+StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN)
 {
     StaffAlignment *alignment = NULL;
     for (int i = 0; i < this->GetChildCount(); ++i) {
-        alignment = vrv_cast<StaffAlignment *>(this->GetChildren()->at(i));
+        alignment = vrv_cast<StaffAlignment *>(this->GetChildren().at(i));
         assert(alignment);
 
         if ((alignment->GetStaff()) && (alignment->GetStaff()->GetN() == staffN)) return alignment;
@@ -111,7 +111,7 @@ void SystemAligner::FindAllPositionerPointingTo(ArrayOfFloatingPositioners *posi
     positioners->clear();
 
     StaffAlignment *alignment = NULL;
-    for (const auto child : *this->GetChildren()) {
+    for (const auto child : this->GetChildren()) {
         alignment = vrv_cast<StaffAlignment *>(child);
         assert(alignment);
         FloatingPositioner *positioner = alignment->GetCorrespFloatingPositioner(object);
@@ -125,7 +125,7 @@ void SystemAligner::FindAllIntersectionPoints(
     SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin)
 {
     StaffAlignment *alignment = NULL;
-    for (const auto child : *this->GetChildren()) {
+    for (const auto child : this->GetChildren()) {
         alignment = vrv_cast<StaffAlignment *>(child);
         assert(alignment);
         alignment->FindAllIntersectionPoints(line, boundingBox, classIds, margin);
@@ -136,7 +136,7 @@ int SystemAligner::GetOverflowAbove(const Doc *, bool scoreDefClef) const
 {
     if (!this->GetChildCount() || this->GetChild(0) == m_bottomAlignment) return 0;
 
-    StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(0));
+    const StaffAlignment *alignment = vrv_cast<const StaffAlignment *>(this->GetChild(0));
     assert(alignment);
     int overflowAbove = scoreDefClef ? alignment->GetScoreDefClefOverflowAbove() : alignment->GetOverflowAbove();
     return overflowAbove;
@@ -146,7 +146,7 @@ int SystemAligner::GetOverflowBelow(const Doc *doc, bool scoreDefClef) const
 {
     if (!this->GetChildCount() || this->GetChild(0) == m_bottomAlignment) return 0;
 
-    StaffAlignment *alignment = vrv_cast<StaffAlignment *>(this->GetChild(this->GetChildCount() - 2));
+    const StaffAlignment *alignment = vrv_cast<const StaffAlignment *>(this->GetChild(this->GetChildCount() - 2));
     assert(alignment);
     int overflowBelow = scoreDefClef ? alignment->GetScoreDefClefOverflowBelow() : alignment->GetOverflowBelow();
     return overflowBelow;
@@ -157,8 +157,8 @@ double SystemAligner::GetJustificationSum(const Doc *doc) const
     assert(doc);
 
     double justificationSum = 0.;
-    for (const auto child : *this->GetChildren()) {
-        StaffAlignment *alignment = dynamic_cast<StaffAlignment *>(child);
+    for (const auto child : this->GetChildren()) {
+        const StaffAlignment *alignment = dynamic_cast<const StaffAlignment *>(child);
         justificationSum += alignment ? alignment->GetJustificationFactor(doc) : 0.;
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1671,7 +1671,7 @@ void View::DrawFb(DeviceContext *dc, Staff *staff, Fb *fb, TextDrawingParams &pa
     dc->SetBrush(m_currentColour, AxSOLID);
     dc->SetFont(fontDim);
 
-    for (auto current : *fb->GetChildren()) {
+    for (auto current : fb->GetChildren()) {
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), HORIZONTALALIGNMENT_left);
         if (current->Is(FIGURE)) {
             // dynamic_cast assert in DrawF

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -89,7 +89,7 @@ void View::DrawCurrentPage(DeviceContext *dc, bool background)
 
     dc->StartPage();
 
-    for (auto child : *m_currentPage->GetChildren()) {
+    for (auto child : m_currentPage->GetChildren()) {
         if (child->IsPageElement()) {
             // cast to PageElement check in DrawSystemEditorial element
             this->DrawPageElement(dc, dynamic_cast<PageElement *>(child));
@@ -1545,7 +1545,7 @@ void View::DrawSystemChildren(DeviceContext *dc, Object *parent, System *system)
     assert(parent);
     assert(system);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->Is(MEASURE)) {
             // cast to Measure check in DrawMeasure
             this->DrawMeasure(dc, dynamic_cast<Measure *>(current), system);
@@ -1584,7 +1584,7 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
     assert(measure);
     assert(system);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->Is(STAFF)) {
             // cast to Staff check in DrawStaff
             this->DrawStaff(dc, dynamic_cast<Staff *>(current), measure, system);
@@ -1611,7 +1611,7 @@ void View::DrawStaffChildren(DeviceContext *dc, Object *parent, Staff *staff, Me
     assert(staff);
     assert(measure);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->Is(LAYER)) {
             // cast to Layer check in DrawLayer
             this->DrawLayer(dc, dynamic_cast<Layer *>(current), staff, measure);
@@ -1634,7 +1634,7 @@ void View::DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, St
     assert(staff);
     assert(measure);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->IsLayerElement()) {
             this->DrawLayerElement(dc, dynamic_cast<LayerElement *>(current), layer, staff, measure);
         }
@@ -1664,7 +1664,7 @@ void View::DrawTextChildren(DeviceContext *dc, Object *parent, TextDrawingParams
         }
     }
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->IsTextElement()) {
             this->DrawTextElement(dc, dynamic_cast<TextElement *>(current), params);
         }
@@ -1683,7 +1683,7 @@ void View::DrawFbChildren(DeviceContext *dc, Object *parent, TextDrawingParams &
     assert(dc);
     assert(parent);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->IsTextElement()) {
             this->DrawTextElement(dc, dynamic_cast<TextElement *>(current), params);
         }
@@ -1702,7 +1702,7 @@ void View::DrawRunningChildren(DeviceContext *dc, Object *parent, TextDrawingPar
     assert(dc);
     assert(parent);
 
-    for (auto current : *parent->GetChildren()) {
+    for (auto current : parent->GetChildren()) {
         if (current->Is(FIG)) {
             this->DrawFig(dc, dynamic_cast<Fig *>(current), params);
         }


### PR DESCRIPTION
So far any element method such as `LayerElement::IsGraceNote` that (directly or indirectly) relies on descendant search cannot be made const even though it changes nothing. This PR resolves this by providing const versions for the major tree search methods. Since descendant search relies on functors we further provide the possibility to implement functors as const. The PR also includes various applications on how to use tree search in a const setting.

**Technical remarks:**

- If a function returns a pointer, then its const overload should usually return a const pointer.

- In order to avoid code duplication for const overloads, the const version of the method should be implemented and the non-const version should rely on the const version via the [following pattern:](https://stackoverflow.com/questions/123758/how-do-i-remove-code-duplication-between-similar-const-and-non-const-member-func)
```cpp
return const_cast<T *>(std::as_const(*this).f(args));
```

- Other usages of `const_cast` often indicate that something is wrong with const correctness. There are two cases where `const_cast` was introduced in the PR: (1) To access interfaces from comparisons. This is temporary and will be resolved in a later PR that improves const correctness for interfaces. (2) To update the current score in the document from a const functor. I am a bit unhappy about this, but didn't find a good solution for this now. I think that storing the current score at one central point leads to trouble when running functors (i.e. descendant search) within functors and should therefore be reconsidered.
