### PR TITLE
Allow clefs in multiRest measures

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1089,15 +1089,23 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
     // Adjust min width based on multirest attributes (@num and @width), but only if these values are larger than
     // current min width
     else if (this->FindDescendantByType(MULTIREST) != NULL) {
+        const int unit = params->m_doc->GetDrawingUnit(params->m_staffSize);
         MultiRest *multiRest = vrv_cast<MultiRest *>(this->FindDescendantByType(MULTIREST));
         const int num = multiRest->GetNum();
         if (multiRest->HasWidth()) {
-            const int fixedWidth
-                = multiRest->AttWidth::GetWidth() * (params->m_doc->GetDrawingUnit(params->m_staffSize) + 4);
+            const int fixedWidth = multiRest->AttWidth::GetWidth() * (unit + 4);
             if (minMeasureWidth < fixedWidth) minMeasureWidth = fixedWidth;
         }
         else if (num > 10) {
             minMeasureWidth *= log1p(num) / 2;
+        }
+        Object *layer = multiRest->GetFirstAncestor(LAYER);
+        if (layer->GetLast() != multiRest) {
+            Object *object = layer->GetNext(multiRest);
+            if (object && object->Is(CLEF)) {
+                const int clefWidth = object->GetContentRight() - object->GetContentLeft();
+                minMeasureWidth += clefWidth + 0.65 * unit;
+            }
         }
     }
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -1104,7 +1104,7 @@ int Measure::AdjustXPos(FunctorParams *functorParams)
             Object *object = layer->GetNext(multiRest);
             if (object && object->Is(CLEF)) {
                 const int clefWidth = object->GetContentRight() - object->GetContentLeft();
-                minMeasureWidth += clefWidth + 0.65 * unit;
+                minMeasureWidth += clefWidth + params->m_doc->GetOptions()->m_clefChangeFactor.GetValue() * unit;
             }
         }
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1131,8 +1131,19 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    const int measureWidth = measure->GetInnerWidth();
-    const int xCentered = multiRest->GetDrawingX();
+    int measureWidth = measure->GetInnerWidth();
+    int xCentered = multiRest->GetDrawingX();
+    // in case there is CLEF element in the same measure to the right of the mRest, we need to adjust width and starting
+    // postion of it to make sure that there is no overlap
+    if (layer->GetLast() != element) {
+        Object *object = layer->GetNext(element);
+        if (object && object->Is(CLEF)) {
+            const int rightMargin = xCentered + measureWidth / 2;
+            const int widthAdjust = rightMargin - object->GetDrawingX();
+            measureWidth -= widthAdjust;
+            xCentered -= widthAdjust / 2;
+        }
+    }
 
     // We do not support more than three chars
     const int num = std::min(multiRest->GetNum(), 999);


### PR DESCRIPTION
closes #2792

Removed overlap of clefs with multiRests.
![image](https://user-images.githubusercontent.com/1819669/163976824-05609c16-548e-4c6f-beac-3907e1d1b2f3.png)
