### PR TITLE
Fix for chord vertical justification

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -940,7 +940,22 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
 
     const int topStaffN = extremalStaves.front()->GetN();
     const int bottomStaffN = extremalStaves.back()->GetN();
-    if (topStaffN < bottomStaffN) {
+
+    bool hasCrossStaffNotes = false;
+    if ((topStaffN == bottomStaffN) && this->HasCrossStaff() && !m_crossStaff) {
+        Staff *staff = vrv_cast<Staff *>(this->GetFirstAncestor(STAFF));
+        if (staff != extremalStaves.front()) {
+            extremalStaves.pop_back();
+            if (staff->GetN() > topStaffN) {
+                extremalStaves.push_back(staff);
+            }
+            else {
+                extremalStaves.push_front(staff);
+            }
+            hasCrossStaffNotes = true;
+        }
+    }
+    if (topStaffN < bottomStaffN || hasCrossStaffNotes) {
         // Now calculate the shift due to vertical justification
         auto getShift = [params](Staff *staff) {
             StaffAlignment *alignment = staff->GetAlignment();

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -968,7 +968,7 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
     // Reposition the stem
     Staff *staff = this->GetAncestorStaff();
     Staff *rootStaff = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? extremalStaves.rbegin()->second
-                                                                        : extremalStaves.begin()->second;
+                                                                       : extremalStaves.begin()->second;
     stem->SetDrawingYRel(stem->GetDrawingYRel() + getShift(staff) - getShift(rootStaff));
 
     // Add the shift to the flag position
@@ -977,7 +977,6 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
         const int sign = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? 1 : -1;
         flag->SetDrawingYRel(flag->GetDrawingYRel() + sign * shift);
     }
-
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -942,9 +942,6 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
 
     if (extremalStaves.size() < 2) return FUNCTOR_CONTINUE;
 
-    const int topStaffN = extremalStaves.begin()->first;
-    const int bottomStaffN = extremalStaves.rbegin()->first;
-
     // Now calculate the shift due to vertical justification
     auto getShift = [params](Staff *staff) {
         StaffAlignment *alignment = staff->GetAlignment();

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -966,7 +966,6 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
     }
 
     // Reposition the stem
-    Staff *staff = this->GetAncestorStaff();
     Staff *rootStaff = (stem->GetDrawingStemDir() == STEMDIRECTION_up) ? extremalStaves.rbegin()->second
                                                                        : extremalStaves.begin()->second;
     stem->SetDrawingYRel(stem->GetDrawingYRel() + getShift(staff) - getShift(rootStaff));


### PR DESCRIPTION
Fixes an issue with vertical justification on chords with all cross-staff elements:
![image](https://user-images.githubusercontent.com/1819669/165927277-03748600-aced-4818-bcc9-5b39406ae0df.png)

After fix:
![image](https://user-images.githubusercontent.com/1819669/165927327-fa4dbac7-bfbb-45de-903c-2bd8c0676376.png)
