### PR TITLE
Draw hairpins with polylines

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -76,7 +76,7 @@ public:
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
     void DrawLine(int x1, int y1, int x2, int y2) override;
-    void DrawPolygon(int n, Point points[], int xOffset, int yOffset, int fillStyle = AxODDEVEN_RULE) override;
+    void DrawPolygon(int n, Point points[], int xOffset, int yOffset) override;
     void DrawRectangle(int x, int y, int width, int height) override;
     void DrawRotatedText(const std::string &text, int x, int y, double angle) override;
     void DrawRoundedRectangle(int x, int y, int width, int height, int radius) override;

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -76,6 +76,7 @@ public:
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
     void DrawLine(int x1, int y1, int x2, int y2) override;
+    void DrawPolyline(int n, Point points[], int xOffset, int yOffset) override;
     void DrawPolygon(int n, Point points[], int xOffset, int yOffset) override;
     void DrawRectangle(int x, int y, int width, int height) override;
     void DrawRotatedText(const std::string &text, int x, int y, double angle) override;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -173,7 +173,8 @@ public:
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;
     virtual void DrawLine(int x1, int y1, int x2, int y2) = 0;
-    virtual void DrawPolygon(int n, Point points[], int xoffset = 0, int yoffset = 0) = 0;
+    virtual void DrawPolyline(int n, Point points[], int xOffset = 0, int yOffset = 0) = 0;
+    virtual void DrawPolygon(int n, Point points[], int xOffset = 0, int yOffset = 0) = 0;
     virtual void DrawRectangle(int x, int y, int width, int height) = 0;
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle) = 0;
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, int radius) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -172,8 +172,7 @@ public:
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;
     virtual void DrawLine(int x1, int y1, int x2, int y2) = 0;
-    virtual void DrawPolygon(int n, Point points[], int xoffset = 0, int yoffset = 0, int fill_style = AxODDEVEN_RULE)
-        = 0;
+    virtual void DrawPolygon(int n, Point points[], int xoffset = 0, int yoffset = 0) = 0;
     virtual void DrawRectangle(int x, int y, int width, int height) = 0;
     virtual void DrawRotatedText(const std::string &text, int x, int y, double angle) = 0;
     virtual void DrawRoundedRectangle(int x, int y, int width, int height, int radius) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -126,7 +126,8 @@ public:
      */
     ///@{
     void SetBrush(int colour, int opacity);
-    void SetPen(int colour, int width, int opacity, int dashLength = 0, int lineCap = 0);
+    void SetPen(
+        int colour, int width, int style, int dashLength = 0, int gapLength = 0, int lineCap = 0, int lineJoin = 0);
     void SetFont(FontInfo *font);
     void ResetBrush();
     void ResetPen();

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -41,6 +41,24 @@ enum {
     AxTRANSPARENT
 };
 
+enum {
+    /* Line cap styles */
+    AxCAP_UNKNOWN = 0,
+    AxCAP_BUTT,
+    AxCAP_ROUND,
+    AxCAP_SQUARE
+};
+
+enum {
+    /* Line join styles */
+    AxJOIN_UNKNOWN = 0,
+    AxJOIN_ARCS,
+    AxJOIN_BEVEL,
+    AxJOIN_MITER,
+    AxJOIN_MITER_CLIP,
+    AxJOIN_ROUND
+};
+
 // ---------------------------------------------------------------------------
 // Pen/Brush
 // ---------------------------------------------------------------------------
