### PR TITLE
Fix minimal white space regression

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -805,8 +805,9 @@ int System::AlignSystems(FunctorParams *functorParams)
         // Alignment is already pre-determined with staff alignment overflow
         // We need to subtract them from the desired spacing
         const int actualSpacing = systemSpacing - std::max(contentOverflow, clefOverflow);
-        // Set the spacing if it exists (greater than 0)
-        if (actualSpacing > 0) params->m_shift -= actualSpacing;
+        // Ensure minimal white space between consecutive systems by adding one staff space
+        const int unit = params->m_doc->GetDrawingUnit(100);
+        params->m_shift -= std::max(actualSpacing, 2 * unit);
     }
 
     this->SetDrawingYRel(params->m_shift);


### PR DESCRIPTION
The changes from #2539 got lost during #2632 :
<img width="1532" alt="NoMinSpace" src="https://user-images.githubusercontent.com/63608463/158973856-c9ee5312-4250-41f0-bf87-1f52743ccbcd.png">

This PR adds minimal white space between consecutive systems again.
