### PR TITLE
Relocate slur endpoints in case of nearby collisions

### DIFF
--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -334,6 +334,15 @@ public:
     ///@}
 
     /**
+     * @name Getter and setter for cached x1 and x2
+     */
+    ///@{
+    bool HasCachedX12() const;
+    std::pair<int, int> GetCachedX12() const { return m_cachedX12; }
+    void SetCachedX12(const std::pair<int, int> &cachedX12) { m_cachedX12 = cachedX12; }
+    ///@}
+
+    /**
      * Deletes all the CurveSpannedElement objects.
      */
     void ClearSpannedElements();
@@ -391,6 +400,9 @@ private:
 
     /** The cached min or max value (depending on the curvature) */
     int m_cachedMinMaxY;
+
+    /** The cached values for x1 and x2 */
+    std::pair<int, int> m_cachedX12;
 
     /**
      * Some curves (S-shaped slurs) can request staff space to prevent collisions from two sides

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -155,18 +155,10 @@ public:
     ///@}
 
     /**
-     * Cache the drawing x1 and x2 values
-     */
-    ///@{
-    bool HasCachedDrawingX12() const;
-    void SetCachedDrawingX12(int x1, int x2);
-    ///@}
-
-    /**
      * Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
      */
     std::pair<Point, Point> CalcEndPoints(
-        Doc *doc, Staff *staff, curvature_CURVEDIR drawingCurveDir, char spanningType);
+        Doc *doc, Staff *staff, int x1, int x2, curvature_CURVEDIR drawingCurveDir, char spanningType);
 
     /**
      * Calculate the initial slur bezier curve and store it in the curve positioner
@@ -315,14 +307,6 @@ private:
      * for s-shaped slurs / mixed direction
      */
     SlurCurveDirection m_drawingCurveDir;
-
-    /**
-     * Cached values for x1 and x2 from the last call of View::DrawSlur
-     */
-    ///@{
-    int m_cachedDrawingX1;
-    int m_cachedDrawingX2;
-    ///@}
 };
 
 } // namespace vrv

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -143,10 +143,18 @@ public:
     ///@}
 
     /**
-     * Adjust starting coordinates for the slurs depending on the curve direction and spanning type of the slur
+     * Cache the drawing x1 and x2 values
      */
-    std::pair<Point, Point> AdjustCoordinates(
-        Doc *doc, Staff *staff, std::pair<Point, Point> points, char spanningType);
+    ///@{
+    bool HasCachedDrawingX12() const;
+    void SetCachedDrawingX12(int x1, int x2);
+    ///@}
+
+    /**
+     * Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
+     */
+    std::pair<Point, Point> CalcEndPoints(
+        Doc *doc, Staff *staff, curvature_CURVEDIR drawingCurveDir, char spanningType);
 
     /**
      * Determine layer elements spanned by the slur
@@ -281,6 +289,14 @@ private:
      * for s-shaped slurs / mixed direction
      */
     SlurCurveDirection m_drawingCurveDir;
+
+    /**
+     * Cached values for x1 and x2 from the last call of View::DrawSlur
+     */
+    ///@{
+    int m_cachedDrawingX1;
+    int m_cachedDrawingX2;
+    ///@}
 };
 
 } // namespace vrv

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -157,6 +157,11 @@ public:
         Doc *doc, Staff *staff, curvature_CURVEDIR drawingCurveDir, char spanningType);
 
     /**
+     * Calculate the initial slur bezier curve and store it in the curve positioner
+     */
+    void CalcInitialCurve(Doc *doc, FloatingCurvePositioner *curve);
+
+    /**
      * Determine layer elements spanned by the slur
      */
     SpannedElements CollectSpannedElements(Staff *staff, int xMin, int xMax);
@@ -170,8 +175,7 @@ public:
     /**
      * Add curve positioner to articulations
      */
