### PR TITLE
Minor justification fix

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -939,7 +939,7 @@ int Chord::JustifyYAdjustCrossStaff(FunctorParams *functorParams)
         extremalStaves.insert({ staff->GetN(), staff });
     }
     // get chord parent staff
-    Staff *staff = this->GetAncestorStaff();
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     extremalStaves.insert({ staff->GetN(), staff });
 
     if (extremalStaves.size() < 2) return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- when justifying cross-staff chords, check for cross-staff elements to make sure that calculations are correct

Before:
![image](https://user-images.githubusercontent.com/1819669/168765332-f622bf3b-6b3c-4e4a-85ad-7208ae50933a.png)

After:
![image](https://user-images.githubusercontent.com/1819669/168765364-f319cf76-7e7c-4390-abc0-d077811be915.png)


