### PR TITLE
Always import facsimile

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3506,12 +3506,14 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     }
 
     facsimile = music.child("facsimile");
-    if (!facsimile.empty()) this->ReadFacsimile(m_doc, facsimile);
-    if (m_doc->GetOptions()->m_useFacsimile.GetValue()) {
-        m_doc->SetType(Facs);
-        m_doc->m_drawingPageHeight = m_doc->GetFacsimile()->GetMaxY();
-        m_doc->m_drawingPageWidth = m_doc->GetFacsimile()->GetMaxX();
-    }
+    if (!facsimile.empty()) {
+        this->ReadFacsimile(m_doc, facsimile);
+        if (m_doc->GetOptions()->m_useFacsimile.GetValue()) {
+            m_doc->SetType(Facs);
+            m_doc->m_drawingPageHeight = m_doc->GetFacsimile()->GetMaxY();
+            m_doc->m_drawingPageWidth = m_doc->GetFacsimile()->GetMaxX();
+        }
+    }    
 
     front = music.child("front");
     if (!front.empty()) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3513,7 +3513,7 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
             m_doc->m_drawingPageHeight = m_doc->GetFacsimile()->GetMaxY();
             m_doc->m_drawingPageWidth = m_doc->GetFacsimile()->GetMaxX();
         }
-    }    
+    }
 
     front = music.child("front");
     if (!front.empty()) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3506,8 +3506,8 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     }
 
     facsimile = music.child("facsimile");
-    if ((!facsimile.empty()) && (m_doc->GetOptions()->m_useFacsimile.GetValue())) {
-        this->ReadFacsimile(m_doc, facsimile);
+    if (!facsimile.empty()) this->ReadFacsimile(m_doc, facsimile);
+    if (m_doc->GetOptions()->m_useFacsimile.GetValue()) {
         m_doc->SetType(Facs);
         m_doc->m_drawingPageHeight = m_doc->GetFacsimile()->GetMaxY();
         m_doc->m_drawingPageWidth = m_doc->GetFacsimile()->GetMaxX();


### PR DESCRIPTION
Changed code to remove dependence of facsimile import on the `--use-facsimile` option. It will now always be imported, but option is still required to change document type.
This is done to make sure that facsimile nodes are not lost during MEI-to-MEI export.