### PR TITLE
Add support for cue lyrics

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1600,6 +1600,9 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     if (syl->HasFontstyle()) {
         currentFont.SetStyle(syl->GetFontstyle());
     }
+    if (syl->GetStart()->GetDrawingCueSize()) {
+        currentFont.SetPointSize(m_doc->GetCueSize(currentFont.GetPointSize()));
+    }
     dc->SetFont(&currentFont);
 
     TextDrawingParams params;
@@ -1671,11 +1674,18 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             graphic = labelAbbr;
         }
 
+        LayerElement *layerElement
+            = vrv_cast<LayerElement *>(element->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
+
         FontInfo labelTxt;
         if (!dc->UseGlobalStyling()) {
             labelTxt.SetFaceName("Times");
         }
-        labelTxt.SetPointSize(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize)->GetPointSize());
+        int pointSize = m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize)->GetPointSize();
+        if (layerElement && layerElement->GetDrawingCueSize()) {
+            pointSize = m_doc->GetCueSize(pointSize);
+        }
+        labelTxt.SetPointSize(pointSize);
 
         TextDrawingParams params;
         params.m_x = verse->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize);


### PR DESCRIPTION
closes #2625

Add support for the cue lyrics. Lyrics that are attached to the cue notes are now going to be adjusted with corresponding grace factor.
![image](https://user-images.githubusercontent.com/1819669/157842133-3f764490-3ff1-40d3-bac2-6fc00b1c7559.png)
