### PR TITLE
Support s-shaped cross staff slurs

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -265,7 +265,7 @@ public:
     /**
      * @name Initialize control point height and offset from end point positions
      */
-    void CalcInitialControlPointParams(Doc *doc, float angle, int staffSize);
+    void CalcInitialControlPointParams(Doc *doc, bool isConvex, float angle, int staffSize);
 
     /**
      * Calculate control point offset and height from points or vice versa

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -204,6 +204,17 @@ public:
     }
 };
 
+//----------------------------------------------------------------------------
+// RelPositions
+//----------------------------------------------------------------------------
+/**
+ * This indicates positions for point pairs
+ */
+struct RelPositions {
+    bool isStartAbove;
+    bool isEndAbove;
+};
+
 // ---------------------------------------------------------------------------
 // BezierCurve
 // ---------------------------------------------------------------------------
@@ -260,8 +271,8 @@ public:
      * Calculate control point offset and height from points or vice versa
      */
     ///@{
-    void UpdateControlPointParams(curvature_CURVEDIR dir);
-    void UpdateControlPoints(curvature_CURVEDIR dir);
+    void UpdateControlPointParams(const RelPositions &controlPointPos);
+    void UpdateControlPoints(const RelPositions &controlPointPos);
     ///@}
 
 private:

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -204,17 +204,6 @@ public:
     }
 };
 
-//----------------------------------------------------------------------------
-// RelPositions
-//----------------------------------------------------------------------------
-/**
- * This indicates positions for point pairs
- */
-struct RelPositions {
-    bool isStartAbove;
-    bool isEndAbove;
-};
-
 // ---------------------------------------------------------------------------
 // BezierCurve
 // ---------------------------------------------------------------------------
@@ -241,14 +230,11 @@ public:
      * @name Getter/setter for control point offset (as well as method to calculate it from options)
      */
     ///@{
-    void SetControlPointOffset(int controlPointOffset)
-    {
-        m_leftControlPointOffset = m_rightControlPointOffset = controlPointOffset;
-    };
-    void SetLeftControlPointOffset(int height) { m_leftControlPointOffset = height; }
-    void SetRightControlPointOffset(int height) { m_rightControlPointOffset = height; }
-    int GetLeftControlPointOffset() const { return m_leftControlPointOffset; }
-    int GetRightControlPointOffset() const { return m_rightControlPointOffset; }
+    void SetControlOffset(int offset) { m_leftControlOffset = m_rightControlOffset = offset; }
+    void SetLeftControlOffset(int offset) { m_leftControlOffset = offset; }
+    void SetRightControlOffset(int offset) { m_rightControlOffset = offset; }
+    int GetLeftControlOffset() const { return m_leftControlOffset; }
+    int GetRightControlOffset() const { return m_rightControlOffset; }
     ///@}
 
     /**
@@ -263,24 +249,35 @@ public:
     ///@}
 
     /**
+     * @name Getter/setter for the side of the control points (left and right)
+     */
+    ///@{
+    void SetControlSides(bool leftAbove, bool rightAbove);
+    bool IsLeftControlAbove() const { return m_leftControlAbove; }
+    bool IsRightControlAbove() const { return m_rightControlAbove; }
+    ///@}
+
+    /**
      * @name Initialize control point height and offset from end point positions
      */
-    void CalcInitialControlPointParams(Doc *doc, bool isConvex, float angle, int staffSize);
+    void CalcInitialControlPointParams(Doc *doc, float angle, int staffSize);
 
     /**
      * Calculate control point offset and height from points or vice versa
      */
     ///@{
-    void UpdateControlPointParams(const RelPositions &controlPointPos);
-    void UpdateControlPoints(const RelPositions &controlPointPos);
+    void UpdateControlPointParams();
+    void UpdateControlPoints();
     ///@}
 
 private:
     // Control point X-axis offset for both start/end points
-    int m_leftControlPointOffset = 0;
-    int m_rightControlPointOffset = 0;
+    int m_leftControlOffset = 0;
+    int m_rightControlOffset = 0;
     int m_leftControlHeight = 0;
     int m_rightControlHeight = 0;
