### PR TITLE
Improve grace note ties

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -358,10 +358,11 @@ public:
  * member 2: the cumulated shift on the previous aligners
  * member 3: the list of staffN in the top-level scoreDef
  * member 4: the flag indicating whereas the alignment is in a Measure or in a Grace
- * member 5: the pointer to the right ALIGNMENT_DEFAULT (if any)
- * member 6: the Doc
- * member 7: the Functor to be redirected to MeasureAligner and GraceAligner
- * member 8: the end Functor for redirection
+ * member 5: list of tie endpoints for the current measure
+ * member 6: the pointer to the right ALIGNMENT_DEFAULT (if any)
+ * member 7: the Doc
+ * member 8: the Functor to be redirected to MeasureAligner and GraceAligner
+ * member 9: the end Functor for redirection
  **/
 
 class AdjustGraceXPosParams : public FunctorParams {
@@ -373,6 +374,7 @@ public:
         m_graceCumulatedXShift = 0;
         m_staffNs = staffNs;
         m_isGraceAlignment = false;
+        m_measureTieEndpoints.clear();
         m_rightDefaultAlignment = NULL;
         m_doc = doc;
         m_functor = functor;
@@ -384,6 +386,7 @@ public:
     int m_graceCumulatedXShift;
     std::vector<int> m_staffNs;
     bool m_isGraceAlignment;
+    MeasureTieEndpoints m_measureTieEndpoints;
     Alignment *m_rightDefaultAlignment;
     Doc *m_doc;
     Functor *m_functor;
@@ -708,7 +711,7 @@ public:
     std::vector<ClassId> m_includes;
     std::vector<ClassId> m_excludes;
     bool m_rightBarLinesOnly;
-    std::vector<std::pair<LayerElement *, LayerElement *>> m_measureTieEndpoints;
+    MeasureTieEndpoints m_measureTieEndpoints;
     Doc *m_doc;
     Functor *m_functor;
     Functor *m_functorEnd;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -370,6 +370,8 @@ typedef std::map<std::string, std::function<Object *(void)>> MapOfStrConstructor
 
 typedef std::map<std::string, ClassId> MapOfStrClassIds;
 
+typedef std::vector<std::pair<LayerElement *, LayerElement *>> MeasureTieEndpoints;
+
 typedef bool (*NotePredicate)(Note *);
 
 /**

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1054,17 +1054,6 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
                 params->m_rightDefaultAlignment->GetLeftRight(*iter, minLeft, maxRight, exclude);
                 if (minLeft != -VRV_UNSET)
                     graceMaxPos = minLeft - params->m_doc->GetLeftMargin(NOTE) * params->m_doc->GetDrawingUnit(75);
-
-                auto it = std::find_if(params->m_measureTieEndpoints.cbegin(), params->m_measureTieEndpoints.cend(),
-                    [this](const std::pair<LayerElement *, LayerElement *> &pair) {
-                        return pair.first->GetAlignment() == this;
-                    });
-                if (it != params->m_measureTieEndpoints.end()) {
-                    const int unit = params->m_doc->GetDrawingUnit(100);
-                    const int minTieLength = params->m_doc->GetOptions()->m_tieMinLength.GetValue() * unit;
-                    const int diff = params->m_rightDefaultAlignment->GetXRel() - graceMaxPos;
-                    if (diff < minTieLength) graceMaxPos -= (unit + minTieLength - diff);
-                }
             }
             // This happens when grace notes are at the end of a measure before a barline
             else {

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1054,6 +1054,17 @@ int Alignment::AdjustGraceXPos(FunctorParams *functorParams)
                 params->m_rightDefaultAlignment->GetLeftRight(*iter, minLeft, maxRight, exclude);
                 if (minLeft != -VRV_UNSET)
                     graceMaxPos = minLeft - params->m_doc->GetLeftMargin(NOTE) * params->m_doc->GetDrawingUnit(75);
+
+                auto it = std::find_if(params->m_measureTieEndpoints.cbegin(), params->m_measureTieEndpoints.cend(),
+                    [this](const std::pair<LayerElement *, LayerElement *> &pair) {
+                        return pair.first->GetAlignment() == this;
+                    });
+                if (it != params->m_measureTieEndpoints.end()) {
+                    const int unit = params->m_doc->GetDrawingUnit(100);
+                    const int minTieLength = params->m_doc->GetOptions()->m_tieMinLength.GetValue() * unit;
+                    const int diff = params->m_rightDefaultAlignment->GetXRel() - graceMaxPos;
+                    if (diff < minTieLength) graceMaxPos -= (unit + minTieLength - diff);
+                }
             }
             // This happens when grace notes are at the end of a measure before a barline
             else {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1865,6 +1865,16 @@ int LayerElement::AdjustGraceXPos(FunctorParams *functorParams)
 
     params->m_graceUpcomingMaxPos = std::min(selfLeft, params->m_graceUpcomingMaxPos);
 
+    auto it = std::find_if(params->m_measureTieEndpoints.cbegin(), params->m_measureTieEndpoints.cend(),
+        [this](const std::pair<LayerElement *, LayerElement *> &pair) { return pair.first == this; });
+    if (it != params->m_measureTieEndpoints.end()) {
+        const int unit = params->m_doc->GetDrawingUnit(100);
+        const int minTieLength = params->m_doc->GetOptions()->m_tieMinLength.GetValue() * unit;
+        const int diff = params->m_rightDefaultAlignment->GetXRel() - this->GetSelfRight();
+
+        if (diff < (minTieLength + unit)) params->m_graceMaxPos -= (unit + minTieLength - diff);
+    }
+
     return FUNCTOR_SIBLINGS;
 }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1017,6 +1017,7 @@ int Measure::AdjustGraceXPos(FunctorParams *functorParams)
     params->m_rightDefaultAlignment = NULL;
 
     params->m_staffNs = staffNsReversed;
+    params->m_measureTieEndpoints = this->GetInternalTieEndpoints();
     m_measureAligner.Process(params->m_functor, params, params->m_functorEnd, NULL, UNLIMITED_DEPTH, BACKWARD);
 
     // Put params back

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -218,12 +218,13 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
 
     // shortTie correction cannot be applied for chords
     const bool isShortTie = !startParentChord && !endParentChord && (endPoint.x - startPoint.x < 4 * drawingUnit);
+    const bool isSameDirection = !(note1 && note2) || (note1->GetStemDir() == note2->GetStemDir());
 
     const int ySign = (drawingCurveDir == curvature_CURVEDIR_above) ? 1 : -1;
 
     startPoint.y += ySign * drawingUnit / 2;
     endPoint.y += ySign * drawingUnit / 2;
-    if (isShortTie) {
+    if (isShortTie && isSameDirection) {
         startPoint.y += ySign * drawingUnit;
         endPoint.y += ySign * drawingUnit;
     }


### PR DESCRIPTION
Changed code to make sure that grace note ties adhere to the --tie-min-length option:

Before:
![image](https://user-images.githubusercontent.com/1819669/163952920-7c5c2640-5130-46fd-800a-b90b519141ff.png)

After:
![image](https://user-images.githubusercontent.com/1819669/163952831-64e7ce28-eddf-458d-b2fc-0fe2cee078a6.png)
