### PR TITLE
Slur improvements

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -189,6 +189,11 @@ public:
         const Point bezier[4], bool isMaxExtrema, int approximationSteps = BEZIER_APPROXIMATION);
 
     /**
+     * Calculate the euclidean distance between two points
+     */
+    static double CalcDistance(const Point &p1, const Point &p2);
+
+    /**
      * @return true if the distance between the points does not exceed margin
      */
     static bool ArePointsClose(const Point &p1, const Point &p2, int margin);

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -270,6 +270,12 @@ public:
     void UpdateControlPoints();
     ///@}
 
+    /**
+     * Estimate the curve parameter corresponding to the control points
+     * Based on the polyline P1-C1-C2-P2
+     */
+    std::pair<double, double> EstimateCurveParamForControlPoints() const;
+
 private:
     // Control point X-axis offset for both start/end points
     int m_leftControlOffset = 0;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -218,8 +218,7 @@ private:
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical shift of the slur end points
-    std::pair<int, int> CalcEndPointShift(
-        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin, int unit);
+    std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the horizontal control point offset
     std::tuple<bool, int, int> CalcControlPointOffset(
@@ -242,9 +241,6 @@ private:
     ///@{
     // Shift end points for collisions nearby
     void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection, bool isBelow) const;
-
-    // Rebalance shifts to avoid awkward tilting of short slurs
-    void RebalanceShifts(int &shiftLeft, int &shiftRight, double distance, int unit) const;
 
     // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis
     // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -763,9 +763,14 @@ Point BoundingBox::CalcPositionAfterRotation(Point point, float alpha, Point cen
     return point;
 }
 
+double BoundingBox::CalcDistance(const Point &p1, const Point &p2)
+{
+    return std::hypot(p1.x - p2.x, p1.y - p2.y);
+}
+
 bool BoundingBox::ArePointsClose(const Point &p1, const Point &p2, int margin)
 {
-    return (hypot(p1.x - p2.x, p1.y - p2.y) <= margin);
+    return (BoundingBox::CalcDistance(p1, p2) <= margin);
 }
 
 double BoundingBox::CalcSlope(const Point &p1, const Point &p2)

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -98,6 +98,20 @@ void BezierCurve::UpdateControlPoints()
     c2.y = p2.y + sign * m_rightControlHeight;
 }
 
+std::pair<double, double> BezierCurve::EstimateCurveParamForControlPoints() const
+{
+    const double dist1 = BoundingBox::CalcDistance(p1, c1);
+    const double dist2 = BoundingBox::CalcDistance(c1, c2);
+    const double dist3 = BoundingBox::CalcDistance(c2, p2);
+    const double distSum = dist1 + dist2 + dist3;
+    if (distSum > 0.0) {
+        return { dist1 / distSum, dist3 / distSum };
+    }
+    else {
+        return { 0.0, 1.0 };
+    }
+}
+
 //----------------------------------------------------------------------------
 // DeviceContext
 //----------------------------------------------------------------------------

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -105,7 +105,7 @@ std::pair<double, double> BezierCurve::EstimateCurveParamForControlPoints() cons
     const double dist3 = BoundingBox::CalcDistance(c2, p2);
     const double distSum = dist1 + dist2 + dist3;
     if (distSum > 0.0) {
-        return { dist1 / distSum, dist3 / distSum };
+        return { dist1 / distSum, (dist1 + dist2) / distSum };
     }
     else {
         return { 0.0, 1.0 };

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -385,10 +385,10 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
         bezier.p1.y += signLeft * endPointShiftLeft;
         bezier.p2.y += signRight * endPointShiftRight;
         if (bezier.p1.x != bezier.p2.x) {
-            double lambda = double(bezier.c1.x - bezier.p1.x) / double(bezier.p2.x - bezier.p1.x);
-            bezier.c1.y += signLeft * (1.0 - lambda) * endPointShiftLeft + signRight * lambda * endPointShiftRight;
-            lambda = double(bezier.c2.x - bezier.p1.x) / double(bezier.p2.x - bezier.p1.x);
-            bezier.c2.y += signLeft * (1.0 - lambda) * endPointShiftLeft + signRight * lambda * endPointShiftRight;
+            double lambda1, lambda2;
+            std::tie(lambda1, lambda2) = bezier.EstimateCurveParamForControlPoints();
+            bezier.c1.y += signLeft * (1.0 - lambda1) * endPointShiftLeft + signRight * lambda1 * endPointShiftRight;
+            bezier.c2.y += signLeft * (1.0 - lambda2) * endPointShiftLeft + signRight * lambda2 * endPointShiftRight;
         }
         bezier.UpdateControlPointParams();
         curve->UpdatePoints(bezier);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -378,7 +378,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     // Only collisions near the endpoints are taken into account.
     int endPointShiftLeft = 0;
     int endPointShiftRight = 0;
-    std::tie(endPointShiftLeft, endPointShiftRight) = this->CalcEndPointShift(curve, bezier, margin, unit);
+    std::tie(endPointShiftLeft, endPointShiftRight) = this->CalcEndPointShift(curve, bezier, margin);
     if ((endPointShiftLeft != 0) || (endPointShiftRight != 0)) {
         const int signLeft = bezier.IsLeftControlAbove() ? 1 : -1;
         const int signRight = bezier.IsRightControlAbove() ? 1 : -1;
@@ -468,7 +468,7 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
 }
 
 std::pair<int, int> Slur::CalcEndPointShift(
-    FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, const int margin, const int unit)
+    FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, const int margin)
 {
     if (bezierCurve.p1.x >= bezierCurve.p2.x) return { 0, 0 };
 
@@ -507,8 +507,6 @@ std::pair<int, int> Slur::CalcEndPointShift(
         }
     }
 
