### PR TITLE
Fix for tuplet bracket overlapping with ledger lines

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1092,7 +1092,7 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         else {
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
         }
-		// if there is no overlap between elements, make additinal checks for some of the edge cases
+        // if there is no overlap between elements, make additinal checks for some of the edge cases
         if (!overlap) {
             // if last element of the tuplet is rest, make sure there is sufficient distance between it and next
             // note/chord (for ledger lines)

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1092,6 +1092,18 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         else {
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
         }
+		// if there is no overlap between elements, make additinal checks for some of the edge cases
+        if (!overlap) {
+            // if last element of the tuplet is rest, make sure there is sufficient distance between it and next
+            // note/chord (for ledger lines)
+            if (this->Is({ NOTE, CHORD }) && !this->GetFirstAncestor(TUPLET) && element->Is(REST)
+                && element->GetFirstAncestor(TUPLET)) {
+                Rest *rest = vrv_cast<Rest *>(element);
+                if (rest->GetDur() > DUR_8) {
+                    overlap = 1.5 * (rest->GetDur() - DUR_8) * drawingUnit;
+                }
+            }
+        }
     }
 
     return { -overlap, selfLeft };


### PR DESCRIPTION
In some cases, when last element of tuplet is rest and note after the tuplet has ledger lines, tuplet bracket would overlap with them:
![image](https://user-images.githubusercontent.com/1819669/170217231-8da50a40-a1bb-41aa-833f-ff4450d38313.png)

After the fix:
![image](https://user-images.githubusercontent.com/1819669/170217543-2f2a2261-c36a-485c-b883-cd3502b9de8c.png)

<details><summary>Example MEI:</summary>

```XML<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt><date isodate="2021-10-25" type="encoding-date">2021-10-25</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2022-05-03T17:57:38" version="3.10.0-dev-[undefined]">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="6">
                        <label>Piano</label>
                        <labelAbbr>Pno.</labelAbbr>
                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="5" unit="8" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="end" n="1">
                     <staff n="1">
                        <layer n="1">
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <note dur.ppq="1" dur="16" oct="6" pname="c" stem.dir="down" />
                              <note dur.ppq="1" dur="16" oct="6" pname="e" stem.dir="down" />
                              <rest xml:id="abc" dur.ppq="1" dur="16" />
                           </tuplet>
                           <note xml:id="abd" dur.ppq="3" dur="8" oct="4" pname="c" stem.dir="up" />
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <beam>
                                 <note dur.ppq="1" dur="16" oct="6" pname="c" stem.dir="down" />
                                 <note dur.ppq="1" dur="16" oct="6" pname="e" stem.dir="down" />
                              </beam>
                              <rest dur.ppq="1" dur="16" />
                           </tuplet>
                           <note dur.ppq="3" dur="8" oct="4" pname="c" stem.dir="up" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```
</details>
