### PR TITLE
Trim leading and trailing spaces from attributes

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -807,6 +807,11 @@ private:
     bool IsEditorialElementName(std::string elementName);
 
     /**
+     * Normalize attributes of xmlElement, removing white spaces if necessary
+     */
+    void NormalizeAttributes(pugi::xml_node &xmlElement);
+
+    /**
      * Read score-based MEI.
      * The data is read into an object, which is then converted to page-based MEI.
      * See MEIInput::ReadDoc, Doc::CreateScoreBuffer and Doc::ConvertToPageBasedDoc

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3874,6 +3874,7 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
     pugi::xml_node current;
     for (current = scoreDef.next_sibling(); current; current = current.next_sibling()) {
         if (!success) break;
+        this->NormalizeAttributes(current);
         std::string elementName = std::string(current.name());
         // editorial
         if (this->IsEditorialElementName(current.name())) {
@@ -7353,10 +7354,12 @@ void MEIInput::NormalizeAttributes(pugi::xml_node &xmlElement)
         std::string name = elem.name();
         std::string value = elem.value();
 
-        if (!std::set<std::string>{ "plist", "staff", "xml:id" }.count(name)) {
-            value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
-            elem.set_value(value.c_str());
-        }
+        size_t pos = value.find_first_not_of(' ');
+        if (pos != std::string::npos) value = value.substr(pos);
+        pos = value.find_last_not_of(' ');
+        if (pos != std::string::npos) value = value.substr(0, pos + 1);
+
+        elem.set_value(value.c_str());
     }
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -7354,7 +7354,7 @@ void MEIInput::NormalizeAttributes(pugi::xml_node &xmlElement)
         std::string value = elem.value();
 
         if (!std::set<std::string>{ "plist", "staff", "xml:id" }.count(name)) {
-            value.erase(std::remove_if(value.begin(), value.end(), std::isspace), value.end());
+            value.erase(std::remove(value.begin(), value.end(), ' '), value.end());
             elem.set_value(value.c_str());
         }
     }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3934,8 +3934,9 @@ bool MEIInput::ReadSectionChildren(Object *parent, pugi::xml_node parentNode)
     Measure *unmeasured = NULL;
     for (current = parentNode.first_child(); current; current = current.next_sibling()) {
         if (!success) break;
+        this->NormalizeAttributes(current);
         // editorial
-        else if (this->IsEditorialElementName(current.name())) {
+        if (this->IsEditorialElementName(current.name())) {
             success = this->ReadEditorialElement(parent, current, EDITORIAL_TOPLEVEL);
         }
         // content
@@ -4099,8 +4100,9 @@ bool MEIInput::ReadSystemChildren(Object *parent, pugi::xml_node parentNode)
     Measure *unmeasured = NULL;
     for (current = parentNode.first_child(); current; current = current.next_sibling()) {
         if (!success) break;
+        this->NormalizeAttributes(current);
         // editorial
-        else if (this->IsEditorialElementName(current.name())) {
+        if (this->IsEditorialElementName(current.name())) {
             success = this->ReadEditorialElement(parent, current, EDITORIAL_TOPLEVEL);
         }
         // section
@@ -4543,6 +4545,7 @@ bool MEIInput::ReadRunningChildren(Object *parent, pugi::xml_node parentNode, Ob
         if (!success) {
             break;
         }
+        this->NormalizeAttributes(xmlElement);
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
             std::string meiElementName = filter->GetClassName();
@@ -5429,8 +5432,9 @@ bool MEIInput::ReadFbChildren(Object *parent, pugi::xml_node parentNode)
     pugi::xml_node current;
     for (current = parentNode.first_child(); current; current = current.next_sibling()) {
         if (!success) break;
+        this->NormalizeAttributes(current);
         // editorial
-        else if (this->IsEditorialElementName(current.name())) {
+        if (this->IsEditorialElementName(current.name())) {
             success = this->ReadEditorialElement(parent, current, EDITORIAL_FB);
         }
         // content
@@ -6362,6 +6366,7 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         if (!success) {
             break;
         }
+        this->NormalizeAttributes(xmlElement);
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
             std::string meiElementName = filter->GetClassName();


### PR DESCRIPTION
closes #2671

Fix for an issue with spaces in attributes without relying on MEI changes. This removes trailing and leading spaces that might be present in any of the attributes in MEI file, while leaving any other spaces (like the ones in @staff or @plist) intact.