### PR TITLE
Allow meterSigGrp in staffDef

### DIFF
--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -363,6 +363,7 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
             staffDef->SetDrawMensur(false);
             MeterSigGrp *meterSigGrp = newStaffDef->GetMeterSigGrpCopy();
             MeterSig *meterSig = meterSigGrp->GetSimplifiedMeterSig();
+            staffDef->SetCurrentMeterSigGrp(meterSigGrp);
             delete meterSigGrp;
             staffDef->SetCurrentMeterSig(meterSig);
             delete meterSig;


### PR DESCRIPTION
This small PR adds missing functionality for rendering `meterSigGrp` on `staffDef` level.