### PR TITLE
Read annot text children instead of storing them

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -6927,6 +6927,7 @@ bool MEIInput::ReadAnnot(Object *parent, pugi::xml_node annot)
         return true;
     }
     else {
+        vrvAnnot->m_content.remove_children();
         return this->ReadTextChildren(vrvAnnot, annot, vrvAnnot);
     }
 }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -6911,16 +6911,9 @@ bool MEIInput::ReadAnnot(Object *parent, pugi::xml_node annot)
     vrvAnnot->ReadPlist(annot);
     vrvAnnot->ReadSource(annot);
 
-    vrvAnnot->m_content.reset();
-    // copy all the nodes inside into the document
-    for (pugi::xml_node child = annot.first_child(); child; child = child.next_sibling()) {
-        vrvAnnot->m_content.append_copy(child);
-    }
-
     parent->AddChild(vrvAnnot);
     this->ReadUnsupportedAttr(annot, vrvAnnot);
-    // for Annot we do not load children because they preserved in Annot::m_content
-    return true;
+    return this->ReadTextChildren(vrvAnnot, annot, vrvAnnot);
 }
 
 bool MEIInput::ReadApp(Object *parent, pugi::xml_node app, EditorialLevel level, Object *filter)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -6912,8 +6912,23 @@ bool MEIInput::ReadAnnot(Object *parent, pugi::xml_node annot)
     vrvAnnot->ReadSource(annot);
 
     parent->AddChild(vrvAnnot);
+    vrvAnnot->m_content.reset();
+
+    bool hasNonTextContent = false;
+    // copy all the nodes inside into the document
+    for (pugi::xml_node child = annot.first_child(); child; child = child.next_sibling()) {
+        const std::string nodeName = child.name();
+        if (!hasNonTextContent && (!nodeName.empty())) hasNonTextContent = true;
+        vrvAnnot->m_content.append_copy(child);
+    }
     this->ReadUnsupportedAttr(annot, vrvAnnot);
-    return this->ReadTextChildren(vrvAnnot, annot, vrvAnnot);
+    // Unless annot has only text we do not load children because they are preserved in Annot::m_content
+    if (hasNonTextContent) {
+        return true;
+    }
+    else {
+        return this->ReadTextChildren(vrvAnnot, annot, vrvAnnot);
+    }
 }
 
 bool MEIInput::ReadApp(Object *parent, pugi::xml_node app, EditorialLevel level, Object *filter)


### PR DESCRIPTION
Right now `<annot>` element is simply being ignored and empty `<desc>` element added to SVG (see annot-001.mei)
Instead of reading content to internal storage, text children should be parsed which would fix the issue.