### PR TITLE
Append transpose revision to header

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -291,6 +291,11 @@ private:
     bool WriteDoc(Doc *doc);
 
     /**
+     * Write revisionDesc to the header
+     */
+    void WriteRevisionDesc(pugi::xml_node meiHead);
+
+    /**
      * Write the @xml:id to the currentNode
      */
     void WriteXmlId(pugi::xml_node currentNode, Object *object);

--- a/include/vrv/transposition.h
+++ b/include/vrv/transposition.h
@@ -63,6 +63,7 @@ public:
     data_ACCIDENTAL_WRITTEN GetAccidW() const;
     data_PITCHNAME GetPitchName() const;
     std::wstring GetPitchString() const;
+    std::string GetSimplePitchString() const;
     bool IsValid(int maxAccid);
     void SetPitch(int aPname, int anAccid, int anOct);
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1365,8 +1365,15 @@ void MEIOutput::WriteRevisionDesc(pugi::xml_node meiHead)
     pugi::xml_node changeDesc = change.append_child("changeDesc");
     pugi::xml_node p1 = changeDesc.append_child("p");
     // Use transposer to convert interval from options to semitones
+    const std::string transposition = m_doc->GetOptions()->m_transpose.GetValue();
     Transposer transposer;
-    const int value = transposer.IntervalToSemitones(m_doc->GetOptions()->m_transpose.GetValue());
+    int value = 0;
+    if (transposer.IsValidIntervalName(transposition)) {
+        value = transposer.IntervalToSemitones(transposition);
+    }
+    else if (transposer.IsValidSemitones(transposition)) {
+        value = stoi(transposition);
+    }
     // Prepare change string
     std::stringstream ss;
     ss << "Transposed";

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1362,7 +1362,8 @@ void MEIOutput::WriteRevisionDesc(pugi::xml_node meiHead)
     std::string dateStr = StringFormat("%d-%02d-%02dT%02d:%02d:%02d", now->tm_year + 1900, now->tm_mon + 1,
         now->tm_mday, now->tm_hour, now->tm_min, now->tm_sec);
     change.append_attribute("isodate").set_value(dateStr.c_str());
-    pugi::xml_node p1 = change.append_child("p");
+    pugi::xml_node changeDesc = change.append_child("changeDesc");
+    pugi::xml_node p1 = changeDesc.append_child("p");
     // Use transposer to convert interval from options to semitones
     Transposer transposer;
     const int value = transposer.IntervalToSemitones(m_doc->GetOptions()->m_transpose.GetValue());

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1386,6 +1386,7 @@ void MEIOutput::WriteRevisionDesc(pugi::xml_node meiHead)
         keyTonic.append("Transposed to ");
         keyTonic.append(direction);
         keyTonic.append(pitch.GetSimplePitchString());
+        keyTonic.append(" by Verovio");
     }
 
     if (!value && keyTonic.empty()) return;

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -190,11 +190,11 @@ std::string TransPitch::GetSimplePitchString() const
     std::string letter;
     letter += pitchLetter;
     switch (m_accid) {
-        case -2: return std::string(letter + "-double-flat");
-        case -1: return std::string(letter + "-flat");
-        case 0: return std::string(letter);
-        case 1: return std::string(letter + "-sharp");
-        case 2: return std::string(letter + "-double-sharp");
+        case -2: return letter + "-double-flat";
+        case -1: return letter + "-flat";
+        case 0: return letter;
+        case 1: return letter + "-sharp";
+        case 2: return letter + "-double-sharp";
         default: LogError("Transposition: Could not get Accidental for %i", m_accid);
     }
     return "";

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -183,6 +183,22 @@ std::wstring TransPitch::GetPitchString() const
     }
     return L"";
 }
+
+std::string TransPitch::GetSimplePitchString() const
+{
+    char pitchLetter = (m_pname + ('C' - 'A')) % 7 + 'A';
+    std::string letter;
+    letter += pitchLetter;
+    switch (m_accid) {
+        case -2: return std::string(letter + "-double-flat");
+        case -1: return std::string(letter + "-flat");
+        case 0: return std::string(letter + " tonic");
+        case 1: return std::string(letter + "-sharp");
+        case 2: return std::string(letter + "-double-sharp");
+        default: LogError("Transposition: Could not get Accidental for %i", m_accid);
+    }
+    return "";
+}
 //////////////////////////////
 //
 // operator= TransPitch -- copy operator for pitches.

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -192,7 +192,7 @@ std::string TransPitch::GetSimplePitchString() const
     switch (m_accid) {
         case -2: return std::string(letter + "-double-flat");
         case -1: return std::string(letter + "-flat");
-        case 0: return std::string(letter + " tonic");
+        case 0: return std::string(letter);
         case 1: return std::string(letter + "-sharp");
         case 2: return std::string(letter + "-double-sharp");
         default: LogError("Transposition: Could not get Accidental for %i", m_accid);


### PR DESCRIPTION
Changed code to write `revisionDesc` to header on export when transposition is done. It contains timestamp and message about transposition action. For Interval/Semitone transposition message will state how many semitones up/own score has been transposed, for KeyTonic - message about transposing to closest/higher/lower key.
E.g.
`Transposed up 7 semitones by Verovio.`
or
`Transposed to closest G-flat by Verovio.`