### PR TITLE
Fix cross-staff beamspan stems

### DIFF
--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -84,6 +84,11 @@ public:
     //----------//
 
     /**
+     * See Object::ResetHorizontalAlignment
+     */
+    int ResetHorizontalAlignment(FunctorParams *functorParams) override;
+
+    /**
      * See Object::CalcStem
      */
     int CalcStem(FunctorParams *functorParams) override;

--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -19,6 +19,7 @@ namespace vrv {
 
 class Layer;
 class Staff;
+class System;
 
 //----------------------------------------------------------------------------
 // BeamSpan
@@ -75,6 +76,8 @@ public:
     void InitBeamSegments();
     void ClearBeamSegments();
     ////@}
+
+    BeamSpanSegment *GetSegmentForSystem(System *system);
 
     //----------//
     // Functors //

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -65,9 +65,12 @@ private:
     //
 public:
     //
-private:
+protected:
     /** The list of object for which drawing is postponed */
     ArrayOfObjects m_drawingList;
+
+private:
+    //
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -271,6 +271,11 @@ public:
     int JustifyY(FunctorParams *functorParams) override;
 
     /**
+     * See Object::AdjustCrossStaffYPos
+     */
+    int AdjustCrossStaffYPos(FunctorParams *functorParams) override;
+
+    /**
      * See Object::AdjustStaffOverlap
      */
     int AdjustStaffOverlap(FunctorParams *functorParams) override;

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -195,6 +195,14 @@ bool BeamSpan::AddSpanningSegment(Doc *doc, const SpanIndexVector &elements, int
 // Functors //
 //----------//
 
+int BeamSpan::ResetHorizontalAlignment(FunctorParams *functorParams)
+{
+    this->ClearBeamSegments();
+    this->InitBeamSegments();
+
+    return ControlElement::ResetHorizontalAlignment(functorParams);
+}
+
 int BeamSpan::CalcStem(FunctorParams *functorParams)
 {
     CalcStemParams *params = vrv_params_cast<CalcStemParams *>(functorParams);

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -89,7 +89,7 @@ BeamSpanSegment *BeamSpan::GetSegmentForSystem(System *system)
     for (auto segment : m_beamSegments) {
         // make sure to process only segments for current system
         Measure *segmentSystem = segment->GetMeasure();
-        if (vrv_cast<System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system) return segment;
+        if (segmentSystem && vrv_cast<System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system) return segment;
     }
     return NULL;
 }

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -19,6 +19,7 @@
 #include "layer.h"
 #include "measure.h"
 #include "staff.h"
+#include "system.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -79,6 +80,18 @@ void BeamSpan::ClearBeamSegments()
         delete segment;
     }
     m_beamSegments.clear();
+}
+
+BeamSpanSegment *BeamSpan::GetSegmentForSystem(System *system)
+{
+    assert(system);
+
+    for (auto segment : m_beamSegments) {
+        // make sure to process only segments for current system
+        Measure *segmentSystem = segment->GetMeasure();
+        if (vrv_cast<System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system) return segment;
+    }
+    return NULL;
 }
 
 ArrayOfObjects BeamSpan::GetBeamSpanElementList(Layer *layer, Staff *staff)

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -13,6 +13,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "beamspan.h"
 #include "comparison.h"
 #include "dir.h"
 #include "doc.h"
@@ -876,6 +877,26 @@ int System::JustifyY(FunctorParams *functorParams)
 
     params->m_relativeShift = 0;
     m_systemAligner.Process(params->m_functor, params);
