### PR TITLE
Improve playback of bTrem inside tuplets

### DIFF
--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -81,7 +81,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     if (this->GetForm() == bTremLog_FORM_unmeas) {
         return FUNCTOR_CONTINUE;
     }
-    
+
     // Adjust duration of the bTrem if it's nested within tuplet
     int num = 0;
     Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
@@ -96,7 +96,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     // Calculate duration of individual note in tremolo
     const data_DURATION individualNoteDur = CalcIndividualNoteDuration();
     if (individualNoteDur == DURATION_NONE) return FUNCTOR_CONTINUE;
-    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur)); 
+    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur));
 
     // Define lambda which expands one note into multiple individual notes of the same pitch
     auto expandNote = [params, noteInQuarterDur, num](Object *obj) {

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -20,6 +20,7 @@
 #include "functorparams.h"
 #include "layer.h"
 #include "note.h"
+#include "tuplet.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -80,20 +81,40 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     if (this->GetForm() == bTremLog_FORM_unmeas) {
         return FUNCTOR_CONTINUE;
     }
+    
+    // Adjust duration of the bTrem if it's nested within tuplet
+    double proportion = 1.0;
+    Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
+    if (tuplet) {
+        const int num = (tuplet->GetNum() > 0) ? tuplet->GetNum() : 1;
+        const int numbase = (tuplet->GetNumbase() > 0) ? tuplet->GetNumbase() : 1;
+        proportion = proportion * numbase / num;
+    }
+    // Get num value if it's set
+    int num = 0;
+    if (this->HasNum()) {
+        num = this->GetNum();
+    }
 
     // Calculate duration of individual note in tremolo
     const data_DURATION individualNoteDur = CalcIndividualNoteDuration();
     if (individualNoteDur == DURATION_NONE) return FUNCTOR_CONTINUE;
-    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur));
+    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur)) * proportion; 
 
     // Define lambda which expands one note into multiple individual notes of the same pitch
-    auto expandNote = [params, noteInQuarterDur](Object *obj) {
+    auto expandNote = [params, noteInQuarterDur, num](Object *obj) {
         Note *note = vrv_cast<Note *>(obj);
         assert(note);
         const int pitch = note->GetMIDIPitch(params->m_transSemi);
         const double totalInQuarterDur = note->GetScoreTimeDuration() + note->GetScoreTimeTiedDuration();
-        const int multiplicity = totalInQuarterDur / noteInQuarterDur;
-        (params->m_expandedNotes)[note] = MIDINoteSequence(multiplicity, { pitch, noteInQuarterDur });
+        int multiplicity = (totalInQuarterDur / noteInQuarterDur + 0.1);
+        double noteDuration = noteInQuarterDur;
+        // if NUM has been set for the bTrem, override calculated values
+        if (num) {
+            multiplicity = num;
+            noteDuration = totalInQuarterDur / double(num);
+        }
+        (params->m_expandedNotes)[note] = MIDINoteSequence(multiplicity, { pitch, noteDuration });
     };
 
     // Apply expansion either to all notes in chord or to first note

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -83,15 +83,12 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     }
     
     // Adjust duration of the bTrem if it's nested within tuplet
-    double proportion = 1.0;
+    int num = 0;
     Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
     if (tuplet) {
-        const int num = (tuplet->GetNum() > 0) ? tuplet->GetNum() : 1;
-        const int numbase = (tuplet->GetNumbase() > 0) ? tuplet->GetNumbase() : 1;
-        proportion = proportion * numbase / num;
+        num = (tuplet->GetNum() > 0) ? tuplet->GetNum() : 0;
     }
     // Get num value if it's set
-    int num = 0;
     if (this->HasNum()) {
         num = this->GetNum();
     }
@@ -99,7 +96,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
     // Calculate duration of individual note in tremolo
     const data_DURATION individualNoteDur = CalcIndividualNoteDuration();
     if (individualNoteDur == DURATION_NONE) return FUNCTOR_CONTINUE;
