### PR TITLE
Store UUID of original element in @corresp

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1637,6 +1637,27 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// FindLayerUuidWithinStaffDefParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a pointer to the element inside Layer StaffDef
+ * member 1: UUID of element to be found
+ **/
+
+class FindLayerUuidWithinStaffDefParams : public FunctorParams {
+public:
+    explicit FindLayerUuidWithinStaffDefParams(const std::string &Uuid)
+    {
+        m_uuid = Uuid;
+        m_object = NULL;
+    }
+
+    Object *m_object;
+    std::string m_uuid;
+};
+
+//----------------------------------------------------------------------------
 // GenerateFeaturesParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -162,12 +162,12 @@ public:
 
     bool DrawKeySigCancellation() const { return m_drawKeySigCancellation; }
     void SetDrawKeySigCancellation(bool drawKeySigCancellation) { m_drawKeySigCancellation = drawKeySigCancellation; }
-    Clef *GetStaffDefClef() { return m_staffDefClef; }
-    KeySig *GetStaffDefKeySig() { return m_staffDefKeySig; }
-    Mensur *GetStaffDefMensur() { return m_staffDefMensur; }
-    MeterSig *GetStaffDefMeterSig() { return m_staffDefMeterSig; }
-    MeterSigGrp *GetStaffDefMeterSigGrp() { return m_staffDefMeterSigGrp; }
-    bool HasStaffDef()
+    Clef *GetStaffDefClef() const { return m_staffDefClef; }
+    KeySig *GetStaffDefKeySig() const { return m_staffDefKeySig; }
+    Mensur *GetStaffDefMensur() const { return m_staffDefMensur; }
+    MeterSig *GetStaffDefMeterSig() const { return m_staffDefMeterSig; }
+    MeterSigGrp *GetStaffDefMeterSigGrp() const { return m_staffDefMeterSigGrp; }
+    bool HasStaffDef() const
     {
         return (m_staffDefClef || m_staffDefKeySig || m_staffDefMensur || m_staffDefMeterSig || m_staffDefMeterSigGrp);
     }
@@ -198,11 +198,6 @@ public:
     void SetCrossStaffFromBelow(bool crossStaff) { m_crossStaffFromBelow = crossStaff; }
     bool HasCrossStaffFromBelow() const { return m_crossStaffFromBelow; }
     ///@}
-
-    /**
-     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.)
-     */
-    Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid) override;
 
     //----------//
     // Functors //
@@ -264,6 +259,11 @@ public:
      * See Object::ResetData
      */
     int ResetData(FunctorParams *functorParams) override;
+
+    /**
+     * See Object::FindElementInLayerStaffDefsByUUID
+     */
+    int FindElementInLayerStaffDefsByUUID(FunctorParams *) const override;
 
     /**
      * @name See Object::GenerateMIDI

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -199,6 +199,11 @@ public:
     bool HasCrossStaffFromBelow() const { return m_crossStaffFromBelow; }
     ///@}
 
+    /**
+     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.)
+     */
+    Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid) override;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -70,7 +70,7 @@ public:
     /**
      * Set @corresp attribute to the UUID (or @corresp) of the object
      */
-    void SetCorrespStr(const Object *object);
+    void AddBackLink(const Object *object);
 
     //-----------------//
     // Pseudo functors //

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -67,6 +67,11 @@ public:
     const Measure *GetNextMeasure() const;
     ///@}
 
