### PR TITLE
Transposition and multiple mdivs

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2546,17 +2546,20 @@ public:
 /**
  * member 0: a pointer to the transposer
  * member 1: a pointer to document
+ * member 2: the functor for redirection
  **/
 
 class TransposeParams : public FunctorParams {
 public:
-    TransposeParams(Doc *doc, Transposer *transposer)
+    TransposeParams(Doc *doc, Functor *functor, Transposer *transposer)
     {
         m_transposer = transposer;
         m_doc = doc;
+        m_functor = functor;
     }
     Transposer *m_transposer;
     Doc *m_doc;
+    Functor *m_functor;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -121,6 +121,11 @@ public:
      */
     int PrepareDuration(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::Transpose
+     */
+    int Transpose(FunctorParams *functorParams) override;
+
 private:
     /**
      * The score/scoreDef (first child of the score)

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1177,60 +1177,14 @@ void Doc::TransposeDoc()
 {
     Transposer transposer;
     transposer.SetBase600(); // Set extended chromatic alteration mode (allowing more than double sharps/flats)
-    std::string transpositionOption = m_options->m_transpose.GetValue();
-    if (transposer.IsValidIntervalName(transpositionOption)) {
-        transposer.SetTransposition(transpositionOption);
-    }
-    else if (transposer.IsValidKeyTonic(transpositionOption)) {
-
-        // Find the starting key tonic of the data to use in calculating the tranposition interval:
-        // Set transposition by key tonic.
-        // Detect the current key from the keysignature.
-        KeySig *keysig = dynamic_cast<KeySig *>(this->GetCurrentScoreDef()->FindDescendantByType(KEYSIG));
-        // If there is no keysignature, assume it is C.
-        TransPitch currentKey = TransPitch(0, 0, 0);
-        if (keysig && keysig->HasPname()) {
-            currentKey = TransPitch(keysig->GetPname(), ACCIDENTAL_GESTURAL_NONE, keysig->GetAccid(), 0);
-        }
-        else if (keysig) {
-            // No tonic pitch in key signature, so infer from key signature.
-            int fifthsInt = keysig->GetFifthsInt();
-            // Check the keySig@mode is present (currently assuming major):
-            currentKey = transposer.CircleOfFifthsToMajorTonic(fifthsInt);
-            // need to add a dummy "0" key signature in score (staffDefs of staffDef).
-        }
-        transposer.SetTransposition(currentKey, transpositionOption);
-    }
-
-    else if (transposer.IsValidSemitones(transpositionOption)) {
-        KeySig *keysig = dynamic_cast<KeySig *>(this->GetCurrentScoreDef()->FindDescendantByType(KEYSIG, 3));
-        int fifths = 0;
-        if (keysig) {
-            fifths = keysig->GetFifthsInt();
-        }
-        else {
-            LogWarning("No key signature in data, assuming no key signature with no sharps/flats.");
-            // need to add a dummy "0" key signature in score (staffDefs of staffDef).
-        }
-        transposer.SetTransposition(fifths, transpositionOption);
-    }
-    else {
-        LogWarning("Transposition option argument is invalid: %s", transpositionOption.c_str());
-        // there is no transposition that can be done so do not try
-        // to transpose any further (if continuing in this function,
-        // there will not be an error, just that the transposition
-        // will be at the unison, so no notes should change.
-        return;
-    }
 
     Functor transpose(&Object::Transpose);
-    TransposeParams transposeParams(this, &transposer);
+    TransposeParams transposeParams(this, &transpose, &transposer);
 
     if (m_options->m_transposeSelectedOnly.GetValue() == false) {
         transpose.m_visibleOnly = false;
     }
 
-    this->GetCurrentScoreDef()->Process(&transpose, &transposeParams);
     this->Process(&transpose, &transposeParams);
 }
 

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -276,4 +276,62 @@ int Score::PrepareDuration(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Score::Transpose(FunctorParams *functorParams)
+{
+    TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
+    assert(params);
+
+    ScoreDef *scoreDef = this->GetScoreDef();
+    Transposer *transposer = params->m_transposer;
+
+    const std::string transpositionOption = params->m_doc->GetOptions()->m_transpose.GetValue();
+    if (transposer->IsValidIntervalName(transpositionOption)) {
+        transposer->SetTransposition(transpositionOption);
+    }
+    else if (transposer->IsValidKeyTonic(transpositionOption)) {
+        // Find the starting key tonic of the data to use in calculating the tranposition interval:
+        // Set transposition by key tonic.
+        // Detect the current key from the keysignature.
+        KeySig *keysig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
+        // If there is no keysignature, assume it is C.
+        TransPitch currentKey = TransPitch(0, 0, 0);
+        if (keysig && keysig->HasPname()) {
+            currentKey = TransPitch(keysig->GetPname(), ACCIDENTAL_GESTURAL_NONE, keysig->GetAccid(), 0);
+        }
+        else if (keysig) {
+            // No tonic pitch in key signature, so infer from key signature.
+            int fifthsInt = keysig->GetFifthsInt();
+            // Check the keySig@mode is present (currently assuming major):
+            currentKey = transposer->CircleOfFifthsToMajorTonic(fifthsInt);
+            // need to add a dummy "0" key signature in score (staffDefs of staffDef).
+        }
+        transposer->SetTransposition(currentKey, transpositionOption);
+    }
+    else if (transposer->IsValidSemitones(transpositionOption)) {
+        KeySig *keysig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
+        int fifths = 0;
+        if (keysig) {
+            fifths = keysig->GetFifthsInt();
+        }
+        else {
+            LogWarning("No key signature in data, assuming no key signature with no sharps/flats.");
+            // need to add a dummy "0" key signature in score (staffDefs of staffDef).
+        }
+        transposer->SetTransposition(fifths, transpositionOption);
+    }
+    else {
+        LogWarning("Transposition option argument is invalid: %s", transpositionOption.c_str());
+        // there is no transposition that can be done so do not try
+        // to transpose any further (if continuing in this function,
+        // there will not be an error, just that the transposition
+        // will be at the unison, so no notes should change.
+        return FUNCTOR_STOP;
+    }
+
+    // Evaluate functor on scoreDef
+    scoreDef->Process(params->m_functor, params);
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv


### PR DESCRIPTION
The key signatures of multiple mdivs are not properly transformed during transposition. This PR fixes the issue.

Example without transposition:
![Base](https://user-images.githubusercontent.com/63608463/158415210-95bbee0c-1b6c-4ab1-bb9e-1731029f1a07.png)

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
           <title>
           </title>
           <composer>
           </composer>
           <respStmt>
           </respStmt>
         </titleStmt>
         <pubStmt>
           <date>2021</date>
           <availability>
             <useRestrict>This encoding is in the public domain. However, the sources used to create it
               may be under copyright. We believe their use by the MEI project for educational and
               research purposes is covered by the Fair Use doctrine. However, we will remove any
               material from the project archive when requested to do so by the copyright
               owner.</useRestrict>
           </availability>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp bar.thru="true" symbol="brace">
                    <staffDef n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="4s" meter.sym="common" />
                    <staffDef n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="4s" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="0">
                     <staff n="1">
                        <layer n="1">
                          <note dur="4" oct="4" pname="e" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="3">
                           <rest dur="4"/>
                        </layer>
                     </staff>
                     <tempo staff="1" place="above" tstamp="1.0"><rend fontname="VerovioText">♩</rend>=80</tempo>
                     <dynam place="between" staff="1 2" tstamp="1.0">p</dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp bar.thru="true" symbol="brace">
                    <staffDef n="1" lines="5" ppq="4" clef.shape="G" clef.line="2" key.sig="2s" meter.sym="common" />
                    <staffDef n="2" lines="5" ppq="4" clef.shape="F" clef.line="4" key.sig="2s" meter.sym="common" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="0">
                     <staff n="1">
                        <layer n="1">
                          <note dur="4" oct="4" pname="d" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="3">
                           <rest dur="4"/>
                        </layer>
                     </staff>
                     <tempo staff="1" place="above" tstamp="1.0"><rend fontname="VerovioText">♩</rend>=80</tempo>
                     <dynam place="between" staff="1 2" tstamp="1.0">p</dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

Transposed example with `--transpose -2`
| Before | After |
| ------ | ----- |
| ![-2-Before](https://user-images.githubusercontent.com/63608463/158415528-eca646c0-6a7c-477c-b445-e3db5ed9bcdd.png) | ![-2-After](https://user-images.githubusercontent.com/63608463/158415568-121d21e2-aefc-429f-aab1-de0947025f7d.png) |

Transposed example with `--transpose C`
| Before | After |
| ------ | ----- |
| ![C-Before](https://user-images.githubusercontent.com/63608463/158415685-e2adc47e-02f3-43e2-8e83-d36b0c158eb0.png) | ![C-After](https://user-images.githubusercontent.com/63608463/158415730-f384e326-ca80-4f6e-8ea5-09ef074db7e2.png) |


 