### PR TITLE
Support for ligature in PAE

### DIFF
--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -571,6 +571,7 @@ private:
     bool ConvertTuplet();
     bool ConvertDuration();
     bool ConvertTie();
+    bool ConvertLigature();
     bool ConvertAccidGes();
     ///@}
 

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -29,6 +29,7 @@
 #include "keyaccid.h"
 #include "keysig.h"
 #include "layer.h"
+#include "ligature.h"
 #include "mdiv.h"
 #include "measure.h"
 #include "metersig.h"
@@ -2258,7 +2259,11 @@ enum {
     ERR_057_MENSUR_CHANGE,
     ERR_058_FERMATA_MREST,
     ERR_059_DOUBLE_DOTS_MENS,
-    ERR_060_CLEF_MISSING
+    ERR_060_CLEF_MISSING,
+    ERR_061_LIGATURE_NOTE_BEFORE,
+    ERR_062_LIGATURE_NOTE_AFTER,
+    ERR_063_LIGATURE_PITCH,
+    ERR_064_LIGATURE_DURATION
 };
 
 // clang-format off
@@ -2322,7 +2327,11 @@ const std::map<int, std::string> PAEInput::s_errCodes{
     { ERR_057_MENSUR_CHANGE, "The mensur sign cannot be changed more than once in a measure." },
     { ERR_058_FERMATA_MREST, "A fermata on measure rest with extra '%s' is invalid." },
     { ERR_059_DOUBLE_DOTS_MENS, "Double-dotted notes are invalid with mensural notation." },
-    { ERR_060_CLEF_MISSING, "A clef is required." }
+    { ERR_060_CLEF_MISSING, "A clef is required." },
+    { ERR_061_LIGATURE_NOTE_BEFORE, "To indicate a ligature, a '+' must be preceded by a note." },
+    { ERR_062_LIGATURE_NOTE_AFTER, "To indicate a ligature, a '+' must be followed by a note." },
+    { ERR_063_LIGATURE_PITCH, "A ligature cannot have two consecutive notes with the same pitch." },
+    { ERR_064_LIGATURE_DURATION, "The duration in a ligature cannot be shorter than a semibreve." }
 };
 // clang-format on
 
