### PR TITLE
Implement part separation of accidentals in altered unisons

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -87,6 +87,14 @@ public:
      * Adjust accid position if it's placed above/below staff so that it does not overlap with ledger lines
      */
     void AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize);
+    
+    /**
+     * @name Set and get same layer alignment
+     */
+    ///@{
+    void IsAlignedWithSameLayer(bool alignWithSameLayer) { m_alignedWithSameLayer = alignWithSameLayer; }
+    bool IsAlignedWithSameLayer() const { return m_alignedWithSameLayer; }
+    ///@}
 
     //----------------//
     // Static methods //
@@ -119,6 +127,7 @@ private:
     Accid *m_drawingOctave;
     Accid *m_drawingUnison;
     bool m_isDrawingOctave;
+    bool m_alignedWithSameLayer;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -87,7 +87,7 @@ public:
      * Adjust accid position if it's placed above/below staff so that it does not overlap with ledger lines
      */
     void AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize);
-    
+
     /**
      * @name Set and get same layer alignment
      */

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -341,6 +341,12 @@ public:
      */
     bool HasCrossStaffElements();
 
+    /**
+     * Set whether accidentals should be aligned with all elements of alignmentReference or elements from same layer
+     * only. Set for each accidental in accidSpace separately
+     */
+    void SetAccidLayerAlignment();
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -450,7 +450,7 @@ protected:
      * their unison notes or if they should be placed separately.
      * Returns true if all elements can safely overlap.
      */
