### PR TITLE
Reduce tie curvature to avoid overlaps with staff lines

### DIFF
--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -240,7 +240,7 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     // control points
     Point c1, c2;
     // the height of the control points
-    height *= 4 / 3;
+    height *= 0.7;
 
     c1.x = startPoint.x + (endPoint.x - startPoint.x) / 4; // point at 1/4
     c2.x = startPoint.x + (endPoint.x - startPoint.x) / 4 * 3; // point at 3/4

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -230,20 +230,16 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
 
     /************** bezier points **************/
 
-    // the 'height' of the bezier
-    int height = drawingUnit;
-    // if the space between the to points is more than two staff height, increase the height
-    if (endPoint.x - startPoint.x > 2 * doc->GetDrawingStaffSize(staff->m_drawingStaffSize)) {
-        height += drawingUnit;
-    }
+    // adjust the 'height' of the bezier based on the width of staff lines to make sure that there tie does not overlap
+    // with them
+    const int height = (1.6 - doc->GetOptions()->m_staffLineWidth.GetValue()) * drawingUnit;
+    const int distance = endPoint.x - startPoint.x; 
 
     // control points
     Point c1, c2;
-    // the height of the control points
-    height *= 0.7;
 
-    c1.x = startPoint.x + (endPoint.x - startPoint.x) / 4; // point at 1/4
-    c2.x = startPoint.x + (endPoint.x - startPoint.x) / 4 * 3; // point at 3/4
+    c1.x = startPoint.x + distance / 4; // point at 1/4
+    c2.x = startPoint.x + distance / 4 * 3; // point at 3/4
 
     c1.y = startPoint.y + ySign * height;
     c2.y = endPoint.y + ySign * height;

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -230,7 +230,7 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
 
     /************** bezier points **************/
 
-    // adjust the 'height' of the bezier based on the width of staff lines to make sure that there tie does not overlap
+    // adjust the 'height' of the bezier based on the width of staff lines to make sure that the tie does not overlap
     // with them
     const int height = (1.6 - doc->GetOptions()->m_staffLineWidth.GetValue()) * drawingUnit;
     const int distance = endPoint.x - startPoint.x; 

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -233,7 +233,7 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     // adjust the 'height' of the bezier based on the width of staff lines to make sure that the tie does not overlap
     // with them
     const int height = (1.6 - doc->GetOptions()->m_staffLineWidth.GetValue()) * drawingUnit;
-    const int distance = endPoint.x - startPoint.x; 
+    const int distance = endPoint.x - startPoint.x;
 
     // control points
     Point c1, c2;


### PR DESCRIPTION
This is a change for tie curves to avoid them overlapping with staff lines:
Before:
![image](https://user-images.githubusercontent.com/1819669/159012807-ba3f9e50-8bfa-427b-a784-550b57e8ffb3.png)

After:
![image](https://user-images.githubusercontent.com/1819669/159012853-4945cde7-b107-46f5-bfb5-90e93ebdfdae.png)

Previously, part of the code for determining height of the control points was calculated incorrectly:
```
height *= 4 / 3;
```
This was pretty much the same as `height *= 1`, since there was a division of two integers.
New changes make ties slightly flatter to avoid overlaps with staff lines at the middle. Additionally, staff line width is taken into consideration to further improve upon this.
There is also a change to short ties to avoid making their height smaller, as they would be subject to the same problem - overlapping with staff lines.
