### PR TITLE
Fix for adjusted rest horizontal overlap

### DIFF
--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -511,7 +511,7 @@ private:
      * Get above/below overflow for the chord elements
      */
     void GetChordOverflow(StaffAlignment *&above, StaffAlignment *&below, int staffN);
-    
+
     /**
      * Calculate offset and left overlap of the element
      */

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -511,6 +511,11 @@ private:
      * Get above/below overflow for the chord elements
      */
     void GetChordOverflow(StaffAlignment *&above, StaffAlignment *&below, int staffN);
+    
+    /**
+     * Calculate offset and left overlap of the element
+     */
+    std::pair<int, int> CalculateXPosOffset(FunctorParams *functorParams);
 
 public:
     /** Absolute position X. This is used for facsimile (transcription) encoding */

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1058,7 +1058,7 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         bool hasOverlap = this->HorizontalContentOverlap(boundingBox, margin);
         if (!hasOverlap) continue;
 
-        // For note to note alignment, make sure there is a standard spacing even if they to not overlap
+        // For note to note alignment, make sure there is a standard spacing even if they do not overlap
         // vertically
         if (this->Is(NOTE) && element->Is(NOTE)) {
             overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
@@ -1082,7 +1082,7 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         else if (this->Is(ACCID) && element->Is(REST)) {
             Rest *rest = vrv_cast<Rest *>(element);
             const bool hasExplicitLoc = ((rest->HasOloc() && rest->HasPloc()) || rest->HasLoc());
-            if (element->GetFirstAncestor(BEAM) && !hasExplicitLoc) {
+            if ((rest->GetFirstAncestor(BEAM) || rest->IsInBeamSpan()) && !hasExplicitLoc) {
                 overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
             }
             else {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1032,11 +1032,11 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         selfLeft = this->GetAlignment()->GetXRel();
         return { 0, selfLeft };
     }
-    
+
     // We add it to the upcoming bounding boxes
     params->m_upcomingBoundingBoxes.push_back(this);
     params->m_currentAlignment.m_alignment = this->GetAlignment();
-    
+
     // only look at the horizontal position
     if (!performBoundingBoxAlignment) {
         selfLeft = this->GetSelfLeft();

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1012,6 +1012,82 @@ int LayerElement::GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDot
     return count;
 }
 
+std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorParams)
+{
+    AdjustXPosParams *params = vrv_params_cast<AdjustXPosParams *>(functorParams);
+    assert(params);
+
+    int selfLeft = 0;
+    const int drawingUnit = params->m_doc->GetDrawingUnit(params->m_staffSize);
+    // Nested alignment of bounding boxes is performed only when both the previous alignment and the current one allow
+    // it. For example, when one of them is a barline, we do not look how bounding boxes can be nested but instead only
+    // look at the horizontal position
+    bool performBoundingBoxAlignment = (params->m_previousAlignment.m_alignment
+        && params->m_previousAlignment.m_alignment->PerformBoundingBoxAlignment()
+        && this->GetAlignment()->PerformBoundingBoxAlignment());
+
+    if (!this->HasSelfBB() || this->HasEmptyBB()) {
+        // If nothing was drawn, do not take it into account. This should happen for barline position none but also
+        // chords in beam. Otherwise the BB should be set to empty with Object::SetEmptyBB()
+        selfLeft = this->GetAlignment()->GetXRel();
+        return { 0, selfLeft };
+    }
+    
+    // We add it to the upcoming bounding boxes
+    params->m_upcomingBoundingBoxes.push_back(this);
+    params->m_currentAlignment.m_alignment = this->GetAlignment();
+    
+    // only look at the horizontal position
+    if (!performBoundingBoxAlignment) {
+        selfLeft = this->GetSelfLeft();
+        selfLeft -= params->m_doc->GetLeftMargin(this) * drawingUnit;
+        return { 0, selfLeft };
+    }
+
+    // Here we look how bounding boxes overlap and adjust the position only when necessary
+    selfLeft = this->GetAlignment()->GetXRel();
+    // If we want the nesting to be reduced, we can set to:
+    // selfLeft = this->GetSelfLeft();
+    // This could be made an option (--spacing-limited-nesting)
+    const double selfLeftMargin = params->m_doc->GetLeftMargin(this);
+    int overlap = 0;
+    for (const auto &boundingBox : params->m_boundingBoxes) {
+        LayerElement *element = vrv_cast<LayerElement *>(boundingBox);
+        assert(element);
+        int margin = (params->m_doc->GetRightMargin(element) + selfLeftMargin) * drawingUnit;
+        bool hasOverlap = this->HorizontalContentOverlap(boundingBox, margin);
+        if (!hasOverlap) continue;
+
+        // For note to note alignment, make sure there is a standard spacing even if they to not overlap
+        // vertically
+        if (this->Is(NOTE) && element->Is(NOTE)) {
+            overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
+        }
+        else if (this->Is(ACCID) && element->Is(NOTE)) {
+            Staff *staff = this->GetAncestorStaff();
+            const int staffTop = staff->GetDrawingY();
+            const int staffBottom = staffTop - params->m_doc->GetDrawingStaffSize(params->m_staffSize);
+            int verticalMargin = 0;
+            if ((this->GetContentTop() > staffTop + 2 * drawingUnit) && (element->GetDrawingY() > staffTop)
+                && (element->GetDrawingY() > this->GetDrawingY())) {
+                verticalMargin = element->GetDrawingY() - this->GetDrawingY();
+            }
+            else if ((this->GetContentBottom() < staffBottom - 2 * drawingUnit)
+                && (element->GetDrawingY() < staffBottom)
+                && (element->GetDrawingY() < this->GetDrawingY())) {
+                verticalMargin = this->GetDrawingY() - element->GetDrawingY();
+            }
+            overlap = std::max(
+                overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin, verticalMargin));
+        }
+        else {
+            overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
+        }
+    }
+
+    return { -overlap, selfLeft };
+}
+
 //----------------------------------------------------------------------------
 // LayerElement functor methods
 //----------------------------------------------------------------------------
@@ -1961,77 +2037,7 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     int offset = 0;
     int selfLeft;
     const int drawingUnit = params->m_doc->GetDrawingUnit(params->m_staffSize);
-
-    // Nested alignment of bounding boxes is performed only when both the previous alignment and
-    // the current one allow it. For example, when one of them is a barline, we do not look how
-    // bounding boxes can be nested but instead only look at the horizontal position
-    bool performBoundingBoxAlignment = (params->m_previousAlignment.m_alignment
-        && params->m_previousAlignment.m_alignment->PerformBoundingBoxAlignment()
-        && this->GetAlignment()->PerformBoundingBoxAlignment());
-
-    if (!this->HasSelfBB() || this->HasEmptyBB()) {
-        // if nothing was drawn, do not take it into account
-        // This should happen for barline position none but also chords in beam. Otherwise the BB should be set to
-        // empty with
-        // Object::SetEmptyBB()
-        // LogDebug("Nothing drawn for '%s' '%s'", this->GetClassName().c_str(), this->GetUuid().c_str());
-        selfLeft = this->GetAlignment()->GetXRel();
-    }
-    else {
-        // We add it to the upcoming bouding boxes
-        params->m_upcomingBoundingBoxes.push_back(this);
-        params->m_currentAlignment.m_alignment = this->GetAlignment();
-        // Here we look how bounding boxes overlap and adjust the position only when necessary
-        if (performBoundingBoxAlignment) {
-            selfLeft = this->GetAlignment()->GetXRel();
-            // If we want the nesting to be reduced, we can set to:
-            // selfLeft = this->GetSelfLeft();
-            // This could be made an option (--spacing-limited-nesting)
-            const double selfLeftMargin = params->m_doc->GetLeftMargin(this);
-            int overlap = 0;
-            for (auto &boundingBox : params->m_boundingBoxes) {
-                LayerElement *element = vrv_cast<LayerElement *>(boundingBox);
-                assert(element);
-                int margin = (params->m_doc->GetRightMargin(element) + selfLeftMargin) * drawingUnit;
-                bool hasOverlap = this->HorizontalContentOverlap(boundingBox, margin);
-
-                if (hasOverlap) {
-                    // For note to note alignment, make sure there is a standard spacing even if they to not overlap
-                    // vertically
-                    if (this->Is(NOTE) && element->Is(NOTE)) {
-                        overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
-                    }
-                    else if (this->Is(ACCID) && element->Is(NOTE)) {
-                        Staff *staff = this->GetAncestorStaff();
-                        const int staffTop = staff->GetDrawingY();
-                        const int staffBottom = staffTop - params->m_doc->GetDrawingStaffSize(params->m_staffSize);
-                        int verticalMargin = 0;
-                        if ((this->GetContentTop() > staffTop + 2 * drawingUnit) && (element->GetDrawingY() > staffTop)
-                            && (element->GetDrawingY() > this->GetDrawingY())) {
-                            verticalMargin = element->GetDrawingY() - this->GetDrawingY();
-                        }
-                        else if ((this->GetContentBottom() < staffBottom - 2 * drawingUnit)
-                            && (element->GetDrawingY() < staffBottom)
-                            && (element->GetDrawingY() < this->GetDrawingY())) {
-                            verticalMargin = this->GetDrawingY() - element->GetDrawingY();
-                        }
-                        overlap = std::max(
-                            overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin, verticalMargin));
-                    }
-                    else {
-                        overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
-                    }
-                    // LogDebug("%s overlaps of %d, margin %d", this->GetClassName().c_str(), overlap, margin);
-                }
-            }
-            offset -= overlap;
-        }
-        // Otherwise only look at the horizontal position
-        else {
-            selfLeft = this->GetSelfLeft();
-            selfLeft -= params->m_doc->GetLeftMargin(this) * drawingUnit;
-        }
-    }
+    std::tie(offset, selfLeft) = this->CalculateXPosOffset(params);
 
     offset = std::min(offset, selfLeft - params->m_minPos);
     if (offset < 0) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1073,12 +1073,21 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
                 verticalMargin = element->GetDrawingY() - this->GetDrawingY();
             }
             else if ((this->GetContentBottom() < staffBottom - 2 * drawingUnit)
-                && (element->GetDrawingY() < staffBottom)
-                && (element->GetDrawingY() < this->GetDrawingY())) {
+                && (element->GetDrawingY() < staffBottom) && (element->GetDrawingY() < this->GetDrawingY())) {
                 verticalMargin = this->GetDrawingY() - element->GetDrawingY();
             }
