### PR TITLE
Collision avoidance for slur vs. slur

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -155,11 +155,9 @@ public:
     ///@}
 
     /**
-     * @name Detection and storage of inner slurs
+     * @name Detection of inner slurs
      */
-    ///@{
     bool HasInnerSlur(const Slur *innerSlur) const;
-    ///@}
 
     /**
      * Calculate the initial slur bezier curve and store it in the curve positioner

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -305,6 +305,10 @@ private:
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
         const ArrayOfFloatingCurvePositioners &innerCurves, double flexibility, int margin);
+
+    // Calculate the vertical control point shift
+    ControlPointAdjustment CalcControlPointVerticalShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
+        const ArrayOfFloatingCurvePositioners &innerCurves, double symmetry, int margin);
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -190,7 +190,10 @@ public:
      * Slur adjustment
      */
     ///@{
-    void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, Staff *staff);
+    void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, int unit);
+
+    void AdjustOuterSlur(
+        Doc *doc, FloatingCurvePositioner *curve, const ArrayOfFloatingCurvePositioners &innerCurves, int unit);
 
     float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
     ///@}

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -300,13 +300,13 @@ private:
      * Adjust slur position based on inner slurs
      */
     ///@{
+    // Calculate the vertical control point shift
+    ControlPointAdjustment CalcControlPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
+        const ArrayOfFloatingCurvePositioners &innerCurves, double symmetry, int margin);
+
     // Calculate the vertical shift of the slur end points
     std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
         const ArrayOfFloatingCurvePositioners &innerCurves, double flexibility, int margin);
-
-    // Calculate the vertical control point shift
-    ControlPointAdjustment CalcControlPointVerticalShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
-        const ArrayOfFloatingCurvePositioners &innerCurves, double symmetry, int margin);
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -155,6 +155,13 @@ public:
     ///@}
 
     /**
+     * @name Detection and storage of inner slurs
+     */
+    ///@{
+    bool IsInnerSlur(const Slur *innerSlur) const;
+    ///@}
+
+    /**
      * Calculate the initial slur bezier curve and store it in the curve positioner
      */
     void CalcInitialCurve(Doc *doc, FloatingCurvePositioner *curve, NearEndCollision *nearEndCollision = NULL);

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -158,7 +158,7 @@ public:
      * @name Detection and storage of inner slurs
      */
     ///@{
-    bool IsInnerSlur(const Slur *innerSlur) const;
+    bool HasInnerSlur(const Slur *innerSlur) const;
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -272,6 +272,10 @@ private:
     std::pair<int, int> CalcEndPointShift(
         FloatingCurvePositioner *curve, const BezierCurve &bezierCurve, double flexibility, int margin);
 
+    // Apply the vertical shift of the slur end points
+    void ApplyEndPointShift(
+        FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int endPointShiftLeft, int endPointShiftRight);
+
     // Calculate slur from bulge values
     void AdjustSlurFromBulge(FloatingCurvePositioner *curve, BezierCurve &bezierCurve, int unit);
 
@@ -292,6 +296,15 @@ private:
 
     // Improve the slur shape by adjusting the control point heights
     void AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int unit);
+    ///@}
+
+    /**
+     * Adjust slur position based on inner slurs
+     */
+    ///@{
+    // Calculate the vertical shift of the slur end points
+    std::pair<int, int> CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
+        const ArrayOfFloatingCurvePositioners &innerCurves, double flexibility, int margin);
     ///@}
 
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -293,6 +293,7 @@ class BoundingBox;
 class Comparison;
 class CurveSpannedElement;
 class FloatingPositioner;
+class FloatingCurvePositioner;
 class GraceAligner;
 class InterfaceComparison;
 class LayerElement;
@@ -345,6 +346,8 @@ typedef std::list<std::pair<TimeSpanningInterface *, ClassId>> ListOfSpanningInt
 typedef std::list<std::pair<TimeSpanningInterface *, Object *>> ListOfSpanningInterOwnerPairs;
 
 typedef std::vector<FloatingPositioner *> ArrayOfFloatingPositioners;
