### PR TITLE
Implement support for extended MeterSig symbols

### DIFF
--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -207,9 +207,6 @@ public:
     std::string ProlatioToStr(data_PROLATIO data) const;
     data_PROLATIO StrToProlatio(const std::string &value, bool logWarning = true) const;
 
-    std::string SummandListToStr(data_SUMMAND_List data) const;
-    data_SUMMAND_List StrToSummandList(std::string value) const;
-
     std::string TempusToStr(data_TEMPUS data) const;
     data_TEMPUS StrToTempus(const std::string &value, bool logWarning = true) const;
 

--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -162,7 +162,7 @@ public:
         return StrToVU(value, logWarning);
     }
 
-    std::string Att::MetercountPairToStr(const data_METERCOUNT_pair &data) const;
+    std::string MetercountPairToStr(const data_METERCOUNT_pair &data) const;
     data_METERCOUNT_pair StrToMetercountPair(const std::string &value) const;
 
     std::string ModusmaiorToStr(data_MODUSMAIOR data) const;

--- a/include/vrv/att.h
+++ b/include/vrv/att.h
@@ -162,6 +162,9 @@ public:
         return StrToVU(value, logWarning);
     }
 
+    std::string Att::MetercountPairToStr(const data_METERCOUNT_pair &data) const;
+    data_METERCOUNT_pair StrToMetercountPair(const std::string &value) const;
+
     std::string ModusmaiorToStr(data_MODUSMAIOR data) const;
     data_MODUSMAIOR StrToModusmaior(const std::string &value, bool logWarning = true) const;
 

--- a/include/vrv/attdef.h
+++ b/include/vrv/attdef.h
@@ -262,11 +262,6 @@ enum data_PITCHNAME_GES {
 enum data_PROLATIO { PROLATIO_NONE = -3, PROLATIO_2 = 2, PROLATIO_3 };
 
 /**
- * A typedef for a list of integer summands.
- */
-typedef std::vector<int> data_SUMMAND_List;
-
-/**
  * MEI data.TIE
  */
 enum data_TIE { TIE_NONE = 0, TIE_i, TIE_m, TIE_t };

--- a/include/vrv/attdef.h
+++ b/include/vrv/attdef.h
@@ -160,6 +160,16 @@ typedef data_VU data_MEASUREMENTABS;
 typedef data_VU data_MEASUREMENTREL;
 
 /**
+ * enum class for the signs used in meter counts
+ */
+enum class MeterCountSign { None, Slash, Minus, Asterisk, Plus };
+
+/**
+ * A typedef for a pair of metersign counts and sign combining them
+ */
+typedef std::pair<std::vector<int>, MeterCountSign> data_METERCOUNT_pair;
+
+/**
  * MEI data.MIDIBPM
  */
 typedef int data_MIDIBPM;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -472,7 +472,7 @@ private:
     /* meter signature */
     std::vector<int> m_meterCount = { 4 };
     int m_meterUnit = 4;
-    MeterSig::MeterCountSign m_meterSign = MeterSig::MeterCountSign::None;
+    MeterCountSign m_meterSign = MeterCountSign::None;
     /* part information */
     Label *m_label = NULL;
     LabelAbbr *m_labelAbbr = NULL;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -17,6 +17,7 @@
 
 #include "attdef.h"
 #include "io.h"
+#include "metersig.h"
 #include "vrvdef.h"
 
 //----------------------------------------------------------------------------
@@ -471,6 +472,7 @@ private:
     /* meter signature */
     std::vector<int> m_meterCount = { 4 };
     int m_meterUnit = 4;
+    MeterSig::CountSign m_meterSign = MeterSig::CountSign::None;
     /* part information */
     Label *m_label = NULL;
     LabelAbbr *m_labelAbbr = NULL;

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -472,7 +472,7 @@ private:
     /* meter signature */
     std::vector<int> m_meterCount = { 4 };
     int m_meterUnit = 4;
-    MeterSig::CountSign m_meterSign = MeterSig::CountSign::None;
+    MeterSig::MeterCountSign m_meterSign = MeterSig::MeterCountSign::None;
     /* part information */
     Label *m_label = NULL;
     LabelAbbr *m_labelAbbr = NULL;

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -25,7 +25,7 @@ class ScoreDefInterface;
  */
 class MeterSig : public LayerElement, public AttEnclosingChars, public AttMeterSigLog, public AttMeterSigVis {
 public:
-    enum class CountSign { None, Divide, Minus, Multiply, Plus };
+    enum class MeterCountSign { None, Slash, Minus, Asterisk, Plus };
     /**
      * @name Constructors, destructors, and other standard methods
      * Reset method resets all attribute classes.
@@ -51,8 +51,8 @@ public:
      * Set/get methods to get operation signa and meter counts as separate values
      */
     ///@{
-    std::pair<std::vector<int>, CountSign> GetMeterCounts() const;
-    void SetMeterCounts(const std::vector<int> &counts, MeterSig::CountSign sign);
+    std::pair<std::vector<int>, MeterCountSign> GetMeterCounts() const;
+    void SetMeterCounts(const std::vector<int> &counts, MeterSig::MeterCountSign sign);
     ///@}
 
     /** Retrieves the symbol glyph */

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -25,6 +25,7 @@ class ScoreDefInterface;
  */
 class MeterSig : public LayerElement, public AttEnclosingChars, public AttMeterSigLog, public AttMeterSigVis {
 public:
+    enum class CountSign { None, Divide, Minus, Multiply, Plus };
     /**
      * @name Constructors, destructors, and other standard methods
      * Reset method resets all attribute classes.
@@ -45,6 +46,14 @@ public:
 
     /** Evaluate additive meter counts */
     int GetTotalCount() const;
+
+    /**
+     * Set/get methods to get operation signa and meter counts as separate values
+     */
+    ///@{
+    std::pair<std::vector<int>, CountSign> GetMeterCounts() const;
+    void SetMeterCounts(const std::vector<int> &counts, MeterSig::CountSign sign);
+    ///@}
 
     /** Retrieves the symbol glyph */
     wchar_t GetSymbolGlyph() const;

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -25,7 +25,6 @@ class ScoreDefInterface;
  */
 class MeterSig : public LayerElement, public AttEnclosingChars, public AttMeterSigLog, public AttMeterSigVis {
 public:
-    enum class MeterCountSign { None, Slash, Minus, Asterisk, Plus };
     /**
      * @name Constructors, destructors, and other standard methods
      * Reset method resets all attribute classes.
@@ -47,14 +46,6 @@ public:
     /** Evaluate additive meter counts */
     int GetTotalCount();
 
-    /**
-     * Set/get methods to get operation signa and meter counts as separate values
-     */
-    ///@{
-    std::pair<std::vector<int>, MeterCountSign> GetMeterCounts();
-    void SetMeterCounts(const std::vector<int> &counts, MeterSig::MeterCountSign sign);
-    ///@}
-
     /** Retrieves the symbol glyph */
     wchar_t GetSymbolGlyph() const;
 
@@ -71,14 +62,11 @@ public:
     int LayerCountInTimeSpan(FunctorParams *functorParams) override;
 
 private:
-    // Helper function to split meter counts and signs within MeterSig
-    void SplitMeterCounts();
-
+    //
 public:
     //
 private:
-    std::vector<int> m_meterCount;
-    MeterCountSign m_meterCountSign;
+    //
 };
 
 } // namespace vrv

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -44,7 +44,7 @@ public:
     bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     /** Evaluate additive meter counts */
-    int GetTotalCount();
+    int GetTotalCount() const;
 
     /** Retrieves the symbol glyph */
     wchar_t GetSymbolGlyph() const;

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -45,13 +45,13 @@ public:
     bool IsScoreDefElement() const override { return (this->GetParent() && this->GetFirstAncestor(SCOREDEF)); }
 
     /** Evaluate additive meter counts */
-    int GetTotalCount() const;
+    int GetTotalCount();
 
     /**
      * Set/get methods to get operation signa and meter counts as separate values
      */
     ///@{
-    std::pair<std::vector<int>, MeterCountSign> GetMeterCounts() const;
+    std::pair<std::vector<int>, MeterCountSign> GetMeterCounts();
     void SetMeterCounts(const std::vector<int> &counts, MeterSig::MeterCountSign sign);
     ///@}
 
@@ -71,10 +71,14 @@ public:
     int LayerCountInTimeSpan(FunctorParams *functorParams) override;
 
 private:
-    //
+    // Helper function to split meter counts and signs within MeterSig
+    void SplitMeterCounts();
+
 public:
     //
 private:
+    std::vector<int> m_meterCount;
+    MeterCountSign m_meterCountSign;
 };
 
 } // namespace vrv

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -345,8 +345,7 @@ protected:
     void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin = false);
     void DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int horizOffset);
     /** Returns the width of the drawn figures */
