### PR TITLE
Fix regression for optimal positioning of quarter rests

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -143,7 +143,7 @@ private:
      * Get the rest vertical location relative to location of elements placed on other layers
      */
     std::pair<int, RestAccidental> GetLocationRelativeToOtherLayers(
-        const ListOfObjects &layersList, Layer *currentLayer, bool isTopLayer);
+        const ListOfObjects &layersList, Layer *currentLayer, bool isTopLayer, bool &restOverlap);
 
     /**
      * Get the rest vertical location relative to location of elements placed on current layers


### PR DESCRIPTION
closes #2713 

Fixes optimal position:
![image](https://user-images.githubusercontent.com/1819669/159006559-5f848819-e068-49ac-af0b-6b044aa31034.png)

Keeps position in other situations:
![image](https://user-images.githubusercontent.com/1819669/159006571-8989260d-984b-4939-8e8c-ff052dc2939d.png)