+    bool m_leftControlAbove = true;
+    bool m_rightControlAbove = true;
 
     // no copy ctor or assignment operator - the defaults are ok
 };

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -310,9 +310,13 @@ public:
      */
     ///@{
     int CalcAdjustment(BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
+    int CalcDirectionalAdjustment(
+        BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin = 0, bool horizontalOverlap = true);
     // Refined version that returns the adjustments on the left and right hand side of the bounding box
     std::pair<int, int> CalcLeftRightAdjustment(
         BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
+    std::pair<int, int> CalcDirectionalLeftRightAdjustment(
+        BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin = 0, bool horizontalOverlap = true);
     ///@}
 
     /**

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -391,14 +391,14 @@ public:
     {
         m_boundingBox = NULL;
         m_discarded = false;
-        m_isAbove = false;
+        m_isBelow = true;
     }
     virtual ~CurveSpannedElement(){};
 
     Point m_rotatedPoints[4];
     BoundingBox *m_boundingBox;
     bool m_discarded;
-    bool m_isAbove;
+    bool m_isBelow;
 };
 
 } // namespace vrv

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -341,7 +341,7 @@ public:
     void AddSpannedElement(CurveSpannedElement *spannedElement) { m_spannedElements.push_back(spannedElement); }
 
     /**
-     * Return a cont pointer to the spanned elements
+     * Return a const pointer to the spanned elements
      */
     const ArrayOfCurveSpannedElements *GetSpannedElements() { return &m_spannedElements; }
 
@@ -353,6 +353,19 @@ public:
     Staff *GetCrossStaff() const { return m_crossStaff; }
     bool IsCrossStaff() const { return m_crossStaff != NULL; }
     ///@}
+
+    /**
+     * @name Getter, setter for the requested staff space
+     */
+    ///@{
+    void SetRequestedStaffSpace(int space) { m_requestedStaffSpace = space; }
+    int GetRequestedStaffSpace() const { return m_requestedStaffSpace; }
+    ///@}
+
+    /**
+     * Calculate the requested staff space above and below
+     */
+    std::pair<int, int> CalcRequestedStaffSpace(StaffAlignment *alignment);
 
 private:
     //
@@ -375,6 +388,11 @@ private:
 
     /** The cached min or max value (depending on the curvature) */
     int m_cachedMinMaxY;
+
+    /**
+     * Some curves (S-shaped slurs) can request staff space to prevent collisions from two sides
+     */
+    int m_requestedStaffSpace;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -387,12 +387,14 @@ public:
     {
         m_boundingBox = NULL;
         m_discarded = false;
+        m_isAbove = false;
     }
     virtual ~CurveSpannedElement(){};
 
     Point m_rotatedPoints[4];
     BoundingBox *m_boundingBox;
     bool m_discarded;
+    bool m_isAbove;
 };
 
 } // namespace vrv

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -126,6 +126,14 @@ public:
     Staff *CalculateExtremalStaff(Staff *staff, int xMin, int xMax, char spanningType);
 
     /**
+     * Determine whether a layer element should lie above or below the slur
+     */
+    ///@{
+    bool IsElementAbove(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
+    bool IsElementAbove(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
+    ///@}
+
+    /**
      * Slur adjustment
      */
     ///@{

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -155,6 +155,11 @@ public:
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
     ///@}
 
+    /**
+     * Calculate the staff space above and below requested by s-shaped slurs
+     */
+    std::pair<int, int> CalcRequestedStaffSpace(StaffAlignment *alignment);
+
     //----------//
     // Functors //
     //----------//
@@ -178,6 +183,8 @@ private:
     std::pair<Layer *, LayerElement *> GetBoundaryLayer();
     // Get cross staff by only considering the slur boundary
     Staff *GetBoundaryCrossStaff();
+    // Determine curve direction for the slurs that start at grace note
+    curvature_CURVEDIR GetGraceCurveDirection(Doc *doc);
     // Get preferred curve direction based on various conditions
     curvature_CURVEDIR GetPreferredCurveDirection(Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
     ///@}
@@ -213,9 +220,6 @@ private:
     ControlPointAdjustment CalcControlPointVerticalShift(
         FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
-    // Helper function to determine curve direction for the slurs that start at grace note
-    curvature_CURVEDIR GetGraceCurveDirection(Doc *doc);
-
     // Solve the constraints for vertical control point adjustment
     std::pair<int, int> SolveControlPointConstraints(const std::list<ControlPointConstraint> &constraints);
 
@@ -248,6 +252,12 @@ private:
      * for s-shaped slurs / mixed direction: whether the slur goes upwards or downwards
      */
     SlurCurveDirection m_drawingCurveDir;
+
+    /**
+     * The requested staff space
+     * S-shaped slurs can request staff space to prevent collisions from two sides
+     */
+    int m_requestedStaffSpace;
 };
 
 } // namespace vrv

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -32,6 +32,19 @@ struct ControlPointConstraint {
     double c;
 };
 
+//----------------------------------------------------------------------------
+// ControlPointAdjustment
+//----------------------------------------------------------------------------
+/**
+ * A vertical adjustment of bezier control points
+ */
+struct ControlPointAdjustment {
+    int leftShift;
+    int rightShift;
+    bool moveUpwards;
+    int requestedStaffSpace;
+};
+
 // Helper enum classes
 enum class SlurCurveDirection { None, Above, Below, MixedDownwards, MixedUpwards };
 enum class PortatoSlurType { None, StemSide, Centered };
@@ -197,7 +210,7 @@ private:
         FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical control point shift
-    std::pair<int, int> CalcControlPointVerticalShift(
+    ControlPointAdjustment CalcControlPointVerticalShift(
         FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Helper function to determine curve direction for the slurs that start at grace note

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -32,17 +32,6 @@ struct ControlPointConstraint {
     double c;
 };
 
-//----------------------------------------------------------------------------
-// RelBoundaryPositions
-//----------------------------------------------------------------------------
-/**
- * This indicates the slur endpoint positions with respect to the targeted elements
- */
-struct RelBoundaryPositions {
-    bool isStartAbove;
-    bool isEndAbove;
-};
-
 // Helper enum classes
 enum class PortatoSlurType { None, StemSide, Centered };
 
@@ -91,13 +80,13 @@ public:
     /**
      * Determines the relative boundary positions from the drawing curve direction
      */
-    RelBoundaryPositions GetRelBoundaryPositions();
+    RelPositions GetRelBoundaryPositions();
 
     /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
-    std::pair<Point, Point> AdjustCoordinates(Doc *doc, Staff *staff, std::pair<Point, Point> points, int spanningType,
-        const RelBoundaryPositions &boundaryPos);
+    std::pair<Point, Point> AdjustCoordinates(
+        Doc *doc, Staff *staff, std::pair<Point, Point> points, int spanningType, const RelPositions &boundaryPos);
 
     /**
      * Determine layer elements spanned by the slur
@@ -150,14 +139,12 @@ private:
      */
     ///@{
     // Retrieve the start and end note locations of the slur
-    std::pair<int, int> GetStartEndLocs(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord,
-        const RelBoundaryPositions &boundaryPos) const;
+    std::pair<int, int> GetStartEndLocs(
+        Note *startNote, Chord *startChord, Note *endNote, Chord *endChord, const RelPositions &boundaryPos) const;
     // Calculate the break location at system start/end and the pitch difference
-    std::pair<int, int> CalcBrokenLoc(
-        Staff *staff, int startLoc, int endLoc, const RelBoundaryPositions &boundaryPos) const;
+    std::pair<int, int> CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, const RelPositions &boundaryPos) const;
     // Check if the slur resembles portato
-    PortatoSlurType IsPortatoSlur(
-        Doc *doc, Note *startNote, Chord *startChord, const RelBoundaryPositions &boundaryPos) const;
+    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord, const RelPositions &boundaryPos) const;
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -89,7 +89,7 @@ public:
     SlurCurveDirection GetDrawingCurveDir() const { return m_drawingCurveDir; }
     void SetDrawingCurveDir(SlurCurveDirection curveDir) { m_drawingCurveDir = curveDir; }
     bool HasDrawingCurveDir() const { return (m_drawingCurveDir != SlurCurveDirection::None); }
-    curvature_CURVEDIR ReduceDrawingCurveDir() const;
+    curvature_CURVEDIR CalcDrawingCurveDir(char spanningType) const;
     ///@}
 
     /**
@@ -126,7 +126,8 @@ public:
     /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
-    std::pair<Point, Point> AdjustCoordinates(Doc *doc, Staff *staff, std::pair<Point, Point> points, int spanningType);
+    std::pair<Point, Point> AdjustCoordinates(
+        Doc *doc, Staff *staff, std::pair<Point, Point> points, char spanningType);
 
     /**
      * Determine layer elements spanned by the slur
@@ -145,6 +146,11 @@ public:
     bool IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
     bool IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
     ///@}
+
+    /**
+     * Set the bezier control sides depending on the curve direction
+     */
+    void InitBezierControlSides(BezierCurve &bezier, curvature_CURVEDIR curveDir) const;
 
     /**
      * Slur adjustment

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -46,7 +46,7 @@ struct ControlPointAdjustment {
 };
 
 // Helper enum classes
-enum class SlurCurveDirection { None, Above, Below, MixedDownwards, MixedUpwards };
+enum class SlurCurveDirection { None, Above, Below, AboveBelow, BelowAbove };
 enum class PortatoSlurType { None, StemSide, Centered };
 
 //----------------------------------------------------------------------------
@@ -98,28 +98,28 @@ public:
     ///@{
     bool HasMixedCurveDir() const
     {
-        return (m_drawingCurveDir == SlurCurveDirection::MixedDownwards)
-            || (m_drawingCurveDir == SlurCurveDirection::MixedUpwards);
+        return (m_drawingCurveDir == SlurCurveDirection::AboveBelow)
+            || (m_drawingCurveDir == SlurCurveDirection::BelowAbove);
     }
     bool HasEndpointAboveStart() const
     {
         return (m_drawingCurveDir == SlurCurveDirection::Above)
-            || (m_drawingCurveDir == SlurCurveDirection::MixedUpwards);
+            || (m_drawingCurveDir == SlurCurveDirection::AboveBelow);
     }
     bool HasEndpointBelowStart() const
     {
         return (m_drawingCurveDir == SlurCurveDirection::Below)
-            || (m_drawingCurveDir == SlurCurveDirection::MixedDownwards);
+            || (m_drawingCurveDir == SlurCurveDirection::BelowAbove);
     }
     bool HasEndpointAboveEnd() const
     {
         return (m_drawingCurveDir == SlurCurveDirection::Above)
-            || (m_drawingCurveDir == SlurCurveDirection::MixedDownwards);
+            || (m_drawingCurveDir == SlurCurveDirection::BelowAbove);
     }
     bool HasEndpointBelowEnd() const
     {
         return (m_drawingCurveDir == SlurCurveDirection::Below)
-            || (m_drawingCurveDir == SlurCurveDirection::MixedUpwards);
+            || (m_drawingCurveDir == SlurCurveDirection::AboveBelow);
     }
     ///@}
 
@@ -255,7 +255,7 @@ private:
     /**
      * The drawing curve direction
      * This is calculated in the PrepareSlurs functor and contains an additional distinction
-     * for s-shaped slurs / mixed direction: whether the slur goes upwards or downwards
+     * for s-shaped slurs / mixed direction
      */
     SlurCurveDirection m_drawingCurveDir;
 

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -215,7 +215,7 @@ private:
      */
     ///@{
     // Shift end points for collisions nearby
-    void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection) const;
+    void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection, bool isBelow) const;
 
     // Rebalance shifts to avoid awkward tilting of short slurs
     void RebalanceShifts(int &shiftLeft, int &shiftRight, double distance, int unit) const;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -32,6 +32,17 @@ struct ControlPointConstraint {
     double c;
 };
 
+//----------------------------------------------------------------------------
+// RelBoundaryPositions
+//----------------------------------------------------------------------------
+/**
+ * This indicates the slur endpoint positions with respect to the targeted elements
+ */
+struct RelBoundaryPositions {
+    bool isStartAbove;
+    bool isEndAbove;
+};
+
 // Helper enum classes
 enum class PortatoSlurType { None, StemSide, Centered };
 
