### PR TITLE
Fixed: Typo in "Chromatic"

### DIFF
--- a/include/vrv/featureextractor.h
+++ b/include/vrv/featureextractor.h
@@ -55,11 +55,11 @@ public:
      */
     std::list<Note *> m_previousNotes;
 
-    jsonxx::Array m_pitchesChomatic;
+    jsonxx::Array m_pitchesChromatic;
     jsonxx::Array m_pitchesDiatonic;
     jsonxx::Array m_pitchesIds;
 
-    jsonxx::Array m_intervalsChomatic;
+    jsonxx::Array m_intervalsChromatic;
     jsonxx::Array m_intervalsDiatonic;
     jsonxx::Array m_intervalsIds;
 

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -104,7 +104,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
         std::transform(pname.begin(), pname.end(), pname.begin(), ::toupper);
         pitch << pname;
 
-        m_pitchesChomatic << pitch.str();
+        m_pitchesChromatic << pitch.str();
         m_pitchesDiatonic << pname;
         jsonxx::Array pitchesIds;
         pitchesIds << note->GetUuid();
@@ -114,7 +114,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
         if (!m_previousNotes.empty()) {
             std::string intervalChromatic
                 = StringFormat("%d", note->GetMIDIPitch() - m_previousNotes.front()->GetMIDIPitch());
-            m_intervalsChomatic << intervalChromatic;
+            m_intervalsChromatic << intervalChromatic;
             std::string intervalDiatonic
                 = StringFormat("%d", note->GetDiatonicPitch() - m_previousNotes.front()->GetDiatonicPitch());
             m_intervalsDiatonic << intervalDiatonic;
@@ -132,11 +132,11 @@ void FeatureExtractor::ToJson(std::string &output)
 {
     jsonxx::Object o;
 
-    o << "pitchesChomatic" << m_pitchesChomatic;
+    o << "pitchesChromatic" << m_pitchesChromatic;
     o << "pitchesDiatonic" << m_pitchesDiatonic;
     o << "pitchesIds" << m_pitchesIds;
 
-    o << "intervalsChomatic" << m_intervalsChomatic;
+    o << "intervalsChromatic" << m_intervalsChromatic;
     o << "intervalsDiatonic" << m_intervalsDiatonic;
     o << "intervalsIds" << m_intervalsIds;
 


### PR DESCRIPTION
Fixes the key in the output JSON, as well as the variable names.