### PR TITLE
Automatic curve direction for grace note slurs

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -210,9 +210,10 @@ private:
     // Get cross staff by only considering the slur boundary
     Staff *GetBoundaryCrossStaff();
     // Determine curve direction for the slurs that start at grace note
-    curvature_CURVEDIR GetGraceCurveDirection(Doc *doc);
+    curvature_CURVEDIR GetGraceCurveDirection() const;
     // Get preferred curve direction based on various conditions
-    curvature_CURVEDIR GetPreferredCurveDirection(Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
+    curvature_CURVEDIR GetPreferredCurveDirection(
+        Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur);
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -213,7 +213,7 @@ private:
     curvature_CURVEDIR GetGraceCurveDirection() const;
     // Get preferred curve direction based on various conditions
     curvature_CURVEDIR GetPreferredCurveDirection(
-        Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur);
+        data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur);
     ///@}
 
     /**

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1008,7 +1008,7 @@ curvature_CURVEDIR Slur::GetGraceCurveDirection() const
 }
 
 curvature_CURVEDIR Slur::GetPreferredCurveDirection(
-    Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur)
+    data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur)
 {
     Note *startNote = NULL;
     Chord *startParentChord = NULL;
@@ -1573,7 +1573,7 @@ int Slur::CalcSlurDirection(FunctorParams *functorParams)
 
         const int center = staff->GetDrawingY() - params->m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) / 2;
         const bool isAboveStaffCenter = (start->GetDrawingY() > center);
-        if (this->GetPreferredCurveDirection(params->m_doc, startStemDir, isAboveStaffCenter, isGraceToNoteSlur)
+        if (this->GetPreferredCurveDirection(startStemDir, isAboveStaffCenter, isGraceToNoteSlur)
             == curvature_CURVEDIR_below) {
             this->SetDrawingCurveDir(SlurCurveDirection::Below);
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -994,53 +994,21 @@ float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVE
     return slurAngle;
 }
 
-curvature_CURVEDIR Slur::GetGraceCurveDirection(Doc *doc)
+curvature_CURVEDIR Slur::GetGraceCurveDirection() const
 {
-    LayerElement *start = this->GetStart();
-    LayerElement *end = this->GetEnd();
-    const bool overlap = start->VerticalContentOverlap(end);
-    const int topDiff = std::abs(start->GetContentTop() - end->GetContentTop());
-    const int bottomDiff = std::abs(start->GetContentBottom() - end->GetContentBottom());
-    if (overlap) {
-        if (bottomDiff < 1.5 * topDiff) {
-            return curvature_CURVEDIR_below;
-        }
-        else if ((bottomDiff < 3 * topDiff) && (NULL != end->IsInBeam())) {
-            return curvature_CURVEDIR_below;
-        }
-        else {
-            return curvature_CURVEDIR_above;
-        }
+    // Always start on the notehead side
+    const LayerElement *start = this->GetStart();
+    const StemmedDrawingInterface *startStemDrawInterface = start->GetStemmedDrawingInterface();
+    data_STEMDIRECTION startStemDir = STEMDIRECTION_NONE;
+    if (startStemDrawInterface) {
+        startStemDir = startStemDrawInterface->GetDrawingStemDir();
     }
-    else {
-        StemmedDrawingInterface *endStemDrawInterface = end->GetStemmedDrawingInterface();
-        data_STEMDIRECTION endStemDir = STEMDIRECTION_NONE;
-        if (endStemDrawInterface) {
-            endStemDir = endStemDrawInterface->GetDrawingStemDir();
-        }
-
-        if (end->GetContentBottom() > start->GetContentTop()) {
-            if (endStemDir == STEMDIRECTION_up)
-                return curvature_CURVEDIR_above;
-            else {
-                return (bottomDiff < topDiff) ? curvature_CURVEDIR_below : curvature_CURVEDIR_above;
-            }
-        }
-        else if (end->GetContentTop() < start->GetContentBottom()) {
-            if (endStemDir == STEMDIRECTION_down)
-                return curvature_CURVEDIR_below;
-            else {
-                return (bottomDiff < topDiff) ? curvature_CURVEDIR_below : curvature_CURVEDIR_above;
-            }
-        }
-    }
-    return curvature_CURVEDIR_below;
+    return (startStemDir == STEMDIRECTION_down) ? curvature_CURVEDIR_above : curvature_CURVEDIR_below;
 }
 
-curvature_CURVEDIR Slur::GetPreferredCurveDirection(Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter)
+curvature_CURVEDIR Slur::GetPreferredCurveDirection(
+    Doc *doc, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur)
 {
-    const bool isGraceToNoteSlur = !this->GetStart()->Is(TIMESTAMP_ATTR) && !this->GetEnd()->Is(TIMESTAMP_ATTR)
-        && this->GetStart()->IsGraceNote() && !this->GetEnd()->IsGraceNote();
     Note *startNote = NULL;
     Chord *startParentChord = NULL;
     if (this->GetStart()->Is(NOTE)) {
@@ -1060,12 +1028,12 @@ curvature_CURVEDIR Slur::GetPreferredCurveDirection(Doc *doc, data_STEMDIRECTION
         drawingCurveDir
             = (this->GetCurvedir() == curvature_CURVEDIR_above) ? curvature_CURVEDIR_above : curvature_CURVEDIR_below;
     }
-    // grace notes - always below unless we have a drawing stem direction on the layer
+    // grace note slurs in case we have no drawing stem direction on the layer
     else if (isGraceToNoteSlur && layer && layerElement
         && (layer->GetDrawingStemDir(layerElement) == STEMDIRECTION_NONE)) {
-        drawingCurveDir = this->GetGraceCurveDirection(doc);
+        drawingCurveDir = this->GetGraceCurveDirection();
     }
-    // then layer direction trumps note direction
+    // otherwise layer direction trumps note direction
     else if (layer && layerElement && ((layerStemDir = layer->GetDrawingStemDir(layerElement)) != STEMDIRECTION_NONE)) {
         drawingCurveDir = (layerStemDir == STEMDIRECTION_up) ? curvature_CURVEDIR_above : curvature_CURVEDIR_below;
     }
@@ -1577,14 +1545,17 @@ int Slur::CalcSlurDirection(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
     Staff *staff = staffList.at(0);
-    Staff *crossStaff = this->GetBoundaryCrossStaff();
-
     System *system = vrv_cast<System *>(staff->GetFirstAncestor(SYSTEM));
     assert(system);
 
-    if (!start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && system->HasMixedDrawingStemDir(start, end)) {
+    const bool isCrossStaff = (this->GetBoundaryCrossStaff() != NULL);
+    const bool isGraceToNoteSlur = !this->GetStart()->Is(TIMESTAMP_ATTR) && !this->GetEnd()->Is(TIMESTAMP_ATTR)
+        && this->GetStart()->IsGraceNote() && !this->GetEnd()->IsGraceNote();
+
+    if (!start->Is(TIMESTAMP_ATTR) && !end->Is(TIMESTAMP_ATTR) && !isGraceToNoteSlur
+        && system->HasMixedDrawingStemDir(start, end)) {
         // Handle mixed stem direction
-        if (crossStaff && (system->GetPreferredCurveDirection(start, end, this) == curvature_CURVEDIR_below)) {
+        if (isCrossStaff && (system->GetPreferredCurveDirection(start, end, this) == curvature_CURVEDIR_below)) {
             this->SetDrawingCurveDir(SlurCurveDirection::Below);
         }
         else {
@@ -1592,7 +1563,7 @@ int Slur::CalcSlurDirection(FunctorParams *functorParams)
         }
     }
     else {
-        // Handle uniform stem direction and time stamp boundaries
+        // Handle uniform stem direction, time stamp boundaries and grace note slurs
         StemmedDrawingInterface *startStemDrawInterface = start->GetStemmedDrawingInterface();
         data_STEMDIRECTION startStemDir = STEMDIRECTION_NONE;
         if (startStemDrawInterface) {
@@ -1601,7 +1572,7 @@ int Slur::CalcSlurDirection(FunctorParams *functorParams)
 
         const int center = staff->GetDrawingY() - params->m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) / 2;
         const bool isAboveStaffCenter = (start->GetDrawingY() > center);
-        if (this->GetPreferredCurveDirection(params->m_doc, startStemDir, isAboveStaffCenter)
+        if (this->GetPreferredCurveDirection(params->m_doc, startStemDir, isAboveStaffCenter, isGraceToNoteSlur)
             == curvature_CURVEDIR_below) {
             this->SetDrawingCurveDir(SlurCurveDirection::Below);
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1003,8 +1003,7 @@ curvature_CURVEDIR Slur::GetGraceCurveDirection() const
     const StemmedDrawingInterface *startStemDrawInterface = start->GetStemmedDrawingInterface();
     const bool isStemDown
         = startStemDrawInterface && (startStemDrawInterface->GetDrawingStemDir() == STEMDIRECTION_down);
-    const bool isBeam = start->IsInBeam() || start->IsInBeamSpan() || start->IsInFTrem();
-    return (isStemDown == isBeam) ? curvature_CURVEDIR_below : curvature_CURVEDIR_above;
+    return isStemDown ? curvature_CURVEDIR_above : curvature_CURVEDIR_below;
 }
 
 curvature_CURVEDIR Slur::GetPreferredCurveDirection(

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -996,14 +996,13 @@ float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVE
 
 curvature_CURVEDIR Slur::GetGraceCurveDirection() const
 {
-    // Always start on the notehead side
+    // Start on the notehead side except for beams
     const LayerElement *start = this->GetStart();
     const StemmedDrawingInterface *startStemDrawInterface = start->GetStemmedDrawingInterface();
-    data_STEMDIRECTION startStemDir = STEMDIRECTION_NONE;
-    if (startStemDrawInterface) {
-        startStemDir = startStemDrawInterface->GetDrawingStemDir();
-    }
-    return (startStemDir == STEMDIRECTION_down) ? curvature_CURVEDIR_above : curvature_CURVEDIR_below;
+    const bool isStemDown
+        = startStemDrawInterface && (startStemDrawInterface->GetDrawingStemDir() == STEMDIRECTION_down);
+    const bool isBeam = start->IsInBeam() || start->IsInBeamSpan() || start->IsInFTrem();
+    return (isStemDown == isBeam) ? curvature_CURVEDIR_below : curvature_CURVEDIR_above;
 }
 
 curvature_CURVEDIR Slur::GetPreferredCurveDirection(

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -134,14 +134,16 @@ std::pair<Layer *, LayerElement *> Slur::GetBoundaryLayer()
 
     Layer *layer = NULL;
     LayerElement *layerElement = NULL;
-    // For now, with timestamps, get the first layer. We should eventually look at the @layerident (not implemented)
     if (!start->Is(TIMESTAMP_ATTR)) {
-        layer = dynamic_cast<Layer *>(start->GetFirstAncestor(LAYER));
+        layer = vrv_cast<Layer *>(start->GetFirstAncestor(LAYER));
         layerElement = start;
     }
-    else if (!end->Is(TIMESTAMP_ATTR)) {
-        layer = dynamic_cast<Layer *>(end->GetFirstAncestor(LAYER));
-        layerElement = end;
+    if (!end->Is(TIMESTAMP_ATTR)) {
+        // Prefer non grace notes if possible
+        if (!layerElement || layerElement->IsGraceNote()) {
+            layer = vrv_cast<Layer *>(end->GetFirstAncestor(LAYER));
+            layerElement = end;
+        }
     }
     if (layerElement && layerElement->m_crossStaff) layer = layerElement->m_crossLayer;
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -998,7 +998,7 @@ float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVE
 
 curvature_CURVEDIR Slur::GetGraceCurveDirection() const
 {
-    // Start on the notehead side except for beams
+    // Start on the notehead side
     const LayerElement *start = this->GetStart();
     const StemmedDrawingInterface *startStemDrawInterface = start->GetStemmedDrawingInterface();
     const bool isStemDown


### PR DESCRIPTION
This PR fixes the automatic curve direction for slurs starting at grace notes. Closes #2836 .
Those slurs now always start on the note head side:
<img width="304" alt="GraceSlur" src="https://user-images.githubusercontent.com/63608463/166880227-dbc540f9-9400-44d8-8968-dc84886f9454.png">
Exceptional cases are:
| Beams | Multi-Layer-Situations |
| ------ | --------------------- |
| <img width="150" alt="GraceSlurBeam" src="https://user-images.githubusercontent.com/63608463/166880290-0ba7266c-ae96-4161-a4b2-a801360235cb.png"> | <img width="150" alt="GraceSlurLayer" src="https://user-images.githubusercontent.com/63608463/166880303-20131e0b-6bd2-4550-8cf8-95f9ad23a966.png"> |
<details>
<summary>Show MEI for beams example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2022-04-30T06:13:39" version="3.10.0-dev-dca5525-dirty">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
  <extMeta>
   <frames xmlns="http://www.humdrum.org/ns/humxml">
    <metaFrame n="28" token="!!!RDF**kern: &lt; = below" xml:id="L29">
     <frameInfo>
      <startTime float="3" />
      <frameType>reference</frameType>
      <referenceKey>RDF**kern</referenceKey>
      <referenceValue>&lt; = below</referenceValue>
     </frameInfo>
    </metaFrame>
   </frames>
  </extMeta>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="morax5m">
    <score xml:id="sz3lddq">
     <scoreDef xml:id="ssmids">
      <staffGrp xml:id="sqya8r2">
       <staffDef xml:id="s97gd1k" n="1" lines="5">
        <clef xml:id="c4a2xf7" shape="G" line="2" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <measure xml:id="measure-L1" n="1">
       <staff xml:id="s21mdrl" n="1">
        <layer xml:id="layer-L1F1N1" n="1">
          <beam>
            <note xml:id="note-L4F1" dur="8" oct="5" pname="d" grace="unacc" accid.ges="n" />
            <note xml:id="note-L4F2" dur="8" oct="4" pname="b" grace="unacc" accid.ges="n" />
          </beam>
         <note xml:id="note-L5F1" dur="4" oct="5" pname="c" accid.ges="n" />
        </layer>
       </staff>
       <slur xml:id="slur-L4F1-L5F1" staff="1" startid="#note-L4F1" endid="#note-L5F1" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details> 

<details>
<summary>Show MEI for multi layer example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
 <meiHead>
  <fileDesc>
   <titleStmt>
    <title />
   </titleStmt>
   <pubStmt />
  </fileDesc>
  <encodingDesc>
   <appInfo>
    <application isodate="2022-04-30T06:13:39" version="3.10.0-dev-dca5525-dirty">
     <name>Verovio</name>
     <p>Transcoded from Humdrum</p>
    </application>
   </appInfo>
  </encodingDesc>
  <workList>
   <work>
    <title />
   </work>
  </workList>
  <extMeta>
   <frames xmlns="http://www.humdrum.org/ns/humxml">
    <metaFrame n="28" token="!!!RDF**kern: &lt; = below" xml:id="L29">
     <frameInfo>
      <startTime float="3" />
      <frameType>reference</frameType>
      <referenceKey>RDF**kern</referenceKey>
      <referenceValue>&lt; = below</referenceValue>
     </frameInfo>
    </metaFrame>
   </frames>
  </extMeta>
 </meiHead>
 <music>
  <body>
   <mdiv xml:id="morax5m">
    <score xml:id="sz3lddq">
     <scoreDef xml:id="ssmids">
      <staffGrp xml:id="sqya8r2">
       <staffDef xml:id="s97gd1k" n="1" lines="5">
        <clef xml:id="c4a2xf7" shape="G" line="2" />
       </staffDef>
      </staffGrp>
     </scoreDef>
     <section xml:id="section-L1F1">
      <measure xml:id="measure-L1" n="1">
       <staff xml:id="s21mdrl" n="1">
        <layer xml:id="layer-L1F1N1" n="1">
         <note xml:id="note-L4F1" dur="8" oct="5" pname="f" grace="unacc" accid.ges="n" />
         <note xml:id="note-L5F1" dur="4" oct="5" pname="e" accid.ges="n" />
        </layer>
        <layer xml:id="layer-L2F1N1" n="2">
          <note xml:id="note-L18F1" dur="8" oct="4" pname="f" grace="unacc" accid.ges="n" />
          <note xml:id="note-L19F1" dur="4" oct="4" pname="e" accid.ges="n" />
        </layer>
       </staff>
       <slur xml:id="slur-L4F1-L5F1" staff="1" startid="#note-L4F1" endid="#note-L5F1" />
       <slur xml:id="slur-L18F1-L19F1" staff="1" startid="#note-L18F1" endid="#note-L19F1" />
      </measure>
     </section>
    </score>
   </mdiv>
  </body>
 </music>
</mei>
```
</details>