+
+typedef std::vector<FloatingCurvePositioner *> ArrayOfFloatingCurvePositioners;
 
 typedef std::vector<BoundingBox *> ArrayOfBoundingBoxes;
 

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -793,9 +793,16 @@ double BoundingBox::CalcBezierParamAtPosition(const Point bezier[4], int x)
     const std::set<double> roots = BoundingBox::SolveCubicPolynomial(a, b, c, d);
 
     // Return the first root in [0,1]
-    auto iter
-        = std::find_if(roots.begin(), roots.end(), [](double value) { return ((value >= 0.0) && (value <= 1.0)); });
-    return (iter != roots.end()) ? *iter : 0.0;
+    constexpr double eps = 1e-6; // Numerical freedom
+    auto iter = std::find_if(
+        roots.begin(), roots.end(), [](double value) { return ((value >= -eps) && (value <= 1.0 + eps)); });
+    double root = 0.0;
+    if (iter != roots.end()) {
+        root = *iter;
+        root = std::max(root, 0.0);
+        root = std::min(root, 1.0);
+    }
+    return root;
 }
 
 int BoundingBox::CalcBezierAtPosition(const Point bezier[4], int x)

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -793,9 +793,10 @@ double BoundingBox::CalcBezierParamAtPosition(const Point bezier[4], int x)
     const std::set<double> roots = BoundingBox::SolveCubicPolynomial(a, b, c, d);
 
     // Return the first root in [0,1]
