### PR TITLE
Import mixed slurs from MusicXML

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -65,26 +65,30 @@ namespace musicxml {
 
     class OpenSlur {
     public:
-        OpenSlur(const std::string &measureNum, short int number)
+        OpenSlur(const std::string &measureNum, short int number, curvature_CURVEDIR curvedir)
         {
             m_measureNum = measureNum;
             m_number = number;
+            m_curvedir = curvedir;
         }
 
         std::string m_measureNum;
         short int m_number;
+        curvature_CURVEDIR m_curvedir;
     };
 
     class CloseSlur {
     public:
-        CloseSlur(const std::string &measureNum, short int number)
+        CloseSlur(const std::string &measureNum, short int number, curvature_CURVEDIR curvedir)
         {
             m_measureNum = measureNum;
             m_number = number;
+            m_curvedir = curvedir;
         }
 
         std::string m_measureNum;
         short int m_number;
+        curvature_CURVEDIR m_curvedir;
     };
 
     class OpenSpanner {
@@ -331,8 +335,8 @@ private:
     ///@{
     void OpenTie(Note *note, Tie *tie);
     void CloseTie(Note *note);
-    void OpenSlur(Measure *measure, short int number, Slur *slur);
-    void CloseSlur(Measure *measure, short int number, LayerElement *element);
+    void OpenSlur(Measure *measure, short int number, Slur *slur, curvature_CURVEDIR dir);
+    void CloseSlur(Measure *measure, short int number, LayerElement *element, curvature_CURVEDIR dir);
     void CloseBeamSpan(Staff *staff, Layer *layer, LayerElement *element);
     ///@}
 
@@ -411,6 +415,11 @@ private:
     ///@{
     static bool IsSameAccidWrittenGestural(data_ACCIDENTAL_WRITTEN written, data_ACCIDENTAL_GESTURAL gestural);
     ///@}
+
+    /*
+     * @name Helper for detecting the slur curve direction
+     */
+    static curvature_CURVEDIR CombineCurvedir(curvature_CURVEDIR startDir, curvature_CURVEDIR stopDir);
 
     /*
      * @name Methods for converting MusicXML values to MEI attributes.

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -538,34 +538,36 @@ void MusicXmlInput::CloseTie(Note *note)
     }
 }
 
-void MusicXmlInput::OpenSlur(Measure *measure, short int number, Slur *slur)
+void MusicXmlInput::OpenSlur(Measure *measure, short int number, Slur *slur, curvature_CURVEDIR dir)
 {
     // try to match open slur with slur stops within that measure
     for (auto iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
         if ((iter->second.m_number == number) && ((iter->second.m_measureNum).compare(measure->GetN()) == 0)) {
             slur->SetEndid("#" + iter->first->GetUuid());
+            slur->SetCurvedir(CombineCurvedir(dir, iter->second.m_curvedir));
             m_slurStopStack.erase(iter);
             return;
         }
     }
     // create new slur otherwise
-    musicxml::OpenSlur openSlur(measure->GetN(), number);
+    musicxml::OpenSlur openSlur(measure->GetN(), number, dir);
     m_slurStack.push_back({ slur, openSlur });
 }
 
-void MusicXmlInput::CloseSlur(Measure *measure, short int number, LayerElement *element)
+void MusicXmlInput::CloseSlur(Measure *measure, short int number, LayerElement *element, curvature_CURVEDIR dir)
 {
     // try to match slur stop to open slurs by slur number
     std::vector<std::pair<Slur *, musicxml::OpenSlur>>::reverse_iterator riter;
     for (riter = m_slurStack.rbegin(); riter != m_slurStack.rend(); ++riter) {
         if (riter->second.m_number == number) {
             riter->first->SetEndid("#" + element->GetUuid());
+            riter->first->SetCurvedir(CombineCurvedir(riter->second.m_curvedir, dir));
             m_slurStack.erase(std::next(riter).base());
             return;
         }
     }
     // add to m_slurStopStack, if not able to be closed
-    musicxml::CloseSlur closeSlur(measure->GetN(), number);
+    musicxml::CloseSlur closeSlur(measure->GetN(), number, dir);
     m_slurStopStack.push_back({ element, closeSlur });
 }
 
@@ -3025,8 +3027,9 @@ void MusicXmlInput::ReadMusicXmlNote(
             pugi::xml_node slur = it->node();
             short int slurNumber = slur.attribute("number").as_int();
             slurNumber = (slurNumber < 1) ? 1 : slurNumber;
+            const curvature_CURVEDIR dir = InferCurvedir(slur);
             if (HasAttributeWithValue(slur, "type", "stop")) {
-                CloseSlur(measure, slurNumber, note);
+                CloseSlur(measure, slurNumber, note, dir);
             }
             else if (HasAttributeWithValue(slur, "type", "start")) {
                 Slur *meiSlur = new Slur();
@@ -3034,13 +3037,11 @@ void MusicXmlInput::ReadMusicXmlNote(
                 meiSlur->SetColor(slur.attribute("color").as_string());
                 // lineform
                 meiSlur->SetLform(meiSlur->AttCurveRend::StrToLineform(slur.attribute("line-type").as_string()));
-                // placement and orientation
-                meiSlur->SetCurvedir(InferCurvedir(slur));
                 if (slur.attribute("id")) meiSlur->SetUuid(slur.attribute("id").as_string());
                 meiSlur->SetStartid("#" + note->GetUuid());
                 // add it to the stack
                 m_controlElements.push_back({ measureNum, meiSlur });
-                OpenSlur(measure, slurNumber, meiSlur);
+                OpenSlur(measure, slurNumber, meiSlur, dir);
             }
         }
 
@@ -3873,6 +3874,19 @@ bool MusicXmlInput::IsSameAccidWrittenGestural(data_ACCIDENTAL_WRITTEN written, 
 
     const auto result = writtenToGesturalMap.find(written);
     return ((result != writtenToGesturalMap.end()) && (result->second == gestural));
+}
+
+curvature_CURVEDIR MusicXmlInput::CombineCurvedir(curvature_CURVEDIR startDir, curvature_CURVEDIR stopDir)
+{
+    if (startDir == curvature_CURVEDIR_NONE) {
+        return stopDir;
+    }
+    else if ((startDir != stopDir) && (stopDir != curvature_CURVEDIR_NONE)) {
+        return curvature_CURVEDIR_mixed;
+    }
+    else {
+        return startDir;
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR considers a mixed curve direction for slurs in the MusicXML import.
![MixedSlur](https://user-images.githubusercontent.com/63608463/157896087-8a6cf347-4773-4ce6-88be-0d0e59d96c96.png)

<details>
<summary>Show MusicXML example</summary>

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE score-partwise PUBLIC
    "-//Recordare//DTD MusicXML 4.0 Partwise//EN"
    "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="4.0">
  <part-list>
    <score-part id="P1">
      <part-name>Music</part-name>
    </score-part>
  </part-list>
  <part id="P1">
    <measure number="1">
     <attributes>
        <divisions>4</divisions>
        <key number="1">
           <fifths>0</fifths>
           <mode>major</mode>
        </key>
        <key number="2">
           <fifths>0</fifths>
           <mode>major</mode>
        </key>
        <time>
           <beats>4</beats>
           <beat-type>4</beat-type>
        </time>
        <staves>2</staves>
        <clef number="1">
           <sign>G</sign>
           <line>2</line>
        </clef>
        <clef number="2">
           <sign>F</sign>
           <line>4</line>
        </clef>
     </attributes>
     <note>
        <pitch>
           <step>D</step>
           <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>1</staff>
        <notations>
           <slur type="start" number="1" placement="below"/>
        </notations>
     </note>
     <note>
        <pitch>
           <step>C</step>
           <octave>5</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>1</staff>
     </note>
     <note>
        <pitch>
           <step>A</step>
           <octave>4</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
        <staff>1</staff>
     </note>
     <note>
        <pitch>
           <step>G</step>
           <octave>3</octave>
        </pitch>
        <duration>4</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
        <staff>2</staff>
        <notations>
           <slur type="stop" number="1" placement="above"/>
        </notations>
     </note>
     <backup>
        <duration>16</duration>
     </backup>
     <note>
        <rest/>
        <duration>16</duration>
        <voice>2</voice>
        <type>whole</type>
        <staff>2</staff>
     </note>
  </measure>
  </part>
</score-partwise>
```
</details>
