### PR TITLE
Add sanity check to GetMinimumSpacing

### DIFF
--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -461,9 +461,10 @@ int StaffAlignment::GetMinimumSpacing(const Doc *doc) const
 {
     assert(doc);
 
+    int spacing = 0;
     const AttSpacing *scoreDefSpacing = this->GetAttSpacing();
 
-    int spacing = 0;
+    if (!scoreDefSpacing) return spacing;
     if (m_staff && m_staff->m_drawingStaffDef) {
         // Default or staffDef spacing
         if (m_staff->m_drawingStaffDef->HasSpacing()) {


### PR DESCRIPTION
Fixes crash happening in following example:

<details><summary>MusicXML file</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 2.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="2.0">
  <identification>
    <miscellaneous>
      <miscellaneous-field name="description">A part with no id attribute.
            Since this piece has only one part, it is clear which part 
            is described by the one part element.</miscellaneous-field>
    </miscellaneous>
  </identification>
  <part-list>
    <score-part id="P1">
      <part-name print-object="no">MusicXML Part</part-name>
    </score-part>
  </part-list>
  <part>
    <measure number="1">
      <note>
        <rest/>
        <duration>4</duration>
        <voice>1</voice>
        <type>whole</type>
      </note>
    </measure>
  </part>
</score-partwise>
```
</details>

Resulting rendering is an empty page, but Verovio should not crash nevertheless.