-    void AddPositionerToArticulations(
-        FloatingCurvePositioner *curve, curvature_CURVEDIR drawingCurveDir, char spanningType);
+    void AddPositionerToArticulations(FloatingCurvePositioner *curve);
 
     /**
      * Calculate the staff where the slur's floating curve positioner lives

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -155,26 +155,14 @@ public:
     ///@}
 
     /**
-     * Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
-     */
-    std::pair<Point, Point> CalcEndPoints(
-        Doc *doc, Staff *staff, int x1, int x2, curvature_CURVEDIR drawingCurveDir, char spanningType);
-
-    /**
      * Calculate the initial slur bezier curve and store it in the curve positioner
      */
-    void CalcInitialCurve(Doc *doc, FloatingCurvePositioner *curve);
+    void CalcInitialCurve(Doc *doc, FloatingCurvePositioner *curve, NearEndCollision *nearEndCollision = NULL);
 
     /**
-     * Determine layer elements spanned by the slur
+     * Recalculate the spanned elements of the curve positioner
      */
-    SpannedElements CollectSpannedElements(Staff *staff, int xMin, int xMax);
-
-    /**
-     * Filter and add layer elements spanned by the slur to the positioner
-     */
-    void AddSpannedElements(
-        FloatingCurvePositioner *curve, const SpannedElements &elements, Staff *staff, int xMin, int xMax);
+    void CalcSpannedElements(FloatingCurvePositioner *curve);
 
     /**
      * Add curve positioner to articulations
@@ -185,14 +173,6 @@ public:
      * Calculate the staff where the slur's floating curve positioner lives
      */
     Staff *CalculateExtremalStaff(Staff *staff, int xMin, int xMax);
-
-    /**
-     * Determine whether a layer element should lie above or below the slur
-     */
-    ///@{
-    bool IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
-    bool IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
-    ///@}
 
     /**
      * Set the bezier control sides depending on the curve direction
@@ -239,9 +219,26 @@ private:
     ///@}
 
     /**
-     * Helper for calculating the initial slur start and end points
+     * Helper for calculating spanned elements
      */
     ///@{
+    // Determine layer elements spanned by the slur
+    SpannedElements CollectSpannedElements(Staff *staff, int xMin, int xMax);
+    // Filter and add layer elements spanned by the slur to the positioner
+    void AddSpannedElements(
+        FloatingCurvePositioner *curve, const SpannedElements &elements, Staff *staff, int xMin, int xMax);
+    // Determine whether a layer element should lie above or below the slur
+    bool IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
+    bool IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
+    ///@}
+
+    /**
+     * Helper for calculating the initial slur
+     */
+    ///@{
+    // Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
+    std::pair<Point, Point> CalcEndPoints(Doc *doc, Staff *staff, NearEndCollision *nearEndCollision, int x1, int x2,
+        curvature_CURVEDIR drawingCurveDir, char spanningType);
     // Retrieve the start and end note locations of the slur
     std::pair<int, int> GetStartEndLocs(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const;
     // Calculate the break location at system start/end and the pitch difference

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -168,6 +168,12 @@ public:
         FloatingCurvePositioner *curve, const SpannedElements &elements, Staff *staff, int xMin, int xMax);
 
     /**
+     * Add curve positioner to articulations
+     */
+    void AddPositionerToArticulations(
+        FloatingCurvePositioner *curve, curvature_CURVEDIR drawingCurveDir, char spanningType);
+
+    /**
      * Calculate the staff where the slur's floating curve positioner lives
      */
     Staff *CalculateExtremalStaff(Staff *staff, int xMin, int xMax);

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -31,6 +31,18 @@ struct SpannedElements {
 };
 
 //----------------------------------------------------------------------------
+// NearEndCollision
+//----------------------------------------------------------------------------
+/**
+ * Measure collisions near the end points
+ */
+struct NearEndCollision {
+    double metricAtStart;
+    double metricAtEnd;
+    bool endPointsAdjusted;
+};
+
+//----------------------------------------------------------------------------
 // ControlPointConstraint
 //----------------------------------------------------------------------------
 /**
@@ -252,6 +264,10 @@ private:
     ///@{
     // Discard certain spanned elements
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+
+    // Detect collisions near the endpoints
+    NearEndCollision DetectCollisionsNearEnd(
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -591,9 +591,8 @@ private:
      * @name Internal methods used for calculating slurs
      */
     ///@{
