### PR TITLE
Const correctness for layer elements

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -68,7 +68,8 @@ public:
     void SetDrawingOctave(bool isDrawingOctave) { m_isDrawingOctave = isDrawingOctave; }
     bool GetDrawingOctave() const { return m_isDrawingOctave; }
     void SetDrawingOctaveAccid(Accid *drawingOctave) { m_drawingOctave = drawingOctave; }
-    Accid *GetDrawingOctaveAccid() const { return m_drawingOctave; }
+    Accid *GetDrawingOctaveAccid() { return m_drawingOctave; }
+    const Accid *GetDrawingOctaveAccid() const { return m_drawingOctave; }
     ///@}
 
     /**
@@ -76,7 +77,8 @@ public:
      */
     ///@{
     void SetDrawingUnisonAccid(Accid *drawingUnison) { m_drawingUnison = drawingUnison; }
-    Accid *GetDrawingUnisonAccid() const { return m_drawingUnison; }
+    Accid *GetDrawingUnisonAccid() { return m_drawingUnison; }
+    const Accid *GetDrawingUnisonAccid() const { return m_drawingUnison; }
     ///@}
 
     /**
@@ -88,13 +90,13 @@ public:
     /**
      * Adjust X position of accid in relation to other element
      */
-    void AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
+    void AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
         std::vector<Accid *> &adjustedAccids);
 
     /**
      * Adjust accid position if it's placed above/below staff so that it does not overlap with ledger lines
      */
-    void AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize);
+    void AdjustToLedgerLines(const Doc *doc, LayerElement *element, int staffSize);
 
     /**
      * @name Set and get same layer alignment

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -54,13 +54,6 @@ public:
     void GetAllArtics(bool direction, std::vector<Artic *> &artics);
 
     /**
-     * Split the articulation content into an array with the values to be displayed inside the staff / slur
-     * and the values to be displayed outside.
-     * Used by Artic::PrepareLayerElementParts that then creates the corresponding ArticPart objects.
-     */
-    void SplitArtic(std::vector<data_ARTICULATION> *insideSlur, std::vector<data_ARTICULATION> *outsideSlur);
-
-    /**
      * Return the inside and outside part of an artic if any (NULL otherwiser)
      */
     ///@{
@@ -71,7 +64,7 @@ public:
     /**
      * Check if the articList contains data_ARTICULATION has to be place above staff.
      */
-    bool AlwaysAbove();
+    bool AlwaysAbove() const;
 
     void AddSlurPositioner(FloatingCurvePositioner *positioner, bool start);
 
@@ -140,7 +133,7 @@ public:
 private:
     bool IsInsideArtic(data_ARTICULATION artic) const;
     // Calculate shift for the articulation based on its type and presence of other articulations
-    int CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const;
+    int CalculateHorizontalShift(const Doc *doc, const LayerElement *parent, data_STEMDIRECTION stemDir) const;
 
 public:
     std::vector<FloatingCurvePositioner *> m_startSlurPositioners;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -44,13 +44,13 @@ public:
 
     void Reset();
 
-    void CalcBeam(Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface,
+    void CalcBeam(Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface,
         data_BEAMPLACE place = BEAMPLACE_NONE, bool init = true);
 
     /**
      *
      */
-    const ArrayOfBeamElementCoords *GetElementCoordRefs() const;
+    const ArrayOfBeamElementCoords *GetElementCoordRefs();
 
     /**
      * Initializes the m_beamElementCoords vector objects.
@@ -94,12 +94,12 @@ public:
     ///@{
     void InitSameasRoles(Beam *sameasBeam, data_BEAMPLACE &drawingPlace);
     void UpdateSameasRoles(data_BEAMPLACE place);
-    void CalcNoteHeadShiftForStemSameas(Doc *doc, Beam *sameasBeam, data_BEAMPLACE place);
+    void CalcNoteHeadShiftForStemSameas(Beam *sameasBeam, data_BEAMPLACE place);
     ///@}
 
 private:
     // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-french-style" is set)
-    void AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface);
+    void AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterface);
 
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
     void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
@@ -112,20 +112,21 @@ private:
 
     void CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
-    void CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff, int &yMax, int &yMin);
+    void CalcBeamInitForNotePair(const Note *note1, const Note *note2, const Staff *staff, int &yMax, int &yMin);
 
-    bool CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step);
+    bool CalcBeamSlope(const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, int &step);
 
-    int CalcBeamSlopeStep(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep);
+    int CalcBeamSlopeStep(
+        const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep);
 
-    void CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step);
+    void CalcMixedBeamStem(const BeamDrawingInterface *beamInterface, int step);
 
-    void CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
+    void CalcBeamPosition(const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
-    void CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step);
+    void CalcAdjustSlope(const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, int &step);
 
     // Helper to adjust position of starting point to make sure that beam start-/endpoints touch the staff lines
-    void CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    void CalcAdjustPosition(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface);
 
     void CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
@@ -133,29 +134,29 @@ private:
      * Helper to calculate the beam position for a beam in tablature.
      * Also adjust the drawingYRel of the TabDurSym if necessary.
      */
-    void CalcBeamPlaceTab(
-        Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
+    void CalcBeamPlaceTab(const Layer *layer, const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface,
+        data_BEAMPLACE place);
 
     // Helper to calculate the longest stem length of the beam (which will be used uniformely)
-    void CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal);
+    void CalcBeamStemLength(const Staff *staff, data_BEAMPLACE place, bool isHorizontal);
 
     // Helper to set the stem values
-    void CalcSetStemValues(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    void CalcSetStemValues(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface);
 
     // Helper to set the stem values for tablature
-    void CalcSetStemValuesTab(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    void CalcSetStemValuesTab(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface);
 
     // Helper to calculate max/min beam points for the relative beam place
     std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;
 
     // Helper to calculate location and duration of the note that would be setting highest/lowest point for the beam
-    std::pair<int, int> CalcStemDefiningNote(Staff *staff, data_BEAMPLACE place);
+    std::pair<int, int> CalcStemDefiningNote(const Staff *staff, data_BEAMPLACE place) const;
 
     // Calculate positioning for the horizontal beams
-    void CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
+    void CalcHorizontalBeam(const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface);
 
     // Helper to calculate relative position of the beam to for each of the coordinates
-    void CalcMixedBeamPlace(Staff *staff);
+    void CalcMixedBeamPlace(const Staff *staff);
 
     // Helper to calculate proper positioning of the additional beamlines for notes
     void CalcPartialFlagPlace();
@@ -164,10 +165,11 @@ private:
     void CalcSetValues();
 
     // Helper to check wheter beam fits within certain bounds
-    bool DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false);
+    bool DoesBeamOverlap(
+        int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false) const;
 
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly
-    bool NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface);
+    bool NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface);
 
 public:
     // values set by CalcBeam
@@ -217,15 +219,20 @@ public:
      * Set/get methods for member variables
      */
     ///@{
-    Measure *GetMeasure() const { return m_measure; }
+    Measure *GetMeasure() { return m_measure; }
+    const Measure *GetMeasure() const { return m_measure; }
     void SetMeasure(Measure *measure) { m_measure = measure; }
-    Staff *GetStaff() const { return m_staff; }
+    Staff *GetStaff() { return m_staff; }
+    const Staff *GetStaff() const { return m_staff; }
     void SetStaff(Staff *staff) { m_staff = staff; }
-    Layer *GetLayer() const { return m_layer; }
+    Layer *GetLayer() { return m_layer; }
+    const Layer *GetLayer() const { return m_layer; }
     void SetLayer(Layer *layer) { m_layer = layer; }
-    BeamElementCoord *GetBeginCoord() const { return m_begin; }
+    BeamElementCoord *GetBeginCoord() { return m_begin; }
+    const BeamElementCoord *GetBeginCoord() const { return m_begin; }
     void SetBeginCoord(BeamElementCoord *begin) { m_begin = begin; }
-    BeamElementCoord *GetEndCoord() const { return m_end; }
+    BeamElementCoord *GetEndCoord() { return m_end; }
+    const BeamElementCoord *GetEndCoord() const { return m_end; }
     void SetEndCoord(BeamElementCoord *end) { m_end = end; }
     ///@}
 
@@ -239,7 +246,7 @@ public:
     ///@}
 
     // Helper to append coordinates for the beamSpans that are drawn over systems
-    void AppendSpanningCoordinates(Measure *measure);
+    void AppendSpanningCoordinates(const Measure *measure);
 
 private:
     // main values to track positioning of the segment
@@ -312,7 +319,8 @@ public:
      */
     ///@{
     bool HasStemSameasBeam() const { return (m_stemSameas); }
-    Beam *GetStemSameasBeam() const { return m_stemSameas; }
+    Beam *GetStemSameasBeam() { return m_stemSameas; }
+    const Beam *GetStemSameasBeam() const { return m_stemSameas; }
     void SetStemSameasBeam(Beam *stemSameas) { m_stemSameas = stemSameas; }
     ///@}
 
@@ -324,7 +332,7 @@ public:
     /**
      * Return duration of beam part that are closest to the specified object X position
      */
-    int GetBeamPartDuration(Object *object) const;
+    int GetBeamPartDuration(const Object *object) const;
 
     //----------//
     // Functors //
@@ -415,22 +423,22 @@ public:
      */
     data_STEMDIRECTION GetStemDir() const;
 
-    void SetDrawingStemDir(
-        data_STEMDIRECTION stemDir, Staff *staff, Doc *doc, BeamSegment *segment, BeamDrawingInterface *interface);
+    void SetDrawingStemDir(data_STEMDIRECTION stemDir, const Staff *staff, const Doc *doc, const BeamSegment *segment,
+        const BeamDrawingInterface *interface);
 
     /** Set the note or closest note for chord or tabdursym for tablature beams placed outside the staff */
     void SetClosestNoteOrTabDurSym(data_STEMDIRECTION stemDir, bool outsideStaff);
 
     /** Heleper for calculating the stem length for staff notation and tablature beams within the staff */
-    int CalculateStemLength(Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal);
+    int CalculateStemLength(const Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal) const;
 
     /** Helper for calculating the stem length for tablature beam placed outside the staff */
-    int CalculateStemLengthTab(Staff *staff, data_STEMDIRECTION stemDir);
+    int CalculateStemLengthTab(const Staff *staff, data_STEMDIRECTION stemDir) const;
 
     /**
      * Return stem length adjustment in half units, depending on the @stem.mode attribute
      */
-    int CalculateStemModAdjustment(int stemLength, int directionBias);
+    int CalculateStemModAdjustment(int stemLength, int directionBias) const;
 
     /**
      * Helper to get the StemmedDrawingInterface associated with the m_element (if any)

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -102,15 +102,16 @@ private:
     void AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterface);
 
     // Helper to adjust beam positioning with regards to ledger lines (top and bottom of the staff)
-    void AdjustBeamToLedgerLines(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
+    void AdjustBeamToLedgerLines(
+        const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface, bool isHorizontal);
 
     /**
      * Helper to calculate required adjustment to beam position and stem length for beams that have tremolos or notes
      * with stem modifiers
      */
-    void AdjustBeamToTremolos(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface);
+    void AdjustBeamToTremolos(const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface);
 
-    void CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
+    void CalcBeamInit(const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
     void CalcBeamInitForNotePair(const Note *note1, const Note *note2, const Staff *staff, int &yMax, int &yMin);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -44,7 +44,7 @@ public:
 
     void Reset();
 
-    void CalcBeam(Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface,
+    void CalcBeam(const Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface,
         data_BEAMPLACE place = BEAMPLACE_NONE, bool init = true);
 
     /**
@@ -128,7 +128,7 @@ private:
     // Helper to adjust position of starting point to make sure that beam start-/endpoints touch the staff lines
     void CalcAdjustPosition(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface);
 
-    void CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
+    void CalcBeamPlace(const Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place);
 
     /**
      * Helper to calculate the beam position for a beam in tablature.

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -145,10 +145,10 @@ public:
      * @name Return the overlap on the left / right / top / bottom looking at bounding box anchor points
      */
     ///@{
-    int HorizontalLeftOverlap(const BoundingBox *other, Doc *doc, int margin = 0, int vMargin = 0) const;
-    int HorizontalRightOverlap(const BoundingBox *other, Doc *doc, int margin = 0, int vMaring = 0) const;
-    int VerticalTopOverlap(const BoundingBox *other, Doc *doc, int margin = 0, int hMargin = 0) const;
-    int VerticalBottomOverlap(const BoundingBox *other, Doc *doc, int margin = 0, int hMargin = 0) const;
+    int HorizontalLeftOverlap(const BoundingBox *other, const Doc *doc, int margin = 0, int vMargin = 0) const;
+    int HorizontalRightOverlap(const BoundingBox *other, const Doc *doc, int margin = 0, int vMargin = 0) const;
+    int VerticalTopOverlap(const BoundingBox *other, const Doc *doc, int margin = 0, int hMargin = 0) const;
+    int VerticalBottomOverlap(const BoundingBox *other, const Doc *doc, int margin = 0, int hMargin = 0) const;
     ////}
 
     /**
@@ -273,20 +273,20 @@ private:
      * Return 1 with no smufl glyph or no anchor, 2 with on anchor point, and 3 with 2 anchor points.
      */
     int GetRectangles(
-        const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, Point rect[3][2], Doc *doc) const;
+        const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, Point rect[3][2], const Doc *doc) const;
 
     /**
      * Calculate the rectangles with 2 anchor points.
      * Return false (and one single rectangle) when anchor points are out of the boundaries.
      */
-    bool GetGlyph2PointRectangles(const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, const Glyph *glyph1,
-        Point rect[3][2], Doc *doc) const;
+    bool GetGlyph2PointRectangles(
+        const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, const Glyph *glyph1, Point rect[3][2]) const;
 
     /**
      * Calculate the rectangles with 1 anchor point.
      * Return false (and one single rectangle) when anchor points are out of the boundaries.
      */
-    bool GetGlyph1PointRectangles(const SMuFLGlyphAnchor &anchor, const Glyph *glyph, Point rect[2][2], Doc *doc) const;
+    bool GetGlyph1PointRectangles(const SMuFLGlyphAnchor &anchor, const Glyph *glyph, Point rect[2][2]) const;
 
 public:
     //

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -158,7 +158,7 @@ public:
      * Helper to adjust overlapping layers for chords
      * Returns the shift of the adjustment
      */
-    int AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted,
+    int AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted,
         bool &isUnison, bool &stemSameas) override;
 
     /**

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -106,15 +106,19 @@ public:
     ///@}
 
     /**
-     * Return the cross staff above or below (if  any).
+     * Return the cross staff above or below (if any).
      */
+    ///@{
     void GetCrossStaffExtremes(
         Staff *&staffAbove, Staff *&staffBelow, Layer **layerAbove = NULL, Layer **layerBelow = NULL);
+    void GetCrossStaffExtremes(const Staff *&staffAbove, const Staff *&staffBelow, const Layer **layerAbove = NULL,
+        const Layer **layerBelow = NULL) const;
+    ///@}
 
     /**
      * Return true if the chord has some cross staff notes.
      */
-    bool HasCrossStaff() override;
+    bool HasCrossStaff() const override;
 
     /**
      * Returns list of notes that have accidentals

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -151,7 +151,7 @@ public:
     /**
      * Return true if the chord has two notes with 1 diatonic step difference in the specific staff
      */
-    bool HasAdjacentNotesInStaff(Staff *staff);
+    bool HasAdjacentNotesInStaff(const Staff *staff) const;
 
     /**
      * Return true if the chord has at least one note with a @dots > 0
@@ -170,7 +170,7 @@ public:
      * Diatonic step difference is take up to 2 points, so HasAdjacentNotesInStaff() needs to be called first, to make
      * sure there actually are adjacent notes.
      */
-    std::list<Note *> GetAdjacentNotesList(Staff *staff, int loc);
+    std::list<Note *> GetAdjacentNotesList(const Staff *staff, int loc);
 
     //----------//
     // Functors //
@@ -248,14 +248,14 @@ protected:
     /**
      * The note locations w.r.t. each staff
      */
-    MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) override;
+    MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) const override;
 
     /**
      * The dot locations w.r.t. each staff
      * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
      * secondary
      */
