### PR TITLE
Improving the ObjectListInterface

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -349,7 +349,7 @@ protected:
      * Filter the flat list and keep only Note and Chords elements.
      * This also initializes the m_beamElementCoords vector
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -349,7 +349,7 @@ protected:
      * Filter the flat list and keep only Note and Chords elements.
      * This also initializes the m_beamElementCoords vector
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -349,7 +349,7 @@ protected:
      * Filter the flat list and keep only Note and Chords elements.
      * This also initializes the m_beamElementCoords vector
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -270,7 +270,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 public:
     mutable std::list<ChordCluster *> m_clusters;

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -83,24 +83,26 @@ public:
     /**
      * Return the maximum and minimum Y positions of the notes in the chord
      */
-    void GetYExtremes(int &yMax, int &yMin);
+    void GetYExtremes(int &yMax, int &yMin) const;
 
     /**
      * Return the top or bottom note or their Y position
      */
     ///@{
     Note *GetTopNote();
+    const Note *GetTopNote() const;
     Note *GetBottomNote();
-    int GetYTop();
-    int GetYBottom();
+    const Note *GetBottomNote() const;
+    int GetYTop() const;
+    int GetYBottom() const;
     ///@}
 
     /**
      * Return min or max note X position
      */
     ///@{
-    int GetXMin();
-    int GetXMax();
+    int GetXMin() const;
+    int GetXMax() const;
     ///@}
 
     /**
@@ -124,7 +126,7 @@ public:
      */
     ///@{
     /** Return 0 if the note is the middle note, -1 if below it and 1 if above */
-    int PositionInChord(Note *note);
+    int PositionInChord(const Note *note) const;
     ///@}
 
     /**
@@ -132,9 +134,9 @@ public:
      * If necessary look at the glyph anchor (if any).
      */
     ///@{
-    Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize) override;
-    Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize) override;
-    int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) override;
+    Point GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const override;
+    Point GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const override;
+    int CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const override;
     ///@}
 
     /**

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -270,7 +270,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 public:
     mutable std::list<ChordCluster *> m_clusters;

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -226,9 +226,9 @@ public:
     int ResetData(FunctorParams *functorParams) override;
 
     /**
-     * See Object::InitializeDrawing
+     * See Object::InitData
      */
-    int InitializeDrawing(FunctorParams *functorParams) override;
+    int InitData(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyYAdjustCrossStaff

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -224,6 +224,11 @@ public:
     int ResetData(FunctorParams *functorParams) override;
 
     /**
+     * See Object::InitializeDrawing
+     */
+    int InitializeDrawing(FunctorParams *functorParams) override;
+
+    /**
      * See Object::JustifyYAdjustCrossStaff
      */
     int JustifyYAdjustCrossStaff(FunctorParams *functorParams) override;
@@ -256,6 +261,11 @@ protected:
      * Clear the m_clusters vector and delete all the objects.
      */
     void ClearClusters() const;
+
+    /**
+     * Recalculate the m_clusters vector
+     */
+    void CalculateClusters();
 
     /**
      * Filter the flat list and keep only Note elements.

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -142,7 +142,7 @@ public:
     /**
      * Check if the chord or one of its children is visible
      */
-    bool IsVisible();
+    bool IsVisible() const;
 
     /**
      * Return true if the chord has two notes with 1 diatonic step difference in the specific staff
@@ -152,7 +152,7 @@ public:
     /**
      * Return true if the chord has at least one note with a @dots > 0
      */
-    bool HasNoteWithDots();
+    bool HasNoteWithDots() const;
 
     /**
      * Helper to adjust overlapping layers for chords
@@ -257,7 +257,7 @@ protected:
      * Calculate stem direction based on the position of the notes in chord. Notes are compared in pairs starting from
      * the top-/bottommost and moving inward towards the center of the chord
      */
-    data_STEMDIRECTION CalcStemDirection(int verticalCenter);
+    data_STEMDIRECTION CalcStemDirection(int verticalCenter) const;
 
     /**
      * Clear the m_clusters vector and delete all the objects.

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -272,7 +272,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 public:
     mutable std::list<ChordCluster *> m_clusters;

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -226,9 +226,9 @@ public:
     int ResetData(FunctorParams *functorParams) override;
 
     /**
-     * See Object::InitData
+     * See Object::PrepareDataInitialization
      */
-    int InitData(FunctorParams *functorParams) override;
+    int PrepareDataInitialization(FunctorParams *functorParams) override;
 
     /**
      * See Object::JustifyYAdjustCrossStaff

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -107,6 +107,7 @@ public:
      * Initializes the m_beamElementCoords vector objects.
      */
     ///@{
+    bool HasCoords() const { return !m_beamElementCoords.empty(); }
     void InitCoords(const ArrayOfObjects &childList, Staff *staff, data_BEAMPLACE place);
     void InitCoords(const ListOfObjects &childList, Staff *staff, data_BEAMPLACE place);
     ///@}

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -107,7 +107,7 @@ public:
      * Initializes the m_beamElementCoords vector objects.
      * This is called by Beam::FilterList
      */
-    void InitCoords(ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place);
+    void InitCoords(const ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place);
 
     /**
      * Initialize m_cueSize value based on the @cue attribute and presence of child elements with @cue/@grace

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -105,9 +105,11 @@ public:
 
     /**
      * Initializes the m_beamElementCoords vector objects.
-     * This is called by Beam::FilterList
      */
+    ///@{
     void InitCoords(const ArrayOfObjects &childList, Staff *staff, data_BEAMPLACE place);
+    void InitCoords(const ListOfObjects &childList, Staff *staff, data_BEAMPLACE place);
+    ///@}
 
     /**
      * Initialize m_cueSize value based on the @cue attribute and presence of child elements with @cue/@grace

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -107,7 +107,7 @@ public:
      * Initializes the m_beamElementCoords vector objects.
      * This is called by Beam::FilterList
      */
-    void InitCoords(const ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place);
+    void InitCoords(const ArrayOfObjects &childList, Staff *staff, data_BEAMPLACE place);
 
     /**
      * Initialize m_cueSize value based on the @cue attribute and presence of child elements with @cue/@grace

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -99,8 +99,8 @@ public:
      * Object * is a pointer to the object implementing the interface (e.g, Beam, fTrem)
      */
     ///@{
-    bool IsFirstIn(Object *object, LayerElement *element);
-    bool IsLastIn(Object *object, LayerElement *element);
+    bool IsFirstIn(const Object *object, const LayerElement *element) const;
+    bool IsLastIn(const Object *object, const LayerElement *element) const;
     ///@}
 
     /**
@@ -160,7 +160,7 @@ protected:
      * Return the position of the element in the beam.
      * For notes, lookup the position of the parent chord.
      */
-    int GetPosition(Object *object, LayerElement *element);
+    int GetPosition(const Object *object, const LayerElement *element) const;
 
     //
 private:
@@ -240,7 +240,7 @@ public:
     void SetDrawMensur(bool drawMensur) { m_drawMensur = drawMensur; }
     bool DrawMeterSig() { return (m_drawMeterSig && (m_currentMeterSig.HasUnit() || m_currentMeterSig.HasSym())); }
     void SetDrawMeterSig(bool drawMeterSig) { m_drawMeterSig = drawMeterSig; }
-    bool DrawMeterSigGrp();
+    bool DrawMeterSigGrp() const;
     void SetDrawMeterSigGrp(bool drawMeterSigGrp) { m_drawMeterSigGrp = drawMeterSigGrp; }
     ///@}
 
@@ -320,9 +320,9 @@ public:
      */
     ///@{
     void SetDrawingStemDir(data_STEMDIRECTION stemDir);
-    data_STEMDIRECTION GetDrawingStemDir();
+    data_STEMDIRECTION GetDrawingStemDir() const;
     void SetDrawingStemLen(int drawingStemLen);
-    int GetDrawingStemLen();
+    int GetDrawingStemLen() const;
     ///@}
 
     Point GetDrawingStemStart(Object *object = NULL);
@@ -332,9 +332,9 @@ public:
      * @name Virtual methods overriden in child classes (Chord and Note)
      */
     ///@{
-    virtual Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize) = 0;
-    virtual Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize) = 0;
-    virtual int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) = 0;
+    virtual Point GetStemUpSE(const Doc *doc, int staffSize, bool graceSize) const = 0;
+    virtual Point GetStemDownNW(const Doc *doc, int staffSize, bool graceSize) const = 0;
+    virtual int CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const = 0;
     ///@}
 
 protected:

--- a/include/vrv/durationinterface.h
+++ b/include/vrv/durationinterface.h
@@ -74,12 +74,12 @@ public:
     /**
      * Return true if the note or rest is the first of a beam.
      */
-    bool IsFirstInBeam(LayerElement *noteOrRest);
+    bool IsFirstInBeam(const LayerElement *noteOrRest) const;
 
     /**
      * Return true if the note or rest is the last of a beam.
      */
-    bool IsLastInBeam(LayerElement *noteOrRest);
+    bool IsLastInBeam(const LayerElement *noteOrRest) const;
 
     /**
      * @name Return the actual (gestural) duration of the note, for both CMN and mensural durations

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -118,8 +118,8 @@ public:
 
     wchar_t GetFlagGlyph(data_STEMDIRECTION stemDir) const;
 
-    Point GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const;
-    Point GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const;
+    Point GetStemUpSE(const Doc *doc, int staffSize, bool graceSize) const;
+    Point GetStemDownNW(const Doc *doc, int staffSize, bool graceSize) const;
 
     //----------//
     // Functors //
@@ -344,9 +344,9 @@ public:
      * @name Setter and getter for darwing stem direction and length
      */
     ///@{
-    data_STEMDIRECTION GetDrawingStemDir() { return m_drawingStemDir; }
+    data_STEMDIRECTION GetDrawingStemDir() const { return m_drawingStemDir; }
     void SetDrawingStemDir(data_STEMDIRECTION drawingStemDir) { m_drawingStemDir = drawingStemDir; }
-    int GetDrawingStemLen() { return m_drawingStemLen; }
+    int GetDrawingStemLen() const { return m_drawingStemLen; }
     void SetDrawingStemLen(int drawingStemLen) { m_drawingStemLen = drawingStemLen; }
     ///@}
 

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -103,7 +103,7 @@ protected:
     /**
      * Filter the flat list and keep only Note or Chords elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -103,7 +103,7 @@ protected:
     /**
      * Filter the flat list and keep only Note or Chords elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -103,7 +103,7 @@ protected:
     /**
      * Filter the flat list and keep only Note or Chords elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
     /**
      * See LayerElement::SetElementShortening

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -105,8 +105,8 @@ public:
 
 class AddLayerElementToFlatListParams : public FunctorParams {
 public:
-    AddLayerElementToFlatListParams(ArrayOfConstObjects *flatList) { m_flatList = flatList; }
-    ArrayOfConstObjects *m_flatList;
+    AddLayerElementToFlatListParams(ListOfConstObjects *flatList) { m_flatList = flatList; }
+    ListOfConstObjects *m_flatList;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1891,6 +1891,26 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// InitializeDrawingParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the functor for redirection
+ * member 1: the doc
+ **/
+
+class InitializeDrawingParams : public FunctorParams {
+public:
+    InitializeDrawingParams(Functor *functor, Doc *doc)
+    {
+        m_functor = functor;
+        m_doc = doc;
+    }
+    Functor *m_functor;
+    Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
 // JustifyXParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1814,26 +1814,6 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// InitDataParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the functor for redirection
- * member 1: the doc
- **/
-
-class InitDataParams : public FunctorParams {
-public:
-    InitDataParams(Functor *functor, Doc *doc)
-    {
-        m_functor = functor;
-        m_doc = doc;
-    }
-    Functor *m_functor;
-    Doc *m_doc;
-};
-
-//----------------------------------------------------------------------------
 // InitMaxMeasureDurationParams
 //----------------------------------------------------------------------------
 
@@ -2085,6 +2065,26 @@ public:
     Measure *m_currentMeasure;
     Staff *m_currentCrossStaff;
     Layer *m_currentCrossLayer;
+};
+
+//----------------------------------------------------------------------------
+// PrepareDataInitializationParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the functor for redirection
+ * member 1: the doc
+ **/
+
+class PrepareDataInitializationParams : public FunctorParams {
+public:
+    PrepareDataInitializationParams(Functor *functor, Doc *doc)
+    {
+        m_functor = functor;
+        m_doc = doc;
+    }
+    Functor *m_functor;
+    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -105,8 +105,8 @@ public:
 
 class AddLayerElementToFlatListParams : public FunctorParams {
 public:
-    AddLayerElementToFlatListParams(ArrayOfObjects *flatList) { m_flatList = flatList; }
-    ArrayOfObjects *m_flatList;
+    AddLayerElementToFlatListParams(ArrayOfConstObjects *flatList) { m_flatList = flatList; }
+    ArrayOfConstObjects *m_flatList;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1814,6 +1814,26 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// InitDataParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the functor for redirection
+ * member 1: the doc
+ **/
+
+class InitDataParams : public FunctorParams {
+public:
+    InitDataParams(Functor *functor, Doc *doc)
+    {
+        m_functor = functor;
+        m_doc = doc;
+    }
+    Functor *m_functor;
+    Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
 // InitMaxMeasureDurationParams
 //----------------------------------------------------------------------------
 
@@ -1888,26 +1908,6 @@ public:
     InitProcessingListsParams() {}
     IntTree m_verseTree;
     IntTree m_layerTree;
-};
-
-//----------------------------------------------------------------------------
-// InitializeDrawingParams
-//----------------------------------------------------------------------------
-
-/**
- * member 0: the functor for redirection
- * member 1: the doc
- **/
-
-class InitializeDrawingParams : public FunctorParams {
-public:
-    InitializeDrawingParams(Functor *functor, Doc *doc)
-    {
-        m_functor = functor;
-        m_doc = doc;
-    }
-    Functor *m_functor;
-    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -66,14 +66,14 @@ public:
     /**
      * Fill the map of modified pitches
      */
-    void FillMap(MapOfPitchAccid &mapOfPitchAccid);
+    void FillMap(MapOfPitchAccid &mapOfPitchAccid) const;
 
     /**
      * Return the string of the alteration at the positon pos.
      * Looks at keyAccid children if any.
      * The accid at pos is return in accid and the pname in pname.
      */
-    std::wstring GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname);
+    std::wstring GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname) const;
 
     int GetFifthsInt() const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -105,7 +105,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -105,7 +105,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -105,7 +105,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -92,9 +92,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitializeDrawing
+     * See Object::InitData
      */
-    int InitializeDrawing(FunctorParams *functorParams) override;
+    int InitData(FunctorParams *functorParams) override;
 
     /**
      * See Object::Transpose

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -58,10 +58,10 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /** Accid number getter */
-    int GetAccidCount();
+    int GetAccidCount() const;
 
     /** Accid type getter */
-    data_ACCIDENTAL_WRITTEN GetAccidType();
+    data_ACCIDENTAL_WRITTEN GetAccidType() const;
 
     /**
      * Fill the map of modified pitches

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -92,6 +92,11 @@ public:
     //----------//
 
     /**
+     * See Object::InitializeDrawing
+     */
+    int InitializeDrawing(FunctorParams *functorParams) override;
+
+    /**
      * See Object::Transpose
      */
     int Transpose(FunctorParams *functorParams) override;

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -92,9 +92,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitData
+     * See Object::PrepareDataInitialization
      */
-    int InitData(FunctorParams *functorParams) override;
+    int PrepareDataInitialization(FunctorParams *functorParams) override;
 
     /**
      * See Object::Transpose

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -122,6 +122,7 @@ public:
     bool IsInLigature() const;
     /** Return the FTrem parten if the element is a note or a chord within a fTrem */
     FTrem *IsInFTrem();
+    const FTrem *IsInFTrem() const;
     /**
      * Return the beam parent if in beam
      * Look if the note or rest is in a beam.
@@ -129,6 +130,7 @@ public:
      * Looking in the content list is necessary for grace notes or imbricated beams.
      */
     Beam *IsInBeam();
+    const Beam *IsInBeam() const;
     bool IsInBeamSpan() const;
     ///@}
 

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -81,7 +81,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 public:
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -83,7 +83,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 public:
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -81,7 +81,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 public:
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -79,11 +79,6 @@ public:
 
 protected:
     /**
-     * Clear the m_clusters vector and delete all the objects.
-     */
-    void ClearClusters();
-
-    /**
      * Filter the flat list and keep only Note elements.
      */
     void FilterList(ArrayOfObjects *childList) override;

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -52,7 +52,9 @@ public:
      */
     ///@{
     Note *GetFirstNote();
+    const Note *GetFirstNote() const;
     Note *GetLastNote();
+    const Note *GetLastNote() const;
     ///@}
 
     /**

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -89,7 +89,7 @@ protected:
     /**
      * Filter the flat list and keep only meterSigGrp elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     // vector with alternating measures to be used only with meterSigGrpLog_FUNC_alternating

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -89,7 +89,7 @@ protected:
     /**
      * Filter the flat list and keep only meterSigGrp elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     // vector with alternating measures to be used only with meterSigGrpLog_FUNC_alternating

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -89,7 +89,7 @@ protected:
     /**
      * Filter the flat list and keep only meterSigGrp elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     // vector with alternating measures to be used only with meterSigGrpLog_FUNC_alternating

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -70,7 +70,7 @@ public:
     /**
      * Get simplified (i.e. single metersig with count/unit) based on the MeterSigGrp function
      */
-    MeterSig *GetSimplifiedMeterSig();
+    MeterSig *GetSimplifiedMeterSig() const;
 
     /**
      * Set counter for the alternating meterSigGrp based on the provided measureId

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -77,7 +77,7 @@ public:
      */
     bool IsSupportedChild(Object *object) override;
 
-    bool IsLastInNeume(LayerElement *element);
+    bool IsLastInNeume(const LayerElement *element) const;
 
     bool GenerateChildMelodic();
 
@@ -89,7 +89,7 @@ public:
     PitchInterface *GetLowestPitch();
 
 private:
-    int GetPosition(LayerElement *element);
+    int GetPosition(const LayerElement *element) const;
 
 public:
     //----------------//

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -217,7 +217,7 @@ public:
     /**
      * Check if a note or its parent chord are visible
      */
-    bool IsVisible();
+    bool IsVisible() const;
 
     /**
      * MIDI pitch

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -194,9 +194,9 @@ public:
      * If necessary look at the glyph anchor (if any).
      */
     ///@{
-    Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize) override;
-    Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize) override;
-    int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) override;
+    Point GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const override;
+    Point GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const override;
+    int CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const override;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1200,7 +1200,7 @@ public:
     /**
      * One time member initialization at the very begin
      */
