### PR TITLE
Control slur endpoint flexibility and symmetry

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -689,6 +689,7 @@ public:
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;
     OptionDbl m_slurCurveFactor;
+    OptionDbl m_slurEndpointFlexibility;
     OptionDbl m_slurEndpointThickness;
     OptionDbl m_slurMargin;
     OptionInt m_slurMaxSlope;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -694,6 +694,7 @@ public:
     OptionDbl m_slurMargin;
     OptionInt m_slurMaxSlope;
     OptionDbl m_slurMidpointThickness;
+    OptionDbl m_slurSymmetry;
     OptionInt m_spacingBraceGroup;
     OptionInt m_spacingBracketGroup;
     OptionBool m_spacingDurDetection;

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -252,10 +252,11 @@ private:
 
     // Calculate the vertical control point shift
     ControlPointAdjustment CalcControlPointVerticalShift(
-        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, double symmetry, int margin);
 
     // Solve the constraints for vertical control point adjustment
-    std::pair<int, int> SolveControlPointConstraints(const std::list<ControlPointConstraint> &constraints);
+    std::pair<int, int> SolveControlPointConstraints(
+        const std::list<ControlPointConstraint> &constraints, double symmetry = 0.0);
 
     // Improve the slur shape by adjusting the control point heights
     void AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int unit);

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -243,6 +243,9 @@ private:
     // Calculate slur from bulge values
     void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
 
+    // Check whether control points should be adjusted horizontally
+    bool AdjustControlPointOffset(const BezierCurve &bezierCurve, double symmetry, int unit) const;
+
     // Calculate the horizontal control point offset
     std::tuple<bool, int, int> CalcControlPointOffset(
         FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
@@ -265,6 +268,7 @@ private:
     // Shift end points for collisions nearby
     void ShiftEndPoints(
         int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility, bool isBelow) const;
+
     // Calculate the coefficients of a quadratic interpolation function
     std::function<double(double)> CalcQuadraticInterpolation(double zeroAt, double oneAt) const;
 

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -270,7 +270,7 @@ private:
     void ShiftEndPoints(
         int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility, bool isBelow) const;
 
-    // Calculate the coefficients of a quadratic interpolation function
+    // Calculate a quadratic interpolation function between zero and one
     std::function<double(double)> CalcQuadraticInterpolation(double zeroAt, double oneAt) const;
 
     // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -10,6 +10,7 @@
 
 #include "controlelement.h"
 #include "timeinterface.h"
+#include "vrvdef.h"
 
 namespace vrv {
 
@@ -236,7 +237,8 @@ private:
     void FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
 
     // Calculate the vertical shift of the slur end points
-    std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, int margin);
+    std::pair<int, int> CalcEndPointShift(
+        FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, double flexibility, int margin);
 
     // Calculate slur from bulge values
     void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
@@ -261,7 +263,10 @@ private:
      */
     ///@{
     // Shift end points for collisions nearby
-    void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection, bool isBelow) const;
+    void ShiftEndPoints(
+        int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility, bool isBelow) const;
+    // Calculate the coefficients of a quadratic interpolation function
+    std::function<double(double)> CalcQuadraticInterpolation(double zeroAt, double oneAt) const;
 
     // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis
     // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -10,7 +10,6 @@
 
 #include "controlelement.h"
 #include "timeinterface.h"