-    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) override;
+    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) const override;
 
     /**
      * Calculate stem direction based on the position of the notes in chord. Notes are compared in pairs starting from

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -41,8 +41,8 @@ public:
     /** Override the method since alignment is required */
     bool HasToBeAligned() const override { return true; }
 
-    std::set<int> GetDotLocsForStaff(Staff *staff) const;
-    std::set<int> &ModifyDotLocsForStaff(Staff *staff);
+    std::set<int> GetDotLocsForStaff(const Staff *staff) const;
+    std::set<int> &ModifyDotLocsForStaff(const Staff *staff);
 
     const MapOfDotLocs &GetMapOfDotLocs() const { return m_dotLocsByStaff; }
     void SetMapOfDotLocs(const MapOfDotLocs &dotLocs) { m_dotLocsByStaff = dotLocs; };
@@ -174,9 +174,9 @@ public:
      * @name Setter and getter for drawing rel positions
      */
     ///@{
-    int GetDrawingXRelLeft() { return m_drawingXRelLeft; }
+    int GetDrawingXRelLeft() const { return m_drawingXRelLeft; }
     void SetDrawingXRelLeft(int drawingXRelLeft) { m_drawingXRelLeft = drawingXRelLeft; }
-    int GetDrawingXRelRight() { return m_drawingXRelRight; }
+    int GetDrawingXRelRight() const { return m_drawingXRelRight; }
     void SetDrawingXRelRight(int drawingXRelRight) { m_drawingXRelRight = drawingXRelRight; }
     // Vertical positions
     int GetDrawingYRelLeft() const { return m_drawingYRelLeft; }
@@ -186,16 +186,16 @@ public:
     ///@}
 
     /**
-     * @name Setter and getter for darwing positions.
+     * @name Setter and getter for drawing positions.
      * Takes into account:
      * - the position of the first and last element.
      * - the position of the beam if aligned with a beam.
      */
     ///@{
-    int GetDrawingXLeft();
-    int GetDrawingXRight();
-    int GetDrawingYLeft();
-    int GetDrawingYRight();
+    int GetDrawingXLeft() const;
+    int GetDrawingXRight() const;
+    int GetDrawingYLeft() const;
+    int GetDrawingYRight() const;
     ///@}
 
     /**
@@ -203,6 +203,7 @@ public:
      */
     ///@{
     TupletNum *GetAlignedNum() { return m_alignedNum; }
+    const TupletNum *GetAlignedNum() const { return m_alignedNum; }
     void SetAlignedNum(TupletNum *alignedNum) { m_alignedNum = alignedNum; }
     ///@}
 
@@ -284,8 +285,8 @@ public:
      * - the position of the beam if aligned with a beam.
      */
     ///@{
-    int GetDrawingYMid();
-    int GetDrawingXMid(Doc *doc = NULL);
+    int GetDrawingYMid() const;
+    int GetDrawingXMid(const Doc *doc = NULL) const;
     ///@}
 
     /**
@@ -293,6 +294,7 @@ public:
      */
     ///@{
     TupletBracket *GetAlignedBracket() { return m_alignedBracket; }
+    const TupletBracket *GetAlignedBracket() const { return m_alignedBracket; }
     void SetAlignedBracket(TupletBracket *alignedBracket);
     ///@}
 
@@ -364,7 +366,7 @@ public:
     void SetDrawingStemDir(data_STEMDIRECTION drawingStemDir) { m_drawingStemDir = drawingStemDir; }
     int GetDrawingStemLen() const { return m_drawingStemLen; }
     void SetDrawingStemLen(int drawingStemLen) { m_drawingStemLen = drawingStemLen; }
-    int GetDrawingStemAdjust() { return m_drawingStemAdjust; }
+    int GetDrawingStemAdjust() const { return m_drawingStemAdjust; }
     void SetDrawingStemAdjust(int drawingStemAdjust) { m_drawingStemAdjust = drawingStemAdjust; }
     int GetStemModRelY() const { return m_stemModRelY; }
     ///@}
@@ -380,7 +382,7 @@ public:
     /**
      * Helper to adjust overlaping layers for stems
      */
-    int CompareToElementPosition(const Doc *doc, LayerElement *otherElement, int margin);
+    int CompareToElementPosition(const Doc *doc, const LayerElement *otherElement, int margin) const;
 
     /**
      * Helper to calculate stem modifier relative Y rel and required adjustment for stem length
@@ -413,7 +415,7 @@ private:
     /**
      * Addjusts flag placement and stem length if they are crossing notehead or ledger lines
      */
-    void AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration);
+    void AdjustFlagPlacement(const Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration);
 
     /**
      * Helper to adjust length of stem based on presence of slashes

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -387,7 +387,7 @@ public:
     /**
      * Helper to calculate stem modifier relative Y rel and required adjustment for stem length
      */
-    int CalculateStemModAdjustment(Doc *doc, Staff *staff, int flagOffset = 0);
+    int CalculateStemModAdjustment(const Doc *doc, const Staff *staff, int flagOffset = 0);
 
     //----------//
     // Functors //
@@ -420,12 +420,12 @@ private:
     /**
      * Helper to adjust length of stem based on presence of slashes
      */
-    int AdjustSlashes(Doc *doc, Staff *staff, int flagOffset);
+    int AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) const;
 
     /**
      * Helper to calculate relative position for the stem modifier
      */
-    void CalculateStemModRelY(Doc *doc, Staff *staff);
+    void CalculateStemModRelY(const Doc *doc, const Staff *staff);
 
 public:
     //

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -380,7 +380,7 @@ public:
     /**
      * Helper to adjust overlaping layers for stems
      */
-    int CompareToElementPosition(Doc *doc, LayerElement *otherElement, int margin);
+    int CompareToElementPosition(const Doc *doc, LayerElement *otherElement, int margin);
 
     /**
      * Helper to calculate stem modifier relative Y rel and required adjustment for stem length

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1832,7 +1832,7 @@ public:
         m_searchDirection = searchDirection;
         m_isInNeighboringLayer = anotherLayer;
     }
-    Object *m_relativeElement;
+    const Object *m_relativeElement;
     int m_initialElementId;
     bool m_searchDirection;
     bool m_isInNeighboringLayer;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -591,7 +591,7 @@ public:
  **/
 class AdjustTupletNumOverlapParams : public FunctorParams {
 public:
-    AdjustTupletNumOverlapParams(TupletNum *tupletNum, Staff *staff)
+    AdjustTupletNumOverlapParams(const TupletNum *tupletNum, const Staff *staff)
     {
         m_tupletNum = tupletNum;
         m_drawingNumPos = STAFFREL_basic_NONE;
@@ -601,11 +601,11 @@ public:
         m_yRel = 0;
     }
 
-    TupletNum *m_tupletNum;
+    const TupletNum *m_tupletNum;
     data_STAFFREL_basic m_drawingNumPos;
     int m_horizontalMargin;
     int m_verticalMargin;
-    Staff *m_staff;
+    const Staff *m_staff;
     int m_yRel;
 };
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2022,7 +2022,7 @@ public:
 
 class LayerCountInTimeSpanParams : public FunctorParams {
 public:
-    LayerCountInTimeSpanParams(MeterSig *meterSig, Mensur *mensur, Functor *functor)
+    LayerCountInTimeSpanParams(const MeterSig *meterSig, const Mensur *mensur, Functor *functor)
     {
         m_time = 0.0;
         m_duration = 0.0;
@@ -2033,8 +2033,8 @@ public:
     double m_time;
     double m_duration;
     std::set<int> m_layers;
-    MeterSig *m_meterSig;
-    Mensur *m_mensur;
+    const MeterSig *m_meterSig;
+    const Mensur *m_mensur;
     Functor *m_functor;
 };
 
@@ -2053,7 +2053,7 @@ public:
 
 class LayerElementsInTimeSpanParams : public FunctorParams {
 public:
-    LayerElementsInTimeSpanParams(MeterSig *meterSig, Mensur *mensur, Layer *layer)
+    LayerElementsInTimeSpanParams(const MeterSig *meterSig, const Mensur *mensur, const Layer *layer)
     {
         m_time = 0.0;
         m_duration = 0.0;
@@ -2065,10 +2065,10 @@ public:
     double m_time;
     double m_duration;
     bool m_allLayersButCurrent;
-    ListOfObjects m_elements;
-    MeterSig *m_meterSig;
-    Mensur *m_mensur;
-    Layer *m_layer;
+    ListOfConstObjects m_elements;
+    const MeterSig *m_meterSig;
+    const Mensur *m_mensur;
+    const Layer *m_layer;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -103,7 +103,7 @@ public:
      * Static methods for calculating position;
      */
     static data_PITCHNAME GetAccidPnameAt(data_ACCIDENTAL_WRITTEN alterationType, int pos);
-    static int GetOctave(data_ACCIDENTAL_WRITTEN alterationType, data_PITCHNAME pitch, Clef *clef);
+    static int GetOctave(data_ACCIDENTAL_WRITTEN alterationType, data_PITCHNAME pitch, const Clef *clef);
 
     //----------//
     // Functors //

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -110,8 +110,8 @@ public:
      */
     ///@{
     void SetDrawingStemDir(data_STEMDIRECTION stemDirection) { m_drawingStemDir = stemDirection; }
-    data_STEMDIRECTION GetDrawingStemDir(LayerElement *element);
-    data_STEMDIRECTION GetDrawingStemDir(const ArrayOfBeamElementCoords *coords);
+    data_STEMDIRECTION GetDrawingStemDir(const LayerElement *element) const;
+    data_STEMDIRECTION GetDrawingStemDir(const ArrayOfBeamElementCoords *coords) const;
     data_STEMDIRECTION GetDrawingStemDir() const { return m_drawingStemDir; }
     ///@}
 
@@ -120,8 +120,8 @@ public:
      * Takes into account cross-staff situations: cross staff layers have negative N.
      */
     ///@{
-    std::set<int> GetLayersNForTimeSpanOf(LayerElement *element);
-    int GetLayerCountForTimeSpanOf(LayerElement *element);
+    std::set<int> GetLayersNForTimeSpanOf(const LayerElement *element) const;
+    int GetLayerCountForTimeSpanOf(const LayerElement *element) const;
     ///@}
 
     /**
@@ -129,8 +129,8 @@ public:
      * Takes into account cross-staff situations: cross staff layers have negative N.
      */
     ///@{
-    std::set<int> GetLayersNInTimeSpan(double time, double duration, Measure *measure, int staff);
-    int GetLayerCountInTimeSpan(double time, double duration, Measure *measure, int staff);
+    std::set<int> GetLayersNInTimeSpan(double time, double duration, const Measure *measure, int staff) const;
+    int GetLayerCountInTimeSpan(double time, double duration, const Measure *measure, int staff) const;
     ///@}
 
     /**
@@ -138,20 +138,35 @@ public:
      * Takes into account cross-staff situations.
      * If excludeCurrent is specified, gets the list of layer elements for all layers except current
      */
-    ListOfObjects GetLayerElementsForTimeSpanOf(LayerElement *element, bool excludeCurrent = false);
+    ///@{
+    ListOfObjects GetLayerElementsForTimeSpanOf(const LayerElement *element, bool excludeCurrent = false);
+    ListOfConstObjects GetLayerElementsForTimeSpanOf(const LayerElement *element, bool excludeCurrent = false) const;
+    ///@}
 
     /**
      * Get the list of the layer elements used within a time span.
      * Takes into account cross-staff situations.
      */
+    ///@{
     ListOfObjects GetLayerElementsInTimeSpan(
-        double time, double duration, Measure *measure, int staff, bool excludeCurrent);
+        double time, double duration, const Measure *measure, int staff, bool excludeCurrent);
+    ListOfConstObjects GetLayerElementsInTimeSpan(
+        double time, double duration, const Measure *measure, int staff, bool excludeCurrent) const;
+    ///@}
 
+    /**
+     * Get the current clef, keysig, mensur and meterSig
+     */
+    ///@{
     Clef *GetCurrentClef();
     const Clef *GetCurrentClef() const;
     KeySig *GetCurrentKeySig();
+    const KeySig *GetCurrentKeySig() const;
     Mensur *GetCurrentMensur();
+    const Mensur *GetCurrentMensur() const;
     MeterSig *GetCurrentMeterSig();
+    const MeterSig *GetCurrentMeterSig() const;
+    ///@}
 
     void ResetStaffDefObjects();
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -446,7 +446,7 @@ public:
     /**
      * See Object::GetRelativeLayerElement
      */
-    int GetRelativeLayerElement(FunctorParams *functorParams) override;
+    int GetRelativeLayerElement(FunctorParams *functorParams) const override;
 
     /**
      * See Object::CalcSlurDirection

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -475,14 +475,14 @@ protected:
     /**
      * The note locations w.r.t. each staff, implemented for note and chord
      */
-    virtual MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) { return {}; }
+    virtual MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) const { return {}; }
 
     /**
      * The dot locations w.r.t. each staff, implemented for note and chord
      * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
      * secondary
      */
-    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) { return {}; }
+    virtual MapOfDotLocs CalcDotLocations(int layerCount, bool primary) const { return {}; }
 
     /**
      * Helper function to calculate overlap with layer elements that

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -400,12 +400,12 @@ public:
     /**
      * See Object::LayerCountInTimeSpan
      */
-    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
+    int LayerCountInTimeSpan(FunctorParams *functorParams) const override;
 
     /**
      * See Object::LayerElementsInTimeSpan
      */
-    int LayerElementsInTimeSpan(FunctorParams *functorParams) override;
+    int LayerElementsInTimeSpan(FunctorParams *functorParams) const override;
 
     /**
      * See Object::InitOnsetOffset

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -97,7 +97,10 @@ public:
     /**
      * Return itself or the resolved @sameas (if any)
      */
-    LayerElement *ThisOrSameasAsLink();
+    ///@{
+    LayerElement *ThisOrSameasLink();
+    const LayerElement *ThisOrSameasLink() const;
+    ///@}
 
     /**
      * @name Set and get the flag for indication whether it is a ScoreDef or StaffDef attribute.
@@ -145,7 +148,7 @@ public:
     /**
      * @return (cross) layer number, parent layer number for cross staff elements
      */
-    int GetOriginalLayerN();
+    int GetOriginalLayerN() const;
 
     /**
      * @name Get the X and Y drawing position
@@ -166,7 +169,7 @@ public:
     ///@}
 
     /**
-     * Ajust the m_drawingYRel for the element to be centered on the inner content of the measure
+     * Adjust the m_drawingYRel for the element to be centered on the inner content of the measure
      */
     void CenterDrawingX();
 
@@ -177,18 +180,22 @@ public:
      * articType indicates if the inside or outside artic part has to be taken into account (inside is taken
      * into account in any case)
      */
-    int GetDrawingTop(Doc *doc, int staffSize, bool withArtic = true, ArticType articType = ARTIC_INSIDE);
-    int GetDrawingBottom(Doc *doc, int staffSize, bool withArtic = true, ArticType articType = ARTIC_INSIDE);
+    int GetDrawingTop(const Doc *doc, int staffSize, bool withArtic = true, ArticType articType = ARTIC_INSIDE) const;
+    int GetDrawingBottom(
+        const Doc *doc, int staffSize, bool withArtic = true, ArticType articType = ARTIC_INSIDE) const;
 
     /**
      * Return the drawing radius for notes and chords
      */
-    int GetDrawingRadius(Doc *doc, bool isInLigature = false);
+    int GetDrawingRadius(const Doc *doc, bool isInLigature = false) const;
 
     /**
      * Alignment getter
      */
-    Alignment *GetAlignment() const { return m_alignment; }
+    ///@{
+    Alignment *GetAlignment() { return m_alignment; }
+    const Alignment *GetAlignment() const { return m_alignment; }
+    ///@}
 
     /**
      * Get the ancestor or cross staff
@@ -205,13 +212,13 @@ public:
      */
     ///@{
     Staff *GetCrossStaff(Layer *&layer);
-    const Staff *GetCrossStaff(Layer *&layer) const;
+    const Staff *GetCrossStaff(const Layer *&layer) const;
     ///@}
 
     /**
      * Retrieve the direction of a cross-staff situation
      */
