### PR TITLE
Transpose to sounding pitch

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2607,7 +2607,7 @@ public:
  * member 4: the mdiv selected for transposition
  * member 5: the list of current (nested) mdivs
  * member 6: transpose to sounding pitch by evaluating @trans.semi
- * member 7: pitch shift in semitones for staff
+ * member 7: transposition interval for staff
  **/
 
 class TransposeParams : public FunctorParams {
@@ -2626,7 +2626,7 @@ public:
     std::string m_selectedMdivUuid;
     std::list<std::string> m_currentMdivUuids;
     bool m_transposeToSoundingPitch;
-    std::map<int, int> m_transSemiForStaffN;
+    std::map<int, int> m_transposeIntervalForStaffN;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2602,30 +2602,36 @@ public:
 /**
  * member 0: a pointer to the document
  * member 1: the functor for redirection
- * member 2: a pointer to the transposer
- * member 3: the transposition to be applied
- * member 4: the mdiv selected for transposition
- * member 5: the list of current (nested) mdivs
- * member 6: transpose to sounding pitch by evaluating @trans.semi
- * member 7: transposition interval for staff
+ * member 2: the end functor for redirection
+ * member 3: a pointer to the transposer
+ * member 4: the transposition to be applied
+ * member 5: the mdiv selected for transposition
+ * member 6: the list of current (nested) mdivs
+ * member 7: transpose to sounding pitch by evaluating @trans.semi
+ * member 8: true if the current scoreDef contains a KeySig (direct child or attribute)
+ * member 9: transposition interval for staff
  **/
 
 class TransposeParams : public FunctorParams {
 public:
-    TransposeParams(Doc *doc, Functor *functor, Transposer *transposer)
+    TransposeParams(Doc *doc, Functor *functor, Functor *functorEnd, Transposer *transposer)
     {
         m_doc = doc;
         m_functor = functor;
+        m_functorEnd = functorEnd;
         m_transposer = transposer;
         m_transposeToSoundingPitch = false;
+        m_hasScoreDefKeySig = false;
     }
     Doc *m_doc;
     Functor *m_functor;
+    Functor *m_functorEnd;
     Transposer *m_transposer;
     std::string m_transposition;
     std::string m_selectedMdivUuid;
     std::list<std::string> m_currentMdivUuids;
     bool m_transposeToSoundingPitch;
+    bool m_hasScoreDefKeySig;
     std::map<int, int> m_transposeIntervalForStaffN;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2606,6 +2606,7 @@ public:
  * member 3: the transposition to be applied
  * member 4: the mdiv selected for transposition
  * member 5: the list of current (nested) mdivs
+ * member 6: transpose to sounding pitch by evaluating @trans.semi
  **/
 
 class TransposeParams : public FunctorParams {
@@ -2615,6 +2616,7 @@ public:
         m_doc = doc;
         m_functor = functor;
         m_transposer = transposer;
+        m_transposeToSoundingPitch = false;
     }
     Doc *m_doc;
     Functor *m_functor;
@@ -2622,6 +2624,7 @@ public:
     std::string m_transposition;
     std::string m_selectedMdivUuid;
     std::list<std::string> m_currentMdivUuids;
+    bool m_transposeToSoundingPitch;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2607,6 +2607,7 @@ public:
  * member 4: the mdiv selected for transposition
  * member 5: the list of current (nested) mdivs
  * member 6: transpose to sounding pitch by evaluating @trans.semi
+ * member 7: pitch shift in semitones for staff
  **/
 
 class TransposeParams : public FunctorParams {
@@ -2625,6 +2626,7 @@ public:
     std::string m_selectedMdivUuid;
     std::list<std::string> m_currentMdivUuids;
     bool m_transposeToSoundingPitch;
+    std::map<int, int> m_transSemiForStaffN;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1501,6 +1501,11 @@ public:
      */
     virtual int Transpose(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
+    /**
+     * End functor for Object::Transpose
+     */
+    virtual int TransposeEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
 private:
     /**
      * Method for generating the uuid.

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -728,6 +728,7 @@ public:
     OptionString m_transpose;
     OptionJson m_transposeMdiv;
     OptionBool m_transposeSelectedOnly;
+    OptionBool m_transposeToSoundingPitch;
 
     /**
      * Element margins

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -285,6 +285,11 @@ public:
      */
     int PrepareDuration(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::Transpose
+     */
+    int Transpose(FunctorParams *functorParams) override;
+
 protected:
     /**
      * Filter the flat list and keep only StaffDef elements.

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -288,7 +288,10 @@ public:
     /**
      * See Object::Transpose
      */
+    ///@{
     int Transpose(FunctorParams *functorParams) override;
+    int TransposeEnd(FunctorParams *functorParams) override;
+    ///@}
 
 protected:
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -264,6 +264,11 @@ public:
      */
     int GenerateMIDI(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::Transpose
+     */
+    int Transpose(FunctorParams *functorParams) override;
+
 private:
     /**
      * Add the ledger line dashes to the legderline array.

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -84,6 +84,11 @@ public:
      */
     int PrepareDuration(FunctorParams *functorParams) override;
 
+    /**
+     * See Object::Transpose
+     */
+    int Transpose(FunctorParams *functorParams) override;
+
 private:
     //
 public:

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1361,6 +1361,7 @@ void Doc::TransposeDoc()
     transposer.SetBase600(); // Set extended chromatic alteration mode (allowing more than double sharps/flats)
 
     Functor transpose(&Object::Transpose);
+    Functor transposeEnd(&Object::TransposeEnd);
     TransposeParams transposeParams(this, &transpose, &transposer);
 
     if (m_options->m_transposeSelectedOnly.GetValue() == false) {
@@ -1374,7 +1375,7 @@ void Doc::TransposeDoc()
                 m_options->m_transposeMdiv.GetKey().c_str(), m_options->m_transpose.GetKey().c_str());
         }
         transposeParams.m_transposition = m_options->m_transpose.GetValue();
-        this->Process(&transpose, &transposeParams);
+        this->Process(&transpose, &transposeParams, &transposeEnd);
     }
     else if (m_options->m_transposeMdiv.IsSet()) {
         // Transpose mdivs individually
@@ -1382,7 +1383,7 @@ void Doc::TransposeDoc()
         for (const std::string &uuid : uuids) {
             transposeParams.m_selectedMdivUuid = uuid;
             transposeParams.m_transposition = m_options->m_transposeMdiv.GetStrValue({ uuid });
-            this->Process(&transpose, &transposeParams);
+            this->Process(&transpose, &transposeParams, &transposeEnd);
         }
     }
 
@@ -1392,7 +1393,7 @@ void Doc::TransposeDoc()
         transposeParams.m_transposition = "";
         transposeParams.m_transposer->SetTransposition(0);
         transposeParams.m_transposeToSoundingPitch = true;
-        this->Process(&transpose, &transposeParams);
+        this->Process(&transpose, &transposeParams, &transposeEnd);
     }
 }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1385,6 +1385,15 @@ void Doc::TransposeDoc()
             this->Process(&transpose, &transposeParams);
         }
     }
