### PR TITLE
Improve dotted barlines for the single staves

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -341,22 +341,22 @@ public:
     /**
      * Check if the segmented line is empty
      */
-    bool IsEmpty() { return (m_segments.empty()); }
+    bool IsEmpty() const { return (m_segments.empty()); }
 
     /**
      * Check if the line is one single segment
      */
-    bool IsUnsegmented() { return (m_segments.size() == 1); }
+    bool IsUnsegmented() const { return (m_segments.size() == 1); }
 
     /**
      * The number of segments
      */
-    int GetSegmentCount() { return (int)m_segments.size(); }
+    int GetSegmentCount() const { return (int)m_segments.size(); }
 
     /**
      * Get the start and end of a segment
      */
-    void GetStartEnd(int &start, int &end, int idx);
+    std::pair<int, int> GetStartEnd(int idx) const;
 
     /**
      * Add a gap in the line

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -564,7 +564,7 @@ protected:
         int horizontalThickness, int verticalThickness);
     void DrawEnclosingBrackets(DeviceContext *dc, int x, int y, int height, int width, int offset, int bracketWidth,
         int horizontalThickness, int verticalThickness);
-    void DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int staffSize, int interval);
+    void DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int barlineWidth, int interval);
     ///@}
 
     /**

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -215,8 +215,8 @@ protected:
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
-    void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, const data_BARRENDITION form,
-        bool eraseIntersections = false);
+    void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, bool eraseIntersections = false,
+        bool singleStaff = true);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerLines &lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);
@@ -564,6 +564,7 @@ protected:
         int horizontalThickness, int verticalThickness);
     void DrawEnclosingBrackets(DeviceContext *dc, int x, int y, int height, int width, int offset, int bracketWidth,
         int horizontalThickness, int verticalThickness);
+    void DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int staffSize, int interval);
     ///@}
 
     /**

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -1083,13 +1083,12 @@ SegmentedLine::SegmentedLine(int start, int end)
     m_segments.push_back({ start, end });
 }
 
-void SegmentedLine::GetStartEnd(int &start, int &end, int idx)
+std::pair<int, int> SegmentedLine::GetStartEnd(int idx) const
 {
     assert(idx >= 0);
     assert(idx < this->GetSegmentCount());
 
-    start = m_segments.at(idx).first;
-    end = m_segments.at(idx).second;
+    return { m_segments.at(idx).first, m_segments.at(idx).second };
 }
 
 void SegmentedLine::AddGap(int start, int end)

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -237,17 +237,24 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
     dc->ResetBrush();
 }
 
-void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int staffSize, int interval)
+void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int barlineWidth, int interval)
 {
     if (line.GetSegmentCount() > 1) return;
 
-    auto [start, end] = line.GetStartEnd(0);
-
+    const auto [start, end] = line.GetStartEnd(0);
+    const int radius = std::max(barlineWidth, 2);
     int drawingPosition = start + interval / 2;
+
+    dc->SetPen(m_currentColour, 0, AxSOLID);
+    dc->SetBrush(m_currentColour, AxSOLID);
+
     while (drawingPosition < end) {
-        this->DrawDot(dc, x, drawingPosition, 100, false);
+        dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(drawingPosition), radius);
         drawingPosition += interval;
     }
+
+    dc->ResetPen();
+    dc->ResetBrush();
 }
 
 void View::DrawSquareBracket(DeviceContext *dc, bool leftBracket, int x, int y, int height, int width,

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -67,7 +67,7 @@ void View::DrawVerticalSegmentedLine(DeviceContext *dc, int x1, SegmentedLine &l
 {
     int i, start, end;
     for (i = 0; i < line.GetSegmentCount(); i++) {
-        line.GetStartEnd(start, end, i);
+        std::tie(start, end) = line.GetStartEnd(i);
         this->DrawVerticalLine(dc, start, end, x1, width, dashLength);
     }
 }
@@ -76,7 +76,7 @@ void View::DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine 
 {
     int i, start, end;
     for (i = 0; i < line.GetSegmentCount(); i++) {
-        line.GetStartEnd(start, end, i);
+        std::tie(start, end) = line.GetStartEnd(i);
         this->DrawHorizontalLine(dc, start, end, y1, width, dashLength);
     }
 }
@@ -235,6 +235,19 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
 
     dc->ResetPen();
     dc->ResetBrush();
+}
+
+void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int staffSize, int interval)
+{
+    if (line.GetSegmentCount() > 1) return;
+
+    auto [start, end] = line.GetStartEnd(0);
+
+    int drawingPosition = start + interval / 2;
+    while (drawingPosition < end) {
+        this->DrawDot(dc, x, drawingPosition, 100, false);
+        drawingPosition += interval;
+    }
 }
 
 void View::DrawSquareBracket(DeviceContext *dc, bool leftBracket, int x, int y, int height, int width,

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -851,7 +851,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
 
         const bool singleStaff = (first == last);
         // erase intersections only if we have more than one staff
-        bool eraseIntersections = !singleStaff ? true : false;
+        bool eraseIntersections = !singleStaff;
         // do not erase intersections with right barline of the last measure of the system
         if (isLastMeasure && (barLine->GetPosition() == BarLinePosition::Right)) {
             eraseIntersections = false;
@@ -939,7 +939,7 @@ void View::DrawBarLine(
             break;
         case BARRENDITION_dotted: //
             if (singleStaff) {
-                this->DrawVerticalDots(dc, x, line, staffSize, m_doc->GetDrawingDoubleUnit(staffSize));
+                this->DrawVerticalDots(dc, x, line, barLineWidth, m_doc->GetDrawingDoubleUnit(staffSize));
             }
             else {
                 this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -785,7 +785,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                     yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
                     yBottom -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
                 }
-                this->DrawBarLine(dc, yTop, yBottom, barLine, form);
+                this->DrawBarLine(dc, yTop, yBottom, barLine);
                 if (barLine->HasRepetitionDots()) {
                     this->DrawBarLineDots(dc, staff, barLine);
                 }
@@ -849,13 +849,14 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
             yBottom -= m_doc->GetDrawingDoubleUnit(last->m_drawingStaffSize);
         }
 
+        const bool singleStaff = (first == last);
         // erase intersections only if we have more than one staff
-        bool eraseIntersections = (first != last) ? true : false;
+        bool eraseIntersections = !singleStaff ? true : false;
         // do not erase intersections with right barline of the last measure of the system
         if (isLastMeasure && (barLine->GetPosition() == BarLinePosition::Right)) {
             eraseIntersections = false;
         }
-        this->DrawBarLine(dc, yTop, yBottom, barLine, barLine->GetForm(), eraseIntersections);
+        this->DrawBarLine(dc, yTop, yBottom, barLine, eraseIntersections, singleStaff);
 
         // Now we have a barthru barLine, but we have dots so we still need to go through each staff
         if (barLine->HasRepetitionDots()) {
@@ -879,11 +880,12 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
 }
 
 void View::DrawBarLine(
-    DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, const data_BARRENDITION form, bool eraseIntersections)
+    DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, bool eraseIntersections, bool singleStaff)
 {
     assert(dc);
     assert(barLine);
 
+    const data_BARRENDITION form = barLine->GetForm();
     Staff *staff = barLine->GetAncestorStaff(ANCESTOR_ONLY, false);
     const int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
 
@@ -936,7 +938,12 @@ void View::DrawBarLine(
             this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength);
             break;
         case BARRENDITION_dotted: //
-            this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);
+            if (singleStaff) {
+                this->DrawVerticalDots(dc, x, line, staffSize, m_doc->GetDrawingDoubleUnit(staffSize));
+            }
+            else {
+                this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);
+            }
             break;
         case BARRENDITION_rptend:
             this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth);


### PR DESCRIPTION
Relates to #2839 

This introduces dotted barlines for single staves. Changes for multi-staff dotted barlines are yet to come.
Default rendering based on the barline width:
![image](https://user-images.githubusercontent.com/1819669/168300746-7540d1bd-1c49-4152-aa1c-fb1590f2f600.png)
