### PR TITLE
Fix beamspan stem length issue during justification

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -198,6 +198,7 @@ protected:
      * Defined in view_page.cpp
      */
     ///@{
+    void DrawBeamspanOnly(DeviceContext *dc, Object *parent, Measure *measure, System *system);
     void DrawPageElement(DeviceContext *dc, PageElement *element);
     void DrawSystem(DeviceContext *dc, System *system);
     void DrawSystemList(DeviceContext *dc, System *system, const ClassId classId);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1188,6 +1188,15 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
     }
 }
 
+void View::DrawBeamspanOnly(DeviceContext *dc, Object *parent, Measure *measure, System *system)
+{
+    for (auto current : parent->GetChildren()) {
+        if (!current->Is(BEAMSPAN)) continue;
+        this->DrawControlElement(dc, dynamic_cast<ControlElement *>(current), measure, system);
+    }
+    this->DrawSystemList(dc, system, BEAMSPAN);
+}
+
 //----------------------------------------------------------------------------
 // View - Staff
 //----------------------------------------------------------------------------
@@ -1625,11 +1634,7 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
 
     // Beamspan has to be processes first to make sure that stems for all notes have correct length and extend all the
     // way to the beam. For this, only beamspans are processed first and are ignored in the next loop
-    for (auto current : parent->GetChildren()) {
-        if (!current->Is(BEAMSPAN)) continue;
-        this->DrawControlElement(dc, dynamic_cast<ControlElement *>(current), measure, system);
-    }
-    this->DrawSystemList(dc, system, BEAMSPAN);
+    this->DrawBeamspanOnly(dc, parent, measure, system);
 
     for (auto current : parent->GetChildren()) {
         if (current->Is(STAFF)) {

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -203,7 +203,7 @@ void View::DrawSystem(DeviceContext *dc, System *system)
     this->DrawSystemChildren(dc, system, system);
 
     this->DrawSystemList(dc, system, SYL);
-    this->DrawSystemList(dc, system, BEAMSPAN);
+    // BEAMSPAN is drawn earlier, inside call to DrawMeasureChildren()
     this->DrawSystemList(dc, system, BRACKETSPAN);
     this->DrawSystemList(dc, system, DYNAM);
     this->DrawSystemList(dc, system, DIR);
@@ -1623,12 +1623,21 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
     assert(measure);
     assert(system);
 
+    // Beamspan has to be processes first to make sure that stems for all notes have correct length and extend all the
+    // way to the beam. For this, only beamspans are processed first and are ignored in the next loop
+    for (auto current : parent->GetChildren()) {
+        if (!current->Is(BEAMSPAN)) continue;
+        this->DrawControlElement(dc, dynamic_cast<ControlElement *>(current), measure, system);
+    }
+    this->DrawSystemList(dc, system, BEAMSPAN);
+
     for (auto current : parent->GetChildren()) {
         if (current->Is(STAFF)) {
             // cast to Staff check in DrawStaff
             this->DrawStaff(dc, dynamic_cast<Staff *>(current), measure, system);
         }
         else if (current->IsControlElement()) {
+            if (current->Is(BEAMSPAN)) continue;
             // cast to ControlElement check in DrawControlElement
             this->DrawControlElement(dc, dynamic_cast<ControlElement *>(current), measure, system);
         }


### PR DESCRIPTION
Fix for the vertical justification issue that happens with `beamSpan` that have cross-staff elements:
![image](https://user-images.githubusercontent.com/1819669/158785913-adffec64-c8cb-4926-b3bc-1ef0bb58f046.png)

This is caused by the fact, that `beamSpan` is control element and is rendered after all layer elements. This means, that stem adjustments that occur inside beam code happen after stems were already rendered and do not impact final result.
With this change this problem should be gone without impacting `beamSpan` performance:
![image](https://user-images.githubusercontent.com/1819669/158786321-db2e825c-c77f-485b-94bf-037ad79f23e5.png)
