### PR TITLE
Add sanity checks to avoid crashes in several places

### DIFF
--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -101,6 +101,8 @@ ArrayOfObjects BeamSpan::GetBeamSpanElementList(Layer *layer, Staff *staff)
     ListOfObjects objects;
     layer->FindAllDescendantsBetween(&objects, &classIds, this->GetStart(), this->GetEnd(), true, 1);
 
+    if (objects.empty()) return {};
+
     ArrayOfObjects beamSpanElements(objects.begin(), objects.end());
     // If last element is not equal to the end, there is high chance that this beamSpan is cross-measure.
     // Look for the same N-staff N-layer in next measure and try finding end there
@@ -208,7 +210,7 @@ int BeamSpan::CalcStem(FunctorParams *functorParams)
     CalcStemParams *params = vrv_params_cast<CalcStemParams *>(functorParams);
     assert(params);
 
-    if (!this->GetStart() || !this->GetEnd()) return FUNCTOR_CONTINUE;
+    if (!this->GetStart() || !this->GetEnd() || m_beamedElements.empty()) return FUNCTOR_CONTINUE;
 
     Layer *layer = vrv_cast<Layer *>(this->GetStart()->GetFirstAncestor(LAYER));
     Staff *staff = vrv_cast<Staff *>(this->GetStart()->GetFirstAncestor(STAFF));
@@ -237,6 +239,8 @@ int BeamSpan::PrepareBeamSpanElements(FunctorParams *functorParams)
     if (!layer || !staff) return FUNCTOR_SIBLINGS;
 
     m_beamedElements = this->HasPlist() ? *this->GetRefs() : this->GetBeamSpanElementList(layer, staff);
+
+    if (m_beamedElements.empty()) return FUNCTOR_SIBLINGS;
 
     // set current beamSpan as referencedElement for all beamed elements (for thesake of figuring if corresponding
     // element is in beamSpan)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2072,7 +2072,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
         LayerElement *element = vrv_cast<LayerElement *>(this);
         assert(element);
         Clef *clef = vrv_cast<Clef *>(element->ThisOrSameasAsLink());
-        assert(clef);
+        if (!clef->Is(CLEF)) return FUNCTOR_CONTINUE;
         if (clef->IsScoreDefElement()) {
             return FUNCTOR_CONTINUE;
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2071,8 +2071,9 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
     if (this->Is(CLEF)) {
         LayerElement *element = vrv_cast<LayerElement *>(this);
         assert(element);
-        Clef *clef = vrv_cast<Clef *>(element->ThisOrSameasAsLink());
-        if (!clef->Is(CLEF)) return FUNCTOR_CONTINUE;
+        LayerElement *elementOrLink = element->ThisOrSameasAsLink();
+        if (!elementOrLink || !elementOrLink->Is(CLEF)) return FUNCTOR_CONTINUE;
+        Clef *clef = vrv_cast<Clef *>(elementOrLink);
         if (clef->IsScoreDefElement()) {
             return FUNCTOR_CONTINUE;
         }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -381,7 +381,7 @@ int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
 
 void Staff::SetAlignmentBeamAdjustment(int adjust)
 {
-    m_staffAlignment->SetBeamAdjust(adjust);
+    if (m_staffAlignment) m_staffAlignment->SetBeamAdjust(adjust);
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1512,11 +1512,12 @@ void View::DrawStemMod(DeviceContext *dc, LayerElement *element, Staff *staff)
         drawingDur = duration->GetActualDur();
     }
     data_STEMMODIFIER stemMod = element->GetDrawingStemMod();
-    if (stemMod == STEMMODIFIER_NONE) return;
+    if ((stemMod == STEMMODIFIER_NONE) || (stemMod == STEMMODIFIER_none)) return;
 
     // calculate height offset for positioning of stem mod elements on the stem
     const int noteLoc = note->GetDrawingLoc();
     const wchar_t code = element->StemModToGlyph(stemMod);
+    if (!code) return;
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int glyphHalfHeight = m_doc->GetGlyphHeight(code, staff->m_drawingStaffSize, false) / 2;
     int height = 2 * unit;


### PR DESCRIPTION
Just a few code changes to avoid crashes that might happen in several cases.
- check that `m_staffAlignment` is initialized before using the pointer
- make sure that glyph code for tremolo is valid
- make sure that `beamSpan` has elements before doing any calculations