### PR TITLE
Adjust beam placement in regards to staff ends

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -102,7 +102,7 @@ private:
     void AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface);
 
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
-    void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
+    void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
     void CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -488,16 +488,18 @@ void BeamSegment::AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface)
     }
 }
 
-void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface)
+void BeamSegment::AdjustBeamToLedgerLines(
+    Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal)
 {
     int adjust = 0;
     const int staffTop = staff->GetDrawingY();
     const int staffHeight = doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
     const int doubleUnit = doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    const int staffMargin = isHorizontal ? doubleUnit / 2 : 0;
     for (auto coord : m_beamElementCoordRefs) {
         if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
             const int topPosition = coord->m_yBeam + beamInterface->GetTotalBeamWidth();
-            if (topPosition > staffTop) {
+            if (topPosition > staffTop - staffMargin) {
                 adjust = ((topPosition - staffTop) / doubleUnit + 1) * doubleUnit;
                 break;
             }
@@ -505,7 +507,7 @@ void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInt
         else if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
             const int bottomPosition = coord->m_yBeam - beamInterface->GetTotalBeamWidth();
             const int bottomMargin = staffTop - staffHeight;
-            if (bottomPosition < bottomMargin) {
+            if (bottomPosition < bottomMargin + staffMargin) {
                 adjust = ((bottomPosition - bottomMargin) / doubleUnit - 1) * doubleUnit;
                 break;
             }
@@ -949,7 +951,7 @@ void BeamSegment::CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface 
         this->CalcHorizontalBeam(doc, staff, beamInterface);
     }
 
-    if (!beamInterface->m_crossStaffContent) this->AdjustBeamToLedgerLines(doc, staff, beamInterface);
+    if (!beamInterface->m_crossStaffContent) this->AdjustBeamToLedgerLines(doc, staff, beamInterface, isHorizontal);
 }
 
 void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step)

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -497,16 +497,15 @@ void BeamSegment::AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInt
     for (auto coord : m_beamElementCoordRefs) {
         if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
             const int topPosition = coord->m_yBeam + beamInterface->GetTotalBeamWidth();
-            const int topMargin = staffTop - doubleUnit / 2;
-            if (topPosition >= topMargin) {
-                adjust = ((topPosition - topMargin) / doubleUnit + 1) * doubleUnit;
+            if (topPosition > staffTop) {
+                adjust = ((topPosition - staffTop) / doubleUnit + 1) * doubleUnit;
                 break;
             }
         }
         else if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
             const int bottomPosition = coord->m_yBeam - beamInterface->GetTotalBeamWidth();
-            const int bottomMargin = staffTop - staffHeight + doubleUnit / 2;
-            if (bottomPosition <= bottomMargin) {
+            const int bottomMargin = staffTop - staffHeight;
+            if (bottomPosition < bottomMargin) {
                 adjust = ((bottomPosition - bottomMargin) / doubleUnit - 1) * doubleUnit;
                 break;
             }


### PR DESCRIPTION
- relaxed constraint for beams outside of the staff - beam will be adjusted only if it explicitly goes outisde of the staff

In attempt to avoid overlapping of beams with ledger lines they ended up being with too long stems:
![image](https://user-images.githubusercontent.com/1819669/168020826-535b8392-cea5-4974-ac25-27bc72bb8464.png)

This change should alleviate the problem a little bit.
![image](https://user-images.githubusercontent.com/1819669/168020917-a13b4782-b422-426d-8b0f-bf4a847a7b52.png)