-    virtual int InitializeDrawing(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int InitData(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
      * Set the drawing cue size of all LayerElement

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -547,7 +547,7 @@ public:
      * Fill the list of all the children LayerElement.
      * This is used for navigating in a Layer (See Layer::GetPrevious and Layer::GetNext).
      */
-    void FillFlatList(ArrayOfConstObjects &list) const;
+    void FillFlatList(ListOfConstObjects &list) const;
 
     /**
      * Check if the content was modified or not
@@ -1676,8 +1676,8 @@ public:
      * Because this is an interface, we need to pass the object - not the best design.
      */
     ///@{
-    const ArrayOfConstObjects &GetList(const Object *node) const;
-    ArrayOfObjects GetList(const Object *node);
+    const ListOfConstObjects &GetList(const Object *node) const;
+    ListOfObjects GetList(const Object *node);
     ///@}
 
     /**
@@ -1694,14 +1694,14 @@ public:
     ///@}
 
 private:
-    mutable ArrayOfConstObjects m_list;
+    mutable ListOfConstObjects m_list;
 
 protected:
     /**
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    virtual void FilterList(ArrayOfConstObjects &childList) const {};
+    virtual void FilterList(ListOfConstObjects &childList) const {};
 
 public:
     /**
@@ -1742,7 +1742,7 @@ protected:
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1200,7 +1200,7 @@ public:
     /**
      * One time member initialization at the very begin
      */
-    virtual int InitData(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int PrepareDataInitialization(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
      * Set the drawing cue size of all LayerElement

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1676,7 +1676,7 @@ protected:
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    virtual void FilterList(ArrayOfObjects *childList){};
+    virtual void FilterList(ArrayOfConstObjects &childList){};
 
 public:
     /**
@@ -1717,7 +1717,7 @@ protected:
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    virtual void FilterList(ArrayOfObjects *childList);
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1665,7 +1665,7 @@ public:
      * If not, it updates the list and also calls FilterList.
      * Because this is an interface, we need to pass the object - not the best design.
      */
-    const ArrayOfObjects *GetList(Object *node);
+    const ArrayOfObjects &GetList(Object *node);
 
 private:
     mutable ArrayOfObjects m_list;

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1198,6 +1198,11 @@ public:
     ///@{
 
     /**
+     * One time member initialization at the very begin
+     */
+    virtual int InitializeDrawing(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Set the drawing cue size of all LayerElement
      */
     virtual int PrepareCueSize(FunctorParams *) { return FUNCTOR_CONTINUE; }

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1730,12 +1730,12 @@ public:
     /**
      * Returns a contatenated version of all the text children
      */
-    std::wstring GetText(Object *node);
+    std::wstring GetText(const Object *node) const;
 
     /**
      * Fill an array of lines with concatenated content of each line
      */
-    void GetTextLines(Object *node, std::vector<std::wstring> &lines);
+    void GetTextLines(const Object *node, std::vector<std::wstring> &lines) const;
 
 protected:
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1667,6 +1667,17 @@ public:
      */
     const ArrayOfObjects &GetList(Object *node);
 
+    /**
+     * Convenience functions that check if the list is up-to-date
+     * If not, the list is updated before returning the result
+     */
+    ///@{
+    bool HasEmptyList(Object *node);
+    int GetListSize(Object *node);
+    Object *GetListFront(Object *node);
+    Object *GetListBack(Object *node);
+    ///@}
+
 private:
     mutable ArrayOfObjects m_list;
     ArrayOfObjects::iterator m_iteratorCurrent;

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1641,23 +1641,33 @@ public:
     /**
      * Look for the Object in the list and return its position (-1 if not found)
      */
-    int GetListIndex(const Object *listElement);
+    int GetListIndex(const Object *listElement) const;
 
     /**
      * Gets the first item of type elementType starting at startFrom
      */
+    ///@{
+    const Object *GetListFirst(const Object *startFrom, const ClassId classId = UNSPECIFIED) const;
     Object *GetListFirst(const Object *startFrom, const ClassId classId = UNSPECIFIED);
-    Object *GetListFirstBackward(Object *startFrom, const ClassId classId = UNSPECIFIED);
+    const Object *GetListFirstBackward(const Object *startFrom, const ClassId classId = UNSPECIFIED) const;
+    Object *GetListFirstBackward(const Object *startFrom, const ClassId classId = UNSPECIFIED);
+    ///@}
 
     /**
      * Returns the previous object in the list (NULL if not found)
      */
-    Object *GetListPrevious(Object *listElement);
+    ///@{
+    const Object *GetListPrevious(const Object *listElement) const;
+    Object *GetListPrevious(const Object *listElement);
+    ///@}
 
     /**
      * Returns the next object in the list (NULL if not found)
      */
-    Object *GetListNext(Object *listElement);
+    ///@{
+    const Object *GetListNext(const Object *listElement) const;
+    Object *GetListNext(const Object *listElement);
+    ///@}
 
     /**
      * Return the list.
@@ -1665,36 +1675,40 @@ public:
      * If not, it updates the list and also calls FilterList.
      * Because this is an interface, we need to pass the object - not the best design.
      */
-    const ArrayOfObjects &GetList(Object *node);
+    ///@{
+    const ArrayOfConstObjects &GetList(const Object *node) const;
+    ArrayOfObjects GetList(const Object *node);
+    ///@}
 
     /**
      * Convenience functions that check if the list is up-to-date
      * If not, the list is updated before returning the result
      */
     ///@{
-    bool HasEmptyList(Object *node);
-    int GetListSize(Object *node);
-    Object *GetListFront(Object *node);
-    Object *GetListBack(Object *node);
+    bool HasEmptyList(const Object *node) const;
+    int GetListSize(const Object *node) const;
+    const Object *GetListFront(const Object *node) const;
+    Object *GetListFront(const Object *node);
+    const Object *GetListBack(const Object *node) const;
+    Object *GetListBack(const Object *node);
     ///@}
 
 private:
-    mutable ArrayOfObjects m_list;
-    ArrayOfObjects::iterator m_iteratorCurrent;
+    mutable ArrayOfConstObjects m_list;
 
 protected:
     /**
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    virtual void FilterList(ArrayOfConstObjects &childList){};
+    virtual void FilterList(ArrayOfConstObjects &childList) const {};
 
 public:
     /**
      * Reset the list of children and call FilterList().
      * As for GetList, we need to pass the object.
      */
-    void ResetList(const Object *node);
+    void ResetList(const Object *node) const;
 };
 
 //----------------------------------------------------------------------------
@@ -1728,7 +1742,7 @@ protected:
      * Filter the list for a specific class.
      * For example, keep only notes in Beam
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     //
@@ -1790,7 +1804,7 @@ class ObjectComparison {
 public:
     ObjectComparison(const ClassId classId) { m_classId = classId; }
 
-    bool operator()(Object *object)
+    bool operator()(const Object *object)
     {
         if (m_classId == UNSPECIFIED) {
             return true;

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -547,7 +547,7 @@ public:
      * Fill the list of all the children LayerElement.
      * This is used for navigating in a Layer (See Layer::GetPrevious and Layer::GetNext).
      */
-    void FillFlatList(ArrayOfObjects *list);
+    void FillFlatList(ArrayOfConstObjects &list) const;
 
     /**
      * Check if the content was modified or not
@@ -557,7 +557,7 @@ public:
     /**
      * Mark the object and its parent (if any) as modified
      */
-    void Modify(bool modified = true);
+    void Modify(bool modified = true) const;
 
     /**
      * @name Setter and getter of the attribute flag
@@ -646,7 +646,7 @@ public:
     /**
      * Add each LayerElements and its children to a flat list
      */
-    virtual int AddLayerElementToFlatList(FunctorParams *functorParams);
+    virtual int AddLayerElementToFlatList(FunctorParams *functorParams) const;
 
     /**
      * Builds a tree of ints (IntTree) with the staff/layer/verse numbers and for staff/layer to be then processed.
@@ -1683,7 +1683,7 @@ public:
      * Reset the list of children and call FilterList().
      * As for GetList, we need to pass the object.
      */
-    void ResetList(Object *node);
+    void ResetList(const Object *node);
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -134,9 +134,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitData
+     * See Object::PrepareDataInitialization
      */
-    int InitData(FunctorParams *functorParams) override;
+    int PrepareDataInitialization(FunctorParams *functorParams) override;
 
     /**
      * See Object::Save

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -134,9 +134,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitializeDrawing
+     * See Object::InitData
      */
-    int InitializeDrawing(FunctorParams *functorParams) override;
+    int InitData(FunctorParams *functorParams) override;
 
     /**
      * See Object::Save

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -158,7 +158,7 @@ protected:
      * Filter the list for a specific class.
      * Keep only the top <rend> and <fig>
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     /**

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -158,7 +158,7 @@ protected:
      * Filter the list for a specific class.
      * Keep only the top <rend> and <fig>
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     /**

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -134,6 +134,11 @@ public:
     //----------//
 
     /**
+     * See Object::InitializeDrawing
+     */
+    int InitializeDrawing(FunctorParams *functorParams) override;
+
+    /**
      * See Object::Save
      */
     ///@{

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -158,7 +158,7 @@ protected:
      * Filter the list for a specific class.
      * Keep only the top <rend> and <fig>
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -74,9 +74,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitializeDrawing
+     * See Object::InitData
      */
-    int InitializeDrawing(FunctorParams *functorParams) override;
+    int InitData(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustDots

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -74,9 +74,9 @@ public:
     //----------//
 
     /**
-     * See Object::InitData
+     * See Object::PrepareDataInitialization
      */
-    int InitData(FunctorParams *functorParams) override;
+    int PrepareDataInitialization(FunctorParams *functorParams) override;
 
     /**
      * See Object::AdjustDots

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -74,6 +74,11 @@ public:
     //----------//
 
     /**
+     * See Object::InitializeDrawing
+     */
+    int InitializeDrawing(FunctorParams *functorParams) override;
+
+    /**
      * See Object::AdjustDots
      */
     int AdjustDots(FunctorParams *functorParams) override;

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -283,7 +283,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     //

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -166,17 +166,23 @@ public:
     /**
      * Get the staffDef with number n (NULL if not found).
      */
+    ///@{
     StaffDef *GetStaffDef(int n);
+    const StaffDef *GetStaffDef(int n) const;
+    ///@}
 
     /**
      * Get the staffGrp with number n (NULL if not found).
      */
+    ///@{
     StaffGrp *GetStaffGrp(const std::string &n);
+    const StaffGrp *GetStaffGrp(const std::string &n) const;
+    ///@}
 
     /**
      * Return all the @n values of the staffDef in a scoreDef
      */
-    std::vector<int> GetStaffNs();
+    std::vector<int> GetStaffNs() const;
 
     /**
      * Set the redraw flag to all staffDefs.

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -283,7 +283,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -289,7 +289,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -110,14 +110,14 @@ public:
      * @name Get notation type
      */
     ///@{
-    bool IsMensural();
-    bool IsNeume();
-    bool IsTablature();
-    bool IsTabGuitar() { return m_drawingNotationType == NOTATIONTYPE_tab_guitar; }
-    bool IsTabLuteFrench() { return m_drawingNotationType == NOTATIONTYPE_tab_lute_french; }
-    bool IsTabLuteGerman() { return m_drawingNotationType == NOTATIONTYPE_tab_lute_german; }
-    bool IsTabLuteItalian() { return m_drawingNotationType == NOTATIONTYPE_tab_lute_italian; }
-    bool IsTabWithStemsOutside();
+    bool IsMensural() const;
+    bool IsNeume() const;
+    bool IsTablature() const;
+    bool IsTabGuitar() const { return m_drawingNotationType == NOTATIONTYPE_tab_guitar; }
+    bool IsTabLuteFrench() const { return m_drawingNotationType == NOTATIONTYPE_tab_lute_french; }
+    bool IsTabLuteGerman() const { return m_drawingNotationType == NOTATIONTYPE_tab_lute_german; }
+    bool IsTabLuteItalian() const { return m_drawingNotationType == NOTATIONTYPE_tab_lute_italian; }
+    bool IsTabWithStemsOutside() const;
     ///@}
 
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -117,7 +117,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -117,7 +117,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -72,7 +72,7 @@ public:
     /**
      * Return the maximum staff size in the staffGrp (100 if empty)
      */
-    int GetMaxStaffSize();
+    int GetMaxStaffSize() const;
 
     /**
      * @name Setter and getter of the group symbol

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -117,7 +117,7 @@ protected:
     /**
      * Filter the flat list and keep only StaffDef elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     //

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -63,9 +63,9 @@ public:
      * If necessary look at the glyph anchor (if any).
      */
     ///@{
-    Point GetStemUpSE(Doc *doc, int staffSize, bool isCueSize) override;
-    Point GetStemDownNW(Doc *doc, int staffSize, bool isCueSize) override;
-    int CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir) override;
+    Point GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const override;
+    Point GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const override;
+    int CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const override;
     ///@}
 
     /**

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -51,9 +51,11 @@ public:
      */
     ///@{
     Note *GetTopNote();
+    const Note *GetTopNote() const;
     Note *GetBottomNote();
-    int GetYTop();
-    int GetYBottom();
+    const Note *GetBottomNote() const;
+    int GetYTop() const;
+    int GetYBottom() const;
     ///@}
 
     //----------//

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -76,7 +76,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -74,7 +74,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     //

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -74,7 +74,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     //

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -116,7 +116,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) const override;
+    void FilterList(ListOfConstObjects &childList) const override;
 
 private:
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -116,7 +116,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfObjects *childList) override;
+    void FilterList(ArrayOfConstObjects &childList) override;
 
 private:
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -116,7 +116,7 @@ protected:
     /**
      * Filter the flat list and keep only Note elements.
      */
-    void FilterList(ArrayOfConstObjects &childList) override;
+    void FilterList(ArrayOfConstObjects &childList) const override;
 
 private:
     /**

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -101,7 +101,7 @@ public:
     /**
      * Calculates and sets spacing for specified ScoreDef
      */
-    void SetSpacing(ScoreDef *scoreDef);
+    void SetSpacing(const ScoreDef *scoreDef);
 
 private:
     /**
@@ -112,7 +112,7 @@ private:
     /**
      * Calculates above spacing type for staffDef
      */
-    SpacingType CalculateSpacingAbove(StaffDef *staffDef) const;
+    SpacingType CalculateSpacingAbove(const StaffDef *staffDef) const;
 
 public:
     //

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -112,7 +112,7 @@ std::set<Note *> Arpeg::GetNotes()
         }
         else if (object->Is(CHORD)) {
             Chord *chord = vrv_cast<Chord *>(object);
-            const ArrayOfObjects &childList = chord->GetList(chord);
+            const ListOfObjects &childList = chord->GetList(chord);
             for (Object *child : childList) {
                 Note *note = vrv_cast<Note *>(child);
                 assert(note);

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -112,8 +112,8 @@ std::set<Note *> Arpeg::GetNotes()
         }
         else if (object->Is(CHORD)) {
             Chord *chord = vrv_cast<Chord *>(object);
-            const ArrayOfObjects *childList = chord->GetList(chord);
-            for (Object *child : *childList) {
+            const ArrayOfObjects &childList = chord->GetList(chord);
+            for (Object *child : childList) {
                 Note *note = vrv_cast<Note *>(child);
                 assert(note);
                 notes.insert(note);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1586,29 +1586,29 @@ bool Beam::IsSupportedChild(Object *child)
     return true;
 }
 
-void Beam::FilterList(ArrayOfObjects *childList)
+void Beam::FilterList(ArrayOfConstObjects &childList)
 {
     bool firstNoteGrace = false;
     // We want to keep only notes and rests
     // Eventually, we also need to filter out grace notes properly (e.g., with sub-beams)
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
     const bool isTabBeam = this->IsTabBeam();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->IsLayerElement()) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc)
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
             continue;
         }
         if (!(*iter)->HasInterface(INTERFACE_DURATION)) {
             // remove anything that has not a DurationInterface
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
             continue;
         }
         else if (isTabBeam) {
             if (!(*iter)->Is(TABGRP)) {
-                iter = childList->erase(iter);
+                iter = childList.erase(iter);
             }
             else {
                 ++iter;
@@ -1616,33 +1616,33 @@ void Beam::FilterList(ArrayOfObjects *childList)
             continue;
         }
         else {
-            LayerElement *element = vrv_cast<LayerElement *>(*iter);
+            const LayerElement *element = vrv_cast<const LayerElement *>(*iter);
             assert(element);
             // if we are at the beginning of the beam
             // and the note is cueSize
             // assume all the beam is of grace notes
-            if (childList->begin() == iter) {
+            if (childList.begin() == iter) {
                 if (element->IsGraceNote()) firstNoteGrace = true;
             }
             // if the first note in beam was NOT a grace
             // we have grace notes embedded in a beam
             // drop them
             if (!firstNoteGrace && (element->IsGraceNote())) {
-                iter = childList->erase(iter);
+                iter = childList.erase(iter);
                 continue;
             }
             // also remove notes within chords
             if (element->Is(NOTE)) {
-                Note *note = vrv_cast<Note *>(element);
+                const Note *note = vrv_cast<const Note *>(element);
                 assert(note);
                 if (note->IsChordTone()) {
-                    iter = childList->erase(iter);
+                    iter = childList.erase(iter);
                     continue;
                 }
             }
             // and spaces
             else if (element->Is(SPACE)) {
-                iter = childList->erase(iter);
+                iter = childList.erase(iter);
                 continue;
             }
             ++iter;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1648,33 +1648,6 @@ void Beam::FilterList(ArrayOfObjects *childList)
             ++iter;
         }
     }
-
-    Staff *beamStaff = this->GetAncestorStaff();
-    /*
-    if (this->HasBeamWith()) {
-        Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
-        assert(measure);
-        if (this->GetBeamWith() == OTHERSTAFF_below) {
-            beamStaff = dynamic_cast<Staff *>(measure->GetNext(staff, STAFF));
-            if (beamStaff == NULL) {
-                LogError("Cannot access staff below for beam '%s'", this->GetUuid().c_str());
-                beamStaff = staff;
-            }
-        }
-        else if (this->GetBeamWith() == OTHERSTAFF_above) {
-            beamStaff = dynamic_cast<Staff *>(measure->GetPrevious(staff, STAFF));
-            if (beamStaff == NULL) {
-                LogError("Cannot access staff above for beam '%s'", this->GetUuid().c_str());
-                beamStaff = staff;
-            }
-        }
-    }
-    */
-
-    this->InitCoords(childList, beamStaff, this->GetPlace());
-
-    const bool isCue = ((this->GetCue() == BOOLEAN_true) || this->GetFirstAncestor(GRACEGRP));
-    this->InitCue(isCue);
 }
 
 const ArrayOfBeamElementCoords *Beam::GetElementCoords()
@@ -2102,15 +2075,19 @@ int Beam::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    m_beamSegment.InitCoordRefs(this->GetElementCoords());
-
-    data_BEAMPLACE initialPlace = this->GetPlace();
-    if (this->HasStemSameasBeam()) m_beamSegment.InitSameasRoles(this->GetStemSameasBeam(), initialPlace);
-
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
+
+    this->InitCoords(beamChildren, staff, this->GetPlace());
+    const bool isCue = ((this->GetCue() == BOOLEAN_true) || this->GetFirstAncestor(GRACEGRP));
+    this->InitCue(isCue);
+
+    m_beamSegment.InitCoordRefs(this->GetElementCoords());
+
+    data_BEAMPLACE initialPlace = this->GetPlace();
+    if (this->HasStemSameasBeam()) m_beamSegment.InitSameasRoles(this->GetStemSameasBeam(), initialPlace);
 
     m_beamSegment.CalcBeam(layer, staff, params->m_doc, this, initialPlace);
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -2080,9 +2080,11 @@ int Beam::CalcStem(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
 
-    this->InitCoords(beamChildren, staff, this->GetPlace());
-    const bool isCue = ((this->GetCue() == BOOLEAN_true) || this->GetFirstAncestor(GRACEGRP));
-    this->InitCue(isCue);
+    if (!this->HasCoords()) {
+        this->InitCoords(beamChildren, staff, this->GetPlace());
+        const bool isCue = ((this->GetCue() == BOOLEAN_true) || this->GetFirstAncestor(GRACEGRP));
+        this->InitCue(isCue);
+    }
 
     m_beamSegment.InitCoordRefs(this->GetElementCoords());
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1586,7 +1586,7 @@ bool Beam::IsSupportedChild(Object *child)
     return true;
 }
 
-void Beam::FilterList(ArrayOfConstObjects &childList)
+void Beam::FilterList(ArrayOfConstObjects &childList) const
 {
     bool firstNoteGrace = false;
     // We want to keep only notes and rests

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1586,12 +1586,12 @@ bool Beam::IsSupportedChild(Object *child)
     return true;
 }
 
-void Beam::FilterList(ArrayOfConstObjects &childList) const
+void Beam::FilterList(ListOfConstObjects &childList) const
 {
     bool firstNoteGrace = false;
     // We want to keep only notes and rests
     // Eventually, we also need to filter out grace notes properly (e.g., with sub-beams)
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     const bool isTabBeam = this->IsTabBeam();
 
@@ -2068,7 +2068,7 @@ int Beam::CalcStem(FunctorParams *functorParams)
 
     if (this->IsTabBeam()) return FUNCTOR_CONTINUE;
 
-    const ArrayOfObjects &beamChildren = this->GetList(this);
+    const ListOfObjects &beamChildren = this->GetList(this);
 
     // Should we assert this at the beginning?
     if (beamChildren.empty()) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -2068,10 +2068,10 @@ int Beam::CalcStem(FunctorParams *functorParams)
 
     if (this->IsTabBeam()) return FUNCTOR_CONTINUE;
 
-    const ArrayOfObjects *beamChildren = this->GetList(this);
+    const ArrayOfObjects &beamChildren = this->GetList(this);
 
     // Should we assert this at the beginning?
-    if (beamChildren->empty()) {
+    if (beamChildren.empty()) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -216,7 +216,7 @@ int BeamSpan::CalcStem(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(this->GetStart()->GetFirstAncestor(STAFF));
     Measure *measure = vrv_cast<Measure *>(this->GetStart()->GetFirstAncestor(MEASURE));
 
-    this->InitCoords(&m_beamedElements, staff, this->GetPlace());
+    this->InitCoords(m_beamedElements, staff, this->GetPlace());
 
     m_beamSegments.at(0)->SetMeasure(measure);
     m_beamSegments.at(0)->SetStaff(staff);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -658,7 +658,7 @@ int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int m
 int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, const int margin) const
 {
     assert(beamInterface);
-    assert(!beamInterface->m_beamElementCoords.empty());
+    assert(beamInterface->HasCoords());
 
     const Point beamLeft(
         beamInterface->m_beamElementCoords.front()->m_x, beamInterface->m_beamElementCoords.front()->m_yBeam);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -229,7 +229,7 @@ void Chord::FilterList(ArrayOfConstObjects &childList)
 
 int Chord::PositionInChord(Note *note)
 {
-    int size = (int)this->GetList(this).size();
+    const int size = this->GetListSize(this);
     int position = this->GetListIndex(note);
     assert(position != -1);
     // this is the middle (only if odd)
@@ -240,50 +240,35 @@ int Chord::PositionInChord(Note *note)
 
 void Chord::GetYExtremes(int &yMax, int &yMin)
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    yMin = childList.front()->GetDrawingY();
+    yMin = this->GetListFront(this)->GetDrawingY();
     // The last note is the top
-    yMax = childList.back()->GetDrawingY();
+    yMax = this->GetListBack(this)->GetDrawingY();
 }
 
 int Chord::GetYTop()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The last note is the top
-    return childList.back()->GetDrawingY();
+    return this->GetListBack(this)->GetDrawingY();
 }
 
 int Chord::GetYBottom()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    return childList.front()->GetDrawingY();
+    return this->GetListFront(this)->GetDrawingY();
 }
 
 Note *Chord::GetTopNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
-    Note *topNote = vrv_cast<Note *>(childList.back());
+    Note *topNote = vrv_cast<Note *>(this->GetListBack(this));
     assert(topNote);
     return topNote;
 }
 
 Note *Chord::GetBottomNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(childList.front());
+    Note *bottomNote = vrv_cast<Note *>(this->GetListFront(this));
     assert(bottomNote);
     return bottomNote;
 }
@@ -925,8 +910,7 @@ int Chord::InitializeDrawing(FunctorParams *functorParams)
     InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
     assert(params);
 
-    const ArrayOfObjects &childList = this->GetList(this);
-    if (childList.empty()) {
+    if (this->HasEmptyList(this)) {
         LogWarning("Chord '%s' has no child note - a default note is added", this->GetUuid().c_str());
         Note *rescueNote = new Note();
         this->AddChild(rescueNote);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -212,19 +212,19 @@ void Chord::AddChild(Object *child)
     Modify();
 }
 
-void Chord::FilterList(ArrayOfObjects *childList)
+void Chord::FilterList(ArrayOfConstObjects &childList)
 {
     // Retain only note children of chords
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if ((*iter)->Is(NOTE))
             ++iter;
         else
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
     }
 
-    std::sort(childList->begin(), childList->end(), DiatonicSort());
+    std::sort(childList.begin(), childList.end(), DiatonicSort());
 }
 
 int Chord::PositionInChord(Note *note)

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -128,8 +128,8 @@ void Chord::CalculateClusters()
 {
     this->ClearClusters();
 
-    const ArrayOfObjects &childList = this->GetList(this);
-    ArrayOfObjects::const_iterator iter = childList.begin();
+    const ListOfObjects &childList = this->GetList(this);
+    ListOfObjects::const_iterator iter = childList.begin();
 
     Note *curNote, *lastNote = vrv_cast<Note *>(*iter);
     assert(lastNote);
@@ -212,10 +212,10 @@ void Chord::AddChild(Object *child)
     Modify();
 }
 
-void Chord::FilterList(ArrayOfConstObjects &childList) const
+void Chord::FilterList(ListOfConstObjects &childList) const
 {
     // Retain only note children of chords
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if ((*iter)->Is(NOTE))
@@ -224,7 +224,7 @@ void Chord::FilterList(ArrayOfConstObjects &childList) const
             iter = childList.erase(iter);
     }
 
-    std::sort(childList.begin(), childList.end(), DiatonicSort());
+    childList.sort(DiatonicSort());
 }
 
 int Chord::PositionInChord(const Note *note) const
@@ -285,11 +285,11 @@ const Note *Chord::GetBottomNote() const
 
 int Chord::GetXMin() const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
+    const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     assert(childList.size() > 0);
 
     int x = -VRV_UNSET;
-    ArrayOfConstObjects::const_iterator iter = childList.begin();
+    ListOfConstObjects::const_iterator iter = childList.begin();
     while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() < x) x = (*iter)->GetDrawingX();
         ++iter;
@@ -299,11 +299,11 @@ int Chord::GetXMin() const
 
 int Chord::GetXMax() const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
+    const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     assert(childList.size() > 0);
 
     int x = VRV_UNSET;
-    ArrayOfConstObjects::const_iterator iter = childList.begin();
+    ListOfConstObjects::const_iterator iter = childList.begin();
     while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() > x) x = (*iter)->GetDrawingX();
         ++iter;
@@ -364,8 +364,8 @@ Point Chord::GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const
 
 data_STEMDIRECTION Chord::CalcStemDirection(int verticalCenter) const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this);