-    this->RebalanceShifts(shiftLeft, shiftRight, dist, unit);
-
     return { shiftLeft, shiftRight };
 }
 
@@ -532,26 +530,6 @@ void Slur::ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int int
             intersection *= pow(10.0 * ratio - 8.5, 2.0);
         }
         shiftRight = std::max(shiftRight, intersection);
-    }
-}
-
-void Slur::RebalanceShifts(int &shiftLeft, int &shiftRight, const double distance, const int unit) const
-{
-    // alpha is 1 for dist <= 4U, 0 for dist >= 8U, interpolated between 4U and 8U
-    double alpha = 0.0;
-    if (distance <= 4.0 * unit) {
-        alpha = 1.0;
-    }
-    else if (distance <= 8.0 * unit) {
-        alpha = 2.0 - distance / (4.0 * unit);
-    }
-
-    const int difference = std::abs(shiftLeft - shiftRight);
-    if (shiftLeft < shiftRight) {
-        shiftLeft += alpha * difference;
-    }
-    else {
-        shiftRight += alpha * difference;
     }
 }
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -790,6 +790,13 @@ void Slur::AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int
 
     // Rotate back
     bezierCurve.Rotate(angle, bezierCurve.p1);
+
+    // Enforce p1.x <= c1.x <= c2.x <= p2.x
+    bezierCurve.c1.x = std::max(bezierCurve.p1.x, bezierCurve.c1.x);
+    bezierCurve.c2.x = std::max(bezierCurve.c1.x, bezierCurve.c2.x);
+    bezierCurve.c2.x = std::min(bezierCurve.p2.x, bezierCurve.c2.x);
+    bezierCurve.c1.x = std::min(bezierCurve.c2.x, bezierCurve.c1.x);
+
     bezierCurve.UpdateControlPointParams();
 }
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -982,14 +982,17 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
     Note *startNote = NULL;
     LayerElement *start = this->GetStart();
     Chord *startChord = NULL;
+    bool hasStartFlag = false;
     if (start->Is(NOTE)) {
         startNote = vrv_cast<Note *>(start);
         assert(startNote);
         startChord = startNote->IsChordTone();
+        hasStartFlag = (startNote->FindDescendantByType(FLAG) != NULL);
     }
     else if (start->Is(CHORD)) {
         startChord = vrv_cast<Chord *>(start);
         assert(startChord);
+        hasStartFlag = (startChord->FindDescendantByType(FLAG) != NULL);
     }
 
     // Pointers for the end point of the slur
@@ -1056,7 +1059,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             // same but in beam - adjust the x too
             else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
                 || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))
-                || isGraceToNoteSlur) {
+                || isGraceToNoteSlur || hasStartFlag) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
                 x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
@@ -1106,7 +1109,7 @@ std::pair<Point, Point> Slur::AdjustCoordinates(
             }
             // same but in beam
             else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
-                || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))) {
+                || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start)) || hasStartFlag) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                 x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }


### PR DESCRIPTION
This PR does some improvements for slurs:

