### PR TITLE
Improve slur thickness

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -226,8 +226,7 @@ public:
     /**
      * Calculate thickness coefficient to be applient for bezier curve to fit MEI units thickness
      */
-    static double GetBezierThicknessCoefficient(
-        const Point bezier[4], int currentThickness, double angle, int penWidth);
+    static double GetBezierThicknessCoefficient(const Point bezier[4], int currentThickness, int penWidth);
 
     /**
      * Calculate the point bezier point position for a t between 0.0 and 1.0
@@ -237,8 +236,7 @@ public:
     /**
      * Calculate the position of the bezier above and below for a thick bezier
      */
-    static void CalcThickBezier(
-        const Point bezier[4], int thickness, float angle, Point *topBezier, Point *bottomBezier);
+    static void CalcThickBezier(const Point bezier[4], int thickness, Point topBezier[4], Point bottomBezier[4]);
 
     /**
      * Approximate the bounding box of a bezier taking into accound the height and the width.

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -285,7 +285,7 @@ public:
      * Stored points are made relative to the curve drawingY.
      */
     ///@{
-    void UpdateCurveParams(const Point points[4], float angle, int thickness, curvature_CURVEDIR curveDir);
+    void UpdateCurveParams(const Point points[4], int thickness, curvature_CURVEDIR curveDir);
     void UpdatePoints(const BezierCurve &bezier);
     ///@}
 
@@ -324,7 +324,6 @@ public:
      */
     ///@{
     void GetPoints(Point points[4]) const;
-    float GetAngle() { return m_angle; }
     int GetThickness() { return m_thickness; }
     curvature_CURVEDIR GetDir() { return m_dir; }
     ///@}
@@ -378,7 +377,6 @@ private:
      */
     ///@{
     Point m_points[4];
-    float m_angle;
     int m_thickness;
     curvature_CURVEDIR m_dir;
     Staff *m_crossStaff;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -646,14 +646,6 @@ protected:
     int m_currentColour;
 
     /**
-     * Values to adjust tie/slur thickness to have proper MEI values for thickness
-     */
-    ///@{
-    double m_tieThicknessCoefficient;
-    double m_slurThicknessCoefficient;
-    ///@}
-
-    /**
      * Control the handling of slurs
      */
     SlurHandling m_slurHandling;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -539,8 +539,8 @@ protected:
     void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
-    void DrawThickBezierCurve(DeviceContext *dc, Point bezier[4], int thickness, int staffSize, int penWidth,
-        float angle = 0.0, int penStyle = AxSOLID);
+    void DrawThickBezierCurve(
+        DeviceContext *dc, Point bezier[4], int thickness, int staffSize, int penWidth, int penStyle = AxSOLID);
     void DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int y2, int fillSection);
     void DrawTextString(DeviceContext *dc, std::wstring str, TextDrawingParams &params);
     void DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParams &params, Rend *rend);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -590,7 +590,7 @@ private:
      */
     ///@{
     void DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, int x2, Staff *staff, char spanningType);
-    float CalcInitialSlur(
+    void CalcInitialSlur(
         FloatingCurvePositioner *curve, Slur *slur, Staff *staff, curvature_CURVEDIR curveDir, Point points[4]);
     ///@}
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -639,7 +639,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
     }
 
     Point topBezier[4], bottomBezier[4];
-    BoundingBox::CalcThickBezier(points, this->GetThickness(), this->GetAngle(), topBezier, bottomBezier);
+    BoundingBox::CalcThickBezier(points, this->GetThickness(), topBezier, bottomBezier);
 
     // Now calculate the left and right adjustments
     int leftAdjustment = 0;

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -513,7 +513,6 @@ void FloatingCurvePositioner::ResetCurveParams()
     m_points[1] = Point(0, 0);
     m_points[2] = Point(0, 0);
     m_points[3] = Point(0, 0);
-    m_angle = 0.0;
     m_thickness = 0;
     m_dir = curvature_CURVEDIR_NONE;
     m_crossStaff = NULL;
@@ -522,8 +521,7 @@ void FloatingCurvePositioner::ResetCurveParams()
     this->ClearSpannedElements();
 }
 
