### PR TITLE
Compare to correct value

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1427,7 +1427,7 @@ void BeamSegment::CalcMixedBeamPlace(Staff *staff)
                 coord->m_beamRelativePlace = beamPlaceBelow ? BEAMPLACE_above : BEAMPLACE_below;
             }
         }
-        else if (coord->GetStemDir() != BEAMPLACE_NONE) {
+        else if (coord->GetStemDir() != STEMDIRECTION_NONE) {
             coord->m_beamRelativePlace = (STEMDIRECTION_up == coord->GetStemDir()) ? BEAMPLACE_above : BEAMPLACE_below;
         }
         else {


### PR DESCRIPTION
Follow-up for changes in #2782 - in one conditions there is incorrect value (wrong enum) that is being compared to.