### PR TITLE
Add support for accid@place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [unreleased]
 * Improved rendering with diamond and slash shaped noteheads (@eNote-GmBH)
 * Improved rendering of slurs (@eNote-GmBH)
+* Support for `accid@place` (@eNote-GmBH)
 * Support for `mRpt@num` and `mRpt@num.place` (@eNote-GmBH)
 * Support for `mixed` croff-staff slurs (@eNote-GmBH)
 * Support for `non-arp` arpeggios (@eNote-GmBH)

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -32,6 +32,7 @@ class Accid : public LayerElement,
               public AttColor,
               public AttEnclosingChars,
               public AttExtSym,
+              public AttPlacementOnStaff,
               public AttPlacementRelEvent {
 public:
     /**

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -31,7 +31,8 @@ class Accid : public LayerElement,
               public AttAccidLog,
               public AttColor,
               public AttEnclosingChars,
-              public AttExtSym {
+              public AttExtSym,
+              public AttPlacementRelEvent {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -37,6 +37,7 @@ Accid::Accid()
     , AttColor()
     , AttEnclosingChars()
     , AttExtSym()
+    , AttPlacementOnStaff()
     , AttPlacementRelEvent()
 {
 
@@ -47,6 +48,7 @@ Accid::Accid()
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
     this->RegisterAttClass(ATT_EXTSYM);
+    this->RegisterAttClass(ATT_PLACEMENTONSTAFF);
     this->RegisterAttClass(ATT_PLACEMENTRELEVENT);
 
     this->Reset();
@@ -64,6 +66,7 @@ void Accid::Reset()
     this->ResetColor();
     this->ResetEnclosingChars();
     this->ResetExtSym();
+    this->ResetPlacementOnStaff();
     this->ResetPlacementRelEvent();
 
     m_drawingUnison = NULL;

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -37,6 +37,7 @@ Accid::Accid()
     , AttColor()
     , AttEnclosingChars()
     , AttExtSym()
+    , AttPlacementRelEvent()
 {
 
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
@@ -46,6 +47,7 @@ Accid::Accid()
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
     this->RegisterAttClass(ATT_EXTSYM);
+    this->RegisterAttClass(ATT_PLACEMENTRELEVENT);
 
     this->Reset();
 }
@@ -62,6 +64,7 @@ void Accid::Reset()
     this->ResetColor();
     this->ResetEnclosingChars();
     this->ResetExtSym();
+    this->ResetPlacementRelEvent();
 
     m_drawingUnison = NULL;
     m_alignedWithSameLayer = false;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2079,6 +2079,7 @@ void MEIOutput::WriteAccid(pugi::xml_node currentNode, Accid *accid)
     accid->WriteColor(currentNode);
     accid->WriteEnclosingChars(currentNode);
     accid->WriteExtSym(currentNode);
+    accid->WritePlacementRelEvent(currentNode);
 }
 
 void MEIOutput::WriteArtic(pugi::xml_node currentNode, Artic *artic)
@@ -5724,6 +5725,7 @@ bool MEIInput::ReadAccid(Object *parent, pugi::xml_node accid)
     vrvAccid->ReadColor(accid);
     vrvAccid->ReadEnclosingChars(accid);
     vrvAccid->ReadExtSym(accid);
+    vrvAccid->ReadPlacementRelEvent(accid);
 
     parent->AddChild(vrvAccid);
     this->ReadUnsupportedAttr(accid, vrvAccid);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2079,6 +2079,7 @@ void MEIOutput::WriteAccid(pugi::xml_node currentNode, Accid *accid)
     accid->WriteColor(currentNode);
     accid->WriteEnclosingChars(currentNode);
     accid->WriteExtSym(currentNode);
+    accid->WritePlacementOnStaff(currentNode);
     accid->WritePlacementRelEvent(currentNode);
 }
 
@@ -5725,6 +5726,7 @@ bool MEIInput::ReadAccid(Object *parent, pugi::xml_node accid)
     vrvAccid->ReadColor(accid);
     vrvAccid->ReadEnclosingChars(accid);
     vrvAccid->ReadExtSym(accid);
+    vrvAccid->ReadPlacementOnStaff(accid);
     vrvAccid->ReadPlacementRelEvent(accid);
 
     parent->AddChild(vrvAccid);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1546,11 +1546,12 @@ int LayerElement::AdjustBeams(FunctorParams *functorParams)
     // ignore elements that have @visible attribute set to false
     AttVisibilityComparison isInvisible(this->GetClassId(), BOOLEAN_false);
     if (isInvisible(this)) return FUNCTOR_SIBLINGS;
-    // ignore editorial accidental
+    // ignore accidentals outside the staff
     if (this->Is(ACCID)) {
         Accid *accid = vrv_cast<Accid *>(this);
         assert(accid);
         if (accid->GetFunc() == accidLog_FUNC_edit) return FUNCTOR_CONTINUE;
+        if (accid->HasPlace()) return FUNCTOR_CONTINUE;
     }
 
     Staff *staff = this->GetAncestorStaff();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -282,11 +282,11 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
                     }
                 }
             }
-            if ((noteTop >= staffTop) || (noteBottom <= staffBottom)) {
-                y = (accid->GetPlace() == STAFFREL_below) ? noteBottom : noteTop;
+            if (accid->GetPlace() == STAFFREL_below) {
+                y = (noteBottom <= staffBottom) ? noteBottom : staffBottom;
             }
             else {
-                y = (accid->GetPlace() == STAFFREL_below) ? staffBottom : staffTop;
+                y = (noteTop >= staffTop) ? noteTop : staffTop;
             }
             // Increase the x position of the accid
             x += note->GetDrawingRadius(m_doc);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -256,7 +256,7 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int x = accid->GetDrawingX();
     int y = accid->GetDrawingY();
 
-    if (accid->HasPlace() || accid->GetFunc() == accidLog_FUNC_edit) {
+    if (accid->HasPlace() || (accid->GetFunc() == accidLog_FUNC_edit)) {
         const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         const int staffTop = staff->GetDrawingY();
         const int staffBottom = staffTop - (staff->m_drawingLines - 1) * unit * 2;
@@ -267,11 +267,11 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             const int drawingDur = note->GetDrawingDur();
             int noteTop = note->GetDrawingTop(m_doc, staff->m_drawingStaffSize);
             int noteBottom = note->GetDrawingBottom(m_doc, staff->m_drawingStaffSize);
-            bool onstaff = (accid->GetOnstaff() == BOOLEAN_true);
+            bool onStaff = (accid->GetOnstaff() == BOOLEAN_true);
 
             // Adjust position to mensural stems
             if (note->IsMensuralDur()) {
-                if (accid->GetFunc() != accidLog_FUNC_edit) onstaff = (accid->GetOnstaff() != BOOLEAN_false);
+                if (accid->GetFunc() != accidLog_FUNC_edit) onStaff = (accid->GetOnstaff() != BOOLEAN_false);
                 const int verticalCenter = staffTop - (staff->m_drawingLines - 1) * unit;
                 const data_STEMDIRECTION stemDir = this->GetMensuralStemDirection(layer, note, verticalCenter);
                 if ((drawingDur > DUR_1) || (drawingDur < DUR_BR)) {
@@ -285,10 +285,10 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
                 }
             }
             if (accid->GetPlace() == STAFFREL_below) {
-                y = ((noteBottom <= staffBottom) || onstaff) ? noteBottom : staffBottom;
+                y = ((noteBottom <= staffBottom) || onStaff) ? noteBottom : staffBottom;
             }
             else {
-                y = ((noteTop >= staffTop) || onstaff) ? noteTop : staffTop;
+                y = ((noteTop >= staffTop) || onStaff) ? noteTop : staffTop;
             }
             // Increase the x position of the accid
             x += note->GetDrawingRadius(m_doc);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -267,9 +267,11 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             const int drawingDur = note->GetDrawingDur();
             int noteTop = note->GetDrawingTop(m_doc, staff->m_drawingStaffSize);
             int noteBottom = note->GetDrawingBottom(m_doc, staff->m_drawingStaffSize);
+            bool onstaff = (accid->GetOnstaff() == BOOLEAN_true);
 
             // Adjust position to mensural stems
             if (note->IsMensuralDur()) {
+                if (accid->GetFunc() != accidLog_FUNC_edit) onstaff = (accid->GetOnstaff() != BOOLEAN_false);
                 const int verticalCenter = staffTop - (staff->m_drawingLines - 1) * unit;
                 const data_STEMDIRECTION stemDir = this->GetMensuralStemDirection(layer, note, verticalCenter);
                 if ((drawingDur > DUR_1) || (drawingDur < DUR_BR)) {
@@ -283,10 +285,10 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
                 }
             }
             if (accid->GetPlace() == STAFFREL_below) {
-                y = (noteBottom <= staffBottom) ? noteBottom : staffBottom;
+                y = ((noteBottom <= staffBottom) || onstaff) ? noteBottom : staffBottom;
             }
             else {
-                y = (noteTop >= staffTop) ? noteTop : staffTop;
+                y = ((noteTop >= staffTop) || onstaff) ? noteTop : staffTop;
             }
             // Increase the x position of the accid
             x += note->GetDrawingRadius(m_doc);


### PR DESCRIPTION
This PR add support for `@place` and `@onstaff` to `accid`. 
By default accidentals above/below a note are printed outside the staff for CMN durations, and are put close to the note with mensural values.

![mensural-007](https://user-images.githubusercontent.com/7693447/169516537-7084efd1-344b-485e-9e28-d171802798a9.png)

Closes #2861.

Also addresses https://github.com/rism-digital/verovio/issues/2334#issuecomment-1128614906
![Mozart](https://user-images.githubusercontent.com/7693447/169515585-9c81fb1c-9161-458b-bfe4-53261041a2d8.png)
