### PR TITLE
Add Clone method to Dots, Stem and Flag classes

### DIFF
--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -35,6 +35,7 @@ public:
     virtual ~Dots();
     void Reset() override;
     std::string GetClassName() const override { return "Dots"; }
+    Object *Clone() const override { return new Dots(*this); }
     ///@}
 
     /** Override the method since alignment is required */
@@ -111,6 +112,7 @@ public:
     virtual ~Flag();
     void Reset() override;
     std::string GetClassName() const override { return "Flag"; }
+    Object *Clone() const override { return new Flag(*this); }
     ///@}
 
     /** Override the method since alignment is required */
@@ -330,6 +332,7 @@ public:
     virtual ~Stem();
     void Reset() override;
     std::string GetClassName() const override { return "Stem"; }
+    Object *Clone() const override { return new Stem(*this); }
     ///@}
 
     /** Override the method since alignment is required */


### PR DESCRIPTION
Normally, files with notes of 'normal' (e.g. "1", "2", etc.) duration would crash if notation were to be `mensural`. This change make so that there is no crash there by introducing `Clone()` method to some of the classes (while retaining the fact that clone does nothing).

<details><summary>Example:</summary>

```
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Custos</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2022-04-19">2022-04-19</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.2.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" notationtype="mensural">
                        <clef shape="F" line="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <note dur="breve" oct="3" pname="c" accid.ges="n" />
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>