### PR TITLE
Improve handling of KeyAccid

### DIFF
--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -11,6 +11,7 @@
 #include "atts_gestural.h"
 #include "layerelement.h"
 #include "pitchinterface.h"
+#include "positioninterface.h"
 
 namespace vrv {
 
@@ -23,6 +24,7 @@ namespace vrv {
  */
 class KeyAccid : public LayerElement,
                  public PitchInterface,
+                 public PositionInterface,
                  public AttAccidental,
                  public AttColor,
                  public AttEnclosingChars {
@@ -45,6 +47,8 @@ public:
     ///@{
     PitchInterface *GetPitchInterface() override { return vrv_cast<PitchInterface *>(this); }
     const PitchInterface *GetPitchInterface() const override { return vrv_cast<const PitchInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return vrv_cast<PositionInterface *>(this); }
+    const PositionInterface *GetPositionInterface() const override { return vrv_cast<const PositionInterface *>(this); }
     ///@}
 
     /**
@@ -52,6 +56,11 @@ public:
      * This will include brackets
      */
     std::wstring GetSymbolStr() const;
+
+    /**
+     * Determine the staff location
+     */
+    int CalcStaffLoc(Clef *clef, int clefLocOffset) const;
 
     //----------//
     // Functors //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -83,6 +83,7 @@ public:
      * Generate KeyAccid attribute children
      */
     ///@{
+    bool HasNonAttribKeyAccidChildren() const;
     void ClearKeyAccidAttribChildren();
     void GenerateKeyAccidAttribChildren();
     ///@}
@@ -131,13 +132,15 @@ private:
     std::optional<KeyAccidInfo> GetKeyAccidInfoAt(int pos) const;
 
 public:
-    bool m_mixedChildrenAccidType;
     /**
      * Variables for storing cancellation introduced by the key sig.
-     * The values are StaffDefDrawingInterface::ReplaceKeySig
+     * Values are set in StaffDefDrawingInterface::ReplaceKeySig
      */
+    ///@{
+    bool m_skipCancellation;
     data_ACCIDENTAL_WRITTEN m_drawingCancelAccidType;
     char m_drawingCancelAccidCount;
+    ///@}
 
     //----------------//
     // Static members //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -9,6 +9,10 @@
 #ifndef __VRV_KEYSIG_H__
 #define __VRV_KEYSIG_H__
 
+#include <optional>
+
+//----------------------------------------------------------------------------
+
 #include "atts_analytical.h"
 #include "atts_shared.h"
 #include "atts_visual.h"

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -27,7 +27,6 @@ class ScoreDefInterface;
  */
 struct KeyAccidInfo {
     std::wstring symbolStr;
-    std::string uuid;
     data_ACCIDENTAL_WRITTEN accid;
     data_PITCHNAME pname;
 };
@@ -72,7 +71,7 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /** Accid number getter */
-    int GetAccidCount() const;
+    int GetAccidCount(bool fromAttribute = false) const;
 
     /** Accid type getter */
     data_ACCIDENTAL_WRITTEN GetAccidType() const;

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -20,6 +20,19 @@ class Clef;
 class ScoreDefInterface;
 
 //----------------------------------------------------------------------------
+// KeyAccidInfo
+//----------------------------------------------------------------------------
+/**
+ * Useful information collected from a KeyAccid child
+ */
+struct KeyAccidInfo {
+    std::wstring symbolStr;
+    std::string uuid;
+    data_ACCIDENTAL_WRITTEN accid;
+    data_PITCHNAME pname;
+};
+
+//----------------------------------------------------------------------------
 // KeySig
 //----------------------------------------------------------------------------
 
@@ -69,11 +82,10 @@ public:
     void FillMap(MapOfPitchAccid &mapOfPitchAccid) const;
 
     /**
-     * Return the string of the alteration at the positon pos.
+     * Return key accid information at the positon pos.
      * Looks at keyAccid children if any.
-     * The accid at pos is return in accid and the pname in pname.
      */
-    std::wstring GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname) const;
+    KeyAccidInfo GetKeyAccidInfoAt(int pos) const;
 
     int GetFifthsInt() const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -58,6 +58,7 @@ public:
     Object *Clone() const override { return new KeySig(*this); }
     void Reset() override;
     std::string GetClassName() const override { return "KeySig"; }
+    ///@}
 
     /** Override the method since alignment is required */
     bool HasToBeAligned() const override { return true; }
@@ -75,6 +76,14 @@ public:
 
     /** Accid type getter */
     data_ACCIDENTAL_WRITTEN GetAccidType() const;
+
+    /**
+     * Generate KeyAccid attribute children
+     */
+    ///@{
+    void ClearKeyAccidAttribChildren();
+    void GenerateKeyAccidAttribChildren();
+    ///@}
 
     /**
      * Fill the map of modified pitches

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -76,6 +76,9 @@ public:
     /** Accid number getter */
     int GetAccidCount(bool fromAttribute = false) const;
 
+    /** Check for duplicates */
+    bool HasAccidDuplicate() const;
+
     /** Accid type getter */
     data_ACCIDENTAL_WRITTEN GetAccidType() const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -26,7 +26,6 @@ class ScoreDefInterface;
  * Useful information collected from a KeyAccid child
  */
 struct KeyAccidInfo {
-    std::wstring symbolStr;
     data_ACCIDENTAL_WRITTEN accid;
     data_PITCHNAME pname;
 };
@@ -89,12 +88,6 @@ public:
      */
     void FillMap(MapOfPitchAccid &mapOfPitchAccid) const;
 
-    /**
-     * Return key accid information at the positon pos.
-     * Looks at keyAccid children if any.
-     */
-    KeyAccidInfo GetKeyAccidInfoAt(int pos) const;
-
     int GetFifthsInt() const;
 
     //----------------//
@@ -128,7 +121,11 @@ protected:
     void FilterList(ListOfConstObjects &childList) const override;
 
 private:
-    //
+    /**
+     * Generate key accid information for a given position
+     */
+    std::optional<KeyAccidInfo> GetKeyAccidInfoAt(int pos) const;
+
 public:
     bool m_mixedChildrenAccidType;
     /**

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -76,9 +76,6 @@ public:
     /** Accid number getter */
     int GetAccidCount(bool fromAttribute = false) const;
 
-    /** Check for duplicates */
-    bool HasAccidDuplicate() const;
-
     /** Accid type getter */
     data_ACCIDENTAL_WRITTEN GetAccidType() const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -23,7 +23,7 @@ class ScoreDefInterface;
 // KeyAccidInfo
 //----------------------------------------------------------------------------
 /**
- * Useful information collected from a KeyAccid child
+ * Useful information regarding a KeyAccid child
  */
 struct KeyAccidInfo {
     data_ACCIDENTAL_WRITTEN accid;

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -83,6 +83,8 @@ public:
     const DurationInterface *GetDurationInterface() const override { return vrv_cast<const DurationInterface *>(this); }
     PitchInterface *GetPitchInterface() override { return vrv_cast<PitchInterface *>(this); }
     const PitchInterface *GetPitchInterface() const override { return vrv_cast<const PitchInterface *>(this); }
+    PositionInterface *GetPositionInterface() override { return vrv_cast<PositionInterface *>(this); }
+    const PositionInterface *GetPositionInterface() const override { return vrv_cast<const PositionInterface *>(this); }
     StemmedDrawingInterface *GetStemmedDrawingInterface() override { return vrv_cast<StemmedDrawingInterface *>(this); }
     const StemmedDrawingInterface *GetStemmedDrawingInterface() const override
     {

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -43,6 +43,7 @@ class Fermata;
 class Gliss;
 class Hairpin;
 class Harm;
+class KeyAccid;
 class Layer;
 class LayerElement;
 class Lb;
@@ -343,6 +344,7 @@ protected:
     void DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff);
     void DrawClefEnclosing(DeviceContext *dc, Clef *clef, Staff *staff, wchar_t glyph, int x, int y, double sizeFactor);
     void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin = false);
+    void DrawKeyAccid(DeviceContext *dc, KeyAccid *keyAccid, Staff *staff, Clef *clef, int clefLocOffset, int &x);
     void DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int horizOffset);
     /** Returns the width of the drawn figures */
     int DrawMeterSigFigures(

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -586,12 +586,19 @@ void StaffDefDrawingInterface::SetCurrentClef(const Clef *clef)
 void StaffDefDrawingInterface::SetCurrentKeySig(const KeySig *keySig)
 {
     if (keySig) {
-        char drawingCancelAccidCount = m_currentKeySig.GetAccidCount();
-        data_ACCIDENTAL_WRITTEN drawingCancelAccidType = m_currentKeySig.GetAccidType();
+        const bool ignoreCancel
+            = (m_currentKeySig.HasNonAttribKeyAccidChildren() || keySig->HasNonAttribKeyAccidChildren());
+        const int drawingCancelAccidCount = m_currentKeySig.GetAccidCount();
+        const data_ACCIDENTAL_WRITTEN drawingCancelAccidType = m_currentKeySig.GetAccidType();
         m_currentKeySig = *keySig;
         m_currentKeySig.CloneReset();
-        m_currentKeySig.m_drawingCancelAccidCount = drawingCancelAccidCount;
-        m_currentKeySig.m_drawingCancelAccidType = drawingCancelAccidType;
+        if (ignoreCancel) {
+            m_currentKeySig.m_skipCancellation = true;
+        }
+        else {
+            m_currentKeySig.m_drawingCancelAccidCount = drawingCancelAccidCount;
+            m_currentKeySig.m_drawingCancelAccidType = drawingCancelAccidType;
+        }
     }
 }
 

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -292,8 +292,6 @@ int Harm::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    LogDebug("Transposing harm");
-
     unsigned int position = 0;
     TransPitch pitch;
     if (this->GetRootPitch(pitch, position)) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -595,8 +595,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         this->WriteHalfmRpt(m_currentNode, vrv_cast<HalfmRpt *>(object));
     }
     else if (object->Is(KEYACCID)) {
-        m_currentNode = m_currentNode.append_child("keyAccid");
-        this->WriteKeyAccid(m_currentNode, vrv_cast<KeyAccid *>(object));
+        if (!object->IsAttribute()) {
+            m_currentNode = m_currentNode.append_child("keyAccid");
+            this->WriteKeyAccid(m_currentNode, vrv_cast<KeyAccid *>(object));
+        }
     }
     else if (object->Is(KEYSIG)) {
         if (!object->IsAttribute()) m_currentNode = m_currentNode.append_child("keySig");

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2241,6 +2241,7 @@ void MEIOutput::WriteKeyAccid(pugi::xml_node currentNode, KeyAccid *keyAccid)
 
     this->WriteLayerElement(currentNode, keyAccid);
     this->WritePitchInterface(currentNode, keyAccid);
+    this->WritePositionInterface(currentNode, keyAccid);
     keyAccid->WriteAccidental(currentNode);
     keyAccid->WriteColor(currentNode);
     keyAccid->WriteEnclosingChars(currentNode);
@@ -5966,6 +5967,7 @@ bool MEIInput::ReadKeyAccid(Object *parent, pugi::xml_node keyAccid)
     this->ReadLayerElement(keyAccid, vrvKeyAccid);
 
     this->ReadPitchInterface(keyAccid, vrvKeyAccid);
+    this->ReadPositionInterface(keyAccid, vrvKeyAccid);
     vrvKeyAccid->ReadAccidental(keyAccid);
     vrvKeyAccid->ReadColor(keyAccid);
     vrvKeyAccid->ReadEnclosingChars(keyAccid);

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -30,10 +30,16 @@ namespace vrv {
 static const ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
 
 KeyAccid::KeyAccid()
-    : LayerElement(KEYACCID, "keyaccid-"), PitchInterface(), AttAccidental(), AttColor(), AttEnclosingChars()
+    : LayerElement(KEYACCID, "keyaccid-")
+    , PitchInterface()
+    , PositionInterface()
+    , AttAccidental()
+    , AttColor()
+    , AttEnclosingChars()
 {
 
     this->RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
+    this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     this->RegisterAttClass(ATT_ACCIDENTAL);
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
@@ -47,6 +53,7 @@ void KeyAccid::Reset()
 {
     LayerElement::Reset();
     PitchInterface::Reset();
+    PositionInterface::Reset();
     this->ResetAccidental();
     this->ResetColor();
     this->ResetEnclosingChars();
@@ -78,6 +85,18 @@ std::wstring KeyAccid::GetSymbolStr() const
         symbolStr.push_back(symc);
     }
     return symbolStr;
+}
+
+int KeyAccid::CalcStaffLoc(Clef *clef, int clefLocOffset) const
+{
+    if (this->HasLoc()) {
+        return this->GetLoc();
+    }
+    else {
+        const data_ACCIDENTAL_WRITTEN accid = this->GetAccid();
+        const data_PITCHNAME pname = this->GetPname();
+        return PitchInterface::CalcLoc(pname, KeySig::GetOctave(accid, pname, clef), clefLocOffset);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -15,7 +15,6 @@
 
 #include "accid.h"
 #include "doc.h"
-#include "editorial.h"
 #include "functorparams.h"
 #include "keysig.h"
 #include "note.h"
@@ -51,24 +50,6 @@ void KeyAccid::Reset()
     this->ResetAccidental();
     this->ResetColor();
     this->ResetEnclosingChars();
-}
-
-bool KeySig::IsSupportedChild(Object *child)
-{
-    if (this->IsAttribute()) {
-        LogError("Adding a child to an attribute is not allowed");
-        assert(false);
-    }
-    else if (child->Is(KEYACCID)) {
-        assert(dynamic_cast<KeyAccid *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
-    }
-    else {
-        return false;
-    }
-    return true;
 }
 
 std::wstring KeyAccid::GetSymbolStr() const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -166,38 +166,38 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid) const
     }
 }
 
-std::wstring KeySig::GetKeyAccidStrAt(int pos, data_ACCIDENTAL_WRITTEN &accid, data_PITCHNAME &pname) const
+KeyAccidInfo KeySig::GetKeyAccidInfoAt(int pos) const
 {
-    pname = PITCHNAME_c;
-    accid = ACCIDENTAL_WRITTEN_s;
-    std::wstring symbolStr = L"";
+    KeyAccidInfo info({ L"", "", ACCIDENTAL_WRITTEN_s, PITCHNAME_c });
 
     const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
     if (childList.size() > 0) {
-        if ((int)childList.size() <= pos) return symbolStr;
+        if ((int)childList.size() <= pos) return info;
         auto iter = std::next(childList.begin(), pos);
         const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(*iter);
         assert(keyAccid);
-        accid = keyAccid->GetAccid();
-        pname = keyAccid->GetPname();
-        return keyAccid->GetSymbolStr();
+        info.symbolStr = keyAccid->GetSymbolStr();
+        info.uuid = keyAccid->GetUuid();
+        info.accid = keyAccid->GetAccid();
+        info.pname = keyAccid->GetPname();
+        return info;
     }
 
-    if (pos > 12) return symbolStr;
+    if (pos > 12) return info;
 
-    int symb;
-    accid = this->GetAccidType();
-    if (accid == ACCIDENTAL_WRITTEN_f) {
+    wchar_t symb = 0;
+    info.accid = this->GetAccidType();
+    if (info.accid == ACCIDENTAL_WRITTEN_f) {
         symb = (pos < 7) ? SMUFL_E260_accidentalFlat : SMUFL_E264_accidentalDoubleFlat;
-        pname = s_pnameForFlats[pos % 7];
+        info.pname = s_pnameForFlats[pos % 7];
     }
     else {
         symb = (pos < 7) ? SMUFL_E262_accidentalSharp : SMUFL_E263_accidentalDoubleSharp;
-        pname = s_pnameForSharps[pos % 7];
+        info.pname = s_pnameForSharps[pos % 7];
     }
 
-    symbolStr.push_back(symb);
-    return symbolStr;
+    info.symbolStr.push_back(symb);
+    return info;
 }
 
 int KeySig::GetFifthsInt() const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -147,18 +147,6 @@ int KeySig::GetAccidCount(bool fromAttribute) const
     }
 }
 
-bool KeySig::HasAccidDuplicate() const
-{
-    std::set<data_PITCHNAME> accidPitches;
-    const ListOfConstObjects &childList = this->GetList(this);
-    for (const Object *child : childList) {
-        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
-        assert(keyAccid);
-        accidPitches.insert(keyAccid->GetPname());
-    }
-    return (accidPitches.size() < childList.size());
-}
-
 data_ACCIDENTAL_WRITTEN KeySig::GetAccidType() const
 {
     const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
@@ -328,11 +316,6 @@ int KeySig::PrepareDataInitialization(FunctorParams *)
 {
     // Clear attribute children
     this->ClearKeyAccidAttribChildren();
-
-    // Check whether children have unique pitch
-    if (this->HasAccidDuplicate()) {
-        LogWarning("KeySig '%s' contains duplicate KeyAccid children.", this->GetUuid().c_str());
-    }
 
     // Determine whether children have mixed accid type
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -243,13 +243,11 @@ int KeySig::GetFifthsInt() const
 
 data_PITCHNAME KeySig::GetAccidPnameAt(data_ACCIDENTAL_WRITTEN accidType, int pos)
 {
-    if (pos > 6) return PITCHNAME_c;
-
     if (accidType == ACCIDENTAL_WRITTEN_f) {
-        return s_pnameForFlats[pos];
+        return s_pnameForFlats[pos % 7];
     }
     else {
-        return s_pnameForSharps[pos];
+        return s_pnameForSharps[pos % 7];
     }
 }
 
@@ -316,9 +314,10 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
 
 int KeySig::PrepareDataInitialization(FunctorParams *)
 {
+    // Clear attribute children
     this->ClearKeyAccidAttribChildren();
-    this->GenerateKeyAccidAttribChildren();
 
+    // Determine whether children have mixed accid type
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;
     m_mixedChildrenAccidType = false;
 
@@ -335,6 +334,9 @@ int KeySig::PrepareDataInitialization(FunctorParams *)
             break;
         }
     }
+
+    // Regenerate attribute children
+    this->GenerateKeyAccidAttribChildren();
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -184,7 +184,7 @@ void KeySig::GenerateKeyAccidAttribChildren()
             }
         }
     }
