### PR TITLE
Allow forcing horizontal beams with options

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -104,16 +104,15 @@ private:
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
     void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
 
-    void CalcBeamInit(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
+    void CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
     void CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff, int &yMax, int &yMin);
 
-    bool CalcBeamSlope(
-        Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step);
+    bool CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step);
 
     void CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step);
 
-    void CalcBeamPosition(Doc *doc, Staff *staff, Layer *layer, BeamDrawingInterface *beamInterface, bool isHorizontal);
+    void CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
     void CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool shorten, int &step);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -108,13 +108,13 @@ private:
 
     void CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff, int &yMax, int &yMin);
 
-    bool CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step);
+    bool CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step);
 
     void CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step);
 
     void CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
-    void CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool shorten, int &step);
+    void CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step);
 
     // Helper to adjust position of starting point to make sure that beam start-/endpoints touch the staff lines
     void CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -110,6 +110,8 @@ private:
 
     bool CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step);
 
+    int CalcBeamSlopeStep(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep);
+
     void CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step);
 
     void CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -95,7 +95,7 @@ void BeamSegment::CalcBeam(
 
     // For recursive calls, avoid to re-init values
     if (init) {
-        this->CalcBeamInit(layer, staff, doc, beamInterface, place);
+        this->CalcBeamInit(staff, doc, beamInterface, place);
     }
 
     bool horizontal = true;
@@ -111,7 +111,8 @@ void BeamSegment::CalcBeam(
     else {
         beamInterface->m_fractionSize = staff->m_drawingStaffSize;
 
-        horizontal = beamInterface->IsHorizontal();
+        if (doc->GetOptions()->m_beamMaxSlope.GetValue())
+            horizontal = beamInterface->IsHorizontal();
         // Beam@place has precedence - however, in some cases, CalcBeam is called recursively because we need to change
         // the place This occurs when mixed makes no sense and the beam is placed above or below instead.
         this->CalcBeamPlace(layer, beamInterface, place);
@@ -124,12 +125,12 @@ void BeamSegment::CalcBeam(
     CalcBeamStemLength(staff, beamInterface->m_drawingPlace, horizontal);
 
     // Set drawing stem positions
-    CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
+    CalcBeamPosition(doc, staff, beamInterface, horizontal);
     if (BEAMPLACE_mixed == beamInterface->m_drawingPlace) {
         if (NeedToResetPosition(staff, doc, beamInterface)) {
-            CalcBeamInit(layer, staff, doc, beamInterface, place);
+            CalcBeamInit(staff, doc, beamInterface, place);
             CalcBeamStemLength(staff, beamInterface->m_drawingPlace, horizontal);
-            CalcBeamPosition(doc, staff, layer, beamInterface, horizontal);
+            CalcBeamPosition(doc, staff, beamInterface, horizontal);
         }
     }
 
@@ -516,10 +517,8 @@ void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInt
     }
 }
 
-void BeamSegment::CalcBeamInit(
-    Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
+void BeamSegment::CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
 {
-    assert(layer);
     assert(staff);
     assert(doc);
     assert(beamInterface);
@@ -669,10 +668,8 @@ void BeamSegment::CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff
     }
 }
 
-bool BeamSegment::CalcBeamSlope(
-    Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step)
+bool BeamSegment::CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, bool &shorten, int &step)
 {
-    assert(layer);
     assert(staff);
     assert(doc);
     assert(beamInterface);
@@ -934,8 +931,7 @@ void BeamSegment::CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int ste
     }
 }
 
-void BeamSegment::CalcBeamPosition(
-    Doc *doc, Staff *staff, Layer *layer, BeamDrawingInterface *beamInterface, bool isHorizontal)
+void BeamSegment::CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal)
 {
     // Set drawing stem positions
     for (auto coord : m_beamElementCoordRefs) {
@@ -970,7 +966,7 @@ void BeamSegment::CalcBeamPosition(
     if (!isHorizontal) {
         bool shorten;
         int step;
-        if (this->CalcBeamSlope(layer, staff, doc, beamInterface, shorten, step)) {
+        if (this->CalcBeamSlope(staff, doc, beamInterface, shorten, step)) {
             this->CalcAdjustSlope(staff, doc, beamInterface, shorten, step);
         }
         else {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -111,8 +111,7 @@ void BeamSegment::CalcBeam(
     else {
         beamInterface->m_fractionSize = staff->m_drawingStaffSize;
 
-        if (doc->GetOptions()->m_beamMaxSlope.GetValue())
-            horizontal = beamInterface->IsHorizontal();
+        if (doc->GetOptions()->m_beamMaxSlope.GetValue()) horizontal = beamInterface->IsHorizontal();
         // Beam@place has precedence - however, in some cases, CalcBeam is called recursively because we need to change
         // the place This occurs when mixed makes no sense and the beam is placed above or below instead.
         this->CalcBeamPlace(layer, beamInterface, place);
@@ -705,7 +704,7 @@ bool BeamSegment::CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *be
     // This occurs with 8th and 16th only and with a reduced distance of 3 stave-spaces (6 units)
     bool shortStep = false;
     step = this->CalcBeamSlopeStep(doc, staff, beamInterface, noteStep, shortStep);
-    
+
     // Short accessors
     const data_BEAMPLACE place = beamInterface->m_drawingPlace;
     // The current step according to stems - this can be flat because of the stem extended

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1149,7 +1149,7 @@ Options::Options()
     this->Register(&m_barLineWidth, "barLineWidth", &m_generalLayout);
 
     m_beamMaxSlope.SetInfo("Beam max slope", "The maximum beam slope");
-    m_beamMaxSlope.Init(10, 1, 20);
+    m_beamMaxSlope.Init(10, 0, 20);
     this->Register(&m_beamMaxSlope, "beamMaxSlope", &m_generalLayout);
 
     m_beamMinSlope.SetInfo("Beam min slope", "The minimum beam slope");


### PR DESCRIPTION
Changed minimal value for `m_beamMaxSlope` option to 0. This will allow to force all beams in the score to be horizontal.
Additionally, refactored parts of the `Beam` code by removing obsolete comments and moving parts of the code to separate method.