### PR TITLE
Add option to limit page justification

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -594,6 +594,7 @@ public:
     OptionBool m_mensuralToMeasure;
     OptionDbl m_midiTempoAdjustment;
     OptionDbl m_minLastJustification;
+    OptionDbl m_maxSingleSystemJustification;
     OptionBool m_mmOutput;
     OptionIntMap m_footer;
     OptionIntMap m_header;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -594,7 +594,6 @@ public:
     OptionBool m_mensuralToMeasure;
     OptionDbl m_midiTempoAdjustment;
     OptionDbl m_minLastJustification;
-    OptionDbl m_maxVerticalJustification;
     OptionBool m_mmOutput;
     OptionIntMap m_footer;
     OptionIntMap m_header;
@@ -658,6 +657,7 @@ public:
     OptionDbl m_justificationBracketGroup;
     OptionDbl m_justificationStaff;
     OptionDbl m_justificationSystem;
+    OptionDbl m_justificationMaxVertical;
     OptionDbl m_ledgerLineThickness;
     OptionDbl m_ledgerLineExtension;
     OptionDbl m_lyricHyphenLength;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -594,7 +594,7 @@ public:
     OptionBool m_mensuralToMeasure;
     OptionDbl m_midiTempoAdjustment;
     OptionDbl m_minLastJustification;
-    OptionDbl m_maxSingleSystemJustification;
+    OptionDbl m_maxVerticalJustification;
     OptionBool m_mmOutput;
     OptionIntMap m_footer;
     OptionIntMap m_header;

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -193,6 +193,11 @@ private:
      */
     void AdjustSylSpacingByVerse(PrepareProcessingListsParams &listsParams, Doc *doc);
 
+    /**
+     * Check whether vertical justification is required for the current page
+     */
+    bool IsJustificationRequired(Doc *doc);
+
     //
 public:
     /** Page width (MEI scoredef@page.width). Saved if != -1 */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -975,6 +975,12 @@ Options::Options()
     m_minLastJustification.Init(0.8, 0.0, 1.0);
     this->Register(&m_minLastJustification, "minLastJustification", &m_general);
 
+    m_maxSingleSystemJustification.SetInfo("Maximum ratio of justifiable height for single system pages",
+        "Pages with single system are jutified vertically only if ratio of justifiable height to page height is lower "
+        "than this percent");
+    m_maxSingleSystemJustification.Init(0.3, 0.0, 1.0);
+    this->Register(&m_maxSingleSystemJustification, "maxSingleSystemJustification", &m_general);
+
     m_mmOutput.SetInfo("MM output", "Specify that the output in the SVG is given in mm (default is px)");
     m_mmOutput.Init(false);
     this->Register(&m_mmOutput, "mmOutput", &m_general);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -975,11 +975,10 @@ Options::Options()
     m_minLastJustification.Init(0.8, 0.0, 1.0);
     this->Register(&m_minLastJustification, "minLastJustification", &m_general);
 
-    m_maxSingleSystemJustification.SetInfo("Maximum ratio of justifiable height for single system pages",
-        "Pages with single system are jutified vertically only if ratio of justifiable height to page height is lower "
-        "than this percent");
-    m_maxSingleSystemJustification.Init(0.3, 0.0, 1.0);
-    this->Register(&m_maxSingleSystemJustification, "maxSingleSystemJustification", &m_general);
+    m_maxVerticalJustification.SetInfo("Maximum ratio of justifiable height for page",
+        "Pages are justified vertically only if ratio of justifiable height to page height is lower than this percent");
+    m_maxVerticalJustification.Init(0.3, 0.0, 1.0);
+    this->Register(&m_maxVerticalJustification, "maxVerticalJustification", &m_general);
 
     m_mmOutput.SetInfo("MM output", "Specify that the output in the SVG is given in mm (default is px)");
     m_mmOutput.Init(false);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -975,11 +975,6 @@ Options::Options()
     m_minLastJustification.Init(0.8, 0.0, 1.0);
     this->Register(&m_minLastJustification, "minLastJustification", &m_general);
 
-    m_maxVerticalJustification.SetInfo("Maximum ratio of justifiable height for page",
-        "Maximum ratio of justifiable height to page height that can be used for the vertical justification");
-    m_maxVerticalJustification.Init(0.3, 0.0, 1.0);
-    this->Register(&m_maxVerticalJustification, "maxVerticalJustification", &m_general);
-
     m_mmOutput.SetInfo("MM output", "Specify that the output in the SVG is given in mm (default is px)");
     m_mmOutput.Init(false);
     this->Register(&m_mmOutput, "mmOutput", &m_general);
@@ -1228,6 +1223,11 @@ Options::Options()
         "Spacing brace group justification", "Space between staves inside a braced group justification");
     m_justificationBraceGroup.Init(1., 0., 10.);
     this->Register(&m_justificationBraceGroup, "justificationBraceGroup", &m_generalLayout);
