### PR TITLE
Improve cue notes

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1679,7 +1679,7 @@ using MIDIChordSequence = std::list<MIDIChord>;
 
 class GenerateMIDIParams : public FunctorParams {
 public:
-    GenerateMIDIParams(smf::MidiFile *midiFile, Functor *functor)
+    GenerateMIDIParams(Doc *doc, smf::MidiFile *midiFile, Functor *functor)
     {
         m_midiFile = midiFile;
         m_midiChannel = 0;
@@ -1690,6 +1690,7 @@ public:
         m_lastNote = NULL;
         m_accentedGraceNote = false;
         m_functor = functor;
+        m_doc = doc;
     }
     smf::MidiFile *m_midiFile;
     int m_midiChannel;
@@ -1704,6 +1705,7 @@ public:
     bool m_accentedGraceNote;
     Functor *m_functor;
     std::vector<MIDIHeldNote> m_heldNotes;
+    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -249,6 +249,13 @@ public:
     int ResetDrawing(FunctorParams *functorParams) override;
 
     /**
+     * @name See Object::GenerateMIDI
+     */
+    ///@{
+    int GenerateMIDI(FunctorParams *functorParams) override;
+    ///@}
+
+    /**
      * See Object::GenerateMIDIEnd
      */
     int GenerateMIDIEnd(FunctorParams *functorParams) override;

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -33,6 +33,7 @@ class StaffDef;
 class Layer : public Object,
               public DrawingListInterface,
               public ObjectListInterface,
+              public AttCue,
               public AttNInteger,
               public AttTyped,
               public AttVisibility {

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -592,7 +592,7 @@ public:
     OptionBool m_landscape;
     OptionBool m_ligatureAsBracket;
     OptionBool m_mensuralToMeasure;
-    OptionBool m_midiCue;
+    OptionBool m_midiNoCue;
     OptionDbl m_midiTempoAdjustment;
     OptionDbl m_minLastJustification;
     OptionBool m_mmOutput;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -668,6 +668,7 @@ public:
     OptionBool m_lyricVerseCollapse;
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
+    OptionBool m_midiCue;
     OptionInt m_mnumInterval;
     OptionIntMap m_multiRestStyle;
     OptionDbl m_multiRestThickness;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -592,6 +592,7 @@ public:
     OptionBool m_landscape;
     OptionBool m_ligatureAsBracket;
     OptionBool m_mensuralToMeasure;
+    OptionBool m_midiCue;
     OptionDbl m_midiTempoAdjustment;
     OptionDbl m_minLastJustification;
     OptionBool m_mmOutput;
@@ -668,7 +669,6 @@ public:
     OptionBool m_lyricVerseCollapse;
     OptionDbl m_lyricWordSpace;
     OptionInt m_measureMinWidth;
-    OptionBool m_midiCue;
     OptionInt m_mnumInterval;
     OptionIntMap m_multiRestStyle;
     OptionDbl m_multiRestThickness;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -339,7 +339,7 @@ protected:
     ///@{
     void DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff);
     void DrawClefEnclosing(DeviceContext *dc, Clef *clef, Staff *staff, wchar_t glyph, int x, int y, double sizeFactor);
-    void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff);
+    void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin = false);
     void DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int horizOffset);
     /** Returns the width of the drawn figures */
     int DrawMeterSigFigures(
@@ -554,7 +554,7 @@ protected:
     void DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int radius);
     void DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2, int height);
     void DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width, bool fill, int linewidth);
