### PR TITLE
Use mensural stem glyphs

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -467,7 +467,7 @@ wchar_t Note::GetMensuralNoteheadGlyph() const
 
     wchar_t code = 0;
     if (mensural_black) {
-        code = SMUFL_E93D_mensuralNoteheadSemiminimaWhite;
+        code = SMUFL_E938_mensuralNoteheadSemibrevisBlack;
     }
     else {
         if (this->GetColored() == BOOLEAN_true) {

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -260,9 +260,11 @@ void View::DrawMensuralStem(
         y2 = verticalCenter;
     }
 
+    const int halfStemWidth = m_doc->GetGlyphWidth(SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize) / 2;
+
     // shorten the stem at its connection with the note head
     // this will not work if the pseudo size is changed
-    int shortening = 0.9 * m_doc->GetDrawingUnit(staffSize);
+    const int shortening = m_doc->GetDrawingUnit(staffSize) - halfStemWidth;
 
     // LogDebug("DrawMensuralStem: drawingDur=%d mensural_black=%d nbFlags=%d", drawingDur, mensural_black, nbFlags);
     int stemY1 = (dir == STEMDIRECTION_up) ? y1 + shortening : y1 - shortening;
@@ -274,7 +276,6 @@ void View::DrawMensuralStem(
         stemY2 = (dir == STEMDIRECTION_up) ? y2 - shortener : y2 + shortener;
     }
 
-    int halfStemWidth = m_doc->GetDrawingStemWidth(staffSize) / 2;
     // draw the stems and the flags
 
     dc->StartCustomGraphic("stem");
@@ -287,7 +288,7 @@ void View::DrawMensuralStem(
             }
         }
         else {
-            this->DrawFilledRectangle(dc, x2 - halfStemWidth, stemY1, x2 + halfStemWidth, stemY2);
+            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize);
         }
     }
     else {
@@ -298,7 +299,7 @@ void View::DrawMensuralStem(
             }
         }
         else {
-            this->DrawFilledRectangle(dc, x2 - halfStemWidth, stemY1, x2 + halfStemWidth, stemY2);
+            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93F_mensuralCombStemDown, staff->m_drawingStaffSize, drawingCueSize);
         }
     }
     dc->EndCustomGraphic();

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -260,7 +260,8 @@ void View::DrawMensuralStem(
         y2 = verticalCenter;
     }
 
-    const int halfStemWidth = m_doc->GetGlyphWidth(SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize) / 2;
+    const int halfStemWidth
+        = m_doc->GetGlyphWidth(SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize) / 2;
 
     // shorten the stem at its connection with the note head
     // this will not work if the pseudo size is changed
@@ -288,7 +289,8 @@ void View::DrawMensuralStem(
             }
         }
         else {
-            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize);
+            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93E_mensuralCombStemUp,
+                staff->m_drawingStaffSize, drawingCueSize);
         }
     }
     else {
@@ -299,7 +301,8 @@ void View::DrawMensuralStem(
             }
         }
         else {
-            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93F_mensuralCombStemDown, staff->m_drawingStaffSize, drawingCueSize);
+            this->DrawSmuflCode(dc, x2 - halfStemWidth, stemY1, SMUFL_E93F_mensuralCombStemDown,
+                staff->m_drawingStaffSize, drawingCueSize);
         }
     }
     dc->EndCustomGraphic();


### PR DESCRIPTION
Horizontal positioning of flagged stems in mensural notation was based on `stemWidth` which led to an odd offset with inappropriate values.

With `--stem-width 0.5`:
![menstem](https://user-images.githubusercontent.com/7693447/161565833-168c302a-0936-4408-b3cb-f3e9413109f0.png)

This PR replaces the primitive with the default glyph for the stem and uses its width for centering the stems. 

![menstem_new](https://user-images.githubusercontent.com/7693447/161565848-91ef2529-040b-4dc1-ae12-b98412ac3081.png)

(Both examples rendered with Bravura.)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Mensural values</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2022-04-04">2022-04-04</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot></annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="1">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
      <extMeta><![CDATA[ { "stemWidth": 0.5 }]]></extMeta>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="C" clef.line="1" notationtype="mensural.white" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <note dur="semibrevis" oct="4" pname="c" accid.ges="n" />
                        <note dur="minima" oct="4" pname="c" accid.ges="n" />
                        <note dur="semiminima" oct="4" pname="c" accid.ges="n" />
                        <note dur="fusa" oct="4" pname="c" accid.ges="n" />
                        <note dur="semifusa" oct="4" pname="c" accid.ges="n" />
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

Also it changes the code point for black mensural notation.