### PR TITLE
Additional check for measure rests in PAE import

### DIFF
--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -622,10 +622,16 @@ private:
     bool CheckHierarchy();
 
     /**
+     * Some additional checked to be performed before the MEI tree has been build.
+     * Unimplemented
+     */
+    bool CheckContentPreBuild();
+
+    /**
      * Some additional checked to be performed one the MEI tree has been build.
      * Unimplemented
      */
-    bool CheckContent();
+    bool CheckContentPostBuild();
 
     /**
      * A helper to remove a token when checking the hierarchy and it is not valid

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2836,6 +2836,8 @@ bool PAEInput::Parse()
 
     if (success) success = this->ConvertAccidGes();
 
+    if (success) success = this->CheckContentPreBuild();
+
     if (success) success = this->CheckHierarchy();
 
     LogDebugTokens();
@@ -3021,6 +3023,8 @@ bool PAEInput::Parse()
             token.m_object = NULL;
         }
     }
+
+    CheckContentPostBuild();
 
     // We should have no object left, just in case they need to be delete.
     this->ClearTokenObjects();
@@ -4444,10 +4448,17 @@ bool PAEInput::CheckHierarchy()
     return true;
 }
 
-bool PAEInput::CheckContent()
+bool PAEInput::CheckContentPreBuild()
 {
     // Additional checks to do here
     // * mRest or multiRest should be unique child of layer
+
+    return true;
+}
+
+bool PAEInput::CheckContentPostBuild()
+{
+    // Additional checks to do here
     // * beam should have more than two children
     // * graceGrp should not be empty
     // * keySig / meterSig change more than once in a measure


### PR DESCRIPTION
Currenlty, PAE incipits with multi rests placed in a measure that includes additional content (e.g., notes), or with mensural notation yield non sense rendering
```
@clef:C+3
@keysig:
@timesig:
@data:=5 CDEDE
```
![image](https://user-images.githubusercontent.com/689412/160402106-6d8b80d0-a6f6-4565-8991-8f2e56f177d5.png)

This PR adds a warning and drops them from the import
```
[Warning] PAE: A measure with a measure rest cannot include anything else. (character 0)
```
![image](https://user-images.githubusercontent.com/689412/160402317-3f3816f7-f592-45e9-a392-f41392171cd4.png)