+    /**
+     * Set @corresp attribute to the UUID (or @corresp) of the object
+     */
+    void SetCorrespStr(const Object *object);
+
     //-----------------//
     // Pseudo functors //
     //-----------------//

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -484,11 +484,6 @@ public:
     ///@}
 
     /**
-     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.) of all layers within
-     */
-    virtual Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid);
-
-    /**
      * Give up ownership of the child at the idx position (NULL if not found)
      * This is a method to be used only in the very particular case where the child
      * object cannot be detached straight away. It is typically the case
@@ -726,6 +721,11 @@ public:
      * Retrieve the layer elements spanned by two points
      */
     virtual int FindSpannedLayerElements(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
+     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.) of all layers within
+     */
+    virtual int FindElementInLayerStaffDefsByUUID(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Retrieve the minimum left and maximum right for an alignment.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -486,7 +486,7 @@ public:
     /**
      * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.) of all layers within
      */
-    Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid);
+    virtual Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid);
 
     /**
      * Give up ownership of the child at the idx position (NULL if not found)

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -484,6 +484,11 @@ public:
     ///@}
 
     /**
+     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.) of all layers within
+     */
+    Object *FindElementInLayerStaffDefsByUUID(const std::string &uuid);
+
+    /**
      * Give up ownership of the child at the idx position (NULL if not found)
      * This is a method to be used only in the very particular case where the child
      * object cannot be detached straight away. It is typically the case

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -538,6 +538,20 @@ void Layer::SetDrawingCautionValues(StaffDef *currentStaffDef)
     currentStaffDef->SetDrawMeterSig(false);
 }
 
+Object *Layer::FindElementInLayerStaffDefsByUUID(const std::string &uuid)
+{
+    if (!this->HasStaffDef()) return NULL;
+    // Get corresponding elements from the layer
+    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetUuid() == uuid)) return this->GetStaffDefClef();
+    if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetUuid() == uuid)) return this->GetStaffDefKeySig();
+    if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetUuid() == uuid)) return this->GetStaffDefMensur();
+    if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetUuid() == uuid))
+        return this->GetStaffDefMeterSig();
+    if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetUuid() == uuid))
+        return this->GetStaffDefMeterSigGrp();
+    return NULL;
+}
+
 //----------------------------------------------------------------------------
 // Layer functor methods
 //----------------------------------------------------------------------------

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -538,20 +538,6 @@ void Layer::SetDrawingCautionValues(StaffDef *currentStaffDef)
     currentStaffDef->SetDrawMeterSig(false);
 }
 
-Object *Layer::FindElementInLayerStaffDefsByUUID(const std::string &uuid)
-{
-    if (!this->HasStaffDef()) return NULL;
-    // Get corresponding elements from the layer
-    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetUuid() == uuid)) return this->GetStaffDefClef();
-    if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetUuid() == uuid)) return this->GetStaffDefKeySig();
-    if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetUuid() == uuid)) return this->GetStaffDefMensur();
-    if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetUuid() == uuid))
-        return this->GetStaffDefMeterSig();
-    if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetUuid() == uuid))
-        return this->GetStaffDefMeterSigGrp();
-    return NULL;
-}
-
 //----------------------------------------------------------------------------
 // Layer functor methods
 //----------------------------------------------------------------------------
@@ -766,6 +752,32 @@ int Layer::InitOnsetOffset(FunctorParams *functorParams)
     params->m_currentMeterSig = this->GetCurrentMeterSig();
 
     return FUNCTOR_CONTINUE;
+}
+
+int Layer::FindElementInLayerStaffDefsByUUID(FunctorParams *functorParams) const
+{
+    FindLayerUuidWithinStaffDefParams *params = vrv_params_cast<FindLayerUuidWithinStaffDefParams *>(functorParams);
+    assert(params);
+
+    if (!this->HasStaffDef()) return FUNCTOR_SIBLINGS;
+    // Get corresponding elements from the layer
+    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetUuid() == params->m_uuid)) {
+        params->m_object = this->GetStaffDefClef();
+    }
+    else if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetUuid() == params->m_uuid)) {
+        params->m_object = this->GetStaffDefKeySig();
+    }
+    else if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetUuid() == params->m_uuid)) {
+        params->m_object = this->GetStaffDefMensur();
+    }
+    else if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetUuid() == params->m_uuid)) {
+        params->m_object = this->GetStaffDefMeterSig();
+    }
+    else if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetUuid() == params->m_uuid)) {
+        params->m_object = this->GetStaffDefMeterSigGrp();
+    }
+
+    return params->m_object ? FUNCTOR_STOP : FUNCTOR_SIBLINGS;
 }
 
 int Layer::ResetData(FunctorParams *functorParams)

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -75,7 +75,7 @@ const Measure *LinkingInterface::GetNextMeasure() const
     return vrv_cast<const Measure *>(m_next->GetFirstAncestor(MEASURE));
 }
 
-void LinkingInterface::SetCorrespStr(const Object *object)
+void LinkingInterface::AddBackLink(const Object *object)
 {
     const LinkingInterface *linking = object->GetLinkingInterface();
     std::string corresp = "#" + object->GetUuid();

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -75,6 +75,16 @@ const Measure *LinkingInterface::GetNextMeasure() const
     return vrv_cast<const Measure *>(m_next->GetFirstAncestor(MEASURE));
 }
 
+void LinkingInterface::SetCorrespStr(const Object *object)
+{
+    const LinkingInterface *linking = object->GetLinkingInterface();
+    std::string corresp = "#" + object->GetUuid();
+    if (linking && linking->HasCorresp()) {
+        corresp = linking->GetCorresp();
+    }
+    this->SetCorresp(corresp.c_str());
+}
+
 //----------------------------------------------------------------------------
 // Interface pseudo functor (redirected)
 //----------------------------------------------------------------------------

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -123,7 +123,7 @@ Object::Object(const Object &object) : BoundingBox(object)
         Object *clone = current->Clone();
         if (clone) {
             LinkingInterface *link = clone->GetLinkingInterface();
-            if (link) link->SetCorrespStr(object.m_children.at(i));
+            if (link) link->AddBackLink(object.m_children.at(i));
             clone->SetParent(this);
             clone->CloneReset();
             m_children.push_back(clone);
@@ -161,7 +161,7 @@ Object &Object::operator=(const Object &object)
         // For now do now copy them
         // m_unsupported = object.m_unsupported;
         LinkingInterface *link = this->GetLinkingInterface();
-        if (link) link->SetCorrespStr(&object);
+        if (link) link->AddBackLink(&object);
 
         if (object.CopyChildren()) {
             int i;
@@ -170,7 +170,7 @@ Object &Object::operator=(const Object &object)
                 Object *clone = current->Clone();
                 if (clone) {
                     LinkingInterface *link = clone->GetLinkingInterface();
-                    if (link) link->SetCorrespStr(object.m_children.at(i));
+                    if (link) link->AddBackLink(object.m_children.at(i));
                     clone->SetParent(this);
                     clone->CloneReset();
                     m_children.push_back(clone);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -706,17 +706,6 @@ void Object::FindAllDescendantsBetween(ListOfConstObjects *objects, Comparison *
     this->Process(&findAllConstBetween, &findAllConstBetweenParams, NULL, NULL, depth, FORWARD, true);
 }
 
-Object *Object::FindElementInLayerStaffDefsByUUID(const std::string &uuid)
-{
-    // Get all layers first
-    ListOfObjects layers = this->FindAllDescendantsByType(LAYER);
-    for (Object *layer : layers) {
-        Object *element = layer->FindElementInLayerStaffDefsByUUID(uuid);
-        if (element) return element;
-    }
-    return NULL;
-}
-
 Object *Object::GetChild(int idx)
 {
     return const_cast<Object *>(std::as_const(*this).GetChild(idx));

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -123,7 +123,7 @@ Object::Object(const Object &object) : BoundingBox(object)
         Object *clone = current->Clone();
         if (clone) {
             LinkingInterface *link = clone->GetLinkingInterface();
-            if (link) link->AddBackLink(object.m_children.at(i));
+            if (link) link->AddBackLink(current);
             clone->SetParent(this);
             clone->CloneReset();
             m_children.push_back(clone);
@@ -170,7 +170,7 @@ Object &Object::operator=(const Object &object)
                 Object *clone = current->Clone();
                 if (clone) {
                     LinkingInterface *link = clone->GetLinkingInterface();
-                    if (link) link->AddBackLink(object.m_children.at(i));
+                    if (link) link->AddBackLink(current);
                     clone->SetParent(this);
                     clone->CloneReset();
                     m_children.push_back(clone);
@@ -710,21 +710,10 @@ Object *Object::FindElementInLayerStaffDefsByUUID(const std::string &uuid)
 {
     // Get all layers first
     ListOfObjects layers = this->FindAllDescendantsByType(LAYER);
-    for (Object *layerObj : layers) {
-        Layer *layer = vrv_cast<Layer *>(layerObj);
-        if (!layer->HasStaffDef()) continue;
-        // Get corresponding elements from the layer
-        if (layer->GetStaffDefClef() && (layer->GetStaffDefClef()->GetUuid() == uuid)) return layer->GetStaffDefClef();
-        if (layer->GetStaffDefKeySig() && (layer->GetStaffDefKeySig()->GetUuid() == uuid))
-            return layer->GetStaffDefKeySig();
-        if (layer->GetStaffDefMensur() && (layer->GetStaffDefMensur()->GetUuid() == uuid))
-            return layer->GetStaffDefMensur();
-        if (layer->GetStaffDefMeterSig() && (layer->GetStaffDefMeterSig()->GetUuid() == uuid))
-            return layer->GetStaffDefMeterSig();
-        if (layer->GetStaffDefMeterSigGrp() && (layer->GetStaffDefMeterSigGrp()->GetUuid() == uuid))
-            return layer->GetStaffDefMeterSigGrp();
+    for (Object *layer : layers) {
+        Object *element = layer->FindElementInLayerStaffDefsByUUID(uuid);
+        if (element) return element;
     }
-
     return NULL;
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1139,26 +1139,36 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
     }
     // If not found again, try looking in the layer staffdefs
     if (!element) {
-        element = m_doc.FindElementInLayerStaffDefsByUUID(xmlId);
+        // Check drawing page elements first
+        if (m_doc.GetDrawingPage()) {
+            element = m_doc.GetDrawingPage()->FindElementInLayerStaffDefsByUUID(xmlId);
+        }
+        if (!element) {
+            element = m_doc.FindElementInLayerStaffDefsByUUID(xmlId);
+        }
+        // If element is found within layer staffdef - check for the linking interface @corresp attribute to find
+        // original ID of the element
+        if (element) {
+            // If element has @corresp set, try finding its origin
+            const LinkingInterface *link = element->GetLinkingInterface();
+            if (link && link->HasCorresp()) {
+                const std::string correspId = ExtractUuidFragment(link->GetCorresp());
+                Object *origin = m_doc.FindDescendantByUuid(correspId);
+                // if no original element was found, try searching through scoredef in score (only for certain elements)
+                if (!origin && element->Is({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
+                    Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
+                    if (page && page->m_score) {
+                        origin = page->m_score->GetScoreDef()->FindDescendantByUuid(correspId);
+                    }
+                }
+                if (origin) element = origin;
+            }
+        }
     }
     // If not found at all
     if (!element) {
         LogMessage("Element with id '%s' could not be found", xmlId.c_str());
         return o.json();
-    }
-    // If element has @corresp set, try finding its origin
-    const LinkingInterface *link = element->GetLinkingInterface();
-    if (link && link->HasCorresp()) {
-        const std::string correspId = ExtractUuidFragment(link->GetCorresp());
-        Object *origin = m_doc.FindDescendantByUuid(correspId);
-        // if no original element was found, try searching through scoredef in score (only for certain elements)
-        if (!origin && element->Is({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
-            Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
-            if (page && page->m_score) {
-                origin = page->m_score->GetScoreDef()->FindDescendantByUuid(correspId);
-            }
-        }
-        if (origin) element = origin;
     }
 
     // Fill the attribute array (pair of std::string) by looking at attributes for all available MEI modules

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1139,12 +1139,16 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
     }
     // If not found again, try looking in the layer staffdefs
     if (!element) {
+        Functor findByUuid(&Object::FindElementInLayerStaffDefsByUUID);
+        FindLayerUuidWithinStaffDefParams params(xmlId);
         // Check drawing page elements first
         if (m_doc.GetDrawingPage()) {
-            element = m_doc.GetDrawingPage()->FindElementInLayerStaffDefsByUUID(xmlId);
+            m_doc.GetDrawingPage()->Process(&findByUuid, &params);
+            element = params.m_object;
         }
         if (!element) {
-            element = m_doc.FindElementInLayerStaffDefsByUUID(xmlId);
+            m_doc.Process(&findByUuid, &params);
+            element = params.m_object;
         }
         // If element is found within layer staffdef - check for the linking interface @corresp attribute to find
         // original ID of the element


### PR DESCRIPTION
This change adds code that stores UUID of original element when it's being clones to the `@corresp` attribute (when applicable). This allow us to track back some of the elements, that are being cloned in the process and new IDs are generated for them as the result. In most cases these elements are KeySig/Clef/MeterSig/etc. (elements of the ScoreDef).

`GetElementAttr` is also changed to get original element whenever found object has @corresp set.