### PR TITLE
Improve margins for accidentals and clefs

### DIFF
--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -150,7 +150,8 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
 
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
-    if (!element->Is(NOTE)) horizontalMargin *= 0.66;
+    // Reduce spacing for successive accidentals
+    if (element->Is(ACCID)) horizontalMargin *= 0.66;
     const int verticalMargin = unit / 4;
 
     if (!this->VerticalSelfOverlap(element, verticalMargin)) {

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -148,10 +148,10 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
 
     if (this == element) return;
 
-    const int verticalMargin = 1 * doc->GetDrawingStemWidth(staffSize);
-    int horizontalMargin = 2 * doc->GetDrawingStemWidth(staffSize);
-
-    if (element->Is(NOTE)) horizontalMargin = 3 * doc->GetDrawingStemWidth(staffSize);
+    const int unit = doc->GetDrawingUnit(staffSize);
+    int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
+    if (!element->Is(NOTE)) horizontalMargin *= 0.66;
+    const int verticalMargin = unit / 4;
 
     if (!this->VerticalSelfOverlap(element, verticalMargin)) {
         this->AdjustToLedgerLines(doc, element, staffSize);

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -317,13 +317,13 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
     if (nextLeft == -VRV_UNSET) nextLeft = nextAlignment->GetXRel();
 
     const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int selfRight = this->GetContentRight() + params->m_doc->GetRightMargin(CLEF) * unit;
+    const int selfRight = this->GetContentRight() + params->m_doc->GetRightMargin(this) * unit;
     // First move it to the left if necessary
     if (selfRight > nextLeft) {
         this->SetDrawingXRel(this->GetDrawingXRel() - selfRight + nextLeft);
     }
     // Then look if it overlaps on the right and make room if necessary
-    const int selfLeft = this->GetContentLeft() - params->m_doc->GetLeftMargin(CLEF) * unit;
+    const int selfLeft = this->GetContentLeft() - params->m_doc->GetLeftMargin(this) * unit;
     if (selfLeft < previousRight) {
         ArrayOfAdjustmentTuples boundaries{ std::make_tuple(
             previousAlignment, this->GetAlignment(), previousRight - selfLeft) };

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -316,13 +316,14 @@ int Clef::AdjustClefChanges(FunctorParams *functorParams)
     // This typically happens with invisible barlines or with --grace-rhythm-align but no grace on that staff
     if (nextLeft == -VRV_UNSET) nextLeft = nextAlignment->GetXRel();
 
-    int selfRight = this->GetContentRight() + params->m_doc->GetRightMargin(CLEF) * staff->m_drawingStaffSize;
+    const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int selfRight = this->GetContentRight() + params->m_doc->GetRightMargin(CLEF) * unit;
     // First move it to the left if necessary
     if (selfRight > nextLeft) {
         this->SetDrawingXRel(this->GetDrawingXRel() - selfRight + nextLeft);
     }
     // Then look if it overlaps on the right and make room if necessary
-    int selfLeft = this->GetContentLeft() - params->m_doc->GetLeftMargin(CLEF) * staff->m_drawingStaffSize;
+    const int selfLeft = this->GetContentLeft() - params->m_doc->GetLeftMargin(CLEF) * unit;
     if (selfLeft < previousRight) {
         ArrayOfAdjustmentTuples boundaries{ std::make_tuple(
             previousAlignment, this->GetAlignment(), previousRight - selfLeft) };

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1611,6 +1611,12 @@ double Doc::GetLeftMargin(Object *object) const
             default: break;
         }
     }
+    else if (id == CLEF) {
+        Clef *clef = vrv_cast<Clef *>(object);
+        if (clef->GetAlignment() && (clef->GetAlignment()->GetType() == ALIGNMENT_CLEF)) {
+            return m_options->m_clefChangeFactor.GetValue() * this->GetLeftMargin(id);
+        }
+    }
     return this->GetLeftMargin(id);
 }
 
@@ -1646,6 +1652,12 @@ double Doc::GetRightMargin(Object *object) const
             case BarLinePosition::Left: return m_options->m_rightMarginLeftBarLine.GetValue();
             case BarLinePosition::Right: return m_options->m_rightMarginRightBarLine.GetValue();
             default: break;
+        }
+    }
+    else if (id == CLEF) {
+        Clef *clef = vrv_cast<Clef *>(object);
+        if (clef->GetAlignment() && (clef->GetAlignment()->GetType() == ALIGNMENT_CLEF)) {
+            return m_options->m_clefChangeFactor.GetValue() * this->GetRightMargin(id);
         }
     }
     return this->GetRightMargin(id);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1878,7 +1878,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
             // If we want the nesting to be reduced, we can set to:
             // selfLeft = this->GetSelfLeft();
             // This could be made an option (--spacing-limited-nesting)