-    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur)) * proportion; 
+    const double noteInQuarterDur = pow(2.0, (DURATION_4 - individualNoteDur)); 
 
     // Define lambda which expands one note into multiple individual notes of the same pitch
     auto expandNote = [params, noteInQuarterDur, num](Object *obj) {
@@ -107,7 +104,7 @@ int BTrem::GenerateMIDI(FunctorParams *functorParams)
         assert(note);
         const int pitch = note->GetMIDIPitch(params->m_transSemi);
         const double totalInQuarterDur = note->GetScoreTimeDuration() + note->GetScoreTimeTiedDuration();
-        int multiplicity = (totalInQuarterDur / noteInQuarterDur + 0.1);
+        int multiplicity = totalInQuarterDur / noteInQuarterDur;
         double noteDuration = noteInQuarterDur;
         // if NUM has been set for the bTrem, override calculated values
         if (num) {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -649,13 +649,18 @@ double LayerElement::GetAlignmentDuration(
     if (this->HasInterface(INTERFACE_DURATION)) {
         int num = 1;
         int numbase = 1;
-        Tuplet *tuplet = dynamic_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
+        Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
         if (tuplet) {
-            num = tuplet->GetNum();
-            numbase = tuplet->GetNumbase();
-            // 0 is not valid in MEI anyway - just correct it silently
-            if (num == 0) num = 1;
-            if (numbase == 0) numbase = 1;
+            ListOfConstObjects objects;
+            ClassIdsComparison ids({ CHORD, NOTE, REST });
+            tuplet->FindAllDescendantsByComparison(&objects, &ids);
+            if (objects.size() > 1) {
+                num = tuplet->GetNum();
+                numbase = tuplet->GetNumbase();
+                // 0 is not valid in MEI anyway - just correct it silently
+                if (num == 0) num = 1;
+                if (numbase == 0) numbase = 1;
+            }
         }
         DurationInterface *duration = this->GetDurationInterface();
         assert(duration);
@@ -663,7 +668,7 @@ double LayerElement::GetAlignmentDuration(
             return duration->GetInterfaceAlignmentMensuralDuration(num, numbase, mensur);
         }
         if (this->Is(NC)) {
-            Neume *neume = dynamic_cast<Neume *>(this->GetFirstAncestor(NEUME));
+            Neume *neume = vrv_cast<Neume *>(this->GetFirstAncestor(NEUME));
             if (neume->IsLastInNeume(this)) {
                 return 128;
             }
@@ -673,7 +678,7 @@ double LayerElement::GetAlignmentDuration(
         }
         double durationValue = duration->GetInterfaceAlignmentDuration(num, numbase);
         // With fTrem we need to divide the duration by two
-        FTrem *fTrem = dynamic_cast<FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
+        FTrem *fTrem = vrv_cast<FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
         if (fTrem) {
             durationValue /= 2.0;
         }


### PR DESCRIPTION
Three notable changes here:
1. Do not reduce duration time of the elements within tuplets, if there is only one such element (note, chord, rest). That should still be working properly with beams and other elements within tuplets, but single notes will retain their duration.
2. Improve playback of bTrem within tuplets by following @num attribute on the tuplet, i.e. override calculated number of notes to be played (`unitdur/dur`) with value of `tuplet@num`.
3. Add support for `bTrem@num` attribute, which behaves in similar fashion to bTrem inside tuplet - `@num` attribute overrides number of notes to be played.

In following example, both tuplets and bTrem sound the same, even though it's achieved in different ways.
<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
         </titleStmt>
         <pubStmt>
            <date isodate="2022-05-02">2022-05-02</date>
         </pubStmt>
      </fileDesc>
      <workList>
         <work>
            <title />
         </work>
      </workList>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                        <meterSig count="6" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <tuplet num="6" numbase="4" bracket.place="below" bracket.visible="false" num.format="count">
                              <beam>
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                                 <note dur="8" oct="4" pname="e" accid.ges="n" />
                              </beam>
                           </tuplet>
                           <tuplet num="6" numbase="4" num.format="count">
                              <bTrem unitdur="8" >
                                 <note dur="2" oct="4" pname="e" accid.ges="n">
                                    <artic artic="dot" glyph.num="U+E22F" />
                                 </note>
                              </bTrem>
                           </tuplet>
                           <bTrem unitdur="8" num="6">
                              <note dur="2" oct="4" pname="e" accid.ges="n">
                                 <artic artic="dot" glyph.num="U+E22F" />
                              </note>
                           </bTrem>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>
