### PR TITLE
Clef space to thick bar line

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -147,7 +147,7 @@ public:
     /**
      * Returns true for Alignment for which we want to do bounding box alignment
      */
-    bool PerfomBoundingBoxAlignment() const;
+    bool PerformBoundingBoxAlignment() const;
 
     /**
      * Return the AlignmentReference holding the element.

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -108,6 +108,14 @@ public:
     ///@}
 
     /**
+     * @name Check if the measure is the first or last in the system
+     */
+    ///@{
+    bool IsFirstInSystem() const;
+    bool IsLastInSystem() const;
+    ///@}
+
+    /**
      * Return the index position of the measure in its system parent
      */
     int GetMeasureIdx() const { return Object::GetIdx(); }

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -218,6 +218,11 @@ public:
 
     bool IsSectionRestart() const;
 
+    /**
+     * @return True if a system start line will be drawn
+     */
+    bool HasSystemStartLine();
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -136,10 +136,10 @@ public:
      * @name Check if the system is the first or last in page or of an mdiv by looking at the next sibling
      */
     ///@{
-    bool IsFirstInPage();
-    bool IsLastInPage();
-    bool IsFirstOfMdiv();
-    bool IsLastOfMdiv();
+    bool IsFirstInPage() const;
+    bool IsLastInPage() const;
+    bool IsFirstOfMdiv() const;
+    bool IsLastOfMdiv() const;
     ///@}
 
     /**

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -629,7 +629,7 @@ bool Alignment::HasGraceAligner(int id) const
     return (m_graceAligners.count(id) == 1);
 }
 
-bool Alignment::PerfomBoundingBoxAlignment() const
+bool Alignment::PerformBoundingBoxAlignment() const
 {
     return this->IsOfType({ ALIGNMENT_ACCID, ALIGNMENT_DOT, ALIGNMENT_DEFAULT });
 }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1857,8 +1857,8 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     // the current one allow it. For example, when one of them is a barline, we do not look how
     // bounding boxes can be nested but instead only look at the horizontal position
     bool performBoundingBoxAlignment = (params->m_previousAlignment.m_alignment
-        && params->m_previousAlignment.m_alignment->PerfomBoundingBoxAlignment()
-        && this->GetAlignment()->PerfomBoundingBoxAlignment());
+        && params->m_previousAlignment.m_alignment->PerformBoundingBoxAlignment()
+        && this->GetAlignment()->PerformBoundingBoxAlignment());
 
     if (!this->HasSelfBB() || this->HasEmptyBB()) {
         // if nothing was drawn, do not take it into account

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1059,6 +1059,11 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
         StaffAlignment *staffAlignment = system->m_systemAligner.GetStaffAlignmentForStaffN(staffN);
         params->m_staffSize = (staffAlignment) ? staffAlignment->GetStaffSize() : 100;
 
+        // Prevent collisions of scoredef clefs with thick barlines
+        if (this->IsFirstInSystem()) {
+            params->m_upcomingMinPos = params->m_doc->GetDrawingBarLineWidth(params->m_staffSize);
+        }
+
         filters.clear();
         // Create ad comparison object for each type / @n
         std::vector<int> ns;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1060,7 +1060,7 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
         params->m_staffSize = (staffAlignment) ? staffAlignment->GetStaffSize() : 100;
 
         // Prevent collisions of scoredef clefs with thick barlines
-        if (this->IsFirstInSystem() && (system->GetDrawingScoreDef()->GetSystemLeftline() != BOOLEAN_false)) {
+        if (this->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine()) {
             params->m_upcomingMinPos = params->m_doc->GetDrawingBarLineWidth(params->m_staffSize);
         }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -238,6 +238,18 @@ void Measure::SetDrawingXRel(int drawingXRel)
     m_drawingXRel = drawingXRel;
 }
 
+bool Measure::IsFirstInSystem() const
+{
+    assert(this->GetParent());
+    return (this->GetParent()->GetFirst(MEASURE) == this);
+}
+
+bool Measure::IsLastInSystem() const
+{
+    assert(this->GetParent());
+    return (this->GetParent()->GetLast(MEASURE) == this);
+}
+
 int Measure::GetLeftBarLineXRel() const
 {
     if (m_measureAligner.GetLeftBarLineAlignment()) {

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1060,7 +1060,7 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
         params->m_staffSize = (staffAlignment) ? staffAlignment->GetStaffSize() : 100;
 
         // Prevent collisions of scoredef clefs with thick barlines
-        if (this->IsFirstInSystem()) {
+        if (this->IsFirstInSystem() && (system->GetDrawingScoreDef()->GetSystemLeftline() != BOOLEAN_false)) {
             params->m_upcomingMinPos = params->m_doc->GetDrawingBarLineWidth(params->m_staffSize);
         }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1047,6 +1047,8 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
     System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
 
+    const bool hasSystemStartLine = this->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine();
+
     ArrayOfComparisons filters;
     for (auto staffN : params->m_staffNs) {
         params->m_minPos = 0;
@@ -1060,7 +1062,7 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
         params->m_staffSize = (staffAlignment) ? staffAlignment->GetStaffSize() : 100;
 
         // Prevent collisions of scoredef clefs with thick barlines
-        if (this->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine()) {
+        if (hasSystemStartLine) {
             params->m_upcomingMinPos = params->m_doc->GetDrawingBarLineWidth(params->m_staffSize);
         }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -583,6 +583,19 @@ bool ScoreDef::IsSectionRestart() const
     return (section && (section->GetRestart() == BOOLEAN_true));
 }
 
+bool ScoreDef::HasSystemStartLine()
+{
+    StaffGrp *staffGrp = vrv_cast<StaffGrp *>(this->FindDescendantByType(STAFFGRP));
+    if (staffGrp) {
+        auto [firstDef, lastDef] = staffGrp->GetFirstLastStaffDef();
+        if ((firstDef && lastDef && (firstDef != lastDef)) || staffGrp->GetFirst(GRPSYM)) {
+            return (this->GetSystemLeftline() != BOOLEAN_false);
+        }
+        return (this->GetSystemLeftline() == BOOLEAN_true);
+    }
+    return false;
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -346,29 +346,29 @@ void System::AddToDrawingListIfNeccessary(Object *object)
     }
 }
 
-bool System::IsFirstInPage()
+bool System::IsFirstInPage() const
 {
     assert(this->GetParent());
     return (this->GetParent()->GetFirst(SYSTEM) == this);
 }
 
-bool System::IsLastInPage()
+bool System::IsLastInPage() const
 {
     assert(this->GetParent());
     return (this->GetParent()->GetLast(SYSTEM) == this);
 }
 
-bool System::IsFirstOfMdiv()
+bool System::IsFirstOfMdiv() const
 {
     assert(this->GetParent());
-    Object *nextSibling = this->GetParent()->GetPrevious(this);
+    const Object *nextSibling = this->GetParent()->GetPrevious(this);
     return (nextSibling && nextSibling->IsPageElement());
 }
 
-bool System::IsLastOfMdiv()
+bool System::IsLastOfMdiv() const
 {
     assert(this->GetParent());
-    Object *nextSibling = this->GetParent()->GetNext(this);
+    const Object *nextSibling = this->GetParent()->GetNext(this);
     return (nextSibling && nextSibling->IsPageElement());
 }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -353,14 +353,14 @@ void View::DrawStaffGrp(
     if (lastDef->GetLines() <= 1) yBottom -= m_doc->GetDrawingDoubleUnit(last->m_drawingStaffSize);
 
     // draw the system start bar line
-    if (topStaffGrp
-        && ((((firstDef != lastDef) || staffGrp->GetFirst(GRPSYM))
-                && (m_doc->GetCurrentScoreDef()->GetSystemLeftline() != BOOLEAN_false))
-            || (m_doc->GetCurrentScoreDef()->GetSystemLeftline() == BOOLEAN_true))) {
-        // int barLineWidth = m_doc->GetDrawingElementDefaultSize("bracketThickness", staffSize);
-        const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
-        this->DrawVerticalLine(dc, yTop, yBottom, x + barLineWidth / 2, barLineWidth);
+    if (topStaffGrp) {
+        ScoreDef *scoreDef = vrv_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
+        if (scoreDef && scoreDef->HasSystemStartLine()) {
+            const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
+            this->DrawVerticalLine(dc, yTop, yBottom, x + barLineWidth / 2, barLineWidth);
+        }
     }
+
     // draw the group symbol
     int staffGrpX = x;
     this->DrawGrpSym(dc, measure, staffGrp, x);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -353,8 +353,8 @@ void View::DrawStaffGrp(
     if (lastDef->GetLines() <= 1) yBottom -= m_doc->GetDrawingDoubleUnit(last->m_drawingStaffSize);
 
     // draw the system start bar line
+    ScoreDef *scoreDef = vrv_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
     if (topStaffGrp) {
-        ScoreDef *scoreDef = vrv_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
         if (scoreDef && scoreDef->HasSystemStartLine()) {
             const int barLineWidth = m_doc->GetDrawingBarLineWidth(staffSize);
             this->DrawVerticalLine(dc, yTop, yBottom, x + barLineWidth / 2, barLineWidth);
@@ -376,7 +376,6 @@ void View::DrawStaffGrp(
     }
 
     // DrawStaffGrpLabel
-    ScoreDef *scoreDef = dynamic_cast<ScoreDef *>(staffGrp->GetFirstAncestor(SCOREDEF));
     const int space = m_doc->GetDrawingDoubleUnit(staffGrp->GetMaxStaffSize());
     int xLabel = x - space;
     int yLabel = yBottom - (yBottom - yTop) / 2 - m_doc->GetDrawingUnit(100);


### PR DESCRIPTION
This PR keeps some space between system clefs and thick bar lines (rendered via `--bar-line-width`).

| Before | After |
| ------ | ----- |
| <img width="344" alt="Before" src="https://user-images.githubusercontent.com/63608463/157644003-9f9082fc-6f88-4a7d-a745-9c2c47e0bcc3.png"> | <img width="361" alt="After" src="https://user-images.githubusercontent.com/63608463/157644036-ccc8a28d-7be2-432a-8b13-1064c53919f3.png"> |
 