### PR TITLE
Add stylistic option for beam rendering

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -98,6 +98,9 @@ public:
     ///@}
 
 private:
+    // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-extend-stems" is set)
+    void AdjustBeamStemExtension(BeamDrawingInterface *beamInterface);
+
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
     void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -98,8 +98,8 @@ public:
     ///@}
 
 private:
-    // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-no-stem-extension" is set)
-    void AdjustBeamStemExtension(BeamDrawingInterface *beamInterface);
+    // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-french-style" is set)
+    void AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface);
 
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
     void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -98,7 +98,7 @@ public:
     ///@}
 
 private:
-    // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-extend-stems" is set)
+    // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-no-stem-extension" is set)
     void AdjustBeamStemExtension(BeamDrawingInterface *beamInterface);
 
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -130,10 +130,10 @@ private:
     void CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal);
 
     // Helper to set the stem values
-    void CalcSetStemValues(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    void CalcSetStemValues(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
 
     // Helper to set the stem values for tablature
-    void CalcSetStemValuesTab(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    void CalcSetStemValuesTab(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
 
     // Helper to calculate max/min beam points for the relative beam place
     std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -639,7 +639,7 @@ public:
     OptionDbl m_barLineWidth;
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
-    OptionBool m_beamNoStemExtension;
+    OptionBool m_beamFrenchStyle;
     OptionDbl m_bracketThickness;
     OptionDbl m_dynamDist;
     OptionDbl m_clefChangeFactor;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -639,6 +639,7 @@ public:
     OptionDbl m_barLineWidth;
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
+    OptionBool m_beamNoStemExtension;
     OptionDbl m_bracketThickness;
     OptionDbl m_dynamDist;
     OptionDbl m_clefChangeFactor;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -472,7 +472,7 @@ void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
         const int minDur = *noteDurations.begin();
         if (minDur == DURATION_8) continue;
 
-        // Get stem and adjust it's lenth
+        // Get stem and adjust it's length
         StemmedDrawingInterface *stemmedInterface = (*it)->GetStemHolderInterface();
         if (!stemmedInterface) continue;
         Stem *stem = stemmedInterface->GetDrawingStem();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -244,8 +244,8 @@ void BeamSegment::CalcSetStemValues(Staff *staff, Doc *doc, BeamDrawingInterface
         stem->SetDrawingStemLen(y2 - y1);
     }
 
-    if (doc->GetOptions()->m_beamNoStemExtension.GetValue() && (m_beamElementCoordRefs.size() > 2)) {
-        this->AdjustBeamStemExtension(beamInterface);
+    if (doc->GetOptions()->m_beamFrenchStyle.GetValue() && (m_beamElementCoordRefs.size() > 2)) {
+        this->AdjustBeamToFrenchStyle(beamInterface);
     }
 }
 
@@ -432,7 +432,7 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterfa
     return true;
 }
 
-void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
+void BeamSegment::AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface)
 {
     assert(beamInterface);
 
@@ -443,9 +443,9 @@ void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
         return (coord->m_element && coord->m_element->Is({ CHORD, NOTE }));
     };
     // iterators
-    using VectorIt = ArrayOfBeamElementCoords::iterator;
-    using VectorReverseIt = ArrayOfBeamElementCoords::reverse_iterator;
-    for (VectorIt it = std::next(m_beamElementCoordRefs.begin()); it != std::prev(m_beamElementCoordRefs.end()); ++it) {
+    using CoordIt = ArrayOfBeamElementCoords::iterator;
+    using CoordReverseIt = ArrayOfBeamElementCoords::reverse_iterator;
+    for (CoordIt it = std::next(m_beamElementCoordRefs.begin()); it != std::prev(m_beamElementCoordRefs.end()); ++it) {
         // clear values
         noteDurations.clear();
         if (!isNoteOrChord(*it)) continue;
@@ -454,13 +454,13 @@ void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
         const int val = (*it)->m_breaksec ? std::min((*it)->m_breaksec + DURATION_4, (*it)->m_dur) : (*it)->m_dur;
         noteDurations.insert(val);
         // get next element duration
-        VectorIt nextElement = std::find_if(it + 1, m_beamElementCoordRefs.end(), isNoteOrChord);
+        CoordIt nextElement = std::find_if(it + 1, m_beamElementCoordRefs.end(), isNoteOrChord);
         if (nextElement != m_beamElementCoordRefs.end()) {
             noteDurations.insert((*nextElement)->m_dur);
         }
         // get previous element duration
-        VectorReverseIt reverse = std::make_reverse_iterator(it);
-        VectorReverseIt prevElement = std::find_if(reverse, m_beamElementCoordRefs.rend(), isNoteOrChord);
+        CoordReverseIt reverse = std::make_reverse_iterator(it);
+        CoordReverseIt prevElement = std::find_if(reverse, m_beamElementCoordRefs.rend(), isNoteOrChord);
         if (prevElement != m_beamElementCoordRefs.rend()) {
             const int prevVal = (*prevElement)->m_breaksec
                 ? std::min((*prevElement)->m_breaksec + DURATION_4, (*prevElement)->m_dur)

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -456,10 +456,7 @@ void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
         // get next element duration
         VectorIt nextElement = std::find_if(it + 1, m_beamElementCoordRefs.end(), isNoteOrChord);
         if (nextElement != m_beamElementCoordRefs.end()) {
-            const int nextVal = (*nextElement)->m_breaksec
-                ? std::min((*nextElement)->m_breaksec + DURATION_4, (*nextElement)->m_dur)
-                : (*nextElement)->m_dur;
-            noteDurations.insert(nextVal);
+            noteDurations.insert((*nextElement)->m_dur);
         }
         // get previous element duration
         VectorReverseIt reverse = std::make_reverse_iterator(it);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -477,7 +477,9 @@ void BeamSegment::AdjustBeamStemExtension(BeamDrawingInterface *beamInterface)
         if (!stemmedInterface) continue;
         Stem *stem = stemmedInterface->GetDrawingStem();
 
-        const int sign = beamInterface->m_drawingPlace == BEAMPLACE_below ? -1 : 1;
+        const int sign = beamInterface->m_drawingPlace == BEAMPLACE_mixed
+            ? ((*it)->m_beamRelativePlace == BEAMPLACE_below ? -1 : 1)
+            : (beamInterface->m_drawingPlace == BEAMPLACE_below ? -1 : 1);
         const int lengthAdjust = sign * (minDur - DURATION_8) * beamInterface->m_beamWidth;
         stem->SetDrawingStemLen(stem->GetDrawingStemLen() + lengthAdjust);
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1147,10 +1147,10 @@ Options::Options()
     m_beamMinSlope.Init(0, 0, 0);
     this->Register(&m_beamMinSlope, "beamMinSlope", &m_generalLayout);
 
-    m_beamNoStemExtension.SetInfo("No stem extension in beams",
+    m_beamFrenchStyle.SetInfo("French style of beams",
         "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
-    m_beamNoStemExtension.Init(false);
-    this->Register(&m_beamNoStemExtension, "beamNoStemExtension", &m_generalLayout);
+    m_beamFrenchStyle.Init(false);
+    this->Register(&m_beamFrenchStyle, "beamFrenchStyle", &m_generalLayout);
 
     m_bracketThickness.SetInfo("Bracket thickness", "The thickness of the system bracket");
     m_bracketThickness.Init(1.0, 0.5, 2.0);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1147,8 +1147,8 @@ Options::Options()
     m_beamMinSlope.Init(0, 0, 0);
     this->Register(&m_beamMinSlope, "beamMinSlope", &m_generalLayout);
 
-    m_beamFrenchStyle.SetInfo("French style of beams",
-        "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
+    m_beamFrenchStyle.SetInfo(
+        "French style of beams", "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
     m_beamFrenchStyle.Init(false);
     this->Register(&m_beamFrenchStyle, "beamFrenchStyle", &m_generalLayout);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1147,6 +1147,11 @@ Options::Options()
     m_beamMinSlope.Init(0, 0, 0);
     this->Register(&m_beamMinSlope, "beamMinSlope", &m_generalLayout);
 
+    m_beamNoStemExtension.SetInfo("No stem extionsion in beams",
+        "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
+    m_beamNoStemExtension.Init(false);
+    this->Register(&m_beamNoStemExtension, "beamNoStemExtension", &m_generalLayout);
+
     m_bracketThickness.SetInfo("Bracket thickness", "The thickness of the system bracket");
     m_bracketThickness.Init(1.0, 0.5, 2.0);
     this->Register(&m_bracketThickness, "bracketThickness", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1147,7 +1147,7 @@ Options::Options()
     m_beamMinSlope.Init(0, 0, 0);
     this->Register(&m_beamMinSlope, "beamMinSlope", &m_generalLayout);
 
-    m_beamNoStemExtension.SetInfo("No stem extionsion in beams",
+    m_beamNoStemExtension.SetInfo("No stem extension in beams",
         "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
     m_beamNoStemExtension.Init(false);
     this->Register(&m_beamNoStemExtension, "beamNoStemExtension", &m_generalLayout);


### PR DESCRIPTION
Added option `--beam-no-stem-extension` for stylistic change of beam rendering. With this option, stems inside beams will stop at first sub-beam.

![image](https://user-images.githubusercontent.com/1819669/160360148-5920f72f-65c4-4827-a0ed-8bdb9290655f.png)
![image](https://user-images.githubusercontent.com/1819669/160360742-92b751b9-ffc6-4e42-b721-015f01384406.png)