-    data_STAFFREL_basic GetCrossStaffRel();
+    data_STAFFREL_basic GetCrossStaffRel() const;
 
     /**
      * Get the StaffAlignment for which overflows need to be calculated against.
@@ -232,37 +239,37 @@ public:
     /**
      * Returns the duration if the element has a DurationInterface
      */
-    double GetAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
+    double GetAlignmentDuration(const Mensur *mensur = NULL, const MeterSig *meterSig = NULL, bool notGraceOnly = true,
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
 
     /**
      * Returns the duration if the content of the layer element with a @sameas attribute.
      * Used only on beam, tuplet or ftrem have.
      */
-    double GetSameAsContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
+    double GetSameAsContentAlignmentDuration(const Mensur *mensur = NULL, const MeterSig *meterSig = NULL,
+        bool notGraceOnly = true, data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
 
-    double GetContentAlignmentDuration(Mensur *mensur = NULL, MeterSig *meterSig = NULL, bool notGraceOnly = true,
-        data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn);
+    double GetContentAlignmentDuration(const Mensur *mensur = NULL, const MeterSig *meterSig = NULL,
+        bool notGraceOnly = true, data_NOTATIONTYPE notationType = NOTATIONTYPE_cmn) const;
 
     /**
      * Get zone bounds using child elements with facsimile information.
      * Returns true if bounds can be constructed, false otherwise.
      */
-    bool GenerateZoneBounds(int *ulx, int *uly, int *lrx, int *lry);
+    bool GenerateZoneBounds(int *ulx, int *uly, int *lrx, int *lry) const;
 
     /**
      * Helper to adjust overlapping layers for notes, chords, stems, etc.
      * Returns the shift of the adjustment
      */
-    virtual int AdjustOverlappingLayers(Doc *doc, const std::vector<LayerElement *> &otherElements,
+    virtual int AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElement *> &otherElements,
         bool areDotsAdjusted, bool &isUnison, bool &stemSameAs);
 
     /**
      * Calculate note horizontal overlap with elemenents from another layers. Returns overlapMargin and index of other
      * element if it's in unison with it
      */
-    std::pair<int, bool> CalcElementHorizontalOverlap(Doc *doc, const std::vector<LayerElement *> &otherElements,
+    std::pair<int, bool> CalcElementHorizontalOverlap(const Doc *doc, const std::vector<LayerElement *> &otherElements,
         bool areDotsAdjusted, bool isChordElement, bool isLowerElement = false, bool unison = true);
 
     /**
@@ -278,7 +285,7 @@ public:
     /**
      * Return true if cross-staff is set
      */
-    virtual bool HasCrossStaff() { return !!m_crossStaff; }
+    virtual bool HasCrossStaff() { return (m_crossStaff != NULL); }
 
     /**
      * Convert stem mode to corresponding glyph code
@@ -463,7 +470,7 @@ protected:
      * Returns vector with all locations of elements in unison.
      */
     std::vector<int> GetElementsInUnison(
-        const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection);
+        const std::set<int> &firstChord, const std::set<int> &secondChord, data_STEMDIRECTION stemDirection) const;
 
     /**
      * The note locations w.r.t. each staff, implemented for note and chord
@@ -481,7 +488,7 @@ protected:
      * Helper function to calculate overlap with layer elements that
      * are placed within the duration of element
      */
-    int CalcLayerOverlap(Doc *doc, int direction, int y1, int y2);
+    int CalcLayerOverlap(const Doc *doc, int direction, int y1, int y2);
 
     /**
      * Calculate the optimal dot location for a note or chord
@@ -505,7 +512,7 @@ protected:
     static int GetCollisionCount(const MapOfDotLocs &dotLocs1, const MapOfDotLocs &dotLocs2);
 
 private:
-    int GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type);
+    int GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type) const;
 
     /**
      * Get above/below overflow for the chord elements

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -285,7 +285,7 @@ public:
     /**
      * Return true if cross-staff is set
      */
-    virtual bool HasCrossStaff() { return (m_crossStaff != NULL); }
+    virtual bool HasCrossStaff() const { return (m_crossStaff != NULL); }
 
     /**
      * Convert stem mode to corresponding glyph code

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -342,7 +342,7 @@ public:
     /**
      * See Object::AdjustTupletNumOverlap
      */
-    int AdjustTupletNumOverlap(FunctorParams *functorParams) override;
+    int AdjustTupletNumOverlap(FunctorParams *functorParams) const override;
 
     /**
      * See Object::AdjustXPos

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -231,7 +231,8 @@ public:
      * @name Setter and getter for the Alignment the grace note is pointing to (NULL by default)
      */
     ///@{
-    Alignment *GetGraceAlignment() const;
+    Alignment *GetGraceAlignment();
+    const Alignment *GetGraceAlignment() const;
     void SetGraceAlignment(Alignment *graceAlignment);
     bool HasGraceAlignment() const { return (m_graceAlignment != NULL); }
     ///@}

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -60,10 +60,7 @@ public:
     /**
      * @name Return shape information about the note ligature
      */
-    ///@{
-    int GetDrawingNoteShape(Note *note);
-    int GetDrawingPreviousNoteShape(Note *note);
-    ///@}
+    int GetDrawingNoteShape(const Note *note) const;
 
     //----------//
     // Functors //

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -170,7 +170,9 @@ public:
      */
     ///@{
     BarLine *GetLeftBarLine() { return &m_leftBarLine; }
+    const BarLine *GetLeftBarLine() const { return &m_leftBarLine; }
     BarLine *GetRightBarLine() { return &m_rightBarLine; }
+    const BarLine *GetRightBarLine() const { return &m_rightBarLine; }
     ///@}
 
     /**

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -58,7 +58,7 @@ public:
     /**
      * See Object::LayerCountInTimeSpan
      */
-    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
+    int LayerCountInTimeSpan(FunctorParams *functorParams) const override;
 
 private:
     //

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -59,7 +59,7 @@ public:
     /**
      * See Object::LayerCountInTimeSpan
      */
-    int LayerCountInTimeSpan(FunctorParams *functorParams) override;
+    int LayerCountInTimeSpan(FunctorParams *functorParams) const override;
 
 private:
     //

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -65,7 +65,7 @@ public:
     /**
      * Add specified measureId to the m_alternatingMeasures vector
      */
-    void AddAlternatingMeasureToVector(Measure *measure);
+    void AddAlternatingMeasureToVector(const Measure *measure);
 
     /**
      * Get simplified (i.e. single metersig with count/unit) based on the MeterSigGrp function

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -54,7 +54,7 @@ public:
     /**
      * Get the vertical location for mRest considering other layer elements
      */
-    int GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation);
+    int GetOptimalLayerLocation(const Layer *layer, int defaultLocation) const;
 
     //----------//
     // Functors //

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -46,7 +46,7 @@ public:
     /**
      * True if block style rendering applies
      */
-    bool UseBlockStyle(Doc *doc) const;
+    bool UseBlockStyle(const Doc *doc) const;
 
 private:
     //

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -168,7 +168,7 @@ public:
      * Return true if the note is a unison.
      * If ignoreAccid is set to true then only @pname and @oct are compared.
      */
-    bool IsUnisonWith(Note *note, bool ignoreAccid = false);
+    bool IsUnisonWith(const Note *note, bool ignoreAccid = false) const;
 
     /**
      * @name Setter and getter for the chord cluster and the position of the note
@@ -214,7 +214,7 @@ public:
     /**
      * Check whether current note is enharmonic with another
      */
-    bool IsEnharmonicWith(Note *note);
+    bool IsEnharmonicWith(const Note *note) const;
 
     /**
      * Check if a note or its parent chord are visible
@@ -224,7 +224,7 @@ public:
     /**
      * MIDI pitch
      */
-    int GetMIDIPitch(int shift = 0);
+    int GetMIDIPitch(int shift = 0) const;
 
     /**
      * @name Checker, getter and setter for a note with which the stem is shared
@@ -365,7 +365,7 @@ private:
     /**
      * Get the pitch difference in semitones of the accidental (implicit or explicit) for this note.
      */
-    int GetChromaticAlteration();
+    int GetChromaticAlteration() const;
 
     TransPitch GetTransPitch();
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -254,14 +254,14 @@ public:
      * Encoded stem direction on the calling note is taken into account.
      * Called from Note::CalcStem
      */
-    data_STEMDIRECTION CalcStemDirForSameasNote(Doc *doc, int verticalCenter);
+    data_STEMDIRECTION CalcStemDirForSameasNote(int verticalCenter);
 
     /**
      * Set the Note::m_flippedNotehead flag if one of the two notes needs to be placed on the side.
      * The note X relative position remains untouched because we do not want the stem position to be changed.
      * This is different than with chords. It means the the X position is actually corrected when drawing the note.
      */
-    void CalcNoteHeadShiftForSameasNote(Doc *doc, Note *stemSameas, data_STEMDIRECTION stemDir);
+    void CalcNoteHeadShiftForSameasNote(Note *stemSameas, data_STEMDIRECTION stemDir);
 
 public:
     //----------------//

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -112,7 +112,7 @@ public:
     /**
      * Align dots shift for two notes. Should be used for unison notes to align dots positioning
      */
-    void AlignDotsShift(Note *otherNote);
+    void AlignDotsShift(const Note *otherNote);
 
     /**
      * @name Setter and getter for accid attribute and other pointers
@@ -175,7 +175,7 @@ public:
      */
     ///@{
     void SetCluster(ChordCluster *cluster, int position);
-    ChordCluster *GetCluster() const { return m_cluster; }
+    ChordCluster *GetCluster() { return m_cluster; }
     ///@}
 
     /**
@@ -231,7 +231,8 @@ public:
      */
     ///@{
     bool HasStemSameasNote() const { return (m_stemSameas); }
-    Note *GetStemSameasNote() const { return m_stemSameas; }
+    Note *GetStemSameasNote() { return m_stemSameas; }
+    const Note *GetStemSameasNote() const { return m_stemSameas; }
     void SetStemSameasNote(Note *stemSameas) { m_stemSameas = stemSameas; }
     ///@}
 
@@ -272,7 +273,7 @@ public:
      * Assume that two notes from different layers are given occuring at the same time
      * Returns true if one note has a ledger line that collides (or is quite close) to the other note's stem
      */
-    static bool HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, Note *note2);
+    static bool HandleLedgerLineStemCollision(const Doc *doc, const Staff *staff, const Note *note1, const Note *note2);
 
     //----------//
     // Functors //
@@ -367,7 +368,7 @@ private:
      */
     int GetChromaticAlteration() const;
 
-    TransPitch GetTransPitch();
+    TransPitch GetTransPitch() const;
 
     void UpdateFromTransPitch(const TransPitch &tp);
 
@@ -375,7 +376,7 @@ private:
      * Return whether dots are overlapping with flag. Take into account flag height, its position as well
      * as position of the note and position of the dots
      */
-    bool IsDotOverlappingWithFlag(Doc *doc, const int staffSize, int dotLocShift);
+    bool IsDotOverlappingWithFlag(const Doc *doc, const int staffSize, int dotLocShift) const;
 
     /**
      * Register deferred notes for MIDI

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -352,14 +352,14 @@ protected:
     /**
      * The note locations w.r.t. each staff
      */
-    MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) override;
+    MapOfNoteLocs CalcNoteLocations(NotePredicate predicate = NULL) const override;
 
     /**
      * The dot locations w.r.t. each staff
      * Since dots for notes on staff lines can be shifted upwards or downwards, there are two choices: primary and
      * secondary
      */
-    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) override;
+    MapOfDotLocs CalcDotLocations(int layerCount, bool primary) const override;
 
 private:
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -710,12 +710,12 @@ public:
     /**
      * Look if the time / duration passed as parameter overlap with a space in the alignment references.
      */
-    virtual int LayerCountInTimeSpan(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int LayerCountInTimeSpan(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Look for all the layer elements that overlap with the time / duration within certain layer passed as parameter.
      */
-    virtual int LayerElementsInTimeSpan(FunctorParams *functorParams) { return FUNCTOR_CONTINUE; }
+    virtual int LayerElementsInTimeSpan(FunctorParams *functorParams) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Retrieve the layer elements spanned by two points

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -537,12 +537,18 @@ public:
      * Return the last ancestor that is NOT of the specified type.
      * The maxSteps parameter limits the search to a certain number of level if not -1.
      */
+    ///@{
     Object *GetLastAncestorNot(const ClassId classId, int maxSteps = -1);
+    const Object *GetLastAncestorNot(const ClassId classId, int maxSteps = -1) const;
+    ///@}
 
     /**
      * Return the first child that is NOT of the specified type.
      */
+    ///@{
     Object *GetFirstChildNot(const ClassId classId);
+    const Object *GetFirstChildNot(const ClassId classId) const;
+    ///@}
 
     /**
      * Fill the list of all the children LayerElement.
@@ -739,7 +745,7 @@ public:
      * It will search recursively through children elements until note, chord or ftrem is found.
      * It can be used to look in neighboring layers for the similar search, but only first element will be checked.
      */
-    virtual int GetRelativeLayerElement(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int GetRelativeLayerElement(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     ///@}
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1094,7 +1094,7 @@ public:
     /**
      * Calculate the Y relative position of tupletNum based on overlaps with other elements
      */
-    virtual int AdjustTupletNumOverlap(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int AdjustTupletNumOverlap(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Adjust the position of the StaffAlignment.

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -89,7 +89,7 @@ public:
     /**
      * Get the vertical location for the rests that are located on other layers
      */
-    int GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation);
+    int GetOptimalLayerLocation(const Staff *staff, const Layer *layer, int defaultLocation) const;
 
     //----------//
     // Functors //
@@ -145,17 +145,18 @@ private:
      * Get the rest vertical location relative to location of elements placed on other layers
      */
     std::pair<int, RestAccidental> GetLocationRelativeToOtherLayers(
-        const ListOfObjects &layersList, Layer *currentLayer, bool isTopLayer, bool &restOverlap);
+        const ListOfConstObjects &layersList, const Layer *currentLayer, bool isTopLayer, bool &restOverlap) const;
 
     /**
      * Get the rest vertical location relative to location of elements placed on current layers
      */
-    int GetLocationRelativeToCurrentLayer(Staff *currentStaff, Layer *currentLayer, bool isTopLayer);
+    int GetLocationRelativeToCurrentLayer(const Staff *currentStaff, const Layer *currentLayer, bool isTopLayer) const;
 
     /**
      * Get location of first/last element of the corresponding layer
      */
-    int GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLayer, bool isPrevious, bool isTopLayer);
+    int GetFirstRelativeElementLocation(
+        const Staff *currentStaff, const Layer *currentLayer, bool isPrevious, bool isTopLayer) const;
 
     /**
      * For two layers, top layer shouldn't go below center and lower layer shouldn't go above it. Enforce this by
@@ -166,7 +167,7 @@ private:
     /**
      * Get location of the object on the layer if it's note, chord or ftrem
      */
-    std::pair<int, RestAccidental> GetElementLocation(Object *object, Layer *layer, bool isTopLayer) const;
+    std::pair<int, RestAccidental> GetElementLocation(const Object *object, const Layer *layer, bool isTopLayer) const;
 
     /**
      * Get correct offset for the rest from the options based on layer and location

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -158,7 +158,7 @@ public:
      * Used for calculating clustered information/dot position.
      * The *Doc is the parent doc but passed as param in order to avoid look-up
      */
-    bool IsOnStaffLine(int y, Doc *doc);
+    bool IsOnStaffLine(int y, const Doc *doc) const;
 
     /**
      * Find the nearest unit position in the direction indicated by place.

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -75,7 +75,7 @@ public:
      * direction has been determined. This is why we have this method called from
      * Beam::CalcTabBeamPlace
      */
-    void AdjustDrawingYRel(Staff *staff, Doc *doc);
+    void AdjustDrawingYRel(const Staff *staff, const Doc *doc);
 
     //----------//
     // Functors //

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -127,17 +127,17 @@ private:
     /**
      * Adjust tuplet relative positioning based on possible overlaps
      */
-    void AdjustTupletBracketY(Doc *doc, Staff *staff);
+    void AdjustTupletBracketY(const Doc *doc, const Staff *staff);
 
     /**
      * Adjust tuplet relative positioning for tuplets based on beams
      */
-    void AdjustTupletBracketBeamY(Doc *doc, Staff *staff, TupletBracket *bracket, Beam *beam);
+    void AdjustTupletBracketBeamY(const Doc *doc, const Staff *staff, TupletBracket *bracket, const Beam *beam);
 
     /**
      * Adjust tuplet relative positioning based on possible overlaps
      */
-    void AdjustTupletNumY(Doc *doc, Staff *staff);
+    void AdjustTupletNumY(const Doc *doc, const Staff *staff);
 
     /**
      * Calculate corresponding cross-staff for the tuplet number if necessary. In case when tuplet is completely

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -53,15 +53,17 @@ public:
     void AddChild(Object *object) override;
 
     /**
-     * @name Setter and getter for darwing elements and position
+     * @name Setter and getter for drawing elements and position
      */
     ///@{
     LayerElement *GetDrawingLeft() { return m_drawingLeft; }
+    const LayerElement *GetDrawingLeft() const { return m_drawingLeft; }
     void SetDrawingLeft(LayerElement *drawingLeft) { m_drawingLeft = drawingLeft; }
     LayerElement *GetDrawingRight() { return m_drawingRight; }
+    const LayerElement *GetDrawingRight() const { return m_drawingRight; }
     void SetDrawingRight(LayerElement *drawingRight) { m_drawingRight = drawingRight; }
-    data_STAFFREL_basic GetDrawingBracketPos() { return m_drawingBracketPos; }
-    data_STAFFREL_basic GetDrawingNumPos() { return m_drawingNumPos; }
+    data_STAFFREL_basic GetDrawingBracketPos() const { return m_drawingBracketPos; }
+    data_STAFFREL_basic GetDrawingNumPos() const { return m_drawingNumPos; }
     ///@}
 
     /**
@@ -69,7 +71,9 @@ public:
      */
     ///@{
     Beam *GetBracketAlignedBeam() { return m_bracketAlignedBeam; }
+    const Beam *GetBracketAlignedBeam() const { return m_bracketAlignedBeam; }
     Beam *GetNumAlignedBeam() { return m_numAlignedBeam; }
+    const Beam *GetNumAlignedBeam() const { return m_numAlignedBeam; }
     ///@}
 
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -86,7 +86,7 @@ public:
      * Return the maximum and minimum X positions of the notes in the tuplets.
      * Look at flipped noteheads in chords.
      */
-    void GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc) const;
+    void GetDrawingLeftRightXRel(int &xRelLeft, int &xRelRight, const Doc *doc) const;
 
     //----------//
     // Functors //
@@ -148,7 +148,7 @@ private:
     /**
      * Check whether tuplet number has valid postioning staffwise
      */
-    bool HasValidTupletNumPosition(Staff *preferredStaff, Staff *otherStaff);
+    bool HasValidTupletNumPosition(const Staff *preferredStaff, const Staff *otherStaff) const;
 
 public:
     //

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -41,11 +41,19 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
+     * @name Getter for the labelAbbr
+     */
+    ///@{
+    LabelAbbr *GetDrawingLabelAbbr() { return m_drawingLabelAbbr; }
+    const LabelAbbr *GetDrawingLabelAbbr() const { return m_drawingLabelAbbr; }
+    ///@}
+
+    /**
      * Calculate the adjustment according to the overlap and the free space available before.
      * Will move the verse accordingly.
      * Called from Verse::AdjustSylSpacing and System::AdjustSylSpacingEnd
      */
-    int AdjustPosition(int &overlap, int freeSpace, Doc *doc);
+    int AdjustPosition(int &overlap, int freeSpace, const Doc *doc);
 
     //----------//
     // Functors //
@@ -74,12 +82,12 @@ public:
 private:
     //
 public:
+    //
+private:
     /**
      *  A pointer to the labelAbbr
      */
     LabelAbbr *m_drawingLabelAbbr;
-
-private:
 };
 
 } // namespace vrv

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -343,7 +343,7 @@ protected:
     ///@{
     void DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff);
     void DrawClefEnclosing(DeviceContext *dc, Clef *clef, Staff *staff, wchar_t glyph, int x, int y);
