### PR TITLE
Fix crash in MusicXML import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2577,6 +2577,8 @@ void MusicXmlInput::ReadMusicXmlNote(
 
     short int tremSlashNum = -1;
 
+    const bool readBeamsAndTuplets = ReadMusicXmlBeamsAndTuplets(node, layer, isChord);
+
     // beam start
     bool beamStart = node.select_node("beam[@number='1'][text()='begin']");
     // tremolos
@@ -2901,8 +2903,8 @@ void MusicXmlInput::ReadMusicXmlNote(
             }
         }
 
-        // beam / beamspan
-        if (!ReadMusicXmlBeamsAndTuplets(node, layer, isChord)) {
+        // beamspan
+        if (!readBeamsAndTuplets) {
             BeamSpan *meiBeamSpan = new BeamSpan();
             meiBeamSpan->SetStartid("#" + element->GetUuid());
             m_controlElements.push_back({ measureNum, meiBeamSpan });


### PR DESCRIPTION
This PR fixes a crash in the MusicXML importer regarding the import of beams and beamSpan.

<details>
<summary>Crash example</summary>

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="3.1">
  <identification>
    <encoding>
      <supports attribute="new-system" element="print" type="yes" value="yes"/>
      <supports attribute="new-page" element="print" type="yes" value="yes"/>
      <encoding-date>2021-02-26</encoding-date>
    </encoding>
  </identification>
  <part-list>
    <score-part id="P1-Clarinet-In-B-Flat">
    </score-part>
  </part-list>
  <!--...Part 1...-->
  <part id="P1-Clarinet-In-B-Flat">
    <!--...Measure 4...-->
    <measure number="4" id="measure-23-mdiv-1">
      <print new-system="yes"/>
      <attributes>
        <divisions>16</divisions>
      </attributes>
      <note id="note-155">
        <pitch>
          <step>D</step>
          <alter>0</alter>
          <octave>4</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>natural</accidental>
        <stem>down</stem>
        <staff>1</staff>
        <beam number="1">begin</beam>
        <notations>
          <slur id="slur-15" number="1" placement="above" type="start"/>
          <articulations>
            <staccato placement="above"/>
          </articulations>
        </notations>
      </note>
      <note id="note-156">
        <chord/>
        <pitch>
          <step>A</step>
          <alter>0</alter>
          <octave>3</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>natural</accidental>
        <stem>down</stem>
        <staff>1</staff>
      </note>
      <note id="note-159">
        <pitch>
          <step>B</step>
          <alter>-1</alter>
          <octave>3</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>down</stem>
        <staff>1</staff>
        <beam number="1">end</beam>
        <notations>
          <slur id="slur-15-stop" number="1" placement="above" type="stop"/>
          <articulations>
            <staccato placement="above"/>
          </articulations>
        </notations>
      </note>
      <note id="note-160">
        <chord/>
        <pitch>
          <step>G</step>
          <alter>-1</alter>
          <octave>3</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>down</stem>
        <staff>1</staff>
      </note>
      <note id="note-162">
        <rest/>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <staff>1</staff>
      </note>
      <attributes>
        <clef number="1" id="clef-6">
          <sign>G</sign>
          <line>2</line>
        </clef>
      </attributes>
      <note id="note-163">
        <pitch>
          <step>B</step>
          <alter>0</alter>
          <octave>3</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>natural</accidental>
        <stem>up</stem>
        <staff>1</staff>
      </note>
      <note id="note-164">
        <chord/>
        <pitch>
          <step>E</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <staff>1</staff>
      </note>
      <note id="note-165">
        <chord/>
        <pitch>
          <step>A</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>8</duration>
        <voice>1</voice>
        <type>eighth</type>
        <accidental>flat</accidental>
        <stem>up</stem>
        <staff>1</staff>
      </note>
    </measure>
  </part>
</score-partwise>
```
</details>