### PR TITLE
Add support for rendering of non-arp arpeggios

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1391,37 +1391,37 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
         const int thickness = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
         this->DrawSquareBracket(dc, true, x - unit, bottom - offset, length + 2 * offset, unit, thickness, thickness);
         dc->EndGraphic(arpeg, this);
-
-        return;
     }
+    else {
+        length += 2 * unit;
+        wchar_t startGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
+        wchar_t fillGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
+        wchar_t endGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAD_wiggleArpeggiatoUpArrow : 0;
 
-    length += 2 * unit;
-    wchar_t startGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
-    wchar_t fillGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
-    wchar_t endGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAD_wiggleArpeggiatoUpArrow : 0;
+        if (order == arpegLog_ORDER_down) {
+            startGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAE_wiggleArpeggiatoDownArrow : 0;
+            fillGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
+            endGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
+        }
 
-    if (order == arpegLog_ORDER_down) {
-        startGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAE_wiggleArpeggiatoDownArrow : 0;
-        fillGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
-        endGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
+        if (arpeg->GetArrowShape() == LINESTARTENDSYMBOL_none) endGlyph = 0;
+
+        Point orig(x, y);
+
+        dc->StartGraphic(arpeg, "", arpeg->GetUuid());
+
+        // Smufl glyphs are horizontal - Rotate them counter clockwise
+        const int angle = -90;
+        dc->RotateGraphic(Point(ToDeviceContextX(x), ToDeviceContextY(y)), angle);
+
+        this->DrawSmuflLine(
+            dc, orig, length, staff->m_drawingStaffSize, drawingCueSize, fillGlyph, startGlyph, endGlyph);
+
+        dc->EndGraphic(arpeg, this);
+
+        // Possibly draw enclosing brackets
+        this->DrawArpegEnclosing(dc, arpeg, staff, startGlyph, fillGlyph, endGlyph, x, y, length, drawingCueSize);
     }
-
-    if (arpeg->GetArrowShape() == LINESTARTENDSYMBOL_none) endGlyph = 0;
-
-    Point orig(x, y);
-
-    dc->StartGraphic(arpeg, "", arpeg->GetUuid());
-
-    // Smufl glyphs are horizontal - Rotate them counter clockwise
-    const int angle = -90;
-    dc->RotateGraphic(Point(ToDeviceContextX(x), ToDeviceContextY(y)), angle);
-
-    this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, drawingCueSize, fillGlyph, startGlyph, endGlyph);
-
-    dc->EndGraphic(arpeg, this);
-
-    // Possibly draw enclosing brackets
-    this->DrawArpegEnclosing(dc, arpeg, staff, startGlyph, fillGlyph, endGlyph, x, y, length, drawingCueSize);
 }
 
 void View::DrawArpegEnclosing(DeviceContext *dc, Arpeg *arpeg, Staff *staff, wchar_t startGlyph, wchar_t fillGlyph,

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1380,16 +1380,27 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
 
     int length = top - bottom;
     // We add - substract a unit in order to have the line going to the edge
-    length += m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int x = arpeg->GetDrawingX();
-    const int y = bottom - m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int angle = -90;
+    const int y = bottom - unit;
 
+    const arpegLog_ORDER order = arpeg->GetOrder();
+    if (order == arpegLog_ORDER_nonarp) {
+        dc->StartGraphic(arpeg, "", arpeg->GetUuid());
+        const int offset = unit / 2;
+        const int thickness = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+        this->DrawSquareBracket(dc, true, x - unit, bottom - offset, length + 2 * offset, unit, thickness, thickness);
+        dc->EndGraphic(arpeg, this);
+
+        return;
+    }
+
+    length += 2 * unit;
     wchar_t startGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
     wchar_t fillGlyph = SMUFL_EAA9_wiggleArpeggiatoUp;
     wchar_t endGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAD_wiggleArpeggiatoUpArrow : 0;
 
-    if (arpeg->GetOrder() == arpegLog_ORDER_down) {
+    if (order == arpegLog_ORDER_down) {
         startGlyph = (arpeg->GetArrow() == BOOLEAN_true) ? SMUFL_EAAE_wiggleArpeggiatoDownArrow : 0;
         fillGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
         endGlyph = SMUFL_EAAA_wiggleArpeggiatoDown;
@@ -1402,6 +1413,7 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
     dc->StartGraphic(arpeg, "", arpeg->GetUuid());
 
     // Smufl glyphs are horizontal - Rotate them counter clockwise
+    const int angle = -90;
     dc->RotateGraphic(Point(ToDeviceContextX(x), ToDeviceContextY(y)), angle);
 
     this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, drawingCueSize, fillGlyph, startGlyph, endGlyph);


### PR DESCRIPTION
Added support for the `order="nonarp"` to arpeggios:
![image](https://user-images.githubusercontent.com/1819669/157472826-8660aa56-9bb7-4ac0-a3ca-a5a801735d1b.png)