@@ -52,9 +70,18 @@ enum {
 
 class Pen {
 public:
-    Pen() : m_penColour(0), m_penWidth(0), m_dashLength(0), m_lineCap(0), m_penOpacity(0.0) {}
-    Pen(int colour, int width, float opacity, int dashLength, int lineCap)
-        : m_penColour(colour), m_penWidth(width), m_dashLength(dashLength), m_lineCap(lineCap), m_penOpacity(opacity)
+    Pen()
+        : m_penColour(0), m_penWidth(0), m_dashLength(0), m_gapLength(0), m_lineCap(0), m_lineJoin(0), m_penOpacity(0.0)
+    {
+    }
+    Pen(int colour, int width, float opacity, int dashLength, int gapLength, int lineCap, int lineJoin)
+        : m_penColour(colour)
+        , m_penWidth(width)
+        , m_dashLength(dashLength)
+        , m_gapLength(gapLength)
+        , m_lineCap(lineCap)
+        , m_lineJoin(lineJoin)
+        , m_penOpacity(opacity)
     {
     }
 
@@ -64,13 +91,17 @@ public:
     void SetWidth(int width) { m_penWidth = width; }
     int GetDashLength() const { return m_dashLength; }
     void SetDashLength(int dashLength) { m_dashLength = dashLength; }
+    int GetGapLength() const { return m_gapLength; }
+    void SetGapLength(int gapLength) { m_gapLength = gapLength; }
     int GetLineCap() const { return m_lineCap; }
     void SetLineCap(int lineCap) { m_lineCap = lineCap; }
+    int GetLineJoin() const { return m_lineJoin; }
+    void SetLineJoin(int lineJoin) { m_lineJoin = lineJoin; }
     float GetOpacity() const { return m_penOpacity; }
     void SetOpacity(float opacity) { m_penOpacity = opacity; }
 
 private:
-    int m_penColour, m_penWidth, m_dashLength, m_lineCap;
+    int m_penColour, m_penWidth, m_dashLength, m_gapLength, m_lineCap, m_lineJoin;
     float m_penOpacity;
 };
 

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -30,9 +30,6 @@ class Doc;
 #undef max
 #undef min
 
-/*  Polygon filling mode */
-enum { AxODDEVEN_RULE = 1, AxWINDING_RULE };
-
 enum {
     /*  Pen styles */
     AxSOLID = 100,

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -82,7 +82,7 @@ public:
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
     void DrawLine(int x1, int y1, int x2, int y2) override;
-    void DrawPolygon(int n, Point points[], int xoffset, int yoffset, int fill_style = AxODDEVEN_RULE) override;
+    void DrawPolygon(int n, Point points[], int xoffset, int yoffset) override;
     void DrawRectangle(int x, int y, int width, int height) override;
     void DrawRotatedText(const std::string &text, int x, int y, double angle) override;
     void DrawRoundedRectangle(int x, int y, int width, int height, int radius) override;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -82,7 +82,8 @@ public:
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;
     void DrawLine(int x1, int y1, int x2, int y2) override;
-    void DrawPolygon(int n, Point points[], int xoffset, int yoffset) override;
+    void DrawPolyline(int n, Point points[], int xOffset, int yOffset) override;
+    void DrawPolygon(int n, Point points[], int xOffset, int yOffset) override;
     void DrawRectangle(int x, int y, int width, int height) override;
     void DrawRotatedText(const std::string &text, int x, int y, double angle) override;
     void DrawRoundedRectangle(int x, int y, int width, int height, int radius) override;
@@ -269,6 +270,15 @@ private:
     std::string GetColour(int colour);
 
     pugi::xml_node AppendChild(std::string name);
+
+    /**
+     * Transform pen properties into stroke attributes
+     */
+    ///@{
+    void AppendStrokeLineCap(pugi::xml_node node, const Pen &pen);
+    void AppendStrokeLineJoin(pugi::xml_node node, const Pen &pen);
+    void AppendStrokeDashArray(pugi::xml_node node, const Pen &pen);
+    ///@}
 
 public:
     //

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -217,6 +217,12 @@ void BBoxDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
     this->UpdateBB(x1 - p1, y1 - p1, x2 + p2, y2 + p2);
 }
 
+void BBoxDeviceContext::DrawPolyline(int n, Point points[], int xOffset, int yOffset)
+{
+    // Same bounding box as corresponding polygon
+    this->DrawPolygon(n, points, xOffset, yOffset);
+}
+
 void BBoxDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffset)
 {
     if (n == 0) {

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -217,7 +217,7 @@ void BBoxDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
     this->UpdateBB(x1 - p1, y1 - p1, x2 + p2, y2 + p2);
 }
 
-void BBoxDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffset, int fillStyle)
+void BBoxDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffset)
 {
     if (n == 0) {
         return;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -129,29 +129,32 @@ const Resources *DeviceContext::GetResources(bool showWarning) const
     return m_resources;
 }
 
-void DeviceContext::SetPen(int colour, int width, int opacity, int dashLength, int lineCap)
+void DeviceContext::SetPen(int colour, int width, int style, int dashLength, int gapLength, int lineCap, int lineJoin)
 {
     float opacityValue;
 
-    switch (opacity) {
+    switch (style) {
         case AxSOLID: opacityValue = 1.0; break;
         case AxDOT:
-            dashLength = dashLength ? dashLength : width * 1;
+            dashLength = dashLength ? dashLength : 1;
+            gapLength = gapLength ? gapLength : width * 3;
             opacityValue = 1.0;
             break;
         case AxLONG_DASH:
             dashLength = dashLength ? dashLength : width * 4;
+            gapLength = gapLength ? gapLength : width * 3;
             opacityValue = 1.0;
             break;
         case AxSHORT_DASH:
             dashLength = dashLength ? dashLength : width * 2;
+            gapLength = gapLength ? gapLength : width * 3;
             opacityValue = 1.0;
             break;
         case AxTRANSPARENT: opacityValue = 0.0; break;
         default: opacityValue = 1.0; // solid brush by default
     }
 
-    m_penStack.push(Pen(colour, width, opacityValue, dashLength, lineCap));
+    m_penStack.push(Pen(colour, width, opacityValue, dashLength, gapLength, lineCap, lineJoin));
 }
 
 void DeviceContext::SetBrush(int colour, int opacity)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -673,7 +673,7 @@ void SvgDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
     if (m_penStack.top().GetWidth() > 1) pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
-void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffset, int fill_style)
+void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffset)
 {
     assert(m_penStack.size());
     assert(m_brushStack.size());
@@ -682,9 +682,7 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffs
     Brush currentBrush = m_brushStack.top();
 
     pugi::xml_node polygonChild = AppendChild("polygon");
-    // if (fillStyle == wxODDEVEN_RULE)
-    //    polygonChild.append_attribute("fill-rule") = "evenodd;";
-    // else
+
     if (currentPen.GetWidth() > 0)
         polygonChild.append_attribute("stroke") = this->GetColour(currentPen.GetColour()).c_str();
     if (currentPen.GetWidth() > 1)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -511,10 +511,9 @@ void SvgDeviceContext::DrawQuadBezierPath(Point bezier[3])
     pathChild.append_attribute("stroke-linejoin") = "round";
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
     if (m_penStack.top().GetDashLength() > 0) {
-        // Since we have stroke-linecap=round, change the dash length to be the percieved length.
-        int dashOn = std::max(m_penStack.top().GetDashLength() - m_penStack.top().GetWidth(), 0);
-        int dashOff = m_penStack.top().GetDashLength() + m_penStack.top().GetWidth();
-        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d, %d", dashOn, dashOff).c_str();
+        const int dashLength = m_penStack.top().GetDashLength();
+        const int gapLength = (m_penStack.top().GetGapLength() > 0) ? m_penStack.top().GetGapLength() : dashLength;
+        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d %d", dashLength, gapLength).c_str();
     }
 }
 