+
+    if (m_options->m_transposeToSoundingPitch.GetValue()) {
+        // Transpose to sounding pitch
+        transposeParams.m_selectedMdivUuid = "";
+        transposeParams.m_transposition = "";
+        transposeParams.m_transposer->SetTransposition(0);
+        transposeParams.m_transposeToSoundingPitch = true;
+        this->Process(&transpose, &transposeParams);
+    }
 }
 
 void Doc::ExpandExpansions()

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1362,7 +1362,7 @@ void Doc::TransposeDoc()
 
     Functor transpose(&Object::Transpose);
     Functor transposeEnd(&Object::TransposeEnd);
-    TransposeParams transposeParams(this, &transpose, &transposer);
+    TransposeParams transposeParams(this, &transpose, &transposeEnd, &transposer);
 
     if (m_options->m_transposeSelectedOnly.GetValue() == false) {
         transpose.m_visibleOnly = false;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -329,6 +329,10 @@ int KeySig::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
+    if (!this->GetFirstAncestor(STAFFDEF)) {
+        params->m_hasScoreDefKeySig = true;
+    }
+
     int sig = this->GetFifthsInt();
 
     int intervalClass = params->m_transposer->CircleOfFifthsToIntervalClass(sig);

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -127,7 +127,7 @@ int Mdiv::Transpose(FunctorParams *functorParams)
     assert(params);
 
     params->m_currentMdivUuids.push_back(this->GetUuid());
-    params->m_transSemiForStaffN.clear();
+    params->m_transposeIntervalForStaffN.clear();
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -127,6 +127,7 @@ int Mdiv::Transpose(FunctorParams *functorParams)
     assert(params);
 
     params->m_currentMdivUuids.push_back(this->GetUuid());
+    params->m_transSemiForStaffN.clear();
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1489,6 +1489,11 @@ Options::Options()
     m_transposeSelectedOnly.Init(false);
     this->Register(&m_transposeSelectedOnly, "transposeSelectedOnly", &m_selectors);
 
+    m_transposeToSoundingPitch.SetInfo(
+        "Transpose to sounding pitch", "Transpose to sounding pitch by evaluating @trans.semi");
+    m_transposeToSoundingPitch.Init(false);
+    this->Register(&m_transposeToSoundingPitch, "transposeToSoundingPitch", &m_selectors);
+
     /********* The layout margins by element *********/
 
     m_elementMargins.SetLabel("Element margins", "4-elementMargins");

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -317,15 +317,15 @@ int Score::Transpose(FunctorParams *functorParams)
         // Find the starting key tonic of the data to use in calculating the tranposition interval:
         // Set transposition by key tonic.
         // Detect the current key from the keysignature.
-        KeySig *keysig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
+        KeySig *keySig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
         // If there is no keysignature, assume it is C.
         TransPitch currentKey = TransPitch(0, 0, 0);
-        if (keysig && keysig->HasPname()) {
-            currentKey = TransPitch(keysig->GetPname(), ACCIDENTAL_GESTURAL_NONE, keysig->GetAccid(), 0);
+        if (keySig && keySig->HasPname()) {
+            currentKey = TransPitch(keySig->GetPname(), ACCIDENTAL_GESTURAL_NONE, keySig->GetAccid(), 0);
         }
-        else if (keysig) {
+        else if (keySig) {
             // No tonic pitch in key signature, so infer from key signature.
-            int fifthsInt = keysig->GetFifthsInt();
+            int fifthsInt = keySig->GetFifthsInt();
             // Check the keySig@mode is present (currently assuming major):
             currentKey = transposer->CircleOfFifthsToMajorTonic(fifthsInt);
             // need to add a dummy "0" key signature in score (staffDefs of staffDef).
@@ -333,10 +333,10 @@ int Score::Transpose(FunctorParams *functorParams)
         transposer->SetTransposition(currentKey, transposition);
     }
     else if (transposer->IsValidSemitones(transposition)) {
-        KeySig *keysig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
+        KeySig *keySig = vrv_cast<KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
         int fifths = 0;
-        if (keysig) {
-            fifths = keysig->GetFifthsInt();
+        if (keySig) {
+            fifths = keySig->GetFifthsInt();
         }
         else {
             LogWarning("No key signature in data, assuming no key signature with no sharps/flats.");

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -299,7 +299,7 @@ int Score::Transpose(FunctorParams *functorParams)
     // Check whether we transpose to sounding pitch
     if (params->m_transposeToSoundingPitch) {
         // Evaluate functor on scoreDef
-        scoreDef->Process(params->m_functor, params);
+        scoreDef->Process(params->m_functor, params, params->m_functorEnd);
         return FUNCTOR_CONTINUE;
     }
 
@@ -354,7 +354,7 @@ int Score::Transpose(FunctorParams *functorParams)
     }
 
     // Evaluate functor on scoreDef
-    scoreDef->Process(params->m_functor, params);
+    scoreDef->Process(params->m_functor, params, params->m_functorEnd);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -292,16 +292,23 @@ int Score::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
+    ScoreDef *scoreDef = this->GetScoreDef();
+    Transposer *transposer = params->m_transposer;
+    const std::string &transposition = params->m_transposition;
+
+    // Check whether we transpose to sounding pitch
+    if (params->m_transposeToSoundingPitch) {
+        // Evaluate functor on scoreDef
+        scoreDef->Process(params->m_functor, params);
+        return FUNCTOR_CONTINUE;
+    }
+
     // Check whether we are in the selected mdiv
     if (!params->m_selectedMdivUuid.empty()
         && (std::find(params->m_currentMdivUuids.begin(), params->m_currentMdivUuids.end(), params->m_selectedMdivUuid)
             == params->m_currentMdivUuids.end())) {
         return FUNCTOR_CONTINUE;
     }
-
-    ScoreDef *scoreDef = this->GetScoreDef();
-    Transposer *transposer = params->m_transposer;
-    const std::string &transposition = params->m_transposition;
 
     if (transposer->IsValidIntervalName(transposition)) {
         transposer->SetTransposition(transposition);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -754,4 +754,28 @@ int ScoreDef::PrepareDuration(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int ScoreDef::Transpose(FunctorParams *functorParams)
+{
+    TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
+    assert(params);
+
+    if (params->m_transposeToSoundingPitch) {
+        // Set the transposition in order to transpose common key signatures
+        // (i.e. encoded as ScoreDef attributes or direct KeySig children)
+        const std::vector<int> staffNs = this->GetStaffNs();
+        if (staffNs.empty()) {
+            int transposeInterval = 0;
+            if (!params->m_transposeIntervalForStaffN.empty()) {
+                transposeInterval = params->m_transposeIntervalForStaffN.begin()->second;
+            }
+            params->m_transposer->SetTransposition(transposeInterval);
+        }
+        else {
+            this->GetStaffDef(staffNs.front())->Transpose(functorParams);
+        }
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -747,4 +747,20 @@ int Staff::GenerateMIDI(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Staff::Transpose(FunctorParams *functorParams)
+{
+    TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
+    assert(params);
+
+    if (params->m_transposeToSoundingPitch) {
+        int transposeInterval = 0;
+        if (this->HasN() && (params->m_transposeIntervalForStaffN.count(this->GetN()) > 0)) {
+            transposeInterval = params->m_transposeIntervalForStaffN.at(this->GetN());
+        }
+        params->m_transposer->SetTransposition(transposeInterval);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -20,6 +20,7 @@
 #include "layerdef.h"
 #include "metersiggrp.h"
 #include "staffgrp.h"
+#include "transposition.h"
 #include "tuning.h"
 #include "vrv.h"
 
@@ -191,6 +192,27 @@ int StaffDef::PrepareDuration(FunctorParams *functorParams)
 
     if (this->HasDurDefault() && this->HasN()) {
         params->m_durDefaultForStaffN[this->GetN()] = this->GetDurDefault();
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+int StaffDef::Transpose(FunctorParams *functorParams)
+{
+    TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
+    assert(params);
+
+    if (params->m_transposeToSoundingPitch) {
+        if (this->HasTransSemi() && this->HasN()) {
+            const int roundedValue = static_cast<int>(std::round(this->GetTransSemi()));
+            params->m_transSemiForStaffN[this->GetN()] = roundedValue;
+            // Set transposition to trigger changes in KeySig
+            params->m_transposer->SetTransposition(roundedValue);
+            this->ResetTransposition();
+        }
+        else {
+            params->m_transposer->SetTransposition(0);
+        }
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -203,7 +203,13 @@ int StaffDef::Transpose(FunctorParams *functorParams)
     assert(params);
 
     if (params->m_transposeToSoundingPitch) {
+        // Retrieve the key signature
         const KeySig *keySig = vrv_cast<const KeySig *>(this->FindDescendantByType(KEYSIG));
+        if (!keySig) {
+            const ScoreDef *scoreDef = vrv_cast<const ScoreDef *>(this->GetFirstAncestor(SCOREDEF));
+            keySig = vrv_cast<const KeySig *>(scoreDef->FindDescendantByType(KEYSIG));
+        }
+        // Determine and store the transposition interval (based on keySig)
         if (keySig && this->HasTransSemi() && this->HasN()) {
             const int fifths = keySig->GetFifthsInt();
             int semitones = static_cast<int>(std::round(this->GetTransSemi()));
@@ -215,7 +221,11 @@ int StaffDef::Transpose(FunctorParams *functorParams)
             this->ResetTransposition();
         }
         else {
-            params->m_transposer->SetTransposition(0);
+            int transposeInterval = 0;
+            if (this->HasN() && (params->m_transposeIntervalForStaffN.count(this->GetN()) > 0)) {
+                transposeInterval = params->m_transposeIntervalForStaffN.at(this->GetN());
+            }
+            params->m_transposer->SetTransposition(transposeInterval);
         }
     }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -705,7 +705,8 @@ bool Toolkit::LoadData(const std::string &data)
     m_doc.GenerateMeasureNumbers();
 
     // transpose the content if necessary
-    if (m_options->m_transpose.IsSet() || m_options->m_transposeMdiv.IsSet()) {
+    if (m_options->m_transpose.IsSet() || m_options->m_transposeMdiv.IsSet()
+        || m_options->m_transposeToSoundingPitch.IsSet()) {
         m_doc.PrepareData();
         m_doc.TransposeDoc();
     }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -424,7 +424,7 @@ bool Transposer::SetTransposition(int keyFifths, const std::string &semitones)
 }
 
 // Note the order of the variables (key signature information is first in all
-// cases where there are two input parametrs to SetTransposition().
+// cases where there are two input parameters to SetTransposition().
 
 bool Transposer::SetTransposition(int keyFifths, int semitones)
 {

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -389,7 +389,7 @@ bool Transposer::SetTransposition(const TransPitch &fromPitch, const std::string
     TransPitch toPitch;
     if (this->GetKeyTonic(toString, toPitch)) {
         // Determine proper octave offset.
-        int numSigns = toPitch.m_oct;
+        const int numSigns = toPitch.m_oct;
         m_transpose = this->GetInterval(fromPitch, toPitch);
         // A transposition with n plus or minus signs should never be more than n octaves away.
         if (numSigns > 0 && m_transpose > this->PerfectOctaveClass() * numSigns) {
@@ -419,7 +419,7 @@ bool Transposer::SetTransposition(int keyFifths, const std::string &semitones)
     if (!this->IsValidSemitones(semitones)) {
         return false;
     }
-    int semis = stoi(semitones);
+    const int semis = stoi(semitones);
     return this->SetTransposition(keyFifths, semis);
 }
 
@@ -428,7 +428,7 @@ bool Transposer::SetTransposition(int keyFifths, const std::string &semitones)
 
 bool Transposer::SetTransposition(int keyFifths, int semitones)
 {
-    int intervalClass = this->SemitonesToIntervalClass(keyFifths, semitones);
+    const int intervalClass = this->SemitonesToIntervalClass(keyFifths, semitones);
     return this->SetTransposition(intervalClass);
 }
 
@@ -440,9 +440,9 @@ bool Transposer::SetTransposition(int keyFifths, int semitones)
 
 int Transposer::SemitonesToIntervalClass(int keyFifths, int semitones)
 {
-    int sign = semitones < 0 ? -1 : +1;
+    const int sign = semitones < 0 ? -1 : +1;
     semitones = semitones < 0 ? -semitones : semitones;
-    int octave = semitones / 12;
+    const int octave = semitones / 12;
     semitones = semitones - octave * 12;
     int sum1, sum2;
     std::string interval = "P1";
@@ -530,7 +530,7 @@ int Transposer::SemitonesToIntervalClass(int keyFifths, int semitones)
 
 std::string Transposer::SemitonesToIntervalName(int keyFifths, int semitones)
 {
-    int intervalClass = this->SemitonesToIntervalClass(keyFifths, semitones);
+    const int intervalClass = this->SemitonesToIntervalClass(keyFifths, semitones);
     return this->GetIntervalName(intervalClass);
 }
 
@@ -545,10 +545,10 @@ std::string Transposer::SemitonesToIntervalName(int keyFifths, int semitones)
 
 int Transposer::IntervalToSemitones(int interval)
 {
-    int sign = interval < 0 ? -1 : +1;
+    const int sign = interval < 0 ? -1 : +1;
     interval = interval < 0 ? -interval : interval;
-    int octave = interval / m_base;
-    int intervalClass = interval - octave * m_base;
+    const int octave = interval / m_base;
+    const int intervalClass = interval - octave * m_base;
     int diatonic = 0;
     int chromatic = 0;
     this->IntervalToDiatonicChromatic(diatonic, chromatic, intervalClass);
@@ -564,7 +564,7 @@ int Transposer::IntervalToSemitones(int interval)
 
 int Transposer::IntervalToSemitones(const std::string &intervalName)
 {
-    int interval = this->GetInterval(intervalName);
+    const int interval = this->GetInterval(intervalName);
     return this->IntervalToSemitones(interval);
 }
 
@@ -1130,7 +1130,7 @@ TransPitch Transposer::IntegerPitchToTransPitch(int ipitch)
         mindiff = chroma - m_diatonicMapping.back();
         mini = (int)m_diatonicMapping.size() - 1;
         for (int i = (int)m_diatonicMapping.size() - 2; i >= 0; i--) {
-            int diff = chroma - m_diatonicMapping[i];
+            const int diff = chroma - m_diatonicMapping[i];
             if (abs(diff) < abs(mindiff)) {
                 mindiff = diff;
                 mini = i;
@@ -1145,7 +1145,7 @@ TransPitch Transposer::IntegerPitchToTransPitch(int ipitch)
         mindiff = chroma - m_diatonicMapping[0];
         mini = 0;
         for (int i = 1; i < (int)m_diatonicMapping.size(); ++i) {
-            int diff = chroma - m_diatonicMapping[i];
+            const int diff = chroma - m_diatonicMapping[i];
             if (abs(diff) < abs(mindiff)) {
                 mindiff = diff;
                 mini = i;
@@ -1197,7 +1197,7 @@ int Transposer::GetInterval(const TransPitch &p1, const TransPitch &p2)
 
 std::string Transposer::GetIntervalName(const TransPitch &p1, const TransPitch &p2)
 {
-    int iclass = this->GetInterval(p1, p2);
+    const int iclass = this->GetInterval(p1, p2);
     return this->GetIntervalName(iclass);
 }
 
@@ -1209,13 +1209,13 @@ std::string Transposer::GetIntervalName(int intervalClass)
         intervalClass = -intervalClass;
     }
 
-    int octave = intervalClass / m_base;
-    int chroma = intervalClass - octave * m_base;
+    const int octave = intervalClass / m_base;
+    const int chroma = intervalClass - octave * m_base;
 
     int mindiff = chroma;
     int mini = 0;
     for (int i = 1; i < (int)m_diatonicMapping.size(); ++i) {
-        int diff = chroma - (m_diatonicMapping[i] - m_diatonicMapping[0]);
+        const int diff = chroma - (m_diatonicMapping[i] - m_diatonicMapping[0]);
         if (abs(diff) < abs(mindiff)) {
             mindiff = diff;
             mini = i;
@@ -1375,7 +1375,7 @@ std::string Transposer::GetIntervalName(int intervalClass)
 
 int Transposer::IntervalToCircleOfFifths(const std::string &transstring)
 {
-    int intervalClass = this->GetInterval(transstring);
+    const int intervalClass = this->GetInterval(transstring);
     return this->IntervalToCircleOfFifths(intervalClass);
 }
 
@@ -1391,8 +1391,8 @@ int Transposer::IntervalToCircleOfFifths(int transval)
         transval %= m_base;
     }
 
-    int p5 = this->PerfectFifthClass();
-    int p4 = this->PerfectFourthClass();
+    const int p5 = this->PerfectFifthClass();
+    const int p4 = this->PerfectFourthClass();
     for (int i = 1; i < m_base; ++i) {
         if ((p5 * i) % m_base == transval) {
             return i;
@@ -1431,7 +1431,7 @@ int Transposer::CircleOfFifthsToIntervalClass(int fifths)
 
 std::string Transposer::CircleOfFifthsToIntervalName(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->GetIntervalName(intervalClass);
 }
 
@@ -1444,7 +1444,7 @@ std::string Transposer::CircleOfFifthsToIntervalName(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToMajorTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetCPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1457,7 +1457,7 @@ TransPitch Transposer::CircleOfFifthsToMajorTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToMinorTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetAPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1470,7 +1470,7 @@ TransPitch Transposer::CircleOfFifthsToMinorTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToDorianTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetDPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1483,7 +1483,7 @@ TransPitch Transposer::CircleOfFifthsToDorianTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToPhrygianTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetEPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1496,7 +1496,7 @@ TransPitch Transposer::CircleOfFifthsToPhrygianTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToLydianTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetFPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1509,7 +1509,7 @@ TransPitch Transposer::CircleOfFifthsToLydianTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToMixolydianTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetGPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1522,7 +1522,7 @@ TransPitch Transposer::CircleOfFifthsToMixolydianTonic(int fifths)
 
 TransPitch Transposer::CircleOfFifthsToLocrianTonic(int fifths)
 {
-    int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
+    const int intervalClass = this->CircleOfFifthsToIntervalClass(fifths);
     return this->IntegerPitchToTransPitch((this->GetBPitchClass() + intervalClass) % this->GetBase());
 }
 
@@ -1699,7 +1699,7 @@ std::string Transposer::DiatonicChromaticToIntervalName(int diatonic, int chroma
 
 int Transposer::DiatonicChromaticToIntervalClass(int diatonic, int chromatic)
 {
-    std::string intervalName = this->DiatonicChromaticToIntervalName(diatonic, chromatic);
+    const std::string intervalName = this->DiatonicChromaticToIntervalName(diatonic, chromatic);
     return this->GetInterval(intervalName);
 }
 
@@ -1710,7 +1710,7 @@ int Transposer::DiatonicChromaticToIntervalClass(int diatonic, int chromatic)
 
 void Transposer::IntervalToDiatonicChromatic(int &diatonic, int &chromatic, int intervalClass)
 {
-    std::string intervalName = this->GetIntervalName(intervalClass);
+    const std::string intervalName = this->GetIntervalName(intervalClass);
     this->IntervalToDiatonicChromatic(diatonic, chromatic, intervalName);
 }
 
@@ -1794,7 +1794,7 @@ void Transposer::IntervalToDiatonicChromatic(int &diatonic, int &chromatic, cons
         return;
     }
     dnum--;
-    int octave = dnum / 7;
+    const int octave = dnum / 7;
     dnum = dnum - octave * 7;
 
     diatonic = direction * (octave * 7 + dnum);
@@ -1975,7 +1975,7 @@ void Transposer::IntervalToDiatonicChromatic(int &diatonic, int &chromatic, cons
 
 bool Transposer::IsValidIntervalName(const std::string &name)
 {
-    std::string pattern = "(-|\\+?)([Pp]|M|m|[aA]+|[dD]+)([1-9][0-9]*)";
+    const std::string pattern = "(-|\\+?)([Pp]|M|m|[aA]+|[dD]+)([1-9][0-9]*)";
     if (std::regex_search(name, std::regex(pattern))) {
         return true;
     }
@@ -2004,7 +2004,7 @@ bool Transposer::IsValidIntervalName(const std::string &name)
 
 bool Transposer::IsValidSemitones(const std::string &name)
 {
-    std::string pattern = "^(-|\\+?)(\\d+)$";
+    const std::string pattern = "^(-|\\+?)(\\d+)$";
     if (std::regex_search(name, std::regex(pattern))) {
         return true;
     }
@@ -2040,7 +2040,7 @@ bool Transposer::IsValidSemitones(const std::string &name)
 
 bool Transposer::IsValidKeyTonic(const std::string &name)
 {
-    std::string pattern = "([+]*|[-]*)([A-Ga-g])([Ss#]*|[Ffb]*)";
+    const std::string pattern = "([+]*|[-]*)([A-Ga-g])([Ss#]*|[Ffb]*)";
     if (std::regex_search(name, std::regex(pattern))) {
         return true;
     }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -136,11 +136,13 @@ int TransPitch::GetChromaticAlteration(data_ACCIDENTAL_GESTURAL accidG, data_ACC
 data_ACCIDENTAL_GESTURAL TransPitch::GetAccidG() const
 {
     switch (m_accid) {
+        case -3: return ACCIDENTAL_GESTURAL_tf;
         case -2: return ACCIDENTAL_GESTURAL_ff;
         case -1: return ACCIDENTAL_GESTURAL_f;
         case 0: return ACCIDENTAL_GESTURAL_n;
         case 1: return ACCIDENTAL_GESTURAL_s;
         case 2: return ACCIDENTAL_GESTURAL_ss;
+        case 3: return ACCIDENTAL_GESTURAL_ts;
         default: break;
     }
     LogWarning("Transposition: Could not get Gestural Accidental for %i", m_accid);


### PR DESCRIPTION
This PR adds a boolean option `--transpose-to-sounding-pitch`. When enabled it uses `@trans.semi` on StaffDef to transpose staves to sounding pitch. Afterwards the attribute is removed such that the MIDI output will still be correct.
| Untransposed | Transposed |
| ------ | ------ |
| <img width="507" alt="Untransposed" src="https://user-images.githubusercontent.com/63608463/170193525-3c669773-9702-4d47-a7f8-e3b96cc3e2fa.png"> | <img width="552" alt="Transposed" src="https://user-images.githubusercontent.com/63608463/170193549-8a89402e-1e2a-4c8f-9c8a-9d85e5b5add2.png"> |

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Key changes example</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2017-05-09">2017-05-09</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio takes into account the "keysig.showchange" and "keysig.show" attributes which are assumed to be respectively false
					and true if not specified. It also shows cautionary key and time signatures at the end of a system when necessary.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="1">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef meter.sym="common">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="4f" trans.semi="-3" />
                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="4f" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="dbl" n="1">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="1">
                              <note oct="4" pname="a" accid.ges="f" />
                              <note oct="5" pname="c" accid.ges="f" />
                              <note oct="5" pname="e" accid.ges="f" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="2">
                           <chord dur="1">
                              <note oct="4" pname="a" accid.ges="f" />
                              <note oct="5" pname="c" accid.ges="f" />
                              <note oct="5" pname="e" accid.ges="f" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef>
                    <staffGrp>
                       <staffDef n="1" keysig.show="true" key.sig="0" />
                       <staffDef n="2" keysig.show="true" key.sig="0" />
                    </staffGrp>
                  </scoreDef>
                  <measure right="dbl" n="4">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="1">
                              <note oct="4" pname="a" />
                              <note oct="5" pname="c" />
                              <note oct="5" pname="e" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="2">
                           <chord dur="1">
                              <note oct="4" pname="a" />
                              <note oct="5" pname="c" />
                              <note oct="5" pname="e" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <scoreDef meter.sym="cut">
                    <staffGrp>
                       <staffDef n="1" key.sig="2s" />
                       <staffDef n="2" key.sig="2s" />
                    </staffGrp>
                  </scoreDef>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="1">
                              <note oct="4" pname="b" />
                              <note oct="5" pname="d" />
                              <note oct="5" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="2">
                           <chord dur="1">
                              <note oct="4" pname="b" />
                              <note oct="5" pname="d" />
                              <note oct="5" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

One restriction to this is that we cannot apply different staff transpositions to common key signature nodes encoded as ScoreDef attribute or direct child. 