### PR TITLE
Font metadata update

### DIFF
--- a/fonts/Leipzig.svg
+++ b/fonts/Leipzig.svg
@@ -2,11 +2,11 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 <metadata>
-Created by FontForge 20220308 at Thu May 19 14:46:44 2022
+Created by FontForge 20220308 at Fri May 20 23:09:56 2022
  By Klaus Rettinghaus
 Created by Etienne Darbellay, Jean-Francois Marti, Laurent Pugin, and Klaus Rettinghaus.
 This font is licensed under the SIL Open Font License \(http://scripts.sil.org/OFL\).
-Version 5.2.71
+Version 5.2.72
 </metadata>
 <defs>
 <font id="Leipzig" horiz-adv-x="624" >

--- a/fonts/json/leipzig_metadata.json
+++ b/fonts/json/leipzig_metadata.json
@@ -30,7 +30,7 @@
         "tupletBracketThickness": 0.16
     },
     "fontName": "Leipzig",
-    "fontVersion": "5.2.69",
+    "fontVersion": "5.2.72",
     "glyphBBoxes": {
         "4stringTabClef": {
             "bBoxNE": [
@@ -454,7 +454,7 @@
         },
         "articAccentStaccatoAbove": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 1.384
             ],
             "bBoxSW": [
@@ -464,7 +464,7 @@
         },
         "articAccentStaccatoBelow": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 0.0
             ],
             "bBoxSW": [
@@ -634,8 +634,8 @@
         },
         "articStaccatoAbove": {
             "bBoxNE": [
-                0.38,
-                0.376
+                0.384,
+                0.384
             ],
             "bBoxSW": [
                 0.0,
@@ -644,12 +644,12 @@
         },
         "articStaccatoBelow": {
             "bBoxNE": [
-                0.38,
+                0.384,
                 0.0
             ],
             "bBoxSW": [
                 0.0,
-                -0.376
+                -0.384
             ]
         },
         "articStressAbove": {
@@ -684,7 +684,7 @@
         },
         "articTenutoAccentAbove": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 1.232
             ],
             "bBoxSW": [
@@ -694,7 +694,7 @@
         },
         "articTenutoAccentBelow": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 0.0
             ],
             "bBoxSW": [
@@ -714,7 +714,7 @@
         },
         "articTenutoStaccatoAbove": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 0.692
             ],
             "bBoxSW": [
@@ -724,7 +724,7 @@
         },
         "articTenutoStaccatoBelow": {
             "bBoxNE": [
-                1.388,
+                1.384,
                 0.0
             ],
             "bBoxSW": [
@@ -934,12 +934,12 @@
         },
         "cClefChange": {
             "bBoxNE": [
-                1.616,
-                1.34
+                1.96,
+                1.624
             ],
             "bBoxSW": [
                 0.0,
-                -1.34
+                -1.624
             ]
         },
         "cClefCombining": {
@@ -960,6 +960,16 @@
             "bBoxSW": [
                 0.0,
                 -2.008
+            ]
+        },
+        "cClefSquare": {
+            "bBoxNE": [
+                2.48,
+                1.8
+            ],
+            "bBoxSW": [
+                0.0,
+                -1.8
             ]
         },
         "chantCclef": {
@@ -1454,12 +1464,12 @@
         },
         "fClefChange": {
             "bBoxNE": [
-                1.848,
-                0.668
+                2.44,
+                0.876
             ],
             "bBoxSW": [
-                0.0,
-                -1.548
+                0.012,
+                -2.032
             ]
         },
         "fClefReversed": {
@@ -1964,12 +1974,12 @@
         },
         "gClefChange": {
             "bBoxNE": [
-                1.7258,
-                2.888
+                2.008,
+                3.364
             ],
             "bBoxSW": [
-                0.0,
-                -1.744
+                -0.004,
+                -2.036
             ]
         },
         "gClefReversed": {
@@ -1985,11 +1995,11 @@
         "gClefTurned": {
             "bBoxNE": [
                 2.584,
-                4.332
+                2.62
             ],
             "bBoxSW": [
                 -0.004,
-                -2.62
+                -4.332
             ]
         },
         "keyboardPedalP": {
@@ -2122,6 +2132,46 @@
                 0.0
             ]
         },
+        "luteFrench10thCourse": {
+            "bBoxNE": [
+                2.44,
+                1.076
+            ],
+            "bBoxSW": [
+                0.0,
+                -0.064
+            ]
+        },
+        "luteFrench7thCourse": {
+            "bBoxNE": [
+                1.116,
+                0.788
+            ],
+            "bBoxSW": [
+                -0.004,
+                -0.024
+            ]
+        },
+        "luteFrench8thCourse": {
+            "bBoxNE": [
+                1.64,
+                1.076
+            ],
+            "bBoxSW": [
+                0.0,
+                -0.064
+            ]
+        },
+        "luteFrench9thCourse": {
+            "bBoxNE": [
+                2.04,
+                1.076
+            ],
+            "bBoxSW": [
+                0.0,
+                -0.064
+            ]
+        },
         "luteFrenchFretA": {
             "bBoxNE": [
                 1.116,
@@ -2252,104 +2302,124 @@
                 -0.0008
             ]
         },
+        "luteFrenchMordentLower": {
+            "bBoxNE": [
+                1.456,
+                1.2
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
+            ]
+        },
+        "luteFrenchMordentUpper": {
+            "bBoxNE": [
+                1.056,
+                1.2
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
+            ]
+        },
         "luteItalianFret0": {
             "bBoxNE": [
-                0.892,
+                0.972,
                 0.996
             ],
             "bBoxSW": [
-                -0.012,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret1": {
             "bBoxNE": [
-                0.612,
+                0.692,
                 0.996
             ],
             "bBoxSW": [
-                -0.0084,
+                0.072,
                 -0.016
             ]
         },
         "luteItalianFret2": {
             "bBoxNE": [
-                0.676,
+                0.756,
                 0.996
             ],
             "bBoxSW": [
-                -0.0156,
+                0.064,
                 -0.012
             ]
         },
         "luteItalianFret3": {
             "bBoxNE": [
-                0.676,
+                0.756,
                 0.996
             ],
             "bBoxSW": [
-                -0.012,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret4": {
             "bBoxNE": [
-                0.804,
+                0.884,
                 0.996
             ],
             "bBoxSW": [
-                -0.016,
-                -0.0121
+                0.064,
+                -0.012
             ]
         },
         "luteItalianFret5": {
             "bBoxNE": [
-                0.608,
+                0.688,
                 1.016
             ],
             "bBoxSW": [
-                -0.012,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret6": {
             "bBoxNE": [
-                0.716,
+                0.796,
                 0.996
             ],
             "bBoxSW": [
-                -0.012,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret7": {
             "bBoxNE": [
-                0.66,
+                0.74,
                 0.996
             ],
             "bBoxSW": [
-                -0.0121,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret8": {
             "bBoxNE": [
-                0.764,
+                0.844,
                 0.996
             ],
             "bBoxSW": [
-                -0.012,
+                0.068,
                 -0.012
             ]
         },
         "luteItalianFret9": {
             "bBoxNE": [
-                0.728,
+                0.808,
                 0.996
             ],
             "bBoxSW": [
-                -0.012,
-                -0.0126
+                0.068,
+                -0.012
             ]
         },
         "medRenFlatHardB": {
@@ -2394,7 +2464,7 @@
         },
         "mensuralCclef": {
             "bBoxNE": [
-                2.976,
+                2.104,
                 2.0
             ],
             "bBoxSW": [
@@ -2630,6 +2700,16 @@
             "bBoxSW": [
                 0.0,
                 -0.008
+            ]
+        },
+        "mensuralFclef": {
+            "bBoxNE": [
+                2.06,
+                0.88
+            ],
+            "bBoxSW": [
+                0.0,
+                -0.88
             ]
         },
         "mensuralFclefPetrucci": {
@@ -4662,6 +4742,46 @@
                 -1.0
             ]
         },
+        "timeSigBracketLeft": {
+            "bBoxNE": [
+                0.48,
+                2.36
+            ],
+            "bBoxSW": [
+                0.0,
+                -2.36
+            ]
+        },
+        "timeSigBracketLeftSmall": {
+            "bBoxNE": [
+                0.48,
+                1.36
+            ],
+            "bBoxSW": [
+                0.0,
+                -1.36
+            ]
+        },
+        "timeSigBracketRight": {
+            "bBoxNE": [
+                0.48,
+                2.36
+            ],
+            "bBoxSW": [
+                0.0,
+                -2.36
+            ]
+        },
+        "timeSigBracketRightSmall": {
+            "bBoxNE": [
+                0.48,
+                1.36
+            ],
+            "bBoxSW": [
+                -0.004,
+                -1.36
+            ]
+        },
         "timeSigCommon": {
             "bBoxNE": [
                 1.656,
@@ -4670,6 +4790,26 @@
             "bBoxSW": [
                 0.0,
                 -0.996
+            ]
+        },
+        "timeSigCut2": {
+            "bBoxNE": [
+                1.688,
+                1.272
+            ],
+            "bBoxSW": [
+                0.08,
+                -1.276
+            ]
+        },
+        "timeSigCut3": {
+            "bBoxNE": [
+                1.568,
+                1.272
+            ],
+            "bBoxSW": [
+                0.08,
+                -1.276
             ]
         },
         "timeSigCutCommon": {
@@ -4782,6 +4922,16 @@
                 -0.504
             ]
         },
+        "timeSigSlash": {
+            "bBoxNE": [
+                1.416,
+                2.072
+            ],
+            "bBoxSW": [
+                0.0,
+                -2.072
+            ]
+        },
         "tremolo1": {
             "bBoxNE": [
                 0.652,
@@ -4830,6 +4980,46 @@
             "bBoxSW": [
                 -0.652,
                 -1.9
+            ]
+        },
+        "tremoloDivisiDots2": {
+            "bBoxNE": [
+                0.984,
+                0.384
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
+            ]
+        },
+        "tremoloDivisiDots3": {
+            "bBoxNE": [
+                1.584,
+                0.384
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
+            ]
+        },
+        "tremoloDivisiDots4": {
+            "bBoxNE": [
+                2.184,
+                0.384
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
+            ]
+        },
+        "tremoloDivisiDots6": {
+            "bBoxNE": [
+                1.584,
+                0.984
+            ],
+            "bBoxSW": [
+                0.0,
+                0.0
             ]
         },
         "tremoloFingered1": {


### PR DESCRIPTION
This is a tiny update to Leipzig, where the `metadata.json` was outdated. 