-    int DrawMeterSigFigures(
-        DeviceContext *dc, int x, int y, const std::vector<int> &numSummands, int den, Staff *staff);
+    int DrawMeterSigFigures(DeviceContext *dc, int x, int y, MeterSig *meterSig, int den, Staff *staff);
     void DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smulfCode, int num, bool line, Staff *staff);
     ///@}
 

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -2273,7 +2273,7 @@ std::string AttConverter::MidinamesToStr(data_MIDINAMES data) const
         case MIDINAMES_Shamisen: value = "Shamisen"; break;
         case MIDINAMES_Koto: value = "Koto"; break;
         case MIDINAMES_Kalimba: value = "Kalimba"; break;
-        case MIDINAMES_Bagpipe: value = "Bagpipe"; break;
+        case MIDINAMES_Bag_pipe: value = "Bag_pipe"; break;
         case MIDINAMES_Fiddle: value = "Fiddle"; break;
         case MIDINAMES_Shanai: value = "Shanai"; break;
         case MIDINAMES_Tinkle_Bell: value = "Tinkle_Bell"; break;
@@ -2458,7 +2458,7 @@ data_MIDINAMES AttConverter::StrToMidinames(const std::string &value, bool logWa
     if (value == "Shamisen") return MIDINAMES_Shamisen;
     if (value == "Koto") return MIDINAMES_Koto;
     if (value == "Kalimba") return MIDINAMES_Kalimba;
-    if (value == "Bagpipe") return MIDINAMES_Bagpipe;
+    if (value == "Bag_pipe") return MIDINAMES_Bag_pipe;
     if (value == "Fiddle") return MIDINAMES_Fiddle;
     if (value == "Shanai") return MIDINAMES_Shanai;
     if (value == "Tinkle_Bell") return MIDINAMES_Tinkle_Bell;

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -3783,7 +3783,7 @@ AttMeterSigLog::~AttMeterSigLog()
 
 void AttMeterSigLog::ResetMeterSigLog()
 {
-    m_count = std::vector<int>();
+    m_count = "";
     m_sym = METERSIGN_NONE;
     m_unit = 0;
 }
@@ -3792,7 +3792,7 @@ bool AttMeterSigLog::ReadMeterSigLog(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("count")) {
-        this->SetCount(StrToSummandList(element.attribute("count").value()));
+        this->SetCount(StrToStr(element.attribute("count").value()));
         element.remove_attribute("count");
         hasAttribute = true;
     }
@@ -3813,7 +3813,7 @@ bool AttMeterSigLog::WriteMeterSigLog(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasCount()) {
-        element.append_attribute("count") = SummandListToStr(this->GetCount()).c_str();
+        element.append_attribute("count") = StrToStr(this->GetCount()).c_str();
         wroteAttribute = true;
     }
     if (this->HasSym()) {
@@ -3829,7 +3829,7 @@ bool AttMeterSigLog::WriteMeterSigLog(pugi::xml_node element)
 
 bool AttMeterSigLog::HasCount() const
 {
-    return (m_count != std::vector<int>());
+    return (m_count != "");
 }
 
 bool AttMeterSigLog::HasSym() const
@@ -3859,7 +3859,7 @@ AttMeterSigDefaultLog::~AttMeterSigDefaultLog()
 
 void AttMeterSigDefaultLog::ResetMeterSigDefaultLog()
 {
-    m_meterCount = std::vector<int>();
+    m_meterCount = "";
     m_meterUnit = 0;
     m_meterSym = METERSIGN_NONE;
 }
@@ -3868,7 +3868,7 @@ bool AttMeterSigDefaultLog::ReadMeterSigDefaultLog(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("meter.count")) {
-        this->SetMeterCount(StrToSummandList(element.attribute("meter.count").value()));
+        this->SetMeterCount(StrToStr(element.attribute("meter.count").value()));
         element.remove_attribute("meter.count");
         hasAttribute = true;
     }
@@ -3889,7 +3889,7 @@ bool AttMeterSigDefaultLog::WriteMeterSigDefaultLog(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasMeterCount()) {
-        element.append_attribute("meter.count") = SummandListToStr(this->GetMeterCount()).c_str();
+        element.append_attribute("meter.count") = StrToStr(this->GetMeterCount()).c_str();
         wroteAttribute = true;
     }
     if (this->HasMeterUnit()) {
@@ -3905,7 +3905,7 @@ bool AttMeterSigDefaultLog::WriteMeterSigDefaultLog(pugi::xml_node element)
 
 bool AttMeterSigDefaultLog::HasMeterCount() const
 {
-    return (m_meterCount != std::vector<int>());
+    return (m_meterCount != "");
 }
 
 bool AttMeterSigDefaultLog::HasMeterUnit() const
@@ -8895,7 +8895,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
         AttMeterSigLog *att = dynamic_cast<AttMeterSigLog *>(element);
         assert(att);
         if (attrType == "count") {
-            att->SetCount(att->StrToSummandList(attrValue));
+            att->SetCount(att->StrToStr(attrValue));
             return true;
         }
         if (attrType == "sym") {
@@ -8911,7 +8911,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
         AttMeterSigDefaultLog *att = dynamic_cast<AttMeterSigDefaultLog *>(element);
         assert(att);
         if (attrType == "meter.count") {
-            att->SetMeterCount(att->StrToSummandList(attrValue));
+            att->SetMeterCount(att->StrToStr(attrValue));
             return true;
         }
         if (attrType == "meter.unit") {
@@ -10362,7 +10362,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttMeterSigLog *att = dynamic_cast<const AttMeterSigLog *>(element);
         assert(att);
         if (att->HasCount()) {
-            attributes->push_back({ "count", att->SummandListToStr(att->GetCount()) });
+            attributes->push_back({ "count", att->StrToStr(att->GetCount()) });
         }
         if (att->HasSym()) {
             attributes->push_back({ "sym", att->MetersignToStr(att->GetSym()) });
@@ -10375,7 +10375,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttMeterSigDefaultLog *att = dynamic_cast<const AttMeterSigDefaultLog *>(element);
         assert(att);
         if (att->HasMeterCount()) {
-            attributes->push_back({ "meter.count", att->SummandListToStr(att->GetMeterCount()) });
+            attributes->push_back({ "meter.count", att->StrToStr(att->GetMeterCount()) });
         }
         if (att->HasMeterUnit()) {
             attributes->push_back({ "meter.unit", att->IntToStr(att->GetMeterUnit()) });

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -3783,7 +3783,7 @@ AttMeterSigLog::~AttMeterSigLog()
 
 void AttMeterSigLog::ResetMeterSigLog()
 {
-    m_count = "";
+    m_count = {};
     m_sym = METERSIGN_NONE;
     m_unit = 0;
 }
@@ -3792,7 +3792,7 @@ bool AttMeterSigLog::ReadMeterSigLog(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("count")) {
-        this->SetCount(StrToStr(element.attribute("count").value()));
+        this->SetCount(StrToMetercountPair(element.attribute("count").value()));
         element.remove_attribute("count");
         hasAttribute = true;
     }
@@ -3813,7 +3813,7 @@ bool AttMeterSigLog::WriteMeterSigLog(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasCount()) {
-        element.append_attribute("count") = StrToStr(this->GetCount()).c_str();
+        element.append_attribute("count") = MetercountPairToStr(this->GetCount()).c_str();
         wroteAttribute = true;
     }
     if (this->HasSym()) {
@@ -3829,7 +3829,7 @@ bool AttMeterSigLog::WriteMeterSigLog(pugi::xml_node element)
 
 bool AttMeterSigLog::HasCount() const
 {
-    return (m_count != "");
+    return m_count.first.empty();
 }
 
 bool AttMeterSigLog::HasSym() const
@@ -3859,7 +3859,7 @@ AttMeterSigDefaultLog::~AttMeterSigDefaultLog()
 
 void AttMeterSigDefaultLog::ResetMeterSigDefaultLog()
 {
-    m_meterCount = "";
+    m_meterCount = {};
     m_meterUnit = 0;
     m_meterSym = METERSIGN_NONE;
 }
@@ -3868,7 +3868,7 @@ bool AttMeterSigDefaultLog::ReadMeterSigDefaultLog(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("meter.count")) {
-        this->SetMeterCount(StrToStr(element.attribute("meter.count").value()));
+        this->SetMeterCount(StrToMetercountPair(element.attribute("meter.count").value()));
         element.remove_attribute("meter.count");
         hasAttribute = true;
     }
@@ -3889,7 +3889,7 @@ bool AttMeterSigDefaultLog::WriteMeterSigDefaultLog(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasMeterCount()) {
-        element.append_attribute("meter.count") = StrToStr(this->GetMeterCount()).c_str();
+        element.append_attribute("meter.count") = MetercountPairToStr(this->GetMeterCount()).c_str();
         wroteAttribute = true;
     }
     if (this->HasMeterUnit()) {
@@ -3905,7 +3905,7 @@ bool AttMeterSigDefaultLog::WriteMeterSigDefaultLog(pugi::xml_node element)
 
 bool AttMeterSigDefaultLog::HasMeterCount() const
 {
-    return (m_meterCount != "");
+    return m_meterCount.first.empty();
 }
 
 bool AttMeterSigDefaultLog::HasMeterUnit() const
@@ -8895,7 +8895,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
         AttMeterSigLog *att = dynamic_cast<AttMeterSigLog *>(element);
         assert(att);
         if (attrType == "count") {
-            att->SetCount(att->StrToStr(attrValue));
+            att->SetCount(att->StrToMetercountPair(attrValue));
             return true;
         }
         if (attrType == "sym") {
@@ -8911,7 +8911,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
         AttMeterSigDefaultLog *att = dynamic_cast<AttMeterSigDefaultLog *>(element);
         assert(att);
         if (attrType == "meter.count") {
-            att->SetMeterCount(att->StrToStr(attrValue));
+            att->SetMeterCount(att->StrToMetercountPair(attrValue));
             return true;
         }
         if (attrType == "meter.unit") {
@@ -10362,7 +10362,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttMeterSigLog *att = dynamic_cast<const AttMeterSigLog *>(element);
         assert(att);
         if (att->HasCount()) {
-            attributes->push_back({ "count", att->StrToStr(att->GetCount()) });
+            attributes->push_back({ "count", att->MetercountPairToStr(att->GetCount()) });
         }
         if (att->HasSym()) {
             attributes->push_back({ "sym", att->MetersignToStr(att->GetSym()) });
@@ -10375,7 +10375,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttMeterSigDefaultLog *att = dynamic_cast<const AttMeterSigDefaultLog *>(element);
         assert(att);
         if (att->HasMeterCount()) {
-            attributes->push_back({ "meter.count", att->StrToStr(att->GetMeterCount()) });
+            attributes->push_back({ "meter.count", att->MetercountPairToStr(att->GetMeterCount()) });
         }
         if (att->HasMeterUnit()) {
             attributes->push_back({ "meter.unit", att->IntToStr(att->GetMeterUnit()) });

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -3829,7 +3829,7 @@ bool AttMeterSigLog::WriteMeterSigLog(pugi::xml_node element)
 
 bool AttMeterSigLog::HasCount() const
 {
-    return m_count.first.empty();
+    return !m_count.first.empty();
 }
 
 bool AttMeterSigLog::HasSym() const
@@ -3905,7 +3905,7 @@ bool AttMeterSigDefaultLog::WriteMeterSigDefaultLog(pugi::xml_node element)
 
 bool AttMeterSigDefaultLog::HasMeterCount() const
 {
-    return m_meterCount.first.empty();
+    return !m_meterCount.first.empty();
 }
 
 bool AttMeterSigDefaultLog::HasMeterUnit() const

--- a/libmei/atts_shared.h
+++ b/libmei/atts_shared.h
@@ -1054,8 +1054,9 @@ private:
      * The first value captures a distance to the left (positive value) or right
      * (negative value) of the line, expressed in virtual units. The second value of
      * each pair represents a point along the line, expressed as a percentage of the
-     * line's length. N.B. An MEI virtual unit (VU) is half the distance between
-     * adjacent staff lines.
+     * line's length. N.B. An MEI virtual unit (vu) is half the distance between
+     * adjacent staff lines where the interline space is measured from the middle of a
+     * staff line.
      **/
     data_BULGE m_bulge;
     /** Describes a curve with a generic term indicating the direction of curvature. **/
@@ -2906,8 +2907,8 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetCount(data_SUMMAND_List count_) { m_count = count_; }
-    data_SUMMAND_List GetCount() const { return m_count; }
+    void SetCount(std::string count_) { m_count = count_; }
+    std::string GetCount() const { return m_count; }
     bool HasCount() const;
     //
     void SetSym(data_METERSIGN sym_) { m_sym = sym_; }
@@ -2921,7 +2922,7 @@ public:
 
 private:
     /** Indicates the number of performers. **/
-    data_SUMMAND_List m_count;
+    std::string m_count;
     /**
      * Indicates the use of a meter symbol instead of a numeric meter signature, that
      * is, 'C' for common time or 'C' with a slash for cut time.
@@ -2957,8 +2958,8 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetMeterCount(data_SUMMAND_List meterCount_) { m_meterCount = meterCount_; }
-    data_SUMMAND_List GetMeterCount() const { return m_meterCount; }
+    void SetMeterCount(std::string meterCount_) { m_meterCount = meterCount_; }
+    std::string GetMeterCount() const { return m_meterCount; }
     bool HasMeterCount() const;
     //
     void SetMeterUnit(int meterUnit_) { m_meterUnit = meterUnit_; }
@@ -2974,10 +2975,10 @@ private:
     /**
      * Captures the number of beats in a measure, that is, the top number of the meter
      * signature.
-     * It must contain a decimal number or an additive expression that evaluates to a
-     * decimal number, such as 2+3.
+     * It must contain a decimal number or an expression that evaluates to a decimal
+     * number, such as 2+3 or 3*2.
      **/
-    data_SUMMAND_List m_meterCount;
+    std::string m_meterCount;
     /**
      * Contains the number indicating the beat unit, that is, the bottom number of the
      * meter signature.

--- a/libmei/atts_shared.h
+++ b/libmei/atts_shared.h
@@ -2907,8 +2907,8 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetCount(std::string count_) { m_count = count_; }
-    std::string GetCount() const { return m_count; }
+    void SetCount(const data_METERCOUNT_pair &count_) { m_count = count_; }
+    data_METERCOUNT_pair GetCount() const { return m_count; }
     bool HasCount() const;
     //
     void SetSym(data_METERSIGN sym_) { m_sym = sym_; }
@@ -2922,7 +2922,7 @@ public:
 
 private:
     /** Indicates the number of performers. **/
-    std::string m_count;
+    data_METERCOUNT_pair m_count;
     /**
      * Indicates the use of a meter symbol instead of a numeric meter signature, that
      * is, 'C' for common time or 'C' with a slash for cut time.
@@ -2958,8 +2958,8 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetMeterCount(std::string meterCount_) { m_meterCount = meterCount_; }
-    std::string GetMeterCount() const { return m_meterCount; }
+    void SetMeterCount(const data_METERCOUNT_pair &meterCount_) { m_meterCount = meterCount_; }
+    data_METERCOUNT_pair GetMeterCount() const { return m_meterCount; }
     bool HasMeterCount() const;
     //
     void SetMeterUnit(int meterUnit_) { m_meterUnit = meterUnit_; }
@@ -2978,7 +2978,7 @@ private:
      * It must contain a decimal number or an expression that evaluates to a decimal
      * number, such as 2+3 or 3*2.
      **/
-    std::string m_meterCount;
+    data_METERCOUNT_pair m_meterCount;
     /**
      * Contains the number indicating the beat unit, that is, the bottom number of the
      * meter signature.

--- a/libmei/atts_visual.h
+++ b/libmei/atts_visual.h
@@ -1301,8 +1301,8 @@ public:
 private:
     /**
      * Defines the height of a "virtual unit" (vu) in terms of real-world units.
-     * A single vu is half the distance between the vertical center point of a staff
-     * line and that of an adjacent staff line.
+     * A single vu is half the distance between adjacent staff lines where the
+     * interline space is measured from the middle of a staff line.
      **/
     std::string m_vuHeight;
 

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -1124,7 +1124,7 @@ enum data_MIDINAMES {
     MIDINAMES_Shamisen,
     MIDINAMES_Koto,
     MIDINAMES_Kalimba,
-    MIDINAMES_Bagpipe,
+    MIDINAMES_Bag_pipe,
     MIDINAMES_Fiddle,
     MIDINAMES_Shanai,
     MIDINAMES_Tinkle_Bell,

--- a/src/att.cpp
+++ b/src/att.cpp
@@ -395,6 +395,54 @@ data_MEASUREBEAT Att::StrToMeasurebeat(std::string value, bool logWarning) const
     return { measure, timePoint };
 }
 
+std::string Att::MetercountPairToStr(const data_METERCOUNT_pair &data) const
+{
+    std::stringstream output;
+    for (const int count : data.first) {
+        output << count;
+        switch (data.second) {
+            case MeterCountSign::Slash: output << '\\'; break;
+            case MeterCountSign::Minus: output << '-'; break;
+            case MeterCountSign::Asterisk: output << '*'; break;
+            case MeterCountSign::Plus: output << '+'; break;
+            case MeterCountSign::None:
+            default: break;
+        }
+    }
+
+    return output.str();
+}
+
+data_METERCOUNT_pair Att::StrToMetercountPair(const std::string &value) const
+{
+    std::regex re("[\\*\\+/-]");
+    std::sregex_token_iterator first{ value.begin(), value.end(), re, -1 }, last;
+    std::vector<std::string> tokens{ first, last };
+
+    // Since there is currently no need for implementation of complex calculus within metersig, only one opperation will
+    // be supported in the meter count. Caclulation will be based on the first mathematical operator in the string
+    MeterCountSign sign = MeterCountSign::None;
+    const size_t pos = value.find_first_of("+-*/");
+    if (pos != std::string::npos) {
+        if (value[pos] == '/') {
+            sign = MeterCountSign::Slash;
+        }
+        else if (value[pos] == '*') {
+            sign = MeterCountSign::Asterisk;
+        }
+        else if (value[pos] == '+') {
+            sign = MeterCountSign::Plus;
+        }
+        else if (value[pos] == '-') {
+            sign = MeterCountSign::Minus;
+        }
+    }
+    std::vector<int> result;
+    std::for_each(tokens.begin(), tokens.end(),
+        [&result](const std::string &elem) { result.emplace_back(std::atoi(elem.c_str())); });
+    return { result, sign };
+}
+
 std::string Att::MidivalueNameToStr(data_MIDIVALUE_NAME data) const
 {
     std::string value;

--- a/src/att.cpp
+++ b/src/att.cpp
@@ -663,27 +663,6 @@ data_PROLATIO Att::StrToProlatio(const std::string &value, bool logWarning) cons
     return PROLATIO_NONE;
 }
 
-std::string Att::SummandListToStr(data_SUMMAND_List data) const
-{
-    std::ostringstream ss;
-    for (int i = 0; i < (int)data.size(); ++i) {
-        if (i != 0) ss << "+";
-        ss << data.at(i);
-    }
-    return ss.str();
-}
-
-data_SUMMAND_List Att::StrToSummandList(std::string value) const
-{
-    data_SUMMAND_List list;
-    std::istringstream iss(value);
-    std::string token;
-    while (std::getline(iss, token, '+')) {
-        list.push_back(atoi(token.c_str()));
-    }
-    return list;
-}
-
 std::string Att::TempusToStr(data_TEMPUS data) const
 {
     std::string value;

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -755,7 +755,7 @@ void ABCInput::parseMeter(const std::string &meterString)
         if (meterCount.front() == '(' && meterCount.back() == ')')
             meterCount = meterCount.substr(1, meterCount.length() - 1);
         // this is a little "hack", until libMEI is fixed
-        m_meter->SetCount({ atoi(meterCount.c_str()) });
+        m_meter->SetCount(meterCount);
         m_meter->SetUnit(atoi(&meterString[meterString.find('/') + 1]));
     }
 }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -741,12 +741,12 @@ void ABCInput::parseMeter(const std::string &meterString)
     if (meterString.find('C') != std::string::npos) {
         if (meterString[meterString.find('C') + 1] == '|') {
             m_meter->SetSym(METERSIGN_cut);
-            m_meter->SetCount("2");
+            m_meter->SetCount({ { 2 }, MeterCountSign::None });
             m_meter->SetUnit(2);
         }
         else {
             m_meter->SetSym(METERSIGN_common);
-            m_meter->SetCount("4");
+            m_meter->SetCount({ { 4 }, MeterCountSign::None });
             m_meter->SetUnit(4);
         }
     }
@@ -755,7 +755,7 @@ void ABCInput::parseMeter(const std::string &meterString)
         if (meterCount.front() == '(' && meterCount.back() == ')')
             meterCount = meterCount.substr(1, meterCount.length() - 1);
         // this is a little "hack", until libMEI is fixed
-        m_meter->SetCount(meterCount);
+        m_meter->SetCount({ { atoi(meterCount.c_str()) }, MeterCountSign::None });
         m_meter->SetUnit(atoi(&meterString[meterString.find('/') + 1]));
     }
 }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -741,12 +741,12 @@ void ABCInput::parseMeter(const std::string &meterString)
     if (meterString.find('C') != std::string::npos) {
         if (meterString[meterString.find('C') + 1] == '|') {
             m_meter->SetSym(METERSIGN_cut);
-            m_meter->SetCount({ 2 });
+            m_meter->SetCount("2");
             m_meter->SetUnit(2);
         }
         else {
             m_meter->SetSym(METERSIGN_common);
-            m_meter->SetCount({ 4 });
+            m_meter->SetCount("4");
             m_meter->SetUnit(4);
         }
     }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -5772,7 +5772,7 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
     if (sscanf(timesig.c_str(), "*M%d/%d%%%d", &top, &bot, &bot2) == 3) {
         // Such as three-triplet whole notes in a 2/1 measure
         if ((metersig == "3") && (bot == 3) && (bot2 == 2)) {
-            vrvmeter->SetCount("3");
+            vrvmeter->SetCount({ { 3 }, MeterCountSign::None });
             vrvmeter->SetUnit(1);
             vrvmeter->SetForm(METERFORM_num);
         }
@@ -5783,7 +5783,7 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
                 // hide time signature
                 vrvmeter->SetForm(METERFORM_invis);
             }
-            vrvmeter->SetCount(std::to_string(top * 2));
+            vrvmeter->SetCount({ { top * 2 }, MeterCountSign::None });
             vrvmeter->SetUnit(1);
         }
         else {
@@ -5791,21 +5791,21 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
                 // Can't add if there is a mensuration; otherwise,
                 // a time signature will be shown.
                 vrvmeter->SetForm(METERFORM_invis);
-                vrvmeter->SetCount(std::to_string(top));
+                vrvmeter->SetCount({ { top }, MeterCountSign::None });
                 vrvmeter->SetUnit(bot);
             }
             else if (metersig == "3") {
-                vrvmeter->SetCount("3");
+                vrvmeter->SetCount({ { 3 }, MeterCountSign::None });
                 vrvmeter->SetUnit(bot);
                 vrvmeter->SetForm(METERFORM_num);
             }
             else if (metersig == "2") {
-                vrvmeter->SetCount("2");
+                vrvmeter->SetCount({ { 2 }, MeterCountSign::None });
                 vrvmeter->SetUnit(bot);
                 vrvmeter->SetForm(METERFORM_num);
             }
             else {
-                vrvmeter->SetCount(std::to_string(top));
+                vrvmeter->SetCount({ { top }, MeterCountSign::None });
                 vrvmeter->SetUnit(bot);
             }
         }
@@ -5842,7 +5842,7 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
         int bot2 = stoi(matches[3]);
         if ((metersig == "3") && (bot == 3) && (bot2 == 2)) {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount("3");
+            vrvmetersig->SetCount({ { 3 }, MeterCountSign::None });
             vrvmetersig->SetUnit(1);
             vrvmetersig->SetForm(METERFORM_num);
         }
@@ -5851,25 +5851,25 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
         if (!metersigtok) {
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount(matches[1]);
+            vrvmetersig->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
         }
         else if (*metersigtok == "*met()") {
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount(matches[1]);
+            vrvmetersig->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_invis);
         }
         else if (metersig == "3") {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount("3");
+            vrvmetersig->SetCount({ { 3 }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_num);
         }
         else if (metersig == "2") {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount("2");
+            vrvmetersig->SetCount({ { 2 }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_num);
         }
@@ -5879,7 +5879,7 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
             // otherwise verovio will display both.
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount(matches[1]);
+            vrvmetersig->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
         }
         else {
@@ -5890,7 +5890,7 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
             vrvmetersig->SetForm(METERFORM_invis);
-            vrvmetersig->SetCount(matches[1]);
+            vrvmetersig->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
             vrvmetersig->SetUnit(unit);
         }
         if (metersigtok) {
@@ -15523,7 +15523,7 @@ void HumdrumInput::insertMeterSigElement(
         setLocationId(msig, tsig);
     }
     appendElement(elements, pointers, msig);
-    msig->SetCount(std::to_string(count));
+    msig->SetCount({ { count }, MeterCountSign::None });
     if (unit > 0) {
         msig->SetUnit(unit);
     }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -5783,7 +5783,7 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
                 // hide time signature
                 vrvmeter->SetForm(METERFORM_invis);
             }
-            vrvmeter->SetCount({ top * 2 });
+            vrvmeter->SetCount(std::to_string(top * 2));
             vrvmeter->SetUnit(1);
         }
         else {
@@ -5791,21 +5791,21 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
                 // Can't add if there is a mensuration; otherwise,
                 // a time signature will be shown.
                 vrvmeter->SetForm(METERFORM_invis);
-                vrvmeter->SetCount({ top });
+                vrvmeter->SetCount(std::to_string(top));
                 vrvmeter->SetUnit(bot);
             }
             else if (metersig == "3") {
-                vrvmeter->SetCount({ 3 });
+                vrvmeter->SetCount("3");
                 vrvmeter->SetUnit(bot);
                 vrvmeter->SetForm(METERFORM_num);
             }
             else if (metersig == "2") {
-                vrvmeter->SetCount({ 2 });
+                vrvmeter->SetCount("2");
                 vrvmeter->SetUnit(bot);
                 vrvmeter->SetForm(METERFORM_num);
             }
             else {
-                vrvmeter->SetCount({ top });
+                vrvmeter->SetCount(std::to_string(top));
                 vrvmeter->SetUnit(bot);
             }
         }
@@ -5849,29 +5849,27 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
     }
     else if (regex_search(*timesigtok, matches, regex("^\\*M(\\d+)/(\\d+)"))) {
         if (!metersigtok) {
-            count = stoi(matches[1]);
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ count });
+            vrvmetersig->SetCount(matches[1]);
             vrvmetersig->SetUnit(unit);
         }
         else if (*metersigtok == "*met()") {
-            count = stoi(matches[1]);
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ count });
+            vrvmetersig->SetCount(matches[1]);
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_invis);
         }
         else if (metersig == "3") {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ 3 });