-void FloatingCurvePositioner::UpdateCurveParams(
-    const Point points[4], float angle, int thickness, curvature_CURVEDIR curveDir)
+void FloatingCurvePositioner::UpdateCurveParams(const Point points[4], int thickness, curvature_CURVEDIR curveDir)
 {
     m_points[0] = points[0];
     m_points[1] = points[1];
@@ -534,7 +532,6 @@ void FloatingCurvePositioner::UpdateCurveParams(
     m_points[1].y -= currentY;
     m_points[2].y -= currentY;
     m_points[3].y -= currentY;
-    m_angle = angle;
     m_thickness = thickness;
     m_dir = curveDir;
     m_cachedMinMaxY = VRV_UNSET;
@@ -547,7 +544,7 @@ void FloatingCurvePositioner::UpdatePoints(const BezierCurve &bezier)
     points[1] = bezier.c1;
     points[2] = bezier.c2;
     points[3] = bezier.p2;
-    this->UpdateCurveParams(points, m_angle, m_thickness, m_dir);
+    this->UpdateCurveParams(points, m_thickness, m_dir);
 }
 
 void FloatingCurvePositioner::MoveFrontHorizontal(int distance)

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -261,15 +261,15 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     assert(curve);
 
     const int thickness = drawingUnit * doc->GetOptions()->m_tieMidpointThickness.GetValue();
-    curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
+    curve->UpdateCurveParams(bezier, thickness, drawingCurveDir);
 
     if ((!startParentChord || isOuterChordNote) && durElement && (spanningType != SPANNING_END)) {
         UpdateTiePositioning(curve, bezier, durElement, note1, drawingUnit, drawingCurveDir);
-        curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
+        curve->UpdateCurveParams(bezier, thickness, drawingCurveDir);
     }
     if (!startParentChord && !endParentChord && note1 && note2 && (spanningType == SPANNING_START_END)) {
         if (this->AdjustEnharmonicTies(doc, curve, bezier, note1, note2, drawingCurveDir)) {
-            curve->UpdateCurveParams(bezier, 0.0, thickness, drawingCurveDir);
+            curve->UpdateCurveParams(bezier, thickness, drawingCurveDir);
         }
     }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -29,8 +29,6 @@ View::View()
     m_doc = NULL;
     m_options = NULL;
     m_pageIdx = 0;
-    m_tieThicknessCoefficient = 0.0;
-    m_slurThicknessCoefficient = 0.0;
     m_slurHandling = SlurHandling::Initialize;
 
     m_currentColour = AxNONE;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -956,9 +956,9 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_doc->GetOptions()->m_tieMidpointThickness.GetValue();
     const int penWidth
         = m_doc->GetOptions()->m_tieEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const double thicknessCoefficient = BoundingBox::GetBezierThicknessCoefficient(bezier, thickness, 0, penWidth);
+    const double thicknessCoefficient = BoundingBox::GetBezierThicknessCoefficient(bezier, thickness, penWidth);
     this->DrawThickBezierCurve(
-        dc, bezier, thicknessCoefficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
+        dc, bezier, thicknessCoefficient * thickness, staff->m_drawingStaffSize, penWidth, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -956,11 +956,9 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_doc->GetOptions()->m_tieMidpointThickness.GetValue();
     const int penWidth
         = m_doc->GetOptions()->m_tieEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (m_tieThicknessCoefficient <= 0) {
-        m_tieThicknessCoefficient = BoundingBox::GetBezierThicknessCoefficient(bezier, thickness, 0, penWidth);
-    }
+    const double thicknessCoefficient = BoundingBox::GetBezierThicknessCoefficient(bezier, thickness, 0, penWidth);
     this->DrawThickBezierCurve(
-        dc, bezier, m_tieThicknessCoefficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
+        dc, bezier, thicknessCoefficient * thickness, staff->m_drawingStaffSize, penWidth, 0, penStyle);
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -349,13 +349,13 @@ void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::wstring s, data
 }
 
 void View::DrawThickBezierCurve(
-    DeviceContext *dc, Point bezier[4], int thickness, int staffSize, int penWidth, float angle, int penStyle)
+    DeviceContext *dc, Point bezier[4], int thickness, int staffSize, int penWidth, int penStyle)
 {
     assert(dc);
 
     Point bez1[4], bez2[4]; // filled array with control points and end point
 
-    BoundingBox::CalcThickBezier(bezier, thickness, angle, bez1, bez2);
+    BoundingBox::CalcThickBezier(bezier, thickness, bez1, bez2);
 
     bez1[0] = ToDeviceContext(bez1[0]);
     bez1[1] = ToDeviceContext(bez1[1]);

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -73,9 +73,9 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     const int penWidth
         = m_doc->GetOptions()->m_slurEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const double thicknessCoefficient
-        = BoundingBox::GetBezierThicknessCoefficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
-    this->DrawThickBezierCurve(dc, points, thicknessCoefficient * curve->GetThickness(), staff->m_drawingStaffSize,
-        penWidth, curve->GetAngle(), penStyle);
+        = BoundingBox::GetBezierThicknessCoefficient(points, curve->GetThickness(), penWidth);
+    this->DrawThickBezierCurve(
+        dc, points, thicknessCoefficient * curve->GetThickness(), staff->m_drawingStaffSize, penWidth, penStyle);
 
     /*
     int i;

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -124,10 +124,10 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     points[0] = adjustedPoints.first;
     points[3] = adjustedPoints.second;
 
-    float angle = CalcInitialSlur(curve, slur, staff, drawingCurveDir, points);
+    this->CalcInitialSlur(curve, slur, staff, drawingCurveDir, points);
     int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_slurMidpointThickness.GetValue();
 
-    curve->UpdateCurveParams(points, angle, thickness, drawingCurveDir);
+    curve->UpdateCurveParams(points, thickness, drawingCurveDir);
 
     /************** articulation **************/
 
@@ -171,7 +171,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
     }
 }
 
