### PR TITLE
Fix midi if note to be played is already sounding, end it first.

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1472,8 +1472,9 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
                 params->m_heldNotes[course - 1].m_stopTime = startTime; // stop now
 
             // end all previously held notes that have reached their stoptime
+            // or if the new pitch is already sounding, on any course
             for (auto &held : params->m_heldNotes) {
-                if (held.m_pitch > 0 && held.m_stopTime <= startTime) {
+                if (held.m_pitch > 0 && (held.m_stopTime <= startTime || held.m_pitch == pitch)) {
                     params->m_midiFile->addNoteOff(params->m_midiTrack, held.m_stopTime * tpq, channel, held.m_pitch);
                     held.m_pitch = 0;
                     held.m_stopTime = 0;


### PR DESCRIPTION
Tablature midi: when starting a note, if the same note is already sounding on another course then end that note first.  Testing using timidity for midi playback did not show any problem.  But using the Verovio web site midi playback the two notes were elided into one continuous sound with no audible break between them.