-    void DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, int x2, Staff *staff, char spanningType);
-    void CalcInitialSlur(
-        FloatingCurvePositioner *curve, Slur *slur, Staff *staff, curvature_CURVEDIR curveDir, Point points[4]);
+    FloatingCurvePositioner *CalcInitialSlur(
+        DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff, char spanningType);
     ///@}
 
     /**

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -512,6 +512,11 @@ void FloatingCurvePositioner::ResetPositioner()
     this->ResetCurveParams();
 }
 
+bool FloatingCurvePositioner::HasCachedX12() const
+{
+    return ((m_cachedX12.first != VRV_UNSET) && (m_cachedX12.second != VRV_UNSET));
+}
+
 void FloatingCurvePositioner::ClearSpannedElements()
 {
     for (auto &spannedElement : m_spannedElements) {
@@ -530,6 +535,7 @@ void FloatingCurvePositioner::ResetCurveParams()
     m_dir = curvature_CURVEDIR_NONE;
     m_crossStaff = NULL;
     m_cachedMinMaxY = VRV_UNSET;
+    m_cachedX12 = { VRV_UNSET, VRV_UNSET };
     m_requestedStaffSpace = 0;
     this->ClearSpannedElements();
 }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -365,6 +365,49 @@ void Slur::AddSpannedElements(
     }
 }
 
+void Slur::AddPositionerToArticulations(
+    FloatingCurvePositioner *curve, curvature_CURVEDIR drawingCurveDir, char spanningType)
+{
+    LayerElement *start = this->GetStart();
+    LayerElement *end = this->GetEnd();
+    if (!start || !end) return;
+
+    // the normal case or start
+    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
+        ListOfObjects artics = start->FindAllDescendantsByType(ARTIC);
+        // Then the @n of each first staffDef
+        for (auto &object : artics) {
+            Artic *artic = vrv_cast<Artic *>(object);
+            assert(artic);
+            if (artic->IsOutsideArtic()) {
+                if ((artic->GetPlace() == STAFFREL_above) && (drawingCurveDir == curvature_CURVEDIR_above)) {
+                    artic->AddSlurPositioner(curve, true);
+                }
+                else if ((artic->GetPlace() == STAFFREL_below) && (drawingCurveDir == curvature_CURVEDIR_below)) {
+                    artic->AddSlurPositioner(curve, true);
+                }
+            }
+        }
+    }
+    // normal case or end
+    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
+        ListOfObjects artics = end->FindAllDescendantsByType(ARTIC);
+        // Then the @n of each first staffDef
+        for (auto &object : artics) {
+            Artic *artic = vrv_cast<Artic *>(object);
+            assert(artic);
+            if (artic->IsOutsideArtic()) {
+                if ((artic->GetPlace() == STAFFREL_above) && (drawingCurveDir == curvature_CURVEDIR_above)) {
+                    artic->AddSlurPositioner(curve, false);
+                }
+                else if ((artic->GetPlace() == STAFFREL_below) && (drawingCurveDir == curvature_CURVEDIR_below)) {
+                    artic->AddSlurPositioner(curve, false);
+                }
+            }
+        }
+    }
+}
+
 Staff *Slur::CalculateExtremalStaff(Staff *staff, int xMin, int xMax)
 {
     Staff *extremalStaff = staff;

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1289,12 +1289,20 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
             }
             // d(^)
             else {
-                // put it on the side, move it right
-                if (startStemLen != 0) x1 += unit * 2;
-                if (startChord)
-                    y1 = yChordMax + unit * 3;
-                else
-                    y1 = start->GetDrawingY() + unit * 3;
+                if (nearEndCollision && nearEndCollision->metricAtStart > 0.3) {
+                    // Secondary endpoint on top
+                    y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                    x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    nearEndCollision->endPointsAdjusted = true;
+                }
+                else {
+                    // Primary endpoint on the side, move it right
+                    if (startStemLen != 0) x1 += unit * 2;
+                    if (startChord)
+                        y1 = yChordMax + unit * 3;
+                    else
+                        y1 = start->GetDrawingY() + unit * 3;
+                }
             }
         }
         // slur is down
@@ -1339,12 +1347,20 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
             }
             // P(_)
             else {
-                // put it on the side, but no need to move it right
-                if (startChord) {
-                    y1 = yChordMin - unit * 3;
+                if (nearEndCollision && nearEndCollision->metricAtStart > 0.3) {
+                    // Secondary endpoint on bottom
+                    y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                    x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    nearEndCollision->endPointsAdjusted = true;
                 }
                 else {
-                    y1 = start->GetDrawingY() - unit * 3;
+                    // Primary endpoint on the side, but no need to move it right
+                    if (startChord) {
+                        y1 = yChordMin - unit * 3;
+                    }
+                    else {
+                        y1 = start->GetDrawingY() - unit * 3;
+                    }
                 }
             }
         }
@@ -1399,12 +1415,20 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
             }
             // (^)d
             else {
-                // put it on the side, no need to move it left
-                if (endChord) {
-                    y2 = yChordMax + unit * 3;
+                if (nearEndCollision && nearEndCollision->metricAtEnd > 0.3) {
+                    // Secondary endpoint on top
+                    y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
+                    x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    nearEndCollision->endPointsAdjusted = true;
                 }
                 else {
-                    y2 = end->GetDrawingY() + unit * 3;
+                    // Primary endpoint on the side, no need to move it left
+                    if (endChord) {
+                        y2 = yChordMax + unit * 3;
+                    }
+                    else {
+                        y2 = end->GetDrawingY() + unit * 3;
+                    }
                 }
             }
         }
@@ -1451,13 +1475,21 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
             }
             // (_)P
             else {
-                // put it on the side, move it left
-                if (endStemLen != 0) x2 -= unit * 2;
-                if (endChord) {
-                    y2 = yChordMin - unit * 3;
+                if (nearEndCollision && nearEndCollision->metricAtEnd > 0.3) {
+                    // Secondary endpoint on bottom
+                    y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
+                    x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+                    nearEndCollision->endPointsAdjusted = true;
                 }
                 else {
-                    y2 = end->GetDrawingY() - unit * 3;
+                    // Primary endpoint on the side, move it left
+                    if (endStemLen != 0) x2 -= unit * 2;
+                    if (endChord) {
+                        y2 = yChordMin - unit * 3;
+                    }
+                    else {
+                        y2 = end->GetDrawingY() - unit * 3;
+                    }
                 }
             }
         }

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -85,7 +85,7 @@ FloatingCurvePositioner *View::CalcInitialSlur(
     if ((this->GetSlurHandling() == SlurHandling::Initialize) && dc->Is(BBOX_DEVICE_CONTEXT)
         && (curve->GetDir() == curvature_CURVEDIR_NONE || curve->IsCrossStaff())) {
         // Initial curve calculation
-        slur->SetCachedDrawingX12(x1, x2);
+        curve->SetCachedX12({ x1, x2 });
         slur->CalcInitialCurve(m_doc, curve);
 
         // Update x1 and x2

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -112,46 +112,7 @@ void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, i
 
     curve->UpdateCurveParams(points, thickness, drawingCurveDir);
 
-    /************** articulation **************/
-
-    // First get all artic children
-    ClassIdComparison matchType(ARTIC);
-    ListOfObjects artics;
-
-    // the normal case or start
-    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
-        start->FindAllDescendantsByComparison(&artics, &matchType);
-        // Then the @n of each first staffDef
-        for (auto &object : artics) {
-            Artic *artic = vrv_cast<Artic *>(object);
-            assert(artic);
-            if (artic->IsOutsideArtic()) {
-                if ((artic->GetPlace() == STAFFREL_above) && (drawingCurveDir == curvature_CURVEDIR_above)) {
-                    artic->AddSlurPositioner(curve, true);
-                }
-                else if ((artic->GetPlace() == STAFFREL_below) && (drawingCurveDir == curvature_CURVEDIR_below)) {
-                    artic->AddSlurPositioner(curve, true);
-                }
-            }
-        }
-    }
-    // normal case or end
-    if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
-        end->FindAllDescendantsByComparison(&artics, &matchType);
-        // Then the @n of each first staffDef
-        for (auto &object : artics) {
-            Artic *artic = vrv_cast<Artic *>(object);
-            assert(artic);
-            if (artic->IsOutsideArtic()) {
-                if ((artic->GetPlace() == STAFFREL_above) && (drawingCurveDir == curvature_CURVEDIR_above)) {
-                    artic->AddSlurPositioner(curve, false);
-                }
-                else if ((artic->GetPlace() == STAFFREL_below) && (drawingCurveDir == curvature_CURVEDIR_below)) {
-                    artic->AddSlurPositioner(curve, false);
-                }
-            }
-        }
-    }
+    slur->AddPositionerToArticulations(curve, drawingCurveDir, spanningType);
 }
 
 void View::CalcInitialSlur(

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -44,17 +44,7 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     assert(slur);
     assert(staff);
 
-    FloatingPositioner *positioner = slur->GetCurrentFloatingPositioner();
-    assert(positioner && positioner->Is(FLOATING_CURVE_POSITIONER));
-    FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(positioner);
-    assert(curve);
-
-    if ((this->GetSlurHandling() == SlurHandling::Initialize) && dc->Is(BBOX_DEVICE_CONTEXT)
-        && (curve->GetDir() == curvature_CURVEDIR_NONE || curve->IsCrossStaff())) {
-        slur->SetCachedDrawingX12(x1, x2);
-        this->DrawSlurInitial(curve, slur, x1, x2, staff, spanningType);
-    }
-
+    FloatingCurvePositioner *curve = this->CalcInitialSlur(dc, slur, x1, x2, staff, spanningType);
     Point points[4];
     curve->GetPoints(points);
 
@@ -78,83 +68,38 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     this->DrawThickBezierCurve(
         dc, points, thicknessCoefficient * curve->GetThickness(), staff->m_drawingStaffSize, penWidth, penStyle);
 
-    /*
-    int i;
-    for (i = 0; i <= 10; ++i) {
-        Point p = BoundingBox::CalcDeCasteljau(points, (double)i / 10.0);
-        this->DrawDot(dc, p.x, p.y, staff->m_drawingStaffSize);
-    }
-    */
-
     if (graphic)
         dc->EndResumedGraphic(graphic, this);
     else
         dc->EndGraphic(slur, this);
 }
 
