### PR TITLE
Improve floating beam position

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -340,10 +340,9 @@ protected:
     void FilterList(ArrayOfObjects *childList) override;
 
     /**
-     * Helper function to calculate overlap with layer elements that
-     * are placed within the duration of the beam
+     * See LayerElement::SetElementShortening
      */
-    int CalcLayerOverlap(Doc *doc, Object *beam, int directionBias, int y1, int y2);
+    void SetElementShortening(int shortening) override;
 
 private:
     /**

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -69,6 +69,16 @@ public:
     //----------//
 
     /**
+     * See Object::AdjustBeams
+     */
+    int AdjustBeams(FunctorParams *functorParams) override;
+
+    /**
+     * See Object::AdjustBeamsEnd
+     */
+    int AdjustBeamsEnd(FunctorParams *functorParams) override;
+
+    /**
      * See Object::CalcStem
      */
     int CalcStem(FunctorParams *functorParams) override;
@@ -90,6 +100,11 @@ protected:
      * Filter the flat list and keep only Note or Chords elements.
      */
     void FilterList(ArrayOfObjects *childList) override;
+
+    /**
+     * See LayerElement::SetElementShortening
+     */
+    void SetElementShortening(int shortening) override;
 
 public:
     /** */

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -251,6 +251,11 @@ public:
      */
     std::pair<int, bool> CalcElementHorizontalOverlap(Doc *doc, const std::vector<LayerElement *> &otherElements,
         bool areDotsAdjusted, bool isChordElement, bool isLowerElement = false, bool unison = true);
+    
+    /**
+     * Helper function to set shortening for elements with beam interface
+     */
+    virtual void SetElementShortening(int shortening){};
 
     //----------//
     // Functors //
@@ -443,6 +448,12 @@ protected:
      * secondary
      */
     virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) { return {}; }
+
+    /**
+     * Helper function to calculate overlap with layer elements that
+     * are placed within the duration of element
+     */
+    int CalcLayerOverlap(Doc *doc, int direction, int y1, int y2);
 
     /**
      * Calculate the optimal dot location for a note or chord

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -251,7 +251,7 @@ public:
      */
     std::pair<int, bool> CalcElementHorizontalOverlap(Doc *doc, const std::vector<LayerElement *> &otherElements,
         bool areDotsAdjusted, bool isChordElement, bool isLowerElement = false, bool unison = true);
-    
+
     /**
      * Helper function to set shortening for elements with beam interface
      */

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -600,10 +600,13 @@ private:
         bool isMensuralBlack, bool firstHalf);
 
     /**
-     * Internal method for drawing a BeamSegment
+     * Internal methods for drawing a BeamSegment
      */
+    ///@{
     void DrawBeamSegment(
         DeviceContext *dc, BeamSegment *segment, BeamDrawingInterface *beamInterface, Layer *layer, Staff *staff);
+    void DrawFTremSegment(DeviceContext *dc, Staff *staff, FTrem *fTrem);
+    ///@}
 
     /**
      * Internal methods for drawing time spanning elements

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -96,14 +96,6 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     FTrem *fTrem = dynamic_cast<FTrem *>(element);
     assert(fTrem);
 
-    // temporary coordinates
-    int x1, x2, y1, y2;
-
-    // temporary variables
-    int shiftY;
-    int polygonHeight;
-    double dy1, dy2;
-
     /******************************************************************/
     // initialization
 
@@ -119,8 +111,6 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         LogError("View draw: <fTrem> element has invalid number of descendants.");
         return;
     }
-    BeamElementCoord *firstElement = beamElementCoords->at(0);
-    BeamElementCoord *secondElement = beamElementCoords->at(1);
 
     /******************************************************************/
     // Calculate the beam slope and position
@@ -140,9 +130,26 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     /******************************************************************/
     // Draw the stems and the bars
 
+    this->DrawFTremSegment(dc, staff, fTrem);
+
+    dc->EndGraphic(element, this);
+}
+
+void View::DrawFTremSegment(DeviceContext *dc, Staff *staff, FTrem *fTrem)
+{
+    assert(dc);
+    assert(staff);
+    assert(fTrem);
+
+    const ArrayOfBeamElementCoords *beamElementCoords = fTrem->GetElementCoords();
+
+    BeamElementCoord *firstElement = beamElementCoords->at(0);
+    BeamElementCoord *secondElement = beamElementCoords->at(1);
+
     // We look only at the first one for the duration since both are expected to be the same
-    assert(dynamic_cast<AttDurationLogical *>(firstElement->m_element));
-    int dur = (dynamic_cast<AttDurationLogical *>(firstElement->m_element))->GetDur();
+    AttDurationLogical *durationElement = dynamic_cast<AttDurationLogical *>(firstElement->m_element);
+    if (!durationElement) return;
+    const int dur = durationElement->GetDur();
 
     if (dur > DUR_1) {
         // Adjust the x position of the first and last element for taking into account the stem width
@@ -151,22 +158,21 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     }
 
     // Number of bars to draw
-    int allBars = fTrem->GetBeams();
+    const int allBars = fTrem->GetBeams();
     int floatingBars = fTrem->HasBeamsFloat() ? fTrem->GetBeamsFloat() : 0;
     int fullBars = allBars - floatingBars;
 
+    // Set initial coordinates for the beam
+    int y1 = firstElement->m_yBeam;
+    int y2 = secondElement->m_yBeam;
+
+    int x1 = firstElement->m_x;
+    int x2 = secondElement->m_x;
+
     // Shift direction
-    shiftY = (fTrem->m_drawingPlace == BEAMPLACE_below) ? 1.0 : -1.0;
-    polygonHeight = fTrem->m_beamWidthBlack * shiftY;
-
-    y1 = firstElement->m_yBeam;
-    y2 = secondElement->m_yBeam;
-
-    x1 = firstElement->m_x;
-    x2 = secondElement->m_x;
-
-    dy1 = shiftY;
-    dy2 = shiftY;
+    const double shiftY = (fTrem->m_drawingPlace == BEAMPLACE_below) ? 1.0 : -1.0;
+    const double dy1 = shiftY;
+    const double dy2 = shiftY;
 
     int space = m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, fTrem->m_cueSize);
     // for non-stem notes the bar should be shortenend
