### PR TITLE
Scale multirest numbers

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1202,7 +1202,8 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
             ? std::min(staff->GetDrawingY() - staffHeight, y2) - offset
             : std::max(staff->GetDrawingY(), y1) + offset;
 
-        this->DrawSmuflString(dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center);
+        this->DrawSmuflString(
+            dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
         dc->ResetFont();
     }
 


### PR DESCRIPTION
Make multirest numbers scale with staffSize

Fixes following issue:
![image](https://user-images.githubusercontent.com/1819669/161094333-2261c49a-928e-48c1-ac66-cfb41b142a11.png)