@@ -78,10 +89,15 @@ public:
     ///@}
 
     /**
+     * Determines the relative boundary positions from the drawing curve direction
+     */
+    RelBoundaryPositions GetRelBoundaryPositions();
+
+    /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
-    std::pair<Point, Point> AdjustCoordinates(
-        Doc *doc, Staff *staff, std::pair<Point, Point> points, int spanningType, curvature_CURVEDIR drawingCurveDir);
+    std::pair<Point, Point> AdjustCoordinates(Doc *doc, Staff *staff, std::pair<Point, Point> points, int spanningType,
+        const RelBoundaryPositions &boundaryPos);
 
     /**
      * Determine layer elements spanned by the slur
@@ -134,12 +150,14 @@ private:
      */
     ///@{
     // Retrieve the start and end note locations of the slur
-    std::pair<int, int> GetStartEndLocs(
-        Note *startNote, Chord *startChord, Note *endNote, Chord *endChord, curvature_CURVEDIR dir) const;
+    std::pair<int, int> GetStartEndLocs(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord,
+        const RelBoundaryPositions &boundaryPos) const;
     // Calculate the break location at system start/end and the pitch difference
-    std::pair<int, int> CalcBrokenLoc(Staff *staff, int startLoc, int endLoc, curvature_CURVEDIR dir) const;
+    std::pair<int, int> CalcBrokenLoc(
+        Staff *staff, int startLoc, int endLoc, const RelBoundaryPositions &boundaryPos) const;
     // Check if the slur resembles portato
-    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord, curvature_CURVEDIR curveDir) const;
+    PortatoSlurType IsPortatoSlur(
+        Doc *doc, Note *startNote, Chord *startChord, const RelBoundaryPositions &boundaryPos) const;
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -161,11 +161,6 @@ public:
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
     ///@}
 
-    /**
-     * Calculate the staff space above and below requested by s-shaped slurs
-     */
-    std::pair<int, int> CalcRequestedStaffSpace(StaffAlignment *alignment);
-
     //----------//
     // Functors //
     //----------//
@@ -258,12 +253,6 @@ private:
      * for s-shaped slurs / mixed direction
      */
     SlurCurveDirection m_drawingCurveDir;
-
-    /**
-     * The requested staff space
-     * S-shaped slurs can request staff space to prevent collisions from two sides
-     */
-    int m_requestedStaffSpace;
 };
 
 } // namespace vrv

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -129,8 +129,8 @@ public:
      * Determine whether a layer element should lie above or below the slur
      */
     ///@{
-    bool IsElementAbove(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
-    bool IsElementAbove(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
+    bool IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
+    bool IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
     ///@}
 
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -218,7 +218,7 @@ public:
     const AttSpacing *GetAttSpacing() const;
 
     /**
-     * @name Calculates the overlow (above or below for the bounding box.
+     * @name Calculates the overflow (above or below) for the bounding box.
      * Looks if the bounding box is a FloatingPositioner or not, in which case it we take into account its m_drawingYRel
      * value.
      */
@@ -245,6 +245,10 @@ public:
     int GetOverflowBelow() const { return m_overflowBelow; }
     void SetOverlap(int overlap);
     int GetOverlap() const { return m_overlap; }
+    void SetRequestedSpaceAbove(int space);
+    int GetRequestedSpaceAbove() const { return m_requestedSpaceAbove; }
+    void SetRequestedSpaceBelow(int space);
+    int GetRequestedSpaceBelow() const { return m_requestedSpaceBelow; }
     int GetStaffHeight() const { return m_staffHeight; }
     void SetOverflowBBoxAbove(BoundingBox *bboxAbove, int overflowAbove);
     BoundingBox *GetOverflowBBoxAbove() const { return m_overflowBBoxAbove; }
@@ -385,12 +389,14 @@ private:
     std::set<int> m_verseNs;
 
     /**
-     * @name values for storing the overlow and overlap
+     * @name values for storing the overflow and overlap
      */
     ///@{
     int m_overflowAbove;
     int m_overflowBelow;
     int m_overlap;
+    int m_requestedSpaceAbove;
+    int m_requestedSpaceBelow;
     int m_staffHeight;
     BoundingBox *m_overflowBBoxAbove;
     BoundingBox *m_overflowBBoxBelow;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -55,21 +55,23 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     this->SetControlHeight(height);
 }
 
-void BezierCurve::UpdateControlPointParams(curvature_CURVEDIR dir)
+void BezierCurve::UpdateControlPointParams(const RelPositions &controlPointPos)
 {
     m_leftControlPointOffset = c1.x - p1.x;
     m_rightControlPointOffset = p2.x - c2.x;
-    const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
+    int sign = controlPointPos.isStartAbove ? 1 : -1;
     m_leftControlHeight = sign * (c1.y - p1.y);
+    sign = controlPointPos.isEndAbove ? 1 : -1;
     m_rightControlHeight = sign * (c2.y - p2.y);
 }
 
-void BezierCurve::UpdateControlPoints(curvature_CURVEDIR dir)
+void BezierCurve::UpdateControlPoints(const RelPositions &controlPointPos)
 {
     c1.x = p1.x + m_leftControlPointOffset;
     c2.x = p2.x - m_rightControlPointOffset;
-    const int sign = (dir == curvature_CURVEDIR_above) ? 1 : -1;
+    int sign = controlPointPos.isStartAbove ? 1 : -1;
     c1.y = p1.y + sign * m_leftControlHeight;
+    sign = controlPointPos.isEndAbove ? 1 : -1;
     c2.y = p2.y + sign * m_rightControlHeight;
 }
 

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -63,16 +63,16 @@ void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staff
     m_rightControlOffset = offset;
 
     // Initialize height
-    int height = 1.2 * unit;
+    int height = 0;
     if (m_leftControlAbove == m_rightControlAbove) {
-        height = std::max(dist / 5, height);
+        height = std::max<int>(dist / 5, 1.2 * unit);
         height = std::min(3 * unit, height);
         height *= doc->GetOptions()->m_slurCurveFactor.GetValue();
         height = std::min(height, 2 * doc->GetDrawingOctaveSize(staffSize));
         height = std::min<int>(height, 2 * offset * cos(angle));
     }
     else {
-        height = std::max(height, std::abs(p2.y - p1.y));
+        height = std::max(std::abs(p2.y - p1.y), 4 * unit);
         height *= doc->GetOptions()->m_slurCurveFactor.GetValue();
     }
     this->SetControlHeight(height);

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -518,7 +518,8 @@ void FloatingCurvePositioner::ResetCurveParams()
     m_dir = curvature_CURVEDIR_NONE;
     m_crossStaff = NULL;
     m_cachedMinMaxY = VRV_UNSET;
-    ClearSpannedElements();
+    m_requestedStaffSpace = 0;
+    this->ClearSpannedElements();
 }
 
 void FloatingCurvePositioner::UpdateCurveParams(
@@ -720,6 +721,32 @@ void FloatingCurvePositioner::GetPoints(Point points[4]) const
     points[1].y += currentY;
     points[2].y += currentY;
     points[3].y += currentY;
+}
+
+std::pair<int, int> FloatingCurvePositioner::CalcRequestedStaffSpace(StaffAlignment *alignment)
+{
+    assert(alignment);
+
+    TimeSpanningInterface *interface = this->GetObject()->GetTimeSpanningInterface();
+    if (interface) {
+        Staff *startStaff = interface->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
+        Staff *endStaff = interface->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
+
+        if (startStaff && endStaff) {
+            const int startStaffN = startStaff->GetN();
+            const int endStaffN = endStaff->GetN();
+            if (startStaffN != endStaffN) {
+                if (alignment->GetStaff()->GetN() == std::min(startStaffN, endStaffN)) {
+                    return { 0, m_requestedStaffSpace };
+                }
+                if (alignment->GetStaff()->GetN() == std::max(startStaffN, endStaffN)) {
+                    return { m_requestedStaffSpace, 0 };
+                }
+            }
+        }
+    }
+
+    return { 0, 0 };
 }
 
 //----------------------------------------------------------------------------

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -469,6 +469,11 @@ void Page::LayOutVertically()
     Functor calcLedgerLinesEnd(&Object::CalcLedgerLinesEnd);
     this->Process(&calcLedgerLines, &calcLedgerLinesParams, &calcLedgerLinesEnd);
 