-            overlap = std::max(
-                overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin, verticalMargin));
+            overlap
+                = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin, verticalMargin));
+        }
+        else if (this->Is(ACCID) && element->Is(REST)) {
+            Rest *rest = vrv_cast<Rest *>(element);
+            const bool hasExplicitLoc = ((rest->HasOloc() && rest->HasPloc()) || rest->HasLoc());
+            if (element->GetFirstAncestor(BEAM) && !hasExplicitLoc) {
+                overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
+            }
+            else {
+                overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
+            }
         }
         else {
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));


### PR DESCRIPTION
Rests that are adjusted to avoid beams end up overlapping with other layer elements (namely, accidentals)

Before:
![image](https://user-images.githubusercontent.com/1819669/169088591-540d6739-7841-4cb2-b40d-c93ffd8a6b23.png)

After:
![image](https://user-images.githubusercontent.com/1819669/169088647-c0ee3cd2-6a08-435f-b5af-a6e413d8aa81.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt/>
         <pubStmt/>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv n="1" type="placeholder" filename="C259_Chopin-Mazurka-op-33-no-3.mei">
            <score>
               <scoreDef xmlns="http://www.music-encoding.org/ns/mei">
                  <staffGrp xml:id="staffgrp-0000000654644337">
                     <staffGrp xml:id="S1" symbol="brace" bar.thru="true">
                        <staffDef xml:id="staffdef-0000001531587499" clef.shape="G" clef.line="2" key.sig="2s" meter.count="3" meter.unit="4" n="1" lines="5"/>
                        <staffDef xml:id="staffdef-0000000537857792" clef.shape="F" clef.line="4" key.sig="2s" meter.count="3" meter.unit="4" n="2" lines="5"/>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xmlns="http://www.music-encoding.org/ns/mei" xml:id="section-0000001322498664">
                  <measure id="measure-55-1" n="54">
                     <staff xml:id="staff-0000001125768790" n="1">
                        <layer xml:id="layer-0000001260298422" n="1">
                           <beam xml:id="beam-0000002025605598">
                              <chord xml:id="chord-0000001541259255" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000916025837" oct="4" pname="b" accid.ges="f"/>
                                 <note xml:id="note-0000001650603713" oct="5" pname="f"/>
                                 <note xml:id="note-0000001614037202" oct="5" pname="b" accid.ges="f"/>
                              </chord>
                              <rest xml:id="rest-0000001514944289" dur="16"/>
                              <chord xml:id="chord-0000002015497924" dur="16" stem.dir="down">
                                 <note xml:id="note-0000001380145343" oct="4" pname="b" accid.ges="f"/>
                                 <note xml:id="note-0000001927036967" oct="5" pname="f"/>
                                 <note xml:id="note-0000001856740159" oct="5" pname="b" accid.ges="f"/>
                              </chord>
                           </beam>
                           <chord xml:id="chord-0000001829401850" dur="4" stem.dir="down">
                              <note xml:id="note-0000000054333139" oct="4" pname="b" accid.ges="f"/>
                              <note xml:id="note-0000000080271089" oct="5" pname="f"/>
                              <note xml:id="note-0000001602758008" oct="5" pname="b" accid.ges="f"/>
                           </chord>
                           <chord xml:id="chord-0000001732643191" dur="4" stem.dir="down">
                              <note xml:id="note-0000000079807916" oct="4" pname="b" accid.ges="f"/>
                              <note xml:id="note-0000001598747363" oct="5" pname="f"/>
                              <note xml:id="note-0000002122901073" oct="5" pname="a"/>
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001651310551" n="2">
                        <layer xml:id="layer-0000001665314196" n="5">
                           <beam xml:id="beam-0000001271691208">
                              <note xml:id="note-0000001101186216" dur="8" oct="2" pname="f" stem.dir="down">
                                 <artic xml:id="artic-0000001169141099" artic="stacc"/>
                              </note>
                              <rest xml:id="rest-0000000384505982" dur="16" />
                              <note xml:id="note-0000000979308166" dur="16" oct="3" pname="b" stem.dir="down">
                                 <accid xml:id="accid-0000002085166936" accid="n"/>
                              </note>
                              <note xml:id="note-0000000373083773" dots="1" dur="8" oct="4" pname="c" stem.dir="down"/>
                              <note xml:id="note-0000001588287002" dur="16" oct="4" pname="d" stem.dir="down">
                                 <accid accid="f"/>
                              </note>
                           </beam>
                           <note xml:id="note-0000000428659396" dur="4" oct="4" pname="c" stem.dir="down"/>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000000962105842" startid="#note-0000000979308166" endid="#note-0000000428659396"/>
                     <pedal vgrp="200" staff="2" tstamp="1" dir="down" place="below"/>
                     <pedal xml:id="pedal-0000002097855229" staff="2" tstamp="3" dir="up" place="below" vgrp="200"/>
                  </measure>
                  <sb xml:id="sb-0000000720591098"/>
                  <measure id="measure-56-1" n="55">
                     <staff xml:id="staff-0000001750402725" n="1">
                        <layer xml:id="layer-0000001205677085" n="1">
                           <beam xml:id="beam-0000001675727351">
                              <chord xml:id="chord-0000001260886894" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000800399015" oct="4" pname="b" accid.ges="f"/>
                                 <note xml:id="note-0000000251662730" oct="5" pname="e">
                                    <accid xml:id="accid-0000000573426493" accid="n"/>
                                 </note>
                                 <note xml:id="note-0000000778717442" oct="5" pname="a"/>
                              </chord>
                              <rest xml:id="rest-0000001523353938" dur="16"/>
                              <chord xml:id="chord-0000001907859920" dur="16" stem.dir="down">
                                 <note xml:id="note-0000001674612709" oct="4" pname="b" accid.ges="f"/>
                                 <note xml:id="note-0000001885541830" oct="5" pname="e"/>
                                 <note xml:id="note-0000000722482115" oct="5" pname="a"/>
                              </chord>
                           </beam>
                           <chord xml:id="chord-0000001151141511" dur="4" stem.dir="down">
                              <note xml:id="note-0000000879521001" oct="4" pname="b" accid.ges="f"/>
                              <note xml:id="note-0000000829892582" oct="5" pname="e"/>
                              <note xml:id="note-0000000134609179" oct="5" pname="a"/>
                           </chord>
                           <chord xml:id="chord-0000000958371098" dur="4" stem.dir="down">
                              <note xml:id="note-0000000812462603" oct="4" pname="b" accid.ges="f"/>
                              <note xml:id="note-0000001996492073" oct="5" pname="e"/>
                              <note xml:id="note-0000000074829354" oct="5" pname="g"/>
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000028260420" n="2">
                        <layer xml:id="layer-0000001491389528" n="5">
                           <beam xml:id="beam-0000000195350643">
                              <note xml:id="note-0000000715149364" dur="8" oct="3" pname="c" stem.dir="down">
                                 <artic artic="stacc"/>
                              </note>
                              <rest xml:id="test" dur="16" />
                              <!-- <rest xml:id="test" dur="16" ploc="c" oloc="4"/> -->
                              <note xml:id="abra" dur="16" oct="3" pname="b" stem.dir="down">
                                 <accid xml:id="blah" accid="n"/>
                              </note>
                              <note xml:id="note-0000001899338414" dots="1" dur="8" oct="4" pname="c" stem.dir="down"/>
                              <note xml:id="note-0000000088655829" dur="16" oct="4" pname="d" stem.dir="down">
                                 <accid accid="n"/>
                              </note>
                           </beam>
                           <note xml:id="note-0000000750511111" dur="4" oct="4" pname="c" stem.dir="down"/>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000000506437227" startid="#chord-0000001260886894" endid="#chord-0000000958371098"/>
                     <slur xml:id="slur-0000000152502043" startid="#note-0000000223611063" endid="#note-0000000750511111"/>
                     <pedal vgrp="200" staff="2" tstamp="1" dir="down" place="below"/>
                     <pedal xml:id="pedal-0000001012741660" staff="2" tstamp="3" dir="up" place="below" vgrp="200"/>
                  </measure>
                  <measure id="measure-57-1" n="56">
                     <staff xml:id="staff-0000000199047237" n="1">
                        <layer xml:id="layer-0000000508753715" n="1">
                           <beam xml:id="beam-0000001350188748">
                              <chord xml:id="chord-0000000643362895" dur="8" stem.dir="down">
                                 <note xml:id="note-0000000919433829" oct="4" pname="b"/>
                                 <note xml:id="note-0000000015167704" oct="5" pname="e">
                                    <accid xml:id="accid-0000000408276313" accid="f" accid.ges="f"/>
                                 </note>
                                 <note xml:id="note-0000001601733993" oct="5" pname="g"/>
                              </chord>
                              <rest xml:id="rest-0000002011659777" dur="16"/>
                              <chord xml:id="chord-0000000945639874" dur="16" stem.dir="down">
                                 <note xml:id="note-0000000483105668" oct="4" pname="b"/>
                                 <note xml:id="note-0000001198255032" oct="5" pname="e" accid.ges="f"/>
                                 <note xml:id="note-0000000283137835" oct="5" pname="g"/>
                              </chord>
                           </beam>
                           <chord xml:id="chord-0000000044966875" dur="4" stem.dir="down">
                              <note xml:id="note-0000000486511846" oct="4" pname="a"/>
                              <note xml:id="note-0000000034992601" oct="5" pname="e" accid.ges="f"/>
                              <note xml:id="note-0000000795477987" oct="5" pname="g"/>
                           </chord>
                           <chord xml:id="chord-0000000915486235" dur="4" stem.dir="down">
                              <note xml:id="note-0000001047734261" oct="4" pname="a"/>
                              <note xml:id="note-0000002119415592" oct="5" pname="e" accid.ges="f"/>
                              <note xml:id="note-0000000631675085" oct="5" pname="f"/>
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000000089541247" n="2">
                        <layer xml:id="layer-0000000822998610" n="5">
                           <beam xml:id="beam-0000000136060064">
                              <note xml:id="note-0000000108240207" dur="8" oct="3" pname="f" stem.dir="down">
                                 <artic artic="stacc"/>
                              </note>
                              <rest xml:id="rest-0000000033018856" dur="16"/>
                              <note xml:id="note-0000001465952243" dur="16" oct="3" pname="b" stem.dir="down">
                                 <accid xml:id="accid-0000000307287444" accid="n"/>
                              </note>
                              <note xml:id="note-0000001974705958" dots="1" dur="8" oct="4" pname="c" stem.dir="down"/>
                              <note xml:id="note-0000001657476192" dur="16" oct="4" pname="e" stem.dir="down">
                                 <accid xml:id="accid-0000001041993932" accid="n"/>
                              </note>
                           </beam>
                           <note xml:id="note-0000000470585205" dur="4" oct="4" pname="f" stem.dir="down"/>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000000059526772" startid="#chord-0000000643362895" endid="#chord-0000000915486235"/>
                     <slur xml:id="slur-0000000122560103" startid="#note-0000001465952243" endid="#note-0000000470585205"/>
                     <pedal vgrp="200" staff="2" tstamp="1" dir="down" place="below"/>
                     <pedal xml:id="pedal-0000001672643896" staff="2" tstamp="3" dir="up" place="below" vgrp="200"/>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>