@@ -184,6 +190,7 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         floatingBars = allBars - fullBars;
     }
 
+    const int polygonHeight = fTrem->m_beamWidthBlack * shiftY;
     for (int j = 0; j < fullBars; ++j) {
         this->DrawObliquePolygon(dc, x1, y1, x2, y2, polygonHeight);
         y1 += polygonHeight;
@@ -194,8 +201,8 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     // If we have no full bar but only floating bars, then move it inside
     if (fullBars == 0) {
-        y1 += dy1 * fTrem->m_beamWidthWhite;
-        y2 += dy2 * fTrem->m_beamWidthWhite;
+        y1 += dy1 * fTrem->m_beamWidthWhite / 2;
+        y2 += dy2 * fTrem->m_beamWidthWhite / 2;
     }
 
     // shorten the bar after having drawn the first one (but the first one)
@@ -211,8 +218,6 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         y1 += dy1 * fTrem->m_beamWidthWhite;
         y2 += dy2 * fTrem->m_beamWidthWhite;
     }
-
-    dc->EndGraphic(element, this);
 }
 
 void View::DrawBeamSegment(


### PR DESCRIPTION
Improve positioning of the beams in the `fTrem` and add adjustment to avoid elements within (e.g. accidentals).

![image](https://user-images.githubusercontent.com/1819669/156381405-5652c4d6-4ccf-42b6-b475-26f3e489a310.png)

<details><summary>Example MEI</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Two-note (fingered) temolo example</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2022-02-17">2022-02-17</date>
         </pubStmt>
         <notesStmt>
            <annot></annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef key.sig="1f" meter.count="4" meter.unit="4">
                  <staffGrp symbol="bracket">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                     <staffDef n="2" lines="5" clef.shape="C" clef.line="3" />
                  </staffGrp>
               </scoreDef>
               <section label="feature-example">
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <fTrem beams="3">
                              <note dur="2" oct="4" pname="f" />
                              <note dur="2" oct="4" pname="a" accid="f" />
                           </fTrem>
                           <fTrem beams="3">
                              <note dur="4" oct="4" pname="a" stem.dir="up" />
                              <note dur="4" oct="5" pname="d" stem.dir="up" accid="f" />
                           </fTrem>
                           <fTrem beams="3">
                              <note dur="8" oct="5" pname="d" stem.dir="up" />
                              <note dur="8" oct="4" pname="a" stem.dir="up" />
                           </fTrem>
                           <fTrem beams="3">
                              <note dur="8" oct="4" pname="a" accid="n" />
                              <note dur="8" oct="4" pname="f" accid="s" />
                           </fTrem>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <fTrem beams="3">
                              <note dur="2" oct="4" pname="d" />
                              <note dur="2" oct="4" pname="f" />
                           </fTrem>
                           <fTrem beams="3">
                              <note dur="2" oct="4" pname="d" />
                              <note dur="2" oct="4" pname="f" />
                           </fTrem>
                        </layer>
                        <layer n="2">
                           <note dur="1" oct="3" pname="d" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <fTrem beams="2">
                              <note dur="2" oct="5" pname="c" />
                              <note dur="2" oct="5" pname="c" accid="s" />
                           </fTrem>
                           <fTrem beams="2">
                              <note dur="4" oct="5" pname="d" stem.dir="down" />
                              <note dur="4" oct="4" pname="a" stem.dir="down" accid="f" />
                           </fTrem>
                           <fTrem beams="2">
                              <note dur="8" oct="4" pname="a" stem.dir="down" accid="f" />
                              <note dur="8" oct="5" pname="d" stem.dir="down" accid="f" />
                           </fTrem>
                           <fTrem beams="2">
                              <note dur="8" oct="5" pname="d" accid="n" />
                              <note dur="8" oct="5" pname="f" accid="s" />
                           </fTrem>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <note dots="1" dur="2" oct="4" pname="d" />
                           <note dur="4" oct="4" pname="d" />
                        </layer>
                        <layer n="2">
                           <fTrem beams="2">
                              <note dur="1" oct="3" pname="d" />
                              <note dur="1" oct="3" pname="f" accid="s" />
                           </fTrem>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>