+            vrvmetersig->SetCount("3");
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_num);
         }
         else if (metersig == "2") {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ 2 });
+            vrvmetersig->SetCount("2");
             vrvmetersig->SetUnit(unit);
             vrvmetersig->SetForm(METERFORM_num);
         }
@@ -5879,10 +5877,9 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
             && (metersigtok->find('O') == std::string::npos)) {
             // Only storing the time signature if there is no mensuration
             // otherwise verovio will display both.
-            count = stoi(matches[1]);
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ count });
+            vrvmetersig->SetCount(matches[1]);
             vrvmetersig->SetUnit(unit);
         }
         else {
@@ -5890,11 +5887,10 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
             // are in reference to it (can't add meter.count since
             // this will also print a time signature.
             // Count now allowed (suppress time signature display with @form="invis").
-            count = stoi(matches[1]);
             unit = stoi(matches[2]);
             MeterSig *vrvmetersig = getMeterSig(element);
             vrvmetersig->SetForm(METERFORM_invis);
-            vrvmetersig->SetCount({ count });
+            vrvmetersig->SetCount(matches[1]);
             vrvmetersig->SetUnit(unit);
         }
         if (metersigtok) {
@@ -15527,7 +15523,7 @@ void HumdrumInput::insertMeterSigElement(
         setLocationId(msig, tsig);
     }
     appendElement(elements, pointers, msig);
-    msig->SetCount({ count });
+    msig->SetCount(std::to_string(count));
     if (unit > 0) {
         msig->SetUnit(unit);
     }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -5772,7 +5772,7 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
     if (sscanf(timesig.c_str(), "*M%d/%d%%%d", &top, &bot, &bot2) == 3) {
         // Such as three-triplet whole notes in a 2/1 measure
         if ((metersig == "3") && (bot == 3) && (bot2 == 2)) {
-            vrvmeter->SetCount({ 3 });
+            vrvmeter->SetCount("3");
             vrvmeter->SetUnit(1);
             vrvmeter->SetForm(METERFORM_num);
         }
@@ -5842,7 +5842,7 @@ void HumdrumInput::setTimeSig(ELEMENT element, hum::HTp timesigtok, hum::HTp met
         int bot2 = stoi(matches[3]);
         if ((metersig == "3") && (bot == 3) && (bot2 == 2)) {
             MeterSig *vrvmetersig = getMeterSig(element);
-            vrvmetersig->SetCount({ 3 });
+            vrvmetersig->SetCount("3");
             vrvmetersig->SetUnit(1);
             vrvmetersig->SetForm(METERFORM_num);
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1488,7 +1488,8 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
         pugi::xml_node beats = time.child("beats");
         pugi::xml_node beatType = time.child("beat-type");
         if (beats) {
-            std::tie(m_meterCount, m_meterSign) = meterSig->Att::StrToMetercountPair(beats.text().as_string());
+            std::tie(m_meterCount, m_meterSign)
+                = meterSig->AttMeterSigLog::StrToMetercountPair(beats.text().as_string());
             meterSig->SetCount({ m_meterCount, m_meterSign });
             m_meterUnit = beatType.text().as_int();
             meterSig->SetUnit(m_meterUnit);
@@ -4536,7 +4537,7 @@ std::pair<std::vector<int>, int> MusicXmlInput::GetMeterSigGrpValues(const pugi:
          ++iter1, ++iter2) {
         // Process current beat/beat-type combination and add it to the meterSigGrp
         MeterSig *meterSig = new MeterSig();
-        data_METERCOUNT_pair count = meterSig->Att::StrToMetercountPair(iter1->node().text().as_string());
+        data_METERCOUNT_pair count = meterSig->AttMeterSigLog::StrToMetercountPair(iter1->node().text().as_string());
         meterSig->SetCount(count);
         int currentUnit = iter2->node().text().as_int();
         meterSig->SetUnit(currentUnit);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1462,9 +1462,9 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
         pugi::xpath_node interchangeable = time.select_node("interchangeable");
         meterSigGrp->SetFunc(interchangeable ? meterSigGrpLog_FUNC_interchanging : meterSigGrpLog_FUNC_mixed);
 
-        std::tie(m_meterCount, m_meterUnit) = GetMeterSigGrpValues(time, meterSigGrp);
+        std::tie(m_meterCount, m_meterUnit) = this->GetMeterSigGrpValues(time, meterSigGrp);
         if (interchangeable) {
-            [[maybe_unused]] auto [interCount, interUnit] = GetMeterSigGrpValues(interchangeable.node(), meterSigGrp);
+            std::tie(std::ignore, std::ignore) = this->GetMeterSigGrpValues(interchangeable.node(), meterSigGrp);
         }
         parent->AddChild(meterSigGrp);
     }
@@ -1488,8 +1488,8 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
         pugi::xml_node beats = time.child("beats");
         pugi::xml_node beatType = time.child("beat-type");
         if (beats) {
-            m_meterCount = meterSig->AttMeterSigLog::StrToSummandList(beats.text().as_string());
-            meterSig->SetCount(m_meterCount);
+            meterSig->SetCount(beats.text().as_string());
+            std::tie(m_meterCount, m_meterSign) = meterSig->GetMeterCounts();
             m_meterUnit = beatType.text().as_int();
             meterSig->SetUnit(m_meterUnit);
         }
@@ -2662,7 +2662,9 @@ void MusicXmlInput::ReadMusicXmlNote(
         // we assume /note without /type or with duration of an entire bar to be mRest
         else if (typeStr.empty() || rest.attribute("measure").as_bool()) {
             if (m_slash) {
-                const int totalCount = std::accumulate(m_meterCount.cbegin(), m_meterCount.cend(), 0);
+                MeterSig tmpMeterSig;
+                tmpMeterSig.SetMeterCounts(m_meterCount, m_meterSign);
+                const int totalCount = tmpMeterSig.GetTotalCount();
                 for (int i = totalCount; i > 0; --i) {
                     BeatRpt *slash = new BeatRpt;
                     AddLayerElement(layer, slash, duration);
@@ -4534,11 +4536,12 @@ std::pair<std::vector<int>, int> MusicXmlInput::GetMeterSigGrpValues(const pugi:
          ++iter1, ++iter2) {
         // Process current beat/beat-type combination and add it to the meterSigGrp
         MeterSig *meterSig = new MeterSig();
-        std::vector<int> currentCount = meterSig->AttMeterSigLog::StrToSummandList(iter1->node().text().as_string());
-        meterSig->SetCount(currentCount);
+        meterSig->SetCount(iter1->node().text().as_string());
         int currentUnit = iter2->node().text().as_int();
         meterSig->SetUnit(currentUnit);
         parent->AddChild(meterSig);
+        std::vector<int> currentCount;
+        std::tie(currentCount, std::ignore) = meterSig->GetMeterCounts();
         // Process meterCount and meterUnit based on current/previous beats
         if (maxUnit == 0) maxUnit = currentUnit;
         if (maxUnit == currentUnit) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1488,8 +1488,8 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
         pugi::xml_node beats = time.child("beats");
         pugi::xml_node beatType = time.child("beat-type");
         if (beats) {
-            meterSig->SetCount(beats.text().as_string());
-            std::tie(m_meterCount, m_meterSign) = meterSig->GetMeterCounts();
+            std::tie(m_meterCount, m_meterSign) = meterSig->Att::StrToMetercountPair(beats.text().as_string());
+            meterSig->SetCount({ m_meterCount, m_meterSign });
             m_meterUnit = beatType.text().as_int();
             meterSig->SetUnit(m_meterUnit);
         }
@@ -2663,7 +2663,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         else if (typeStr.empty() || rest.attribute("measure").as_bool()) {
             if (m_slash) {
                 MeterSig tmpMeterSig;
-                tmpMeterSig.SetMeterCounts(m_meterCount, m_meterSign);
+                tmpMeterSig.SetCount({ m_meterCount, m_meterSign });
                 const int totalCount = tmpMeterSig.GetTotalCount();
                 for (int i = totalCount; i > 0; --i) {
                     BeatRpt *slash = new BeatRpt;
@@ -4536,12 +4536,13 @@ std::pair<std::vector<int>, int> MusicXmlInput::GetMeterSigGrpValues(const pugi:
          ++iter1, ++iter2) {
         // Process current beat/beat-type combination and add it to the meterSigGrp
         MeterSig *meterSig = new MeterSig();
-        meterSig->SetCount(iter1->node().text().as_string());
+        data_METERCOUNT_pair count = meterSig->Att::StrToMetercountPair(iter1->node().text().as_string());
+        meterSig->SetCount(count);
         int currentUnit = iter2->node().text().as_int();
         meterSig->SetUnit(currentUnit);
         parent->AddChild(meterSig);
         std::vector<int> currentCount;
-        std::tie(currentCount, std::ignore) = meterSig->GetMeterCounts();
+        std::tie(currentCount, std::ignore) = meterSig->GetCount();
         // Process meterCount and meterUnit based on current/previous beats
         if (maxUnit == 0) maxUnit = currentUnit;
         if (maxUnit == currentUnit) {

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -4727,16 +4727,15 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
     else if (paeStr == "c3/2") {
         // C3/2
         meterSig->SetSym(METERSIGN_common); // ??
-        meterSig->SetCount({ 3 }, MeterCountSign::None
-    });
-    meterSig->SetUnit(2);
-}
-else
-{
-    LogPAE(ERR_048_TIMESIG_INVALID, token, paeStr);
-    if (m_pedanticMode) return false;
-}
-return true;
+        meterSig->SetCount({ { 3 }, MeterCountSign::None });
+        meterSig->SetUnit(2);
+    }
+    else
+    {
+        LogPAE(ERR_048_TIMESIG_INVALID, token, paeStr);
+        if (m_pedanticMode) return false;
+    }
+    return true;
 }
 
 bool PAEInput::ParseMensur(Mensur *mensur, const std::string &paeStr, pae::Token &token)

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -4727,14 +4727,16 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
     else if (paeStr == "c3/2") {
         // C3/2
         meterSig->SetSym(METERSIGN_common); // ??
-        meterSig->SetCount({ 3 }, MeterCountSign::None });
-        meterSig->SetUnit(2);
-    }
-    else {
-        LogPAE(ERR_048_TIMESIG_INVALID, token, paeStr);
-        if (m_pedanticMode) return false;
-    }
-    return true;
+        meterSig->SetCount({ 3 }, MeterCountSign::None
+    });
+    meterSig->SetUnit(2);
+}
+else
+{
+    LogPAE(ERR_048_TIMESIG_INVALID, token, paeStr);
+    if (m_pedanticMode) return false;
+}
+return true;
 }
 
 bool PAEInput::ParseMensur(Mensur *mensur, const std::string &paeStr, pae::Token &token)

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -1390,11 +1390,11 @@ int PAEInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
     std::cmatch matches;
     if (meter) {
         if (regex_match(timesig_str, matches, std::regex("(\\d+)/(\\d+)"))) {
-            meter->SetCount(matches[1]);
+            meter->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
             meter->SetUnit(std::stoi(matches[2]));
         }
         else if (regex_match(timesig_str, matches, std::regex("\\d+"))) {
-            meter->SetCount(timesig_str);
+            meter->SetCount({ { std::stoi(timesig_str) }, MeterCountSign::None });
             meter->SetUnit(1);
             meter->SetForm(METERFORM_num);
         }
@@ -1409,12 +1409,12 @@ int PAEInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
         else if (strcmp(timesig_str, "c3") == 0) {
             // C3
             meter->SetSym(METERSIGN_common);
-            meter->SetCount("3");
+            meter->SetCount({ { 3 }, MeterCountSign::None });
         }
         else if (strcmp(timesig_str, "c3/2") == 0) {
             // C3/2
             meter->SetSym(METERSIGN_common); // ??
-            meter->SetCount("3");
+            meter->SetCount({ { 2 }, MeterCountSign::None });
             meter->SetUnit(2);
         }
         else {
@@ -4696,18 +4696,18 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
     if (paeStr.size() < 1) {
         LogPAE(ERR_047_TIMESIG_INCOMPLETE, token);
         if (m_pedanticMode) return false;
-        meterSig->SetCount({ 4 });
+        meterSig->SetCount({ { 4 }, MeterCountSign::None });
         meterSig->SetUnit(4);
         return true;
     }
 
     std::cmatch matches;
     if (regex_match(paeStr.c_str(), matches, std::regex("(\\d+)/(\\d+)"))) {
-        meterSig->SetCount(matches[1]);
+        meterSig->SetCount({ { std::stoi(matches[1]) }, MeterCountSign::None });
         meterSig->SetUnit(std::stoi(matches[2]));
     }
     else if (regex_match(paeStr.c_str(), matches, std::regex("\\d+"))) {
-        meterSig->SetCount(paeStr);
+        meterSig->SetCount({ { std::stoi(paeStr) }, MeterCountSign::None });
         meterSig->SetUnit(1);
         meterSig->SetForm(METERFORM_num);
     }
@@ -4722,12 +4722,12 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
     else if (paeStr == "c3") {
         // C3
         meterSig->SetSym(METERSIGN_common);
-        meterSig->SetCount("3");
+        meterSig->SetCount({ { 3 }, MeterCountSign::None });
     }
     else if (paeStr == "c3/2") {
         // C3/2
         meterSig->SetSym(METERSIGN_common); // ??
-        meterSig->SetCount("3");
+        meterSig->SetCount({ 3 }, MeterCountSign::None });
         meterSig->SetUnit(2);
     }
     else {

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -4730,8 +4730,7 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
         meterSig->SetCount({ { 3 }, MeterCountSign::None });
         meterSig->SetUnit(2);
     }
-    else
-    {
+    else {
         LogPAE(ERR_048_TIMESIG_INVALID, token, paeStr);
         if (m_pedanticMode) return false;
     }

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -1390,11 +1390,11 @@ int PAEInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
     std::cmatch matches;
     if (meter) {
         if (regex_match(timesig_str, matches, std::regex("(\\d+)/(\\d+)"))) {
-            meter->SetCount({ std::stoi(matches[1]) });
+            meter->SetCount(matches[1]);
             meter->SetUnit(std::stoi(matches[2]));
         }
         else if (regex_match(timesig_str, matches, std::regex("\\d+"))) {
-            meter->SetCount({ std::stoi(timesig_str) });
+            meter->SetCount(timesig_str);
             meter->SetUnit(1);
             meter->SetForm(METERFORM_num);
         }
@@ -1409,12 +1409,12 @@ int PAEInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
         else if (strcmp(timesig_str, "c3") == 0) {
             // C3
             meter->SetSym(METERSIGN_common);
-            meter->SetCount({ 3 });
+            meter->SetCount("3");
         }
         else if (strcmp(timesig_str, "c3/2") == 0) {
             // C3/2
             meter->SetSym(METERSIGN_common); // ??
-            meter->SetCount({ 3 });
+            meter->SetCount("3");
             meter->SetUnit(2);
         }
         else {
@@ -4703,11 +4703,11 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
 
     std::cmatch matches;
     if (regex_match(paeStr.c_str(), matches, std::regex("(\\d+)/(\\d+)"))) {
-        meterSig->SetCount({ std::stoi(matches[1]) });
+        meterSig->SetCount(matches[1]);
         meterSig->SetUnit(std::stoi(matches[2]));
     }
     else if (regex_match(paeStr.c_str(), matches, std::regex("\\d+"))) {
-        meterSig->SetCount({ std::stoi(paeStr.c_str()) });
+        meterSig->SetCount(paeStr);
         meterSig->SetUnit(1);
         meterSig->SetForm(METERFORM_num);
     }
@@ -4722,12 +4722,12 @@ bool PAEInput::ParseMeterSig(MeterSig *meterSig, const std::string &paeStr, pae:
     else if (paeStr == "c3") {
         // C3
         meterSig->SetSym(METERSIGN_common);
-        meterSig->SetCount({ 3 });
+        meterSig->SetCount("3");
     }
     else if (paeStr == "c3/2") {
         // C3/2
         meterSig->SetSym(METERSIGN_common); // ??
-        meterSig->SetCount({ 3 });
+        meterSig->SetCount("3");
         meterSig->SetUnit(2);
     }
     else {

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -47,7 +47,7 @@ void MeterSig::Reset()
     this->ResetMeterSigVis();
 }
 
-int MeterSig::GetTotalCount()
+int MeterSig::GetTotalCount() const
 {
     auto [counts, sign] = this->GetCount();
     switch (sign) {

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -49,16 +49,30 @@ void MeterSig::Reset()
 
 int MeterSig::GetTotalCount() const
 {
-    const auto [counts, sign] = this->GetMeterCounts();
+    auto [counts, sign] = this->GetMeterCounts();
     switch (sign) {
-        case CountSign::Divide:
-            return std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::divides<int>());
-        case CountSign::Minus:
-            return std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::minus<int>());
-        case CountSign::Multiply:
-            return std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::multiplies<int>());
-        case CountSign::Plus:
-            return std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::plus<int>());
+        case CountSign::Divide: {
+            // make sure that there is no division by zero
+            std::for_each(counts.begin(), counts.end(), [](int &elem) {
+                if (!elem) elem = 1;
+            });
+            int result = std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::divides<int>());
+            if (!result) result = 1;
+            return result;
+        }
+        case CountSign::Minus: {
+            int result = std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::minus<int>());
+            if (result <= 0) result = 1;
+            return result;
+        }
+        case CountSign::Multiply: {
+            int result = std::accumulate(counts.begin(), counts.end(), 1, std::multiplies<int>());
+            if (!result) result = 1;
+            return result;
+        }
+        case CountSign::Plus: {
+            return std::accumulate(counts.begin(), counts.end(), 0, std::plus<int>());
+        }
         case CountSign::None:
         default: break;
     }

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -51,7 +51,7 @@ int MeterSig::GetTotalCount() const
 {
     auto [counts, sign] = this->GetMeterCounts();
     switch (sign) {
-        case CountSign::Divide: {
+        case MeterCountSign::Divide: {
             // make sure that there is no division by zero
             std::for_each(counts.begin(), counts.end(), [](int &elem) {
                 if (!elem) elem = 1;
@@ -60,27 +60,27 @@ int MeterSig::GetTotalCount() const
             if (!result) result = 1;
             return result;
         }
-        case CountSign::Minus: {
+        case MeterCountSign::Minus: {
             int result = std::accumulate(std::next(counts.begin()), counts.end(), *counts.begin(), std::minus<int>());
             if (result <= 0) result = 1;
             return result;
         }
-        case CountSign::Multiply: {
+        case MeterCountSign::Multiply: {
             int result = std::accumulate(counts.begin(), counts.end(), 1, std::multiplies<int>());
             if (!result) result = 1;
             return result;
         }
-        case CountSign::Plus: {
+        case MeterCountSign::Plus: {
             return std::accumulate(counts.begin(), counts.end(), 0, std::plus<int>());
         }
-        case CountSign::None:
+        case MeterCountSign::None:
         default: break;
     }
 
     return counts.front();
 }
 
-std::pair<std::vector<int>, MeterSig::CountSign> MeterSig::GetMeterCounts() const 
+std::pair<std::vector<int>, MeterSig::MeterCountSign> MeterSig::GetMeterCounts() const
 {
     const std::string count = this->GetCount();
     std::regex re("[\\*\\+/-]");
@@ -89,20 +89,20 @@ std::pair<std::vector<int>, MeterSig::CountSign> MeterSig::GetMeterCounts() cons
 
     // Since there is currently no need for implementation of complex calculus within metersig, only one opperation will
     // be supported in the meter count. Caclulation will be based on the first mathematical operator in the string
-    MeterSig::CountSign sign = CountSign::None;
+    MeterSig::MeterCountSign sign = MeterCountSign::None;
     const size_t pos = count.find_first_of("+-*/");
     if (pos != std::string::npos) {
         if (count[pos] == '/') {
-            sign = CountSign::Divide;
+            sign = MeterCountSign::Divide;
         }
         else if (count[pos] == '*') {
-            sign = CountSign::Multiply;
+            sign = MeterCountSign::Multiply;
         }
         else if (count[pos] == '+') {
-            sign = CountSign::Plus;
+            sign = MeterCountSign::Plus;
         }
         else if (count[pos] == '-') {
-            sign = CountSign::Minus;
+            sign = MeterCountSign::Minus;
         }
     }
     std::vector<int> result;
@@ -111,17 +111,17 @@ std::pair<std::vector<int>, MeterSig::CountSign> MeterSig::GetMeterCounts() cons
     return { result, sign };
 }
 
-void MeterSig::SetMeterCounts(const std::vector<int> &counts, MeterSig::CountSign sign) 
+void MeterSig::SetMeterCounts(const std::vector<int> &counts, MeterSig::MeterCountSign sign)
 {
     std::stringstream output;
     for (const int count : counts) {
         output << count;
         switch (sign) {
-            case CountSign::Divide: output << '\\'; break;
-            case CountSign::Minus: output << '-'; break;
-            case CountSign::Multiply: output << '*'; break;
-            case CountSign::Plus: output << '+'; break;
-            case CountSign::None:
+            case MeterCountSign::Divide: output << '\\'; break;
+            case MeterCountSign::Minus: output << '-'; break;
+            case MeterCountSign::Multiply: output << '*'; break;
+            case MeterCountSign::Plus: output << '+'; break;
+            case MeterCountSign::None:
             default: break;
         }
     }

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -51,7 +51,7 @@ int MeterSig::GetTotalCount() const
 {
     auto [counts, sign] = this->GetMeterCounts();
     switch (sign) {
-        case MeterCountSign::Divide: {
+        case MeterCountSign::Slash: {
             // make sure that there is no division by zero
             std::for_each(counts.begin(), counts.end(), [](int &elem) {
                 if (!elem) elem = 1;
@@ -65,7 +65,7 @@ int MeterSig::GetTotalCount() const
             if (result <= 0) result = 1;
             return result;
         }
-        case MeterCountSign::Multiply: {
+        case MeterCountSign::Asterisk: {
             int result = std::accumulate(counts.begin(), counts.end(), 1, std::multiplies<int>());
             if (!result) result = 1;
             return result;
@@ -93,10 +93,10 @@ std::pair<std::vector<int>, MeterSig::MeterCountSign> MeterSig::GetMeterCounts()
     const size_t pos = count.find_first_of("+-*/");
     if (pos != std::string::npos) {
         if (count[pos] == '/') {
-            sign = MeterCountSign::Divide;
+            sign = MeterCountSign::Slash;
         }
         else if (count[pos] == '*') {
-            sign = MeterCountSign::Multiply;
+            sign = MeterCountSign::Asterisk;
         }
         else if (count[pos] == '+') {
             sign = MeterCountSign::Plus;
@@ -117,9 +117,9 @@ void MeterSig::SetMeterCounts(const std::vector<int> &counts, MeterSig::MeterCou
     for (const int count : counts) {
         output << count;
         switch (sign) {
-            case MeterCountSign::Divide: output << '\\'; break;
+            case MeterCountSign::Slash: output << '\\'; break;
             case MeterCountSign::Minus: output << '-'; break;
-            case MeterCountSign::Multiply: output << '*'; break;
+            case MeterCountSign::Asterisk: output << '*'; break;
             case MeterCountSign::Plus: output << '+'; break;
             case MeterCountSign::None:
             default: break;

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -56,12 +56,14 @@ int MeterSig::GetTotalCount()
             std::for_each(counts.begin(), counts.end(), [](int &elem) {
                 if (!elem) elem = 1;
             });
-            int result = std::accumulate(std::next(counts.cbegin()), counts.cend(), *counts.cbegin(), std::divides<int>());
+            int result
+                = std::accumulate(std::next(counts.cbegin()), counts.cend(), *counts.cbegin(), std::divides<int>());
             if (!result) result = 1;
             return result;
         }
         case MeterCountSign::Minus: {
-            int result = std::accumulate(std::next(counts.cbegin()), counts.cend(), *counts.cbegin(), std::minus<int>());
+            int result
+                = std::accumulate(std::next(counts.cbegin()), counts.cend(), *counts.cbegin(), std::minus<int>());
             if (result <= 0) result = 1;
             return result;
         }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -111,10 +111,10 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
             newMeterSig = vrv_cast<MeterSig *>((*it)->Clone());
             if (newMeterSig->GetUnit() < maxUnit) {
                 const int ratio = maxUnit / newMeterSig->GetUnit();
-                auto [currentCount, sign] = newMeterSig->GetMeterCounts();
+                auto [currentCount, sign] = newMeterSig->GetCount();
                 std::transform(currentCount.begin(), currentCount.end(), currentCount.begin(),
                     [&ratio](int elem) -> int { return elem * ratio; });
-                newMeterSig->SetMeterCounts(currentCount, sign);
+                newMeterSig->SetCount({ currentCount, sign });
                 newMeterSig->SetUnit(maxUnit);
             }
             break;
@@ -150,7 +150,7 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
                 }
             }
             newMeterSig->SetUnit(maxUnit);
-            newMeterSig->SetCount(std::to_string(currentCount));
+            newMeterSig->SetCount({ { currentCount }, MeterCountSign::None });
             break;
         }
         default: {

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -111,10 +111,10 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
             newMeterSig = vrv_cast<MeterSig *>((*it)->Clone());
             if (newMeterSig->GetUnit() < maxUnit) {
                 const int ratio = maxUnit / newMeterSig->GetUnit();
-                data_SUMMAND_List currentCount = newMeterSig->GetCount();
+                auto [currentCount, sign] = newMeterSig->GetMeterCounts();
                 std::transform(currentCount.begin(), currentCount.end(), currentCount.begin(),
                     [&ratio](int elem) -> int { return elem * ratio; });
-                newMeterSig->SetCount(currentCount);
+                newMeterSig->SetMeterCounts(currentCount, sign);
                 newMeterSig->SetUnit(maxUnit);
             }
             break;
@@ -150,7 +150,7 @@ MeterSig *MeterSigGrp::GetSimplifiedMeterSig() const
                 }
             }
             newMeterSig->SetUnit(maxUnit);
-            newMeterSig->SetCount({ currentCount });
+            newMeterSig->SetCount(std::to_string(currentCount));
             break;
         }
         default: {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1004,10 +1004,10 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
         x += m_doc->GetGlyphWidth(code, glyphSize, false);
     }
     else if (meterSig->GetForm() == METERFORM_num) {
-        x += this->DrawMeterSigFigures(dc, x, y, meterSig->GetCount(), 0, staff);
+        x += this->DrawMeterSigFigures(dc, x, y, meterSig, 0, staff);
     }
     else if (meterSig->HasCount()) {
-        x += this->DrawMeterSigFigures(dc, x, y, meterSig->GetCount(), meterSig->GetUnit(), staff);
+        x += this->DrawMeterSigFigures(dc, x, y, meterSig, meterSig->GetUnit(), staff);
     }
 
     if (enclosingBack) {
@@ -1823,16 +1823,25 @@ void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Sta
     }
 }
 
-int View::DrawMeterSigFigures(
-    DeviceContext *dc, int x, int y, const std::vector<int> &numSummands, int den, Staff *staff)
+int View::DrawMeterSigFigures(DeviceContext *dc, int x, int y, MeterSig *meterSig, int den, Staff *staff)
 {
     assert(dc);
     assert(staff);
 
+    const auto [numSummands, numSign] = meterSig->GetMeterCounts();
     std::wstring timeSigCombNumerator, timeSigCombDenominator;
     for (int summand : numSummands) {
-        if (!timeSigCombNumerator.empty()) timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall;
-        timeSigCombNumerator += this->IntToTimeSigFigures(summand);
+        if (!timeSigCombNumerator.empty()) {
+            switch (numSign) {
+                case MeterSig::CountSign::Divide: timeSigCombNumerator += SMUFL_E08E_timeSigFractionalSlash; break;
+                case MeterSig::CountSign::Minus: timeSigCombNumerator += SMUFL_E090_timeSigMinus; break;
+                case MeterSig::CountSign::Multiply: timeSigCombNumerator += SMUFL_E091_timeSigMultiply; break;
+                case MeterSig::CountSign::Plus: timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall; break;
+                case MeterSig::CountSign::None:
+                default: break;
+            }            
+        }
+        timeSigCombNumerator += IntToTimeSigFigures(summand);
     }
     if (den) timeSigCombDenominator = this->IntToTimeSigFigures(den);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1833,13 +1833,13 @@ int View::DrawMeterSigFigures(DeviceContext *dc, int x, int y, MeterSig *meterSi
     for (int summand : numSummands) {
         if (!timeSigCombNumerator.empty()) {
             switch (numSign) {
-                case MeterSig::CountSign::Divide: timeSigCombNumerator += SMUFL_E08E_timeSigFractionalSlash; break;
-                case MeterSig::CountSign::Minus: timeSigCombNumerator += SMUFL_E090_timeSigMinus; break;
-                case MeterSig::CountSign::Multiply: timeSigCombNumerator += SMUFL_E091_timeSigMultiply; break;
-                case MeterSig::CountSign::Plus: timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall; break;
-                case MeterSig::CountSign::None:
+                case MeterSig::MeterCountSign::Slash: timeSigCombNumerator += SMUFL_E08E_timeSigFractionalSlash; break;
+                case MeterSig::MeterCountSign::Minus: timeSigCombNumerator += SMUFL_E090_timeSigMinus; break;
+                case MeterSig::MeterCountSign::Asterisk: timeSigCombNumerator += SMUFL_E091_timeSigMultiply; break;
+                case MeterSig::MeterCountSign::Plus: timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall; break;
+                case MeterSig::MeterCountSign::None:
                 default: break;
-            }            
+            }
         }
         timeSigCombNumerator += IntToTimeSigFigures(summand);
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1828,16 +1828,16 @@ int View::DrawMeterSigFigures(DeviceContext *dc, int x, int y, MeterSig *meterSi
     assert(dc);
     assert(staff);
 
-    const auto [numSummands, numSign] = meterSig->GetMeterCounts();
+    const auto [numSummands, numSign] = meterSig->GetCount();
     std::wstring timeSigCombNumerator, timeSigCombDenominator;
     for (int summand : numSummands) {
         if (!timeSigCombNumerator.empty()) {
             switch (numSign) {
-                case MeterSig::MeterCountSign::Slash: timeSigCombNumerator += SMUFL_E08E_timeSigFractionalSlash; break;
-                case MeterSig::MeterCountSign::Minus: timeSigCombNumerator += SMUFL_E090_timeSigMinus; break;
-                case MeterSig::MeterCountSign::Asterisk: timeSigCombNumerator += SMUFL_E091_timeSigMultiply; break;
-                case MeterSig::MeterCountSign::Plus: timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall; break;
-                case MeterSig::MeterCountSign::None:
+                case MeterCountSign::Slash: timeSigCombNumerator += SMUFL_E08E_timeSigFractionalSlash; break;
+                case MeterCountSign::Minus: timeSigCombNumerator += SMUFL_E090_timeSigMinus; break;
+                case MeterCountSign::Asterisk: timeSigCombNumerator += SMUFL_E091_timeSigMultiply; break;
+                case MeterCountSign::Plus: timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall; break;
+                case MeterCountSign::None:
                 default: break;
             }
         }


### PR DESCRIPTION
Updated libMEI and added support for the MeterSig count values, that contain symbols `\`, `*` and `-`.
![image](https://user-images.githubusercontent.com/1819669/165043948-8a183b33-9716-4139-b5ab-e905d7b9d2d6.png)