-    constexpr double eps = 1e-6; // Numerical freedom
-    auto iter = std::find_if(
-        roots.begin(), roots.end(), [](double value) { return ((value >= -eps) && (value <= 1.0 + eps)); });
+    auto iter = std::find_if(roots.begin(), roots.end(), [](double value) {
+        constexpr double eps = 1e-6; // Numerical freedom
+        return ((value >= -eps) && (value <= 1.0 + eps));
+    });
     double root = 0.0;
     if (iter != roots.end()) {
         root = *iter;

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1181,8 +1181,7 @@ void Slur::AdjustOuterSlur(
     // where x, y denote the vertical adjustments of the control points and c is the size of the collision.
     // The coefficients a, b are calculated from the Bezier curve equation.
     // After collecting all constraints we calculate a solution.
-    const ControlPointAdjustment adjustment
-        = this->CalcControlPointVerticalShift(curve, bezier, innerCurves, symmetry, margin);
+    const ControlPointAdjustment adjustment = this->CalcControlPointShift(curve, bezier, innerCurves, symmetry, margin);
     bezier.SetLeftControlHeight(bezier.GetLeftControlHeight() + adjustment.leftShift);
     bezier.SetRightControlHeight(bezier.GetRightControlHeight() + adjustment.rightShift);
     bezier.UpdateControlPoints();
@@ -1197,6 +1196,50 @@ void Slur::AdjustOuterSlur(
 
     // Since we are going to redraw it, reset its bounding box
     curve->BoundingBox::ResetBoundingBox();
+}
+
+ControlPointAdjustment Slur::CalcControlPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
+    const ArrayOfFloatingCurvePositioners &innerCurves, double symmetry, int margin)
+{
+    ControlPointAdjustment adjustment{ 0, 0, false, 0 };
+    if (bezierCurve.p1.x >= bezierCurve.p2.x) return adjustment;
+
+    const int dist = bezierCurve.p2.x - bezierCurve.p1.x;
+    const bool isBelow = (curve->GetDir() == curvature_CURVEDIR_above);
+    const int sign = isBelow ? 1 : -1;
+    Point points[4];
+    points[0] = bezierCurve.p1;
+    points[1] = bezierCurve.c1;
+    points[2] = bezierCurve.c2;
+    points[3] = bezierCurve.p2;
+
+    std::list<ControlPointConstraint> constraints;
+    for (FloatingCurvePositioner *innerCurve : innerCurves) {
+        Point innerPoints[4];
+        innerCurve->GetPoints(innerPoints);
+
+        // Create five constraints for each inner slur
+        for (int step = 0; step <= 4; ++step) {
+            const Point innerPoint = BoundingBox::CalcPointAtBezier(innerPoints, 0.25 * step);
+            if ((bezierCurve.p1.x <= innerPoint.x) && (innerPoint.x <= bezierCurve.p2.x)) {
+                const int y = CalcBezierAtPosition(points, innerPoint.x);
+                const int intersection = (innerPoint.y - y) * sign + margin;
+                const float distanceRatio = float(innerPoint.x - bezierCurve.p1.x) / float(dist);
+
+                // Ignore obstacles close to the endpoints, because this would result in very large shifts
+                if ((std::abs(0.5 - distanceRatio) < 0.45) && (intersection > 0)) {
+                    const double t = BoundingBox::CalcBezierParamAtPosition(points, innerPoint.x);
+                    constraints.push_back(
+                        { 3.0 * pow(1.0 - t, 2.0) * t, 3.0 * (1.0 - t) * pow(t, 2.0), double(intersection) });
+                }
+            }
+        }
+    }
+
+    // Solve the constraints and calculate the adjustment
+    std::tie(adjustment.leftShift, adjustment.rightShift) = this->SolveControlPointConstraints(constraints, symmetry);
+
+    return adjustment;
 }
 
 std::pair<int, int> Slur::CalcEndPointShift(FloatingCurvePositioner *curve, const BezierCurve &bezierCurve,
@@ -1256,50 +1299,6 @@ std::pair<int, int> Slur::CalcEndPointShift(FloatingCurvePositioner *curve, cons
     }
 
     return { shiftLeft, shiftRight };
-}
-
-ControlPointAdjustment Slur::CalcControlPointVerticalShift(FloatingCurvePositioner *curve,
-    const BezierCurve &bezierCurve, const ArrayOfFloatingCurvePositioners &innerCurves, double symmetry, int margin)
-{
-    ControlPointAdjustment adjustment{ 0, 0, false, 0 };
-    if (bezierCurve.p1.x >= bezierCurve.p2.x) return adjustment;
-
-    const int dist = bezierCurve.p2.x - bezierCurve.p1.x;
-    const bool isBelow = (curve->GetDir() == curvature_CURVEDIR_above);
-    const int sign = isBelow ? 1 : -1;
-    Point points[4];
-    points[0] = bezierCurve.p1;
-    points[1] = bezierCurve.c1;
-    points[2] = bezierCurve.c2;
-    points[3] = bezierCurve.p2;
-
-    std::list<ControlPointConstraint> constraints;
-    for (FloatingCurvePositioner *innerCurve : innerCurves) {
-        Point innerPoints[4];
-        innerCurve->GetPoints(innerPoints);
-
-        // Create five constraints for each inner slur
-        for (int step = 0; step <= 4; ++step) {
-            const Point innerPoint = BoundingBox::CalcPointAtBezier(innerPoints, 0.25 * step);
-            if ((bezierCurve.p1.x <= innerPoint.x) && (innerPoint.x <= bezierCurve.p2.x)) {
-                const int y = CalcBezierAtPosition(points, innerPoint.x);
-                const int intersection = (innerPoint.y - y) * sign + margin;
-                const float distanceRatio = float(innerPoint.x - bezierCurve.p1.x) / float(dist);
-
-                // Ignore obstacles close to the endpoints, because this would result in very large shifts
-                if ((std::abs(0.5 - distanceRatio) < 0.45) && (intersection > 0)) {
-                    const double t = BoundingBox::CalcBezierParamAtPosition(points, innerPoint.x);
-                    constraints.push_back(
-                        { 3.0 * pow(1.0 - t, 2.0) * t, 3.0 * (1.0 - t) * pow(t, 2.0), double(intersection) });
-                }
-            }
-        }
-    }
-
-    // Solve the constraints and calculate the adjustment
-    std::tie(adjustment.leftShift, adjustment.rightShift) = this->SolveControlPointConstraints(constraints, symmetry);
-
-    return adjustment;
 }
 
 float Slur::GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir)

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -125,7 +125,7 @@ curvature_CURVEDIR Slur::CalcDrawingCurveDir(char spanningType) const
     }
 }
 
-bool Slur::IsInnerSlur(const Slur *innerSlur) const
+bool Slur::HasInnerSlur(const Slur *innerSlur) const
 {
     // Check drawing curve direction
     if (this->GetDrawingCurveDir() != innerSlur->GetDrawingCurveDir()) return false;

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -125,6 +125,28 @@ curvature_CURVEDIR Slur::CalcDrawingCurveDir(char spanningType) const
     }
 }
 