-    ArrayOfConstObjects topNotes, bottomNotes;
+    const ListOfConstObjects &childList = this->GetList(this);
+    ListOfConstObjects topNotes, bottomNotes;
 
     // split notes into two vectors - notes above vertical center and below
     std::partition_copy(childList.begin(), childList.end(), std::back_inserter(topNotes),
@@ -426,7 +426,7 @@ bool Chord::IsVisible() const
     }
 
     // if the chord doesn't have it, see if all the children are invisible
-    const ArrayOfConstObjects &notes = this->GetList(this);
+    const ListOfConstObjects &notes = this->GetList(this);
 
     for (auto &iter : notes) {
         const Note *note = vrv_cast<const Note *>(iter);
@@ -458,7 +458,7 @@ bool Chord::HasAdjacentNotesInStaff(Staff *staff)
 
 bool Chord::HasNoteWithDots() const
 {
-    const ArrayOfConstObjects &notes = this->GetList(this);
+    const ListOfConstObjects &notes = this->GetList(this);
 
     return std::any_of(notes.cbegin(), notes.cend(), [](const Object *object) {
         const Note *note = vrv_cast<const Note *>(object);
@@ -480,7 +480,7 @@ int Chord::AdjustOverlappingLayers(
             otherElementLocations.insert(note->GetDrawingLoc());
         }
     }
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ListOfObjects &notes = this->GetList(this);
     // get current chord positions
     std::set<int> chordElementLocations;
     for (const auto iter : notes) {
@@ -538,7 +538,7 @@ int Chord::AdjustOverlappingLayers(
 
 std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
 {
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ListOfObjects &notes = this->GetList(this);
 
     std::list<Note *> adjacentNotes;
     for (Object *obj : notes) {
@@ -743,7 +743,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
 
 MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate)
 {
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ListOfObjects &notes = this->GetList(this);
 
     MapOfNoteLocs noteLocations;
     for (Object *obj : notes) {
@@ -842,8 +842,8 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
     this->CalculateClusters();
 
     // Also set the drawing stem object (or NULL) to all child notes
-    const ArrayOfObjects &childList = this->GetList(this);
-    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
+    const ListOfObjects &childList = this->GetList(this);
+    for (ListOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         assert((*it)->Is(NOTE));
         Note *note = vrv_cast<Note *>(*it);
         assert(note);
@@ -994,7 +994,7 @@ int Chord::GenerateMIDI(FunctorParams *functorParams)
     // Handle grace chords
     if (this->IsGraceNote()) {
         std::set<int> pitches;
-        const ArrayOfObjects &notes = this->GetList(this);
+        const ListOfObjects &notes = this->GetList(this);
         for (Object *obj : notes) {
             Note *note = vrv_cast<Note *>(obj);
             assert(note);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -915,9 +915,9 @@ int Chord::ResetData(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Chord::InitializeDrawing(FunctorParams *functorParams)
+int Chord::InitData(FunctorParams *functorParams)
 {
-    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
     assert(params);
 
     if (this->HasEmptyList(this)) {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -212,7 +212,7 @@ void Chord::AddChild(Object *child)
     Modify();
 }
 
-void Chord::FilterList(ArrayOfConstObjects &childList)
+void Chord::FilterList(ArrayOfConstObjects &childList) const
 {
     // Retain only note children of chords
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -915,9 +915,9 @@ int Chord::ResetData(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Chord::InitData(FunctorParams *functorParams)
+int Chord::PrepareDataInitialization(FunctorParams *functorParams)
 {
-    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
+    PrepareDataInitializationParams *params = vrv_params_cast<PrepareDataInitializationParams *>(functorParams);
     assert(params);
 
     if (this->HasEmptyList(this)) {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -362,10 +362,10 @@ Point Chord::GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const
     return topNote->GetStemDownNW(doc, staffSize, isCueSize);
 }
 
-data_STEMDIRECTION Chord::CalcStemDirection(int verticalCenter)
+data_STEMDIRECTION Chord::CalcStemDirection(int verticalCenter) const
 {
-    const ArrayOfObjects &childList = this->GetList(this);
-    ArrayOfObjects topNotes, bottomNotes;
+    const ArrayOfConstObjects &childList = this->GetList(this);
+    ArrayOfConstObjects topNotes, bottomNotes;
 
     // split notes into two vectors - notes above vertical center and below
     std::partition_copy(childList.begin(), childList.end(), std::back_inserter(topNotes),
@@ -419,17 +419,17 @@ int Chord::CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDi
     }
 }
 
-bool Chord::IsVisible()
+bool Chord::IsVisible() const
 {
     if (this->HasVisible()) {
         return this->GetVisible() == BOOLEAN_true;
     }
 
     // if the chord doesn't have it, see if all the children are invisible
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ArrayOfConstObjects &notes = this->GetList(this);
 
     for (auto &iter : notes) {
-        Note *note = vrv_cast<Note *>(iter);
+        const Note *note = vrv_cast<const Note *>(iter);
         assert(note);
         if (!note->HasVisible() || note->GetVisible() == BOOLEAN_true) {
             return true;
@@ -456,12 +456,12 @@ bool Chord::HasAdjacentNotesInStaff(Staff *staff)
     return (diff.end() != std::find(std::next(diff.begin()), diff.end(), 1));
 }
 
-bool Chord::HasNoteWithDots()
+bool Chord::HasNoteWithDots() const
 {
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ArrayOfConstObjects &notes = this->GetList(this);
 
-    return std::any_of(notes.cbegin(), notes.cend(), [](Object *object) {
-        Note *note = vrv_cast<Note *>(object);
+    return std::any_of(notes.cbegin(), notes.cend(), [](const Object *object) {
+        const Note *note = vrv_cast<const Note *>(object);
         assert(note);
         return (note->GetDots() > 0);
     });

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -227,7 +227,7 @@ void Chord::FilterList(ArrayOfConstObjects &childList) const
     std::sort(childList.begin(), childList.end(), DiatonicSort());
 }
 
-int Chord::PositionInChord(Note *note)
+int Chord::PositionInChord(const Note *note) const
 {
     const int size = this->GetListSize(this);
     int position = this->GetListIndex(note);
@@ -238,7 +238,7 @@ int Chord::PositionInChord(Note *note)
     return 1;
 }
 
-void Chord::GetYExtremes(int &yMax, int &yMin)
+void Chord::GetYExtremes(int &yMax, int &yMin) const
 {
     // The first note is the bottom
     yMin = this->GetListFront(this)->GetDrawingY();
@@ -246,13 +246,13 @@ void Chord::GetYExtremes(int &yMax, int &yMin)
     yMax = this->GetListBack(this)->GetDrawingY();
 }
 
-int Chord::GetYTop()
+int Chord::GetYTop() const
 {
     // The last note is the top
     return this->GetListBack(this)->GetDrawingY();
 }
 
-int Chord::GetYBottom()
+int Chord::GetYBottom() const
 {
     // The first note is the bottom
     return this->GetListFront(this)->GetDrawingY();
@@ -260,26 +260,36 @@ int Chord::GetYBottom()
 
 Note *Chord::GetTopNote()
 {
-    Note *topNote = vrv_cast<Note *>(this->GetListBack(this));
+    return const_cast<Note *>(std::as_const(*this).GetTopNote());
+}
+
+const Note *Chord::GetTopNote() const
+{
+    const Note *topNote = vrv_cast<const Note *>(this->GetListBack(this));
     assert(topNote);
     return topNote;
 }
 
 Note *Chord::GetBottomNote()
 {
+    return const_cast<Note *>(std::as_const(*this).GetBottomNote());
+}
+
+const Note *Chord::GetBottomNote() const
+{
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(this->GetListFront(this));
+    const Note *bottomNote = vrv_cast<const Note *>(this->GetListFront(this));
     assert(bottomNote);
     return bottomNote;
 }
 
-int Chord::GetXMin()
+int Chord::GetXMin() const
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     assert(childList.size() > 0);
 
     int x = -VRV_UNSET;
-    ArrayOfObjects::const_iterator iter = childList.begin();
+    ArrayOfConstObjects::const_iterator iter = childList.begin();
     while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() < x) x = (*iter)->GetDrawingX();
         ++iter;
@@ -287,13 +297,13 @@ int Chord::GetXMin()
     return x;
 }
 
-int Chord::GetXMax()
+int Chord::GetXMax() const
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     assert(childList.size() > 0);
 
     int x = VRV_UNSET;
-    ArrayOfObjects::const_iterator iter = childList.begin();
+    ArrayOfConstObjects::const_iterator iter = childList.begin();
     while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() > x) x = (*iter)->GetDrawingX();
         ++iter;
@@ -338,16 +348,16 @@ bool Chord::HasCrossStaff()
     return ((staffAbove != NULL) || (staffBelow != NULL));
 }
 
-Point Chord::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
+Point Chord::GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const
 {
-    Note *bottomNote = this->GetBottomNote();
+    const Note *bottomNote = this->GetBottomNote();
     assert(bottomNote);
     return bottomNote->GetStemUpSE(doc, staffSize, isCueSize);
 }
 
-Point Chord::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
+Point Chord::GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const
 {
-    Note *topNote = this->GetTopNote();
+    const Note *topNote = this->GetTopNote();
     assert(topNote);
     return topNote->GetStemDownNW(doc, staffSize, isCueSize);
 }
@@ -390,17 +400,17 @@ data_STEMDIRECTION Chord::CalcStemDirection(int verticalCenter)
     return STEMDIRECTION_down;
 }
 
-int Chord::CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir)
+int Chord::CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const
 {
     assert(staff);
 
     if (stemDir == STEMDIRECTION_up) {
-        Note *topNote = this->GetTopNote();
+        const Note *topNote = this->GetTopNote();
         assert(topNote);
         return topNote->CalcStemLenInThirdUnits(staff, stemDir);
     }
     else if (stemDir == STEMDIRECTION_down) {
-        Note *bottomNote = this->GetBottomNote();
+        const Note *bottomNote = this->GetBottomNote();
         assert(bottomNote);
         return bottomNote->CalcStemLenInThirdUnits(staff, stemDir);
     }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -128,8 +128,8 @@ void Chord::CalculateClusters()
 {
     this->ClearClusters();
 
-    const ArrayOfObjects *childList = this->GetList(this);
-    ArrayOfObjects::const_iterator iter = childList->begin();
+    const ArrayOfObjects &childList = this->GetList(this);
+    ArrayOfObjects::const_iterator iter = childList.begin();
 
     Note *curNote, *lastNote = vrv_cast<Note *>(*iter);
     assert(lastNote);
@@ -141,7 +141,7 @@ void Chord::CalculateClusters()
     Layer *layer1 = NULL;
     Layer *layer2 = NULL;
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         curNote = vrv_cast<Note *>(*iter);
         assert(curNote);
         const int curPitch = curNote->GetDiatonicPitch();
@@ -229,7 +229,7 @@ void Chord::FilterList(ArrayOfConstObjects &childList)
 
 int Chord::PositionInChord(Note *note)
 {
-    int size = (int)this->GetList(this)->size();
+    int size = (int)this->GetList(this).size();
     int position = this->GetListIndex(note);
     assert(position != -1);
     // this is the middle (only if odd)
@@ -240,62 +240,62 @@ int Chord::PositionInChord(Note *note)
 
 void Chord::GetYExtremes(int &yMax, int &yMin)
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    yMin = childList->front()->GetDrawingY();
+    yMin = childList.front()->GetDrawingY();
     // The last note is the top
-    yMax = childList->back()->GetDrawingY();
+    yMax = childList.back()->GetDrawingY();
 }
 
 int Chord::GetYTop()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The last note is the top
-    return childList->back()->GetDrawingY();
+    return childList.back()->GetDrawingY();
 }
 
 int Chord::GetYBottom()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    return childList->front()->GetDrawingY();
+    return childList.front()->GetDrawingY();
 }
 
 Note *Chord::GetTopNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
-    Note *topNote = vrv_cast<Note *>(childList->back());
+    Note *topNote = vrv_cast<Note *>(childList.back());
     assert(topNote);
     return topNote;
 }
 
 Note *Chord::GetBottomNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(childList->front());
+    Note *bottomNote = vrv_cast<Note *>(childList.front());
     assert(bottomNote);
     return bottomNote;
 }
 
 int Chord::GetXMin()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     int x = -VRV_UNSET;
-    ArrayOfObjects::const_iterator iter = childList->begin();
-    while (iter != childList->end()) {
+    ArrayOfObjects::const_iterator iter = childList.begin();
+    while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() < x) x = (*iter)->GetDrawingX();
         ++iter;
     }
@@ -304,12 +304,12 @@ int Chord::GetXMin()
 
 int Chord::GetXMax()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     int x = VRV_UNSET;
-    ArrayOfObjects::const_iterator iter = childList->begin();
-    while (iter != childList->end()) {
+    ArrayOfObjects::const_iterator iter = childList.begin();
+    while (iter != childList.end()) {
         if ((*iter)->GetDrawingX() > x) x = (*iter)->GetDrawingX();
         ++iter;
     }
@@ -369,11 +369,11 @@ Point Chord::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
 
 data_STEMDIRECTION Chord::CalcStemDirection(int verticalCenter)
 {
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
     ArrayOfObjects topNotes, bottomNotes;
 
     // split notes into two vectors - notes above vertical center and below
-    std::partition_copy(childList->begin(), childList->end(), std::back_inserter(topNotes),
+    std::partition_copy(childList.begin(), childList.end(), std::back_inserter(topNotes),
         std::back_inserter(bottomNotes),
         [verticalCenter](const Object *note) { return note->GetDrawingY() > verticalCenter; });
 
@@ -431,10 +431,9 @@ bool Chord::IsVisible()
     }
 
     // if the chord doesn't have it, see if all the children are invisible
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
+    const ArrayOfObjects &notes = this->GetList(this);
 
-    for (auto &iter : *notes) {
+    for (auto &iter : notes) {
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
         if (!note->HasVisible() || note->GetVisible() == BOOLEAN_true) {
@@ -464,10 +463,9 @@ bool Chord::HasAdjacentNotesInStaff(Staff *staff)
 
 bool Chord::HasNoteWithDots()
 {
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
+    const ArrayOfObjects &notes = this->GetList(this);
 
-    return std::any_of(notes->cbegin(), notes->cend(), [](Object *object) {
+    return std::any_of(notes.cbegin(), notes.cend(), [](Object *object) {
         Note *note = vrv_cast<Note *>(object);
         assert(note);
         return (note->GetDots() > 0);
@@ -487,11 +485,10 @@ int Chord::AdjustOverlappingLayers(
             otherElementLocations.insert(note->GetDrawingLoc());
         }
     }
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
+    const ArrayOfObjects &notes = this->GetList(this);
     // get current chord positions
     std::set<int> chordElementLocations;
-    for (const auto iter : *notes) {
+    for (const auto iter : notes) {
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
         chordElementLocations.insert(note->GetDrawingLoc());
@@ -506,7 +503,7 @@ int Chord::AdjustOverlappingLayers(
     int actualElementsInUnison = 0;
 
     // process each note of the chord separately, storing locations in the set
-    for (auto iter : *notes) {
+    for (auto iter : notes) {
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
         auto [overlap, isInUnison] = note->CalcElementHorizontalOverlap(
@@ -546,11 +543,10 @@ int Chord::AdjustOverlappingLayers(
 
 std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
 {
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
+    const ArrayOfObjects &notes = this->GetList(this);
 
     std::list<Note *> adjacentNotes;
-    for (Object *obj : *notes) {
+    for (Object *obj : notes) {
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
 
@@ -752,11 +748,10 @@ int Chord::CalcStem(FunctorParams *functorParams)
 
 MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate)
 {
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
+    const ArrayOfObjects &notes = this->GetList(this);
 
     MapOfNoteLocs noteLocations;
-    for (Object *obj : *notes) {
+    for (Object *obj : notes) {
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
 
@@ -852,8 +847,8 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
     this->CalculateClusters();
 
     // Also set the drawing stem object (or NULL) to all child notes
-    const ArrayOfObjects *childList = this->GetList(this);
-    for (ArrayOfObjects::const_iterator it = childList->begin(); it != childList->end(); ++it) {
+    const ArrayOfObjects &childList = this->GetList(this);
+    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         assert((*it)->Is(NOTE));
         Note *note = vrv_cast<Note *>(*it);
         assert(note);
@@ -930,8 +925,8 @@ int Chord::InitializeDrawing(FunctorParams *functorParams)
     InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
     assert(params);
 
-    const ArrayOfObjects *childList = this->GetList(this);
-    if (childList->empty()) {
+    const ArrayOfObjects &childList = this->GetList(this);
+    if (childList.empty()) {
         LogWarning("Chord '%s' has no child note - a default note is added", this->GetUuid().c_str());
         Note *rescueNote = new Note();
         this->AddChild(rescueNote);
@@ -1005,9 +1000,8 @@ int Chord::GenerateMIDI(FunctorParams *functorParams)
     // Handle grace chords
     if (this->IsGraceNote()) {
         std::set<int> pitches;
-        const ArrayOfObjects *notes = this->GetList(this);
-        assert(notes);
-        for (Object *obj : *notes) {
+        const ArrayOfObjects &notes = this->GetList(this);
+        for (Object *obj : notes) {
             Note *note = vrv_cast<Note *>(obj);
             assert(note);
             pitches.insert(note->GetMIDIPitch(params->m_transSemi));

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -476,9 +476,9 @@ void Doc::PrepareData()
         Functor resetData(&Object::ResetData);
         this->Process(&resetData, NULL);
     }
-    Functor initData(&Object::InitData);
-    InitDataParams initDataParams(&initData, this);
-    this->Process(&initData, &initDataParams);
+    Functor prepareDataInitialization(&Object::PrepareDataInitialization);
+    PrepareDataInitializationParams prepareDataInitializationParams(&prepareDataInitialization, this);
+    this->Process(&prepareDataInitialization, &prepareDataInitializationParams);
 
     /************ Store default durations ************/
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -476,9 +476,9 @@ void Doc::PrepareData()
         Functor resetData(&Object::ResetData);
         this->Process(&resetData, NULL);
     }
-    Functor initializeDrawing(&Object::InitializeDrawing);
-    InitializeDrawingParams initializeDrawingParams(&initializeDrawing, this);
-    this->Process(&initializeDrawing, &initializeDrawingParams);
+    Functor initData(&Object::InitData);
+    InitDataParams initDataParams(&initData, this);
+    this->Process(&initData, &initDataParams);
 
     /************ Store default durations ************/
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -471,10 +471,14 @@ bool Doc::ExportFeatures(std::string &output, const std::string &options)
 
 void Doc::PrepareData()
 {
+    /************ Reset and initialization ************/
     if (m_dataPreparationDone) {
         Functor resetData(&Object::ResetData);
         this->Process(&resetData, NULL);
     }
+    Functor initializeDrawing(&Object::InitializeDrawing);
+    InitializeDrawingParams initializeDrawingParams(&initializeDrawing, this);
+    this->Process(&initializeDrawing, &initializeDrawingParams);
 
     /************ Store default durations ************/
 

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -479,7 +479,7 @@ bool BeamDrawingInterface::IsFirstIn(Object *object, LayerElement *element)
 
 bool BeamDrawingInterface::IsLastIn(Object *object, LayerElement *element)
 {
-    int size = (int)this->GetList(object).size();
+    const int size = this->GetListSize(object);
     int position = this->GetPosition(object, element);
     // This method should be called only if the note is part of a beam
     assert(position != -1);
@@ -619,8 +619,8 @@ void StaffDefDrawingInterface::SetCurrentMeterSigGrp(MeterSigGrp const *meterSig
 bool StaffDefDrawingInterface::DrawMeterSigGrp()
 {
     if (m_drawMeterSigGrp) {
-        const ArrayOfObjects &childList = m_currentMeterSigGrp.GetList(&m_currentMeterSigGrp);
-        if (childList.size() > 1) return true;
+        const int childListSize = m_currentMeterSigGrp.GetListSize(&m_currentMeterSigGrp);
+        if (childListSize > 1) return true;
     }
     return false;
 }

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -466,7 +466,7 @@ bool BeamDrawingInterface::HasOneStepHeight()
     return (abs(top - bottom) <= 1);
 }
 
-bool BeamDrawingInterface::IsFirstIn(Object *object, LayerElement *element)
+bool BeamDrawingInterface::IsFirstIn(const Object *object, const LayerElement *element) const
 {
     this->GetList(object);
     int position = this->GetPosition(object, element);
@@ -477,7 +477,7 @@ bool BeamDrawingInterface::IsFirstIn(Object *object, LayerElement *element)
     return false;
 }
 
-bool BeamDrawingInterface::IsLastIn(Object *object, LayerElement *element)
+bool BeamDrawingInterface::IsLastIn(const Object *object, const LayerElement *element) const
 {
     const int size = this->GetListSize(object);
     int position = this->GetPosition(object, element);
@@ -488,15 +488,15 @@ bool BeamDrawingInterface::IsLastIn(Object *object, LayerElement *element)
     return false;
 }
 
-int BeamDrawingInterface::GetPosition(Object *object, LayerElement *element)
+int BeamDrawingInterface::GetPosition(const Object *object, const LayerElement *element) const
 {
     this->GetList(object);
     int position = this->GetListIndex(element);
     // Check if this is a note in the chord
     if ((position == -1) && (element->Is(NOTE))) {
-        Note *note = vrv_cast<Note *>(element);
+        const Note *note = vrv_cast<const Note *>(element);
         assert(note);
-        Chord *chord = note->IsChordTone();
+        const Chord *chord = note->IsChordTone();
         if (chord) position = this->GetListIndex(chord);
     }
     return position;
@@ -616,7 +616,7 @@ void StaffDefDrawingInterface::SetCurrentMeterSigGrp(MeterSigGrp const *meterSig
     }
 }
 
-bool StaffDefDrawingInterface::DrawMeterSigGrp()
+bool StaffDefDrawingInterface::DrawMeterSigGrp() const
 {
     if (m_drawMeterSigGrp) {
         const int childListSize = m_currentMeterSigGrp.GetListSize(&m_currentMeterSigGrp);
@@ -662,7 +662,7 @@ void StemmedDrawingInterface::SetDrawingStemDir(data_STEMDIRECTION stemDir)
     if (m_drawingStem) m_drawingStem->SetDrawingStemDir(stemDir);
 }
 
-data_STEMDIRECTION StemmedDrawingInterface::GetDrawingStemDir()
+data_STEMDIRECTION StemmedDrawingInterface::GetDrawingStemDir() const
 {
     if (m_drawingStem) return m_drawingStem->GetDrawingStemDir();
     return STEMDIRECTION_NONE;
@@ -673,7 +673,7 @@ void StemmedDrawingInterface::SetDrawingStemLen(int stemLen)
     if (m_drawingStem) m_drawingStem->SetDrawingStemLen(stemLen);
 }
 
-int StemmedDrawingInterface::GetDrawingStemLen()
+int StemmedDrawingInterface::GetDrawingStemLen() const
 {
     if (m_drawingStem) return m_drawingStem->GetDrawingStemLen();
     return 0;

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -119,6 +119,12 @@ void BeamDrawingInterface::ClearCoords()
 
 void BeamDrawingInterface::InitCoords(const ArrayOfObjects &childList, Staff *staff, data_BEAMPLACE place)
 {
+    ListOfObjects children(childList.begin(), childList.end());
+    this->InitCoords(children, staff, place);
+}
+
+void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *staff, data_BEAMPLACE place)
+{
     assert(staff);
 
     BeamDrawingInterface::Reset();
@@ -156,7 +162,7 @@ void BeamDrawingInterface::InitCoords(const ArrayOfObjects &childList, Staff *st
 
     int elementCount = 0;
 
-    ArrayOfObjects::const_iterator iter = childList.begin();
+    ListOfObjects::const_iterator iter = childList.begin();
     do {
         // Beam list should contain only DurationInterface objects
         assert(current->GetDurationInterface());

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -117,7 +117,7 @@ void BeamDrawingInterface::ClearCoords()
     m_beamElementCoords.clear();
 }
 
-void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place)
+void BeamDrawingInterface::InitCoords(const ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place)
 {
     assert(staff);
 
@@ -156,7 +156,7 @@ void BeamDrawingInterface::InitCoords(ArrayOfObjects *childList, Staff *staff, d
 
     int elementCount = 0;
 
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfObjects::const_iterator iter = childList->begin();
     do {
         // Beam list should contain only DurationInterface objects
         assert(current->GetDurationInterface());

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -117,14 +117,14 @@ void BeamDrawingInterface::ClearCoords()
     m_beamElementCoords.clear();
 }
 
-void BeamDrawingInterface::InitCoords(const ArrayOfObjects *childList, Staff *staff, data_BEAMPLACE place)
+void BeamDrawingInterface::InitCoords(const ArrayOfObjects &childList, Staff *staff, data_BEAMPLACE place)
 {
     assert(staff);
 
     BeamDrawingInterface::Reset();
     ClearCoords();
 
-    if (childList->empty()) {
+    if (childList.empty()) {
         return;
     }
 
@@ -133,14 +133,14 @@ void BeamDrawingInterface::InitCoords(const ArrayOfObjects *childList, Staff *st
     // duration variables
     int lastDur, currentDur;
 
-    m_beamElementCoords.reserve(childList->size());
+    m_beamElementCoords.reserve(childList.size());
     int i;
-    for (i = 0; i < (int)childList->size(); ++i) {
+    for (i = 0; i < (int)childList.size(); ++i) {
         m_beamElementCoords.push_back(new BeamElementCoord());
     }
 
     // current point to the first Note in the layed out layer
-    LayerElement *current = dynamic_cast<LayerElement *>(childList->front());
+    LayerElement *current = dynamic_cast<LayerElement *>(childList.front());
     // Beam list should contain only DurationInterface objects
     assert(current->GetDurationInterface());
 
@@ -156,7 +156,7 @@ void BeamDrawingInterface::InitCoords(const ArrayOfObjects *childList, Staff *st
 
     int elementCount = 0;
 
-    ArrayOfObjects::const_iterator iter = childList->begin();
+    ArrayOfObjects::const_iterator iter = childList.begin();
     do {
         // Beam list should contain only DurationInterface objects
         assert(current->GetDurationInterface());
@@ -225,7 +225,7 @@ void BeamDrawingInterface::InitCoords(const ArrayOfObjects *childList, Staff *st
         elementCount++;
 
         ++iter;
-        if (iter == childList->end()) {
+        if (iter == childList.end()) {
             break;
         }
         current = dynamic_cast<LayerElement *>(*iter);
@@ -479,7 +479,7 @@ bool BeamDrawingInterface::IsFirstIn(Object *object, LayerElement *element)
 
 bool BeamDrawingInterface::IsLastIn(Object *object, LayerElement *element)
 {
-    int size = (int)this->GetList(object)->size();
+    int size = (int)this->GetList(object).size();
     int position = this->GetPosition(object, element);
     // This method should be called only if the note is part of a beam
     assert(position != -1);
@@ -619,8 +619,8 @@ void StaffDefDrawingInterface::SetCurrentMeterSigGrp(MeterSigGrp const *meterSig
 bool StaffDefDrawingInterface::DrawMeterSigGrp()
 {
     if (m_drawMeterSigGrp) {
-        const ArrayOfObjects *childList = m_currentMeterSigGrp.GetList(&m_currentMeterSigGrp);
-        if (childList->size() > 1) return true;
+        const ArrayOfObjects &childList = m_currentMeterSigGrp.GetList(&m_currentMeterSigGrp);
+        if (childList.size() > 1) return true;
     }
     return false;
 }

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -163,8 +163,8 @@ bool DurationInterface::IsFirstInBeam(LayerElement *noteOrRest)
     if (!beam) {
         return false;
     }
-    const ArrayOfObjects *notesOrRests = beam->GetList(beam);
-    ArrayOfObjects::const_iterator iter = notesOrRests->begin();
+    const ArrayOfObjects &notesOrRests = beam->GetList(beam);
+    ArrayOfObjects::const_iterator iter = notesOrRests.begin();
     if (*iter == noteOrRest) {
         return true;
     }
@@ -177,8 +177,8 @@ bool DurationInterface::IsLastInBeam(LayerElement *noteOrRest)
     if (!beam) {
         return false;
     }
-    const ArrayOfObjects *notesOrRests = beam->GetList(beam);
-    ArrayOfObjects::const_reverse_iterator iter = notesOrRests->rbegin();
+    const ArrayOfObjects &notesOrRests = beam->GetList(beam);
+    ArrayOfObjects::const_reverse_iterator iter = notesOrRests.rbegin();
     if (*iter == noteOrRest) {
         return true;
     }

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -157,32 +157,22 @@ double DurationInterface::GetInterfaceAlignmentMensuralDuration(int num, int num
     return duration;
 }
 
-bool DurationInterface::IsFirstInBeam(LayerElement *noteOrRest)
+bool DurationInterface::IsFirstInBeam(const LayerElement *noteOrRest) const
 {
-    Beam *beam = dynamic_cast<Beam *>(noteOrRest->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
+    const Beam *beam = dynamic_cast<const Beam *>(noteOrRest->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
     if (!beam) {
         return false;
     }
-    const ArrayOfObjects &notesOrRests = beam->GetList(beam);
-    ArrayOfObjects::const_iterator iter = notesOrRests.begin();
-    if (*iter == noteOrRest) {
-        return true;
-    }
-    return false;
+    return (noteOrRest == beam->GetListFront(beam));
 }
 
-bool DurationInterface::IsLastInBeam(LayerElement *noteOrRest)
+bool DurationInterface::IsLastInBeam(const LayerElement *noteOrRest) const
 {
-    Beam *beam = dynamic_cast<Beam *>(noteOrRest->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
+    const Beam *beam = dynamic_cast<const Beam *>(noteOrRest->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
     if (!beam) {
         return false;
     }
-    const ArrayOfObjects &notesOrRests = beam->GetList(beam);
-    ArrayOfObjects::const_reverse_iterator iter = notesOrRests.rbegin();
-    if (*iter == noteOrRest) {
-        return true;
-    }
-    return false;
+    return (noteOrRest == beam->GetListBack(beam));
 }
 
 int DurationInterface::GetActualDur() const

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -111,16 +111,16 @@ wchar_t Flag::GetFlagGlyph(data_STEMDIRECTION stemDir) const
     }
 }
 
-Point Flag::GetStemUpSE(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const
+Point Flag::GetStemUpSE(const Doc *doc, int staffSize, bool graceSize) const
 {
-    code = this->GetFlagGlyph(STEMDIRECTION_up);
+    const wchar_t code = this->GetFlagGlyph(STEMDIRECTION_up);
 
     return Point(0, doc->GetGlyphTop(code, staffSize, graceSize));
 }
 
-Point Flag::GetStemDownNW(Doc *doc, int staffSize, bool graceSize, wchar_t &code) const
+Point Flag::GetStemDownNW(const Doc *doc, int staffSize, bool graceSize) const
 {
-    code = this->GetFlagGlyph(STEMDIRECTION_down);
+    const wchar_t code = this->GetFlagGlyph(STEMDIRECTION_down);
 
     return Point(0, doc->GetGlyphBottom(code, staffSize, graceSize));
 }
@@ -615,12 +615,11 @@ int Stem::CalcStem(FunctorParams *functorParams)
     if (params->m_dur > DUR_16) {
         assert(flag);
         Point stemEnd;
-        wchar_t flagCode = 0;
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
-            stemEnd = flag->GetStemUpSE(params->m_doc, staffSize, drawingCueSize, flagCode);
+            stemEnd = flag->GetStemUpSE(params->m_doc, staffSize, drawingCueSize);
         }
         else {
-            stemEnd = flag->GetStemDownNW(params->m_doc, staffSize, drawingCueSize, flagCode);
+            stemEnd = flag->GetStemDownNW(params->m_doc, staffSize, drawingCueSize);
         }
         // Trick for shortening the stem with DUR_8
         flagHeight = stemEnd.y;

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -79,9 +79,9 @@ const ArrayOfBeamElementCoords *FTrem::GetElementCoords()
     return &m_beamElementCoords;
 }
 
-void FTrem::FilterList(ArrayOfConstObjects &childList) const
+void FTrem::FilterList(ListOfConstObjects &childList) const
 {
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if (!(*iter)->Is(NOTE) && !(*iter)->Is(CHORD)) {
@@ -197,7 +197,7 @@ int FTrem::CalcStem(FunctorParams *functorParams)
     CalcStemParams *params = vrv_params_cast<CalcStemParams *>(functorParams);
     assert(params);
 
-    const ArrayOfObjects &fTremChildren = this->GetList(this);
+    const ListOfObjects &fTremChildren = this->GetList(this);
 
     // Should we assert this at the beginning?
     if (fTremChildren.empty()) {

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -79,22 +79,22 @@ const ArrayOfBeamElementCoords *FTrem::GetElementCoords()
     return &m_beamElementCoords;
 }
 
-void FTrem::FilterList(ArrayOfObjects *childList)
+void FTrem::FilterList(ArrayOfConstObjects &childList)
 {
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->Is(NOTE) && !(*iter)->Is(CHORD)) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc.)
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
             continue;
         }
         // also remove notes within chords
         if ((*iter)->Is(NOTE)) {
-            Note *note = vrv_cast<Note *>(*iter);
+            const Note *note = vrv_cast<const Note *>(*iter);
             assert(note);
             if (note->IsChordTone()) {
-                iter = childList->erase(iter);
+                iter = childList.erase(iter);
                 continue;
             }
         }

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -204,11 +204,6 @@ int FTrem::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    if (this->GetElementCoords()->size() != 2) {
-        LogError("Stem calculation: <fTrem> element has invalid number of descendants.");
-        return FUNCTOR_CONTINUE;
-    }
-
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
@@ -216,6 +211,11 @@ int FTrem::CalcStem(FunctorParams *functorParams)
 
     this->InitCoords(fTremChildren, staff, BEAMPLACE_NONE);
     this->InitCue(false);
+
+    if (this->GetElementCoords()->size() != 2) {
+        LogError("Stem calculation: <fTrem> element has invalid number of descendants.");
+        return FUNCTOR_CONTINUE;
+    }
 
     m_beamSegment.InitCoordRefs(this->GetElementCoords());
 

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -79,7 +79,7 @@ const ArrayOfBeamElementCoords *FTrem::GetElementCoords()
     return &m_beamElementCoords;
 }
 
-void FTrem::FilterList(ArrayOfConstObjects &childList)
+void FTrem::FilterList(ArrayOfConstObjects &childList) const
 {
     ArrayOfConstObjects::iterator iter = childList.begin();
 

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -209,8 +209,10 @@ int FTrem::CalcStem(FunctorParams *functorParams)
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
 
-    this->InitCoords(fTremChildren, staff, BEAMPLACE_NONE);
-    this->InitCue(false);
+    if (!this->HasCoords()) {
+        this->InitCoords(fTremChildren, staff, BEAMPLACE_NONE);
+        this->InitCue(false);
+    }
 
     if (this->GetElementCoords()->size() != 2) {
         LogError("Stem calculation: <fTrem> element has invalid number of descendants.");

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -100,11 +100,6 @@ void FTrem::FilterList(ArrayOfObjects *childList)
         }
         ++iter;
     }
-
-    Staff *staff = this->GetAncestorStaff();
-
-    this->InitCoords(childList, staff, BEAMPLACE_NONE);
-    this->InitCue(false);
 }
 
 std::pair<int, int> FTrem::GetAdditionalBeamCount() const
@@ -214,12 +209,15 @@ int FTrem::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    m_beamSegment.InitCoordRefs(this->GetElementCoords());
-
     Layer *layer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
     assert(layer);
     Staff *staff = vrv_cast<Staff *>(layer->GetFirstAncestor(STAFF));
     assert(staff);
+
+    this->InitCoords(fTremChildren, staff, BEAMPLACE_NONE);
+    this->InitCue(false);
+
+    m_beamSegment.InitCoordRefs(this->GetElementCoords());
 
     m_beamSegment.CalcBeam(layer, staff, params->m_doc, this);
 

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -197,10 +197,10 @@ int FTrem::CalcStem(FunctorParams *functorParams)
     CalcStemParams *params = vrv_params_cast<CalcStemParams *>(functorParams);
     assert(params);
 
-    const ArrayOfObjects *fTremChildren = this->GetList(this);
+    const ArrayOfObjects &fTremChildren = this->GetList(this);
 
     // Should we assert this at the beginning?
-    if (fTremChildren->empty()) {
+    if (fTremChildren.empty()) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -147,14 +147,14 @@ data_ACCIDENTAL_WRITTEN KeySig::GetAccidType() const
     return (this->GetSig().second);
 }
 
-void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid)
+void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid) const
 {
     mapOfPitchAccid.clear();
 
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         for (auto &child : childList) {
-            KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
+            const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
             assert(keyAccid);
             mapOfPitchAccid[keyAccid->GetPname()] = keyAccid->GetAccid();
         }
@@ -168,16 +168,16 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid)
     }
 }
 
-std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname)
+std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname) const
 {
     pname = PITCHNAME_c;
     accid = ACCIDENTAL_WRITTEN_s;
     std::wstring symbolStr = L"";
 
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         if ((int)childList.size() <= pos) return symbolStr;
-        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList.at(pos));
+        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(childList.at(pos));
         assert(keyAccid);
         accid = keyAccid->GetAccid();
         pname = keyAccid->GetPname();

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -288,9 +288,9 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
 // Functors methods
 //----------------------------------------------------------------------------
 
-int KeySig::InitData(FunctorParams *functorParams)
+int KeySig::PrepareDataInitialization(FunctorParams *functorParams)
 {
-    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
+    PrepareDataInitializationParams *params = vrv_params_cast<PrepareDataInitializationParams *>(functorParams);
     assert(params);
 
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -120,7 +120,7 @@ void KeySig::FilterList(ArrayOfConstObjects &childList) const
     }
 }
 
-int KeySig::GetAccidCount()
+int KeySig::GetAccidCount() const
 {
     const int childListSize = this->GetListSize(this); // make sure it's initialized
     if (childListSize > 0) {
@@ -132,12 +132,12 @@ int KeySig::GetAccidCount()
     return (this->GetSig().first);
 }
 
-data_ACCIDENTAL_WRITTEN KeySig::GetAccidType()
+data_ACCIDENTAL_WRITTEN KeySig::GetAccidType() const
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         if (m_mixedChildrenAccidType) return ACCIDENTAL_WRITTEN_NONE;
-        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList.at(0));
+        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(childList.at(0));
         assert(keyAccid);
         return keyAccid->GetAccid();
     }

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -122,9 +122,9 @@ void KeySig::FilterList(ArrayOfConstObjects &childList)
 
 int KeySig::GetAccidCount()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    if (childList.size() > 0) {
-        return (int)childList.size();
+    const int childListSize = this->GetListSize(this); // make sure it's initialized
+    if (childListSize > 0) {
+        return childListSize;
     }
 
     if (!this->HasSig()) return 0;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -122,9 +122,9 @@ void KeySig::FilterList(ArrayOfConstObjects &childList)
 
 int KeySig::GetAccidCount()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    if (childList->size() > 0) {
-        return (int)childList->size();
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    if (childList.size() > 0) {
+        return (int)childList.size();
     }
 
     if (!this->HasSig()) return 0;
@@ -134,10 +134,10 @@ int KeySig::GetAccidCount()
 
 data_ACCIDENTAL_WRITTEN KeySig::GetAccidType()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    if (childList->size() > 0) {
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    if (childList.size() > 0) {
         if (m_mixedChildrenAccidType) return ACCIDENTAL_WRITTEN_NONE;
-        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList->at(0));
+        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList.at(0));
         assert(keyAccid);
         return keyAccid->GetAccid();
     }
@@ -151,9 +151,9 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid)
 {
     mapOfPitchAccid.clear();
 
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    if (childList->size() > 0) {
-        for (auto &child : *childList) {
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    if (childList.size() > 0) {
+        for (auto &child : childList) {
             KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
             assert(keyAccid);
             mapOfPitchAccid[keyAccid->GetPname()] = keyAccid->GetAccid();
@@ -174,10 +174,10 @@ std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, d
     accid = ACCIDENTAL_WRITTEN_s;
     std::wstring symbolStr = L"";
 
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    if (childList->size() > 0) {
-        if ((int)childList->size() <= pos) return symbolStr;
-        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList->at(pos));
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    if (childList.size() > 0) {
+        if ((int)childList.size() <= pos) return symbolStr;
+        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(childList.at(pos));
         assert(keyAccid);
         accid = keyAccid->GetAccid();
         pname = keyAccid->GetPname();
@@ -297,8 +297,8 @@ int KeySig::InitializeDrawing(FunctorParams *functorParams)
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;
     m_mixedChildrenAccidType = false;
 
-    const ArrayOfObjects *childList = this->GetList(this);
-    for (auto &child : *childList) {
+    const ArrayOfObjects &childList = this->GetList(this);
+    for (auto &child : childList) {
         KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
         assert(keyAccid);
         if (type == ACCIDENTAL_WRITTEN_NONE) {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -107,11 +107,9 @@ void KeySig::Reset()
     m_drawingCancelAccidCount = 0;
 }
 
-void KeySig::FilterList(ArrayOfConstObjects &childList) const
+void KeySig::FilterList(ListOfConstObjects &childList) const
 {
-    // nothing  to filter since we allow only KeyAccid for now.
-    ArrayOfConstObjects::iterator iter = childList.begin();
-
+    ListOfConstObjects::iterator iter = childList.begin();
     while (iter != childList.end()) {
         if ((*iter)->Is(KEYACCID))
             ++iter;
@@ -134,10 +132,10 @@ int KeySig::GetAccidCount() const
 
 data_ACCIDENTAL_WRITTEN KeySig::GetAccidType() const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
+    const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         if (m_mixedChildrenAccidType) return ACCIDENTAL_WRITTEN_NONE;
-        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(childList.at(0));
+        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(childList.front());
         assert(keyAccid);
         return keyAccid->GetAccid();
     }
@@ -151,7 +149,7 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid) const
 {
     mapOfPitchAccid.clear();
 
-    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
+    const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         for (auto &child : childList) {
             const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
@@ -174,10 +172,11 @@ std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, d
     accid = ACCIDENTAL_WRITTEN_s;
     std::wstring symbolStr = L"";
 
-    const ArrayOfConstObjects &childList = this->GetList(this); // make sure it's initialized
+    const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
         if ((int)childList.size() <= pos) return symbolStr;
-        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(childList.at(pos));
+        auto iter = std::next(childList.begin(), pos);
+        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(*iter);
         assert(keyAccid);
         accid = keyAccid->GetAccid();
         pname = keyAccid->GetPname();
@@ -297,7 +296,7 @@ int KeySig::InitData(FunctorParams *functorParams)
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;
     m_mixedChildrenAccidType = false;
 
-    const ArrayOfObjects &childList = this->GetList(this);
+    const ListOfObjects &childList = this->GetList(this);
     for (auto &child : childList) {
         KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
         assert(keyAccid);

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -107,16 +107,16 @@ void KeySig::Reset()
     m_drawingCancelAccidCount = 0;
 }
 
-void KeySig::FilterList(ArrayOfObjects *childList)
+void KeySig::FilterList(ArrayOfConstObjects &childList)
 {
     // nothing  to filter since we allow only KeyAccid for now.
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if ((*iter)->Is(KEYACCID))
             ++iter;
         else
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
     }
 }
 

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -289,9 +289,9 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
 // Functors methods
 //----------------------------------------------------------------------------
 
-int KeySig::InitializeDrawing(FunctorParams *functorParams)
+int KeySig::InitData(FunctorParams *functorParams)
 {
-    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
     assert(params);
 
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -118,22 +118,6 @@ void KeySig::FilterList(ArrayOfObjects *childList)
         else
             iter = childList->erase(iter);
     }
-
-    data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;
-    m_mixedChildrenAccidType = false;
-
-    for (auto &child : *childList) {
-        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
-        assert(keyAccid);
-        if (type == ACCIDENTAL_WRITTEN_NONE) {
-            type = keyAccid->GetAccid();
-            continue;
-        }
-        if (type != keyAccid->GetAccid()) {
-            m_mixedChildrenAccidType = true;
-            break;
-        }
-    }
 }
 
 int KeySig::GetAccidCount()
@@ -304,6 +288,31 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------
+
+int KeySig::InitializeDrawing(FunctorParams *functorParams)
+{
+    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    assert(params);
+
+    data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;
+    m_mixedChildrenAccidType = false;
+
+    const ArrayOfObjects *childList = this->GetList(this);
+    for (auto &child : *childList) {
+        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
+        assert(keyAccid);
+        if (type == ACCIDENTAL_WRITTEN_NONE) {
+            type = keyAccid->GetAccid();
+            continue;
+        }
+        if (type != keyAccid->GetAccid()) {
+            m_mixedChildrenAccidType = true;
+            break;
+        }
+    }
+
+    return FUNCTOR_CONTINUE;
+}
 
 int KeySig::Transpose(FunctorParams *functorParams)
 {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -107,7 +107,7 @@ void KeySig::Reset()
     m_drawingCancelAccidCount = 0;
 }
 
-void KeySig::FilterList(ArrayOfConstObjects &childList)
+void KeySig::FilterList(ArrayOfConstObjects &childList) const
 {
     // nothing  to filter since we allow only KeyAccid for now.
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -177,7 +177,7 @@ bool Layer::IsSupportedChild(Object *child)
 LayerElement *Layer::GetPrevious(LayerElement *element)
 {
     this->ResetList(this);
-    if (!element || this->GetList(this)->empty()) return NULL;
+    if (!element || this->GetList(this).empty()) return NULL;
 
     return dynamic_cast<LayerElement *>(this->GetListPrevious(element));
 }
@@ -369,10 +369,10 @@ ListOfObjects Layer::GetLayerElementsForTimeSpanOf(LayerElement *element, bool e
     // the duration of the beam based on those
     else if (element->Is(BEAM)) {
         Beam *beam = vrv_cast<Beam *>(element);
-        const ArrayOfObjects *beamChildren = beam->GetList(beam);
+        const ArrayOfObjects &beamChildren = beam->GetList(beam);
 
-        LayerElement *first = vrv_cast<LayerElement *>(beamChildren->front());
-        LayerElement *last = vrv_cast<LayerElement *>(beamChildren->back());
+        LayerElement *first = vrv_cast<LayerElement *>(beamChildren.front());
+        LayerElement *last = vrv_cast<LayerElement *>(beamChildren.back());
 
         if (!first || !last) return {};
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -177,7 +177,7 @@ bool Layer::IsSupportedChild(Object *child)
 LayerElement *Layer::GetPrevious(LayerElement *element)
 {
     this->ResetList(this);
-    if (!element || this->GetList(this).empty()) return NULL;
+    if (!element || this->HasEmptyList(this)) return NULL;
 
     return dynamic_cast<LayerElement *>(this->GetListPrevious(element));
 }
@@ -369,10 +369,9 @@ ListOfObjects Layer::GetLayerElementsForTimeSpanOf(LayerElement *element, bool e
     // the duration of the beam based on those
     else if (element->Is(BEAM)) {
         Beam *beam = vrv_cast<Beam *>(element);
-        const ArrayOfObjects &beamChildren = beam->GetList(beam);
 
-        LayerElement *first = vrv_cast<LayerElement *>(beamChildren.front());
-        LayerElement *last = vrv_cast<LayerElement *>(beamChildren.back());
+        LayerElement *first = vrv_cast<LayerElement *>(beam->GetListFront(beam));
+        LayerElement *last = vrv_cast<LayerElement *>(beam->GetListBack(beam));
 
         if (!first || !last) return {};
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -210,22 +210,32 @@ bool LayerElement::IsInLigature() const
 
 FTrem *LayerElement::IsInFTrem()
 {
+    return const_cast<FTrem *>(std::as_const(*this).IsInFTrem());
+}
+
+const FTrem *LayerElement::IsInFTrem() const
+{
     if (!this->Is({ CHORD, NOTE })) return NULL;
-    return dynamic_cast<FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
+    return dynamic_cast<const FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
 }
 
 Beam *LayerElement::IsInBeam()
 {
+    return const_cast<Beam *>(std::as_const(*this).IsInBeam());
+}
+
+const Beam *LayerElement::IsInBeam() const
+{
     if (!this->Is({ CHORD, NOTE, TABGRP, TABDURSYM, STEM })) return NULL;
-    Beam *beamParent = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
+    const Beam *beamParent = vrv_cast<const Beam *>(this->GetFirstAncestor(BEAM));
     if (beamParent != NULL) {
         if (!this->IsGraceNote()) return beamParent;
         // This note is beamed and cue-sized - we will be able to get rid of this once MEI has a better modeling for
         // beamed grace notes
-        LayerElement *graceElement = this;
+        const LayerElement *graceElement = this;
         if (this->Is(STEM)) {
-            graceElement = vrv_cast<LayerElement *>(this->GetFirstAncestor(NOTE));
-            if (!graceElement) graceElement = vrv_cast<LayerElement *>(this->GetFirstAncestor(CHORD));
+            graceElement = vrv_cast<const LayerElement *>(this->GetFirstAncestor(NOTE));
+            if (!graceElement) graceElement = vrv_cast<const LayerElement *>(this->GetFirstAncestor(CHORD));
             assert(graceElement);
         }
         // Make sure the object list is set

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1079,7 +1079,7 @@ int LayerElement::AlignHorizontally(FunctorParams *functorParams)
         // Ligature notes are all aligned with the first note
         Note *note = vrv_cast<Note *>(this);
         assert(note);
-        Note *firstNote = dynamic_cast<Note *>(ligatureParent->GetList(ligatureParent).front());
+        Note *firstNote = dynamic_cast<Note *>(ligatureParent->GetListFront(ligatureParent));
         if (firstNote && (firstNote != note)) {
             m_alignment = firstNote->GetAlignment();
             m_alignment->AddLayerElementRef(this);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1079,7 +1079,7 @@ int LayerElement::AlignHorizontally(FunctorParams *functorParams)
         // Ligature notes are all aligned with the first note
         Note *note = vrv_cast<Note *>(this);
         assert(note);
-        Note *firstNote = dynamic_cast<Note *>(ligatureParent->GetList(ligatureParent)->front());
+        Note *firstNote = dynamic_cast<Note *>(ligatureParent->GetList(ligatureParent).front());
         if (firstNote && (firstNote != note)) {
             m_alignment = firstNote->GetAlignment();
             m_alignment->AddLayerElementRef(this);
@@ -1394,17 +1394,17 @@ int LayerElement::CalcAlignmentPitchPos(FunctorParams *functorParams)
             if (beam) {
                 beam->ResetList(beam);
 
-                const ArrayOfObjects *beamList = beam->GetList(beam);
+                const ArrayOfObjects &beamList = beam->GetList(beam);
                 const int restIndex = beam->GetListIndex(rest);
                 assert(restIndex >= 0);
 
                 int leftLoc = loc;
-                ArrayOfObjects::const_iterator it = beamList->begin();
+                ArrayOfObjects::const_iterator it = beamList.begin();
                 std::advance(it, restIndex);
                 ArrayOfObjects::const_reverse_iterator rit(it);
                 // iterate through the elements from the rest to the beginning of the beam
                 // until we hit a note or chord, which we will use to determine where the rest should be placed
-                for (; rit != beamList->rend(); ++rit) {
+                for (; rit != beamList.rend(); ++rit) {
                     LayerElement *layerElement = vrv_cast<LayerElement *>(*rit);
                     assert(layerElement);
                     if (layerElement->Is(NOTE)) {
@@ -1421,11 +1421,11 @@ int LayerElement::CalcAlignmentPitchPos(FunctorParams *functorParams)
                 }
 
                 int rightLoc = loc;
-                it = beamList->begin();
+                it = beamList.begin();
                 std::advance(it, restIndex);
                 // iterate through the elements from the rest to the end of the beam
                 // until we hit a note or chord, which we will use to determine where the rest should be placed
-                for (; it != beamList->end(); ++it) {
+                for (; it != beamList.end(); ++it) {
                     LayerElement *layerElement = vrv_cast<LayerElement *>(*it);
                     assert(layerElement);
                     if (layerElement->Is(NOTE)) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1404,14 +1404,14 @@ int LayerElement::CalcAlignmentPitchPos(FunctorParams *functorParams)
             if (beam) {
                 beam->ResetList(beam);
 
-                const ArrayOfObjects &beamList = beam->GetList(beam);
+                const ListOfObjects &beamList = beam->GetList(beam);
                 const int restIndex = beam->GetListIndex(rest);
                 assert(restIndex >= 0);
 
                 int leftLoc = loc;
-                ArrayOfObjects::const_iterator it = beamList.begin();
+                ListOfObjects::const_iterator it = beamList.begin();
                 std::advance(it, restIndex);
-                ArrayOfObjects::const_reverse_iterator rit(it);
+                ListOfObjects::const_reverse_iterator rit(it);
                 // iterate through the elements from the rest to the beginning of the beam
                 // until we hit a note or chord, which we will use to determine where the rest should be placed
                 for (; rit != beamList.rend(); ++rit) {

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -87,10 +87,10 @@ const Note *Ligature::GetLastNote() const
     return lastNote;
 }
 
-void Ligature::FilterList(ArrayOfConstObjects &childList) const
+void Ligature::FilterList(ListOfConstObjects &childList) const
 {
     // Retain only note children of ligatures
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if (!(*iter)->Is(NOTE)) {
@@ -128,7 +128,7 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
 
     m_drawingShapes.clear();
 
-    const ArrayOfObjects &notes = this->GetList(this);
+    const ListOfObjects &notes = this->GetList(this);
     Note *lastNote = dynamic_cast<Note *>(notes.back());
     Staff *staff = this->GetAncestorStaff();
 

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -37,20 +37,13 @@ Ligature::Ligature() : LayerElement(LIGATURE, "ligature-"), ObjectListInterface(
     this->Reset();
 }
 
-Ligature::~Ligature()
-{
-    ClearClusters();
-}
+Ligature::~Ligature() {}
 
 void Ligature::Reset()
 {
     LayerElement::Reset();
     this->ResetLigatureVis();
-
-    ClearClusters();
 }
-
-void Ligature::ClearClusters() {}
 
 bool Ligature::IsSupportedChild(Object *child)
 {
@@ -106,10 +99,6 @@ void Ligature::FilterList(ArrayOfObjects *childList)
             ++iter;
         }
     }
-
-    iter = childList->begin();
-
-    this->ClearClusters();
 }
 
 int Ligature::GetDrawingNoteShape(Note *note)

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -77,7 +77,7 @@ Note *Ligature::GetLastNote()
     return lastNote;
 }
 
-void Ligature::FilterList(ArrayOfConstObjects &childList)
+void Ligature::FilterList(ArrayOfConstObjects &childList) const
 {
     // Retain only note children of ligatures
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -64,21 +64,21 @@ bool Ligature::IsSupportedChild(Object *child)
 
 Note *Ligature::GetFirstNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
-    Note *firstNote = vrv_cast<Note *>(childList->front());
+    Note *firstNote = vrv_cast<Note *>(childList.front());
     assert(firstNote);
     return firstNote;
 }
 
 Note *Ligature::GetLastNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    Note *lastNote = vrv_cast<Note *>(childList->back());
+    Note *lastNote = vrv_cast<Note *>(childList.back());
     assert(lastNote);
     return lastNote;
 }
@@ -124,12 +124,11 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
 
     m_drawingShapes.clear();
 
-    Note *lastNote = dynamic_cast<Note *>(this->GetList(this)->back());
+    Note *lastNote = dynamic_cast<Note *>(this->GetList(this).back());
     Staff *staff = this->GetAncestorStaff();
 
-    const ArrayOfObjects *notes = this->GetList(this);
-    assert(notes);
-    if (notes->size() < 2) return FUNCTOR_SIBLINGS;
+    const ArrayOfObjects &notes = this->GetList(this);
+    if (notes.size() < 2) return FUNCTOR_SIBLINGS;
 
     Note *previousNote = NULL;
     bool previousUp = false;
@@ -138,12 +137,12 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
 
     bool isMensuralBlack = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
     bool oblique = false;
-    if ((notes->size() == 2) && this->GetForm() == LIGATUREFORM_obliqua) oblique = true;
+    if ((notes.size() == 2) && this->GetForm() == LIGATUREFORM_obliqua) oblique = true;
 
     // For better clarify, we loop withing the Ligature::CalcLigatureNotePos instead of
     // implementing Note::CalcLigatureNotePos.
 
-    for (auto &iter : *notes) {
+    for (auto &iter : notes) {
 
         Note *note = vrv_cast<Note *>(iter);
         assert(note);
@@ -287,7 +286,7 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
     previousNote = NULL;
     n1 = 0;
 
-    for (auto &iter : *notes) {
+    for (auto &iter : notes) {
 
         Note *note = vrv_cast<Note *>(iter);
         assert(note);

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -83,19 +83,19 @@ Note *Ligature::GetLastNote()
     return lastNote;
 }
 
-void Ligature::FilterList(ArrayOfObjects *childList)
+void Ligature::FilterList(ArrayOfConstObjects &childList)
 {
     // Retain only note children of ligatures
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->Is(NOTE)) {
             // remove anything that is not an LayerElement
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
         }
         else {
             // assert that we keep only notes
-            assert(dynamic_cast<Note *>(*iter));
+            assert(dynamic_cast<const Note *>(*iter));
             ++iter;
         }
     }

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -64,15 +64,25 @@ bool Ligature::IsSupportedChild(Object *child)
 
 Note *Ligature::GetFirstNote()
 {
-    Note *firstNote = vrv_cast<Note *>(this->GetListFront(this));
+    return const_cast<Note *>(std::as_const(*this).GetFirstNote());
+}
+
+const Note *Ligature::GetFirstNote() const
+{
+    const Note *firstNote = vrv_cast<const Note *>(this->GetListFront(this));
     assert(firstNote);
     return firstNote;
 }
 
 Note *Ligature::GetLastNote()
 {
+    return const_cast<Note *>(std::as_const(*this).GetLastNote());
+}
+
+const Note *Ligature::GetLastNote() const
+{
     // The first note is the bottom
-    Note *lastNote = vrv_cast<Note *>(this->GetListBack(this));
+    const Note *lastNote = vrv_cast<const Note *>(this->GetListBack(this));
     assert(lastNote);
     return lastNote;
 }

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -64,21 +64,15 @@ bool Ligature::IsSupportedChild(Object *child)
 
 Note *Ligature::GetFirstNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
-    Note *firstNote = vrv_cast<Note *>(childList.front());
+    Note *firstNote = vrv_cast<Note *>(this->GetListFront(this));
     assert(firstNote);
     return firstNote;
 }
 
 Note *Ligature::GetLastNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    Note *lastNote = vrv_cast<Note *>(childList.back());
+    Note *lastNote = vrv_cast<Note *>(this->GetListBack(this));
     assert(lastNote);
     return lastNote;
 }
@@ -124,10 +118,10 @@ int Ligature::CalcLigatureNotePos(FunctorParams *functorParams)
 
     m_drawingShapes.clear();
 
-    Note *lastNote = dynamic_cast<Note *>(this->GetList(this).back());
+    const ArrayOfObjects &notes = this->GetList(this);
+    Note *lastNote = dynamic_cast<Note *>(notes.back());
     Staff *staff = this->GetAncestorStaff();
 
-    const ArrayOfObjects &notes = this->GetList(this);
     if (notes.size() < 2) return FUNCTOR_SIBLINGS;
 
     Note *previousNote = NULL;

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -65,7 +65,7 @@ bool MeterSigGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void MeterSigGrp::FilterList(ArrayOfConstObjects &childList) const
+void MeterSigGrp::FilterList(ListOfConstObjects &childList) const
 {
     // We want to keep only MeterSig
     childList.erase(std::remove_if(childList.begin(), childList.end(),
@@ -81,12 +81,13 @@ void MeterSigGrp::AddAlternatingMeasureToVector(Measure *measure)
 MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
 {
     MeterSig *newMeterSig = NULL;
-    const ArrayOfConstObjects &childList = this->GetList(this);
+    const ListOfConstObjects &childList = this->GetList(this);
     switch (this->GetFunc()) {
         // For alternating meterSig group alternate between children sequentially
         case meterSigGrpLog_FUNC_alternating: {
             const int index = m_count % childList.size();
-            newMeterSig = vrv_cast<MeterSig *>((childList.at(index))->Clone());
+            auto iter = std::next(childList.begin(), index);
+            newMeterSig = vrv_cast<MeterSig *>((*iter)->Clone());
             break;
         }
         // For interchanging meterSig group select the largest signature, but make sure to align unit with the shortest

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -65,7 +65,7 @@ bool MeterSigGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void MeterSigGrp::FilterList(ArrayOfConstObjects &childList)
+void MeterSigGrp::FilterList(ArrayOfConstObjects &childList) const
 {
     // We want to keep only MeterSig
     childList.erase(std::remove_if(childList.begin(), childList.end(),

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -78,10 +78,10 @@ void MeterSigGrp::AddAlternatingMeasureToVector(Measure *measure)
     m_alternatingMeasures.emplace_back(measure);
 }
 
-MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
+MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
 {
     MeterSig *newMeterSig = NULL;
-    const ArrayOfObjects &childList = this->GetList(this);
+    const ArrayOfConstObjects &childList = this->GetList(this);
     switch (this->GetFunc()) {
         // For alternating meterSig group alternate between children sequentially
         case meterSigGrpLog_FUNC_alternating: {
@@ -92,16 +92,18 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
         // For interchanging meterSig group select the largest signature, but make sure to align unit with the shortest
         case meterSigGrpLog_FUNC_interchanging: {
             // Get element with highest count
-            auto it = std::max_element(childList.begin(), childList.end(), [](Object *firstObj, Object *secondObj) {
-                MeterSig *firstMeterSig = vrv_cast<MeterSig *>(firstObj);
-                MeterSig *secondMeterSig = vrv_cast<MeterSig *>(secondObj);
-                const double firstRatio = (double)firstMeterSig->GetTotalCount() / (double)firstMeterSig->GetUnit();
-                const double secondRatio = (double)secondMeterSig->GetTotalCount() / (double)secondMeterSig->GetUnit();
-                return firstRatio < secondRatio;
-            });
+            auto it = std::max_element(
+                childList.begin(), childList.end(), [](const Object *firstObj, const Object *secondObj) {
+                    const MeterSig *firstMeterSig = vrv_cast<const MeterSig *>(firstObj);
+                    const MeterSig *secondMeterSig = vrv_cast<const MeterSig *>(secondObj);
+                    const double firstRatio = (double)firstMeterSig->GetTotalCount() / (double)firstMeterSig->GetUnit();
+                    const double secondRatio
+                        = (double)secondMeterSig->GetTotalCount() / (double)secondMeterSig->GetUnit();
+                    return firstRatio < secondRatio;
+                });
             int maxUnit = 0;
-            std::for_each(childList.begin(), childList.end(), [&maxUnit](Object *obj) {
-                MeterSig *meterSig = vrv_cast<MeterSig *>(obj);
+            std::for_each(childList.begin(), childList.end(), [&maxUnit](const Object *obj) {
+                const MeterSig *meterSig = vrv_cast<const MeterSig *>(obj);
                 if (meterSig->GetUnit() > maxUnit) maxUnit = meterSig->GetUnit();
             });
 
@@ -126,7 +128,7 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
                     LogWarning("Skipping over non-meterSig child of <MeterSigGrp>");
                     continue;
                 }
-                MeterSig *meterSig = vrv_cast<MeterSig *>(object);
+                const MeterSig *meterSig = vrv_cast<const MeterSig *>(object);
                 if (!newMeterSig) {
                     newMeterSig = vrv_cast<MeterSig *>(meterSig->Clone());
                 }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -65,12 +65,12 @@ bool MeterSigGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void MeterSigGrp::FilterList(ArrayOfObjects *childList)
+void MeterSigGrp::FilterList(ArrayOfConstObjects &childList)
 {
     // We want to keep only MeterSig
-    childList->erase(std::remove_if(childList->begin(), childList->end(),
-                         [](const Object *object) -> bool { return !object->Is(METERSIG); }),
-        childList->end());
+    childList.erase(std::remove_if(childList.begin(), childList.end(),
+                        [](const Object *object) -> bool { return !object->Is(METERSIG); }),
+        childList.end());
 }
 
 void MeterSigGrp::AddAlternatingMeasureToVector(Measure *measure)

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -81,18 +81,18 @@ void MeterSigGrp::AddAlternatingMeasureToVector(Measure *measure)
 MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
 {
     MeterSig *newMeterSig = NULL;
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
     switch (this->GetFunc()) {
         // For alternating meterSig group alternate between children sequentially
         case meterSigGrpLog_FUNC_alternating: {
-            const int index = m_count % childList->size();
-            newMeterSig = vrv_cast<MeterSig *>((childList->at(index))->Clone());
+            const int index = m_count % childList.size();
+            newMeterSig = vrv_cast<MeterSig *>((childList.at(index))->Clone());
             break;
         }
         // For interchanging meterSig group select the largest signature, but make sure to align unit with the shortest
         case meterSigGrpLog_FUNC_interchanging: {
             // Get element with highest count
-            auto it = std::max_element(childList->begin(), childList->end(), [](Object *firstObj, Object *secondObj) {
+            auto it = std::max_element(childList.begin(), childList.end(), [](Object *firstObj, Object *secondObj) {
                 MeterSig *firstMeterSig = vrv_cast<MeterSig *>(firstObj);
                 MeterSig *secondMeterSig = vrv_cast<MeterSig *>(secondObj);
                 const double firstRatio = (double)firstMeterSig->GetTotalCount() / (double)firstMeterSig->GetUnit();
@@ -100,7 +100,7 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
                 return firstRatio < secondRatio;
             });
             int maxUnit = 0;
-            std::for_each(childList->begin(), childList->end(), [&maxUnit](Object *obj) {
+            std::for_each(childList.begin(), childList.end(), [&maxUnit](Object *obj) {
                 MeterSig *meterSig = vrv_cast<MeterSig *>(obj);
                 if (meterSig->GetUnit() > maxUnit) maxUnit = meterSig->GetUnit();
             });
@@ -121,7 +121,7 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig()
         case meterSigGrpLog_FUNC_mixed: {
             int maxUnit = 0;
             int currentCount = 0;
-            for (const auto object : *childList) {
+            for (const auto object : childList) {
                 if (!object->Is(METERSIG)) {
                     LogWarning("Skipping over non-meterSig child of <MeterSigGrp>");
                     continue;

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -78,7 +78,7 @@ int Neume::GetPosition(LayerElement *element)
 
 bool Neume::IsLastInNeume(LayerElement *element)
 {
-    int size = (int)this->GetList(this).size();
+    const int size = this->GetListSize(this);
     int position = this->GetPosition(element);
 
     // This method should be called only if the note is part of a neume

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -78,7 +78,7 @@ int Neume::GetPosition(LayerElement *element)
 
 bool Neume::IsLastInNeume(LayerElement *element)
 {
-    int size = (int)this->GetList(this)->size();
+    int size = (int)this->GetList(this).size();
     int position = this->GetPosition(element);
 
     // This method should be called only if the note is part of a neume

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -69,14 +69,14 @@ bool Neume::IsSupportedChild(Object *child)
     return true;
 }
 
-int Neume::GetPosition(LayerElement *element)
+int Neume::GetPosition(const LayerElement *element) const
 {
     this->GetList(this);
     int position = this->GetListIndex(element);
     return position;
 }
 
-bool Neume::IsLastInNeume(LayerElement *element)
+bool Neume::IsLastInNeume(const LayerElement *element) const
 {
     const int size = this->GetListSize(this);
     int position = this->GetPosition(element);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -549,14 +549,14 @@ wchar_t Note::GetNoteheadGlyph(const int duration) const
     return SMUFL_E0A4_noteheadBlack;
 }
 
-bool Note::IsVisible()
+bool Note::IsVisible() const
 {
     if (this->HasVisible()) {
         return this->GetVisible() == BOOLEAN_true;
     }
     // if the chord doens't have it, see if all the children are invisible
     else if (this->GetParent() && this->GetParent()->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(this->GetParent());
+        const Chord *chord = vrv_cast<const Chord *>(this->GetParent());
         assert(chord);
         return chord->IsVisible();
     }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -346,7 +346,7 @@ void Note::SetCluster(ChordCluster *cluster, int position)
     m_clusterPosition = position;
 }
 
-Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
+Point Note::GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const
 {
     int defaultYShift = doc->GetDrawingUnit(staffSize) / 4;
     if (isCueSize) defaultYShift = doc->GetCueSize(defaultYShift);
@@ -379,7 +379,7 @@ Point Note::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
     return p;
 }
 
-Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
+Point Note::GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const
 {
     int defaultYShift = doc->GetDrawingUnit(staffSize) / 4;
     if (isCueSize) defaultYShift = doc->GetCueSize(defaultYShift);
@@ -411,7 +411,7 @@ Point Note::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
     return p;
 }
 
-int Note::CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir)
+int Note::CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const
 {
     assert(staff);
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -791,10 +791,9 @@ void Note::DeferMIDINote(FunctorParams *functorParams, double shift, bool includ
     // Recursive call for chords
     Chord *chord = this->IsChordTone();
     if (chord && includeChordSiblings) {
-        const ArrayOfObjects *notes = chord->GetList(chord);
-        assert(notes);
+        const ArrayOfObjects &notes = chord->GetList(chord);
 
-        for (Object *obj : *notes) {
+        for (Object *obj : notes) {
             Note *note = vrv_cast<Note *>(obj);
             assert(note);
             note->DeferMIDINote(functorParams, shift, false);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -791,7 +791,7 @@ void Note::DeferMIDINote(FunctorParams *functorParams, double shift, bool includ
     // Recursive call for chords
     Chord *chord = this->IsChordTone();
     if (chord && includeChordSiblings) {
-        const ArrayOfObjects &notes = chord->GetList(chord);
+        const ListOfObjects &notes = chord->GetList(chord);
 
         for (Object *obj : notes) {
             Note *note = vrv_cast<Note *>(obj);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1308,7 +1308,14 @@ void ObjectListInterface::ResetList(Object *node)
     node->Modify(false);
     m_list.clear();
     node->FillFlatList(&m_list);
-    this->FilterList(&m_list);
+    // TODO: remove later (BEGIN)
+    ArrayOfConstObjects tempList(m_list.begin(), m_list.end());
+    this->FilterList(tempList);
+    m_list.clear();
+    for (auto ptr : tempList) {
+        m_list.push_back(const_cast<Object *>(ptr));
+    }
+    // TODO: remove later (END)
 }
 
 const ArrayOfObjects *ObjectListInterface::GetList(Object *node)
@@ -1424,13 +1431,13 @@ void TextListInterface::GetTextLines(Object *node, std::vector<std::wstring> &li
     }
 }
 
-void TextListInterface::FilterList(ArrayOfObjects *childList)
+void TextListInterface::FilterList(ArrayOfConstObjects &childList)
 {
-    ArrayOfObjects::iterator iter = childList->begin();
-    while (iter != childList->end()) {
+    ArrayOfConstObjects::iterator iter = childList.begin();
+    while (iter != childList.end()) {
         if (!(*iter)->Is({ LB, TEXT })) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc. but keep Lb)
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
             continue;
         }
         ++iter;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -846,7 +846,7 @@ int Object::GetDescendantIndex(const Object *child, const ClassId classId, int d
     return -1;
 }
 
-void Object::Modify(bool modified)
+void Object::Modify(bool modified) const
 {
     // if we have a parent and a new modification, propagate it
     if (m_parent && modified) {
@@ -855,10 +855,10 @@ void Object::Modify(bool modified)
     m_isModified = modified;
 }
 
-void Object::FillFlatList(ArrayOfObjects *flatList)
+void Object::FillFlatList(ArrayOfConstObjects &flatList) const
 {
     Functor addToFlatList(&Object::AddLayerElementToFlatList);
-    AddLayerElementToFlatListParams addLayerElementToFlatListParams(flatList);
+    AddLayerElementToFlatListParams addLayerElementToFlatListParams(&flatList);
     this->Process(&addToFlatList, &addLayerElementToFlatListParams);
 }
 
@@ -1298,7 +1298,7 @@ ObjectListInterface &ObjectListInterface::operator=(const ObjectListInterface &i
     return *this;
 }
 
-void ObjectListInterface::ResetList(Object *node)
+void ObjectListInterface::ResetList(const Object *node)
 {
     // nothing to do, the list if up to date
     if (!node->IsModified()) {
@@ -1307,9 +1307,9 @@ void ObjectListInterface::ResetList(Object *node)
 
     node->Modify(false);
     m_list.clear();
-    node->FillFlatList(&m_list);
     // TODO: remove later (BEGIN)
     ArrayOfConstObjects tempList(m_list.begin(), m_list.end());
+    node->FillFlatList(tempList);
     this->FilterList(tempList);
     m_list.clear();
     for (auto ptr : tempList) {
@@ -1554,7 +1554,7 @@ void ObjectFactory::Register(std::string name, ClassId classId, std::function<Ob
 // Object functor methods
 //----------------------------------------------------------------------------
 
-int Object::AddLayerElementToFlatList(FunctorParams *functorParams)
+int Object::AddLayerElementToFlatList(FunctorParams *functorParams) const
 {
     AddLayerElementToFlatListParams *params = vrv_params_cast<AddLayerElementToFlatListParams *>(functorParams);
     assert(params);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1324,6 +1324,32 @@ const ArrayOfObjects &ObjectListInterface::GetList(Object *node)
     return m_list;
 }
 
+bool ObjectListInterface::HasEmptyList(Object *node)
+{
+    this->ResetList(node);
+    return m_list.empty();
+}
+
+int ObjectListInterface::GetListSize(Object *node)
+{
+    this->ResetList(node);
+    return static_cast<int>(m_list.size());
+}
+
+Object *ObjectListInterface::GetListFront(Object *node)
+{
+    this->ResetList(node);
+    assert(!m_list.empty());
+    return m_list.front();
+}
+
+Object *ObjectListInterface::GetListBack(Object *node)
+{
+    this->ResetList(node);
+    assert(!m_list.empty());
+    return m_list.back();
+}
+
 int ObjectListInterface::GetListIndex(const Object *listElement)
 {
     ArrayOfObjects::iterator iter;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1453,34 +1453,34 @@ Object *ObjectListInterface::GetListNext(const Object *listElement)
 // TextListInterface
 //----------------------------------------------------------------------------
 
-std::wstring TextListInterface::GetText(Object *node)
+std::wstring TextListInterface::GetText(const Object *node) const
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfObjects &childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
+    const ArrayOfConstObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ArrayOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB)) {
             continue;
         }
-        Text *text = vrv_cast<Text *>(*it);
+        const Text *text = vrv_cast<const Text *>(*it);
         assert(text);
         concatText += text->GetText();
     }
     return concatText;
 }
 
-void TextListInterface::GetTextLines(Object *node, std::vector<std::wstring> &lines)
+void TextListInterface::GetTextLines(const Object *node, std::vector<std::wstring> &lines) const
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfObjects &childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
+    const ArrayOfConstObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ArrayOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB) && !concatText.empty()) {
             lines.push_back(concatText);
             concatText.clear();
             continue;
         }
-        Text *text = vrv_cast<Text *>(*it);
+        const Text *text = vrv_cast<const Text *>(*it);
         assert(text);
         concatText += text->GetText();
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -855,7 +855,7 @@ void Object::Modify(bool modified) const
     m_isModified = modified;
 }
 
-void Object::FillFlatList(ArrayOfConstObjects &flatList) const
+void Object::FillFlatList(ListOfConstObjects &flatList) const
 {
     Functor addToFlatList(&Object::AddLayerElementToFlatList);
     AddLayerElementToFlatListParams addLayerElementToFlatListParams(&flatList);
@@ -1311,16 +1311,16 @@ void ObjectListInterface::ResetList(const Object *node) const
     this->FilterList(m_list);
 }
 
-const ArrayOfConstObjects &ObjectListInterface::GetList(const Object *node) const
+const ListOfConstObjects &ObjectListInterface::GetList(const Object *node) const
 {
     this->ResetList(node);
     return m_list;
 }
 
-ArrayOfObjects ObjectListInterface::GetList(const Object *node)
+ListOfObjects ObjectListInterface::GetList(const Object *node)
 {
     this->ResetList(node);
-    ArrayOfObjects result;
+    ListOfObjects result;
     std::transform(m_list.begin(), m_list.end(), std::back_inserter(result),
         [](const Object *obj) { return const_cast<Object *>(obj); });
     return result;
@@ -1364,7 +1364,7 @@ Object *ObjectListInterface::GetListBack(const Object *node)
 
 int ObjectListInterface::GetListIndex(const Object *listElement) const
 {
-    ArrayOfConstObjects::iterator iter;
+    ListOfConstObjects::iterator iter;
     int i;
     for (iter = m_list.begin(), i = 0; iter != m_list.end(); ++iter, ++i) {
         if (listElement == *iter) {
@@ -1376,7 +1376,7 @@ int ObjectListInterface::GetListIndex(const Object *listElement) const
 
 const Object *ObjectListInterface::GetListFirst(const Object *startFrom, const ClassId classId) const
 {
-    ArrayOfConstObjects::iterator it = m_list.begin();
+    ListOfConstObjects::iterator it = m_list.begin();
     int idx = this->GetListIndex(startFrom);
     if (idx == -1) return NULL;
     std::advance(it, idx);
@@ -1391,11 +1391,11 @@ Object *ObjectListInterface::GetListFirst(const Object *startFrom, const ClassId
 
 const Object *ObjectListInterface::GetListFirstBackward(const Object *startFrom, const ClassId classId) const
 {
-    ArrayOfConstObjects::iterator it = m_list.begin();
+    ListOfConstObjects::iterator it = m_list.begin();
     int idx = this->GetListIndex(startFrom);
     if (idx == -1) return NULL;
     std::advance(it, idx);
-    ArrayOfConstObjects::reverse_iterator rit(it);
+    ListOfConstObjects::reverse_iterator rit(it);
     rit = std::find_if(rit, m_list.rend(), ObjectComparison(classId));
     return (rit == m_list.rend()) ? NULL : *rit;
 }
@@ -1407,7 +1407,7 @@ Object *ObjectListInterface::GetListFirstBackward(const Object *startFrom, const
 
 const Object *ObjectListInterface::GetListPrevious(const Object *listElement) const
 {
-    ArrayOfConstObjects::iterator iter;
+    ListOfConstObjects::iterator iter;
     int i;
     for (iter = m_list.begin(), i = 0; iter != m_list.end(); ++iter, ++i) {
         if (listElement == *iter) {
@@ -1429,7 +1429,7 @@ Object *ObjectListInterface::GetListPrevious(const Object *listElement)
 
 const Object *ObjectListInterface::GetListNext(const Object *listElement) const
 {
-    ArrayOfConstObjects::reverse_iterator iter;
+    ListOfConstObjects::reverse_iterator iter;
     int i;
     for (iter = m_list.rbegin(), i = 0; iter != m_list.rend(); ++iter, ++i) {
         if (listElement == *iter) {
@@ -1457,8 +1457,8 @@ std::wstring TextListInterface::GetText(const Object *node) const
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfConstObjects &childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
+    const ListOfConstObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ListOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB)) {
             continue;
         }
@@ -1473,8 +1473,8 @@ void TextListInterface::GetTextLines(const Object *node, std::vector<std::wstrin
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfConstObjects &childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
+    const ListOfConstObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ListOfConstObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB) && !concatText.empty()) {
             lines.push_back(concatText);
             concatText.clear();
@@ -1489,9 +1489,9 @@ void TextListInterface::GetTextLines(const Object *node, std::vector<std::wstrin
     }
 }
 
-void TextListInterface::FilterList(ArrayOfConstObjects &childList) const
+void TextListInterface::FilterList(ListOfConstObjects &childList) const
 {
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
     while (iter != childList.end()) {
         if (!(*iter)->Is({ LB, TEXT })) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc. but keep Lb)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1318,10 +1318,10 @@ void ObjectListInterface::ResetList(const Object *node)
     // TODO: remove later (END)
 }
 
-const ArrayOfObjects *ObjectListInterface::GetList(Object *node)
+const ArrayOfObjects &ObjectListInterface::GetList(Object *node)
 {
     this->ResetList(node);
-    return &m_list;
+    return m_list;
 }
 
 int ObjectListInterface::GetListIndex(const Object *listElement)
@@ -1399,8 +1399,8 @@ std::wstring TextListInterface::GetText(Object *node)
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfObjects *childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = childList->begin(); it != childList->end(); ++it) {
+    const ArrayOfObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB)) {
             continue;
         }
@@ -1415,8 +1415,8 @@ void TextListInterface::GetTextLines(Object *node, std::vector<std::wstring> &li
 {
     // alternatively we could cache the concatString in the interface and instantiate it in FilterList
     std::wstring concatText;
-    const ArrayOfObjects *childList = this->GetList(node); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = childList->begin(); it != childList->end(); ++it) {
+    const ArrayOfObjects &childList = this->GetList(node); // make sure it's initialized
+    for (ArrayOfObjects::const_iterator it = childList.begin(); it != childList.end(); ++it) {
         if ((*it)->Is(LB) && !concatText.empty()) {
             lines.push_back(concatText);
             concatText.clear();

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -391,8 +391,8 @@ int RunningElement::InitializeDrawing(FunctorParams *functorParams)
         m_drawingScalingPercent[i] = 100;
     }
 
-    const ArrayOfObjects *childList = this->GetList(this);
-    for (ArrayOfObjects::const_iterator iter = childList->begin(); iter != childList->end(); ++iter) {
+    const ArrayOfObjects &childList = this->GetList(this);
+    for (ArrayOfObjects::const_iterator iter = childList.begin(); iter != childList.end(); ++iter) {
         int pos = 0;
         AreaPosInterface *interface = dynamic_cast<AreaPosInterface *>(*iter);
         assert(interface);

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -378,9 +378,9 @@ void RunningElement::AddPageNum(data_HORIZONTALALIGNMENT halign, data_VERTICALAL
 // Functor methods
 //----------------------------------------------------------------------------
 
-int RunningElement::InitializeDrawing(FunctorParams *functorParams)
+int RunningElement::InitData(FunctorParams *functorParams)
 {
-    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
     assert(params);
 
     int i;

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -91,9 +91,9 @@ bool RunningElement::IsSupportedChild(Object *child)
     return true;
 }
 
-void RunningElement::FilterList(ArrayOfConstObjects &childList) const
+void RunningElement::FilterList(ListOfConstObjects &childList) const
 {
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         // remove nested rend elements
@@ -391,8 +391,8 @@ int RunningElement::InitData(FunctorParams *functorParams)
         m_drawingScalingPercent[i] = 100;
     }
 
-    const ArrayOfObjects &childList = this->GetList(this);
-    for (ArrayOfObjects::const_iterator iter = childList.begin(); iter != childList.end(); ++iter) {
+    const ListOfObjects &childList = this->GetList(this);
+    for (ListOfObjects::const_iterator iter = childList.begin(); iter != childList.end(); ++iter) {
         int pos = 0;
         AreaPosInterface *interface = dynamic_cast<AreaPosInterface *>(*iter);
         assert(interface);

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -110,24 +110,6 @@ void RunningElement::FilterList(ArrayOfObjects *childList)
         }
         ++iter;
     }
-
-    int i;
-    for (i = 0; i < 9; ++i) {
-        m_cells[i].clear();
-    }
-    for (i = 0; i < 3; ++i) {
-        m_drawingScalingPercent[i] = 100;
-    }
-
-    for (iter = childList->begin(); iter != childList->end(); ++iter) {
-        int pos = 0;
-        AreaPosInterface *interface = dynamic_cast<AreaPosInterface *>(*iter);
-        assert(interface);
-        pos = this->GetAlignmentPos(interface->GetHalign(), interface->GetValign());
-        TextElement *text = vrv_cast<TextElement *>(*iter);
-        assert(text);
-        m_cells[pos].push_back(text);
-    }
 }
 
 int RunningElement::GetDrawingX() const
@@ -395,6 +377,33 @@ void RunningElement::AddPageNum(data_HORIZONTALALIGNMENT halign, data_VERTICALAL
 //----------------------------------------------------------------------------
 // Functor methods
 //----------------------------------------------------------------------------
+
+int RunningElement::InitializeDrawing(FunctorParams *functorParams)
+{
+    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    assert(params);
+
+    int i;
+    for (i = 0; i < 9; ++i) {
+        m_cells[i].clear();
+    }
+    for (i = 0; i < 3; ++i) {
+        m_drawingScalingPercent[i] = 100;
+    }
+
+    const ArrayOfObjects *childList = this->GetList(this);
+    for (ArrayOfObjects::const_iterator iter = childList->begin(); iter != childList->end(); ++iter) {
+        int pos = 0;
+        AreaPosInterface *interface = dynamic_cast<AreaPosInterface *>(*iter);
+        assert(interface);
+        pos = this->GetAlignmentPos(interface->GetHalign(), interface->GetValign());
+        TextElement *text = vrv_cast<TextElement *>(*iter);
+        assert(text);
+        m_cells[pos].push_back(text);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
 
 int RunningElement::Save(FunctorParams *functorParams)
 {

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -378,9 +378,9 @@ void RunningElement::AddPageNum(data_HORIZONTALALIGNMENT halign, data_VERTICALAL
 // Functor methods
 //----------------------------------------------------------------------------
 
-int RunningElement::InitData(FunctorParams *functorParams)
+int RunningElement::PrepareDataInitialization(FunctorParams *functorParams)
 {
-    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
+    PrepareDataInitializationParams *params = vrv_params_cast<PrepareDataInitializationParams *>(functorParams);
     assert(params);
 
     int i;

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -91,7 +91,7 @@ bool RunningElement::IsSupportedChild(Object *child)
     return true;
 }
 
-void RunningElement::FilterList(ArrayOfConstObjects &childList)
+void RunningElement::FilterList(ArrayOfConstObjects &childList) const
 {
     ArrayOfConstObjects::iterator iter = childList.begin();
 

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -91,21 +91,21 @@ bool RunningElement::IsSupportedChild(Object *child)
     return true;
 }
 
-void RunningElement::FilterList(ArrayOfObjects *childList)
+void RunningElement::FilterList(ArrayOfConstObjects &childList)
 {
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         // remove nested rend elements
         if ((*iter)->Is(REND)) {
             if ((*iter)->GetFirstAncestor(REND)) {
-                iter = childList->erase(iter);
+                iter = childList.erase(iter);
                 continue;
             }
         }
         // Also remove anything that is not a fig
         else if (!(*iter)->Is(FIG)) {
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
             continue;
         }
         ++iter;

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -154,9 +154,9 @@ bool Score::ScoreDefNeedsOptimization(int optionCondense) const
 // Functor methods
 //----------------------------------------------------------------------------
 
-int Score::InitData(FunctorParams *functorParams)
+int Score::PrepareDataInitialization(FunctorParams *functorParams)
 {
-    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
+    PrepareDataInitializationParams *params = vrv_params_cast<PrepareDataInitializationParams *>(functorParams);
     assert(params);
 
     // Evaluate functor on scoreDef

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -154,9 +154,9 @@ bool Score::ScoreDefNeedsOptimization(int optionCondense) const
 // Functor methods
 //----------------------------------------------------------------------------
 
-int Score::InitializeDrawing(FunctorParams *functorParams)
+int Score::InitData(FunctorParams *functorParams)
 {
-    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    InitDataParams *params = vrv_params_cast<InitDataParams *>(functorParams);
     assert(params);
 
     // Evaluate functor on scoreDef

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -154,6 +154,17 @@ bool Score::ScoreDefNeedsOptimization(int optionCondense) const
 // Functor methods
 //----------------------------------------------------------------------------
 
+int Score::InitializeDrawing(FunctorParams *functorParams)
+{
+    InitializeDrawingParams *params = vrv_params_cast<InitializeDrawingParams *>(functorParams);
+    assert(params);
+
+    // Evaluate functor on scoreDef
+    this->GetScoreDef()->Process(params->m_functor, params);
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Score::AdjustDots(FunctorParams *functorParams)
 {
     AdjustDotsParams *params = vrv_params_cast<AdjustDotsParams *>(functorParams);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -441,14 +441,14 @@ void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
     }
 }
 
-void ScoreDef::FilterList(ArrayOfObjects *childList)
+void ScoreDef::FilterList(ArrayOfConstObjects &childList)
 {
     // We want to keep only staffDef
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->Is(STAFFDEF)) {
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
         }
         else {
             ++iter;

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -490,11 +490,11 @@ void ScoreDef::ResetFromDrawingValues()
 StaffDef *ScoreDef::GetStaffDef(int n)
 {
     this->ResetList(this);
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
     ArrayOfObjects::const_iterator iter;
 
     StaffDef *staffDef = NULL;
-    for (iter = childList->begin(); iter != childList->end(); ++iter) {
+    for (iter = childList.begin(); iter != childList.end(); ++iter) {
         if (!(*iter)->Is(STAFFDEF)) continue;
         staffDef = vrv_cast<StaffDef *>(*iter);
         assert(staffDef);
@@ -523,12 +523,12 @@ StaffGrp *ScoreDef::GetStaffGrp(const std::string &n)
 std::vector<int> ScoreDef::GetStaffNs()
 {
     this->ResetList(this);
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
     ArrayOfObjects::const_iterator iter;
 
     std::vector<int> ns;
     StaffDef *staffDef = NULL;
-    for (iter = childList->begin(); iter != childList->end(); ++iter) {
+    for (iter = childList.begin(); iter != childList.end(); ++iter) {
         // It should be staffDef only, but double check.
         if (!(*iter)->Is(STAFFDEF)) continue;
         staffDef = vrv_cast<StaffDef *>(*iter);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -489,14 +489,18 @@ void ScoreDef::ResetFromDrawingValues()
 
 StaffDef *ScoreDef::GetStaffDef(int n)
 {
-    this->ResetList(this);
-    const ArrayOfObjects &childList = this->GetList(this);
-    ArrayOfObjects::const_iterator iter;
+    return const_cast<StaffDef *>(std::as_const(*this).GetStaffDef(n));
+}
 
-    StaffDef *staffDef = NULL;
+const StaffDef *ScoreDef::GetStaffDef(int n) const
+{
+    const ArrayOfConstObjects &childList = this->GetList(this);
+    ArrayOfConstObjects::const_iterator iter;
+
+    const StaffDef *staffDef = NULL;
     for (iter = childList.begin(); iter != childList.end(); ++iter) {
         if (!(*iter)->Is(STAFFDEF)) continue;
-        staffDef = vrv_cast<StaffDef *>(*iter);
+        staffDef = vrv_cast<const StaffDef *>(*iter);
         assert(staffDef);
         if (staffDef->GetN() == n) {
             return staffDef;
@@ -508,30 +512,34 @@ StaffDef *ScoreDef::GetStaffDef(int n)
 
 StaffGrp *ScoreDef::GetStaffGrp(const std::string &n)
 {
+    return const_cast<StaffGrp *>(std::as_const(*this).GetStaffGrp(n));
+}
+
+const StaffGrp *ScoreDef::GetStaffGrp(const std::string &n) const
+{
     // First get all the staffGrps
-    ListOfObjects staffGrps = this->FindAllDescendantsByType(STAFFGRP);
+    ListOfConstObjects staffGrps = this->FindAllDescendantsByType(STAFFGRP);
 
     // Then the @n of each first staffDef
     for (auto &item : staffGrps) {
-        StaffGrp *staffGrp = vrv_cast<StaffGrp *>(item);
+        const StaffGrp *staffGrp = vrv_cast<const StaffGrp *>(item);
         assert(staffGrp);
         if (staffGrp->GetN() == n) return staffGrp;
     }
     return NULL;
 }
 
-std::vector<int> ScoreDef::GetStaffNs()
+std::vector<int> ScoreDef::GetStaffNs() const
 {
-    this->ResetList(this);
-    const ArrayOfObjects &childList = this->GetList(this);
-    ArrayOfObjects::const_iterator iter;
+    const ArrayOfConstObjects &childList = this->GetList(this);
+    ArrayOfConstObjects::const_iterator iter;
 
     std::vector<int> ns;
-    StaffDef *staffDef = NULL;
+    const StaffDef *staffDef = NULL;
     for (iter = childList.begin(); iter != childList.end(); ++iter) {
         // It should be staffDef only, but double check.
         if (!(*iter)->Is(STAFFDEF)) continue;
-        staffDef = vrv_cast<StaffDef *>(*iter);
+        staffDef = vrv_cast<const StaffDef *>(*iter);
         assert(staffDef);
         ns.push_back(staffDef->GetN());
     }

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -441,10 +441,10 @@ void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
     }
 }
 
-void ScoreDef::FilterList(ArrayOfConstObjects &childList) const
+void ScoreDef::FilterList(ListOfConstObjects &childList) const
 {
     // We want to keep only staffDef
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if (!(*iter)->Is(STAFFDEF)) {
@@ -458,7 +458,7 @@ void ScoreDef::FilterList(ArrayOfConstObjects &childList) const
 
 void ScoreDef::ResetFromDrawingValues()
 {
-    const ArrayOfObjects &childList = this->GetList(this);
+    const ListOfObjects &childList = this->GetList(this);
 
     StaffDef *staffDef = NULL;
     for (auto item : childList) {
@@ -493,8 +493,8 @@ StaffDef *ScoreDef::GetStaffDef(int n)
 
 const StaffDef *ScoreDef::GetStaffDef(int n) const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this);
-    ArrayOfConstObjects::const_iterator iter;
+    const ListOfConstObjects &childList = this->GetList(this);
+    ListOfConstObjects::const_iterator iter;
 
     const StaffDef *staffDef = NULL;
     for (iter = childList.begin(); iter != childList.end(); ++iter) {
@@ -530,8 +530,8 @@ const StaffGrp *ScoreDef::GetStaffGrp(const std::string &n) const
 
 std::vector<int> ScoreDef::GetStaffNs() const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this);
-    ArrayOfConstObjects::const_iterator iter;
+    const ListOfConstObjects &childList = this->GetList(this);
+    ListOfConstObjects::const_iterator iter;
 
     std::vector<int> ns;
     const StaffDef *staffDef = NULL;

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -441,7 +441,7 @@ void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
     }
 }
 
-void ScoreDef::FilterList(ArrayOfConstObjects &childList)
+void ScoreDef::FilterList(ArrayOfConstObjects &childList) const
 {
     // We want to keep only staffDef
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -458,11 +458,10 @@ void ScoreDef::FilterList(ArrayOfConstObjects &childList) const
 
 void ScoreDef::ResetFromDrawingValues()
 {
-    this->ResetList(this);
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
 
     StaffDef *staffDef = NULL;
-    for (auto item : *childList) {
+    for (auto item : childList) {
         if (!item->Is(STAFFDEF)) continue;
         staffDef = vrv_cast<StaffDef *>(item);
         assert(staffDef);

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -198,7 +198,7 @@ bool Staff::DrawingIsVisible()
     return (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN);
 }
 
-bool Staff::IsMensural()
+bool Staff::IsMensural() const
 {
     bool isMensural
         = (m_drawingNotationType == NOTATIONTYPE_mensural || m_drawingNotationType == NOTATIONTYPE_mensural_white
@@ -206,13 +206,13 @@ bool Staff::IsMensural()
     return isMensural;
 }
 
-bool Staff::IsNeume()
+bool Staff::IsNeume() const
 {
     bool isNeume = (m_drawingNotationType == NOTATIONTYPE_neume);
     return isNeume;
 }
 
-bool Staff::IsTablature()
+bool Staff::IsTablature() const
 {
     bool isTablature = (m_drawingNotationType == NOTATIONTYPE_tab || m_drawingNotationType == NOTATIONTYPE_tab_guitar
         || m_drawingNotationType == NOTATIONTYPE_tab_lute_italian
@@ -221,7 +221,7 @@ bool Staff::IsTablature()
     return isTablature;
 }
 
-bool Staff::IsTabWithStemsOutside()
+bool Staff::IsTabWithStemsOutside() const
 {
     if (!m_drawingStaffDef) return false;
     // Temporary implementation looking at staffDef@type

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -112,14 +112,14 @@ void StaffGrp::FilterList(ArrayOfConstObjects &childList)
 int StaffGrp::GetMaxStaffSize()
 {
     this->ResetList(this);
-    const ArrayOfObjects *childList = this->GetList(this);
+    const ArrayOfObjects &childList = this->GetList(this);
 
-    if (childList->empty()) return 100;
+    if (childList.empty()) return 100;
 
     int max = 0;
 
     StaffDef *staffDef = NULL;
-    for (auto &child : *childList) {
+    for (auto &child : childList) {
         staffDef = vrv_cast<StaffDef *>(child);
         assert(staffDef);
         if (staffDef->HasScale() && staffDef->GetScale() >= max) {
@@ -135,14 +135,14 @@ int StaffGrp::GetMaxStaffSize()
 
 std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
 {
-    const ArrayOfObjects *staffDefs = this->GetList(this);
-    if (staffDefs->empty()) {
+    const ArrayOfObjects &staffDefs = this->GetList(this);
+    if (staffDefs.empty()) {
         return { NULL, NULL };
     }
 
     StaffDef *firstDef = NULL;
     ArrayOfObjects::const_iterator iter;
-    for (iter = staffDefs->begin(); iter != staffDefs->end(); ++iter) {
+    for (iter = staffDefs.begin(); iter != staffDefs.end(); ++iter) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
         assert(staffDef);
         if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
@@ -153,7 +153,7 @@ std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
 
     StaffDef *lastDef = NULL;
     ArrayOfObjects::const_reverse_iterator riter;
-    for (riter = staffDefs->rbegin(); riter != staffDefs->rend(); ++riter) {
+    for (riter = staffDefs.rbegin(); riter != staffDefs.rend(); ++riter) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*riter);
         assert(staffDef);
         if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -94,7 +94,7 @@ bool StaffGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void StaffGrp::FilterList(ArrayOfConstObjects &childList)
+void StaffGrp::FilterList(ArrayOfConstObjects &childList) const
 {
     // We want to keep only staffDef
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -109,18 +109,17 @@ void StaffGrp::FilterList(ArrayOfConstObjects &childList) const
     }
 }
 
-int StaffGrp::GetMaxStaffSize()
+int StaffGrp::GetMaxStaffSize() const
 {
-    this->ResetList(this);
-    const ArrayOfObjects &childList = this->GetList(this);
+    const ArrayOfConstObjects &childList = this->GetList(this);
 
     if (childList.empty()) return 100;
 
     int max = 0;
 
-    StaffDef *staffDef = NULL;
+    const StaffDef *staffDef = NULL;
     for (auto &child : childList) {
-        staffDef = vrv_cast<StaffDef *>(child);
+        staffDef = vrv_cast<const StaffDef *>(child);
         assert(staffDef);
         if (staffDef->HasScale() && staffDef->GetScale() >= max) {
             max = staffDef->GetScale();

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -94,14 +94,14 @@ bool StaffGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void StaffGrp::FilterList(ArrayOfObjects *childList)
+void StaffGrp::FilterList(ArrayOfConstObjects &childList)
 {
     // We want to keep only staffDef
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->Is(STAFFDEF)) {
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
         }
         else {
             ++iter;

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -94,10 +94,10 @@ bool StaffGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void StaffGrp::FilterList(ArrayOfConstObjects &childList) const
+void StaffGrp::FilterList(ListOfConstObjects &childList) const
 {
     // We want to keep only staffDef
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if (!(*iter)->Is(STAFFDEF)) {
@@ -111,7 +111,7 @@ void StaffGrp::FilterList(ArrayOfConstObjects &childList) const
 
 int StaffGrp::GetMaxStaffSize() const
 {
-    const ArrayOfConstObjects &childList = this->GetList(this);
+    const ListOfConstObjects &childList = this->GetList(this);
 
     if (childList.empty()) return 100;
 
@@ -134,13 +134,13 @@ int StaffGrp::GetMaxStaffSize() const
 
 std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
 {
-    const ArrayOfObjects &staffDefs = this->GetList(this);
+    const ListOfObjects &staffDefs = this->GetList(this);
     if (staffDefs.empty()) {
         return { NULL, NULL };
     }
 
     StaffDef *firstDef = NULL;
-    ArrayOfObjects::const_iterator iter;
+    ListOfObjects::const_iterator iter;
     for (iter = staffDefs.begin(); iter != staffDefs.end(); ++iter) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
         assert(staffDef);
@@ -151,7 +151,7 @@ std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
     }
 
     StaffDef *lastDef = NULL;
-    ArrayOfObjects::const_reverse_iterator riter;
+    ListOfObjects::const_reverse_iterator riter;
     for (riter = staffDefs.rbegin(); riter != staffDefs.rend(); ++riter) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*riter);
         assert(staffDef);

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -93,19 +93,17 @@ void TabDurSym::AdjustDrawingYRel(Staff *staff, Doc *doc)
     this->SetDrawingYRel(-yRel);
 }
 
-Point TabDurSym::GetStemUpSE(Doc *doc, int staffSize, bool isCueSize)
+Point TabDurSym::GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const
 {
-    Point p(0, 0);
-    return p;
+    return Point();
 }
 
-Point TabDurSym::GetStemDownNW(Doc *doc, int staffSize, bool isCueSize)
+Point TabDurSym::GetStemDownNW(const Doc *doc, int staffSize, bool isCueSize) const
 {
-    Point p(0, 0);
-    return p;
+    return Point();
 }
 
-int TabDurSym::CalcStemLenInThirdUnits(Staff *staff, data_STEMDIRECTION stemDir)
+int TabDurSym::CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir) const
 {
     assert(staff);
 

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -58,7 +58,7 @@ bool TabGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void TabGrp::FilterList(ArrayOfConstObjects &childList)
+void TabGrp::FilterList(ArrayOfConstObjects &childList) const
 {
     // Retain only note children of chords
     ArrayOfConstObjects::iterator iter = childList.begin();

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -72,39 +72,39 @@ void TabGrp::FilterList(ArrayOfConstObjects &childList)
 
 int TabGrp::GetYTop()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The last note is the top
-    return childList->back()->GetDrawingY();
+    return childList.back()->GetDrawingY();
 }
 
 int TabGrp::GetYBottom()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    return childList->front()->GetDrawingY();
+    return childList.front()->GetDrawingY();
 }
 
 Note *TabGrp::GetTopNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
-    Note *topNote = vrv_cast<Note *>(childList->back());
+    Note *topNote = vrv_cast<Note *>(childList.back());
     assert(topNote);
     return topNote;
 }
 
 Note *TabGrp::GetBottomNote()
 {
-    const ArrayOfObjects *childList = this->GetList(this); // make sure it's initialized
-    assert(childList->size() > 0);
+    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
+    assert(childList.size() > 0);
 
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(childList->front());
+    Note *bottomNote = vrv_cast<Note *>(childList.front());
     assert(bottomNote);
     return bottomNote;
 }

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -72,39 +72,27 @@ void TabGrp::FilterList(ArrayOfConstObjects &childList)
 
 int TabGrp::GetYTop()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The last note is the top
-    return childList.back()->GetDrawingY();
+    return this->GetListBack(this)->GetDrawingY();
 }
 
 int TabGrp::GetYBottom()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    return childList.front()->GetDrawingY();
+    return this->GetListFront(this)->GetDrawingY();
 }
 
 Note *TabGrp::GetTopNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
-    Note *topNote = vrv_cast<Note *>(childList.back());
+    Note *topNote = vrv_cast<Note *>(this->GetListBack(this));
     assert(topNote);
     return topNote;
 }
 
 Note *TabGrp::GetBottomNote()
 {
-    const ArrayOfObjects &childList = this->GetList(this); // make sure it's initialized
-    assert(childList.size() > 0);
-
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(childList.front());
+    Note *bottomNote = vrv_cast<Note *>(this->GetListFront(this));
     assert(bottomNote);
     return bottomNote;
 }

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -70,13 +70,13 @@ void TabGrp::FilterList(ArrayOfConstObjects &childList) const
     std::sort(childList.begin(), childList.end(), TabCourseSort());
 }
 
-int TabGrp::GetYTop()
+int TabGrp::GetYTop() const
 {
     // The last note is the top
     return this->GetListBack(this)->GetDrawingY();
 }
 
-int TabGrp::GetYBottom()
+int TabGrp::GetYBottom() const
 {
     // The first note is the bottom
     return this->GetListFront(this)->GetDrawingY();
@@ -84,15 +84,25 @@ int TabGrp::GetYBottom()
 
 Note *TabGrp::GetTopNote()
 {
-    Note *topNote = vrv_cast<Note *>(this->GetListBack(this));
+    return const_cast<Note *>(std::as_const(*this).GetTopNote());
+}
+
+const Note *TabGrp::GetTopNote() const
+{
+    const Note *topNote = vrv_cast<const Note *>(this->GetListBack(this));
     assert(topNote);
     return topNote;
 }
 
 Note *TabGrp::GetBottomNote()
 {
+    return const_cast<Note *>(std::as_const(*this).GetBottomNote());
+}
+
+const Note *TabGrp::GetBottomNote() const
+{
     // The first note is the bottom
-    Note *bottomNote = vrv_cast<Note *>(this->GetListFront(this));
+    const Note *bottomNote = vrv_cast<const Note *>(this->GetListFront(this));
     assert(bottomNote);
     return bottomNote;
 }

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -58,16 +58,16 @@ bool TabGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void TabGrp::FilterList(ArrayOfObjects *childList)
+void TabGrp::FilterList(ArrayOfConstObjects &childList)
 {
     // Retain only note children of chords
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
-        iter = ((*iter)->Is(NOTE)) ? iter + 1 : childList->erase(iter);
+    while (iter != childList.end()) {
+        iter = ((*iter)->Is(NOTE)) ? iter + 1 : childList.erase(iter);
     }
 
-    std::sort(childList->begin(), childList->end(), TabCourseSort());
+    std::sort(childList.begin(), childList.end(), TabCourseSort());
 }
 
 int TabGrp::GetYTop()

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -58,16 +58,21 @@ bool TabGrp::IsSupportedChild(Object *child)
     return true;
 }
 
-void TabGrp::FilterList(ArrayOfConstObjects &childList) const
+void TabGrp::FilterList(ListOfConstObjects &childList) const
 {
     // Retain only note children of chords
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
-        iter = ((*iter)->Is(NOTE)) ? iter + 1 : childList.erase(iter);
+        if ((*iter)->Is(NOTE)) {
+            ++iter;
+        }
+        else {
+            iter = childList.erase(iter);
+        }
     }
 
-    std::sort(childList.begin(), childList.end(), TabCourseSort());
+    childList.sort(TabCourseSort());
 }
 
 int TabGrp::GetYTop() const

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -298,15 +298,15 @@ void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff, int staffSize)
     tupletNum->SetDrawingYRel(yRel);
 }
 
-void Tuplet::FilterList(ArrayOfObjects *childList)
+void Tuplet::FilterList(ArrayOfConstObjects &childList)
 {
     // We want to keep only notes and rests
     // Eventually, we also need to filter out grace notes properly (e.g., with sub-beams)
-    ArrayOfObjects::iterator iter = childList->begin();
+    ArrayOfConstObjects::iterator iter = childList.begin();
 
-    while (iter != childList->end()) {
+    while (iter != childList.end()) {
         if (!(*iter)->IsLayerElement() || !(*iter)->HasInterface(INTERFACE_DURATION)) {
-            iter = childList->erase(iter);
+            iter = childList.erase(iter);
         }
         else {
             ++iter;

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -298,11 +298,11 @@ void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff, int staffSize)
     tupletNum->SetDrawingYRel(yRel);
 }
 
-void Tuplet::FilterList(ArrayOfConstObjects &childList) const
+void Tuplet::FilterList(ListOfConstObjects &childList) const
 {
     // We want to keep only notes and rests
     // Eventually, we also need to filter out grace notes properly (e.g., with sub-beams)
-    ArrayOfConstObjects::iterator iter = childList.begin();
+    ListOfConstObjects::iterator iter = childList.begin();
 
     while (iter != childList.end()) {
         if (!(*iter)->IsLayerElement() || !(*iter)->HasInterface(INTERFACE_DURATION)) {
@@ -396,7 +396,7 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
         return;
     }
 
-    const ArrayOfObjects &tupletChildren = this->GetList(this);
+    const ListOfObjects &tupletChildren = this->GetList(this);
 
     // There are unbeamed notes of two different beams
     // treat all the notes as unbeamed
@@ -404,7 +404,7 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
 
     // The first step is to calculate all the stem directions
     // cycle into the elements and count the up and down dirs
-    ArrayOfObjects::const_iterator iter = tupletChildren.begin();
+    ListOfObjects::const_iterator iter = tupletChildren.begin();
     while (iter != tupletChildren.end()) {
         if ((*iter)->Is(CHORD)) {
             Chord *currentChord = vrv_cast<Chord *>(*iter);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -298,7 +298,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff, int staffSize)
     tupletNum->SetDrawingYRel(yRel);
 }
 
-void Tuplet::FilterList(ArrayOfConstObjects &childList)
+void Tuplet::FilterList(ArrayOfConstObjects &childList) const
 {
     // We want to keep only notes and rests
     // Eventually, we also need to filter out grace notes properly (e.g., with sub-beams)

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -396,7 +396,7 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
         return;
     }
 
-    const ArrayOfObjects *tupletChildren = this->GetList(this);
+    const ArrayOfObjects &tupletChildren = this->GetList(this);
 
     // There are unbeamed notes of two different beams
     // treat all the notes as unbeamed
@@ -404,8 +404,8 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
 
     // The first step is to calculate all the stem directions
     // cycle into the elements and count the up and down dirs
-    ArrayOfObjects::const_iterator iter = tupletChildren->begin();
-    while (iter != tupletChildren->end()) {
+    ArrayOfObjects::const_iterator iter = tupletChildren.begin();
+    while (iter != tupletChildren.end()) {
         if ((*iter)->Is(CHORD)) {
             Chord *currentChord = vrv_cast<Chord *>(*iter);
             assert(currentChord);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -170,7 +170,7 @@ void SystemAligner::SetSpacing(const ScoreDef *scoreDef)
 
     m_spacingTypes.clear();
 
-    const ArrayOfConstObjects &childList = scoreDef->GetList(scoreDef);
+    const ListOfConstObjects &childList = scoreDef->GetList(scoreDef);
     for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         // It should be staffDef only, but double check.
         if (!(*iter)->Is(STAFFDEF)) continue;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -164,17 +164,17 @@ double SystemAligner::GetJustificationSum(const Doc *doc) const
 
     return justificationSum;
 }
-void SystemAligner::SetSpacing(ScoreDef *scoreDef)
+void SystemAligner::SetSpacing(const ScoreDef *scoreDef)
 {
     assert(scoreDef);
 
     m_spacingTypes.clear();
 
-    const ArrayOfObjects &childList = scoreDef->GetList(scoreDef);
+    const ArrayOfConstObjects &childList = scoreDef->GetList(scoreDef);
     for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         // It should be staffDef only, but double check.
         if (!(*iter)->Is(STAFFDEF)) continue;
-        StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
+        const StaffDef *staffDef = vrv_cast<const StaffDef *>(*iter);
         assert(staffDef);
 
         m_spacingTypes[staffDef->GetN()] = CalculateSpacingAbove(staffDef);
@@ -200,27 +200,27 @@ SystemAligner::SpacingType SystemAligner::GetAboveSpacingType(Staff *staff)
     return iter->second;
 }
 
-SystemAligner::SpacingType SystemAligner::CalculateSpacingAbove(StaffDef *staffDef) const
+SystemAligner::SpacingType SystemAligner::CalculateSpacingAbove(const StaffDef *staffDef) const
 {
     assert(staffDef);
 
     SpacingType spacingType = SpacingType::None;
     if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
-        Object *staffChild = staffDef;
-        Object *staffParent = staffChild->GetParent();
+        const Object *staffChild = staffDef;
+        const Object *staffParent = staffChild->GetParent();
         bool notFirstInGroup = false;
         VisibleStaffDefOrGrpObject matchType;
         while (spacingType == SpacingType::None) {
             matchType.Skip(staffParent);
-            Object *firstVisible = staffParent->FindDescendantByComparison(&matchType, 1);
+            const Object *firstVisible = staffParent->FindDescendantByComparison(&matchType, 1);
 
             // for first child in staff group parent's symbol should be taken, except
             // when we had a child which not on the first place in group, than take first symbol
             notFirstInGroup = notFirstInGroup || (firstVisible && firstVisible != staffChild);
             if (notFirstInGroup) {
-                StaffGrp *staffGrp = dynamic_cast<StaffGrp *>(staffParent);
+                const StaffGrp *staffGrp = dynamic_cast<const StaffGrp *>(staffParent);
                 if (staffGrp && staffGrp->GetFirst(GRPSYM)) {
-                    GrpSym *grpSym = vrv_cast<GrpSym *>(staffGrp->GetFirst(GRPSYM));
+                    const GrpSym *grpSym = vrv_cast<const GrpSym *>(staffGrp->GetFirst(GRPSYM));
                     assert(grpSym);
                     switch (grpSym->GetSymbol()) {
                         case staffGroupingSym_SYMBOL_brace: spacingType = SpacingType::Brace; break;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -170,8 +170,8 @@ void SystemAligner::SetSpacing(ScoreDef *scoreDef)
 
     m_spacingTypes.clear();
 
-    const ArrayOfObjects *childList = scoreDef->GetList(scoreDef);
-    for (auto iter = childList->begin(); iter != childList->end(); ++iter) {
+    const ArrayOfObjects &childList = scoreDef->GetList(scoreDef);
+    for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         // It should be staffDef only, but double check.
         if (!(*iter)->Is(STAFFDEF)) continue;
         StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -47,10 +47,8 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     /******************************************************************/
     // initialization
 
-    const ArrayOfObjects &beamChildren = beam->GetList(beam);
-
     // Should we assert this at the beginning?
-    if (beamChildren.empty()) {
+    if (beam->HasEmptyList(beam)) {
         return;
     }
 
@@ -99,10 +97,8 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     /******************************************************************/
     // initialization
 
-    const ArrayOfObjects &fTremChildren = fTrem->GetList(fTrem);
-
     // Should we assert this at the beginning?
-    if (fTremChildren.empty()) {
+    if (fTrem->HasEmptyList(fTrem)) {
         return;
     }
     const ArrayOfBeamElementCoords *beamElementCoords = fTrem->GetElementCoords();

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -47,10 +47,10 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     /******************************************************************/
     // initialization
 
-    const ArrayOfObjects *beamChildren = beam->GetList(beam);
+    const ArrayOfObjects &beamChildren = beam->GetList(beam);
 
     // Should we assert this at the beginning?
-    if (beamChildren->empty()) {
+    if (beamChildren.empty()) {
         return;
     }
 
@@ -99,10 +99,10 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     /******************************************************************/
     // initialization
 
-    const ArrayOfObjects *fTremChildren = fTrem->GetList(fTrem);
+    const ArrayOfObjects &fTremChildren = fTrem->GetList(fTrem);
 
     // Should we assert this at the beginning?
-    if (fTremChildren->empty()) {
+    if (fTremChildren.empty()) {
         return;
     }
     const ArrayOfBeamElementCoords *beamElementCoords = fTrem->GetElementCoords();

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -330,7 +330,7 @@ void View::DrawLigature(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     // Render a bracket for the ligature
     if (m_options->m_ligatureAsBracket.GetValue()) {
-        const ArrayOfObjects &notes = ligature->GetList(ligature);
+        const ListOfObjects &notes = ligature->GetList(ligature);
 
         if (notes.size() > 0) {
             int y = staff->GetDrawingY();

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -330,17 +330,16 @@ void View::DrawLigature(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     // Render a bracket for the ligature
     if (m_options->m_ligatureAsBracket.GetValue()) {
-        const ArrayOfObjects *notes = ligature->GetList(ligature);
-        assert(notes);
+        const ArrayOfObjects &notes = ligature->GetList(ligature);
 
-        if (notes->size() > 0) {
+        if (notes.size() > 0) {
             int y = staff->GetDrawingY();
             Note *firstNote = ligature->GetFirstNote();
             int x1 = firstNote->GetContentLeft();
             Note *lastNote = ligature->GetLastNote();
             int x2 = lastNote->GetContentRight();
             // Look for the highest note position in the ligature
-            for (auto &iter : *notes) {
+            for (auto &iter : notes) {
                 Note *note = vrv_cast<Note *>(iter);
                 assert(note);
                 y = std::max(y, note->GetContentTop());

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -137,8 +137,8 @@ void View::SetScoreDefDrawingWidth(DeviceContext *dc, ScoreDef *scoreDef)
     }
 
     // longest key signature of the staffDefs
-    const ArrayOfObjects *scoreDefList = scoreDef->GetList(scoreDef); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = scoreDefList->begin(); it != scoreDefList->end(); ++it) {
+    const ArrayOfObjects &scoreDefList = scoreDef->GetList(scoreDef); // make sure it's initialized
+    for (ArrayOfObjects::const_iterator it = scoreDefList.begin(); it != scoreDefList.end(); ++it) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*it);
         assert(staffDef);
         if (!staffDef->HasKeySigInfo()) continue;
@@ -794,14 +794,14 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
     }
     else {
         if (barLine->GetForm() == BARRENDITION_NONE) return;
-        const ArrayOfObjects *staffDefs = staffGrp->GetList(staffGrp);
-        if (staffDefs->empty()) {
+        const ArrayOfObjects &staffDefs = staffGrp->GetList(staffGrp);
+        if (staffDefs.empty()) {
             return;
         }
 
         StaffDef *firstDef = NULL;
         ArrayOfObjects::const_iterator iter;
-        for (iter = staffDefs->begin(); iter != staffDefs->end(); ++iter) {
+        for (iter = staffDefs.begin(); iter != staffDefs.end(); ++iter) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
             assert(staffDef);
             if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
@@ -812,7 +812,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
 
         StaffDef *lastDef = NULL;
         ArrayOfObjects::const_reverse_iterator riter;
-        for (riter = staffDefs->rbegin(); riter != staffDefs->rend(); ++riter) {
+        for (riter = staffDefs.rbegin(); riter != staffDefs.rend(); ++riter) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(*riter);
             assert(staffDef);
             if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
@@ -860,8 +860,8 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // Now we have a barthru barLine, but we have dots so we still need to go through each staff
         if (barLine->HasRepetitionDots()) {
             StaffDef *childStaffDef = NULL;
-            const ArrayOfObjects *childList = staffGrp->GetList(staffGrp); // make sure it's initialized
-            for (ArrayOfObjects::const_reverse_iterator it = childList->rbegin(); it != childList->rend(); ++it) {
+            const ArrayOfObjects &childList = staffGrp->GetList(staffGrp); // make sure it's initialized
+            for (ArrayOfObjects::const_reverse_iterator it = childList.rbegin(); it != childList.rend(); ++it) {
                 childStaffDef = dynamic_cast<StaffDef *>((*it));
                 if (childStaffDef) {
                     AttNIntegerComparison comparison(STAFF, childStaffDef->GetN());
@@ -1103,7 +1103,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     assert(staff);
 
     MeterSigGrp *meterSigGrp = layer->GetStaffDefMeterSigGrp();
-    const ArrayOfObjects *childList = meterSigGrp->GetList(meterSigGrp);
+    const ArrayOfObjects &childList = meterSigGrp->GetList(meterSigGrp);
 
     const int glyphSize = staff->GetDrawingStaffNotationSize();
 
@@ -1111,7 +1111,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     int offset = 0;
     dc->StartGraphic(meterSigGrp, "", meterSigGrp->GetUuid());
     // Draw meterSigGrp by alternating meterSig and plus sign (when required)
-    for (auto iter = childList->begin(); iter != childList->end(); ++iter) {
+    for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         MeterSig *meterSig = vrv_cast<MeterSig *>(*iter);
         assert(meterSig);
 
@@ -1122,7 +1122,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
         const int y = staff->GetDrawingY() - unit * (staff->m_drawingLines - 1);
         const int x = meterSig->GetDrawingX() + offset;
         const int width = meterSig->GetContentRight() - meterSig->GetContentLeft();
-        if ((meterSigGrp->GetFunc() == meterSigGrpLog_FUNC_mixed) && (iter != std::prev(childList->end()))) {
+        if ((meterSigGrp->GetFunc() == meterSigGrpLog_FUNC_mixed) && (iter != std::prev(childList.end()))) {
             // draw plus sign here
             const int plusX = x + width + unit / 2;
             this->DrawSmuflCode(dc, plusX, y, SMUFL_E08C_timeSigPlus, glyphSize, false);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -137,8 +137,8 @@ void View::SetScoreDefDrawingWidth(DeviceContext *dc, ScoreDef *scoreDef)
     }
 
     // longest key signature of the staffDefs
-    const ArrayOfObjects &scoreDefList = scoreDef->GetList(scoreDef); // make sure it's initialized
-    for (ArrayOfObjects::const_iterator it = scoreDefList.begin(); it != scoreDefList.end(); ++it) {
+    const ListOfObjects &scoreDefList = scoreDef->GetList(scoreDef); // make sure it's initialized
+    for (ListOfObjects::const_iterator it = scoreDefList.begin(); it != scoreDefList.end(); ++it) {
         StaffDef *staffDef = vrv_cast<StaffDef *>(*it);
         assert(staffDef);
         if (!staffDef->HasKeySigInfo()) continue;
@@ -794,13 +794,13 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
     }
     else {
         if (barLine->GetForm() == BARRENDITION_NONE) return;
-        const ArrayOfObjects &staffDefs = staffGrp->GetList(staffGrp);
+        const ListOfObjects &staffDefs = staffGrp->GetList(staffGrp);
         if (staffDefs.empty()) {
             return;
         }
 
         StaffDef *firstDef = NULL;
-        ArrayOfObjects::const_iterator iter;
+        ListOfObjects::const_iterator iter;
         for (iter = staffDefs.begin(); iter != staffDefs.end(); ++iter) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
             assert(staffDef);
@@ -811,7 +811,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         }
 
         StaffDef *lastDef = NULL;
-        ArrayOfObjects::const_reverse_iterator riter;
+        ListOfObjects::const_reverse_iterator riter;
         for (riter = staffDefs.rbegin(); riter != staffDefs.rend(); ++riter) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(*riter);
             assert(staffDef);
@@ -860,8 +860,8 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // Now we have a barthru barLine, but we have dots so we still need to go through each staff
         if (barLine->HasRepetitionDots()) {
             StaffDef *childStaffDef = NULL;
-            const ArrayOfObjects &childList = staffGrp->GetList(staffGrp); // make sure it's initialized
-            for (ArrayOfObjects::const_reverse_iterator it = childList.rbegin(); it != childList.rend(); ++it) {
+            const ListOfObjects &childList = staffGrp->GetList(staffGrp); // make sure it's initialized
+            for (ListOfObjects::const_reverse_iterator it = childList.rbegin(); it != childList.rend(); ++it) {
                 childStaffDef = dynamic_cast<StaffDef *>((*it));
                 if (childStaffDef) {
                     AttNIntegerComparison comparison(STAFF, childStaffDef->GetN());
@@ -1103,7 +1103,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     assert(staff);
 
     MeterSigGrp *meterSigGrp = layer->GetStaffDefMeterSigGrp();
-    const ArrayOfObjects &childList = meterSigGrp->GetList(meterSigGrp);
+    const ListOfObjects &childList = meterSigGrp->GetList(meterSigGrp);
 
     const int glyphSize = staff->GetDrawingStaffNotationSize();
 


### PR DESCRIPTION
The `ObjectListInterface` has a virtual method `FilterList` which was designed to filter the list managed by the interface for specific classes. The list is lazy initialised: whenever `GetList` is called, the list is calculated and filtered on demand. Over time people started using `FilterList` for lazy initialisation of class members that depend on the tree structure, but have nothing to do with the interface. This has the following disadvantages:
- One has bad control over when the initialisation will actually happen (due to the multiple calls of `GetList` in various places).
- Any function that relies on the list interface cannot be made const, since there is always a small chance that some initialization happens in the background. Examples are `Chord::GetYTop()` and `StaffGrp::GetMaxStaffSize()`.

This PR factors the initialisation not belonging to the interface out of `FilterList`. Mostly this is moved to a new functor `InitData`. Moreover, we add some convenience methods to the `ObjectListInterface` and improve const correctness. In particular, the list now manages a list of const objects. As an application we turn many methods into const that rely on the interface.