-    void DrawDot(DeviceContext *dc, int x, int y, int staffSize);
+    void DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin = false);
     void DrawSquareBracket(DeviceContext *dc, bool leftBracket, int x, int y, int height, int width,
         int horizontalThickness, int verticalThickness);
     void DrawEnclosingBrackets(DeviceContext *dc, int x, int y, int height, int width, int offset, int bracketWidth,

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -391,7 +391,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
 
             Functor generateMIDI(&Object::GenerateMIDI);
             Functor generateMIDIEnd(&Object::GenerateMIDIEnd);
-            GenerateMIDIParams generateMIDIParams(midiFile, &generateMIDI);
+            GenerateMIDIParams generateMIDIParams(this, midiFile, &generateMIDI);
             generateMIDIParams.m_midiChannel = midiChannel;
             generateMIDIParams.m_midiTrack = midiTrack;
             generateMIDIParams.m_transSemi = transSemi;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2021,6 +2021,7 @@ void MEIOutput::WriteLayer(pugi::xml_node currentNode, Layer *layer)
     assert(layer);
 
     this->WriteXmlId(currentNode, layer);
+    layer->WriteCue(currentNode);
     layer->WriteNInteger(currentNode);
     layer->WriteTyped(currentNode);
     layer->WriteVisibility(currentNode);
@@ -5442,6 +5443,7 @@ bool MEIInput::ReadLayer(Object *parent, pugi::xml_node layer)
     Layer *vrvLayer = new Layer();
     this->SetMeiUuid(layer, vrvLayer);
 
+    vrvLayer->ReadCue(layer);
     vrvLayer->ReadNInteger(layer);
     vrvLayer->ReadTyped(layer);
     vrvLayer->ReadVisibility(layer);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -739,7 +739,7 @@ int Layer::GenerateMIDI(FunctorParams *functorParams)
 
     const bool midiCue = params->m_doc->GetOptions()->m_midiCue.GetValue();
 
-    if (this->GetCue() == BOOLEAN_true and !midiCue) return FUNCTOR_SIBLINGS;
+    if (this->GetCue() == BOOLEAN_true && !midiCue) return FUNCTOR_SIBLINGS;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -44,8 +44,15 @@ namespace vrv {
 static const ClassRegistrar<Layer> s_factory("layer", LAYER);
 
 Layer::Layer()
-    : Object(LAYER, "layer-"), DrawingListInterface(), ObjectListInterface(), AttNInteger(), AttTyped(), AttVisibility()
+    : Object(LAYER, "layer-")
+    , DrawingListInterface()
+    , ObjectListInterface()
+    , AttCue()
+    , AttNInteger()
+    , AttTyped()
+    , AttVisibility()
 {
+    this->RegisterAttClass(ATT_CUE);
     this->RegisterAttClass(ATT_NINTEGER);
     this->RegisterAttClass(ATT_TYPED);
     this->RegisterAttClass(ATT_VISIBILITY);
@@ -74,6 +81,7 @@ void Layer::Reset()
 {
     Object::Reset();
     DrawingListInterface::Reset();
+    this->ResetCue();
     this->ResetNInteger();
     this->ResetTyped();
     this->ResetVisibility();

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -732,6 +732,13 @@ int Layer::ResetDrawing(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Layer::GenerateMIDI(FunctorParams *functorParams)
+{
+    if (this->GetCue() == BOOLEAN_true) return FUNCTOR_SIBLINGS;
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Layer::GenerateMIDIEnd(FunctorParams *functorParams)
 {
     GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -734,7 +734,12 @@ int Layer::ResetDrawing(FunctorParams *functorParams)
 
 int Layer::GenerateMIDI(FunctorParams *functorParams)
 {
-    if (this->GetCue() == BOOLEAN_true) return FUNCTOR_SIBLINGS;
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    const bool midiCue = params->m_doc->GetOptions()->m_midiCue.GetValue();
+
+    if (this->GetCue() == BOOLEAN_true and !midiCue) return FUNCTOR_SIBLINGS;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -737,9 +737,9 @@ int Layer::GenerateMIDI(FunctorParams *functorParams)
     GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
     assert(params);
 
-    const bool midiCue = params->m_doc->GetOptions()->m_midiCue.GetValue();
+    const bool midiNoCue = params->m_doc->GetOptions()->m_midiNoCue.GetValue();
 
-    if (this->GetCue() == BOOLEAN_true && !midiCue) return FUNCTOR_SIBLINGS;
+    if (this->GetCue() == BOOLEAN_true && midiNoCue) return FUNCTOR_SIBLINGS;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1996,6 +1996,7 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     Layer *currentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+    assert(currentLayer);
     if (currentLayer->GetCue() == BOOLEAN_true) {
         m_drawingCueSize = true;
         return FUNCTOR_CONTINUE;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1995,6 +1995,12 @@ int LayerElement::PrepareDrawingCueSize(FunctorParams *functorParams)
 {
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
+    Layer *currentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+    if (currentLayer->GetCue() == BOOLEAN_true) {
+        m_drawingCueSize = true;
+        return FUNCTOR_CONTINUE;
+    }
+
     if (this->IsGraceNote()) {
         m_drawingCueSize = true;
     }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1400,8 +1400,8 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    // Skip cue notes
-    if (this->GetCue() == BOOLEAN_true && !params->m_doc->GetOptions()->m_midiCue.GetValue()) {
+    // Skip cue notes when midiNoCue is activated
+    if (this->GetCue() == BOOLEAN_true && params->m_doc->GetOptions()->m_midiNoCue.GetValue()) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1401,7 +1401,7 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
     }
 
     // Skip cue notes
-    if (this->GetCue() == BOOLEAN_true and !params->m_doc->GetOptions()->m_midiCue.GetValue()) {
+    if (this->GetCue() == BOOLEAN_true && !params->m_doc->GetOptions()->m_midiCue.GetValue()) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1401,7 +1401,7 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
     }
 
     // Skip cue notes
-    if (this->GetCue() == BOOLEAN_true) {
+    if (this->GetCue() == BOOLEAN_true and !params->m_doc->GetOptions()->m_midiCue.GetValue()) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1400,6 +1400,11 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
+    // Skip cue notes
+    if (this->GetCue() == BOOLEAN_true) {
+        return FUNCTOR_SIBLINGS;
+    }
+
     // If the note is a secondary tied note, then ignore it
     if (this->GetScoreTimeTiedDuration() < 0.0) {
         return FUNCTOR_SIBLINGS;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -966,9 +966,9 @@ Options::Options()
     m_mensuralToMeasure.Init(false);
     this->Register(&m_mensuralToMeasure, "mensuralToMeasure", &m_general);
 
-    m_midiCue.SetInfo("MIDI playback of cue notes", "Include cue notes in MIDI output");
-    m_midiCue.Init(false);
-    this->Register(&m_midiCue, "midiCue", &m_general);
+    m_midiNoCue.SetInfo("MIDI playback of cue notes", "Skip cue notes in MIDI output");
+    m_midiNoCue.Init(false);
+    this->Register(&m_midiNoCue, "midiNoCue", &m_general);
 
     m_midiTempoAdjustment.SetInfo("MIDI tempo adjustment", "The MIDI tempo adjustment factor");
     m_midiTempoAdjustment.Init(1.0, 0.2, 4.0);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -966,6 +966,10 @@ Options::Options()
     m_mensuralToMeasure.Init(false);
     this->Register(&m_mensuralToMeasure, "mensuralToMeasure", &m_general);
 
+    m_midiCue.SetInfo("MIDI playback of cue notes", "Include cue notes in MIDI output");
+    m_midiCue.Init(false);
+    this->Register(&m_midiCue, "midiCue", &m_general);
+
     m_midiTempoAdjustment.SetInfo("MIDI tempo adjustment", "The MIDI tempo adjustment factor");
     m_midiTempoAdjustment.Init(1.0, 0.2, 4.0);
     this->Register(&m_midiTempoAdjustment, "midiTempoAdjustment", &m_generalLayout);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -843,8 +843,8 @@ void View::DrawDots(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
             - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (dotStaff->m_drawingLines - 1);
         int x = dots->GetDrawingX() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         for (int loc : mapEntry.second) {
-            this->DrawDotsPart(
-                dc, x, y + loc * m_doc->GetDrawingUnit(staff->m_drawingStaffSize), dots->GetDots(), dotStaff);
+            this->DrawDotsPart(dc, x, y + loc * m_doc->GetDrawingUnit(staff->m_drawingStaffSize), dots->GetDots(),
+                dotStaff, element->GetDrawingCueSize());
         }
     }
 
@@ -1755,17 +1755,18 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     dc->ResetBrush();
 }
 
-void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff)
+void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin)
 {
     int i;
 
     if (staff->IsOnStaffLine(y, m_doc)) {
         y += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }
+    const double distance = dimin ? m_doc->GetOptions()->m_graceFactor.GetValue() : 1.0;
     for (i = 0; i < dots; ++i) {
-        this->DrawDot(dc, x, y, staff->m_drawingStaffSize);
+        this->DrawDot(dc, x, y, staff->m_drawingStaffSize, dimin);
         // HARDCODED
-        x += m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 1.5;
+        x += m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 1.5 * distance;
     }
 }
 

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -223,9 +223,10 @@ void View::DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width,
     dc->ResetBrush();
 }
 
-void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize)
+void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
 {
-    const int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
+    int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
+    if (dimin) r *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
     dc->SetPen(m_currentColour, 0, AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);


### PR DESCRIPTION
This PR adds support for the newly introduced `@cue` on `layer`, skips cue notes in MIDI playback and fixes augmentation dots size in cue notation.