+
+    return FUNCTOR_SIBLINGS;
+}
+
+int System::AdjustCrossStaffYPos(FunctorParams *functorParams)
+{
+    FunctorDocParams *params = vrv_params_cast<FunctorDocParams *>(functorParams);
+    assert(params);
+
+    for (auto &item : m_drawingList) {
+        if (item->Is(BEAMSPAN)) {
+            // Here we could check that the beamSpan is actually cross-staff. Otherwise doing this is pointless
+            BeamSpan *beamSpan = vrv_cast<BeamSpan *>(item);
+            assert(beamSpan);
+            BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(this);
+            if (segment)
+                segment->CalcBeam(
+                    segment->GetLayer(), segment->GetStaff(), params->m_doc, beamSpan, beamSpan->m_drawingPlace);
+        }
+    }
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -438,7 +438,7 @@ void View::DrawBeamSpan(DeviceContext *dc, BeamSpan *beamSpan, System *system, O
     else {
         dc->StartGraphic(beamSpan, "", beamSpan->GetUuid(), false);
     }
-    
+
     BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
     if (segment) {
         // Reset current segment and set coordinates based on stored begin/end iterators for the ElementCoords
@@ -448,8 +448,9 @@ void View::DrawBeamSpan(DeviceContext *dc, BeamSpan *beamSpan, System *system, O
             beamSpan->m_beamElementCoords.begin(), beamSpan->m_beamElementCoords.end(), segment->GetBeginCoord());
         const auto coordsLast = std::find(
             beamSpan->m_beamElementCoords.begin(), beamSpan->m_beamElementCoords.end(), segment->GetEndCoord());
-        
-        if ((coordsFirst != beamSpan->m_beamElementCoords.end()) && (coordsLast != beamSpan->m_beamElementCoords.end())) {
+
+        if ((coordsFirst != beamSpan->m_beamElementCoords.end())
+            && (coordsLast != beamSpan->m_beamElementCoords.end())) {
             ArrayOfBeamElementCoords coord(coordsFirst, coordsLast + 1);
             segment->InitCoordRefs(&coord);
             segment->CalcBeam(segment->GetLayer(), segment->GetStaff(), m_doc, beamSpan, beamSpan->m_drawingPlace);

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -438,11 +438,9 @@ void View::DrawBeamSpan(DeviceContext *dc, BeamSpan *beamSpan, System *system, O
     else {
         dc->StartGraphic(beamSpan, "", beamSpan->GetUuid(), false);
     }
-
-    for (auto segment : beamSpan->m_beamSegments) {
-        // make sure to process only segments for current system
-        Measure *segmentSystem = segment->GetMeasure();
-        if (vrv_cast<System *>(segmentSystem->GetFirstAncestor(SYSTEM)) != system) continue;
+    
+    BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
+    if (segment) {
         // Reset current segment and set coordinates based on stored begin/end iterators for the ElementCoords
         segment->Reset();
 
@@ -450,16 +448,16 @@ void View::DrawBeamSpan(DeviceContext *dc, BeamSpan *beamSpan, System *system, O
             beamSpan->m_beamElementCoords.begin(), beamSpan->m_beamElementCoords.end(), segment->GetBeginCoord());
         const auto coordsLast = std::find(
             beamSpan->m_beamElementCoords.begin(), beamSpan->m_beamElementCoords.end(), segment->GetEndCoord());
-        if ((coordsFirst == beamSpan->m_beamElementCoords.end()) || (coordsLast == beamSpan->m_beamElementCoords.end()))
-            continue;
+        
+        if ((coordsFirst != beamSpan->m_beamElementCoords.end()) && (coordsLast != beamSpan->m_beamElementCoords.end())) {
+            ArrayOfBeamElementCoords coord(coordsFirst, coordsLast + 1);
+            segment->InitCoordRefs(&coord);
+            segment->CalcBeam(segment->GetLayer(), segment->GetStaff(), m_doc, beamSpan, beamSpan->m_drawingPlace);
+            segment->AppendSpanningCoordinates(segment->GetMeasure());
 
-        ArrayOfBeamElementCoords coord(coordsFirst, coordsLast + 1);
-        segment->InitCoordRefs(&coord);
-        segment->CalcBeam(segment->GetLayer(), segment->GetStaff(), m_doc, beamSpan, beamSpan->m_drawingPlace);
-        segment->AppendSpanningCoordinates(segment->GetMeasure());
-
-        // Draw corresponding beam segment
-        this->DrawBeamSegment(dc, segment, beamSpan, segment->GetLayer(), segment->GetStaff());
+            // Draw corresponding beam segment
+            this->DrawBeamSegment(dc, segment, beamSpan, segment->GetLayer(), segment->GetStaff());
+        }
     }
 
     if (graphic) {


### PR DESCRIPTION
Another approach for the fix proposed in https://github.com/rism-digital/verovio/pull/2718

Before
![image](https://user-images.githubusercontent.com/689412/159443976-522e1916-401a-4ec6-b33e-7c82f2c93819.png)

After
![image](https://user-images.githubusercontent.com/689412/159443844-34165e1d-9817-458b-9f0f-37afb22cb6aa.png)



<details>
<summary>MEI code</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Beam span</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="editor">Laurent Pugin</persName>
               <persName role="encoder">Andriy Makarchuk</persName>
            </respStmt>
            <date isodate="2022-02-15">2022-01-15</date>
            <pubPlace>
               <ref target="https://github.com/rism-digital/verovio/pull/2640" />
            </pubPlace>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>BeamSpans can be cross-staff and cross-measure.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.9.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="120" key.mode="major" key.sig="2f" meter.count="4" meter.unit="2" meter.sym="common">
                  <staffGrp symbol="brace" bar.thru="true">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                        <instrDef midi.channel="0" midi.instrnum="0" />
                     </staffDef>
                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4">
                        <instrDef midi.channel="1" midi.instrnum="0" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure metcon="false" n="222">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="c01" dur="32" oct="4" pname="g" stem.dir="up" />
                           <note xml:id="c02" dur="32" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="c03" dur="32" oct="4" pname="e" stem.dir="up" />
                           <note xml:id="c04" dur="32" oct="4" pname="d" stem.dir="up" />
                           <note xml:id="c05" dur="32" oct="4" pname="c" stem.dir="up" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                        </layer>
                     </staff>
                     <beamSpan startid="#c01" endid="#c16" plist="#c01 #c02 #c03 #c04 #c05 #c13 #c14 #c15 #c16"/>
                     <dynam startid="#c05">ppp</dynam>
                  </measure>
                  <measure metcon="false" n="223">
                     <staff n="1">
                        <layer n="1">
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <note xml:id="c13" dur="32" oct="3" pname="b" stem.dir="up" />
                           <note xml:id="c14" dur="32" oct="3" pname="a" stem.dir="up" />
                           <note xml:id="c15" dur="32" oct="3" pname="g" stem.dir="up" />
                           <note xml:id="c16" dur="32" oct="3" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>


Instead of switching the drawing sequence, this PR adjusts the beam spans during the vertical layout calculation. The new idea here is to use, during the vertical alignement, the system DrawingListInterface::m_drawingList that has been instantiated before when drawing the bounding boxes for layout calculation. I never thought about it but it seems to work and can maybe used in other cases (e.g. slurs).

We probably need to do something similar after the vertical justification process in `Object::AdjustCrossStaffContent`.