### PR TITLE
Improve timemap for grace notes and cue notes

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1700,28 +1700,29 @@ using MIDIChordSequence = std::list<MIDIChord>;
  * member 8: deferred notes which start slightly later
  * member 9: grace note sequence
  * member 10: flag indicating whether the last grace note/chord was accented
- * member 11: the functor
- * member 12: Tablature held notes indexed by (course - 1)
+ * member 11: flag indicating whether cue notes should be included
+ * member 12: the functor
+ * member 13: Tablature held notes indexed by (course - 1)
  **/
 
 class GenerateMIDIParams : public FunctorParams {
 public:
-    GenerateMIDIParams(Doc *doc, smf::MidiFile *midiFile, Functor *functor)
+    GenerateMIDIParams(smf::MidiFile *midiFile, Functor *functor)
     {
         m_midiFile = midiFile;
-        m_midiChannel = 0;
         m_midiTrack = 1;
+        m_midiChannel = 0;
         m_totalTime = 0.0;
         m_transSemi = 0;
         m_currentTempo = MIDI_TEMPO;
         m_lastNote = NULL;
         m_accentedGraceNote = false;
+        m_cueExclusion = false;
         m_functor = functor;
-        m_doc = doc;
     }
     smf::MidiFile *m_midiFile;
-    int m_midiChannel;
     int m_midiTrack;
+    int m_midiChannel;
     double m_totalTime;
     int m_transSemi;
     double m_currentTempo;
@@ -1730,9 +1731,9 @@ public:
     std::map<Note *, double> m_deferredNotes;
     MIDIChordSequence m_graceNotes;
     bool m_accentedGraceNote;
+    bool m_cueExclusion;
     Functor *m_functor;
     std::vector<MIDIHeldNote> m_heldNotes;
-    Doc *m_doc;
 };
 
 //----------------------------------------------------------------------------
@@ -1743,8 +1744,9 @@ public:
  * member 0: Score time from the start of the piece to previous barline in quarter notes
  * member 1: Real time from the start of the piece to previous barline in ms
  * member 2: Currently active tempo
- * member 3: A pointer to the Timemap
- * member 4: The functor for redirection
+ * member 3: flag indicating whether cue notes should be included
+ * member 4: a pointer to the Timemap
+ * member 5: the functor for redirection
  **/
 
 class GenerateTimemapParams : public FunctorParams {
@@ -1754,12 +1756,14 @@ public:
         m_scoreTimeOffset = 0.0;
         m_realTimeOffsetMilliseconds = 0;
         m_currentTempo = MIDI_TEMPO;
+        m_cueExclusion = false;
         m_timemap = timemap;
         m_functor = functor;
     }
     double m_scoreTimeOffset;
     double m_realTimeOffsetMilliseconds;
     double m_currentTempo;
+    bool m_cueExclusion;
     Timemap *m_timemap;
     Functor *m_functor;
 };

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -415,12 +415,13 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
 
             Functor generateMIDI(&Object::GenerateMIDI);
             Functor generateMIDIEnd(&Object::GenerateMIDIEnd);
-            GenerateMIDIParams generateMIDIParams(this, midiFile, &generateMIDI);
+            GenerateMIDIParams generateMIDIParams(midiFile, &generateMIDI);
             generateMIDIParams.m_midiChannel = midiChannel;
             generateMIDIParams.m_midiTrack = midiTrack;
             generateMIDIParams.m_transSemi = transSemi;
             generateMIDIParams.m_currentTempo = tempo;
             generateMIDIParams.m_deferredNotes = initMIDIParams.m_deferredNotes;
+            generateMIDIParams.m_cueExclusion = this->GetOptions()->m_midiNoCue.GetValue();
 
             // LogDebug("Exporting track %d ----------------", midiTrack);
             this->Process(&generateMIDI, &generateMIDIParams, &generateMIDIEnd, &filters);
@@ -442,6 +443,7 @@ bool Doc::ExportTimemap(std::string &output, bool includeRests, bool includeMeas
     Timemap timemap;
     Functor generateTimemap(&Object::GenerateTimemap);
     GenerateTimemapParams generateTimemapParams(&timemap, &generateTimemap);
+    generateTimemapParams.m_cueExclusion = this->GetOptions()->m_midiNoCue.GetValue();
     this->Process(&generateTimemap, &generateTimemapParams);
 
     timemap.ToJson(output, includeRests, includeMeasures);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -736,9 +736,7 @@ int Layer::GenerateMIDI(FunctorParams *functorParams)
     GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
     assert(params);
 
-    const bool midiNoCue = params->m_doc->GetOptions()->m_midiNoCue.GetValue();
-
-    if (this->GetCue() == BOOLEAN_true && midiNoCue) return FUNCTOR_SIBLINGS;
+    if (this->GetCue() == BOOLEAN_true && params->m_cueExclusion) return FUNCTOR_SIBLINGS;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1425,7 +1425,7 @@ int Note::GenerateMIDI(FunctorParams *functorParams)
     }
 
     // Skip cue notes when midiNoCue is activated
-    if (this->GetCue() == BOOLEAN_true && params->m_doc->GetOptions()->m_midiNoCue.GetValue()) {
+    if (this->GetCue() == BOOLEAN_true && params->m_cueExclusion) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -1537,6 +1537,13 @@ int Note::GenerateTimemap(FunctorParams *functorParams)
 {
     GenerateTimemapParams *params = vrv_params_cast<GenerateTimemapParams *>(functorParams);
     assert(params);
+
+    if (this->HasGrace()) return FUNCTOR_SIBLINGS;
+
+    // Skip cue notes when midiNoCue is activated
+    if (this->GetCue() == BOOLEAN_true && params->m_cueExclusion) {
+        return FUNCTOR_SIBLINGS;
+    }
 
     Note *note = vrv_cast<Note *>(this->ThisOrSameasAsLink());
     assert(note);


### PR DESCRIPTION
This PR improves handling of cue notes in MIDI and timemap by adding a functor member for cue exclusion. 
When the option `midiNoCue` cue notes will be excluded from MIDI output and the timemap. 
Also grace notes will not show up in the timemap.

closes #2824