### PR TITLE
Steep slurs

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -250,6 +250,9 @@ private:
     // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:
     // tan(atan(doublingBound) + degrees * PI / 180.0) ≈ 2.0 * doublingBound
     double RotateSlope(double slope, double degrees, double doublingBound, bool upwards) const;
+
+    // Calculate the minimal angle <)C1P1P2 or <)P1P2C2
+    float GetMinControlPointAngle(const BezierCurve &bezierCurve, float angle, int unit) const;
     ///@}
 
 public:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1316,7 +1316,7 @@ Options::Options()
     this->Register(&m_slurMargin, "slurMargin", &m_generalLayout);
 
     m_slurMaxSlope.SetInfo("Slur max slope", "The maximum slur slope in degrees");
-    m_slurMaxSlope.Init(40, 0, 80);
+    m_slurMaxSlope.Init(60, 30, 85);
     this->Register(&m_slurMaxSlope, "slurMaxSlope", &m_generalLayout);
 
     m_slurEndpointThickness.SetInfo("Slur Endpoint thickness", "The Endpoint slur thickness in MEI units");

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -236,12 +236,7 @@ void View::CalcInitialSlur(
 
     /************** angle **************/
 
-    bool dontAdjustAngle = curve->IsCrossStaff() || slur->GetStart()->IsGraceNote();
-    // If slur is cross-staff (where we don't want to adjust angle) but x distance is too small - adjust angle anyway
-    if ((bezier.p2.x - bezier.p1.x) != 0 && curve->IsCrossStaff()) {
-        dontAdjustAngle = std::abs((bezier.p2.y - bezier.p1.y) / (bezier.p2.x - bezier.p1.x)) < 4;
-    }
-
+    const bool dontAdjustAngle = curve->IsCrossStaff() || slur->GetStart()->IsGraceNote();
     const float nonAdjustedAngle
         = (bezier.p2 == bezier.p1) ? 0 : atan2(bezier.p2.y - bezier.p1.y, bezier.p2.x - bezier.p1.x);
     const float slurAngle


### PR DESCRIPTION
The look of steep slurs is somewhat inconsistent due to the bound by `--slur-max-slope`.
This PR increases the default angle and does some improvements for the shape correction of steep slurs.
| Before | After |
| ------ | ----- |
| <img width="355" alt="Before" src="https://user-images.githubusercontent.com/63608463/159911251-04c3296b-61ef-4317-8bcf-39d38228bb71.png"> | <img width="353" alt="After" src="https://user-images.githubusercontent.com/63608463/159911322-18ca3637-c1b2-47a1-beaa-dc9a5b05e52d.png"> |

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-07-30" type="encoding-date">2021-07-30</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-vaq0wr">
         <appInfo xml:id="appinfo-3qkozc">
            <application xml:id="application-x2dyp" isodate="2022-02-01T09:09:06" version="3.9.0-dev-4366ff2">
               <name xml:id="name-nod86h">Verovio</name>
               <p xml:id="p-m2aolf">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m9f26ke">
            <score xml:id="s1ude8r">
               <scoreDef xml:id="sh2smh1">
                  <staffGrp xml:id="sk5779y">
                     <staffGrp xml:id="S1-WudXPlSyWae1CbNa6dCgQA" bar.thru="true">
                        <staffDef xml:id="sf891ir" n="1" lines="5" ppq="8">
                           <clef xml:id="clef-1" shape="G" line="2" />
                           <keySig xml:id="key-1" sig="0" />
                           <meterSig xml:id="time-1" count="3" unit="8" />
                        </staffDef>
                        <staffDef xml:id="sj5lkyk" n="2" lines="5" ppq="8">
                           <clef xml:id="clef-2" shape="F" line="4" />
                           <keySig xml:id="key-2" sig="0" />
                           <meterSig xml:id="time-2" count="3" unit="8" />
                        </staffDef>
                        <grpSym xml:id="gvafifs" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="snjy8lw">
                  <measure xml:id="measure-0165-10280-10910-1-mdiv-1" n="49">
                     <staff xml:id="s31456p" n="1">
                        <layer xml:id="laebdlz" n="1">
                           <note xml:id="note-0165-10320-11030-2" dur.ppq="4" dur="8" oct="4" pname="b" stem.dir="down" />
                           <rest xml:id="rest-0165-10430-11070" dur.ppq="2" dur="16" />
                           <beam xml:id="bvn4fh2">
                              <note xml:id="note-0165-10470-11070-2" dur.ppq="2" dur="16" oct="4" pname="e" stem.dir="down" />
                              <note xml:id="note-0165-10520-11000-2" dur.ppq="2" dur="16" oct="5" pname="e" stem.dir="down" />
                           </beam>
                           <rest xml:id="rest-0165-10600-11070" dur.ppq="2" dur="16" />
                        </layer>
                     </staff>
                     <staff xml:id="scfxt6p" n="2">
                        <layer xml:id="lsar0ob" n="5">
                           <beam xml:id="brkd3z0">
                              <note xml:id="note-0165-10330-11280-2" dur.ppq="2" dur="16" oct="2" pname="e" stem.dir="down" />
                              <note xml:id="note-0165-10370-11210-2" dur.ppq="2" dur="16" oct="3" pname="e" stem.dir="down" />
                              <note xml:id="note-0165-10420-11150-2" dur.ppq="2" dur="16" oct="4" pname="e" stem.dir="down" />
                           </beam>
                           <rest xml:id="rest-0165-10480-11260" dur.ppq="2" dur="16" />
                           <rest xml:id="rest-0165-10530-11260" dur.ppq="2" dur="16" />
                           <clef xml:id="clef-11" shape="G" line="2" />
                           <note xml:id="note-0165-10590-11260-2" dur.ppq="2" dur="16" oct="4" pname="e" stem.dir="down" />
                        </layer>
                     </staff>
                     <slur xml:id="bow-0165-10490-11010" startid="#note-0165-10470-11070-2" endid="#note-0165-10520-11000-2" curvedir="above" />
                     <slur xml:id="bow-0165-10630-11200" startid="#note-0165-10590-11260-2" endid="#note-0165-10670-11190-2" curvedir="above" />
                  </measure>
                  <measure xml:id="measure-0165-10620-10910-1-mdiv-1" n="50">
                     <staff xml:id="sjn73nh" n="1">
                        <layer xml:id="l2jhld3" n="1">
                           <rest xml:id="rest-0165-10680-11070" dur.ppq="2" dur="16" />
                           <beam xml:id="bxfk0vy">
                              <note xml:id="note-0165-10710-11000-2" dur.ppq="2" dur="16" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="note-0165-10760-10940-2" dur.ppq="2" dur="16" oct="6" pname="e" stem.dir="down" />
                           </beam>
                           <rest xml:id="rest-0165-10830-11070" dur.ppq="2" dur="16" />
                           <rest xml:id="rest-0165-10880-11070" dur.ppq="2" dur="16" />
                        </layer>
                     </staff>
                     <staff xml:id="sb8v57f" n="2">
                        <layer xml:id="lok38oo" n="5">
                           <note xml:id="note-0165-10670-11190-2" dur.ppq="2" dur="16" oct="5" pname="e" stem.dir="down" />
                           <rest xml:id="rest-0165-10730-11260" dur.ppq="2" dur="16" />
                           <rest xml:id="rest-0165-10770-11260" dur.ppq="2" dur="16" />
                           <beam xml:id="babg3k7">
                              <note xml:id="note-0165-10820-11200-2" dur.ppq="2" dur="16" oct="5" pname="d" stem.dir="down" accid="s" />
                              <note xml:id="note-0165-10860-11190-2" dur.ppq="2" dur="16" oct="5" pname="e" stem.dir="down" />
                           </beam>
                           <rest xml:id="rest-0165-10930-11260" dur.ppq="2" dur="16" />
                        </layer>
                     </staff>
                     <slur xml:id="bow-0165-10740-10950" startid="#note-0165-10710-11000-2" endid="#note-0165-10760-10940-2" curvedir="above" />
                     <slur xml:id="bow-0165-10840-11180" startid="#note-0165-10820-11200-2" endid="#note-0165-10860-11190-2" curvedir="above" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
 