### PR TITLE
Fix overlap of accidentals with ledger lines

### DIFF
--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -126,9 +126,9 @@ void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
 
     const int unit = doc->GetDrawingUnit(staffSize);
+    const int rightMargin = doc->GetRightMargin(ACCID) * unit;
     if (element->Is(NOTE) && chord && chord->HasAdjacentNotesInStaff(staff)) {
-        const int horizontalMargin
-            = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + doc->GetDrawingStemWidth(staffSize);
+        const int horizontalMargin = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + 0.5 * rightMargin;
         const int drawingUnit = doc->GetDrawingUnit(staffSize);
         const int staffTop = staff->GetDrawingY();
         const int staffBottom = staffTop - doc->GetDrawingStaffSize(staffSize);
@@ -161,8 +161,7 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
         int ledgerAbove = 0;
         int ledgerBelow = 0;
         if (note->HasLedgerLines(ledgerAbove, ledgerBelow)) {
-            const int value
-                = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + doc->GetDrawingStemWidth(staffSize);
+            const int value = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + 0.5 * horizontalMargin;
             horizontalMargin = std::max(horizontalMargin, value);
         }
     }

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -154,7 +154,8 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
     // Reduce spacing for successive accidentals
-    if (element->Is(ACCID)) horizontalMargin *= 0.66;
+    if (element->Is(ACCID))
+        horizontalMargin *= 0.66;
     else if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);
         int ledgerAbove = 0;

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -154,8 +154,9 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
     // Reduce spacing for successive accidentals
-    if (element->Is(ACCID))
+    if (element->Is(ACCID)) {
         horizontalMargin *= 0.66;
+    }
     else if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);
         int ledgerAbove = 0;

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -125,8 +125,10 @@ void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
     Staff *staff = element->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
 
+    const int unit = doc->GetDrawingUnit(staffSize);
     if (element->Is(NOTE) && chord && chord->HasAdjacentNotesInStaff(staff)) {
-        const int horizontalMargin = 4 * doc->GetDrawingStemWidth(staffSize);
+        const int horizontalMargin
+            = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + doc->GetDrawingStemWidth(staffSize);
         const int drawingUnit = doc->GetDrawingUnit(staffSize);
         const int staffTop = staff->GetDrawingY();
         const int staffBottom = staffTop - doc->GetDrawingStaffSize(staffSize);
@@ -153,6 +155,16 @@ void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
     // Reduce spacing for successive accidentals
     if (element->Is(ACCID)) horizontalMargin *= 0.66;
+    else if (element->Is(NOTE)) {
+        Note *note = vrv_cast<Note *>(element);
+        int ledgerAbove = 0;
+        int ledgerBelow = 0;
+        if (note->HasLedgerLines(ledgerAbove, ledgerBelow)) {
+            const int value
+                = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + doc->GetDrawingStemWidth(staffSize);
+            horizontalMargin = std::max(horizontalMargin, value);
+        }
+    }
     const int verticalMargin = unit / 4;
 
     if (!this->VerticalSelfOverlap(element, verticalMargin)) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1555,7 +1555,7 @@ Options::Options()
     /// custom right
 
     m_rightMarginAccid.SetInfo("Right margin accid", "The right margin for accid in MEI units");
-    m_rightMarginAccid.Init(0.5, 0.0, 2.0);
+    m_rightMarginAccid.Init(0.75, 0.0, 2.0);
     this->Register(&m_rightMarginAccid, "rightMarginAccid", &m_elementMargins);
 
     m_rightMarginBarLine.SetInfo("Right margin barLine", "The right margin for barLine in MEI units");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1555,7 +1555,7 @@ Options::Options()
     /// custom right
 
     m_rightMarginAccid.SetInfo("Right margin accid", "The right margin for accid in MEI units");
-    m_rightMarginAccid.Init(0.75, 0.0, 2.0);
+    m_rightMarginAccid.Init(0.5, 0.0, 2.0);
     this->Register(&m_rightMarginAccid, "rightMarginAccid", &m_elementMargins);
 
     m_rightMarginBarLine.SetInfo("Right margin barLine", "The right margin for barLine in MEI units");


### PR DESCRIPTION
Fix overlap that happens between ledger lines and accidentals, especially when `--ledger-line-extension` option is specified:
![image](https://user-images.githubusercontent.com/1819669/159695199-cbfef645-7e7b-4c12-a0bc-b3e28a2c23aa.png)
After fix:
![image](https://user-images.githubusercontent.com/1819669/159695231-34bc926e-1f44-4166-82de-543f0e19599d.png)
