### PR TITLE
Add support for number attributes on mRpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 * Improved rendering with diamond and slash shaped noteheads (@eNote-GmBH)
 * Improved rendering of slurs (@eNote-GmBH)
+* Support for `mRpt@num` and `mRpt@num.place` (@eNote-GmBH)
 * Support for `mixed` croff-staff slurs (@eNote-GmBH)
 * Support for `non-arp` arpeggios (@eNote-GmBH)
 * Option --beam-french-style for french beam style (@eNote-GmBH)

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -23,7 +23,7 @@ namespace vrv {
 /**
  * This class models the MEI <mRpt> element.
  */
-class MRpt : public LayerElement, public AttColor {
+class MRpt : public LayerElement, public AttColor, public AttNumbered, public AttNumberPlacement {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2356,6 +2356,8 @@ void MEIOutput::WriteMRpt(pugi::xml_node currentNode, MRpt *mRpt)
 
     this->WriteLayerElement(currentNode, mRpt);
     mRpt->WriteColor(currentNode);
+    mRpt->WriteNumbered(currentNode);
+    mRpt->WriteNumberPlacement(currentNode);
 }
 
 void MEIOutput::WriteMRpt2(pugi::xml_node currentNode, MRpt2 *mRpt2)
@@ -6077,6 +6079,8 @@ bool MEIInput::ReadMRpt(Object *parent, pugi::xml_node mRpt)
     this->ReadLayerElement(mRpt, vrvMRpt);
 
     vrvMRpt->ReadColor(mRpt);
+    vrvMRpt->ReadNumbered(mRpt);
+    vrvMRpt->ReadNumberPlacement(mRpt);
 
     parent->AddChild(vrvMRpt);
     this->ReadUnsupportedAttr(mRpt, vrvMRpt);

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -30,9 +30,11 @@ namespace vrv {
 
 static const ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
 
-MRpt::MRpt() : LayerElement(MRPT, "mrpt-"), AttColor()
+MRpt::MRpt() : LayerElement(MRPT, "mrpt-"), AttColor(), AttNumbered(), AttNumberPlacement()
 {
     this->RegisterAttClass(ATT_COLOR);
+    this->RegisterAttClass(ATT_NUMBERED);
+    this->RegisterAttClass(ATT_NUMBERPLACEMENT);
 
     this->Reset();
 }
@@ -43,6 +45,7 @@ void MRpt::Reset()
 {
     LayerElement::Reset();
     this->ResetColor();
+    this->ResetNumbered();
 
     m_drawingMeasureCount = 0;
 }

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -46,6 +46,7 @@ void MRpt::Reset()
     LayerElement::Reset();
     this->ResetColor();
     this->ResetNumbered();
+    this->ResetNumberPlacement();
 
     m_drawingMeasureCount = 0;
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -431,21 +431,19 @@ void View::DrawBeatRpt(DeviceContext *dc, LayerElement *element, Layer *layer, S
     dc->StartGraphic(element, "", element->GetUuid());
 
     const int x = element->GetDrawingX();
-    int xSymbol = x;
-    int y = element->GetDrawingY();
-    y -= staff->m_drawingLines / 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int staffSize = staff->m_drawingStaffSize;
+    const int xSymbol = x;
+    const int ySymbol = element->GetDrawingY() - (staff->m_drawingLines - 1) * m_doc->GetDrawingUnit(staffSize);
 
     if (beatRpt->GetSlash() == BEATRPT_REND_mixed) {
-        this->DrawSmuflCode(dc, xSymbol, y, SMUFL_E501_repeat2Bars, staff->m_drawingStaffSize, false);
+        this->DrawSmuflCode(dc, xSymbol, ySymbol, SMUFL_E501_repeat2Bars, staffSize, false);
     }
     else {
         wchar_t slash = SMUFL_E504_repeatBarSlash;
-        this->DrawSmuflCode(dc, xSymbol, y, slash, staff->m_drawingStaffSize, false);
         const int slashNum = beatRpt->GetSlash();
-        const int halfWidth = m_doc->GetGlyphWidth(slash, staff->m_drawingStaffSize, false) / 2;
-        for (int i = 0; i < (slashNum - 1); ++i) {
-            xSymbol += halfWidth;
-            this->DrawSmuflCode(dc, xSymbol, y, slash, staff->m_drawingStaffSize, false);
+        const int halfWidth = m_doc->GetGlyphWidth(slash, staffSize, false) / 2;
+        for (int i = 0; i < slashNum; ++i) {
+            this->DrawSmuflCode(dc, xSymbol + i * halfWidth, ySymbol, slash, staffSize, false);
         }
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1080,14 +1080,15 @@ void View::DrawMRpt(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
         // calculate the extend of the number
         TextExtend extend;
-        std::wstring figures = IntToTupletFigures(mRptNum);
+        const std::wstring figures = this->IntToTupletFigures(mRptNum);
         dc->GetSmuflTextExtent(figures, &extend);
         const int staffSize = staff->m_drawingStaffSize;
         const int staffHeight = (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize);
         const int offset = std::max(m_doc->GetGlyphHeight(SMUFL_E500_repeat1Bar, staffSize, false) - staffHeight, 0);
         int yNum = staff->GetDrawingY() + m_doc->GetDrawingUnit(staffSize) + offset / 2;
-        if (mRpt->GetNumPlace() == STAFFREL_basic_below)
+        if (mRpt->GetNumPlace() == STAFFREL_basic_below) {
             yNum -= staff->m_drawingLines * m_doc->GetDrawingDoubleUnit(staffSize) + extend.m_height + offset;
+        }
         dc->DrawMusicText(
             figures, ToDeviceContextX(element->GetDrawingX() - extend.m_width / 2), ToDeviceContextY(yNum));
         dc->ResetFont();
@@ -1233,7 +1234,7 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
             : std::max(staff->GetDrawingY(), y1) + offset;
 
         this->DrawSmuflString(
-            dc, xCentered, y, IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
+            dc, xCentered, y, this->IntToTimeSigFigures(num), HORIZONTALALIGNMENT_center, staff->m_drawingStaffSize);
         dc->ResetFont();
     }
 
@@ -1810,9 +1811,9 @@ int View::DrawMeterSigFigures(
     std::wstring timeSigCombNumerator, timeSigCombDenominator;
     for (int summand : numSummands) {
         if (!timeSigCombNumerator.empty()) timeSigCombNumerator += SMUFL_E08D_timeSigPlusSmall;
-        timeSigCombNumerator += IntToTimeSigFigures(summand);
+        timeSigCombNumerator += this->IntToTimeSigFigures(summand);
     }
-    if (den) timeSigCombDenominator = IntToTimeSigFigures(den);
+    if (den) timeSigCombDenominator = this->IntToTimeSigFigures(den);
 
     const int glyphSize = staff->GetDrawingStaffNotationSize();
 
@@ -1874,7 +1875,7 @@ void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t rptGlyph, int 
         dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
         // calculate the width of the figures
         TextExtend extend;
-        std::wstring figures = IntToTimeSigFigures(num);
+        const std::wstring figures = this->IntToTimeSigFigures(num);
         dc->GetSmuflTextExtent(figures, &extend);
         const int symHeight = m_doc->GetGlyphHeight(rptGlyph, staffSize, false);
         const int yNum = (y > ySymbol + symHeight / 2)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1841,27 +1841,30 @@ int View::DrawMeterSigFigures(
 
 void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smuflCode, int num, bool line, Staff *staff)
 {
-    int xSymbol = xCentered - m_doc->GetGlyphWidth(smuflCode, staff->m_drawingStaffSize, false) / 2;
-    int y = staff->GetDrawingY();
-    int ySymbol = y - staff->m_drawingLines / 2 * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int staffSize = staff->m_drawingStaffSize;
+    const int y = staff->GetDrawingY();
+    const int xSymbol = xCentered - m_doc->GetGlyphWidth(smuflCode, staffSize, false) / 2;
+    const int ySymbol = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize) / 2;
 
-    this->DrawSmuflCode(dc, xSymbol, ySymbol, smuflCode, staff->m_drawingStaffSize, false);
+    this->DrawSmuflCode(dc, xSymbol, ySymbol, smuflCode, staffSize, false);
 
     if (line) {
-        this->DrawVerticalLine(dc, y, y - m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize), xCentered,
-            m_doc->GetDrawingBarLineWidth(staff->m_drawingStaffSize));
+        const int yBottom = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize);
+        const int offset = (y == ySymbol) ? m_doc->GetDrawingDoubleUnit(staffSize) : 0;
+        this->DrawVerticalLine(dc, y + offset, yBottom - offset, xCentered, m_doc->GetDrawingBarLineWidth(staffSize));
     }
 
     if (num > 0) {
-        dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
+        dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
         // calculate the width of the figures
         TextExtend extend;
-        std::wstring figures = IntToTupletFigures(num);
+        std::wstring figures = IntToTimeSigFigures(num);
         dc->GetSmuflTextExtent(figures, &extend);
-        int y = (staff->GetDrawingY() > ySymbol)
-            ? staff->GetDrawingY() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize)
-            : ySymbol + 3 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        dc->DrawMusicText(figures, ToDeviceContextX(xCentered - extend.m_width / 2), ToDeviceContextY(y));
+        const int numHeight = m_doc->GetGlyphHeight(smuflCode, staffSize, false);
+        const int yNum = (y > ySymbol + numHeight / 2)
+            ? staff->GetDrawingY() + m_doc->GetDrawingUnit(staffSize) + extend.m_height / 2
+            : ySymbol + 3 * m_doc->GetDrawingUnit(staffSize) + extend.m_height / 2;
+        dc->DrawMusicText(figures, ToDeviceContextX(xCentered - extend.m_width / 2), ToDeviceContextY(yNum));
         dc->ResetFont();
     }
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -404,10 +404,10 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    int yTop = staff->GetDrawingY();
-    int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int yTop = staff->GetDrawingY();
+    const int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
 
-    int offset = (yTop == yBottom) ? m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) : 0;
+    const int offset = (yTop == yBottom) ? m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) : 0;
 
     this->DrawBarLine(dc, yTop + offset, yBottom - offset, barLine, barLine->GetForm());
     if (barLine->HasRepetitionDots()) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1082,9 +1082,12 @@ void View::DrawMRpt(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         TextExtend extend;
         std::wstring figures = IntToTupletFigures(mRptNum);
         dc->GetSmuflTextExtent(figures, &extend);
-        int yNum = staff->GetDrawingY() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        const int staffSize = staff->m_drawingStaffSize;
+        const int staffHeight = (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize);
+        const int offset = std::max(m_doc->GetGlyphHeight(SMUFL_E500_repeat1Bar, staffSize, false) - staffHeight, 0);
+        int yNum = staff->GetDrawingY() + m_doc->GetDrawingUnit(staffSize) + offset / 2;
         if (mRpt->GetNumPlace() == STAFFREL_basic_below)
-            yNum -= staff->m_drawingLines * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) + extend.m_height;
+            yNum -= staff->m_drawingLines * m_doc->GetDrawingDoubleUnit(staffSize) + extend.m_height + offset;
         dc->DrawMusicText(
             figures, ToDeviceContextX(element->GetDrawingX() - extend.m_width / 2), ToDeviceContextY(yNum));
         dc->ResetFont();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -430,9 +430,8 @@ void View::DrawBeatRpt(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    const int x = element->GetDrawingX();
     const int staffSize = staff->m_drawingStaffSize;
-    const int xSymbol = x;
+    const int xSymbol = element->GetDrawingX();
     const int ySymbol = element->GetDrawingY() - (staff->m_drawingLines - 1) * m_doc->GetDrawingUnit(staffSize);
 
     if (beatRpt->GetSlash() == BEATRPT_REND_mixed) {
@@ -1858,7 +1857,7 @@ void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smuflCode, int
     const int staffSize = staff->m_drawingStaffSize;
     const int y = staff->GetDrawingY();
     const int xSymbol = xCentered - m_doc->GetGlyphWidth(smuflCode, staffSize, false) / 2;
-    const int ySymbol = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize) / 2;
+    const int ySymbol = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingUnit(staffSize);
 
     this->DrawSmuflCode(dc, xSymbol, ySymbol, smuflCode, staffSize, false);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1075,7 +1075,23 @@ void View::DrawMRpt(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     dc->StartGraphic(element, "", element->GetUuid());
 
-    this->DrawMRptPart(dc, element->GetDrawingX(), SMUFL_E500_repeat1Bar, mRpt->m_drawingMeasureCount, false, staff);
+    this->DrawMRptPart(dc, element->GetDrawingX(), SMUFL_E500_repeat1Bar, 0, false, staff);
+
+    // draw the measure count
+    const int mRptNum = mRpt->HasNum() ? mRpt->GetNum() : mRpt->m_drawingMeasureCount;
+    if ((mRptNum > 0) && (mRpt->GetNumVisible() != BOOLEAN_false)) {
+        dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
+        // calculate the extend of the number
+        TextExtend extend;
+        std::wstring figures = IntToTupletFigures(mRptNum);
+        dc->GetSmuflTextExtent(figures, &extend);
+        int yNum = staff->GetDrawingY() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        if (mRpt->GetNumPlace() == STAFFREL_basic_below)
+            yNum -= staff->m_drawingLines * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) + extend.m_height;
+        dc->DrawMusicText(
+            figures, ToDeviceContextX(element->GetDrawingX() - extend.m_width / 2), ToDeviceContextY(yNum));
+        dc->ResetFont();
+    }
 
     dc->EndGraphic(element, this);
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1855,14 +1855,14 @@ int View::DrawMeterSigFigures(
     return width;
 }
 
-void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smuflCode, int num, bool line, Staff *staff)
+void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t rptGlyph, int num, bool line, Staff *staff)
 {
     const int staffSize = staff->m_drawingStaffSize;
     const int y = staff->GetDrawingY();
-    const int xSymbol = xCentered - m_doc->GetGlyphWidth(smuflCode, staffSize, false) / 2;
+    const int xSymbol = xCentered - m_doc->GetGlyphWidth(rptGlyph, staffSize, false) / 2;
     const int ySymbol = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingUnit(staffSize);
 
-    this->DrawSmuflCode(dc, xSymbol, ySymbol, smuflCode, staffSize, false);
+    this->DrawSmuflCode(dc, xSymbol, ySymbol, rptGlyph, staffSize, false);
 
     if (line) {
         const int yBottom = y - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize);
@@ -1876,8 +1876,8 @@ void View::DrawMRptPart(DeviceContext *dc, int xCentered, wchar_t smuflCode, int
         TextExtend extend;
         std::wstring figures = IntToTimeSigFigures(num);
         dc->GetSmuflTextExtent(figures, &extend);
-        const int numHeight = m_doc->GetGlyphHeight(smuflCode, staffSize, false);
-        const int yNum = (y > ySymbol + numHeight / 2)
+        const int symHeight = m_doc->GetGlyphHeight(rptGlyph, staffSize, false);
+        const int yNum = (y > ySymbol + symHeight / 2)
             ? staff->GetDrawingY() + m_doc->GetDrawingUnit(staffSize) + extend.m_height / 2
             : ySymbol + 3 * m_doc->GetDrawingUnit(staffSize) + extend.m_height / 2;
         dc->DrawMusicText(figures, ToDeviceContextX(xCentered - extend.m_width / 2), ToDeviceContextY(yNum));

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1264,7 +1264,7 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
         y2 = y1;
     }
 
-    int lineWidth = m_doc->GetDrawingStaffLineWidth(staff->m_drawingStaffSize);
+    const int lineWidth = m_doc->GetDrawingStaffLineWidth(staff->m_drawingStaffSize);
     dc->SetPen(m_currentColour, ToDeviceContextX(lineWidth), AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);
 


### PR DESCRIPTION
This PR adds support for `@num`, `@num.place`, and `@num.visible` to `mRpt`. 

![B-new](https://user-images.githubusercontent.com/7693447/165478265-2226e950-01fc-4453-90fa-8357921aafcc.png)

<details>
  <summary>Click to view MEI data for above example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Measure repetition numbers</title>
      </titleStmt>
      <pubStmt>
        <respStmt>
          <persName role="encoder">Klaus Rettinghaus</persName>
          <corpName role="funder">Enote GmbH</corpName>
       </respStmt>
       <date isodate="2022-04-25">2022-04-25</date>
      </pubStmt>
      <seriesStmt>
         <title>Verovio test suite</title>
      </seriesStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef meter.count="6" meter.unit="8">
            <staffGrp>
              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="1">
              <staff n="1">
                <layer n="1">
                  <beam>
                    <note dur="8" oct="4" pname="f" />
                    <note dur="16" oct="4" pname="a" />
                    <note dur="16" oct="5" pname="c" />
                    <note dur="8" oct="4" pname="a" />
                  </beam>
                  <beam>
                    <note dur="8" oct="5" pname="c" />
                    <note dur="8" oct="4" pname="a" />
                    <note dur="8" oct="4" pname="g" />
                  </beam>
                </layer>
              </staff>
            </measure>
            <measure n="2">
              <staff n="1">
                <layer n="1">
                  <supplied>
                    <mRpt num="253" />
                  </supplied>
                </layer>
              </staff>
            </measure>
            <measure n="3">
              <staff n="1">
                <layer n="1">
                  <mRpt num.place="below"  />
                </layer>
              </staff>
            </measure>
            <measure n="4">
              <staff n="1">
                <layer n="1">
                  <mRpt num.visible="false" />
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

Also it changes rendering for `mRpt2` and `multiRpt` to match the style seen elsewhere (e.g. Gould and default Finale) with bigger numbers and fixes rendering for staves that do not consist of five lines:

### Before

![A-old](https://user-images.githubusercontent.com/7693447/165478797-9e4d1b57-5b36-49ca-9214-46abe530e114.png)

### After

![A-new](https://user-images.githubusercontent.com/7693447/165478808-12b65357-ac8c-4541-92ea-de59494bb42b.png)

<details>
  <summary>Click to view MEI data for above example</summary>
  
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Two-measure repetition on single-line staff</title>
      </titleStmt>
      <pubStmt>
        <respStmt>
          <persName role="encoder">Klaus Rettinghaus</persName>
          <corpName role="funder">Enote GmbH</corpName>
       </respStmt>
       <date isodate="2022-04-25">2022-04-25</date>
      </pubStmt>
      <seriesStmt>
        <title>Verovio test suite</title>
     </seriesStmt>
      <notesStmt>
        <annot>Verovio supports repetition signs for two measures with the element "mRpt2".</annot>
      </notesStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef meter.count="2" meter.unit="4">
            <staffGrp>
              <staffDef n="1" lines="1" clef.shape="perc" lines.visible="true"/>
            </staffGrp>
          </scoreDef>
          <section>
            <measure n="1">
              <staff n="1">
                <layer n="1">
                  <beam>
                    <note dur="8" pname="c" />
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                  </beam>
                  <?edit-end ?>
                  <beam>
                    <note dur="8" pname="c" />
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                  </beam>
                  <beam>
                    <note dur="8" pname="c" />
                    <note dur="8" pname="c" />
                  </beam>
                </layer>
              </staff>
            </measure>
            <measure n="2">
              <staff n="1">
                <layer n="1">
                  <beam>
                    <note dur="8" pname="c" />
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                  </beam>
                  <?edit-end ?>
                  <beam>
                    <note dur="8" pname="c" />
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                  </beam>
                  <beam>
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                    <tuplet num="3" numbase="2">
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                      <note dur="16" pname="c" />
                    </tuplet>
                  </beam>
                </layer>
              </staff>
            </measure>
            <measure n="3">
              <staff n="1">
                <layer n="1">
                  <mRpt2 />
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>