### PR TITLE
Rename IsInBeam method to be more specific

### DIFF
--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -121,16 +121,17 @@ public:
     /** Return true if the element is a note within a ligature */
     bool IsInLigature() const;
     /** Return the FTrem parten if the element is a note or a chord within a fTrem */
-    FTrem *IsInFTrem();
-    const FTrem *IsInFTrem() const;
+    FTrem *GetAncestorFTrem();
+    const FTrem *GetAncestorFTrem() const;
     /**
      * Return the beam parent if in beam
      * Look if the note or rest is in a beam.
      * Look for the first beam parent and check if the note is in its content list.
      * Looking in the content list is necessary for grace notes or imbricated beams.
      */
-    Beam *IsInBeam();
-    const Beam *IsInBeam() const;
+    Beam *GetAncestorBeam();
+    const Beam *GetAncestorBeam() const;
+    bool IsInBeam() const;
     bool IsInBeamSpan() const;
     ///@}
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -133,7 +133,7 @@ public:
     const Beam *GetAncestorBeam() const;
     bool IsInBeam() const;
     ///@}
-    
+
     /**
      * @name Setter and getter for isInBeamspan flag
      */

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -132,7 +132,14 @@ public:
     Beam *GetAncestorBeam();
     const Beam *GetAncestorBeam() const;
     bool IsInBeam() const;
-    bool IsInBeamSpan() const;
+    ///@}
+    
+    /**
+     * @name Setter and getter for isInBeamspan flag
+     */
+    ///@{
+    void SetIsInBeamSpan(bool isInBeamSpan);
+    bool GetIsInBeamSpan() const { return m_isInBeamspan; }
     ///@}
 
     /**
@@ -528,9 +535,6 @@ public:
     Staff *m_crossStaff;
     Layer *m_crossLayer;
 
-    // flag to indicate that layerElement belongs to the beamSpan
-    bool m_isInBeamspan;
-
 protected:
     Alignment *m_alignment;
 
@@ -577,6 +581,9 @@ private:
      * This also stores the negative values for identifying cross-staff
      */
     int m_alignmentLayerN;
+
+    // flag to indicate that layerElement belongs to the beamSpan
+    bool m_isInBeamspan;
 };
 
 } // namespace vrv

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -250,7 +250,7 @@ int BeamSpan::PrepareBeamSpanElements(FunctorParams *functorParams)
 
         Measure *measure = vrv_cast<Measure *>(layerElem->GetFirstAncestor(MEASURE));
         if (!measure) continue;
