### PR TITLE
Minor fix for the rest placement

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -315,6 +315,11 @@ public:
      */
     std::pair<int, int> GetAdditionalBeamCount() const override;
 
+    /**
+     * Return duration of beam part that are closest to the specified object X position
+     */
+    int GetBeamPartDuration(Object *object) const;
+
     //----------//
     // Functors //
     //----------//

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1974,6 +1974,11 @@ int Beam::GetBeamPartDuration(int x) const
     return std::min((*it)->m_dur, (*std::prev(it))->m_dur);
 }
 
+int Beam::GetBeamPartDuration(Object *object) const
+{
+    return this->GetBeamPartDuration(object->GetDrawingX());
+}
+
 //----------------------------------------------------------------------------
 // Functors methods
 //----------------------------------------------------------------------------

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -525,7 +525,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
 
     // Calculate possible overlap for the rest with beams
     int leftMargin = 0, rightMargin = 0;
-    const int beams = vrv_cast<Beam *>(params->m_beam)->m_shortestDur - DUR_4;
+    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this) - DUR_4;
     const int beamWidth = vrv_cast<Beam *>(params->m_beam)->m_beamWidth;
     if (params->m_directionBias > 0) {
         leftMargin = params->m_y1 - beams * beamWidth - this->GetSelfTop();

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -570,7 +570,8 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
     }
 
     const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    params->m_overlapMargin = ((std::abs(overlapMargin)) / staffOffset - 1) * staffOffset * params->m_directionBias;
+    const int unitChangeNumber = ((std::abs(overlapMargin)) / staffOffset - 1);
+    if (unitChangeNumber > 0) params->m_overlapMargin = unitChangeNumber * staffOffset * params->m_directionBias;
 
     return FUNCTOR_CONTINUE;
 }


### PR DESCRIPTION
- changed code to use method for checking relevant beam shortest duration, instead of using beam-wide value

Before:
![image](https://user-images.githubusercontent.com/1819669/167088490-edc1a1aa-2f27-4f9f-9473-d8a4535b582f.png)

After:
![image](https://user-images.githubusercontent.com/1819669/167088809-343a5f3a-41a8-4b06-80b3-bff2a833cd56.png)