-            int selfLeftMargin = params->m_doc->GetLeftMargin(this);
+            const double selfLeftMargin = params->m_doc->GetLeftMargin(this);
             int overlap = 0;
             for (auto &boundingBox : params->m_boundingBoxes) {
                 LayerElement *element = vrv_cast<LayerElement *>(boundingBox);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1551,7 +1551,7 @@ Options::Options()
     /// custom right
 
     m_rightMarginAccid.SetInfo("Right margin accid", "The right margin for accid in MEI units");
-    m_rightMarginAccid.Init(0.0, 0.0, 2.0);
+    m_rightMarginAccid.Init(0.5, 0.0, 2.0);
     this->Register(&m_rightMarginAccid, "rightMarginAccid", &m_elementMargins);
 
     m_rightMarginBarLine.SetInfo("Right margin barLine", "The right margin for barLine in MEI units");

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -140,14 +140,14 @@ void View::SetScoreDefDrawingWidth(DeviceContext *dc, ScoreDef *scoreDef)
         numAlteration = (keySig->GetAccidCount() > numAlteration) ? keySig->GetAccidCount() : numAlteration;
     }
 
+    const int unit = m_doc->GetDrawingUnit(100);
     int width = 0;
     // G-clef as default width
-    width += m_doc->GetLeftMargin(CLEF) + m_doc->GetGlyphWidth(SMUFL_E050_gClef, 100, false)
-        + m_doc->GetRightMargin(CLEF);
+    width += m_doc->GetGlyphWidth(SMUFL_E050_gClef, 100, false)
+        + (m_doc->GetLeftMargin(CLEF) + m_doc->GetRightMargin(CLEF)) * unit;
     if (numAlteration > 0) {
-        width += m_doc->GetLeftMargin(KEYSIG)
-            + m_doc->GetGlyphWidth(SMUFL_E262_accidentalSharp, 100, false) * TEMP_KEYSIG_STEP
-            + m_doc->GetRightMargin(KEYSIG);
+        width += m_doc->GetGlyphWidth(SMUFL_E262_accidentalSharp, 100, false) * TEMP_KEYSIG_STEP
+            + (m_doc->GetLeftMargin(KEYSIG) + m_doc->GetRightMargin(KEYSIG)) * unit;
     }
 
     scoreDef->SetDrawingWidth(width);


### PR DESCRIPTION
This PR does some improvements for margins:
- Ensure that option margins are always multiplied with unit in the codebase
- Use `--right-margin-accid` to influence the spacing between successive accidentals and accidental to note

| Default (0.5) | Value 1.0 |
| ------ | ------ |
|  <img width="142" alt="Default" src="https://user-images.githubusercontent.com/63608463/156546543-c0338d77-686a-459f-9185-711f127ada34.png"> | <img width="150" alt="1-0" src="https://user-images.githubusercontent.com/63608463/156546619-eb0970c0-b47c-4bb6-87d9-e9529c54786c.png"> |

- Scale the margins for layer clefs according to `--clef-change-factor`