@@ -2365,6 +2374,7 @@ namespace pae {
 
     enum status_FIGURE { FIGURE_NONE = 0, FIGURE_START, FIGURE_END, FIGURE_REPEAT };
     enum status_CHORD { CHORD_NONE = 0, CHORD_MARKER, CHORD_NOTE };
+    enum status_LIGATURE { LIGATURE_NONE = 0, LIGATURE_MARKER, LIGATURE_NOTE };
 
     // specific positions with negative numbers
     enum { UNKOWN_POS = -1, KEYSIG_POS = -2, CLEF_POS = -3, TIMESIG_POS = -4, INPUT_POS = -5 };
@@ -2822,6 +2832,8 @@ bool PAEInput::Parse()
 
     if (success) success = this->ConvertTie();
 
+    if (success) success = this->ConvertLigature();
+
     if (success) success = this->ConvertAccidGes();
 
     if (success) success = this->CheckHierarchy();
@@ -2835,6 +2847,8 @@ bool PAEInput::Parse()
 
     m_doc->Reset();
     m_doc->SetType(Raw);
+    // Set the notation type
+    if (m_isMensural) m_doc->m_notationType = NOTATIONTYPE_mensural;
     // The mdiv
     Mdiv *mdiv = new Mdiv();
     mdiv->m_visibility = Visible;
@@ -2987,7 +3001,7 @@ bool PAEInput::Parse()
             layerElementContainers.back()->AddChild(element);
 
             // Add to the stack the layer element that are containers
-            if (element->Is({ BEAM, CHORD, GRACEGRP, TUPLET })) {
+            if (element->Is({ BEAM, CHORD, GRACEGRP, LIGATURE, TUPLET })) {
                 layerElementContainers.push_back(element);
             }
         }
@@ -4104,8 +4118,14 @@ bool PAEInput::ConvertDuration()
 
 bool PAEInput::ConvertTie()
 {
+    // No ties in mensural
+    // Since now we use the same symbol just return - eventually we want to check them in pedantic mode
+    // if (m_isMensural) return true;
+
     Note *note = NULL;
     Tie *tie = NULL;
+    // A pointer to the token be able to reset it to '+' in mensural notation
+    pae::Token *tieToken = NULL;
 
     for (auto &token : m_pae) {
         if (token.IsVoid()) continue;
@@ -4115,11 +4135,24 @@ bool PAEInput::ConvertTie()
             assert(tokenNote);
             if (tie && note) {
                 if (note->GetOct() != tokenNote->GetOct() || note->GetPname() != tokenNote->GetPname()) {
-                    LogPAE(ERR_037_TIE_PITCH, token);
-                    if (m_pedanticMode) return false;
+                    if (m_isMensural && tieToken) {
+                        // This is probably a ligature - reset it back
+                        delete tie;
+                        tie = NULL;
+                        tieToken->m_object = NULL;
+                        tieToken->m_char = '+';
+                        tieToken = NULL;
+                        note = NULL;
+                    }
+                    else {
+                        LogPAE(ERR_037_TIE_PITCH, token);
+                        if (m_pedanticMode) return false;
+                    }
                 }
-                tie->SetEndid("#" + tokenNote->GetUuid());
-                tie = NULL;
+                else {
+                    tie->SetEndid("#" + tokenNote->GetUuid());
+                    tie = NULL;
+                }
             }
             note = tokenNote;
             continue;
@@ -4132,6 +4165,8 @@ bool PAEInput::ConvertTie()
                 continue;
             }
             if (note) {
+                // Keep a pointer to the token in case this is a ligature
+                tieToken = &token;
                 tie = new Tie();
                 tie->SetStartid("#" + note->GetUuid());
                 token.m_object = tie;
@@ -4149,6 +4184,112 @@ bool PAEInput::ConvertTie()
         else if (!tie) {
             note = NULL;
         }
+    }
+
+    return true;
+}
+
+bool PAEInput::ConvertLigature()
+{
+    // No ligatures in non mensural
+    // Since now we use the same symbol just return
+    // Eventually, once we have a distinct symbol we will want to check them in pedantic mode
+    if (!m_isMensural) return true;
+
+    if (!this->HasInput('+')) return true;
+
+    // A flag for the ligature status NONE|MARKER|NOTE
+    pae::status_LIGATURE status = pae::LIGATURE_NONE;
+    // The iterator of the last note that can become the first note of a ligature
+    std::list<pae::Token>::iterator note = m_pae.end();
+    // The previous ligature note for checking that is it not of the same pitch
+    Note *previousNote = NULL;
+
+    std::list<pae::Token>::iterator token = m_pae.begin();
+    while (token != m_pae.end()) {
+        if (token->IsVoid()) {
+            ++token;
+            continue;
+        }
+
+        // We encounter a ligature marker - change the status if we have a note previously
+        if (token->m_char == '+') {
+            token->m_char = 0;
+            if (note == m_pae.end()) {
+                LogPAE(ERR_061_LIGATURE_NOTE_BEFORE, *token);
+                if (m_pedanticMode) return false;
+            }
+            else {
+                assert(previousNote);
+                status = pae::LIGATURE_MARKER;
+            }
+            ++token;
+            continue;
+        }
+
+        // We expect a note
+        if (status == pae::LIGATURE_MARKER) {
+            // If we have a note, we change the status - we will be able to decide to close the ligature on the next
+            // token
+            if (token->Is(NOTE)) {
+                Note *tokenNote = vrv_cast<Note *>(token->m_object);
+                assert(tokenNote);
+                assert(previousNote);
+                // Check we don't have two consecutive notes with the same pitch
+                if (previousNote->GetOct() == tokenNote->GetOct()
+                    && previousNote->GetPname() == tokenNote->GetPname()) {
+                    LogPAE(ERR_063_LIGATURE_PITCH, *token);
+                    if (m_pedanticMode) return false;
+                    status = pae::LIGATURE_NONE;
+                    note = m_pae.end();
+                    previousNote = NULL;
+                }
+                // Check the duration is valid for a ligature
+                else if (tokenNote->GetDur() > DURATION_semibrevis) {
+                    LogPAE(ERR_064_LIGATURE_DURATION, *token);
+                    if (m_pedanticMode) return false;
+                    status = pae::LIGATURE_NONE;
+                    note = m_pae.end();
+                    previousNote = NULL;
+                }
+                else {
+                    status = pae::LIGATURE_NOTE;
+                    previousNote = tokenNote;
+                }
+            }
+            // After a marker, we should allow accidentals, octave, duration or fermata markers but nothing else
+            else if (!this->Was(*token, pae::ACCIDENTAL_INTERNAL) && !this->Was(*token, pae::OCTAVE)
+                && !this->Was(*token, pae::DURATION) && token->m_inputChar != '(') {
+                LogPAE(ERR_062_LIGATURE_NOTE_AFTER, *token);
+                if (m_pedanticMode) return false;
+                status = pae::LIGATURE_NONE;
+                note = m_pae.end();
+                previousNote = NULL;
+            }
+            ++token;
+            continue;
+        }
+
+        // We passed the last note of the ligature - create it
+        if (status == pae::LIGATURE_NOTE) {
+            Ligature *ligature = new Ligature();
+            m_pae.insert(note, pae::Token(0, pae::UNKOWN_POS, ligature));
+            m_pae.insert(token, pae::Token(pae::CONTAINER_END, pae::UNKOWN_POS, ligature));
+        }
+
+        status = pae::LIGATURE_NONE;
+        if (token->Is(NOTE)) {
+            note = token;
+            previousNote = vrv_cast<Note *>(token->m_object);
+            assert(previousNote);
+        }
+        // Previous token was a note but current is a ')' skip it because we allow fermata on a ligature note
+        else if (token->m_inputChar != ')') {
+            note = m_pae.end();
+            previousNote = NULL;
+        }
+
+        ++token;
     }
 
     return true;


### PR DESCRIPTION
Undocumented coding of ligatures in mensural PAE uses the `+` sign. There are currently about 3,500 of them in the RISM dataset.

This PR implements support for ligature.
```
@clef:C+1
@data:1DFD+F9(F)D(F)+D0F(D)F+(D)
```
![image](https://user-images.githubusercontent.com/689412/160123928-a7923be2-061d-4df5-b267-733c67a7e8b1.png)

The importer checks that the durations are valid durations for a ligature and that there are now consecutive notes with the same pitch.

Examples
```
@clef:C+1
@data:1GG+/BG/
```
```
[Warning] PAE: To indicate a ligature, a '+' must be followed by a note. (character 4)
```
![image](https://user-images.githubusercontent.com/689412/160124510-4a0e29bd-b6ef-4532-b503-72578e05d517.png)

```
@clef:C+1
@data:1'A+2.''C4C2CC
```
```
[Warning] PAE: The duration in a ligature cannot be shorter than a semibreve. (character 8)
```
![image](https://user-images.githubusercontent.com/689412/160124986-32655fcc-7e66-4ade-9669-3b6b6cd14232.png)

Limitation: there is no check the the ligature is actually valid (e.g., a pair SB B would still be imported as ligature)
