### PR TITLE
Allow additional markers within fermata

### DIFF
--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -3515,8 +3515,10 @@ bool PAEInput::ConvertFermata()
                     fermataTarget = token.m_object;
                     continue;
                 }
-                // This was probably not a fermata sign but a tuplet one
-                else {
+                // We still allow duration, accidental or octave markers within a fermata ()
+                else if (!this->Is(token, pae::DURATION) && this->Is(token, pae::ACCIDENTAL_INTERNAL)
+                    && this->Was(token, pae::OCTAVE)) {
+                    // This was probably not a fermata sign but a tuplet one
                     fermataToken = NULL;
                     continue;
                 }


### PR DESCRIPTION
Allow for duration, accidental and octave markers to be placed within a fermata `()`

```
@clef:G-2
@keysig:
@timesig:
@data:8-{CEG}{''C'EG''C}/{E'G''CE}2(''G)/8{E'G''CE}(2G)/8{E'G''CE}2(nG)/8{E'G''CE}(2''nG)/
```
![image](https://user-images.githubusercontent.com/689412/160129790-cbb42432-19da-4d3f-99ac-04eed926169f.png)
