### PR TITLE
Slur endpoints for flipped notes

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -275,12 +275,12 @@ protected:
     void FilterList(ListOfConstObjects &childList) const override;
 
 public:
-    mutable std::list<ChordCluster *> m_clusters;
-
+    //
+private:
     /**
-     * Positions of dots in the chord to avoid overlapping
+     * The list of chord clusters
      */
-    std::list<int> m_dots;
+    mutable std::list<ChordCluster *> m_clusters;
 };
 
 } // namespace vrv

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -402,7 +402,7 @@ private:
 
     /**
      * flags for determining clusters in chord (cluster this belongs to)
-     **/
+     */
     ChordCluster *m_cluster;
 
     /**

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1285,9 +1285,14 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
     if (((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) && !start->Is(TIMESTAMP_ATTR)) {
         // get the radius for adjusting the x position
         const int startRadius = start->GetDrawingRadius(doc);
-        // get the min max of the chord (if any)
+        // get the min max of the chord (if any) and horizontal correction for flipped notes
         if (startChord) {
             startChord->GetYExtremes(yChordMax, yChordMin);
+            if (startNote && startNote->GetFlippedNotehead()) {
+                Note *refNote
+                    = (startStemDir == STEMDIRECTION_down) ? startChord->GetTopNote() : startChord->GetBottomNote();
+                x1 += refNote->GetDrawingX() - startNote->GetDrawingX();
+            }
         }
         // slur is up
         if (this->HasEndpointAboveStart()) {
@@ -1401,9 +1406,13 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
     if (((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) && !end->Is(TIMESTAMP_ATTR)) {
         // get the radius for adjusting the x position
         const int endRadius = end->GetDrawingRadius(doc);
-        // get the min max of the chord if any
+        // get the min max of the chord (if any) and horizontal correction for flipped notes
         if (endChord) {
             endChord->GetYExtremes(yChordMax, yChordMin);
+            if (endNote && endNote->GetFlippedNotehead()) {
+                Note *refNote = (endStemDir == STEMDIRECTION_down) ? endChord->GetTopNote() : endChord->GetBottomNote();
+                x2 += refNote->GetDrawingX() - endNote->GetDrawingX();
+            }
         }
         // get the stem direction of the end
         // slur is up


### PR DESCRIPTION
This PR fixes the position of slur endpoints at flipped notes (i.e. notes on the "wrong" stem side in chords with adjacent notes).
| Before | After |
| ------ | ----- |
|  <img width="473" alt="Before" src="https://user-images.githubusercontent.com/63608463/171574504-7b528f84-a63f-4450-a0be-01014bf8f23e.png"> | <img width="491" alt="After" src="https://user-images.githubusercontent.com/63608463/171574574-d55a0e80-5b5b-4443-8114-c9f26b547b4d.png"> |

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt/>
         <pubStmt>
            <date isodate="2017-05-17">2021-04-23</date>
         </pubStmt>
         <notesStmt>
            <annot />
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.3.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.sym="common" key.sig="0" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="end" n="1">
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note xml:id="note-1" oct="4" pname="g" />
                              <note oct="4" pname="d" />
                              <note oct="4" pname="c" />
                           </chord>
                           <chord dur="4">
                              <note xml:id="note-2" oct="4" pname="g" />
                              <note oct="4" pname="f" />
                           </chord>
                           <chord dur="4">
                              <note xml:id="note-3" oct="5" pname="c" />
                              <note oct="5" pname="d" />
                              <note oct="5" pname="g" />
                           </chord>
                           <chord dur="4">
                              <note xml:id="note-4" oct="5" pname="f" />
                              <note oct="5" pname="g" />
                           </chord>
                        </layer>
                     </staff>
                     <slur startid="#note-1" endid="#note-2" curve.dir="above" />
                     <slur startid="#note-3" endid="#note-4" curve.dir="below" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>