### PR TITLE
Stacked fingering

### DIFF
--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -55,6 +55,11 @@ public:
      */
     bool IsSupportedChild(Object *object) override;
 
+    /**
+     * Check whether the current object must be positioned closer to the staff than the other
+     */
+    bool IsCloserToStaffThan(const FloatingObject *other, data_STAFFREL drawingPlace) const override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -85,6 +85,11 @@ public:
      */
     virtual bool IsExtenderElement() const { return false; }
 
+    /**
+     * Check whether the current object must be positioned closer to the staff than the other
+     */
+    virtual bool IsCloserToStaffThan(const FloatingObject *other, data_STAFFREL drawingPlace) const { return false; }
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -339,7 +339,7 @@ public:
         m_doc = doc;
         m_functor = functor;
     }
-    ArrayOfFloatingPositioners *m_previousStaffPositioners;
+    const ArrayOfFloatingPositioners *m_previousStaffPositioners;
     StaffAlignment *m_previousStaffAlignment;
     Doc *m_doc;
     Functor *m_functor;

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -281,6 +281,11 @@ public:
     void ClearPositioners();
 
     /**
+     * Sort the FloatingPositioner objects.
+     */
+    void SortPositioners();
+
+    /**
      * Find all the intersection points with a vertical line (top to bottom)
      */
     void FindAllIntersectionPoints(
@@ -369,6 +374,10 @@ private:
      * The list of FloatingPositioner for the staff.
      */
     ArrayOfFloatingPositioners m_floatingPositioners;
+    /**
+     * Flag indicating whether the list of FloatingPositioner is sorted
+     */
+    bool m_floatingPositionersSorted;
     /**
      * Stores a pointer to the staff from which the aligner was created.
      * This is necessary since we don't always have all the staves.

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -13,6 +13,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "layerelement.h"
 #include "text.h"
 
 namespace vrv {
@@ -50,6 +51,26 @@ bool Fing::IsSupportedChild(Object *child)
         return false;
     }
     return true;
+}
+
+bool Fing::IsCloserToStaffThan(const FloatingObject *other, data_STAFFREL drawingPlace) const
+{
+    if (!other->Is(FING)) return false;
+    const Fing *otherFing = vrv_cast<const Fing *>(other);
+
+    const LayerElement *element = dynamic_cast<const LayerElement *>(this->GetStart());
+    const LayerElement *otherElement = dynamic_cast<const LayerElement *>(otherFing->GetStart());
+    if (!element || !otherElement) return false;
+
+    if (drawingPlace == STAFFREL_above) {
+        return (element->GetDrawingY() < otherElement->GetDrawingY());
+    }
+    else if (drawingPlace == STAFFREL_below) {
+        return (element->GetDrawingY() > otherElement->GetDrawingY());
+    }
+    else {
+        return false;
+    }
 }
 
 } // namespace vrv

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -58,15 +58,14 @@ bool Fing::IsCloserToStaffThan(const FloatingObject *other, data_STAFFREL drawin
     if (!other->Is(FING)) return false;
     const Fing *otherFing = vrv_cast<const Fing *>(other);
 
-    const LayerElement *element = dynamic_cast<const LayerElement *>(this->GetStart());
-    const LayerElement *otherElement = dynamic_cast<const LayerElement *>(otherFing->GetStart());
-    if (!element || !otherElement) return false;
+    if (!this->GetStart() || this->GetStart()->Is(TIMESTAMP_ATTR)) return false;
+    if (!otherFing->GetStart() || otherFing->GetStart()->Is(TIMESTAMP_ATTR)) return false;
 
     if (drawingPlace == STAFFREL_above) {
-        return (element->GetDrawingY() < otherElement->GetDrawingY());
+        return (this->GetStart()->GetDrawingY() < otherFing->GetStart()->GetDrawingY());
     }
     else if (drawingPlace == STAFFREL_below) {
-        return (element->GetDrawingY() > otherElement->GetDrawingY());
+        return (this->GetStart()->GetDrawingY() > otherFing->GetStart()->GetDrawingY());
     }
     else {
         return false;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2627,7 +2627,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         }
     }
 
-    std::string noteID = node.attribute("id").as_string();
+    const std::string noteID = node.attribute("id").as_string();
     const int duration = node.child("duration").text().as_int();
     const int noteStaffNum = node.child("staff").text().as_int();
     const pugi::xml_node rest = node.child("rest");
@@ -2717,10 +2717,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         element = note;
         note->SetVisible(ConvertWordToBool(node.attribute("print-object").as_string()));
         note->SetColor(node.attribute("color").as_string());
-        if (noteID.empty()) {
-            noteID = note->GetUuid();
-        }
-        else {
+        if (!noteID.empty()) {
             note->SetUuid(noteID);
         }
         note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
@@ -3250,7 +3247,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         Text *text = new Text();
         text->SetText(UTF8to16(fingText));
         m_controlElements.push_back({ measureNum, fing });
-        fing->SetStartid("#" + noteID);
+        fing->SetStartid(m_ID);
         fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         fing->SetPlace(fing->AttPlacementRelStaff::StrToStaffrel(xmlFing.node().attribute("placement").as_string()));
         fing->AddChild(text);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2560,6 +2560,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     m_durFb = 0;
 
     LayerElement *element = NULL;
+    Note *note = NULL;
 
     bool nextIsChord = false;
     double onset = m_durTotal; // keep note onsets for later
@@ -2713,7 +2714,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         }
     }
     else {
-        Note *note = new Note();
+        note = new Note();
         element = note;
         note->SetVisible(ConvertWordToBool(node.attribute("print-object").as_string()));
         note->SetColor(node.attribute("color").as_string());
@@ -3247,7 +3248,8 @@ void MusicXmlInput::ReadMusicXmlNote(
         Text *text = new Text();
         text->SetText(UTF8to16(fingText));
         m_controlElements.push_back({ measureNum, fing });
-        fing->SetStartid(m_ID);
+        const std::string startID = note ? ("#" + note->GetUuid()) : m_ID;
+        fing->SetStartid(startID);
         fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         fing->SetPlace(fing->AttPlacementRelStaff::StrToStaffrel(xmlFing.node().attribute("placement").as_string()));
         fing->AddChild(text);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2627,7 +2627,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         }
     }
 
-    const std::string noteID = node.attribute("id").as_string();
+    std::string noteID = node.attribute("id").as_string();
     const int duration = node.child("duration").text().as_int();
     const int noteStaffNum = node.child("staff").text().as_int();
     const pugi::xml_node rest = node.child("rest");
@@ -2717,7 +2717,10 @@ void MusicXmlInput::ReadMusicXmlNote(
         element = note;
         note->SetVisible(ConvertWordToBool(node.attribute("print-object").as_string()));
         note->SetColor(node.attribute("color").as_string());
-        if (!noteID.empty()) {
+        if (noteID.empty()) {
+            noteID = note->GetUuid();
+        }
+        else {
             note->SetUuid(noteID);
         }
         note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
@@ -3247,7 +3250,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         Text *text = new Text();
         text->SetText(UTF8to16(fingText));
         m_controlElements.push_back({ measureNum, fing });
-        fing->SetStartid(m_ID);
+        fing->SetStartid("#" + noteID);
         fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         fing->SetPlace(fing->AttPlacementRelStaff::StrToStaffrel(xmlFing.node().attribute("placement").as_string()));
         fing->AddChild(text);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -288,14 +288,9 @@ void StaffAlignment::SortPositioners()
     if (!m_floatingPositionersSorted) {
         std::stable_sort(m_floatingPositioners.begin(), m_floatingPositioners.end(),
             [](FloatingPositioner *left, FloatingPositioner *right) {
-                // Move fingering elements that should appear closer to the staff to the front
-                if (left->GetObject()->Is(FING) && right->GetObject()->Is(FING)) {
-                    if ((left->GetDrawingPlace() == STAFFREL_above) && (right->GetDrawingPlace() == STAFFREL_above)) {
-                        return (left->GetObjectX()->GetDrawingY() < right->GetObjectX()->GetDrawingY());
-                    }
-                    if ((left->GetDrawingPlace() == STAFFREL_below) && (right->GetDrawingPlace() == STAFFREL_below)) {
-                        return (left->GetObjectX()->GetDrawingY() > right->GetObjectX()->GetDrawingY());
-                    }
+                if ((left->GetObject()->GetClassId() == right->GetObject()->GetClassId())
+                    && (left->GetDrawingPlace() == right->GetDrawingPlace())) {
+                    return left->GetObject()->IsCloserToStaffThan(right->GetObject(), right->GetDrawingPlace());
                 }
                 return false;
             });

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -288,9 +288,16 @@ void StaffAlignment::SortPositioners()
     if (!m_floatingPositionersSorted) {
         std::stable_sort(m_floatingPositioners.begin(), m_floatingPositioners.end(),
             [](FloatingPositioner *left, FloatingPositioner *right) {
-                if ((left->GetObject()->GetClassId() == right->GetObject()->GetClassId())
-                    && (left->GetDrawingPlace() == right->GetDrawingPlace())) {
-                    return left->GetObject()->IsCloserToStaffThan(right->GetObject(), right->GetDrawingPlace());
+                if (left->GetObject()->GetClassId() == right->GetObject()->GetClassId()) {
+                    if (left->GetDrawingPlace() == right->GetDrawingPlace()) {
+                        return left->GetObject()->IsCloserToStaffThan(right->GetObject(), right->GetDrawingPlace());
+                    }
+                    else {
+                        return (left->GetDrawingPlace() < right->GetDrawingPlace());
+                    }
+                }
+                else {
+                    return (left->GetObject()->GetClassId() < right->GetObject()->GetClassId());
                 }
                 return false;
             });


### PR DESCRIPTION
This PR fixes the fingering order for chords. Closes #2562 .

| Before | After |
| ------ | ----- |
| <img width="291" alt="Before" src="https://user-images.githubusercontent.com/63608463/161022033-b4862b19-cd85-4b39-9f65-501c6b426cf3.png"> | <img width="309" alt="After" src="https://user-images.githubusercontent.com/63608463/161022068-a38ab92a-bbd5-4b1d-a663-324468132922.png"> |

<details>
<summary> Show MEI example </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Chord example</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2017-05-04">2017-05-04</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio supports chords with an optimized placement of noteheads, dots and accidental.
               The chords in the example were chosen following the Steinberg accidental stacking comparison.</annot>
         </notesStmt>
         <sourceDesc>
            <source>
               <bibl>
                  <ref target="https://web.archive.org/web/20150922230802/https://blog.steinberg.net/accidental-stacking-comparison/">Accidental stacking comparison</ref>
               </bibl>
            </source>
         </sourceDesc>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="1.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef system.leftline="false">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="invis" n="1">
                     <staff n="1">
                        <layer n="1">
                          <chord xml:id="mychord" dur.ppq="12" dur="4" stem.dir="down">
                            <note xml:id="note-d" oct="5" pname="d" />
                            <note xml:id="note-f" oct="5" pname="f" />
                          </chord>
                          <chord xml:id="mychord" dur.ppq="12" dur="4" stem.dir="up">
                            <note xml:id="note-d2" oct="4" pname="d" />
                            <note xml:id="note-f2" oct="4" pname="f" />
                          </chord>
                        </layer>
                     </staff>
                     <fing xml:id="fing-3" startid="#note-f">3</fing> 
                     <fing xml:id="fing-1" startid="#note-d">1</fing>
                     <fing xml:id="fing-4" startid="#note-d2" place="below">4</fing>
                     <fing xml:id="fing-2" startid="#note-f2" place="below">2</fing> 
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

We also ensure that Fing elements are connected to notes in the MusicXML importer:
<img width="1513" alt="After2" src="https://user-images.githubusercontent.com/63608463/161022293-5f045a71-037f-471a-ba5e-0033f450925d.png">
 