+bool Slur::IsInnerSlur(const Slur *innerSlur) const
+{
+    // Check drawing curve direction
+    if (this->GetDrawingCurveDir() != innerSlur->GetDrawingCurveDir()) return false;
+    if (this->HasMixedCurveDir()) return false;
+
+    // Check the layer
+    const LayerElement *start = this->GetStart();
+    const LayerElement *end = this->GetEnd();
+    if (!start || !end) return false;
+    const LayerElement *innerStart = innerSlur->GetStart();
+    const LayerElement *innerEnd = innerSlur->GetEnd();
+    if (!innerStart || !innerEnd) return false;
+
+    if (std::abs(start->GetAlignmentLayerN()) != std::abs(innerStart->GetAlignmentLayerN())) return false;
+    if (std::abs(end->GetAlignmentLayerN()) != std::abs(innerEnd->GetAlignmentLayerN())) return false;
+
+    // Check the alignment
+    if (this->IsOrdered(innerStart, start) || this->IsOrdered(end, innerEnd)) return false;
+    return ((this->IsOrdered(start, innerStart)) || (this->IsOrdered(innerEnd, end)));
+}
+
 std::pair<Layer *, LayerElement *> Slur::GetBoundaryLayer()
 {
     LayerElement *start = this->GetStart();

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1040,6 +1040,7 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
                 if (positioners[j]->GetSpanningType() == SPANNING_START_END) {
                     if (firstSlur->HasInnerSlur(secondSlur)) {
                         innerCurves.push_back(positioners[j]);
+                        continue;
                     }
                 }
             }
@@ -1051,6 +1052,18 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
                 && BoundingBox::ArePointsClose(points1[3], points2[0], unit)) {
                 positioners[i]->MoveBackHorizontal(-unit / 2);
                 positioners[j]->MoveFrontHorizontal(unit / 2);
+            }
+            if ((firstSlur->GetStart() == secondSlur->GetStart())
+                && BoundingBox::ArePointsClose(points1[0], points2[0], unit) && (points1[3].x > points2[3].x)) {
+                int diff = points2[0].y - points1[0].y;
+                diff += ((positioners[i]->GetDir() == curvature_CURVEDIR_below) ? -unit : unit);
+                positioners[i]->MoveFrontVertical(diff);
+            }
+            if ((firstSlur->GetEnd() == secondSlur->GetEnd())
+                && BoundingBox::ArePointsClose(points1[3], points2[3], unit) && (points1[0].x < points2[0].x)) {
+                int diff = points2[3].y - points1[3].y;
+                diff += ((positioners[i]->GetDir() == curvature_CURVEDIR_below) ? -unit : unit);
+                positioners[i]->MoveBackVertical(diff);
             }
         }
         if (!innerCurves.empty()) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1000,6 +1000,10 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
     AdjustSlursParams *params = vrv_params_cast<AdjustSlursParams *>(functorParams);
     assert(params);
 