-        layerElem->m_isInBeamspan = true;
+        layerElem->SetIsInBeamSpan(true);
 
         Staff *elementStaff = vrv_cast<Staff *>(layerElem->GetFirstAncestor(STAFF));
         if (elementStaff->GetN() != staff->GetN()) {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -679,7 +679,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
 
     // Stems have been calculated previously in beam or fTrem - siblings because flags do not need to
     // be processed either
-    if (this->IsInBeam() || this->IsInFTrem() || this->IsInBeamSpan()) {
+    if (this->IsInBeam() || this->GetAncestorFTrem()) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -822,7 +822,7 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
         currentStem->IsVirtual(true);
     }
 
-    if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->IsInBeamSpan() && !this->IsInFTrem()) {
+    if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->GetAncestorFTrem()) {
         // We should have a stem at this stage
         assert(currentStem);
         if (!currentFlag) {

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -204,8 +204,8 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
             // Look at the stemDir to see if we have multiple stem Dir
             if (!m_hasMultipleStemDir) {
                 // At this stage, BeamCoord::m_stem is not necessary set, so we need to look at the Note / Chord
-                // original value Example: IsInBeam called in Note::PrepareLayerElementParts when reaching the first
-                // note of the beam
+                // original value Example: GetAncestorBeam called in Note::PrepareLayerElementParts when reaching the
+                // first note of the beam
                 currentStemDir = m_beamElementCoords.at(elementCount)->GetStemDir();
                 if (currentStemDir != STEMDIRECTION_NONE) {
                     if ((m_notesStemDir != STEMDIRECTION_NONE) && (m_notesStemDir != currentStemDir)) {

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -515,7 +515,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
     assert(note);
 
     Chord *chord = note->IsChordTone();
-    Beam *beam = note->IsInBeam();
+    Beam *beam = note->GetAncestorBeam();
 
     if (chord) {
         if (chord->HasEditorialContent()) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -260,16 +260,15 @@ int LayerElement::GetOriginalLayerN()
     return layerN;
 }
 
-bool LayerElement::IsInBeamSpan() const
+void LayerElement::SetIsInBeamSpan(bool isInBeamSpan)
 {
-    if (!this->Is({ CHORD, NOTE, REST })) return false;
-
-    return m_isInBeamspan;
+    if (!this->Is({ CHORD, NOTE, REST })) return;
+    m_isInBeamspan = isInBeamSpan;
 }
 
 bool LayerElement::IsInBeam() const
 {
-    return (this->GetAncestorBeam() || this->IsInBeamSpan());
+    return (this->GetAncestorBeam() || this->GetIsInBeamSpan());
 }
 
 Staff *LayerElement::GetAncestorStaff(const StaffSearch strategy, const bool assertExistence)

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -439,7 +439,7 @@ int Note::CalcStemLenInThirdUnits(const Staff *staff, data_STEMDIRECTION stemDir
 
     // Limit shortening with duration shorter than quarter not when not in a beam
 
-    if ((this->GetDrawingDur() > DUR_4) && !this->IsInBeam() && !this->IsInBeamSpan()) {
+    if ((this->GetDrawingDur() > DUR_4) && !this->IsInBeam()) {
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
             shortening = std::min(4, shortening);
         }
@@ -585,9 +585,9 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
             noteStemSameas->SetStemSameasNote(this);
             noteStemSameas->m_stemSameasRole = SAMEAS_UNSET;
             // Also resovle beams and instanciate the bi-directional references
-            Beam *beamStemSameas = noteStemSameas->IsInBeam();
+            Beam *beamStemSameas = noteStemSameas->GetAncestorBeam();
             if (beamStemSameas) {
-                Beam *thisBeam = this->IsInBeam();
+                Beam *thisBeam = this->GetAncestorBeam();
                 if (!thisBeam) {
                     // This is one thing that can go wrong. We can have many others here...
                     // E.g., not the same number of notes, conflicting durations, not all notes sharing stems, ...
@@ -1012,7 +1012,7 @@ int Note::CalcStem(FunctorParams *functorParams)
 
     // Stems have been calculated previously in Beam or fTrem - siblings because flags do not need to
     // be processed either
-    if (this->IsInBeam() || this->IsInFTrem() || this->IsInBeamSpan()) {
+    if (this->IsInBeam() || this->GetAncestorFTrem()) {
         return FUNCTOR_SIBLINGS;
     }
 
@@ -1219,7 +1219,7 @@ int Note::CalcDots(FunctorParams *functorParams)
 
         // Stem up, shorter than 4th and not in beam
         if ((this->GetDots() != 0) && (params->m_chordStemDir == STEMDIRECTION_up) && (this->GetDrawingDur() > DUR_4)
-            && !this->IsInBeam() && !this->IsInBeamSpan()) {
+            && !this->IsInBeam()) {
             // Shift according to the flag width if the top note is not flipped
             if ((this == chord->GetTopNote()) && !this->GetFlippedNotehead()) {
                 // HARDCODED
@@ -1245,7 +1245,7 @@ int Note::CalcDots(FunctorParams *functorParams)
             flagShift += shift;
         }
         else if ((this->GetDrawingStemDir() == STEMDIRECTION_up) && !this->IsInBeam() && (this->GetDrawingStemLen() < 3)
-            && !this->IsInBeamSpan() && (this->IsDotOverlappingWithFlag(params->m_doc, staffSize, dotLocShift))) {
+            && (this->IsDotOverlappingWithFlag(params->m_doc, staffSize, dotLocShift))) {
             // HARDCODED
             const int shift = params->m_doc->GetGlyphWidth(SMUFL_E240_flag8thUp, staffSize, drawingCueSize) * 0.8;
             flagShift += shift;
@@ -1327,8 +1327,8 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
         }
     }
 
-    if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->IsInFTrem() && !this->IsChordTone()
-        && !this->IsMensuralDur() && !this->IsTabGrpNote() && !this->IsInBeamSpan()) {
+    if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->GetAncestorFTrem() && !this->IsChordTone()
+        && !this->IsMensuralDur() && !this->IsTabGrpNote()) {
         // We should have a stem at this stage
         assert(currentStem);
         if (!currentFlag) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2284,7 +2284,7 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
                 // Ignore it but only if the beam is not entirely cross-staff itself
                 if (!beam->m_crossStaff) return FUNCTOR_CONTINUE;
             }
-            else if (noteOrChord->IsInBeamSpan()) {
+            else if (noteOrChord->GetIsInBeamSpan()) {
                 return FUNCTOR_CONTINUE;
             }
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2278,7 +2278,7 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
     if (this->Is(STEM)) {
         LayerElement *noteOrChord = dynamic_cast<LayerElement *>(this->GetParent());
         if (noteOrChord && noteOrChord->m_crossStaff) {
-            if (noteOrChord->IsInBeam()) {
+            if (noteOrChord->GetAncestorBeam()) {
                 Beam *beam = vrv_cast<Beam *>(noteOrChord->GetFirstAncestor(BEAM));
                 assert(beam);
                 // Ignore it but only if the beam is not entirely cross-staff itself

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -437,7 +437,7 @@ Staff *Slur::CalculateExtremalStaff(Staff *staff, int xMin, int xMax)
 
     // Also check the beams of spanned elements
     std::for_each(spanned.elements.begin(), spanned.elements.end(), [&adaptStaff](LayerElement *element) {
-        if (Beam *beam = element->IsInBeam(); beam) {
+        if (Beam *beam = element->GetAncestorBeam(); beam) {
             adaptStaff(beam);
         }
     });
@@ -1314,8 +1314,8 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
                 }
             }
             // same but in beam - adjust the x too
-            else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
-                || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))
+            else if (((parentBeam = start->GetAncestorBeam()) && !parentBeam->IsLastIn(parentBeam, start))
+                || ((parentFTrem = start->GetAncestorFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))
                 || isGraceToNoteSlur || hasStartFlag) {
                 y1 = start->GetDrawingTop(doc, staff->m_drawingStaffSize);
                 x1 += startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
@@ -1373,8 +1373,9 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
                 }
             }
             // same but in beam
-            else if (((parentBeam = start->IsInBeam()) && !parentBeam->IsLastIn(parentBeam, start))
-                || ((parentFTrem = start->IsInFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start)) || hasStartFlag) {
+            else if (((parentBeam = start->GetAncestorBeam()) && !parentBeam->IsLastIn(parentBeam, start))
+                || ((parentFTrem = start->GetAncestorFTrem()) && !parentFTrem->IsLastIn(parentFTrem, start))
+                || hasStartFlag) {
                 y1 = start->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                 x1 -= startRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
@@ -1441,8 +1442,8 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
                 }
             }
             // same but in beam - adjust the x too
-            else if (((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
-                || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
+            else if (((parentBeam = end->GetAncestorBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
+                || ((parentFTrem = end->GetAncestorFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
                 y2 = end->GetDrawingTop(doc, staff->m_drawingStaffSize);
                 x2 += endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }
@@ -1500,9 +1501,8 @@ std::pair<Point, Point> Slur::CalcEndPoints(Doc *doc, Staff *staff, NearEndColli
                 }
             }
             // same but in beam
-            else if (((parentBeam = end->IsInBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
-                || ((parentFTrem = end->IsInFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
-
+            else if (((parentBeam = end->GetAncestorBeam()) && !parentBeam->IsFirstIn(parentBeam, end))
+                || ((parentFTrem = end->GetAncestorFTrem()) && !parentFTrem->IsFirstIn(parentFTrem, end))) {
                 y2 = end->GetDrawingBottom(doc, staff->m_drawingStaffSize);
                 x2 -= endRadius - doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
             }


### PR DESCRIPTION
- renamed IsInBeam and IsInFTrem to better convey their purpose - returning Beam object
- added method IsInBeam for purposes where Beam object is not required and only bool check is needed
- replaced previous usages of IsInBeam with GetAncestorBeam (where Beam is necessary) and removed check of IsInBeamSpan (since it's included within other method)