-    virtual int CountElementsInUnison(
+    virtual std::vector<int> GetElementsInUnison(
         const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -448,9 +448,9 @@ protected:
      * Helper to figure whether two chords are in fully in unison based on the locations of the notes.
      * This function assumes that two chords are already in unison and checks whether chords can overlap with
      * their unison notes or if they should be placed separately.
-     * Returns true if all elements can safely overlap.
+     * Returns vector with all locations of elements in unison.
      */
-    virtual std::vector<int> GetElementsInUnison(
+    std::vector<int> GetElementsInUnison(
         const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
 
     /**

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -64,6 +64,7 @@ void Accid::Reset()
     this->ResetExtSym();
 
     m_drawingUnison = NULL;
+    m_alignedWithSameLayer = false;
 }
 
 std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -494,16 +494,18 @@ int Chord::AdjustOverlappingLayers(
     assert(notes);
     // get current chord positions
     std::set<int> chordElementLocations;
-    for (auto iter : *notes) {
+    for (const auto iter : *notes) {
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
         chordElementLocations.insert(note->GetDrawingLoc());
     }
-    const int expectedElementsInUnison
-        = CountElementsInUnison(chordElementLocations, otherElementLocations, this->GetDrawingStemDir());
+    
+    std::vector<int> locationsInUnison
+        = this->GetElementsInUnison(chordElementLocations, otherElementLocations, this->GetDrawingStemDir());
+    const size_t expectedElementsInUnison = locationsInUnison.size();
     const bool isLowerPosition = (STEMDIRECTION_down == this->GetDrawingStemDir() && (otherElementLocations.size() > 0)
         && (*chordElementLocations.begin() >= *otherElementLocations.begin()));
-    int actualElementsInUnison = 0;
+    size_t actualElementsInUnison = 0;
     // process each note of the chord separately, storing locations in the set
     for (auto iter : *notes) {
         Note *note = vrv_cast<Note *>(iter);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -502,10 +502,10 @@ int Chord::AdjustOverlappingLayers(
 
     std::vector<int> locationsInUnison
         = this->GetElementsInUnison(chordElementLocations, otherElementLocations, this->GetDrawingStemDir());
-    const size_t expectedElementsInUnison = locationsInUnison.size();
+    const int expectedElementsInUnison = locationsInUnison.size();
     const bool isLowerPosition = (STEMDIRECTION_down == this->GetDrawingStemDir() && (otherElementLocations.size() > 0)
         && (*chordElementLocations.begin() >= *otherElementLocations.begin()));
-    size_t actualElementsInUnison = 0;
+    int actualElementsInUnison = 0;
     // process each note of the chord separately, storing locations in the set
     for (auto iter : *notes) {
         Note *note = vrv_cast<Note *>(iter);

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -767,14 +767,11 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
 
     Note *parentNote = vrv_cast<Note *>(accid->GetFirstAncestor(NOTE));
     const bool hasUnisonOverlap = std::any_of(children->begin(), children->end(), [parentNote](Object *object) {
-        if (object->Is(NOTE)) {
-            Note *otherNote = vrv_cast<Note *>(object);
-            // in case notes are in unison but have different accidentals
-            if (parentNote && parentNote->IsUnisonWith(otherNote, true)
-                && !parentNote->IsUnisonWith(otherNote, false)) {
-                return true;
-            }
-        }
+        if (!object->Is(NOTE)) return false;
+
+        Note *otherNote = vrv_cast<Note *>(object);
+        // in case notes are in unison but have different accidentals
+        return parentNote && parentNote->IsUnisonWith(otherNote, true) && !parentNote->IsUnisonWith(otherNote, false);
     });
 
     // bottom one

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -763,10 +763,10 @@ void AlignmentReference::AdjustAccidWithAccidSpace(
     Accid *accid, Doc *doc, int staffSize, std::vector<Accid *> &adjustedAccids)
 {
     std::vector<Accid *> leftAccids;
-    const ArrayOfObjects *children = this->GetChildren();
+    const ArrayOfObjects &children = this->GetChildren();
 
     // bottom one
-    for (auto child : *children) {
+    for (auto child : children) {
         // if accidental has unison overlap, ignore elements on other layers for overlap
         if (accid->IsAlignedWithSameLayer() && (accid->GetFirstAncestor(LAYER) != child->GetFirstAncestor(LAYER)))
             continue;
@@ -795,12 +795,12 @@ bool AlignmentReference::HasAccidVerticalOverlap(const ArrayOfObjects *objects)
 
 void AlignmentReference::SetAccidLayerAlignment()
 {
-    const ArrayOfObjects *children = this->GetChildren();
+    const ArrayOfObjects &children = this->GetChildren();
     for (Accid *accid : m_accidSpace) {
         if (accid->IsAlignedWithSameLayer()) continue;
 
         Note *parentNote = vrv_cast<Note *>(accid->GetFirstAncestor(NOTE));
-        const bool hasUnisonOverlap = std::any_of(children->begin(), children->end(), [parentNote](Object *object) {
+        const bool hasUnisonOverlap = std::any_of(children.begin(), children.end(), [parentNote](Object *object) {
             if (!object->Is(NOTE)) return false;
             Note *otherNote = vrv_cast<Note *>(object);
             // in case notes are in unison but have different accidentals

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1652,7 +1652,8 @@ int LayerElement::AdjustOverlappingLayers(
     }
 
     if (this->Is({ ACCID, DOTS, STEM })) {
-        LayerElement *parent = vrv_cast<LayerElement *>(this->GetParent());
+        LayerElement *parent
+            = vrv_cast<LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
         assert(parent);
         parent->SetDrawingXRel(parent->GetDrawingXRel() + margin);
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -764,10 +764,10 @@ bool LayerElement::GenerateZoneBounds(int *ulx, int *uly, int *lrx, int *lry)
     return result;
 }
 
-int LayerElement::CountElementsInUnison(
+std::vector<int> LayerElement::GetElementsInUnison(
     const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection)
 {
-    if (firstChord.empty() || secondChord.empty()) return 0;
+    if (firstChord.empty() || secondChord.empty()) return {};
     // Set always sorts elements, hence note locations stored will always be in ascending order, regardless
     // of how they are encoded in the MEI file
     std::set<int> difference;
@@ -789,7 +789,7 @@ int LayerElement::CountElementsInUnison(
                     && (element < *firstChord.rbegin()))
                 || ((firstChord.size() > secondChord.size()) && (element > *secondChord.begin())
                     && (element < *secondChord.rbegin()))) {
-                return 0;
+                return {};
             }
         }
     }
@@ -799,10 +799,10 @@ int LayerElement::CountElementsInUnison(
     // is higher than topmost location of the opposing chord it means that these elements cannot be in unison.
     // Same applies to the UP stem direction, just with reversed condition
     if (stemDirection == STEMDIRECTION_down) {
-        if ((*firstChord.rbegin() > *secondChord.rbegin()) || (*firstChord.begin() > *secondChord.begin())) return 0;
+        if ((*firstChord.rbegin() > *secondChord.rbegin()) || (*firstChord.begin() > *secondChord.begin())) return {};
     }
     else {
-        if ((*firstChord.rbegin() < *secondChord.rbegin()) || (*firstChord.begin() < *secondChord.begin())) return 0;
+        if ((*firstChord.rbegin() < *secondChord.rbegin()) || (*firstChord.begin() < *secondChord.begin())) return {};
     }
 
     // Finally, check if notes in unison are at the proper distance to be drawn as unison, as well as get number of
@@ -812,14 +812,14 @@ int LayerElement::CountElementsInUnison(
     auto it = std::set_intersection(
         firstChord.begin(), firstChord.end(), secondChord.begin(), secondChord.end(), intersection.begin());
     intersection.resize(it - intersection.begin());
-    if (intersection.empty()) return false;
+    if (intersection.empty()) return {};
     for (int i = 0; i < (int)intersection.size() - 1; ++i) {
         if (std::abs(intersection.at(i) - intersection.at(i + 1)) == 1) {
-            return 0;
+            return {};
         }
     }
 
-    return (int)intersection.size();
+    return intersection;
 }
 
 MapOfDotLocs LayerElement::CalcOptimalDotLocations()

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1651,9 +1651,7 @@ int LayerElement::AdjustOverlappingLayers(
         stemSameas = note->HasStemSameasNote();
     }
 
-    if (this->Is({ DOTS, STEM })) {
-        assert(this->GetParent());
-        assert(this->GetParent()->IsLayerElement());
+    if (this->Is({ ACCID, DOTS, STEM })) {
         LayerElement *parent = vrv_cast<LayerElement *>(this->GetParent());
         assert(parent);
         parent->SetDrawingXRel(parent->GetDrawingXRel() + margin);
@@ -1772,6 +1770,11 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             else {
                 shift -= HorizontalRightOverlap(otherElements.at(i), doc, -shift, verticalMargin);
             }
+        }
+        else if (this->Is(ACCID) && otherElements.at(i)->Is(NOTE)) {
+            if (this->HorizontalContentOverlap(otherElements.at(i)))
+                shift += this->HorizontalRightOverlap(
+                    otherElements.at(i), doc, -doc->GetDrawingUnit(staff->m_drawingStaffSize));
         }
 
         if (this->Is(NOTE) && !otherElements.at(i)->Is(STEM)) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1773,7 +1773,11 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(Doc *doc,
             }
         }
         else if (this->Is(ACCID) && otherElements.at(i)->Is(NOTE)) {
-            if (this->HorizontalContentOverlap(otherElements.at(i)))
+            Note *parentNote = vrv_cast<Note *>(this->GetFirstAncestor(NOTE));
+            Note *otherNote = vrv_cast<Note *>(otherElements.at(i));
+            const bool isUnisonOverlap = parentNote && parentNote->IsUnisonWith(otherNote, true)
+                && !parentNote->IsUnisonWith(otherNote, false);
+            if (isUnisonOverlap && this->HorizontalContentOverlap(otherElements.at(i)))
                 shift += this->HorizontalRightOverlap(
                     otherElements.at(i), doc, -doc->GetDrawingUnit(staff->m_drawingStaffSize));
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -335,13 +335,7 @@ std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const
 
 bool Note::IsUnisonWith(Note *note, bool ignoreAccid)
 {
-    if (!ignoreAccid) {
-        Accid *accid = this->GetDrawingAccid();
-        Accid *noteAccid = note->GetDrawingAccid();
-        data_ACCIDENTAL_WRITTEN accidVal = (accid) ? accid->GetAccid() : ACCIDENTAL_WRITTEN_NONE;
-        data_ACCIDENTAL_WRITTEN noteAccidVal = (noteAccid) ? noteAccid->GetAccid() : ACCIDENTAL_WRITTEN_NONE;
-        if (accidVal != noteAccidVal) return false;
-    }
+    if (!ignoreAccid && !this->IsEnharmonicWith(note)) return false;
 
     return ((this->GetPname() == note->GetPname()) && (this->GetOct() == note->GetOct()));
 }


### PR DESCRIPTION
closes #1656
addresses a few cases from #1569

Examples from the linked issues:
![image](https://user-images.githubusercontent.com/1819669/157871117-c4d175d5-09bc-4f52-9609-54aa4f00b840.png)
![image](https://user-images.githubusercontent.com/1819669/157871141-1d33ce45-ee19-4c31-8d4e-ccddc52ca274.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei meiversion="4.0.1" xmlns="http://www.music-encoding.org/ns/mei">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title type="unit">Placing of accidentals in altered unisons.</title>
      </titleStmt>
      <pubStmt/>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv n="1" xml:id="mdiv_310001">
        <score xml:id="score_310001">
          <scoreDef key.mode="minor" key.pname="a" key.sig="0" meter.count="4" meter.unit="4" xml:id="scoreDef_01">
            <staffGrp bar.thru="false" symbol="line" xml:id="staffGrp_01">
              <staffDef clef.line="2" clef.shape="G" lines="5" n="1" xml:id="staffDef_P1"/>
            </staffGrp>
          </scoreDef>
          <section xml:id="section_allegro_maestoso">
            <measure n="95" xml:id="m95_k310_001">
              <staff n="1" xml:id="staff_27030">
                <layer n="1" xml:id="layer_27036">
                  <beam xml:id="beam_27042">
                    <note dur="8" oct="4" pname="a" tstamp="1" xml:id="note_27048"/>
                    <note dur="8" oct="4" pname="b" tstamp="1.5" xml:id="note_27054"/>
                  </beam>
                  <space dots="1" dur="2" tstamp="2" xml:id="space_27107"/>
                </layer>
                <layer n="2" xml:id="layer_27096">
                  <note accid="n" dur="4" oct="4" pname="a" tstamp="1" xml:id="note_27102"/>
                  <space dots="1" dur="2" tstamp="2" xml:id="space_27108"/>
                </layer>
              </staff>
            </measure>
            <measure n="96" >
              <staff n="1" >
                <layer n="1" >
                  <note accid="n" dur="4" oct="4" pname="a" tstamp="1" />
                  <space dots="1" dur="2" tstamp="2" />
                </layer>
                <layer n="2" >
                  <beam >
                    <note accid="s" dur="8" oct="4" pname="a" tstamp="1"/>
                    <note dur="8" oct="4" pname="b" tstamp="1.5" />
                  </beam>
                  <space dots="1" dur="2" tstamp="2" />
                </layer>
              </staff>
            </measure>
            <measure n="97" >
              <staff n="1" >
                <layer n="1" >
                  <beam >
                    <note accid="f" dur="8" oct="4" pname="a" tstamp="1"/>
                    <note accid="f" dur="8" oct="4" pname="b" tstamp="1.5" />
                  </beam>
                </layer>
                <layer n="2" >
                  <beam >
                    <note accid="f" dur="8" oct="4" pname="a" tstamp="1"/>
                    <note accid="s" dur="8" oct="4" pname="b" tstamp="1.5" />
                  </beam>
                </layer>
              </staff>
            </measure>
            <measure n="98" >
              <staff n="1" >
                <layer n="1" >
                  <beam >
                    <note accid="f" dur="8" oct="4" pname="a" tstamp="1"/>
                    <note accid="s" dur="8" oct="4" pname="b" tstamp="1.5" />
                  </beam>
                </layer>
                <layer n="2" >
                  <beam >
                    <note accid="s" dur="8" oct="4" pname="a" tstamp="1"/>
                    <note accid="s" dur="8" oct="4" pname="b" tstamp="1.5" />
                  </beam>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```

</details>

![image](https://user-images.githubusercontent.com/1819669/157871447-12b3d606-b2d5-4169-a5cf-5d90a43fafdd.png)