+    // Calculate the slur direction
+    PrepareSlursParams prepareSlursParams(doc);
+    Functor prepareSlurs(&Object::PrepareSlurs);
+    this->Process(&prepareSlurs, &prepareSlursParams);
+
     // Align the content of the page using system aligners
     // After this:
     // - each Staff object will then have its StaffAlignment pointer initialized

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -430,6 +430,11 @@ void Page::LayOutHorizontally()
     Functor alignMeasuresEnd(&Object::AlignMeasuresEnd);
     this->Process(&alignMeasures, &alignMeasuresParams, &alignMeasuresEnd);
 
+    // Calculate the slur direction
+    PrepareSlursParams prepareSlursParams(doc);
+    Functor prepareSlurs(&Object::PrepareSlurs);
+    this->Process(&prepareSlurs, &prepareSlursParams);
+
     FunctorDocParams resolveSpanningBeamSpansParams(doc);
     Functor resolveSpanningBeamSpans(&Object::ResolveSpanningBeamSpans);
     this->Process(&resolveSpanningBeamSpans, &resolveSpanningBeamSpansParams);
@@ -463,11 +468,6 @@ void Page::LayOutVertically()
     Functor calcLedgerLines(&Object::CalcLedgerLines);
     Functor calcLedgerLinesEnd(&Object::CalcLedgerLinesEnd);
     this->Process(&calcLedgerLines, &calcLedgerLinesParams, &calcLedgerLinesEnd);
-
-    // Calculate the slur direction
-    PrepareSlursParams prepareSlursParams(doc);
-    Functor prepareSlurs(&Object::PrepareSlurs);
-    this->Process(&prepareSlurs, &prepareSlursParams);
 
     // Align the content of the page using system aligners
     // After this:

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -430,11 +430,6 @@ void Page::LayOutHorizontally()
     Functor alignMeasuresEnd(&Object::AlignMeasuresEnd);
     this->Process(&alignMeasures, &alignMeasuresParams, &alignMeasuresEnd);
 
-    // Calculate the slur direction
-    PrepareSlursParams prepareSlursParams(doc);
-    Functor prepareSlurs(&Object::PrepareSlurs);
-    this->Process(&prepareSlurs, &prepareSlursParams);
-
     FunctorDocParams resolveSpanningBeamSpansParams(doc);
     Functor resolveSpanningBeamSpans(&Object::ResolveSpanningBeamSpans);
     this->Process(&resolveSpanningBeamSpans, &resolveSpanningBeamSpansParams);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -306,28 +306,28 @@ Staff *Slur::CalculateExtremalStaff(Staff *staff, int xMin, int xMax, char spann
     return extremalStaff;
 }
 
-bool Slur::IsElementAbove(LayerElement *element, Staff *startStaff, Staff *endStaff) const
+bool Slur::IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const
 {
     switch (this->GetDrawingCurveDir()) {
-        case SlurCurveDirection::Above: return false;
-        case SlurCurveDirection::Below: return true;
+        case SlurCurveDirection::Above: return true;
+        case SlurCurveDirection::Below: return false;
         case SlurCurveDirection::MixedDownwards:
-            return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == startStaff->GetN());
-        case SlurCurveDirection::MixedUpwards:
             return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == endStaff->GetN());
+        case SlurCurveDirection::MixedUpwards:
+            return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == startStaff->GetN());
         default: return false;
     }
 }
 
-bool Slur::IsElementAbove(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const
+bool Slur::IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const
 {
     switch (this->GetDrawingCurveDir()) {
-        case SlurCurveDirection::Above: return false;
-        case SlurCurveDirection::Below: return true;
+        case SlurCurveDirection::Above: return true;
+        case SlurCurveDirection::Below: return false;
         case SlurCurveDirection::MixedDownwards:
-            return (positioner->GetAlignment()->GetStaff()->GetN() == startStaff->GetN());
-        case SlurCurveDirection::MixedUpwards:
             return (positioner->GetAlignment()->GetStaff()->GetN() == endStaff->GetN());
+        case SlurCurveDirection::MixedUpwards:
+            return (positioner->GetAlignment()->GetStaff()->GetN() == startStaff->GetN());
         default: return false;
     }
 }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -108,18 +108,18 @@ curvature_CURVEDIR Slur::CalcDrawingCurveDir(char spanningType) const
     switch (m_drawingCurveDir) {
         case SlurCurveDirection::Above: return curvature_CURVEDIR_above;
         case SlurCurveDirection::Below: return curvature_CURVEDIR_below;
-        case SlurCurveDirection::MixedDownwards: {
-            switch (spanningType) {
-                case SPANNING_START_END: return curvature_CURVEDIR_mixed;
-                case SPANNING_START: return curvature_CURVEDIR_below;
-                default: return curvature_CURVEDIR_above;
-            }
-        }
-        case SlurCurveDirection::MixedUpwards: {
+        case SlurCurveDirection::AboveBelow: {
             switch (spanningType) {
                 case SPANNING_START_END: return curvature_CURVEDIR_mixed;
                 case SPANNING_START: return curvature_CURVEDIR_above;
                 default: return curvature_CURVEDIR_below;
+            }
+        }
+        case SlurCurveDirection::BelowAbove: {
+            switch (spanningType) {
+                case SPANNING_START_END: return curvature_CURVEDIR_mixed;
+                case SPANNING_START: return curvature_CURVEDIR_below;
+                default: return curvature_CURVEDIR_above;
             }
         }
         default: return curvature_CURVEDIR_NONE;
@@ -324,10 +324,10 @@ bool Slur::IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endSt
     switch (this->GetDrawingCurveDir()) {
         case SlurCurveDirection::Above: return true;
         case SlurCurveDirection::Below: return false;
-        case SlurCurveDirection::MixedDownwards:
-            return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == endStaff->GetN());
-        case SlurCurveDirection::MixedUpwards:
+        case SlurCurveDirection::AboveBelow:
             return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == startStaff->GetN());
+        case SlurCurveDirection::BelowAbove:
+            return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == endStaff->GetN());
         default: return false;
     }
 }
@@ -337,10 +337,10 @@ bool Slur::IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Sta
     switch (this->GetDrawingCurveDir()) {
         case SlurCurveDirection::Above: return true;
         case SlurCurveDirection::Below: return false;
-        case SlurCurveDirection::MixedDownwards:
-            return (positioner->GetAlignment()->GetStaff()->GetN() == endStaff->GetN());
-        case SlurCurveDirection::MixedUpwards:
+        case SlurCurveDirection::AboveBelow:
             return (positioner->GetAlignment()->GetStaff()->GetN() == startStaff->GetN());
+        case SlurCurveDirection::BelowAbove:
+            return (positioner->GetAlignment()->GetStaff()->GetN() == endStaff->GetN());
         default: return false;
     }
 }