@@ -532,10 +531,9 @@ void SvgDeviceContext::DrawCubicBezierPath(Point bezier[4])
     pathChild.append_attribute("stroke-linejoin") = "round";
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
     if (m_penStack.top().GetDashLength() > 0) {
-        // Since we have stroke-linecap=round, change the dash length to be the percieved length.
-        int dashOn = std::max(m_penStack.top().GetDashLength() - m_penStack.top().GetWidth(), 0);
-        int dashOff = m_penStack.top().GetDashLength() + m_penStack.top().GetWidth();
-        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d, %d", dashOn, dashOff).c_str();
+        const int dashLength = m_penStack.top().GetDashLength();
+        const int gapLength = (m_penStack.top().GetGapLength() > 0) ? m_penStack.top().GetGapLength() : dashLength;
+        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d %d", dashLength, gapLength).c_str();
     }
 }
 
@@ -662,14 +660,17 @@ void SvgDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
     pugi::xml_node pathChild = AppendChild("path");
     pathChild.append_attribute("d") = StringFormat("M%d %d L%d %d", x1, y1, x2, y2).c_str();
     pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
-    if (m_penStack.top().GetLineCap() > 0) {
-        pathChild.append_attribute("stroke-linecap") = "round";
-        pathChild.append_attribute("stroke-dasharray")
-            = StringFormat("1, %d", int(2.5 * m_penStack.top().GetDashLength())).c_str();
+    switch (m_penStack.top().GetLineCap()) {
+        case AxCAP_BUTT: pathChild.append_attribute("stroke-linecap") = "butt"; break;
+        case AxCAP_ROUND: pathChild.append_attribute("stroke-linecap") = "round"; break;
+        case AxCAP_SQUARE: pathChild.append_attribute("stroke-linecap") = "square"; break;
+        default: break;
     }
-    else if (m_penStack.top().GetDashLength() > 0)
-        pathChild.append_attribute("stroke-dasharray")
-            = StringFormat("%d, %d", m_penStack.top().GetDashLength(), m_penStack.top().GetDashLength()).c_str();
+    if (m_penStack.top().GetDashLength() > 0) {
+        const int dashLength = m_penStack.top().GetDashLength();
+        const int gapLength = (m_penStack.top().GetGapLength() > 0) ? m_penStack.top().GetGapLength() : dashLength;
+        pathChild.append_attribute("stroke-dasharray") = StringFormat("%d %d", dashLength, gapLength).c_str();
+    }
     if (m_penStack.top().GetWidth() > 1) pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
@@ -689,6 +690,14 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xoffset, int yoffs
         polygonChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
     if (currentPen.GetOpacity() != 1.0)
         polygonChild.append_attribute("stroke-opacity") = StringFormat("%f", currentPen.GetOpacity()).c_str();
+    switch (currentPen.GetLineJoin()) {
+        case AxJOIN_ARCS: polygonChild.append_attribute("stroke-linejoin") = "arcs"; break;
+        case AxJOIN_BEVEL: polygonChild.append_attribute("stroke-linejoin") = "bevel"; break;
+        case AxJOIN_MITER: polygonChild.append_attribute("stroke-linejoin") = "miter"; break;
+        case AxJOIN_MITER_CLIP: polygonChild.append_attribute("stroke-linejoin") = "miter-clip"; break;
+        case AxJOIN_ROUND: polygonChild.append_attribute("stroke-linejoin") = "round"; break;
+        default: break;
+    }
     if (currentBrush.GetColour() != AxNONE)
         polygonChild.append_attribute("fill") = this->GetColour(currentBrush.GetColour()).c_str();
     if (currentBrush.GetOpacity() != 1.0)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -709,6 +709,8 @@ void SvgDeviceContext::DrawPolyline(int n, Point points[], int xOffset, int yOff
     this->AppendStrokeLineJoin(polylineChild, currentPen);
     this->AppendStrokeDashArray(polylineChild, currentPen);
 
+    polylineChild.append_attribute("fill") = "none";
+
     std::string pointsString;
     for (int i = 0; i < n; ++i) {
         pointsString += StringFormat("%d,%d ", points[i].x + xOffset, points[i].y + yOffset);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -527,7 +527,7 @@ void View::DrawBracketSpan(
             dc->ResetBrush();
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
-            dc->SetPen(m_currentColour, lineWidth, AxDOT, lineWidth, 1);
+            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
             dc->SetBrush(m_currentColour, AxSOLID);
             // Adjust the start and end because the horizontal line of the was drawn in that case
             int x1Dotted
@@ -799,11 +799,11 @@ void View::DrawOctave(
         int dotShift = 0;
         if (octave->HasLform()) {
             if (octave->GetLform() == LINEFORM_solid) {
-                dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0);
+                dc->SetPen(m_currentColour, lineWidth, AxSOLID);
                 dc->SetBrush(m_currentColour, AxSOLID);
             }
             else if (octave->GetLform() == LINEFORM_dotted) {
-                dc->SetPen(m_currentColour, lineWidth, AxDOT, lineWidth, 1);
+                dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
                 dc->SetBrush(m_currentColour, AxSOLID);
                 dotShift = lineShift;
             }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -603,21 +603,21 @@ void View::DrawHairpin(
     int startY = 0;
     int endY = hairpin->CalcHeight(m_doc, staff->m_drawingStaffSize, spanningType, leftLink, rightLink);
 
-    // To get things right, we need to mirror the spanning type
-    char mirrorSpanningType = spanningType;
+    // To get things right, we need to consider the corresponding spanning type for dim.
+    char correspSpanningType = spanningType;
     if (form == hairpinLog_FORM_dim) {
-        if (spanningType == SPANNING_START) mirrorSpanningType = SPANNING_END;
-        if (spanningType == SPANNING_END) mirrorSpanningType = SPANNING_START;
+        if (spanningType == SPANNING_START) correspSpanningType = SPANNING_END;
+        if (spanningType == SPANNING_END) correspSpanningType = SPANNING_START;
     }
 
     // Adjust start/end for broken hairpins
-    if (mirrorSpanningType == SPANNING_START) {
+    if (correspSpanningType == SPANNING_START) {
         endY = endY * 2 / 3;
     }
-    else if (mirrorSpanningType == SPANNING_END) {
+    else if (correspSpanningType == SPANNING_END) {
         startY = endY / 3;
     }
-    else if (mirrorSpanningType == SPANNING_MIDDLE) {
+    else if (correspSpanningType == SPANNING_MIDDLE) {
         startY = endY / 3;
         endY = endY * 2 / 3;
     }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -660,12 +660,13 @@ void View::DrawHairpin(
         dc->DrawPolyline(3, p);
     }
     else {
-        Point startPoint(ToDeviceContextX(x1), ToDeviceContextY(y1 - startY / 2));
-        Point endPoint(ToDeviceContextX(x2), ToDeviceContextY(y2 - endY / 2));
-        dc->DrawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y);
-        startPoint.y = ToDeviceContextY(y1 + startY / 2);
-        endPoint.y = ToDeviceContextY(y2 + endY / 2);
-        dc->DrawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y);
+        Point p[2];
+        p[0] = { ToDeviceContextX(x1), ToDeviceContextY(y1 - startY / 2) };
+        p[1] = { ToDeviceContextX(x2), ToDeviceContextY(y2 - endY / 2) };
+        dc->DrawPolyline(2, p);
+        p[0].y = ToDeviceContextY(y1 + startY / 2);
+        p[1].y = ToDeviceContextY(y2 + endY / 2);
+        dc->DrawPolyline(2, p);
     }
     dc->ResetPen();
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -667,8 +667,30 @@ void View::DrawHairpin(
 
     const double hairpinThickness
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_hairpinThickness.GetValue();
-    this->DrawObliquePolygon(dc, x1, y1 - startY / 2, x2, y2 - endY / 2, hairpinThickness);
-    this->DrawObliquePolygon(dc, x1, y1 + startY / 2, x2, y2 + endY / 2, hairpinThickness);
+    dc->SetPen(m_currentColour, hairpinThickness, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_BEVEL);
+    if (startY == 0) {
+        Point p[3];
+        p[0] = { ToDeviceContextX(x2), ToDeviceContextY(y2 - endY / 2) };
+        p[1] = { ToDeviceContextX(x1), ToDeviceContextY(y1) };
+        p[2] = { p[0].x, ToDeviceContextY(y2 + endY / 2) };
+        dc->DrawPolyline(3, p);
+    }
+    else if (endY == 0) {
+        Point p[3];
+        p[0] = { ToDeviceContextX(x1), ToDeviceContextY(y1 - startY / 2) };
+        p[1] = { ToDeviceContextX(x2), ToDeviceContextY(y2) };
+        p[2] = { p[0].x, ToDeviceContextY(y1 + startY / 2) };
+        dc->DrawPolyline(3, p);
+    }
+    else {
+        Point startPoint(ToDeviceContextX(x1), ToDeviceContextY(y1 - startY / 2));
+        Point endPoint(ToDeviceContextX(x2), ToDeviceContextY(y2 - endY / 2));
+        dc->DrawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y);
+        startPoint.y = ToDeviceContextY(y1 + startY / 2);
+        endPoint.y = ToDeviceContextY(y2 + endY / 2);
+        dc->DrawLine(startPoint.x, startPoint.y, endPoint.x, endPoint.y);
+    }
+    dc->ResetPen();
 
     // dc->ReactivateGraphic();
     if (graphic)

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -53,7 +53,7 @@ void View::DrawRoundedLine(DeviceContext *dc, int x1, int y1, int x2, int y2, in
 {
     assert(dc);
 
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, 0, 1);
+    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, 0, 0, AxCAP_ROUND);
     dc->SetBrush(m_currentColour, AxSOLID);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));


### PR DESCRIPTION
This PR adds support for drawing polylines in the device context. We add some pen properties to support various cap and join styles.

Drawing with polylines is then applied in the rendering of hairpins:
| Before | After |
| ------ | ----- |
| <img width="705" alt="Before1" src="https://user-images.githubusercontent.com/63608463/171803034-c48d5b8b-0610-40ff-a008-5a5bd12b8599.png"> | <img width="700" alt="After1" src="https://user-images.githubusercontent.com/63608463/171803085-84a52f7f-7778-4fa8-8eee-a4a61a299493.png"> |

SVG output:
```xml
<polyline stroke="currentColor" stroke-width="18" stroke-linecap="square" stroke-linejoin="bevel" fill="none" points="4795,2349 2013,2214 4795,2079 " />
```

We also adjusted the opening gap of broken hairpins a bit:
| Before | After |
| ------ | ----- |
| <img width="1152" alt="Before2" src="https://user-images.githubusercontent.com/63608463/171803391-7c5e5ce2-3f1f-4929-a611-31bb7cefc972.png"> | <img width="1151" alt="After2" src="https://user-images.githubusercontent.com/63608463/171803434-b7dd7b6b-2368-40d9-830f-b1bc4694ae62.png"> |


 