### PR TITLE
Minor fix for beam positioning

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1101,6 +1101,8 @@ void BeamSegment::CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterfac
     const int staffHeight = doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
+    if (!m_firstNoteOrChord || !m_lastNoteOrChord) return;
+
     int adjust = 0;
     const int start = m_firstNoteOrChord->m_yBeam;
     const int end = m_lastNoteOrChord->m_yBeam;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1102,17 +1102,19 @@ void BeamSegment::CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterfac
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     int adjust = 0;
-    const int start = m_beamElementCoordRefs.at(0)->m_yBeam;
+    const int start = m_firstNoteOrChord->m_yBeam;
+    const int end = m_lastNoteOrChord->m_yBeam;
+    const int height = std::abs(end - start);
     if ((start <= staffTop) && (start >= staffTop - staffHeight)) {
         const int positionWithinStaffLines = std::abs((staffTop - start) % (unit * 2));
         if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
-            if (((positionWithinStaffLines == unit) && (m_beamSlope > 0))
+            if (((positionWithinStaffLines == unit) && (m_beamSlope > 0) && (height != unit))
                 || ((positionWithinStaffLines == 0.5 * unit) && (m_beamSlope < 0))) {
                 adjust = -0.5 * unit;
             }
         }
         else if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
-            if (((positionWithinStaffLines == unit) && (m_beamSlope < 0))
+            if (((positionWithinStaffLines == unit) && (m_beamSlope < 0) && (height != unit))
                 || ((positionWithinStaffLines == 1.5 * unit) && (m_beamSlope > 0))) {
                 adjust = 0.5 * unit;
             }


### PR DESCRIPTION
- changed code to make sure that beams with unit height are not adjusted up/down which results in hanging beam ends

Fix for some cases where beam were still not touching staff lines:
![image](https://user-images.githubusercontent.com/1819669/160378283-0d7c9a5d-6771-464b-b1f1-bb0928d4ca14.png)
![image](https://user-images.githubusercontent.com/1819669/160378303-09fba1da-653f-4b20-a9c6-d0f196bb48cb.png)

After fix:
![image](https://user-images.githubusercontent.com/1819669/160378326-a2a13f08-9c27-472e-9430-635bf4e2ba9d.png)
![image](https://user-images.githubusercontent.com/1819669/160378339-0f0e72b3-994a-4468-bce8-aaa393296151.png)