@@ -1424,11 +1424,11 @@ int Slur::PrepareSlurs(FunctorParams *functorParams)
         const int startStaffN = start->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN();
         const int endStaffN = end->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN();
         if (startStaffN < endStaffN) {
-            this->SetDrawingCurveDir(SlurCurveDirection::MixedDownwards);
+            this->SetDrawingCurveDir(SlurCurveDirection::BelowAbove);
             return FUNCTOR_CONTINUE;
         }
         else if (startStaffN > endStaffN) {
-            this->SetDrawingCurveDir(SlurCurveDirection::MixedUpwards);
+            this->SetDrawingCurveDir(SlurCurveDirection::AboveBelow);
             return FUNCTOR_CONTINUE;
         }
         else {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1044,8 +1044,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             //  d(^)d
-            else if (isSshaped || isShortSlur) {
+            else if (isShortSlur) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+            }
+            // s-shaped slurs
+            else if (isSshaped) {
+                y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {
@@ -1090,8 +1095,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             // P(_)P
-            else if (isSshaped || isShortSlur) {
+            else if (isShortSlur) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+            }
+            // s-shaped slurs
+            else if (isSshaped) {
+                y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {
@@ -1135,9 +1145,15 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             // d(^)d
-            else if (isSshaped || isShortSlur) {
+            else if (isShortSlur) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
+            // s-shaped slurs
+            else if (isSshaped) {
+                y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+            }
+            // grace note
             else if (isGraceToNoteSlur) {
                 const int yMin = y1 - unit * 4;
                 const int yTop = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
@@ -1190,8 +1206,13 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                     x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
             }
-            else if (isSshaped || isShortSlur) {
+            else if (isShortSlur) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+            }
+            // s-shaped slurs
+            else if (isSshaped) {
+                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
             // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -301,6 +301,9 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     assert(curve);
     assert(staff);
 
+    // For now we disable collision avoidance for s-slurs
+    if (curve->GetDir() == curvature_CURVEDIR_mixed) return;
+
     Point points[4];
     curve->GetPoints(points);
     BezierCurve bezier(points[0], points[1], points[2], points[3]);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -904,6 +904,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
         assert(endChord);
     }
 
+    const bool isSshaped = this->HasMixedCurveDir();
     const bool isGraceToNoteSlur
         = !start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && start->IsGraceNote() && !end->IsGraceNote();
 
@@ -933,7 +934,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             //  d(^)d
-            else if (isShortSlur) {
+            else if (isSshaped || isShortSlur) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             // portato slurs
@@ -979,7 +980,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             // P(_)P
-            else if (isShortSlur) {
+            else if (isSshaped || isShortSlur) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             // portato slurs
@@ -1024,7 +1025,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             // d(^)d
-            else if (isShortSlur) {
+            else if (isSshaped || isShortSlur) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
             }
             else if (isGraceToNoteSlur) {
@@ -1068,9 +1069,6 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             // P(_)P
-            else if (isShortSlur && !isGraceToNoteSlur) {
-                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
-            }
             else if (isGraceToNoteSlur) {
                 const int yMax = y1 + unit;
                 const int yBottom = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
@@ -1081,6 +1079,9 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
                 else {
                     x2 -= endRadius + 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
                 }
+            }
+            else if (isSshaped || isShortSlur) {
+                y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             }
             // portato slurs
             else if (portatoSlurType != PortatoSlurType::None) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -100,7 +100,6 @@ void Slur::Reset()
     this->ResetLayerIdent();
 
     m_drawingCurveDir = SlurCurveDirection::None;
-    m_requestedStaffSpace = 0;
 }
 
 curvature_CURVEDIR Slur::CalcDrawingCurveDir(char spanningType) const
@@ -422,7 +421,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     bezier.SetRightControlHeight(bezier.GetRightControlHeight() + rightSign * adjustment.rightShift);
     bezier.UpdateControlPoints();
     curve->UpdatePoints(bezier);
-    m_requestedStaffSpace = adjustment.requestedStaffSpace;
+    curve->SetRequestedStaffSpace(adjustment.requestedStaffSpace);
 
     // STEP 5: Adjust the slur shape
     // Through the control point adjustments in step 3 and 4 it can happen that the slur looses its desired shape.
@@ -816,29 +815,6 @@ double Slur::RotateSlope(double slope, double degrees, double doublingBound, boo
     if (!upwards && (slope <= -doublingBound)) return slope * 2.0;
     const int sign = upwards ? 1 : -1;
     return tan(atan(slope) + sign * M_PI * degrees / 180.0);
-}
-
-std::pair<int, int> Slur::CalcRequestedStaffSpace(StaffAlignment *alignment)
-{
-    assert(alignment);
-
-    Staff *startStaff = this->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
-    Staff *endStaff = this->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
-
-    if (startStaff && endStaff) {
-        const int startStaffN = startStaff->GetN();
-        const int endStaffN = endStaff->GetN();
-        if (startStaffN != endStaffN) {
-            if (alignment->GetStaff()->GetN() == std::min(startStaffN, endStaffN)) {
-                return { 0, m_requestedStaffSpace };
-            }
-            if (alignment->GetStaff()->GetN() == std::max(startStaffN, endStaffN)) {
-                return { m_requestedStaffSpace, 0 };
-            }
-        }
-    }
-
-    return { 0, 0 };
 }
 
 float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -792,13 +792,10 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
 
             int spaceAbove = 0;
             int spaceBelow = 0;
-            if ((*iter)->GetObject()->Is({ LV, SLUR })) {
-                Slur *slur = vrv_cast<Slur *>((*iter)->GetObject());
-                assert(slur);
-                std::tie(spaceAbove, spaceBelow) = slur->CalcRequestedStaffSpace(this);
-                this->SetRequestedSpaceAbove(spaceAbove);
-                this->SetRequestedSpaceBelow(spaceBelow);
-            }
+            std::tie(spaceAbove, spaceBelow) = curve->CalcRequestedStaffSpace(this);
+            this->SetRequestedSpaceAbove(spaceAbove);
+            this->SetRequestedSpaceBelow(spaceBelow);
+
             continue;
         }
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -197,7 +197,7 @@ float View::CalcInitialSlur(
             || ((pRight.x > bezier.p1.x) && (pRight.x < bezier.p2.x))) {
             CurveSpannedElement *spannedElement = new CurveSpannedElement();
             spannedElement->m_boundingBox = element;
-            spannedElement->m_isAbove = slur->IsElementAbove(element, startStaff, endStaff);
+            spannedElement->m_isBelow = slur->IsElementBelow(element, startStaff, endStaff);
             curve->AddSpannedElement(spannedElement);
         }
 
@@ -225,7 +225,7 @@ float View::CalcInitialSlur(
                 && (positioner->GetContentLeft() < bezier.p2.x)) {
                 CurveSpannedElement *spannedElement = new CurveSpannedElement();
                 spannedElement->m_boundingBox = positioner;
-                spannedElement->m_isAbove = slur->IsElementAbove(positioner, startStaff, endStaff);
+                spannedElement->m_isBelow = slur->IsElementBelow(positioner, startStaff, endStaff);
                 curve->AddSpannedElement(spannedElement);
             }
         }

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -182,7 +182,7 @@ float View::CalcInitialSlur(
 
     Staff *startStaff = slur->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
     Staff *endStaff = slur->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
-    if (startStaff && endStaff && (startStaff != endStaff)) {
+    if (startStaff && endStaff && (startStaff->GetN() != endStaff->GetN())) {
         curve->SetCrossStaff(endStaff);
     }
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -178,7 +178,7 @@ float View::CalcInitialSlur(
 {
     // For now we pick C1 = P1 and C2 = P2
     BezierCurve bezier(points[0], points[0], points[3], points[3]);
-    slur->InitBezierControlSides(bezier, curve->GetDir());
+    slur->InitBezierControlSides(bezier, curveDir);
 
     /************** content **************/
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -197,6 +197,7 @@ float View::CalcInitialSlur(
             || ((pRight.x > bezier.p1.x) && (pRight.x < bezier.p2.x))) {
             CurveSpannedElement *spannedElement = new CurveSpannedElement();
             spannedElement->m_boundingBox = element;
+            spannedElement->m_isAbove = slur->IsElementAbove(element, startStaff, endStaff);
             curve->AddSpannedElement(spannedElement);
         }
 
@@ -224,6 +225,7 @@ float View::CalcInitialSlur(
                 && (positioner->GetContentLeft() < bezier.p2.x)) {
                 CurveSpannedElement *spannedElement = new CurveSpannedElement();
                 spannedElement->m_boundingBox = positioner;
+                spannedElement->m_isAbove = slur->IsElementAbove(positioner, startStaff, endStaff);
                 curve->AddSpannedElement(spannedElement);
             }
         }

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -100,7 +100,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 
     if (!start || !end) return;
 
-    const curvature_CURVEDIR drawingCurveDir = slur->ReduceDrawingCurveDir();
+    const curvature_CURVEDIR drawingCurveDir = slur->CalcDrawingCurveDir(spanningType);
 
     /************** adjusting y position **************/
 
@@ -111,10 +111,15 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 
     /************** y position **************/
 
-    int sign = slur->HasEndpointAboveStart() ? 1 : -1;
+    int sign = (drawingCurveDir == curvature_CURVEDIR_above) ? 1 : -1;
+    if (drawingCurveDir == curvature_CURVEDIR_mixed) {
+        sign = slur->HasEndpointAboveStart() ? 1 : -1;
+    }
     adjustedPoints.first.y += 1.25 * sign * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
-    sign = slur->HasEndpointAboveEnd() ? 1 : -1;
+    if (drawingCurveDir == curvature_CURVEDIR_mixed) {
+        sign = slur->HasEndpointAboveEnd() ? 1 : -1;
+    }
     adjustedPoints.second.y += 1.25 * sign * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     Point points[4];
@@ -173,7 +178,7 @@ float View::CalcInitialSlur(
 {
     // For now we pick C1 = P1 and C2 = P2
     BezierCurve bezier(points[0], points[0], points[3], points[3]);
-    bezier.SetControlSides(slur->HasEndpointAboveStart(), slur->HasEndpointAboveEnd());
+    slur->InitBezierControlSides(bezier, curve->GetDir());
 
     /************** content **************/
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -101,7 +101,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     if (!start || !end) return;
 
     const curvature_CURVEDIR drawingCurveDir = slur->GetDrawingCurvedir();
-    const RelBoundaryPositions boundaryPos = slur->GetRelBoundaryPositions();
+    const RelPositions boundaryPos = slur->GetRelBoundaryPositions();
 
     /************** adjusting y position **************/
 
@@ -243,8 +243,9 @@ float View::CalcInitialSlur(
 
     /************** control points **************/
 
+    const RelPositions controlPointPos = slur->GetRelBoundaryPositions();
     bezier.CalcInitialControlPointParams(m_doc, slurAngle, staff->m_drawingStaffSize);
-    bezier.UpdateControlPoints(curveDir);
+    bezier.UpdateControlPoints(controlPointPos);
     bezier.Rotate(slurAngle, bezier.p1);
 
     points[0] = bezier.p1;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -101,24 +101,22 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     if (!start || !end) return;
 
     const curvature_CURVEDIR drawingCurveDir = slur->GetDrawingCurvedir();
+    const RelBoundaryPositions boundaryPos = slur->GetRelBoundaryPositions();
 
     /************** adjusting y position **************/
 
     int y1 = staff->GetDrawingY();
     int y2 = staff->GetDrawingY();
     std::pair<Point, Point> adjustedPoints = slur->AdjustCoordinates(
-        m_doc, staff, std::make_pair(Point(x1, y1), Point(x2, y2)), spanningType, drawingCurveDir);
+        m_doc, staff, std::make_pair(Point(x1, y1), Point(x2, y2)), spanningType, boundaryPos);
 
     /************** y position **************/
 
-    if (drawingCurveDir == curvature_CURVEDIR_above) {
-        adjustedPoints.first.y += 1.25 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        adjustedPoints.second.y += 1.25 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    }
-    else {
-        adjustedPoints.first.y -= 1.25 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        adjustedPoints.second.y -= 1.25 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    }
+    int sign = boundaryPos.isStartAbove ? 1 : -1;
+    adjustedPoints.first.y += 1.25 * sign * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+
+    sign = boundaryPos.isEndAbove ? 1 : -1;
+    adjustedPoints.second.y += 1.25 * sign * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     Point points[4];
     points[0] = adjustedPoints.first;


### PR DESCRIPTION
This PR adds support for s-shaped cross staff slurs and closes #1583 .

<img width="678" alt="S-slurs4" src="https://user-images.githubusercontent.com/63608463/155732130-93fb5887-5ae6-4c1b-84bb-0fafd2f2d4a0.png">

The main changes involve support for the initial rendering of the s-shape and tracking signs in order to deal with collisions from two sides. Furthermore s-shaped slurs can request the addition of staff space when collisions happen from both sides.

Another example:
<img width="1483" alt="S-slurs3" src="https://user-images.githubusercontent.com/63608463/155733130-33d175ab-ab89-4281-907b-aa405d21288e.png">

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
 <meiHead>
  <fileDesc>
   <titleStmt>
   </titleStmt>
   <pubStmt>
   </pubStmt>
  </fileDesc>
  <encodingDesc xml:id="encodingdesc-opxjj4">
   <appInfo xml:id="appinfo-5skeys">
    <application xml:id="application-fwbl7x" isodate="2022-02-07T17:32:26" version="3.9.0-dev-6332b7e">
     <name xml:id="name-i64343">Verovio</name>
     <p xml:id="p-odu21t">Transcoded from MusicXML</p>
    </application>
   </appInfo>
  </encodingDesc>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mt9fp2q">
    <score xml:id="s24ma82">
     <scoreDef xml:id="sjlw3o2">
      <staffGrp xml:id="P2" bar.thru="true">
        <label xml:id="ltqjtcr">Piano</label>
        <instrDef xml:id="ikq4w97" midi.channel="1" midi.instrnum="0" midi.volume="78.00%" />
        <staffDef xml:id="s3psp84" n="2" lines="5" ppq="12">
         <clef xml:id="c36o8y9" shape="G" line="2" />
         <keySig xml:id="k49z14r" sig="2f" />
         <meterSig xml:id="mmm9knh" count="4" sym="common" unit="4" />
        </staffDef>
        <staffDef xml:id="s6v5z9o" n="3" lines="5" ppq="12">
         <clef xml:id="cv3h3kz" shape="F" line="4" />
         <keySig xml:id="k1qgehb" sig="2f" />
         <meterSig xml:id="mxazv3p" count="4" sym="common" unit="4" />
        </staffDef>
        <grpSym xml:id="gunom6r" symbol="brace" />
      </staffGrp>
     </scoreDef>
     <section xml:id="slruy1t">
      <pb xml:id="p7m2ec6" />
      <measure xml:id="mld2utm" n="0">
       <mNum xml:id="m6ana2r" />
       <staff xml:id="syyrfcl" n="2">
        <layer xml:id="lfq4tfc" n="1">
         <note xml:id="nybrrhe" dur.ppq="12" dur="4" oct="5" pname="f" stem.dir="down" />
        </layer>
       </staff>
       <staff xml:id="sk4d8l7" n="3">
        <layer xml:id="lnpm7xs" n="5">
         <rest xml:id="rb9qck1" dur.ppq="12" dur="4" />
        </layer>
       </staff>
       <tempo xml:id="tz1im66" place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="92.000000">
        <rend xml:id="rhokuix" fontweight="bold">Andante</rend>
        <lb xml:id="lxzh4ev" />Con molto espress.<lb xml:id="lpim9c8" />
       </tempo>
       <dynam xml:id="d2wcr7b" place="below" staff="2" tstamp="1.000000" val="49" vgrp="40">p</dynam>
      </measure>
      <measure xml:id="mc3pvmx" n="1">
       <staff xml:id="ssyjpae" n="2">
        <layer xml:id="l91ia7j" n="1">
         <note xml:id="nl8zhe3" dur.ppq="12" dur="4" oct="5" pname="f" stem.dir="down" />
         <note xml:id="ncdycm8" dur.ppq="12" dur="4" oct="5" pname="f" stem.dir="down" />
         <note xml:id="nht8ta0" dots="1" dur.ppq="18" dur="4" oct="6" pname="d" stem.dir="down" />
         <note xml:id="n1usd42" dur="8" oct="6" pname="f" grace="unacc" stem.dir="up" stem.mod="1slash" />
         <note xml:id="ngb4o9q" dur.ppq="6" dur="8" oct="6" pname="e" stem.dir="down" accid.ges="f" />
        </layer>
       </staff>
       <staff xml:id="stvzh8e" n="3">
        <layer xml:id="lel7fuo" n="5">
         <beam xml:id="bx3mjr9">
          <note xml:id="n5q7mei" dur.ppq="6" dur="8" oct="2" pname="f" stem.dir="down" />
          <note xml:id="nelbrux" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" />
          <chord xml:id="cwfs2ac" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nrvg6s3" oct="3" pname="a" />
           <note xml:id="ncjxq6f" oct="4" pname="c" />
           <note xml:id="n3z2nb5" oct="4" pname="e" accid.ges="f" />
          </chord>
          <note xml:id="nt84i2m" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" />
         </beam>
         <beam xml:id="bcti8di">
          <note xml:id="nimfxo5" dur.ppq="6" dur="8" oct="2" pname="b" stem.dir="down" accid.ges="f" />
          <note xml:id="n9izbg" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" />
          <chord xml:id="c4gfb88" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nb46i0r" oct="3" pname="b" accid.ges="f" />
           <note xml:id="n3v6iu9" oct="4" pname="d" />
          </chord>
          <note xml:id="n8p6kuq" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" />
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-1" startid="#n5q7mei" endid="#ngb4o9q" curvedir="mixed" />
      </measure>
      <measure xml:id="md3r1ii" n="2">
       <staff xml:id="s5x6pjj" n="2">
        <layer xml:id="l9yuwep" n="1">
         <beam xml:id="bgczvz4">
          <note xml:id="nirlx0f" dur.ppq="6" dur="8" oct="6" pname="d" stem.dir="down" />
          <note xml:id="n6oz6ep" dur.ppq="6" dur="8" oct="6" pname="c" stem.dir="down" />
          <note xml:id="nu0b41u" dur.ppq="6" dur="8" oct="5" pname="b" stem.dir="down" accid.ges="f" />
          <note xml:id="nnci5z4" dur.ppq="3" dur="16" oct="6" pname="d" stem.dir="down" />
          <note xml:id="ns980nr" dur.ppq="3" dur="16" oct="6" pname="c" stem.dir="down" />
         </beam>
         <note xml:id="ncnojc2" dur.ppq="12" dur="4" oct="5" pname="b" stem.dir="down" accid.ges="f" />
         <rest xml:id="rq55ltv" dur.ppq="6" dur="8" />
         <note xml:id="n4n19qp" dur.ppq="6" dur="8" oct="5" pname="b" stem.dir="down" accid.ges="f" />
        </layer>
       </staff>
       <staff xml:id="srs4i6k" n="3">
        <layer xml:id="l7u3r1i" n="5">
         <beam xml:id="bu4k1kl">
          <note xml:id="n1ya64q" dur.ppq="6" dur="8" oct="2" pname="f" stem.dir="down" accid="s" />
          <note xml:id="n9erbnw" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" accid="s" />
          <chord xml:id="ce57d28" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="n4eq2a3" oct="3" pname="a" />
           <note xml:id="n782o0p" oct="4" pname="c" />
           <note xml:id="nn8gd8i" oct="4" pname="e" accid.ges="f" />
          </chord>
          <note xml:id="n8orphf" dur.ppq="6" dur="8" oct="3" pname="f" stem.dir="down" accid.ges="s" />
         </beam>
         <beam xml:id="b2k6wi">
          <note xml:id="nca8sya" dur.ppq="6" dur="8" oct="2" pname="g" stem.dir="down" />
          <note xml:id="nktab00" dur.ppq="6" dur="8" oct="3" pname="g" stem.dir="down" />
          <chord xml:id="c4b08sr" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="n13hqcx" oct="3" pname="b" accid.ges="f" />
           <note xml:id="nvehpte" oct="4" pname="d" />
          </chord>
          <note xml:id="nrm1xa5" dur.ppq="6" dur="8" oct="3" pname="g" stem.dir="down" />
         </beam>
        </layer>
       </staff>
       <slur xml:id="s1gy797" startid="#nirlx0f" endid="#ns980nr" curvedir="above" />
       <slur xml:id="slur-2" startid="#nirlx0f" endid="#nrm1xa5" curvedir="mixed" />
       <mordent xml:id="mgabgnq" staff="2" startid="#nirlx0f" form="upper" />
       <turn xml:id="tdzxgh6" staff="2" startid="#nu0b41u" form="upper" />
      </measure>
      <measure xml:id="mbtk18z" n="3">
       <staff xml:id="slzh434" n="2">
        <layer xml:id="ltuq1nu" n="1">
         <rest xml:id="re6smu9" dur.ppq="6" dur="8" />
         <beam xml:id="btptg8l">
          <chord xml:id="cqp2e5x" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="n7qwujf" oct="5" pname="g" />
           <note xml:id="no6jxc2" oct="5" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="c1qa2z4" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nsbmtoj" oct="5" pname="f" />
           <note xml:id="n7x673" oct="5" pname="a" />
          </chord>
          <chord xml:id="cr6xxl4" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="n7mhwez" oct="5" pname="e" accid.ges="f" />
           <note xml:id="nnz9ll6" oct="5" pname="g" />
          </chord>
         </beam>
         <beam xml:id="b60us1n">
          <chord xml:id="ctntath" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nj03nu4" oct="5" pname="d" />
           <note xml:id="nm2wzgm" oct="5" pname="f" />
          </chord>
          <chord xml:id="c8au8eu" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="ns1stih" oct="4" pname="f" />
           <note xml:id="na4whja" oct="5" pname="d" />
          </chord>
          <chord xml:id="cdi97y" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nr4f3qa" oct="4" pname="g" />
           <note xml:id="n24imr0" oct="5" pname="e" accid.ges="f" />
          </chord>
          <chord xml:id="co06yad" dur.ppq="6" dur="8" stem.dir="down">
           <note xml:id="nz2r7s7" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nocnqu7" oct="5" pname="c" />
          </chord>
         </beam>
        </layer>
       </staff>
       <staff xml:id="smdyxts" n="3">
        <layer xml:id="lx8cf5" n="5">
         <chord xml:id="cbt0ndk" dur.ppq="12" dur="4" stem.dir="up">
          <note xml:id="n40sruv" oct="2" pname="e" accid.ges="f" />
          <note xml:id="nm7o6yi" oct="3" pname="e" accid.ges="f" />
         </chord>
         <rest xml:id="rvlkeuk" dur.ppq="12" dur="4" />
         <note xml:id="nmnb74a" dur.ppq="12" dur="4" oct="2" pname="b" stem.dir="up" accid.ges="f" />
         <note xml:id="ngamc6r" dur.ppq="12" dur="4" oct="3" pname="e" stem.dir="down" accid.ges="f" />
        </layer>
       </staff>
       <dynam xml:id="dnqt0fr" place="below" staff="2" tstamp="1.000000" val="96" vgrp="40">f</dynam>
       <slur xml:id="sh2hh2q" startid="#n7qwujf" endid="#n7mhwez" curvedir="above" />
       <slur xml:id="suxlksz" startid="#nj03nu4" endid="#nz2r7s7" curvedir="above" />
       <slur xml:id="slur-3" startid="#cbt0ndk" endid="#co06yad" curvedir="mixed" />
      </measure>
      <sb xml:id="spnkudk" />
      <measure xml:id="mz3gb98" n="4">
       <staff xml:id="sk5zd08" n="2">
        <layer xml:id="lx028vm" n="1">
         <beam xml:id="by3r0zw">
          <chord xml:id="cv1tuo4" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="nn2oj6r" oct="4" pname="f" />
           <note xml:id="nc3ghso" oct="5" pname="d" />
          </chord>
          <chord xml:id="craqhwy" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="negb57e" oct="4" pname="d" />
           <note xml:id="nhpcvmx" oct="4" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="cum46zy" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="ne20h1p" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nj8pex8" oct="5" pname="c" />
          </chord>
          <chord xml:id="cjxaksi" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="n5lanwp" oct="4" pname="c" />
           <note xml:id="n4b8683" oct="4" pname="a" />
          </chord>
         </beam>
         <beam xml:id="bhmxzp6">
          <chord xml:id="cioeki0" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="nmc6fbe" oct="4" pname="d" />
           <note xml:id="na12ngr" oct="4" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="cipufpj" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="nvaduar" oct="4" pname="f" />
           <note xml:id="nsoh23t" oct="4" pname="a" />
          </chord>
          <chord xml:id="ccdp7jp" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="n4qblfg" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nypyb5v" oct="4" pname="g" />
          </chord>
          <chord xml:id="cwcahm4" dur.ppq="6" dur="8" stem.dir="up">
           <note xml:id="n34lggy" oct="4" pname="d" />
           <note xml:id="nv9w9iy" oct="4" pname="f" />
          </chord>
         </beam>
        </layer>
       </staff>
       <staff xml:id="sd8hy4w" n="3">
        <layer xml:id="lpgo9l7" n="5">
         <note xml:id="ngsbsuo" dur.ppq="12" dur="4" oct="3" pname="f" stem.dir="down" />
         <note xml:id="n1w6xkf" dur.ppq="12" dur="4" oct="2" pname="f" stem.dir="up" />
         <note xml:id="nkht8ni" dur.ppq="12" dur="4" oct="2" pname="b" stem.dir="up" accid.ges="f" />
         <rest xml:id="rro8xxx" dur.ppq="12" dur="4" />
        </layer>
       </staff>
       <slur xml:id="sovccmb" startid="#nn2oj6r" endid="#n1w6xkf" curvedir="mixed" />
       <slur xml:id="s9d5me1" startid="#nkht8ni" endid="#n34lggy" curvedir="mixed" />
      </measure>
      <measure xml:id="m19ebou" n="5">
       <staff xml:id="s64sep5" n="2">
        <layer xml:id="lgmeiz9" n="1">
         <rest xml:id="r64ma3p" dur.ppq="6" dur="8" />
         <beam xml:id="bwqam31">
          <chord xml:id="cybz783" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="am8c47e" artic="stacc" />
           <note xml:id="njlrtne" oct="4" pname="e" accid.ges="f" />
           <note xml:id="ngd1r2d" oct="4" pname="f" />
          </chord>
          <chord xml:id="cbf25od" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="a60ja7g" artic="stacc" />
           <note xml:id="n3jvj91" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nr7th50" oct="4" pname="f" />
          </chord>
          <chord xml:id="c43au6b" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="a9qnc3a" artic="stacc" />
           <note xml:id="na7ncto" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nn7j1bk" oct="4" pname="f" accid="s" />
          </chord>
         </beam>
         <beam xml:id="bdcxti2">
          <chord xml:id="cke7zat" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="as0mc3r" artic="stacc" />
           <note xml:id="naehw4u" oct="4" pname="e" accid.ges="f" />
           <note xml:id="ncbixts" oct="4" pname="g" />
          </chord>
          <chord xml:id="caoonlp" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="apjr6z4" artic="stacc" />
           <note xml:id="nxvz6iy" oct="4" pname="e" accid.ges="f" />
           <note xml:id="nc64eks" oct="4" pname="g" />
          </chord>
          <chord xml:id="ciaypkc" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="amjjohl" artic="stacc" />
           <note xml:id="nsv891l" oct="4" pname="e" accid.ges="f" />
           <note xml:id="n8c4j8n" oct="4" pname="a" />
          </chord>
          <chord xml:id="ct9w3ae" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="aldebjb" artic="stacc" />
           <note xml:id="nxfutz8" oct="4" pname="e" accid.ges="f" />
           <note xml:id="npaboar" oct="4" pname="a" />
          </chord>
         </beam>
        </layer>
       </staff>
       <staff xml:id="snjsega" n="3">
        <layer xml:id="ltv36ck" n="5">
         <beam xml:id="bsjm5bo">
          <note xml:id="nx8w0wd" dur.ppq="6" dur="8" oct="2" pname="f" stem.dir="down">
           <artic xml:id="a2899vw" artic="stacc" />
          </note>
          <chord xml:id="cghmwc7" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="awgdk7k" artic="stacc" />
           <note xml:id="nrkpk7n" oct="3" pname="f" />
           <note xml:id="nc0x34l" oct="3" pname="a" />
          </chord>
          <chord xml:id="ct2w9vg" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="adrsmaq" artic="stacc" />
           <note xml:id="n8i29og" oct="3" pname="f" />
           <note xml:id="nci7ndi" oct="3" pname="a" />
          </chord>
          <chord xml:id="c4r41d2" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="a9l1hz4" artic="stacc" />
           <note xml:id="nw9rv54" oct="3" pname="f" />
           <note xml:id="nkumm8n" oct="3" pname="a" />
          </chord>
         </beam>
         <beam xml:id="b7hlwdj">
          <chord xml:id="cd3b6yc" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="a7ke32u" artic="stacc" />
           <note xml:id="n55toqs" oct="3" pname="f" />
           <note xml:id="ncykbfi" oct="3" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="cnpyole" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="ad1hmq" artic="stacc" />
           <note xml:id="ny2isfb" oct="3" pname="f" />
           <note xml:id="n9qayn1" oct="3" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="cvo1vkv" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="ae8on7i" artic="stacc" />
           <note xml:id="n9o54nt" oct="3" pname="f" />
           <note xml:id="noqd0hj" oct="4" pname="c" />
          </chord>
          <chord xml:id="cyvfk42" dur.ppq="6" dur="8" stem.dir="down">
           <artic xml:id="acbiavk" artic="stacc" />
           <note xml:id="nks7v4f" oct="3" pname="f" />
           <note xml:id="nmkc20c" oct="4" pname="c" />
          </chord>
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-4" startid="#nx8w0wd" endid="#ct9w3ae" curvedir="mixed" />
       <hairpin xml:id="hyhngs0" staff="2" tstamp="1.000000" tstamp2="0m+4.5000" form="cres" place="below" vgrp="75" />
      </measure>
      <measure xml:id="moetc9d" n="6">
       <staff xml:id="scrtfao" n="2">
        <layer xml:id="lut7pr5" n="1">
         <rest xml:id="rwdfypx" dur.ppq="6" dur="8" />
         <beam xml:id="bornmsz">
          <chord xml:id="c2ofh1b" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="aa0vgig" artic="stacc" />
           <note xml:id="nl0xcja" oct="4" pname="d" />
           <note xml:id="nhq6dhs" oct="4" pname="f" />
           <note xml:id="npq0flw" oct="4" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="cadkf4b" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="akgkyli" artic="stacc" />
           <note xml:id="nkzvic7" oct="4" pname="d" />
           <note xml:id="n9010h8" oct="4" pname="f" />
           <note xml:id="n11hu30" oct="4" pname="b" accid.ges="f" />
          </chord>
          <chord xml:id="coei6ms" dur.ppq="6" dur="8" stem.dir="up">
           <artic xml:id="a7kcio4" artic="stacc" />
           <note xml:id="nphawbt" oct="4" pname="d" />
           <note xml:id="ns8l78u" oct="4" pname="f" />
           <note xml:id="nrejh8k" oct="4" pname="b" accid.ges="f" />
          </chord>
         </beam>
         <chord xml:id="cvfaakb" dur.ppq="12" dur="4" stem.dir="down">
          <note xml:id="nngs3ij" oct="4" pname="b" accid.ges="f" />
          <note xml:id="npzux72" oct="5" pname="d" />
          <note xml:id="nh0tj6c" oct="5" pname="f" />
          <note xml:id="ndulpg7" oct="5" pname="b" accid.ges="f" />
         </chord>
        </layer>
       </staff>
       <staff xml:id="sj227eg" n="3">
        <layer xml:id="lhlr127" n="5">
         <beam xml:id="bz1o4h6">
          <note xml:id="n9d6j78" dur.ppq="6" dur="8" oct="2" pname="b" stem.dir="down" accid.ges="f">
           <artic xml:id="afadic8" artic="stacc" />
          </note>
          <note xml:id="nrvmwim" dur.ppq="6" dur="8" oct="3" pname="b" stem.dir="down" accid.ges="f">
           <artic xml:id="a9qe8ec" artic="stacc" />
          </note>
          <note xml:id="nlyvw03" dur.ppq="6" dur="8" oct="3" pname="b" stem.dir="down" accid.ges="f">
           <artic xml:id="a8zhqji" artic="stacc" />
          </note>
          <note xml:id="nvgfsyi" dur.ppq="6" dur="8" oct="3" pname="b" stem.dir="down" accid.ges="f">
           <artic xml:id="ado42qn" artic="stacc" />
          </note>
         </beam>
         <chord xml:id="cr6oqqw" dur.ppq="12" dur="4" stem.dir="up">
          <note xml:id="nj4rrx8" oct="1" pname="b" accid.ges="f" />
          <note xml:id="ncs3i3l" oct="2" pname="d" />
          <note xml:id="n7s77ma" oct="2" pname="f" />
          <note xml:id="nlxx2s8" oct="2" pname="b" accid.ges="f" />
         </chord>
        </layer>
       </staff>
       <slur xml:id="slur-5" startid="#n9d6j78" endid="#coei6ms" curvedir="mixed" />
       <dynam xml:id="dtpo5z7" place="below" staff="2" tstamp="3.000000" val="96" vgrp="40">f</dynam>
       <arpeg xml:id="aahhbkw" plist="#cvfaakb #cr6oqqw" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>