-float View::CalcInitialSlur(
+void View::CalcInitialSlur(
     FloatingCurvePositioner *curve, Slur *slur, Staff *staff, curvature_CURVEDIR curveDir, Point points[4])
 {
     // For now we pick C1 = P1 and C2 = P2
@@ -262,8 +262,6 @@ float View::CalcInitialSlur(
     points[1] = bezier.c1;
     points[2] = bezier.c2;
     points[3] = bezier.p2;
-
-    return slurAngle;
 }
 
 } // namespace vrv

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -72,12 +72,10 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     }
     const int penWidth
         = m_doc->GetOptions()->m_slurEndpointThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    if (m_slurThicknessCoefficient <= 0) {
-        m_slurThicknessCoefficient
-            = BoundingBox::GetBezierThicknessCoefficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
-    }
-    this->DrawThickBezierCurve(dc, points, m_slurThicknessCoefficient * curve->GetThickness(),
-        staff->m_drawingStaffSize, penWidth, curve->GetAngle(), penStyle);
+    const double thicknessCoefficient
+        = BoundingBox::GetBezierThicknessCoefficient(points, curve->GetThickness(), curve->GetAngle(), penWidth);
+    this->DrawThickBezierCurve(dc, points, thicknessCoefficient * curve->GetThickness(), staff->m_drawingStaffSize,
+        penWidth, curve->GetAngle(), penStyle);
 
     /*
     int i;


### PR DESCRIPTION
This PR improves the slur thickness of angled, curved slurs.

| Before | After |
| ------ | ----- |
| ![Before1](https://user-images.githubusercontent.com/63608463/158540439-143b7d61-f32e-4d2e-92f4-c20be105f14d.png) | ![After1](https://user-images.githubusercontent.com/63608463/158540488-caa78b1e-3c38-49ec-a03b-9500fdeee2f6.png) |

<details>
<summary>Show example MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt>
            <availability>
               <distributor>©</distributor>
            </availability>
            <date isodate="2021-01-19" type="encoding-date">2021-01-19</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000002025321718">
         <appInfo xml:id="appinfo-0000001966309476">
            <application xml:id="application-0000000137519449" isodate="2021-08-16T13:52:09" version="3.6.0-dev-a7daec8">
               <name xml:id="name-0000000596975171">Verovio</name>
               <p xml:id="p-0000000318100213">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000001223482508">
            <score xml:id="score-0000000914591931">
               <scoreDef xml:id="scoredef-0000000114734246" midi.bpm="120.000000">
                  <staffGrp xml:id="staffgrp-0000001503738053">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <instrDef xml:id="instrdef-0000001737898875" midi.channel="0" midi.instrnum="0" midi.volume="80.00%" />
                        <staffDef xml:id="staffdef-0000000073007897" n="1" lines="5" ppq="2">
                           <clef xml:id="clef-0000001551868381" shape="G" line="2" />
                           <keySig xml:id="keysig-0000001062986652" mode="major" sig="0" />
                           <meterSig xml:id="msig-0000000700200771" count="6" unit="8" />
                        </staffDef>
                        <staffDef xml:id="staffdef-0000000063972637" n="2" lines="5" ppq="2">
                           <clef xml:id="clef-0000001169911052" shape="F" line="4" />
                           <keySig xml:id="keysig-0000000334779032" mode="major" sig="0" />
                           <meterSig xml:id="msig-0000000224035684" count="6" unit="8" />
                        </staffDef>
                        <grpSym xml:id="grpsym-0000000828907797" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000002006122738">
                  <measure xml:id="measure-0000001518852559" n="5">
                     <staff xml:id="staff-0000000696731609" n="1">
                        <layer xml:id="layer-0000001669216143" n="1">
                           <mSpace xml:id="mSpace-0000000822673254" />
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001887309019" n="2">
                        <layer xml:id="layer-0000001169660592" n="3">
                           <beam xml:id="beam-0000000420265106">
                              <note xml:id="note-0000000321921559" dur.ppq="1" dur="8" oct="2" pname="a" stem.dir="up" />
                              <note xml:id="note-0000001774808888" dur.ppq="1" dur="8" oct="3" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000665123786" dur.ppq="1" dur="8" staff="1" oct="4" pname="a" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000001083088667">
                              <note xml:id="note-0000001399834297" dur.ppq="1" dur="8" staff="1" oct="7" pname="c" stem.dir="down" />
                              <note xml:id="note-0000001331676794" dur.ppq="1" dur="8" staff="1" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0000000417307724" dur.ppq="1" dur="8" staff="1" oct="4" pname="a" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000001024335320" startid="#note-0000000321921559" endid="#note-0000000417307724" curvedir="above" />
                  </measure>
                  <sb xml:id="sb-0000000077342252" />
                  <measure xml:id="measure-0000000009326166" n="6">
                     <staff xml:id="staff-0000000094565761" n="1">
                        <layer xml:id="layer-0000000663622929" n="1">
                           <mSpace xml:id="mSpace-0000000519152997" />
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000228846347" n="2">
                        <layer xml:id="layer-0000000178362818" n="3">
                           <beam xml:id="beam-0000002004194561">
                              <note xml:id="note-0000001216983532" dur.ppq="1" dur="8" oct="2" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000012752134" dur.ppq="1" dur="8" oct="3" pname="a" stem.dir="up" />
                              <note xml:id="note-0000001724235085" dur.ppq="1" dur="8" staff="1" oct="4" pname="a" stem.dir="down" />
                           </beam>
                           <beam xml:id="beam-0000001074740977">
                              <note xml:id="note-0000000686645522" dur.ppq="1" dur="8" staff="1" oct="5" pname="a" stem.dir="down" />
                              <note xml:id="note-0000002021652923" dur.ppq="1" dur="8" staff="1" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="note-0000000434414027" dur.ppq="1" dur="8" oct="3" pname="a" stem.dir="up" />
                           </beam>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000001207968296" startid="#note-0000001216983532" endid="#note-0000000434414027" curvedir="above" />
                  </measure>
                  <measure xml:id="measure-0000001899635636" n="7">
                     <staff xml:id="staff-0000002005635655" n="1">
                        <layer xml:id="layer-0000001889292676" n="1">
                           <mSpace xml:id="mSpace-0000001623763111" />
                        </layer>
                        <layer xml:id="layer-0000000364420501" n="3">
                           <beam xml:id="beam-0000000191999063">
                              <note xml:id="note-0000001407814047" dur.ppq="1" dur="8" oct="5" pname="a" stem.dir="down" />
                              <note xml:id="note-0000001845245688" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="note-0000001232931889" dur.ppq="1" dur="8" staff="2" oct="2" pname="a" stem.dir="up" />
                           </beam>
                           <beam xml:id="beam-0000000816548520">
                              <note xml:id="note-0000001310471310" dur.ppq="1" dur="8" staff="2" oct="0" pname="a" stem.dir="up" />
                              <note xml:id="note-0000000499023538" dur.ppq="1" dur="8" staff="2" oct="2" pname="a" stem.dir="up" />
                              <note xml:id="note-0000001164961631" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001815130273" n="2">
                        <layer xml:id="layer-0000000901722518" n="1">
                           <mSpace xml:id="mSpace-0000000458263147" />
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000000155865283" startid="#note-0000001407814047" endid="#note-0000001164961631" curvedir="below" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

In extreme cases the boundary curves of the slur did even intersect. This should not happen anymore.
| Before | After |
| ------ | ----- |
| ![Before2](https://user-images.githubusercontent.com/63608463/158540936-c6b057e6-8410-4719-b82b-03cdeeb5d99f.png) | ![After2](https://user-images.githubusercontent.com/63608463/158540977-4527b166-ef85-4547-a415-35cda8c6e090.png) |


 