-    void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin = false);
+    void DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, const Staff *staff, bool dimin = false);
     void DrawKeyAccid(DeviceContext *dc, KeyAccid *keyAccid, Staff *staff, Clef *clef, int clefLocOffset, int &x);
     void DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int horizOffset);
     /** Returns the width of the drawn figures */

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -373,7 +373,7 @@ typedef std::map<std::string, ClassId> MapOfStrClassIds;
 
 typedef std::vector<std::pair<LayerElement *, LayerElement *>> MeasureTieEndpoints;
 
-typedef bool (*NotePredicate)(Note *);
+typedef bool (*NotePredicate)(const Note *);
 
 /**
  * Generic int map recursive structure for storing hierachy of values

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -355,9 +355,9 @@ typedef std::vector<LedgerLine> ArrayOfLedgerLines;
 
 typedef std::vector<TextElement *> ArrayOfTextElements;
 
-typedef std::map<Staff *, std::multiset<int>> MapOfNoteLocs;
+typedef std::map<const Staff *, std::multiset<int>> MapOfNoteLocs;
 
-typedef std::map<Staff *, std::set<int>> MapOfDotLocs;
+typedef std::map<const Staff *, std::set<int>> MapOfDotLocs;
 
 typedef std::map<std::string, Option *> MapOfStrOptions;
 

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -129,7 +129,7 @@ std::wstring Accid::GetSymbolStr(const data_NOTATIONTYPE notationType) const
     return symbolStr;
 }
 
-void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
+void Accid::AdjustToLedgerLines(const Doc *doc, LayerElement *element, int staffSize)
 {
     Staff *staff = element->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
@@ -152,7 +152,7 @@ void Accid::AdjustToLedgerLines(Doc *doc, LayerElement *element, int staffSize)
     }
 }
 
-void Accid::AdjustX(LayerElement *element, Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
+void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
     std::vector<Accid *> &adjustedAccids)
 {
     assert(element);

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -148,23 +148,7 @@ void Artic::GetAllArtics(bool direction, std::vector<Artic *> &artics)
     }
 }
 
-void Artic::SplitArtic(std::vector<data_ARTICULATION> *insideSlur, std::vector<data_ARTICULATION> *outsideSlur)
-{
-    assert(insideSlur);
-    assert(outsideSlur);
-
-    std::vector<data_ARTICULATION> articList = this->GetArtic();
-    for (data_ARTICULATION artic : articList) {
-        if (IsInsideArtic(artic)) {
-            insideSlur->push_back(artic);
-        }
-        else {
-            outsideSlur->push_back(artic);
-        }
-    }
-}
-
-bool Artic::AlwaysAbove()
+bool Artic::AlwaysAbove() const
 {
     auto end = Artic::s_aboveStaffArtic.end();
     auto i = std::find(Artic::s_aboveStaffArtic.begin(), end, this->GetArticFirst());
@@ -549,7 +533,7 @@ int Artic::ResetData(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Artic::CalculateHorizontalShift(Doc *doc, LayerElement *parent, data_STEMDIRECTION stemDir) const
+int Artic::CalculateHorizontalShift(const Doc *doc, const LayerElement *parent, data_STEMDIRECTION stemDir) const
 {
     int shift = parent->GetDrawingRadius(doc);
     if ((parent->GetChildCount(ARTIC) > 1) || (doc->GetOptions()->m_staccatoCenter.GetValue())) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -68,7 +68,7 @@ void BeamSegment::Reset()
     m_stemSameasReverseRole = NULL;
 }
 
-const ArrayOfBeamElementCoords *BeamSegment::GetElementCoordRefs() const
+const ArrayOfBeamElementCoords *BeamSegment::GetElementCoordRefs()
 {
     // this->GetList(this);
     return &m_beamElementCoordRefs;
@@ -85,7 +85,7 @@ void BeamSegment::InitCoordRefs(const ArrayOfBeamElementCoords *beamElementCoord
 }
 
 void BeamSegment::CalcBeam(
-    Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place, bool init)
+    Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place, bool init)
 {
     assert(layer);
     assert(staff);
@@ -144,7 +144,7 @@ void BeamSegment::CalcBeam(
     }
 }
 
-void BeamSegment::CalcSetStemValues(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface)
+void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface)
 {
     assert(staff);
     assert(doc);
@@ -255,7 +255,7 @@ void BeamSegment::CalcSetStemValues(Staff *staff, Doc *doc, BeamDrawingInterface
     this->AdjustBeamToTremolos(doc, staff, beamInterface);
 }
 
-void BeamSegment::CalcSetStemValuesTab(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface)
+void BeamSegment::CalcSetStemValuesTab(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface)
 {
     assert(staff);
     assert(doc);
@@ -302,7 +302,8 @@ void BeamSegment::CalcSetStemValuesTab(Staff *staff, Doc *doc, BeamDrawingInterf
     }
 }
 
-bool BeamSegment::DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff)
+bool BeamSegment::DoesBeamOverlap(
+    int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff) const
 {
     // find if current beam fits within the staff
     auto outsideBounds
@@ -329,7 +330,7 @@ bool BeamSegment::DoesBeamOverlap(int staffTop, int topOffset, int staffBottom, 
     return (overlapping != m_beamElementCoordRefs.end());
 }
 
-bool BeamSegment::NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface)
+bool BeamSegment::NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface)
 {
     const int unit = doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     const auto [topBeams, bottomBeams] = beamInterface->GetAdditionalBeamCount();
@@ -438,7 +439,7 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, Doc *doc, BeamDrawingInterfa
     return true;
 }
 
-void BeamSegment::AdjustBeamToFrenchStyle(BeamDrawingInterface *beamInterface)
+void BeamSegment::AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterface)
 {
     assert(beamInterface);
 
@@ -683,13 +684,14 @@ void BeamSegment::CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *bea
     m_weightedPlace = ((m_verticalCenter - yMin) > (yMax - m_verticalCenter)) ? BEAMPLACE_above : BEAMPLACE_below;
 }
 
-void BeamSegment::CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff, int &yMax, int &yMin)
+void BeamSegment::CalcBeamInitForNotePair(
+    const Note *note1, const Note *note2, const Staff *staff, int &yMax, int &yMin)
 {
     assert(note1);
     assert(note2);
 
-    Note *bottomNote = (note1->GetDrawingY() > note2->GetDrawingY()) ? note2 : note1;
-    Note *topNote = (note1->GetDrawingY() > note2->GetDrawingY()) ? note1 : note2;
+    const Note *bottomNote = (note1->GetDrawingY() > note2->GetDrawingY()) ? note2 : note1;
+    const Note *topNote = (note1->GetDrawingY() > note2->GetDrawingY()) ? note1 : note2;
 
     yMax = bottomNote->GetDrawingY();
     yMin = topNote->GetDrawingY();
@@ -704,7 +706,7 @@ void BeamSegment::CalcBeamInitForNotePair(Note *note1, Note *note2, Staff *staff
     }
 }
 
-bool BeamSegment::CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step)
+bool BeamSegment::CalcBeamSlope(const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, int &step)
 {
     assert(staff);
     assert(doc);
@@ -843,7 +845,7 @@ bool BeamSegment::CalcBeamSlope(Staff *staff, Doc *doc, BeamDrawingInterface *be
 }
 
 int BeamSegment::CalcBeamSlopeStep(
-    Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep)
+    const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep)
 {
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     // Default (maximum) step is two stave-spaces (4 units)
@@ -900,7 +902,7 @@ int BeamSegment::CalcBeamSlopeStep(
     return step;
 }
 
-void BeamSegment::CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int step)
+void BeamSegment::CalcMixedBeamStem(const BeamDrawingInterface *beamInterface, int step)
 {
     // In cases, when both first and last notes/chords of the beam have same relative places (i.e. they have same stem
     // direction and/or same staff), - we don't need additional calculations
@@ -939,7 +941,8 @@ void BeamSegment::CalcMixedBeamStem(BeamDrawingInterface *beamInterface, int ste
     }
 }
 
-void BeamSegment::CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal)
+void BeamSegment::CalcBeamPosition(
+    const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal)
 {
     // Set drawing stem positions
     for (auto coord : m_beamElementCoordRefs) {
@@ -987,7 +990,7 @@ void BeamSegment::CalcBeamPosition(Doc *doc, Staff *staff, BeamDrawingInterface 
     if (!beamInterface->m_crossStaffContent) this->AdjustBeamToLedgerLines(doc, staff, beamInterface, isHorizontal);
 }
 
-void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, int &step)
+void BeamSegment::CalcAdjustSlope(const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, int &step)
 {
     assert(staff);
     assert(doc);
@@ -1107,7 +1110,7 @@ void BeamSegment::CalcAdjustSlope(Staff *staff, Doc *doc, BeamDrawingInterface *
     }
 }
 
-void BeamSegment::CalcAdjustPosition(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface)
+void BeamSegment::CalcAdjustPosition(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface)
 {
     const int staffTop = staff->GetDrawingY();
     const int staffHeight = doc->GetDrawingStaffSize(staff->m_drawingStaffSize);
@@ -1194,7 +1197,7 @@ void BeamSegment::CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterfac
 }
 
 void BeamSegment::CalcBeamPlaceTab(
-    Layer *layer, Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
+    const Layer *layer, const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
 {
     assert(layer);
     assert(staff);
@@ -1223,7 +1226,7 @@ void BeamSegment::CalcBeamPlaceTab(
     }
 }
 
-void BeamSegment::CalcBeamStemLength(Staff *staff, data_BEAMPLACE place, bool isHorizontal)
+void BeamSegment::CalcBeamStemLength(const Staff *staff, data_BEAMPLACE place, bool isHorizontal)
 {
     const auto [noteLoc, noteDur] = this->CalcStemDefiningNote(staff, place);
     const data_STEMDIRECTION globalStemDir = (place == BEAMPLACE_below) ? STEMDIRECTION_down : STEMDIRECTION_up;
@@ -1272,7 +1275,7 @@ std::pair<int, int> BeamSegment::CalcBeamRelativeMinMax(data_BEAMPLACE place) co
     return { highestPoint, lowestPoint };
 }
 
-std::pair<int, int> BeamSegment::CalcStemDefiningNote(Staff *staff, data_BEAMPLACE place)
+std::pair<int, int> BeamSegment::CalcStemDefiningNote(const Staff *staff, data_BEAMPLACE place) const
 {
     int shortestDuration = DUR_4;
     int shortestLoc = VRV_UNSET;
@@ -1336,7 +1339,7 @@ std::pair<int, int> BeamSegment::CalcStemDefiningNote(Staff *staff, data_BEAMPLA
     return { relevantLoc, relevantDuration };
 }
 
-void BeamSegment::CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface)
+void BeamSegment::CalcHorizontalBeam(const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface)
 {
 
     if (beamInterface->m_drawingPlace == BEAMPLACE_mixed) {
@@ -1365,7 +1368,7 @@ void BeamSegment::CalcHorizontalBeam(Doc *doc, Staff *staff, BeamDrawingInterfac
     this->CalcAdjustPosition(staff, doc, beamInterface);
 }
 
-void BeamSegment::CalcMixedBeamPlace(Staff *staff)
+void BeamSegment::CalcMixedBeamPlace(const Staff *staff)
 {
     const int currentStaffN = staff->GetN();
     const auto it = std::find_if(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(),
@@ -1528,10 +1531,8 @@ void BeamSegment::UpdateSameasRoles(data_BEAMPLACE place)
     }
 }
 
-void BeamSegment::CalcNoteHeadShiftForStemSameas(Doc *doc, Beam *sameasBeam, data_BEAMPLACE place)
+void BeamSegment::CalcNoteHeadShiftForStemSameas(Beam *sameasBeam, data_BEAMPLACE place)
 {
-    assert(doc);
-
     if (!sameasBeam) return;
 
     // We want to do this only from the second beams sharing the stems and if the role is set
@@ -1553,7 +1554,7 @@ void BeamSegment::CalcNoteHeadShiftForStemSameas(Doc *doc, Beam *sameasBeam, dat
 
         if (!note1 || !note2) continue;
 
-        note1->CalcNoteHeadShiftForSameasNote(doc, note2, stemDir);
+        note1->CalcNoteHeadShiftForSameasNote(note2, stemDir);
     }
 }
 
@@ -1730,12 +1731,12 @@ void BeamSpanSegment::SetSpanningType(int systemIndex, int systemCount)
     }
 }
 
-void BeamSpanSegment::AppendSpanningCoordinates(Measure *measure)
+void BeamSpanSegment::AppendSpanningCoordinates(const Measure *measure)
 {
     const int spanningType = m_spanningType;
     if (SPANNING_START_END == spanningType) return;
 
-    BarLine *bar = measure->GetRightBarLine();
+    const BarLine *bar = measure->GetRightBarLine();
     const int rightSide = bar->GetDrawingX();
     BeamElementCoord *front = m_beamElementCoordRefs.front();
     BeamElementCoord *back = m_beamElementCoordRefs.back();
@@ -1799,8 +1800,8 @@ data_STEMDIRECTION BeamElementCoord::GetStemDir() const
     return stemInterface->GetStemDir();
 }
 
-void BeamElementCoord::SetDrawingStemDir(
-    data_STEMDIRECTION stemDir, Staff *staff, Doc *doc, BeamSegment *segment, BeamDrawingInterface *interface)
+void BeamElementCoord::SetDrawingStemDir(data_STEMDIRECTION stemDir, const Staff *staff, const Doc *doc,
+    const BeamSegment *segment, const BeamDrawingInterface *interface)
 {
     assert(staff);
     assert(doc);
@@ -1869,7 +1870,7 @@ void BeamElementCoord::SetDrawingStemDir(
     m_yBeam += m_overlapMargin;
 }
 
-int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal)
+int BeamElementCoord::CalculateStemLength(const Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal) const
 {
     if (!m_closestNote) return 0;
 
@@ -1916,7 +1917,7 @@ int BeamElementCoord::CalculateStemLength(Staff *staff, data_STEMDIRECTION stemD
     return stemLen + CalculateStemModAdjustment(stemLen, directionBias);
 }
 
-int BeamElementCoord::CalculateStemLengthTab(Staff *staff, data_STEMDIRECTION stemDir)
+int BeamElementCoord::CalculateStemLengthTab(const Staff *staff, data_STEMDIRECTION stemDir) const
 {
     if (!m_tabDurSym) return 0;
 
@@ -1924,7 +1925,7 @@ int BeamElementCoord::CalculateStemLengthTab(Staff *staff, data_STEMDIRECTION st
     return m_tabDurSym->CalcStemLenInThirdUnits(staff, stemDir) * 2 / 3 * directionBias;
 }
 
-int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBias)
+int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBias) const
 {
     // handle @stem.mod attribute to properly draw beams with tremolos
     int slashFactor = 0;
@@ -1932,7 +1933,7 @@ int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBi
         if (m_closestNote->GetStemMod() < STEMMODIFIER_sprech) slashFactor = m_closestNote->GetStemMod() - 1;
     }
     else if (m_element->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(m_element);
+        const Chord *chord = vrv_cast<const Chord *>(m_element);
         assert(chord);
         if (chord->GetStemMod() < STEMMODIFIER_sprech) slashFactor = chord->GetStemMod() - 1;
     }
@@ -2016,7 +2017,7 @@ int Beam::GetBeamPartDuration(int x) const
     return std::min((*it)->m_dur, (*std::prev(it))->m_dur);
 }
 
-int Beam::GetBeamPartDuration(Object *object) const
+int Beam::GetBeamPartDuration(const Object *object) const
 {
     return this->GetBeamPartDuration(object->GetDrawingX());
 }
@@ -2141,7 +2142,7 @@ int Beam::CalcStem(FunctorParams *functorParams)
     m_beamSegment.CalcBeam(layer, staff, params->m_doc, this, initialPlace);
 
     if (this->HasStemSameasBeam())
-        m_beamSegment.CalcNoteHeadShiftForStemSameas(params->m_doc, this->GetStemSameasBeam(), initialPlace);
+        m_beamSegment.CalcNoteHeadShiftForStemSameas(this->GetStemSameasBeam(), initialPlace);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -84,8 +84,8 @@ void BeamSegment::InitCoordRefs(const ArrayOfBeamElementCoords *beamElementCoord
     m_beamElementCoordRefs = *beamElementCoords;
 }
 
-void BeamSegment::CalcBeam(
-    Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place, bool init)
+void BeamSegment::CalcBeam(const Layer *layer, Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface,
+    data_BEAMPLACE place, bool init)
 {
     assert(layer);
     assert(staff);
@@ -1143,7 +1143,7 @@ void BeamSegment::CalcAdjustPosition(const Staff *staff, const Doc *doc, const B
     this->CalcSetValues();
 }
 
-void BeamSegment::CalcBeamPlace(Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
+void BeamSegment::CalcBeamPlace(const Layer *layer, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
 {
     assert(layer);
     assert(beamInterface);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -493,7 +493,7 @@ void BeamSegment::AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterf
 }
 
 void BeamSegment::AdjustBeamToLedgerLines(
-    Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal)
+    const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface, bool isHorizontal)
 {
     int adjust = 0;
     const int staffTop = staff->GetDrawingY();
@@ -524,7 +524,7 @@ void BeamSegment::AdjustBeamToLedgerLines(
     }
 }
 
-void BeamSegment::AdjustBeamToTremolos(Doc *doc, Staff *staff, BeamDrawingInterface *beamInterface)
+void BeamSegment::AdjustBeamToTremolos(const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface)
 {
     // iterate over all coords and find maximum required adjustment for stems and beam; additional beams should be taken
     // into account to make sure that correct value is calculated
@@ -554,7 +554,8 @@ void BeamSegment::AdjustBeamToTremolos(Doc *doc, Staff *staff, BeamDrawingInterf
     }
 }
 
-void BeamSegment::CalcBeamInit(Staff *staff, Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
+void BeamSegment::CalcBeamInit(
+    const Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface, data_BEAMPLACE place)
 {
     assert(staff);
     assert(doc);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -235,7 +235,7 @@ bool BoundingBox::VerticalSelfOverlap(const BoundingBox *other, int margin) cons
     return true;
 }
 
-int BoundingBox::HorizontalLeftOverlap(const BoundingBox *other, Doc *doc, int margin, int vMargin) const
+int BoundingBox::HorizontalLeftOverlap(const BoundingBox *other, const Doc *doc, int margin, int vMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
     int i, j;
@@ -253,7 +253,7 @@ int BoundingBox::HorizontalLeftOverlap(const BoundingBox *other, Doc *doc, int m
     return overlap;
 }
 
-int BoundingBox::HorizontalRightOverlap(const BoundingBox *other, Doc *doc, int margin, int vMargin) const
+int BoundingBox::HorizontalRightOverlap(const BoundingBox *other, const Doc *doc, int margin, int vMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
     int i, j;
@@ -271,7 +271,7 @@ int BoundingBox::HorizontalRightOverlap(const BoundingBox *other, Doc *doc, int 
     return overlap;
 }
 
-int BoundingBox::VerticalTopOverlap(const BoundingBox *other, Doc *doc, int margin, int hMargin) const
+int BoundingBox::VerticalTopOverlap(const BoundingBox *other, const Doc *doc, int margin, int hMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
     int i, j;
@@ -289,7 +289,7 @@ int BoundingBox::VerticalTopOverlap(const BoundingBox *other, Doc *doc, int marg
     return overlap;
 }
 
-int BoundingBox::VerticalBottomOverlap(const BoundingBox *other, Doc *doc, int margin, int hMargin) const
+int BoundingBox::VerticalBottomOverlap(const BoundingBox *other, const Doc *doc, int margin, int hMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
     int i, j;
@@ -308,7 +308,7 @@ int BoundingBox::VerticalBottomOverlap(const BoundingBox *other, Doc *doc, int m
 }
 
 int BoundingBox::GetRectangles(
-    const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, Point rect[3][2], Doc *doc) const
+    const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, Point rect[3][2], const Doc *doc) const
 {
     const Glyph *glyph = NULL;
 
@@ -320,15 +320,15 @@ int BoundingBox::GetRectangles(
         assert(glyph);
 
         if (glyph->HasAnchor(anchor1) && glyph->HasAnchor(anchor2)) {
-            glyphRect = this->GetGlyph2PointRectangles(anchor1, anchor2, glyph, rect, doc);
+            glyphRect = this->GetGlyph2PointRectangles(anchor1, anchor2, glyph, rect);
             if (glyphRect) return 3;
         }
         else if (glyph->HasAnchor(anchor1)) {
-            glyphRect = this->GetGlyph1PointRectangles(anchor1, glyph, rect, doc);
+            glyphRect = this->GetGlyph1PointRectangles(anchor1, glyph, rect);
             if (glyphRect) return 2;
         }
         else if (glyph->HasAnchor(anchor2)) {
-            glyphRect = this->GetGlyph1PointRectangles(anchor2, glyph, rect, doc);
+            glyphRect = this->GetGlyph1PointRectangles(anchor2, glyph, rect);
             if (glyphRect) return 2;
         }
     }
@@ -342,8 +342,8 @@ int BoundingBox::GetRectangles(
     return 1;
 }
 
-bool BoundingBox::GetGlyph2PointRectangles(const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2,
-    const Glyph *glyph, Point rect[3][2], Doc *doc) const
+bool BoundingBox::GetGlyph2PointRectangles(
+    const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, const Glyph *glyph, Point rect[3][2]) const
 {
     assert(glyph);
 
@@ -430,8 +430,7 @@ bool BoundingBox::GetGlyph2PointRectangles(const SMuFLGlyphAnchor &anchor1, cons
     return true;
 }
 
-bool BoundingBox::GetGlyph1PointRectangles(
-    const SMuFLGlyphAnchor &anchor, const Glyph *glyph, Point rect[2][2], Doc *doc) const
+bool BoundingBox::GetGlyph1PointRectangles(const SMuFLGlyphAnchor &anchor, const Glyph *glyph, Point rect[2][2]) const
 {
     assert(glyph);
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -453,7 +453,7 @@ bool Chord::IsVisible() const
     return false;
 }
 
-bool Chord::HasAdjacentNotesInStaff(Staff *staff)
+bool Chord::HasAdjacentNotesInStaff(const Staff *staff) const
 {
     assert(staff);
     MapOfNoteLocs locations = this->CalcNoteLocations();
@@ -550,7 +550,7 @@ int Chord::AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElemen
     return 0;
 }
 
-std::list<Note *> Chord::GetAdjacentNotesList(Staff *staff, int loc)
+std::list<Note *> Chord::GetAdjacentNotesList(const Staff *staff, int loc)
 {
     const ListOfObjects &notes = this->GetList(this);
 
@@ -755,25 +755,25 @@ int Chord::CalcStem(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate)
+MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate) const
 {
-    const ListOfObjects &notes = this->GetList(this);
+    const ListOfConstObjects &notes = this->GetList(this);
 
     MapOfNoteLocs noteLocations;
-    for (Object *obj : notes) {
-        Note *note = vrv_cast<Note *>(obj);
+    for (const Object *obj : notes) {
+        const Note *note = vrv_cast<const Note *>(obj);
         assert(note);
 
         if (predicate && !predicate(note)) continue;
 
-        Staff *staff = note->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+        const Staff *staff = note->GetAncestorStaff(RESOLVE_CROSS_STAFF);
 
         noteLocations[staff].insert(note->GetDrawingLoc());
     }
     return noteLocations;
 }
 
-MapOfDotLocs Chord::CalcDotLocations(int layerCount, bool primary)
+MapOfDotLocs Chord::CalcDotLocations(int layerCount, bool primary) const
 {
     const bool isUpwardDirection = (this->GetDrawingStemDir() == STEMDIRECTION_up) || (layerCount == 1);
     const bool useReverseOrder = (isUpwardDirection != primary);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -313,6 +313,20 @@ int Chord::GetXMax() const
 
 void Chord::GetCrossStaffExtremes(Staff *&staffAbove, Staff *&staffBelow, Layer **layerAbove, Layer **layerBelow)
 {
+    const Staff *staffAboveRef = NULL;
+    const Staff *staffBelowRef = NULL;
+    const Layer *layerAboveRef = NULL;
+    const Layer *layerBelowRef = NULL;
+    std::as_const(*this).GetCrossStaffExtremes(staffAboveRef, staffBelowRef, &layerAboveRef, &layerBelowRef);
+    staffAbove = const_cast<Staff *>(staffAboveRef);
+    staffBelow = const_cast<Staff *>(staffBelowRef);
+    if (layerAbove) *layerAbove = const_cast<Layer *>(layerAboveRef);
+    if (layerBelow) *layerBelow = const_cast<Layer *>(layerBelowRef);
+}
+
+void Chord::GetCrossStaffExtremes(
+    const Staff *&staffAbove, const Staff *&staffBelow, const Layer **layerAbove, const Layer **layerBelow) const
+{
     staffAbove = NULL;
     staffBelow = NULL;
 
@@ -320,7 +334,7 @@ void Chord::GetCrossStaffExtremes(Staff *&staffAbove, Staff *&staffBelow, Layer 
     if (m_crossStaff) return;
 
     // The first note is the bottom
-    Note *bottomNote = this->GetBottomNote();
+    const Note *bottomNote = this->GetBottomNote();
     assert(bottomNote);
     if (bottomNote->m_crossStaff && bottomNote->m_crossLayer) {
         staffBelow = bottomNote->m_crossStaff;
@@ -328,7 +342,7 @@ void Chord::GetCrossStaffExtremes(Staff *&staffAbove, Staff *&staffBelow, Layer 
     }
 
     // The last note is the top
-    Note *topNote = this->GetTopNote();
+    const Note *topNote = this->GetTopNote();
     assert(topNote);
     if (topNote->m_crossStaff && topNote->m_crossLayer) {
         staffAbove = topNote->m_crossStaff;
@@ -336,12 +350,12 @@ void Chord::GetCrossStaffExtremes(Staff *&staffAbove, Staff *&staffBelow, Layer 
     }
 }
 
-bool Chord::HasCrossStaff()
+bool Chord::HasCrossStaff() const
 {
     if (m_crossStaff) return true;
 
-    Staff *staffAbove = NULL;
-    Staff *staffBelow = NULL;
+    const Staff *staffAbove = NULL;
+    const Staff *staffBelow = NULL;
 
     this->GetCrossStaffExtremes(staffAbove, staffBelow);
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -467,8 +467,8 @@ bool Chord::HasNoteWithDots() const
     });
 }
 
-int Chord::AdjustOverlappingLayers(
-    Doc *doc, const std::vector<LayerElement *> &otherElements, bool areDotsAdjusted, bool &isUnison, bool &stemSameas)
+int Chord::AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElement *> &otherElements,
+    bool areDotsAdjusted, bool &isUnison, bool &stemSameas)
 {
     int margin = 0;
     // get positions of other elements
@@ -763,7 +763,7 @@ MapOfDotLocs Chord::CalcDotLocations(int layerCount, bool primary)
 {
     const bool isUpwardDirection = (this->GetDrawingStemDir() == STEMDIRECTION_up) || (layerCount == 1);
     const bool useReverseOrder = (isUpwardDirection != primary);
-    MapOfNoteLocs noteLocs = this->CalcNoteLocations([](Note *note) { return !note->HasDots(); });
+    MapOfNoteLocs noteLocs = this->CalcNoteLocations([](const Note *note) { return !note->HasDots(); });
     MapOfDotLocs dotLocs;
     for (const auto &mapEntry : noteLocs) {
         if (useReverseOrder)
@@ -892,7 +892,7 @@ int Chord::InitOnsetOffsetEnd(FunctorParams *functorParams)
     InitOnsetOffsetParams *params = vrv_params_cast<InitOnsetOffsetParams *>(functorParams);
     assert(params);
 
-    LayerElement *element = this->ThisOrSameasAsLink();
+    LayerElement *element = this->ThisOrSameasLink();
 
     double incrementScoreTime = element->GetAlignmentDuration(
         params->m_currentMensur, params->m_currentMeterSig, true, params->m_notationType);

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -470,7 +470,7 @@ int TupletNum::ResetVerticalAlignment(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Stem::AdjustSlashes(Doc *doc, Staff *staff, int flagOffset)
+int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) const
 {
     // if stem length is explicitly set - exit
     if (this->HasStemLen()) return 0;
@@ -478,7 +478,7 @@ int Stem::AdjustSlashes(Doc *doc, Staff *staff, int flagOffset)
     const int staffSize = staff->m_drawingStaffSize;
     const int unit = doc->GetDrawingUnit(staffSize);
     data_STEMMODIFIER stemMod = STEMMODIFIER_NONE;
-    BTrem *bTrem = vrv_cast<BTrem *>(this->GetFirstAncestor(BTREM));
+    const BTrem *bTrem = vrv_cast<const BTrem *>(this->GetFirstAncestor(BTREM));
     if (bTrem) {
         stemMod = bTrem->GetDrawingStemMod();
     }
@@ -493,7 +493,7 @@ int Stem::AdjustSlashes(Doc *doc, Staff *staff, int flagOffset)
 
     int lenAdjust = flagOffset;
     if (this->GetParent()->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(this->GetParent());
+        const Chord *chord = vrv_cast<const Chord *>(this->GetParent());
         lenAdjust += std::abs(chord->GetTopNote()->GetDrawingY() - chord->GetBottomNote()->GetDrawingY());
     }
 
@@ -662,7 +662,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-void Stem::CalculateStemModRelY(Doc *doc, Staff *staff)
+void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
 {
     const int sign = (this->GetDrawingStemDir() == STEMDIRECTION_up) ? 1 : -1;
     LayerElement *parent = vrv_cast<LayerElement *>(this->GetParent());
@@ -728,7 +728,7 @@ void Stem::CalculateStemModRelY(Doc *doc, Staff *staff)
     m_stemModRelY = sign * height + adjust;
 }
 
-int Stem::CalculateStemModAdjustment(Doc *doc, Staff *staff, int flagOffset)
+int Stem::CalculateStemModAdjustment(const Doc *doc, const Staff *staff, int flagOffset)
 {
     this->CalculateStemModRelY(doc, staff);
     return this->AdjustSlashes(doc, staff, flagOffset);

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -311,7 +311,7 @@ bool Stem::IsSupportedChild(Object *child)
     return true;
 }
 
-int Stem::CompareToElementPosition(Doc *doc, LayerElement *otherElement, int margin)
+int Stem::CompareToElementPosition(const Doc *doc, LayerElement *otherElement, int margin)
 {
     Staff *staff = this->GetAncestorStaff();
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -49,7 +49,7 @@ void Dots::Reset()
     m_dotLocsByStaff.clear();
 }
 
-std::set<int> Dots::GetDotLocsForStaff(Staff *staff) const
+std::set<int> Dots::GetDotLocsForStaff(const Staff *staff) const
 {
     if (m_dotLocsByStaff.find(staff) != m_dotLocsByStaff.end()) {
         return m_dotLocsByStaff.at(staff);
@@ -57,7 +57,7 @@ std::set<int> Dots::GetDotLocsForStaff(Staff *staff) const
     return {};
 }
 
-std::set<int> &Dots::ModifyDotLocsForStaff(Staff *staff)
+std::set<int> &Dots::ModifyDotLocsForStaff(const Staff *staff)
 {
     return m_dotLocsByStaff[staff];
 }
@@ -150,28 +150,28 @@ void TupletBracket::Reset()
     m_alignedNum = NULL;
 }
 
-int TupletBracket::GetDrawingXLeft()
+int TupletBracket::GetDrawingXLeft() const
 {
-    Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
+    const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET));
     assert(tuplet && tuplet->GetDrawingLeft());
 
     return tuplet->GetDrawingLeft()->GetDrawingX() + m_drawingXRelLeft;
 }
 
-int TupletBracket::GetDrawingXRight()
+int TupletBracket::GetDrawingXRight() const
 {
-    Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
+    const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET));
     assert(tuplet && tuplet->GetDrawingRight());
 
     return tuplet->GetDrawingRight()->GetDrawingX() + m_drawingXRelRight;
 }
 
-int TupletBracket::GetDrawingYLeft()
+int TupletBracket::GetDrawingYLeft() const
 {
-    Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
+    const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET));
     assert(tuplet && tuplet->GetDrawingLeft());
 
-    Beam *beam = tuplet->GetBracketAlignedBeam();
+    const Beam *beam = tuplet->GetBracketAlignedBeam();
     if (beam) {
         // Calculate the y point aligning with the beam
         int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + m_drawingXRelLeft;
@@ -184,12 +184,12 @@ int TupletBracket::GetDrawingYLeft()
     }
 }
 
-int TupletBracket::GetDrawingYRight()
+int TupletBracket::GetDrawingYRight() const
 {
-    Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
+    const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET));
     assert(tuplet && tuplet->GetDrawingRight());
 
-    Beam *beam = tuplet->GetBracketAlignedBeam();
+    const Beam *beam = tuplet->GetBracketAlignedBeam();
     if (beam) {
         // Calculate the y point aligning with the beam
         int xRight = tuplet->GetDrawingRight()->GetDrawingX() + m_drawingXRelRight;
@@ -225,7 +225,7 @@ void TupletNum::Reset()
     m_alignedBracket = NULL;
 }
 
-int TupletNum::GetDrawingYMid()
+int TupletNum::GetDrawingYMid() const
 {
     if (m_alignedBracket) {
         int yLeft = m_alignedBracket->GetDrawingYLeft();
@@ -237,7 +237,7 @@ int TupletNum::GetDrawingYMid()
     }
 }
 
-int TupletNum::GetDrawingXMid(Doc *doc)
+int TupletNum::GetDrawingXMid(const Doc *doc) const
 {
     if (m_alignedBracket) {
         int xLeft = m_alignedBracket->GetDrawingXLeft();
@@ -245,7 +245,7 @@ int TupletNum::GetDrawingXMid(Doc *doc)
         return xLeft + ((xRight - xLeft) / 2);
     }
     else {
-        Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET));
+        const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET));
         assert(tuplet && tuplet->GetDrawingLeft() && tuplet->GetDrawingRight());
         int xLeft = tuplet->GetDrawingLeft()->GetDrawingX();
         int xRight = tuplet->GetDrawingRight()->GetDrawingX();
@@ -253,7 +253,7 @@ int TupletNum::GetDrawingXMid(Doc *doc)
             xRight += (tuplet->GetDrawingRight()->GetDrawingRadius(doc) * 2);
         }
         if (tuplet->GetNumAlignedBeam()) {
-            Beam *beam = tuplet->GetNumAlignedBeam();
+            const Beam *beam = tuplet->GetNumAlignedBeam();
             switch (beam->m_drawingPlace) {
                 case BEAMPLACE_above: xLeft += (tuplet->GetDrawingLeft()->GetDrawingRadius(doc)); break;
                 case BEAMPLACE_below: xRight -= (tuplet->GetDrawingRight()->GetDrawingRadius(doc)); break;
@@ -311,9 +311,9 @@ bool Stem::IsSupportedChild(Object *child)
     return true;
 }
 
-int Stem::CompareToElementPosition(const Doc *doc, LayerElement *otherElement, int margin)
+int Stem::CompareToElementPosition(const Doc *doc, const LayerElement *otherElement, int margin) const
 {
-    Staff *staff = this->GetAncestorStaff();
+    const Staff *staff = this->GetAncestorStaff();
 
     // check if there is an overlap on the left or on the right and displace stem's parent correspondingly
     const int right = HorizontalLeftOverlap(otherElement, doc, margin, 0);
@@ -321,8 +321,7 @@ int Stem::CompareToElementPosition(const Doc *doc, LayerElement *otherElement, i
     if (!right || !left) return 0;
 
     int horizontalMargin = 2 * doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-    Flag *currentFlag = NULL;
-    currentFlag = vrv_cast<Flag *>(FindDescendantByType(FLAG, 1));
+    const Flag *currentFlag = vrv_cast<const Flag *>(this->FindDescendantByType(FLAG, 1));
     if (currentFlag && currentFlag->m_drawingNbFlags) {
         wchar_t flagGlyph = currentFlag->GetFlagGlyph(STEMDIRECTION_down);
         const int flagWidth = doc->GetGlyphWidth(flagGlyph, staff->m_drawingStaffSize, this->GetDrawingCueSize());
@@ -337,7 +336,7 @@ int Stem::CompareToElementPosition(const Doc *doc, LayerElement *otherElement, i
     }
 }
 
-void Stem::AdjustFlagPlacement(Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration)
+void Stem::AdjustFlagPlacement(const Doc *doc, Flag *flag, int staffSize, int verticalCenter, int duration)
 {
     assert(this->GetParent());
     assert(this->GetParent()->IsLayerElement());

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -254,7 +254,7 @@ data_PITCHNAME KeySig::GetAccidPnameAt(data_ACCIDENTAL_WRITTEN accidType, int po
     }
 }
 
-int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, Clef *clef)
+int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, const Clef *clef)
 {
     int accidSet = 0; // flats
     int keySet = 0;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -367,7 +367,12 @@ void LayerElement::GetChordOverflow(StaffAlignment *&above, StaffAlignment *&bel
     }
 }
 
-Alignment *LayerElement::GetGraceAlignment() const
+Alignment *LayerElement::GetGraceAlignment()
+{
+    return const_cast<Alignment *>(std::as_const(*this).GetGraceAlignment());
+}
+
+const Alignment *LayerElement::GetGraceAlignment() const
 {
     assert(m_graceAlignment);
     return m_graceAlignment;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1487,7 +1487,7 @@ int LayerElement::CalcAlignmentPitchPos(FunctorParams *functorParams)
             // should be refined later
             bool hasMultipleLayer = (staffY->GetChildCount(LAYER) > 1);
             if (hasMultipleLayer) {
-                loc = mRest->GetOptimalLayerLocation(staffY, layerY, loc);
+                loc = mRest->GetOptimalLayerLocation(layerY, loc);
             }
         }
 
@@ -2426,7 +2426,7 @@ int LayerElement::PrepareTimeSpanning(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams)
+int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams) const
 {
     LayerCountInTimeSpanParams *params = vrv_params_cast<LayerCountInTimeSpanParams *>(functorParams);
     assert(params);
@@ -2464,12 +2464,12 @@ int LayerElement::LayerCountInTimeSpan(FunctorParams *functorParams)
     return (this->Is(CHORD)) ? FUNCTOR_SIBLINGS : FUNCTOR_CONTINUE;
 }
 
-int LayerElement::LayerElementsInTimeSpan(FunctorParams *functorParams)
+int LayerElement::LayerElementsInTimeSpan(FunctorParams *functorParams) const
 {
     LayerElementsInTimeSpanParams *params = vrv_params_cast<LayerElementsInTimeSpanParams *>(functorParams);
     assert(params);
 
-    Layer *currentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+    const Layer *currentLayer = vrv_cast<const Layer *>(this->GetFirstAncestor(LAYER));
     // Either get layer refernced by @m_layer or all layers but it, depending on the @m_allLayersButCurrent flag
     if ((!params->m_allLayersButCurrent && (currentLayer != params->m_layer))
         || (params->m_allLayersButCurrent && (currentLayer == params->m_layer))) {
@@ -2480,7 +2480,8 @@ int LayerElement::LayerElementsInTimeSpan(FunctorParams *functorParams)
 
     const double duration = !this->GetFirstAncestor(CHORD)
         ? this->GetAlignmentDuration(params->m_mensur, params->m_meterSig)
-        : vrv_cast<Chord *>(this->GetFirstAncestor(CHORD))->GetAlignmentDuration(params->m_mensur, params->m_meterSig);
+        : vrv_cast<const Chord *>(this->GetFirstAncestor(CHORD))
+              ->GetAlignmentDuration(params->m_mensur, params->m_meterSig);
 
     const double time = m_alignment->GetTime();
 

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2004,7 +2004,7 @@ int LayerElement::AdjustGraceXPos(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-int LayerElement::AdjustTupletNumOverlap(FunctorParams *functorParams)
+int LayerElement::AdjustTupletNumOverlap(FunctorParams *functorParams) const
 {
     AdjustTupletNumOverlapParams *params = vrv_params_cast<AdjustTupletNumOverlapParams *>(functorParams);
     assert(params);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -662,7 +662,7 @@ double LayerElement::GetAlignmentDuration(
     if (this->HasInterface(INTERFACE_DURATION)) {
         int num = 1;
         int numbase = 1;
-        Tuplet *tuplet = vrv_cast<Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
+        const Tuplet *tuplet = vrv_cast<const Tuplet *>(this->GetFirstAncestor(TUPLET, MAX_TUPLET_DEPTH));
         if (tuplet) {
             ListOfConstObjects objects;
             ClassIdsComparison ids({ CHORD, NOTE, REST });
@@ -681,7 +681,7 @@ double LayerElement::GetAlignmentDuration(
             return duration->GetInterfaceAlignmentMensuralDuration(num, numbase, mensur);
         }
         if (this->Is(NC)) {
-            Neume *neume = vrv_cast<Neume *>(this->GetFirstAncestor(NEUME));
+            const Neume *neume = vrv_cast<const Neume *>(this->GetFirstAncestor(NEUME));
             if (neume->IsLastInNeume(this)) {
                 return 128;
             }
@@ -691,7 +691,7 @@ double LayerElement::GetAlignmentDuration(
         }
         double durationValue = duration->GetInterfaceAlignmentDuration(num, numbase);
         // With fTrem we need to divide the duration by two
-        FTrem *fTrem = vrv_cast<FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
+        const FTrem *fTrem = vrv_cast<const FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
         if (fTrem) {
             durationValue /= 2.0;
         }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2723,7 +2723,7 @@ int LayerElement::ResetData(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int LayerElement::GetRelativeLayerElement(FunctorParams *functorParams)
+int LayerElement::GetRelativeLayerElement(FunctorParams *functorParams) const
 {
     GetRelativeLayerElementParams *params = vrv_params_cast<GetRelativeLayerElementParams *>(functorParams);
     assert(params);

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -105,7 +105,7 @@ void Ligature::FilterList(ListOfConstObjects &childList) const
     }
 }
 
-int Ligature::GetDrawingNoteShape(Note *note)
+int Ligature::GetDrawingNoteShape(const Note *note) const
 {
     assert(note);
     int position = this->GetListIndex(note);

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -68,7 +68,7 @@ void Mensur::Reset()
 // Functors methods
 //----------------------------------------------------------------------------
 
-int Mensur::LayerCountInTimeSpan(FunctorParams *functorParams)
+int Mensur::LayerCountInTimeSpan(FunctorParams *functorParams) const
 {
     LayerCountInTimeSpanParams *params = vrv_params_cast<LayerCountInTimeSpanParams *>(functorParams);
     assert(params);

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -127,7 +127,7 @@ std::pair<wchar_t, wchar_t> MeterSig::GetEnclosingGlyphs(bool smallGlyph) const
 // Functors methods
 //----------------------------------------------------------------------------
 
-int MeterSig::LayerCountInTimeSpan(FunctorParams *functorParams)
+int MeterSig::LayerCountInTimeSpan(FunctorParams *functorParams) const
 {
     LayerCountInTimeSpanParams *params = vrv_params_cast<LayerCountInTimeSpanParams *>(functorParams);
     assert(params);

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -73,7 +73,7 @@ void MeterSigGrp::FilterList(ListOfConstObjects &childList) const
         childList.end());
 }
 
-void MeterSigGrp::AddAlternatingMeasureToVector(Measure *measure)
+void MeterSigGrp::AddAlternatingMeasureToVector(const Measure *measure)
 {
     m_alternatingMeasures.emplace_back(measure);
 }

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -87,30 +87,31 @@ int MRest::ResetHorizontalAlignment(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int MRest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation)
+int MRest::GetOptimalLayerLocation(const Layer *layer, int defaultLocation) const
 {
     if (!layer) return defaultLocation;
-    Staff *parentStaff = this->GetAncestorStaff();
+    const Staff *parentStaff = this->GetAncestorStaff();
 
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
     if (parentStaff->GetChildCount(LAYER) != 2) return defaultLocation;
 
-    ListOfObjects layers = parentStaff->FindAllDescendantsByType(LAYER, false);
-    const bool isTopLayer = (vrv_cast<Layer *>(*layers.begin())->GetN() == layer->GetN());
+    ListOfConstObjects layers = parentStaff->FindAllDescendantsByType(LAYER, false);
+    const bool isTopLayer = (vrv_cast<const Layer *>(*layers.begin())->GetN() == layer->GetN());
 
-    ListOfObjects::iterator otherLayerIter = isTopLayer ? std::prev(layers.end()) : layers.begin();
-    ListOfObjects collidingElementsList = vrv_cast<Layer *>(*otherLayerIter)->GetLayerElementsForTimeSpanOf(this);
+    ListOfConstObjects::iterator otherLayerIter = isTopLayer ? std::prev(layers.end()) : layers.begin();
+    ListOfConstObjects collidingElementsList
+        = vrv_cast<const Layer *>(*otherLayerIter)->GetLayerElementsForTimeSpanOf(this);
 
     // find all locations for other layer
     std::vector<int> locations;
     for (auto element : collidingElementsList) {
         if (element->Is({ CHORD, NOTE })) {
-            LayerElement *layerElement = vrv_cast<LayerElement *>(element);
+            const LayerElement *layerElement = vrv_cast<const LayerElement *>(element);
             int loc = PitchInterface::CalcLoc(layerElement, layer, layerElement, isTopLayer);
             locations.push_back(loc);
         }
         else if (element->Is(REST)) {
-            Rest *rest = vrv_cast<Rest *>(element);
+            const Rest *rest = vrv_cast<const Rest *>(element);
             int loc = rest->GetDrawingLoc();
             locations.push_back(loc);
         }

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -50,7 +50,7 @@ void MultiRest::Reset()
     this->ResetWidth();
 }
 
-bool MultiRest::UseBlockStyle(Doc *doc) const
+bool MultiRest::UseBlockStyle(const Doc *doc) const
 {
     bool useBlock = false;
     switch (doc->GetOptions()->m_multiRestStyle.GetValue()) {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -333,7 +333,7 @@ std::wstring Note::GetTabFretString(data_NOTATIONTYPE notationType) const
     }
 }
 
-bool Note::IsUnisonWith(Note *note, bool ignoreAccid)
+bool Note::IsUnisonWith(const Note *note, bool ignoreAccid) const
 {
     if (!ignoreAccid && !this->IsEnharmonicWith(note)) return false;
 
@@ -660,12 +660,12 @@ void Note::CalcNoteHeadShiftForSameasNote(Note *stemSameas, data_STEMDIRECTION s
     noteToShift->SetFlippedNotehead(true);
 }
 
-bool Note::IsEnharmonicWith(Note *note)
+bool Note::IsEnharmonicWith(const Note *note) const
 {
     return (this->GetMIDIPitch() == note->GetMIDIPitch());
 }
 
-int Note::GetMIDIPitch(const int shift)
+int Note::GetMIDIPitch(const int shift) const
 {
     int pitch = 0;
 
@@ -697,7 +697,7 @@ int Note::GetMIDIPitch(const int shift)
     }
     else if (this->HasTabCourse()) {
         // tablature
-        Staff *staff = this->GetAncestorStaff();
+        const Staff *staff = this->GetAncestorStaff();
         if (staff->m_drawingTuning) {
             pitch = staff->m_drawingTuning->CalcPitchNumber(
                 this->GetTabCourse(), this->GetTabFret(), staff->m_drawingNotationType);
@@ -708,9 +708,9 @@ int Note::GetMIDIPitch(const int shift)
     return pitch + shift;
 }
 
-int Note::GetChromaticAlteration()
+int Note::GetChromaticAlteration() const
 {
-    Accid *accid = this->GetDrawingAccid();
+    const Accid *accid = this->GetDrawingAccid();
 
     if (accid) {
         return TransPitch::GetChromaticAlteration(accid->GetAccidGes(), accid->GetAccid());

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -189,10 +189,10 @@ void Note::AddChild(Object *child)
     Modify();
 }
 
-void Note::AlignDotsShift(Note *otherNote)
+void Note::AlignDotsShift(const Note *otherNote)
 {
     Dots *dots = vrv_cast<Dots *>(this->FindDescendantByType(DOTS, 1));
-    Dots *otherDots = vrv_cast<Dots *>(otherNote->FindDescendantByType(DOTS, 1));
+    const Dots *otherDots = vrv_cast<const Dots *>(otherNote->FindDescendantByType(DOTS, 1));
     if (!dots || !otherDots) return;
     if (otherDots->GetFlagShift()) {
         dots->SetFlagShift(otherDots->GetFlagShift());
@@ -718,7 +718,7 @@ int Note::GetChromaticAlteration() const
     return 0;
 }
 
-TransPitch Note::GetTransPitch()
+TransPitch Note::GetTransPitch() const
 {
     int pname = this->GetPname() - PITCHNAME_c;
     return TransPitch(pname, this->GetChromaticAlteration(), this->GetOct());
@@ -761,12 +761,12 @@ void Note::UpdateFromTransPitch(const TransPitch &tp)
     }
 }
 
-bool Note::IsDotOverlappingWithFlag(Doc *doc, const int staffSize, int dotLocShift)
+bool Note::IsDotOverlappingWithFlag(const Doc *doc, const int staffSize, int dotLocShift) const
 {
-    Object *stem = this->GetFirst(STEM);
+    const Object *stem = this->GetFirst(STEM);
     if (!stem) return false;
 
-    Flag *flag = dynamic_cast<Flag *>(stem->GetFirst(FLAG));
+    const Flag *flag = dynamic_cast<const Flag *>(stem->GetFirst(FLAG));
     if (!flag) return false;
 
     // for the purposes of vertical spacing we care only up to 16th flags - shorter ones grow upwards
@@ -841,7 +841,7 @@ void Note::GenerateGraceNoteMIDI(FunctorParams *functorParams, double startTime,
 // Static methods //
 //----------------//
 
-bool Note::HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, Note *note2)
+bool Note::HandleLedgerLineStemCollision(const Doc *doc, const Staff *staff, const Note *note1, const Note *note2)
 {
     assert(doc);
     assert(staff);
@@ -849,8 +849,8 @@ bool Note::HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, No
     assert(note2);
 
     if (note1->GetDrawingLoc() == note2->GetDrawingLoc()) return false;
-    Note *upperNote = (note1->GetDrawingLoc() > note2->GetDrawingLoc()) ? note1 : note2;
-    Note *lowerNote = (note1->GetDrawingLoc() > note2->GetDrawingLoc()) ? note2 : note1;
+    const Note *upperNote = (note1->GetDrawingLoc() > note2->GetDrawingLoc()) ? note1 : note2;
+    const Note *lowerNote = (note1->GetDrawingLoc() > note2->GetDrawingLoc()) ? note2 : note1;
 
     if (upperNote->GetDrawingStemDir() != STEMDIRECTION_down) return false;
     if (lowerNote->GetDrawingStemDir() != STEMDIRECTION_up) return false;
@@ -866,8 +866,8 @@ bool Note::HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, No
     // If one note has more ledger lines, then check if the stems tip of the other note is outside of the staff on this
     // side
     if (linesBelowLower > linesBelowUpper) {
-        Chord *upperChord = upperNote->IsChordTone();
-        Stem *upperStem = upperChord ? upperChord->GetDrawingStem() : upperNote->GetDrawingStem();
+        const Chord *upperChord = upperNote->IsChordTone();
+        const Stem *upperStem = upperChord ? upperChord->GetDrawingStem() : upperNote->GetDrawingStem();
         if (upperStem) {
             const int staffBottom = staff->GetDrawingY() - 2 * unit * (staff->m_drawingLines - 1);
             const int stemBottom = upperStem->GetSelfBottom();
@@ -878,8 +878,8 @@ bool Note::HandleLedgerLineStemCollision(Doc *doc, Staff *staff, Note *note1, No
     }
 
     if (linesAboveUpper > linesAboveLower) {
-        Chord *lowerChord = lowerNote->IsChordTone();
-        Stem *lowerStem = lowerChord ? lowerChord->GetDrawingStem() : lowerNote->GetDrawingStem();
+        const Chord *lowerChord = lowerNote->IsChordTone();
+        const Stem *lowerStem = lowerChord ? lowerChord->GetDrawingStem() : lowerNote->GetDrawingStem();
         if (lowerStem) {
             const int staffTop = staff->GetDrawingY();
             const int stemTop = lowerStem->GetSelfTop();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1161,18 +1161,18 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
-MapOfNoteLocs Note::CalcNoteLocations(NotePredicate predicate)
+MapOfNoteLocs Note::CalcNoteLocations(NotePredicate predicate) const
 {
     if (predicate && !predicate(this)) return {};
 
-    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+    const Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
 
     MapOfNoteLocs noteLocations;
     noteLocations[staff] = { this->GetDrawingLoc() };
     return noteLocations;
 }
 
-MapOfDotLocs Note::CalcDotLocations(int layerCount, bool primary)
+MapOfDotLocs Note::CalcDotLocations(int layerCount, bool primary) const
 {
     const bool isUpwardDirection = (this->GetDrawingStemDir() == STEMDIRECTION_up) || (layerCount == 1);
     const bool shiftUpwards = (isUpwardDirection == primary);
@@ -1180,7 +1180,7 @@ MapOfDotLocs Note::CalcDotLocations(int layerCount, bool primary)
     assert(noteLocs.size() == 1);
 
     MapOfDotLocs dotLocs;
-    Staff *staff = noteLocs.cbegin()->first;
+    const Staff *staff = noteLocs.cbegin()->first;
     int loc = *noteLocs.cbegin()->second.cbegin();
     if (loc % 2 == 0) loc += (shiftUpwards ? 1 : -1);
     dotLocs[staff] = { loc };

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -604,9 +604,8 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
     }
 }
 
-data_STEMDIRECTION Note::CalcStemDirForSameasNote(Doc *doc, int verticalCenter)
+data_STEMDIRECTION Note::CalcStemDirForSameasNote(int verticalCenter)
 {
-    assert(doc);
     assert(m_stemSameas);
     assert(m_stemSameas->HasStemSameasNote());
     assert(m_stemSameas->GetStemSameasNote() == this);
@@ -631,7 +630,7 @@ data_STEMDIRECTION Note::CalcStemDirForSameasNote(Doc *doc, int verticalCenter)
         topNote->m_stemSameasRole = (stemDir == STEMDIRECTION_up) ? SAMEAS_PRIMARY : SAMEAS_SECONDARY;
         bottomNote->m_stemSameasRole = (stemDir == STEMDIRECTION_up) ? SAMEAS_SECONDARY : SAMEAS_PRIMARY;
 
-        this->CalcNoteHeadShiftForSameasNote(doc, m_stemSameas, stemDir);
+        this->CalcNoteHeadShiftForSameasNote(m_stemSameas, stemDir);
 
         return stemDir;
     }
@@ -641,9 +640,8 @@ data_STEMDIRECTION Note::CalcStemDirForSameasNote(Doc *doc, int verticalCenter)
     }
 }
 
-void Note::CalcNoteHeadShiftForSameasNote(Doc *doc, Note *stemSameas, data_STEMDIRECTION stemDir)
+void Note::CalcNoteHeadShiftForSameasNote(Note *stemSameas, data_STEMDIRECTION stemDir)
 {
-    assert(doc);
     assert(stemSameas);
 
     if (abs(this->GetDiatonicPitch() - stemSameas->GetDiatonicPitch()) > 1) return;
@@ -1061,7 +1059,7 @@ int Note::CalcStem(FunctorParams *functorParams)
     data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
 
     if (this->HasStemSameasNote()) {
-        stemDir = this->CalcStemDirForSameasNote(params->m_doc, params->m_verticalCenter);
+        stemDir = this->CalcStemDirForSameasNote(params->m_verticalCenter);
     }
     else if (stem->HasStemDir()) {
         stemDir = stem->GetStemDir();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1545,7 +1545,7 @@ int Note::GenerateTimemap(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    Note *note = vrv_cast<Note *>(this->ThisOrSameasAsLink());
+    Note *note = vrv_cast<Note *>(this->ThisOrSameasLink());
     assert(note);
 
     params->m_timemap->AddEntry(note, params);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2153,7 +2153,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
     if (this->Is(CLEF)) {
         LayerElement *element = vrv_cast<LayerElement *>(this);
         assert(element);
-        LayerElement *elementOrLink = element->ThisOrSameasAsLink();
+        LayerElement *elementOrLink = element->ThisOrSameasLink();
         if (!elementOrLink || !elementOrLink->Is(CLEF)) return FUNCTOR_CONTINUE;
         Clef *clef = vrv_cast<Clef *>(elementOrLink);
         if (clef->IsScoreDefElement()) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -930,6 +930,11 @@ const Object *Object::GetFirstAncestorInRange(const ClassId classIdMin, const Cl
 
 Object *Object::GetLastAncestorNot(const ClassId classId, int maxDepth)
 {
+    return const_cast<Object *>(std::as_const(*this).GetLastAncestorNot(classId, maxDepth));
+}
+
+const Object *Object::GetLastAncestorNot(const ClassId classId, int maxDepth) const
+{
     if ((maxDepth == 0) || !m_parent) {
         return NULL;
     }
@@ -943,6 +948,11 @@ Object *Object::GetLastAncestorNot(const ClassId classId, int maxDepth)
 }
 
 Object *Object::GetFirstChildNot(const ClassId classId)
+{
+    return const_cast<Object *>(std::as_const(*this).GetFirstChildNot(classId));
+}
+
+const Object *Object::GetFirstChildNot(const ClassId classId) const
 {
     for (const auto child : m_children) {
         if (!child->Is(classId)) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -269,9 +269,9 @@ void Rest::UpdateFromTransLoc(const TransPitch &tp)
     }
 }
 
-int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocation)
+int Rest::GetOptimalLayerLocation(const Staff *staff, const Layer *layer, int defaultLocation) const
 {
-    Layer *parentLayer = vrv_cast<Layer *>(this->GetFirstAncestor(LAYER));
+    const Layer *parentLayer = vrv_cast<const Layer *>(this->GetFirstAncestor(LAYER));
     if (!layer) return defaultLocation;
     const std::set<int> layersN = parentLayer->GetLayersNForTimeSpanOf(this);
     // handle rest positioning for 2 layers. 3 layers and more are much more complex to solve
@@ -281,8 +281,8 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
         = m_crossStaff ? (staff->GetN() < m_crossStaff->GetN()) : (layer->GetN() == *layersN.cbegin());
 
     // find best rest location relative to elements on other layers
-    Staff *realStaff = m_crossStaff ? m_crossStaff : staff;
-    ListOfObjects layers = realStaff->FindAllDescendantsByType(LAYER, false);
+    const Staff *realStaff = m_crossStaff ? m_crossStaff : staff;
+    ListOfConstObjects layers = realStaff->FindAllDescendantsByType(LAYER, false);
     bool restOverlap = true;
     const auto otherLayerRelativeLocationInfo
         = this->GetLocationRelativeToOtherLayers(layers, layer, isTopLayer, restOverlap);
@@ -315,28 +315,28 @@ int Rest::GetOptimalLayerLocation(Staff *staff, Layer *layer, int defaultLocatio
 }
 
 std::pair<int, RestAccidental> Rest::GetLocationRelativeToOtherLayers(
-    const ListOfObjects &layersList, Layer *currentLayer, bool isTopLayer, bool &restOverlap)
+    const ListOfConstObjects &layersList, const Layer *currentLayer, bool isTopLayer, bool &restOverlap) const
 {
     if (!currentLayer) return { VRV_UNSET, RA_none };
 
     // Get iterator to another layer. We're going to find coliding elements there
     auto layerIter = std::find_if(layersList.begin(), layersList.end(),
-        [&](Object *foundLayer) { return vrv_cast<Layer *>(foundLayer)->GetN() != currentLayer->GetN(); });
+        [&](const Object *foundLayer) { return vrv_cast<const Layer *>(foundLayer)->GetN() != currentLayer->GetN(); });
     if (layerIter == layersList.end()) {
         if (!m_crossStaff) return { VRV_UNSET, RA_none };
         // if we're dealing with cross-staff item, get first/last layer, depending whether rest is on top or bottom
         layerIter = isTopLayer ? layersList.begin() : std::prev(layersList.end());
     }
-    auto collidingElementsList = vrv_cast<Layer *>(*layerIter)->GetLayerElementsForTimeSpanOf(this);
+    auto collidingElementsList = vrv_cast<const Layer *>(*layerIter)->GetLayerElementsForTimeSpanOf(this);
 
     std::pair<int, RestAccidental> finalElementInfo = { VRV_UNSET, RA_none };
     // Go through each colliding element and figure out optimal location for the rest
-    for (Object *object : collidingElementsList) {
+    for (const Object *object : collidingElementsList) {
         if (object->Is(NOTE)) restOverlap = false;
-        auto currentElementInfo = this->GetElementLocation(object, vrv_cast<Layer *>(*layerIter), isTopLayer);
+        auto currentElementInfo = this->GetElementLocation(object, vrv_cast<const Layer *>(*layerIter), isTopLayer);
         if (currentElementInfo.first == VRV_UNSET) continue;
         //  If note on other layer is not on the same x position as rest - ignore its accidental
-        if (this->GetAlignment()->GetTime() != vrv_cast<LayerElement *>(object)->GetAlignment()->GetTime()) {
+        if (this->GetAlignment()->GetTime() != vrv_cast<const LayerElement *>(object)->GetAlignment()->GetTime()) {
             currentElementInfo.second = RA_none;
             // limit how much rest can be offset when there is duration overlap, but no x position overlap
             if ((isTopLayer && (currentElementInfo.first > 12)) || (!isTopLayer && (currentElementInfo.first < -4))) {
@@ -353,15 +353,15 @@ std::pair<int, RestAccidental> Rest::GetLocationRelativeToOtherLayers(
     return finalElementInfo;
 }
 
-int Rest::GetLocationRelativeToCurrentLayer(Staff *currentStaff, Layer *currentLayer, bool isTopLayer)
+int Rest::GetLocationRelativeToCurrentLayer(const Staff *currentStaff, const Layer *currentLayer, bool isTopLayer) const
 {
     if (!currentStaff || !currentLayer) return VRV_UNSET;
 
     Functor getRelativeLayerElement(&Object::GetRelativeLayerElement);
     GetRelativeLayerElementParams getRelativeLayerElementParams(this->GetIdx(), BACKWARD, false);
 
-    Object *previousElement = NULL;
-    Object *nextElement = NULL;
+    const Object *previousElement = NULL;
+    const Object *nextElement = NULL;
     // Get previous and next elements from the current layer
     if (currentLayer->GetFirstChildNot(REST)) {
         currentLayer->Process(
@@ -411,28 +411,29 @@ int Rest::GetLocationRelativeToCurrentLayer(Staff *currentStaff, Layer *currentL
     return currentOptimalLocation;
 }
 
-int Rest::GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLayer, bool isPrevious, bool isTopLayer)
+int Rest::GetFirstRelativeElementLocation(
+    const Staff *currentStaff, const Layer *currentLayer, bool isPrevious, bool isTopLayer) const
 {
     // current system
-    System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+    const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     // current measure
-    Measure *measure = vrv_cast<Measure *>(this->GetFirstAncestor(MEASURE));
+    const Measure *measure = vrv_cast<const Measure *>(this->GetFirstAncestor(MEASURE));
     assert(measure);
 
     const int index = system->GetChildIndex(measure);
-    Object *relativeMeasure = system->GetChild(isPrevious ? index - 1 : index + 1);
+    const Object *relativeMeasure = system->GetChild(isPrevious ? index - 1 : index + 1);
     if (!relativeMeasure || !relativeMeasure->Is(MEASURE)) return VRV_UNSET;
 
     // Find staff with the same N as current staff
     AttNIntegerComparison snc(STAFF, currentStaff->GetN());
-    Staff *previousStaff = vrv_cast<Staff *>(relativeMeasure->FindDescendantByComparison(&snc));
+    const Staff *previousStaff = vrv_cast<const Staff *>(relativeMeasure->FindDescendantByComparison(&snc));
     if (!previousStaff) return VRV_UNSET;
 
     // Compare number of layers in the next/previous staff and if it's the same - find layer with same N
-    ListOfObjects layers = previousStaff->FindAllDescendantsByType(LAYER, false);
+    ListOfConstObjects layers = previousStaff->FindAllDescendantsByType(LAYER, false);
     auto layerIter = std::find_if(layers.begin(), layers.end(),
-        [&](Object *foundLayer) { return vrv_cast<Layer *>(foundLayer)->GetN() == currentLayer->GetN(); });
+        [&](const Object *foundLayer) { return vrv_cast<const Layer *>(foundLayer)->GetN() == currentLayer->GetN(); });
     if (((int)layers.size() != currentStaff->GetChildCount(LAYER)) || (layerIter == layers.end())) return VRV_UNSET;
 
     // Get last element if it's previous layer, get first one otherwise
@@ -441,28 +442,28 @@ int Rest::GetFirstRelativeElementLocation(Staff *currentStaff, Layer *currentLay
     (*layerIter)
         ->Process(&getRelativeLayerElement, &getRelativeLayerElementParams, NULL, NULL, UNLIMITED_DEPTH, !isPrevious);
 
-    Object *lastLayerElement = getRelativeLayerElementParams.m_relativeElement;
+    const Object *lastLayerElement = getRelativeLayerElementParams.m_relativeElement;
     if (lastLayerElement && lastLayerElement->Is({ NOTE, CHORD, FTREM })) {
-        return this->GetElementLocation(lastLayerElement, vrv_cast<Layer *>(*layerIter), !isTopLayer).first;
+        return this->GetElementLocation(lastLayerElement, vrv_cast<const Layer *>(*layerIter), !isTopLayer).first;
     }
 
     return VRV_UNSET;
 }
 
-std::pair<int, RestAccidental> Rest::GetElementLocation(Object *object, Layer *layer, bool isTopLayer) const
+std::pair<int, RestAccidental> Rest::GetElementLocation(const Object *object, const Layer *layer, bool isTopLayer) const
 {
     if (object->Is(NOTE)) {
-        Note *note = vrv_cast<Note *>(object);
+        const Note *note = vrv_cast<const Note *>(object);
         assert(note);
-        Accid *accid = note->GetDrawingAccid();
+        const Accid *accid = note->GetDrawingAccid();
         return { PitchInterface::CalcLoc(note, layer, note),
             (accid && accid->GetAccid() != 0) ? MeiAccidentalToRestAccidental(accid->GetAccid()) : RA_none };
     }
     if (object->Is(CHORD)) {
-        Chord *chord = vrv_cast<Chord *>(object);
+        const Chord *chord = vrv_cast<const Chord *>(object);
         assert(chord);
-        Note *relevantNote = isTopLayer ? chord->GetTopNote() : chord->GetBottomNote();
-        Accid *accid = relevantNote->GetDrawingAccid();
+        const Note *relevantNote = isTopLayer ? chord->GetTopNote() : chord->GetBottomNote();
+        const Accid *accid = relevantNote->GetDrawingAccid();
         return { PitchInterface::CalcLoc(chord, layer, relevantNote, isTopLayer),
             (accid && accid->GetAccid() != 0) ? MeiAccidentalToRestAccidental(accid->GetAccid()) : RA_none };
     }
@@ -476,7 +477,7 @@ std::pair<int, RestAccidental> Rest::GetElementLocation(Object *object, Layer *l
     }
     if (object->Is(REST)) {
         if (!m_crossStaff) return { VRV_UNSET, RA_none };
-        Rest *rest = vrv_cast<Rest *>(object);
+        const Rest *rest = vrv_cast<const Rest *>(object);
         assert(rest);
         return { rest->GetDrawingLoc(), RA_none };
     }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -356,7 +356,7 @@ void Staff::SetFromFacsimile(Doc *doc)
     this->AdjustDrawingStaffSize();
 }
 
-bool Staff::IsOnStaffLine(int y, Doc *doc)
+bool Staff::IsOnStaffLine(int y, const Doc *doc) const
 {
     assert(doc);
 

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -77,7 +77,7 @@ void TabDurSym::AddChild(Object *child)
     Modify();
 }
 
-void TabDurSym::AdjustDrawingYRel(Staff *staff, Doc *doc)
+void TabDurSym::AdjustDrawingYRel(const Staff *staff, const Doc *doc)
 {
     assert(staff);
     assert(doc);

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -121,7 +121,7 @@ int TabGrp::InitOnsetOffsetEnd(FunctorParams *functorParams)
     InitOnsetOffsetParams *params = vrv_params_cast<InitOnsetOffsetParams *>(functorParams);
     assert(params);
 
-    LayerElement *element = this->ThisOrSameasAsLink();
+    LayerElement *element = this->ThisOrSameasLink();
 
     double incrementScoreTime = element->GetAlignmentDuration(
         params->m_currentMensur, params->m_currentMeterSig, true, params->m_notationType);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -381,9 +381,9 @@ void Tuplet::CalculateTupletNumCrossStaff(LayerElement *layerElement)
     }
 }
 
-bool Tuplet::HasValidTupletNumPosition(Staff *preferredStaff, Staff *otherStaff)
+bool Tuplet::HasValidTupletNumPosition(const Staff *preferredStaff, const Staff *otherStaff) const
 {
-    Beam *beam = this->GetNumAlignedBeam();
+    const Beam *beam = this->GetNumAlignedBeam();
     if (!beam) return true;
     if (beam->m_drawingPlace == BEAMPLACE_mixed) return false;
 
@@ -465,12 +465,12 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
     return;
 }
 
-void Tuplet::GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc) const
+void Tuplet::GetDrawingLeftRightXRel(int &xRelLeft, int &xRelRight, const Doc *doc) const
 {
     assert(m_drawingLeft);
     assert(m_drawingRight);
 
-    XRelLeft = 0;
+    xRelLeft = 0;
 
     if (m_drawingLeft->Is(NOTE)) {
         //
@@ -481,21 +481,21 @@ void Tuplet::GetDrawingLeftRightXRel(int &XRelLeft, int &XRelRight, Doc *doc) co
     else if (m_drawingLeft->Is(CHORD)) {
         Chord *chord = vrv_cast<Chord *>(m_drawingLeft);
         assert(chord);
-        XRelLeft = chord->GetXMin() - m_drawingLeft->GetDrawingX();
+        xRelLeft = chord->GetXMin() - m_drawingLeft->GetDrawingX();
     }
 
-    XRelRight = 0;
+    xRelRight = 0;
 
     if (m_drawingRight->Is(NOTE)) {
-        XRelRight += (2 * m_drawingRight->GetDrawingRadius(doc));
+        xRelRight += (2 * m_drawingRight->GetDrawingRadius(doc));
     }
     else if (m_drawingRight->Is(REST)) {
-        XRelRight += m_drawingRight->GetSelfX2();
+        xRelRight += m_drawingRight->GetSelfX2();
     }
     else if (m_drawingRight->Is(CHORD)) {
         Chord *chord = vrv_cast<Chord *>(m_drawingRight);
         assert(chord);
-        XRelRight = chord->GetXMax() - chord->GetDrawingX() + (2 * chord->GetDrawingRadius(doc));
+        xRelRight = chord->GetXMax() - chord->GetDrawingX() + (2 * chord->GetDrawingRadius(doc));
     }
 }
 
@@ -625,14 +625,14 @@ int Tuplet::AdjustTupletsX(FunctorParams *functorParams)
         m_numAlignedBeam = NULL;
     }
 
-    int XRelLeft;
-    int XRelRight;
-    this->GetDrawingLeftRightXRel(XRelLeft, XRelRight, params->m_doc);
+    int xRelLeft;
+    int xRelRight;
+    this->GetDrawingLeftRightXRel(xRelLeft, xRelRight, params->m_doc);
 
     TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
     if (tupletBracket && (this->GetBracketVisible() != BOOLEAN_false)) {
-        tupletBracket->SetDrawingXRelLeft(XRelLeft);
-        tupletBracket->SetDrawingXRelRight(XRelRight);
+        tupletBracket->SetDrawingXRelLeft(xRelLeft);
+        tupletBracket->SetDrawingXRelRight(xRelRight);
     }
 
     TupletNum *tupletNum = dynamic_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM));

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -140,7 +140,7 @@ void Tuplet::AddChild(Object *child)
     Modify();
 }
 
-void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff)
+void Tuplet::AdjustTupletBracketY(const Doc *doc, const Staff *staff)
 {
     TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
     if (!tupletBracket || (this->GetBracketVisible() == BOOLEAN_false)) return;
@@ -178,7 +178,7 @@ void Tuplet::AdjustTupletBracketY(Doc *doc, Staff *staff)
     tupletBracket->SetDrawingYRel(tupletBracket->GetDrawingYRel() + yRel + bracketVerticalMargin);
 }
 
-void Tuplet::AdjustTupletBracketBeamY(Doc *doc, Staff *staff, TupletBracket *bracket, Beam *beam)
+void Tuplet::AdjustTupletBracketBeamY(const Doc *doc, const Staff *staff, TupletBracket *bracket, const Beam *beam)
 {
     const int staffSize = staff->m_drawingStaffSize;
     const int doubleUnit = doc->GetDrawingDoubleUnit(staffSize);
@@ -257,7 +257,7 @@ void Tuplet::AdjustTupletBracketBeamY(Doc *doc, Staff *staff, TupletBracket *bra
     }
 }
 
-void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff)
+void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
 {
     TupletNum *tupletNum = dynamic_cast<TupletNum *>(FindDescendantByType(TUPLET_NUM));
     if (!tupletNum || (this->GetNumVisible() == BOOLEAN_false)) return;
@@ -271,7 +271,7 @@ void Tuplet::AdjustTupletNumY(Doc *doc, Staff *staff)
 
     this->CalculateTupletNumCrossStaff(tupletNum);
 
-    Staff *tupletNumStaff = tupletNum->m_crossStaff ? tupletNum->m_crossStaff : staff;
+    const Staff *tupletNumStaff = tupletNum->m_crossStaff ? tupletNum->m_crossStaff : staff;
     const int staffSize = staff->m_drawingStaffSize;
     const int yReference = tupletNumStaff->GetDrawingY();
     const int doubleUnit = doc->GetDrawingDoubleUnit(staffSize);

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -76,7 +76,7 @@ bool Verse::IsSupportedChild(Object *child)
     return true;
 }
 
-int Verse::AdjustPosition(int &overlap, int freeSpace, Doc *doc)
+int Verse::AdjustPosition(int &overlap, int freeSpace, const Doc *doc)
 {
     assert(doc);
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1689,7 +1689,7 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     assert(verse);
 
     Label *label = dynamic_cast<Label *>(verse->FindDescendantByType(LABEL, 1));
-    LabelAbbr *labelAbbr = verse->m_drawingLabelAbbr;
+    LabelAbbr *labelAbbr = verse->GetDrawingLabelAbbr();
 
     if (label || labelAbbr) {
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -778,7 +778,7 @@ void View::DrawDots(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     dc->StartGraphic(element, "", element->GetUuid());
 
     for (const auto &mapEntry : dots->GetMapOfDotLocs()) {
-        Staff *dotStaff = (mapEntry.first) ? mapEntry.first : staff;
+        const Staff *dotStaff = (mapEntry.first) ? mapEntry.first : staff;
         int y = dotStaff->GetDrawingY()
             - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (dotStaff->m_drawingLines - 1);
         int x = dots->GetDrawingX() + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
@@ -1792,7 +1792,7 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     dc->ResetBrush();
 }
 
-void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, Staff *staff, bool dimin)
+void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, const Staff *staff, bool dimin)
 {
     int i;
 


### PR DESCRIPTION
This PR improves const correctness for layer elements by adding `const` to relevant member functions and arguments. No changes in behaviour are expected.