-    else {
+    else if (this->HasSig()) {
         LogWarning("Attribute key signature is ignored, since KeySig '%s' contains KeyAccid children.",
             this->GetUuid().c_str());
     }

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -147,6 +147,18 @@ int KeySig::GetAccidCount(bool fromAttribute) const
     }
 }
 
+bool KeySig::HasAccidDuplicate() const
+{
+    std::set<data_PITCHNAME> accidPitches;
+    const ListOfConstObjects &childList = this->GetList(this);
+    for (const Object *child : childList) {
+        const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
+        assert(keyAccid);
+        accidPitches.insert(keyAccid->GetPname());
+    }
+    return (accidPitches.size() < childList.size());
+}
+
 data_ACCIDENTAL_WRITTEN KeySig::GetAccidType() const
 {
     const ListOfConstObjects &childList = this->GetList(this); // make sure it's initialized
@@ -316,6 +328,11 @@ int KeySig::PrepareDataInitialization(FunctorParams *)
 {
     // Clear attribute children
     this->ClearKeyAccidAttribChildren();
+
+    // Check whether children have unique pitch
+    if (this->HasAccidDuplicate()) {
+        LogWarning("KeySig '%s' contains duplicate KeyAccid children.", this->GetUuid().c_str());
+    }
 
     // Determine whether children have mixed accid type
     data_ACCIDENTAL_WRITTEN type = ACCIDENTAL_WRITTEN_NONE;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -212,7 +212,7 @@ void KeySig::FillMap(MapOfPitchAccid &mapOfPitchAccid) const
 
 std::optional<KeyAccidInfo> KeySig::GetKeyAccidInfoAt(int pos) const
 {
-    if (pos > 12) return std::nullopt;
+    if ((pos < 0) || (pos > 12)) return std::nullopt;
 
     KeyAccidInfo info;
     if (this->GetAccidType() == ACCIDENTAL_WRITTEN_f) {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -344,7 +344,6 @@ int KeySig::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    LogDebug("Transposing keySig");
     int sig = this->GetFifthsInt();
 
     int intervalClass = params->m_transposer->CircleOfFifthsToIntervalClass(sig);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1560,8 +1560,6 @@ int Note::Transpose(FunctorParams *functorParams)
 
     if (!this->HasPname()) return FUNCTOR_SIBLINGS;
 
-    LogDebug("Transposing note");
-
     TransPitch pitch = this->GetTransPitch();
     params->m_transposer->Transpose(pitch);
     this->UpdateFromTransPitch(pitch);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -32,6 +32,7 @@
 #include "ftrem.h"
 #include "functorparams.h"
 #include "halfmrpt.h"
+#include "keyaccid.h"
 #include "keysig.h"
 #include "label.h"
 #include "labelabbr.h"
@@ -976,19 +977,22 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     for (int i = 0; i < keySig->GetAccidCount(); ++i) {
         // We get the pitch from the keySig (looks for keyAccid children if any)
-        KeyAccidInfo info = keySig->GetKeyAccidInfoAt(i);
+        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(keySig->GetChild(i, KEYACCID));
+        const data_ACCIDENTAL_WRITTEN accid = keyAccid->GetAccid();
+        const data_PITCHNAME pname = keyAccid->GetPname();
+        const std::wstring symbolStr = keyAccid->GetSymbolStr();
 
-        loc = PitchInterface::CalcLoc(info.pname, KeySig::GetOctave(info.accid, info.pname, c), clefLocOffset);
+        loc = PitchInterface::CalcLoc(pname, KeySig::GetOctave(accid, pname, c), clefLocOffset);
         y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 
         dc->StartCustomGraphic("keyAccid");
 
-        this->DrawSmuflString(dc, x, y, info.symbolStr, HORIZONTALALIGNMENT_left, staff->m_drawingStaffSize, false);
+        this->DrawSmuflString(dc, x, y, symbolStr, HORIZONTALALIGNMENT_left, staff->m_drawingStaffSize, false);
 
         dc->EndCustomGraphic();
 
         TextExtend extend;
-        dc->GetSmuflTextExtent(info.symbolStr, &extend);
+        dc->GetSmuflTextExtent(symbolStr, &extend);
         x += extend.m_width + step;
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -976,21 +976,19 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     for (int i = 0; i < keySig->GetAccidCount(); ++i) {
         // We get the pitch from the keySig (looks for keyAccid children if any)
-        data_ACCIDENTAL_WRITTEN accid;
-        data_PITCHNAME pname;
-        std::wstring accidStr = keySig->GetKeyAccidStrAt(i, accid, pname);
+        KeyAccidInfo info = keySig->GetKeyAccidInfoAt(i);
 
-        loc = PitchInterface::CalcLoc(pname, KeySig::GetOctave(accid, pname, c), clefLocOffset);
+        loc = PitchInterface::CalcLoc(info.pname, KeySig::GetOctave(info.accid, info.pname, c), clefLocOffset);
         y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 
         dc->StartCustomGraphic("keyAccid");
 
-        this->DrawSmuflString(dc, x, y, accidStr, HORIZONTALALIGNMENT_left, staff->m_drawingStaffSize, false);
+        this->DrawSmuflString(dc, x, y, info.symbolStr, HORIZONTALALIGNMENT_left, staff->m_drawingStaffSize, false);
 
         dc->EndCustomGraphic();
 
         TextExtend extend;
-        dc->GetSmuflTextExtent(accidStr, &extend);
+        dc->GetSmuflTextExtent(info.symbolStr, &extend);
         x += extend.m_width + step;
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -925,27 +925,31 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     dc->StartGraphic(element, "", element->GetUuid());
 
     // Show cancellation if showchange is true (false by default) or if C major
-    // This is not meant to make sense with mixed key signature
     if ((keySig->GetScoreDefRole() != SCOREDEF_SYSTEM)
         && ((keySig->GetSigShowchange() == BOOLEAN_true) || (keySig->GetAccidCount() == 0))) {
-        const int beginCancel
-            = (keySig->GetAccidType() == keySig->m_drawingCancelAccidType) ? keySig->GetAccidCount() : 0;
-        for (int i = beginCancel; i < keySig->m_drawingCancelAccidCount; ++i) {
-            data_PITCHNAME pitch = KeySig::GetAccidPnameAt(keySig->m_drawingCancelAccidType, i);
-            loc = PitchInterface::CalcLoc(
-                pitch, KeySig::GetOctave(keySig->m_drawingCancelAccidType, pitch, clef), clefLocOffset);
-            y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
+        if (keySig->m_skipCancellation) {
+            LogWarning("Cautionary accidentals are skipped if the new or previous KeySig contains KeyAccid children.");
+        }
+        else {
+            const int beginCancel
+                = (keySig->GetAccidType() == keySig->m_drawingCancelAccidType) ? keySig->GetAccidCount() : 0;
+            for (int i = beginCancel; i < keySig->m_drawingCancelAccidCount; ++i) {
+                data_PITCHNAME pitch = KeySig::GetAccidPnameAt(keySig->m_drawingCancelAccidType, i);
+                loc = PitchInterface::CalcLoc(
+                    pitch, KeySig::GetOctave(keySig->m_drawingCancelAccidType, pitch, clef), clefLocOffset);
+                y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 
-            dc->StartCustomGraphic("keyAccid");
+                dc->StartCustomGraphic("keyAccid");
 
-            this->DrawSmuflCode(dc, x, y, SMUFL_E261_accidentalNatural, staff->m_drawingStaffSize, false);
+                this->DrawSmuflCode(dc, x, y, SMUFL_E261_accidentalNatural, staff->m_drawingStaffSize, false);
 
-            dc->EndCustomGraphic();
+                dc->EndCustomGraphic();
 
-            x += naturalGlyphWidth + naturalStep;
-            if ((keySig->GetAccidCount() > 0) && (i + 1 == keySig->m_drawingCancelAccidCount)) {
-                // Add some extra space after last natural
-                x += step;
+                x += naturalGlyphWidth + naturalStep;
+                if ((keySig->GetAccidCount() > 0) && (i + 1 == keySig->m_drawingCancelAccidCount)) {
+                    // Add some extra space after last natural
+                    x += step;
+                }
             }
         }
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -952,12 +952,12 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     dc->SetFont(m_doc->GetDrawingSmuflFont(staff->m_drawingStaffSize, false));
 
-    for (Object *child : keySig->GetChildren()) {
-        if (child->Is(KEYACCID)) {
-            KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
-            this->DrawKeyAccid(dc, keyAccid, staff, clef, clefLocOffset, x);
-            x += step;
-        }
+    ListOfObjects childList = keySig->GetList(keySig);
+    for (Object *child : childList) {
+        KeyAccid *keyAccid = vrv_cast<KeyAccid *>(child);
+        assert(keyAccid);
+        this->DrawKeyAccid(dc, keyAccid, staff, clef, clefLocOffset, x);
+        x += step;
     }
 
     dc->ResetFont();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -922,35 +922,12 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     int clefLocOffset = layer->GetClefLocOffset(element);
     int loc;
 
-    // Show cancellation if C major (0)
-    // This is not meant to make sense with mixed key signature
-    if ((keySig->GetScoreDefRole() != SCOREDEF_SYSTEM) && (keySig->GetAccidCount() == 0)) {
-        dc->StartGraphic(element, "", element->GetUuid());
-
-        for (int i = 0; i < keySig->m_drawingCancelAccidCount; ++i) {
-            data_PITCHNAME pitch = KeySig::GetAccidPnameAt(keySig->m_drawingCancelAccidType, i);
-            loc = PitchInterface::CalcLoc(
-                pitch, KeySig::GetOctave(keySig->m_drawingCancelAccidType, pitch, clef), clefLocOffset);
-            y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
-
-            dc->StartCustomGraphic("keyAccid");
-
-            this->DrawSmuflCode(dc, x, y, SMUFL_E261_accidentalNatural, staff->m_drawingStaffSize, false);
-
-            dc->EndCustomGraphic();
-
-            x += naturalGlyphWidth + naturalStep;
-        }
-
-        dc->EndGraphic(element, this);
-        return;
-    }
-
     dc->StartGraphic(element, "", element->GetUuid());
 
-    // Show cancellation if show cancellation (showchange) is true (false by default)
+    // Show cancellation if showchange is true (false by default) or if C major
     // This is not meant to make sense with mixed key signature
-    if ((keySig->GetScoreDefRole() != SCOREDEF_SYSTEM) && (keySig->GetSigShowchange() == BOOLEAN_true)) {
+    if ((keySig->GetScoreDefRole() != SCOREDEF_SYSTEM)
+        && ((keySig->GetSigShowchange() == BOOLEAN_true) || (keySig->GetAccidCount() == 0))) {
         const int beginCancel
             = (keySig->GetAccidType() == keySig->m_drawingCancelAccidType) ? keySig->GetAccidCount() : 0;
         for (int i = beginCancel; i < keySig->m_drawingCancelAccidCount; ++i) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -981,11 +981,8 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
 void View::DrawKeyAccid(DeviceContext *dc, KeyAccid *keyAccid, Staff *staff, Clef *clef, int clefLocOffset, int &x)
 {
-    const data_ACCIDENTAL_WRITTEN accid = keyAccid->GetAccid();
-    const data_PITCHNAME pname = keyAccid->GetPname();
     const std::wstring symbolStr = keyAccid->GetSymbolStr();
-
-    const int loc = PitchInterface::CalcLoc(pname, KeySig::GetOctave(accid, pname, clef), clefLocOffset);
+    const int loc = keyAccid->CalcStaffLoc(clef, clefLocOffset);
     const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 
     dc->StartCustomGraphic("keyAccid", "", keyAccid->GetUuid());


### PR DESCRIPTION
This PR does several improvements regarding the treatment of KeyAccid children:
- If a key signature is prescribed via attribute, then KeyAccid children are generated in `PrepareData`. This allows uniform treatment of KeyAccid children independent whether they are encoded via attribute or explicitly.
- The drawing code for KeySig and KeyAccid is refactored.
- We fix a bug regarding the location of cautionary accidentals for double flats/sharps:

| Before | After |
| ------ | ----- |
| ![Example8-Before](https://user-images.githubusercontent.com/63608463/168535225-1d6fe51d-f37a-421a-b1c5-f942684b2521.png) | ![Example8-After](https://user-images.githubusercontent.com/63608463/168535246-41c5536f-7b0a-4911-82bd-10cde8c96768.png) |

<details>
<summary> Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Key changes example</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2017-05-09">2017-05-09</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio takes into account the "keysig.showchange" and "keysig.show" attributes which are assumed to be respectively false
					and true if not specified. It also shows cautionary key and time signatures at the end of a system when necessary.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="1">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef key.sig="4f" meter.sym="common">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                       <keySig sig.showchange="true" sig="9f" xml:id="keysig-0123" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="dbl" n="1">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="1">
                              <note oct="4" pname="a" accid.ges="f" />
                              <note oct="5" pname="c" accid.ges="f" />
                              <note oct="5" pname="e" accid.ges="f" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                    <keySig sig.showchange="true" sig="5s" xml:id="keysig-1234" />
                  </scoreDef>
                  <measure right="dbl" n="4">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="1">
                              <note oct="4" pname="a" />
                              <note oct="5" pname="c" />
                              <note oct="5" pname="e" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

-  We add support for @loc in KeyAccid:
<img width="300" alt="Example4" src="https://user-images.githubusercontent.com/63608463/168536004-4801d1c1-7164-473d-8791-14405f79e4d0.png">

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Non-standard key signatures</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
            <date isodate="2019-09-09">9 Sep 2019</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio renders non-standard key signatures encoded with keyAccid.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.2.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="400" key.mode="aeolian" keysig.showchange="false">
                  <staffGrp bar.thru="false">
                     <staffDef n="1" lines="5" meter.count="4" meter.unit="2">
                        <label>Canto</label>
                        <labelAbbr>C</labelAbbr>
                        <clef shape="G" line="2" visible="false" />
                        <keySig xml:id="keysig-0123">
                           <keyAccid pname="b" accid="f" loc="2" />
                           <keyAccid pname="b" accid="f" loc="3" />
                           <keyAccid pname="b" accid="f" />
                           <keyAccid pname="f" accid="s" />
                        </keySig>
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure type="m--1">
                     <staff n="1">
                        <layer n="1">
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>