+    Staff *staff = this->GetStaff();
+    if (!staff) return FUNCTOR_CONTINUE;
+
+    // Adjust each slur such that spanned elements are avoided
     std::vector<FloatingCurvePositioner *> positioners;
     for (FloatingPositioner *positioner : m_floatingPositioners) {
         assert(positioner->GetObject());
@@ -1015,7 +1019,7 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
         if (!curve->HasContentBB()) continue;
         positioners.push_back(curve);
 
-        slur->AdjustSlur(params->m_doc, curve, this->GetStaff());
+        slur->AdjustSlur(params->m_doc, curve, staff);
 
         if (curve->IsCrossStaff()) {
             params->m_crossStaffSlurs = true;
@@ -1023,36 +1027,23 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
     }
 
     // Adjust positioning of slurs with common start/end
-    Staff *staff = this->GetStaff();
-    if (staff) {
-        const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        for (size_t i = 0; i + 1 < positioners.size(); ++i) {
-            Slur *firstSlur = vrv_cast<Slur *>(positioners[i]->GetObject());
-            for (size_t j = i + 1; j < positioners.size(); ++j) {
-                Slur *secondSlur = vrv_cast<Slur *>(positioners[j]->GetObject());
-                Point points1[4], points2[4];
-                positioners[i]->GetPoints(points1);
-                positioners[j]->GetPoints(points2);
-                if ((firstSlur->GetStart() == secondSlur->GetStart())
-                    && BoundingBox::ArePointsClose(points1[0], points2[0], unit)) {
-                    FloatingCurvePositioner *positioner = positioners[points1[3].x > points2[3].x ? i : j];
-                    positioner->MoveFrontVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -unit : unit);
-                }
-                else if ((firstSlur->GetEnd() == secondSlur->GetEnd())
-                    && BoundingBox::ArePointsClose(points1[3], points2[3], unit)) {
-                    FloatingCurvePositioner *positioner = positioners[points1[0].x < points2[0].x ? i : j];
-                    positioner->MoveBackVertical(positioner->GetDir() == curvature_CURVEDIR_below ? -unit : unit);
-                }
-                else if ((firstSlur->GetStart() == secondSlur->GetEnd())
-                    && BoundingBox::ArePointsClose(points1[0], points2[3], unit)) {
-                    positioners[i]->MoveFrontHorizontal(unit / 2);
-                    positioners[j]->MoveBackHorizontal(-unit / 2);
-                }
-                else if ((firstSlur->GetEnd() == secondSlur->GetStart())
-                    && BoundingBox::ArePointsClose(points1[3], points2[0], unit)) {
-                    positioners[i]->MoveBackHorizontal(-unit / 2);
-                    positioners[j]->MoveFrontHorizontal(unit / 2);
-                }
+    const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    for (size_t i = 0; i + 1 < positioners.size(); ++i) {
+        Slur *firstSlur = vrv_cast<Slur *>(positioners[i]->GetObject());
+        for (size_t j = i + 1; j < positioners.size(); ++j) {
+            Slur *secondSlur = vrv_cast<Slur *>(positioners[j]->GetObject());
+            Point points1[4], points2[4];
+            positioners[i]->GetPoints(points1);
+            positioners[j]->GetPoints(points2);
+            if ((firstSlur->GetStart() == secondSlur->GetEnd())
+                && BoundingBox::ArePointsClose(points1[0], points2[3], unit)) {
+                positioners[i]->MoveFrontHorizontal(unit / 2);
+                positioners[j]->MoveBackHorizontal(-unit / 2);
+            }
+            else if ((firstSlur->GetEnd() == secondSlur->GetStart())
+                && BoundingBox::ArePointsClose(points1[3], points2[0], unit)) {
+                positioners[i]->MoveBackHorizontal(-unit / 2);
+                positioners[j]->MoveFrontHorizontal(unit / 2);
             }
         }
     }


### PR DESCRIPTION
This PR adds collision avoidance for outer slurs w.r.t. inner slurs. It closes #1150 and #2422 .

The avoidance takes the recently introduced parameters `--slur-endpoint-flexibility` and `--slur-symmetry` into account.

Examples:
| Default (flexibility = 0, symmetry = 0) | Symmetric (flexibility = 1, symmetry = 1) |
| ---------- | ---------- |
|  <img width="483" alt="Def1" src="https://user-images.githubusercontent.com/63608463/171005934-51114297-d498-4245-842c-20bfd8546e08.png"> | <img width="509" alt="Sym1" src="https://user-images.githubusercontent.com/63608463/171005957-c4fbcbcb-6900-4f9f-9b5a-6b577f4699bb.png"> |
| <img width="280" alt="Def2" src="https://user-images.githubusercontent.com/63608463/171006050-c0eae70d-1841-4af7-a2a5-8f2ed4eb1429.png"> | <img width="280" alt="Sym2" src="https://user-images.githubusercontent.com/63608463/171006099-a24f6007-25ca-4915-b588-3619fc7e4cfa.png"> |
| <img width="948" alt="Def3" src="https://user-images.githubusercontent.com/63608463/171006141-2dc44df2-3a91-4a3d-9744-0b97fbef90cc.png"> | <img width="964" alt="Sym3" src="https://user-images.githubusercontent.com/63608463/171006162-b06f4c1a-9b75-4fb1-b20e-9629bd8c36fa.png"> |