-void View::DrawSlurInitial(FloatingCurvePositioner *curve, Slur *slur, int x1, int x2, Staff *staff, char spanningType)
+FloatingCurvePositioner *View::CalcInitialSlur(
+    DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff, char spanningType)
 {
-    LayerElement *start = slur->GetStart();
-    LayerElement *end = slur->GetEnd();
+    FloatingPositioner *positioner = slur->GetCurrentFloatingPositioner();
+    assert(positioner && positioner->Is(FLOATING_CURVE_POSITIONER));
+    FloatingCurvePositioner *curve = vrv_cast<FloatingCurvePositioner *>(positioner);
+    assert(curve);
 
-    if (!start || !end) return;
+    if ((this->GetSlurHandling() == SlurHandling::Initialize) && dc->Is(BBOX_DEVICE_CONTEXT)
+        && (curve->GetDir() == curvature_CURVEDIR_NONE || curve->IsCrossStaff())) {
+        // Initial curve calculation
+        slur->SetCachedDrawingX12(x1, x2);
+        slur->CalcInitialCurve(m_doc, curve);
 
-    const curvature_CURVEDIR drawingCurveDir = slur->CalcDrawingCurveDir(spanningType);
+        // Update x1 and x2
+        Point points[4];
+        curve->GetPoints(points);
+        x1 = points[0].x;
+        x2 = points[3].x;
 
-    const std::pair<Point, Point> endPoints = slur->CalcEndPoints(m_doc, staff, drawingCurveDir, spanningType);
-
-    Point points[4];
-    points[0] = endPoints.first;
-    points[3] = endPoints.second;
-
-    this->CalcInitialSlur(curve, slur, staff, drawingCurveDir, points);
-    int thickness = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_slurMidpointThickness.GetValue();
-
-    curve->UpdateCurveParams(points, thickness, drawingCurveDir);
-
-    slur->AddPositionerToArticulations(curve, drawingCurveDir, spanningType);
-}
-
-void View::CalcInitialSlur(
-    FloatingCurvePositioner *curve, Slur *slur, Staff *staff, curvature_CURVEDIR curveDir, Point points[4])
-{
-    // For now we pick C1 = P1 and C2 = P2
-    BezierCurve bezier(points[0], points[0], points[3], points[3]);
-    slur->InitBezierControlSides(bezier, curveDir);
-
-    /************** content **************/
-
-    const SpannedElements spannedElements = slur->CollectSpannedElements(staff, bezier.p1.x, bezier.p2.x);
-    slur->AddSpannedElements(curve, spannedElements, staff, bezier.p1.x, bezier.p2.x);
-
-    /************** angle **************/
-
-    const bool dontAdjustAngle = curve->IsCrossStaff() || slur->GetStart()->IsGraceNote();
-    const float nonAdjustedAngle
-        = (bezier.p2 == bezier.p1) ? 0 : atan2(bezier.p2.y - bezier.p1.y, bezier.p2.x - bezier.p1.x);
-    const float slurAngle
-        = dontAdjustAngle ? nonAdjustedAngle : slur->GetAdjustedSlurAngle(m_doc, bezier.p1, bezier.p2, curveDir);
-    if (curveDir != curvature_CURVEDIR_mixed) {
-        bezier.p2 = BoundingBox::CalcPositionAfterRotation(bezier.p2, -slurAngle, bezier.p1);
+        // Register content
+        const SpannedElements spannedElements = slur->CollectSpannedElements(staff, x1, x2);
+        slur->AddSpannedElements(curve, spannedElements, staff, x1, x2);
+        slur->AddPositionerToArticulations(curve);
     }
-
-    /************** control points **************/
-
-    if (slur->HasBulge()) {
-        bezier.CalcInitialControlPointParams();
-    }
-    else {
-        bezier.CalcInitialControlPointParams(m_doc, slurAngle, staff->m_drawingStaffSize);
-    }
-    bezier.UpdateControlPoints();
-    if (curveDir != curvature_CURVEDIR_mixed) {
-        bezier.Rotate(slurAngle, bezier.p1);
-    }
-
-    points[0] = bezier.p1;
-    points[1] = bezier.c1;
-    points[2] = bezier.c2;
-    points[3] = bezier.p2;
+    return curve;
 }
 
 } // namespace vrv

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -88,15 +88,8 @@ FloatingCurvePositioner *View::CalcInitialSlur(
         curve->SetCachedX12({ x1, x2 });
         slur->CalcInitialCurve(m_doc, curve);
 
-        // Update x1 and x2
-        Point points[4];
-        curve->GetPoints(points);
-        x1 = points[0].x;
-        x2 = points[3].x;
-
         // Register content
-        const SpannedElements spannedElements = slur->CollectSpannedElements(staff, x1, x2);
-        slur->AddSpannedElements(curve, spannedElements, staff, x1, x2);
+        slur->CalcSpannedElements(curve);
         slur->AddPositionerToArticulations(curve);
     }
     return curve;


### PR DESCRIPTION
This PR implements slur endpoint relocation depending on nearby collisions. Closes #2819 .
<img width="1483" alt="Beethoven" src="https://user-images.githubusercontent.com/63608463/168539777-8cf8f5d2-275a-4fd5-b30a-437a40e30bad.png">

Another example with beams:
| Before | After |
| ------ | ----- |
| <img width="177" alt="Before" src="https://user-images.githubusercontent.com/63608463/168539864-dfbd33a0-bfc4-446f-823d-b05e97ce606b.png"> | <img width="176" alt="After" src="https://user-images.githubusercontent.com/63608463/168539894-db63d94d-e736-4144-877e-592ba14b1d56.png"> |

