### PR TITLE
Prescribing slur bulge

### DIFF
--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -132,6 +132,9 @@ public:
     std::string BeatrptRendToStr(data_BEATRPT_REND data) const;
     data_BEATRPT_REND StrToBeatrptRend(const std::string &value, bool logWarning = true) const;
 
+    std::string BulgeToStr(const data_BULGE &data) const;
+    data_BULGE StrToBulge(const std::string &value, bool logWarning = true) const;
+
     std::string DurationToStr(data_DURATION data) const;
     data_DURATION StrToDuration(const std::string &value, bool logWarning = true) const;
 

--- a/include/vrv/attdef.h
+++ b/include/vrv/attdef.h
@@ -94,6 +94,11 @@ enum data_BEATRPT_REND {
 };
 
 /**
+ * For storing bulge values (see slur@bulge)
+ */
+typedef std::vector<std::pair<double, double>> data_BULGE;
+
+/**
  * MEI data.DURATION
  */
 enum data_DURATION {

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -260,7 +260,10 @@ public:
     /**
      * @name Initialize control point height and offset from end point positions
      */
+    ///@{
+    void CalcInitialControlPointParams();
     void CalcInitialControlPointParams(Doc *doc, float angle, int staffSize);
+    ///@}
 
     /**
      * Calculate control point offset and height from points or vice versa

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -143,11 +143,6 @@ public:
     ///@}
 
     /**
-     * @name Parse the bulge attribute
-     */
-    std::list<std::pair<data_VU, data_PERCENT>> ParseBulge() const;
-
-    /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
     std::pair<Point, Point> AdjustCoordinates(

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -236,14 +236,14 @@ private:
      * Adjust slur position based on overlapping objects within its spanning elements
      */
     ///@{
-    // Calculate slur from bulge values
-    void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
-
     // Discard certain spanned elements
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+
+    // Calculate slur from bulge values
+    void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
 
     // Calculate the horizontal control point offset
     std::tuple<bool, int, int> CalcControlPointOffset(

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -143,6 +143,11 @@ public:
     ///@}
 
     /**
+     * @name Parse the bulge attribute
+     */
+    std::list<std::pair<data_VU, data_PERCENT>> ParseBulge() const;
+
+    /**
      * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
      */
     std::pair<Point, Point> AdjustCoordinates(

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -236,6 +236,9 @@ private:
      * Adjust slur position based on overlapping objects within its spanning elements
      */
     ///@{
+    // Calculate slur from bulge values
+    void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
+
     // Discard certain spanned elements
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -1296,7 +1296,7 @@ AttCurvature::~AttCurvature()
 void AttCurvature::ResetCurvature()
 {
     m_bezier = "";
-    m_bulge = "";
+    m_bulge = std::vector<std::pair<double, double>>();
     m_curvedir = curvature_CURVEDIR_NONE;
 }
 
@@ -1309,7 +1309,7 @@ bool AttCurvature::ReadCurvature(pugi::xml_node element)
         hasAttribute = true;
     }
     if (element.attribute("bulge")) {
-        this->SetBulge(StrToStr(element.attribute("bulge").value()));
+        this->SetBulge(StrToBulge(element.attribute("bulge").value()));
         element.remove_attribute("bulge");
         hasAttribute = true;
     }
@@ -1329,7 +1329,7 @@ bool AttCurvature::WriteCurvature(pugi::xml_node element)
         wroteAttribute = true;
     }
     if (this->HasBulge()) {
-        element.append_attribute("bulge") = StrToStr(this->GetBulge()).c_str();
+        element.append_attribute("bulge") = BulgeToStr(this->GetBulge()).c_str();
         wroteAttribute = true;
     }
     if (this->HasCurvedir()) {
@@ -1346,7 +1346,7 @@ bool AttCurvature::HasBezier() const
 
 bool AttCurvature::HasBulge() const
 {
-    return (m_bulge != "");
+    return (m_bulge != std::vector<std::pair<double, double>>());
 }
 
 bool AttCurvature::HasCurvedir() const
@@ -8419,7 +8419,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
             return true;
         }
         if (attrType == "bulge") {
-            att->SetBulge(att->StrToStr(attrValue));
+            att->SetBulge(att->StrToBulge(attrValue));
             return true;
         }
         if (attrType == "curvedir") {
@@ -9962,7 +9962,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
             attributes->push_back({ "bezier", att->StrToStr(att->GetBezier()) });
         }
         if (att->HasBulge()) {
-            attributes->push_back({ "bulge", att->StrToStr(att->GetBulge()) });
+            attributes->push_back({ "bulge", att->BulgeToStr(att->GetBulge()) });
         }
         if (att->HasCurvedir()) {
             attributes->push_back({ "curvedir", att->CurvatureCurvedirToStr(att->GetCurvedir()) });

--- a/libmei/atts_shared.h
+++ b/libmei/atts_shared.h
@@ -1033,8 +1033,8 @@ public:
     std::string GetBezier() const { return m_bezier; }
     bool HasBezier() const;
     //
-    void SetBulge(std::string bulge_) { m_bulge = bulge_; }
-    std::string GetBulge() const { return m_bulge; }
+    void SetBulge(data_BULGE bulge_) { m_bulge = bulge_; }
+    data_BULGE GetBulge() const { return m_bulge; }
     bool HasBulge() const;
     //
     void SetCurvedir(curvature_CURVEDIR curvedir_) { m_curvedir = curvedir_; }
@@ -1057,7 +1057,7 @@ private:
      * line's length. N.B. An MEI virtual unit (VU) is half the distance between
      * adjacent staff lines.
      **/
-    std::string m_bulge;
+    data_BULGE m_bulge;
     /** Describes a curve with a generic term indicating the direction of curvature. **/
     curvature_CURVEDIR m_curvedir;
 

--- a/src/att.cpp
+++ b/src/att.cpp
@@ -125,6 +125,42 @@ data_BEATRPT_REND Att::StrToBeatrptRend(const std::string &value, bool logWarnin
     return BEATRPT_REND_NONE;
 }
 
+std::string Att::BulgeToStr(const data_BULGE &data) const
+{
+    std::ostringstream ss;
+    for (int i = 0; i < data.size(); ++i) {
+        if (i != 0) ss << " ";
+        ss << data[i].first << " " << data[i].second;
+    }
+    return ss.str();
+}
+
+data_BULGE Att::StrToBulge(const std::string &value, bool logWarning) const
+{
+    // Split content by spaces
+    std::istringstream content;
+    content.str(value);
+    std::vector<std::string> entries;
+    std::string token;
+    while (std::getline(content, token, ' ')) {
+        if (!token.empty()) entries.push_back(token);
+    }
+
+    // Convert entries to numerical values
+    data_BULGE bulge;
+    Att converter;
+    for (int i = 0; i < entries.size() - 1; i += 2) {
+        const double distance = converter.StrToDbl(entries[i]);
+        const double offset = converter.StrToDbl(entries[i + 1]);
+        if ((offset < 0.0) || (offset > 100.0)) {
+            if (logWarning) LogWarning("Unsupported percentage value '%f' in bulge", offset);
+            continue;
+        }
+        bulge.push_back({ distance, offset });
+    }
+    return bulge;
+}
+
 std::string Att::DurationToStr(data_DURATION data) const
 {
     std::string value;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -36,6 +36,13 @@ void BezierCurve::Rotate(float angle, const Point &rotationPoint)
     c2 = BoundingBox::CalcPositionAfterRotation(c2, angle, rotationPoint);
 }
 
+void BezierCurve::CalcInitialControlPointParams()
+{
+    const int dist = abs(p2.x - p1.x);
+    this->SetControlOffset(dist / 3.0);
+    this->SetControlHeight(0);
+}
+
 void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staffSize)
 {
     // Note: For convex curves (both control points on the same side) we assume that the curve is rotated

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -465,12 +465,6 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     const int unit = doc->GetDrawingUnit(100);
     const int margin = doc->GetOptions()->m_slurMargin.GetValue() * unit;
 
-    // Special handling if bulge is prescribed
-    if (this->HasBulge()) {
-        this->AdjustSlurFromBulge(curve, bezier, unit);
-        return;
-    }
-
     // STEP 1: Filter spanned elements and discard certain bounding boxes even though they collide
     this->FilterSpannedElements(curve, bezier, margin);
 
@@ -492,6 +486,12 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
         }
         bezier.UpdateControlPointParams();
         curve->UpdatePoints(bezier);
+    }
+
+    // Special handling if bulge is prescribed from here on
+    if (this->HasBulge()) {
+        this->AdjustSlurFromBulge(curve, bezier, unit);
+        return;
     }
 
     // STEP 3: Calculate the horizontal offset of the control points.

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -467,7 +467,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
 
     // Special handling if bulge is prescribed
     if (this->HasBulge()) {
-        const std::list<std::pair<data_VU, data_PERCENT>> bulgeEntries = this->ParseBulge();
+        this->AdjustSlurFromBulge(curve, bezier, unit);
         return;
     }
 
@@ -530,6 +530,43 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
         this->AdjustSlurShape(bezier, curve->GetDir(), unit);
         curve->UpdatePoints(bezier);
     }
