### PR TITLE
Minor adjustment to margin of minimum allow stem length in beams

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1028,7 +1028,7 @@ void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *
             }
             // Here we should look at duration too because longer values in the middle could actually be OK as they are
             else if (((coord != m_lastNoteOrChord) || (coord != m_firstNoteOrChord)) && (coord->m_dur > DUR_8)) {
-                const int durLen = len - unit;
+                const int durLen = len - 0.9 * unit;
                 if (durLen < refLen) {
                     lengthen = true;
                     break;


### PR DESCRIPTION
This is a fix for the rare issue that might happen with beams.
Sometimes, during horizontal justification some beams might end up being horizontal due to the check that is done to compare stem length to minimal allowed length. Despite that, same example looks perfectly fine without horizontal justification.

Without justification:
![image](https://user-images.githubusercontent.com/1819669/161249318-455f1cf7-8e80-4cfa-af56-099db258daaf.png)

With `--breaks encoded`:
![image](https://user-images.githubusercontent.com/1819669/161249405-5ffe8d93-5405-447b-99f9-c8985622e4e7.png)

In this case, this happens due to the difference of 1 point (539 vs threshold 540) which results in beam being horizontal.
This change relaxes this check just slightly to allow cases where difference is negligible (withing 10% of unit) and most likely caused by calculation, and should not influence the cases where we actually want beam to be horizontal.

After the change:
![image](https://user-images.githubusercontent.com/1819669/161250467-dd4240e0-622c-4cce-a125-d00265e0114e.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Weird horizontal beam case</title>
         </titleStmt>
         <pubStmt><date isodate="2017-12-21" type="encoding-date">2017-12-21</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2022-03-31T12:50:33" version="3.10.0-dev-[undefined]">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="2" lines="5" ppq="24">
                        <label>Oboe I</label>
                        <labelAbbr>Ob. I</labelAbbr>
                        <instrDef midi.channel="1" midi.instrnum="68" midi.volume="78.00%" />
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="4" sym="common" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <pb/>
                  <measure n="1">
                     <staff n="2">
                        <layer n="1">
                           <note dur.ppq="24" dur="4" oct="5" pname="c" stem.dir="down" />
                           <rest dur.ppq="12" dur="8" />
                           <beam>
                              <tuplet num="3" numbase="2" bracket.visible="false">
                                 <note dur.ppq="4" dur="16" oct="4" pname="g" stem.dir="up" />
                                 <note dur.ppq="4" dur="16" oct="4" pname="a" stem.dir="up" />
                                 <note dur.ppq="4" dur="16" oct="4" pname="b" stem.dir="up" />
                              </tuplet>
                           </beam>
                           <note dur.ppq="24" dur="4" oct="5" pname="c" stem.dir="down" />
                           <rest dur.ppq="12" dur="8" />
                           <beam>
                              <tuplet num="3" numbase="2" bracket.visible="false">
                                 <note dur.ppq="4" dur="16" oct="4" pname="g" stem.dir="up" />
                                 <note dur.ppq="4" dur="16" oct="4" pname="a" stem.dir="up" />
                                 <note dur.ppq="4" dur="16" oct="4" pname="b" stem.dir="up" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="2">
                        <layer n="1">
                           <note dur.ppq="24" dur="4" oct="5" pname="c" stem.dir="down" />
                           <rest dur.ppq="24" dur="4" />
                           <rest dur.ppq="48" dur="2" />
                        </layer>
                     </staff>
                     <dynam place="below" staff="13" tstamp="4.500000" val="49">p</dynam>
                  </measure>
                  <measure n="3">
                     <staff n="2">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="4">
                     <staff n="2">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="5">
                     <staff n="2">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <sb/>
                  <measure n="6">
                     <staff n="2">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```
</details>