**1. Detached slurs**
We fix the regressions observed in #2730 and #2770 by reverting the changes in PR #2583. 
<img width="300" alt="Fixed3" src="https://user-images.githubusercontent.com/63608463/162200302-05d16207-0068-42a7-a4f9-2150b29638a5.png">
<img width="500" alt="Fixed1" src="https://user-images.githubusercontent.com/63608463/162196249-97891b58-611f-40e2-b550-d2338a698246.png">
 @craigsapp Please check if #2418 should be reopened again. Note that due to recent changes in slur thickness the example doesn't look as ridiculous anymore.
<img width="400" alt="Unfixed" src="https://user-images.githubusercontent.com/63608463/162196736-bb14f051-a716-4021-ae45-45c71863b20d.png">
However the directional problem (slur going down while notes going up) still persists. In retrospect it probably makes more sense to address this in the initial slur calculation instead of collision avoidance.

**2. Slurs moving outwards at end points**
We enforce that the slur direction at the end points is vertical in the worst case.
| Before | After |
| ------ | ----- |
| <img width="514" alt="Before" src="https://user-images.githubusercontent.com/63608463/162199570-4632e8d2-fe4f-4f52-a06f-12c9572d8688.png"> | <img width="521" alt="After" src="https://user-images.githubusercontent.com/63608463/162199593-cd519dea-9143-4078-b487-22f1fa1401de.png"> |



<details>
<summary> Show MEI example </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2022-03-25T05:47:52" version="3.8.0-dev-c01277e">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="mu8bh4q">
    <score xml:id="s78qk69">
     <scoreDef xml:id="s62kb8i">
      <staffGrp xml:id="sqks0o8">
       <staffDef xml:id="sum0tzs" n="1" lines="5">
        <clef xml:id="cydwnv2" shape="G" line="2" />
        <meterSig xml:id="metersig-L2F1" count="4" unit="4" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <measure xml:id="measure-L1" n="1">
       <staff xml:id="spibhi9" n="1">
        <layer xml:id="layer-L1F1N1" n="1">
         <beam xml:id="beam-L12F1-L13F1">
          <note xml:id="note-L12F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L13F1" type="placed" dur="16" oct="5" pname="g" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L14F1-L15F1">
          <note xml:id="note-L14F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L15F1" type="placed" dur="16" oct="5" pname="a" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L16F1-L17F1">
          <note xml:id="note-L16F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L17F1" type="placed" dur="16" oct="5" pname="b" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L18F1-L19F1">
          <note xml:id="note-L18F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L19F1" type="placed" dur="16" oct="6" pname="c" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L21F1-L22F1">
          <note xml:id="note-L21F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L22F1" type="placed" dur="16" oct="6" pname="d" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L23F1-L24F1">
          <note xml:id="note-L23F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L24F1" type="placed" dur="16" oct="6" pname="e" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L25F1-L26F1">
          <note xml:id="note-L25F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L26F1" type="placed" dur="16" oct="6" pname="f" stem.dir="down" accid.ges="n" />
         </beam>
         <beam xml:id="beam-L27F1-L28F1">
          <note xml:id="note-L27F1" type="placed" dur="16" oct="4" pname="b" stem.dir="down" accid.ges="n" />
          <note xml:id="note-L28F1" type="placed" dur="16" oct="6" pname="g" stem.dir="down" accid.ges="n" />
         </beam>
        </layer>
       </staff>
       <slur xml:id="slur-L12F1-L13F1" staff="1" startid="#note-L12F1" endid="#note-L13F1" />
       <slur xml:id="slur-L14F1-L15F1" staff="1" startid="#note-L14F1" endid="#note-L15F1" />
       <slur xml:id="slur-L16F1-L17F1" staff="1" startid="#note-L16F1" endid="#note-L17F1" />
       <slur xml:id="slur-L18F1-L19F1" staff="1" startid="#note-L18F1" endid="#note-L19F1" />
       <slur xml:id="slur-L21F1-L22F1" staff="1" startid="#note-L21F1" endid="#note-L22F1" />
       <slur xml:id="slur-L23F1-L24F1" staff="1" startid="#note-L23F1" endid="#note-L24F1" />
       <slur xml:id="slur-L25F1-L26F1" staff="1" startid="#note-L25F1" endid="#note-L26F1" />
       <slur xml:id="slur-L27F1-L28F1" staff="1" startid="#note-L27F1" endid="#note-L28F1" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>