+
+    // Since we are going to redraw it, reset its bounding box
+    curve->BoundingBox::ResetBoundingBox();
+}
+
+void Slur::AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, const int unit)
+{
+    if (bezierCurve.p1.x >= bezierCurve.p2.x) return;
+
+    const std::list<std::pair<data_VU, data_PERCENT>> bulgeEntries = this->ParseBulge();
+
+    // Generate a control point constraint for each bulge entry
+    std::list<ControlPointConstraint> constraints;
+    Point points[4];
+    points[0] = bezierCurve.p1;
+    points[1] = bezierCurve.c1;
+    points[2] = bezierCurve.c2;
+    points[3] = bezierCurve.p2;
+
+    for (const std::pair<data_VU, data_PERCENT> &bulgeEntry : bulgeEntries) {
+        const double lambda = bulgeEntry.second / 100.0;
+        if ((lambda > 0.0) && (lambda < 1.0) && (bulgeEntry.first > 0.0)) {
+            const double x = (1.0 - lambda) * bezierCurve.p1.x + lambda * bezierCurve.p2.x;
+            const double t = BoundingBox::CalcBezierParamAtPosition(points, x);
+            constraints.push_back(
+                { 3.0 * pow(1.0 - t, 2.0) * t, 3.0 * (1.0 - t) * pow(t, 2.0), bulgeEntry.first * unit });
+        }
+    }
+
+    // Solve these constraints and calculate the adjustment
+    int leftShift = 0;
+    int rightShift = 0;
+    std::tie(leftShift, rightShift) = this->SolveControlPointConstraints(constraints);
+    bezierCurve.SetLeftControlHeight(bezierCurve.GetLeftControlHeight() + leftShift);
+    bezierCurve.SetRightControlHeight(bezierCurve.GetRightControlHeight() + rightShift);
+    bezierCurve.UpdateControlPoints();
+    curve->UpdatePoints(bezierCurve);
 
     // Since we are going to redraw it, reset its bounding box
     curve->BoundingBox::ResetBoundingBox();

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -607,9 +607,7 @@ void Slur::AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezi
 {
     if (bezierCurve.p1.x >= bezierCurve.p2.x) return;
 
-    // Read the bulge attribute
-    Att converter;
-    data_BULGE bulge = converter.StrToBulge(this->GetBulge());
+    data_BULGE bulge = this->GetBulge();
 
     // Filter admissible values
     bulge.erase(std::remove_if(bulge.begin(), bulge.end(),

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -196,7 +196,12 @@ void View::CalcInitialSlur(
 
     /************** control points **************/
 
-    bezier.CalcInitialControlPointParams(m_doc, slurAngle, staff->m_drawingStaffSize);
+    if (slur->HasBulge()) {
+        bezier.CalcInitialControlPointParams();
+    }
+    else {
+        bezier.CalcInitialControlPointParams(m_doc, slurAngle, staff->m_drawingStaffSize);
+    }
     bezier.UpdateControlPoints();
     if (curveDir != curvature_CURVEDIR_mixed) {
         bezier.Rotate(slurAngle, bezier.p1);


### PR DESCRIPTION
This PR adds support for the bulge attribute in slurs. Closes #1455 .
<img width="1192" alt="Bulge-Example" src="https://user-images.githubusercontent.com/63608463/162680952-b9760c38-95dd-4980-bf64-5b50f41da1cb.png">
<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Bulge test</title>
        <respStmt>
          <persName>Klaus Rettinghaus</persName>
        </respStmt>
      </titleStmt>
      <pubStmt>
        <date>2020-05-09</date>
      </pubStmt>
      <notesStmt>
        <annot>Verovio takes bulge values of slurs into account.</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="unknown" label="1">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef>
                        <staffGrp>
                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-01"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-02" />
                                </layer>
                            </staff>
                            <slur startid="#n-01" endid="#n-02" curvedir="above" bulge="5 20%" />
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-03"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-04" />
                                </layer>
                            </staff>
                            <slur startid="#n-03" endid="#n-04" curvedir="above" bulge="5 40%" />
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-05"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-06" />
                                </layer>
                            </staff>
                            <slur startid="#n-05" endid="#n-06" curvedir="above" bulge="5 60%" />
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-07"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-08" />
                                </layer>
                            </staff>
                            <slur startid="#n-07" endid="#n-08" curvedir="above" bulge="5 80%" />
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-09"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-10" />
                                </layer>
                            </staff>
                            <slur startid="#n-09" endid="#n-10" curvedir="above" bulge="1 10% 1 90%" />
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="2" oct="4" pname="g" xml:id="n-11"/>
                                    <note dur="2" oct="5" pname="d" xml:id="n-12" />
                                </layer>
                            </staff>
                            <slur startid="#n-11" endid="#n-12" curvedir="above" bulge="2 20% 4 80%" />
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
</details>

Note that collision avoidance is disabled for slurs with prescribed bulge.