-#include "vrvdef.h"
 
 namespace vrv {
 
@@ -244,7 +243,7 @@ private:
     void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
 
     // Check whether control points should be adjusted horizontally
-    bool AdjustControlPointOffset(const BezierCurve &bezierCurve, double symmetry, int unit) const;
+    bool AllowControlOffsetAdjustment(const BezierCurve &bezierCurve, double symmetry, int unit) const;
 
     // Calculate the horizontal control point offset
     std::tuple<bool, int, int> CalcControlPointOffset(
@@ -270,8 +269,8 @@ private:
     void ShiftEndPoints(
         int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility, bool isBelow) const;
 
-    // Calculate a quadratic interpolation function between zero and one
-    std::function<double(double)> CalcQuadraticInterpolation(double zeroAt, double oneAt) const;
+    // Determine a quadratic interpolation function between zero and one and evaluate it
+    double CalcQuadraticInterpolation(double zeroAt, double oneAt, double arg) const;
 
     // Rotate the slope by a given number of degrees, but choose smaller angles if already close to the vertical axis
     // Choose doublingBound as the positive slope value where doubling has the same effect as rotating:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1339,11 +1339,11 @@ Options::Options()
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
     m_slurEndpointFlexibility.SetInfo(
-        "Slur endpoint flexibility", "Slur end point flexibility - allow more endpoint movement during adjustment");
+        "Slur endpoint flexibility", "Slur endpoint flexibility - allow more endpoint movement during adjustment");
     m_slurEndpointFlexibility.Init(0.0, 0.0, 1.0);
     this->Register(&m_slurEndpointFlexibility, "slurEndpointFlexibility", &m_generalLayout);
 
-    m_slurEndpointThickness.SetInfo("Slur Endpoint thickness", "The Endpoint slur thickness in MEI units");
+    m_slurEndpointThickness.SetInfo("Slur endpoint thickness", "The endpoint slur thickness in MEI units");
     m_slurEndpointThickness.Init(0.1, 0.05, 0.25);
     this->Register(&m_slurEndpointThickness, "slurEndpointThickness", &m_generalLayout);
 
@@ -1358,6 +1358,10 @@ Options::Options()
     m_slurMidpointThickness.SetInfo("Slur midpoint thickness", "The midpoint slur thickness in MEI units");
     m_slurMidpointThickness.Init(0.6, 0.2, 1.2);
     this->Register(&m_slurMidpointThickness, "slurMidpointThickness", &m_generalLayout);
+
+    m_slurSymmetry.SetInfo("Slur symmetry", "Slur symmetry - high value means more symmetric slurs");
+    m_slurSymmetry.Init(0.0, 0.0, 1.0);
+    this->Register(&m_slurSymmetry, "slurSymmetry", &m_generalLayout);
 
     m_spacingBraceGroup.SetInfo(
         "Spacing brace group", "Minimum space between staves inside a braced group in MEI units");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1338,8 +1338,8 @@ Options::Options()
     m_slurCurveFactor.Init(1.0, 0.2, 5.0);
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
-    m_slurEndpointFlexibility.SetInfo("Slur endpoint flexibility",
-        "Slur end point flexibility - avoid asymmetric slurs by allowing more endpoint movement during adjustment");
+    m_slurEndpointFlexibility.SetInfo(
+        "Slur endpoint flexibility", "Slur end point flexibility - allow more endpoint movement during adjustment");
     m_slurEndpointFlexibility.Init(0.0, 0.0, 1.0);
     this->Register(&m_slurEndpointFlexibility, "slurEndpointFlexibility", &m_generalLayout);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1338,6 +1338,11 @@ Options::Options()
     m_slurCurveFactor.Init(1.0, 0.2, 5.0);
     this->Register(&m_slurCurveFactor, "slurCurveFactor", &m_generalLayout);
 
+    m_slurEndpointFlexibility.SetInfo("Slur endpoint flexibility",
+        "Slur end point flexibility - avoid asymmetric slurs by allowing more endpoint movement during adjustment");
+    m_slurEndpointFlexibility.Init(0.0, 0.0, 1.0);
+    this->Register(&m_slurEndpointFlexibility, "slurEndpointFlexibility", &m_generalLayout);
+
     m_slurEndpointThickness.SetInfo("Slur Endpoint thickness", "The Endpoint slur thickness in MEI units");
     m_slurEndpointThickness.Init(0.1, 0.05, 0.25);
     this->Register(&m_slurEndpointThickness, "slurEndpointThickness", &m_generalLayout);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -437,6 +437,7 @@ void Slur::AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff)
     const int unit = doc->GetDrawingUnit(100);
     const int margin = doc->GetOptions()->m_slurMargin.GetValue() * unit;
     const double flexibility = doc->GetOptions()->m_slurEndpointFlexibility.GetValue();
+    const double symmetry = doc->GetOptions()->m_slurSymmetry.GetValue();
 
     // STEP 1: Filter spanned elements and discard certain bounding boxes even though they collide
     this->FilterSpannedElements(curve, bezier, margin);


### PR DESCRIPTION
This PR adds two options regarding slur adjustment:

1. `--slur-endpoint-flexibility` controls how much endpoints are allowed to move during adjustment. Its range is between 0 and 1. The default is zero which corresponds to previous behaviour.
2. `--slur-symmetry` controls how much symmetry is enforced during adjustment. Its range is also between 0 and 1 with default zero corresponding to previous behaviour.

This closes #2731 and addresses some ideas that came up in the discussion of #2819 . 

When playing around with these parameters I would recommend to trade more symmetry against increased endpoint flexibility, i.e. choosing similar values for both parameters. 

_Default values_
For now I kept the default at (0, 0), since these values correspond to the previous behaviour and as such have been extensively tested. We might adapt this in the future, but this requires more testing and just because (0.5, 0.5) is in the middle doesn't mean that it is the best default.

_Examples_
| Endpoint flexibility | Symmetry | Rendering |
| -------- | ------ | --------- |
| 0.0 | 0.0 | <img width="500" alt="Flex0-Sym0" src="https://user-images.githubusercontent.com/63608463/169228982-632ffc62-0d97-44d2-abe1-91612db293aa.png"> |
| 0.5 | 0.5 | <img width="500" alt="Flex05-Sym05" src="https://user-images.githubusercontent.com/63608463/169229081-0e9021ca-abd8-4297-87dc-ef31ec0077e1.png"> |
| 1.0 | 1.0 | <img width="500" alt="Flex1-Sym1" src="https://user-images.githubusercontent.com/63608463/169229136-3a7b2464-0bbc-4ca3-9a7c-ab731d15289d.png"> |
| 0.0 | 1.0 | <img width="500" alt="Flex0-Sym1" src="https://user-images.githubusercontent.com/63608463/169229204-4c5459d2-1772-4fba-84ce-fe0d94880de4.png"> |
| 1.0 | 0.0 | <img width="500" alt="Flex1-Sym0" src="https://user-images.githubusercontent.com/63608463/169229245-e49b01b9-fb79-48ce-aeb2-91b681eaf7d8.png"> |