+
+    m_justificationMaxVertical.SetInfo("Maximum ratio of justifiable height for page",
+        "Maximum ratio of justifiable height to page height that can be used for the vertical justification");
+    m_justificationMaxVertical.Init(0.3, 0.0, 1.0);
+    this->Register(&m_justificationMaxVertical, "justificationMaxVertical", &m_general);
 
     m_ledgerLineThickness.SetInfo("Ledger line thickness", "The thickness of the ledger lines");
     m_ledgerLineThickness.Init(0.25, 0.10, 0.50);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -976,7 +976,7 @@ Options::Options()
     this->Register(&m_minLastJustification, "minLastJustification", &m_general);
 
     m_maxVerticalJustification.SetInfo("Maximum ratio of justifiable height for page",
-        "Pages are justified vertically only if ratio of justifiable height to page height is lower than this percent");
+        "Maximum ratio of justifiable height to page height that can be used for the vertical justification");
     m_maxVerticalJustification.Init(0.3, 0.0, 1.0);
     this->Register(&m_maxVerticalJustification, "maxVerticalJustification", &m_general);
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -665,9 +665,9 @@ bool Page::IsJustificationRequired(Doc *doc)
         }
     }
     const double ratio = (double)m_drawingJustifiableHeight / (double)doc->m_drawingPageHeight;
-    if (ratio > doc->GetOptions()->m_maxVerticalJustification.GetValue()) {
+    if (ratio > doc->GetOptions()->m_justificationMaxVertical.GetValue()) {
         m_drawingJustifiableHeight
-            = doc->m_drawingPageHeight * doc->GetOptions()->m_maxVerticalJustification.GetValue();
+            = doc->m_drawingPageHeight * doc->GetOptions()->m_justificationMaxVertical.GetValue();
     }
 
     return true;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -619,9 +619,9 @@ void Page::JustifyVertically()
     // Last page and justification of last page is not enabled
     Pages *pages = doc->GetPages();
     assert(pages);
+    const int childSystems = this->GetChildCount(SYSTEM);
     if (pages->GetLast() == this) {
         int idx = this->GetIdx();
-        const int childSystems = this->GetChildCount(SYSTEM);
         if (idx > 0) {
             Page *penultimatePage = dynamic_cast<Page *>(pages->GetPrevious(this));
             assert(penultimatePage);
@@ -638,6 +638,13 @@ void Page::JustifyVertically()
         else {
             const int stavesPerSystem = m_drawingScoreDef.GetDescendantCount(STAFFDEF);
             if (childSystems * stavesPerSystem < 8) return;
+        }
+    }
+    else if (childSystems == 1) {
+        const double ratio = (double)m_drawingJustifiableHeight / (double)doc->m_drawingPageHeight;
+        if (ratio > doc->GetOptions()->m_maxSingleSystemJustification.GetValue()) {
+            m_drawingJustifiableHeight = 0;
+            return;
         }
     }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -617,7 +617,7 @@ void Page::JustifyVertically()
     }
 
     // Ignore vertical justification if it's not required
-    if (!IsJustificationRequired(doc)) return;
+    if (!this->IsJustificationRequired(doc)) return;
 
     // Justify Y position
     Functor justifyY(&Object::JustifyY);
@@ -640,21 +640,16 @@ bool Page::IsJustificationRequired(Doc *doc)
     Pages *pages = doc->GetPages();
     assert(pages);
 
-    const int idx = this->GetIdx();
-    int previousJustifiableHeight = 0;
-    int previousJustificationSum = 0;
-    // get values from the previous page
-    if (idx > 0) {
-        Page *previousPage = dynamic_cast<Page *>(pages->GetPrevious(this));
-        assert(previousPage);
-        previousJustifiableHeight = previousPage->m_drawingJustifiableHeight;
-        previousJustificationSum = previousPage->m_justificationSum;
-    }
-
     const int childSystems = this->GetChildCount(SYSTEM);
     // Last page and justification of last page is not enabled
     if (pages->GetLast() == this) {
+        const int idx = this->GetIdx();
         if (idx > 0) {
+            Page *previousPage = dynamic_cast<Page *>(pages->GetPrevious(this));
+            assert(previousPage);
+            const int previousJustifiableHeight = previousPage->m_drawingJustifiableHeight;
+            const int previousJustificationSum = previousPage->m_justificationSum;
+
             if (previousJustifiableHeight < m_drawingJustifiableHeight) {
                 m_drawingJustifiableHeight = previousJustifiableHeight;
             }
@@ -671,7 +666,8 @@ bool Page::IsJustificationRequired(Doc *doc)
     }
     const double ratio = (double)m_drawingJustifiableHeight / (double)doc->m_drawingPageHeight;
     if (ratio > doc->GetOptions()->m_maxVerticalJustification.GetValue()) {
-        m_drawingJustifiableHeight = previousJustifiableHeight;
+        m_drawingJustifiableHeight
+            = doc->m_drawingPageHeight * doc->GetOptions()->m_maxVerticalJustification.GetValue();
     }
 
     return true;

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -661,7 +661,7 @@ bool Page::IsJustificationRequired(Doc *doc)
         }
         else {
             const int stavesPerSystem = m_drawingScoreDef.GetDescendantCount(STAFFDEF);
-            if (childSystems * stavesPerSystem < 8) return;
+            if (childSystems * stavesPerSystem < 8) return false;
         }
     }
     const double ratio = (double)m_drawingJustifiableHeight / (double)doc->m_drawingPageHeight;


### PR DESCRIPTION
Add option `--max-vertical-justification` to limit justification of the systems on page to certain ratio.
It specifies ratio of justifiable height to page height, and enforces justification to that value. This is useful for cases where there is only one system per page which ends up being stretched to fit height of the page.
Value of 1 pretty much disables this feature, returning previous functionality.
Value of 0 functions in the same way, as if there was no justification enabled.
Default value is set to **30% (0.3)** of the page.