### PR TITLE
Clean-up handling keySig attributes

### DIFF
--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -84,7 +84,6 @@ public:
      */
     ///@{
     bool HasNonAttribKeyAccidChildren() const;
-    void ClearKeyAccidAttribChildren();
     void GenerateKeyAccidAttribChildren();
     ///@}
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -512,6 +512,12 @@ public:
     bool DeleteChild(Object *child);
 
     /**
+     * Delete the children that match the comparison.
+     * Return the number of children deleted. Also mark the object as modified for invalidating the list.
+     */
+    int DeleteChildrenByComparison(Comparison *comparison);
+
+    /**
      * Returns all ancestors
      */
     ///@{

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -15,6 +15,7 @@
 //----------------------------------------------------------------------------
 
 #include "clef.h"
+#include "comparison.h"
 #include "editorial.h"
 #include "functorparams.h"
 #include "keyaccid.h"
@@ -162,16 +163,11 @@ bool KeySig::HasNonAttribKeyAccidChildren() const
     return std::any_of(childList.begin(), childList.end(), [](const Object *child) { return !child->IsAttribute(); });
 }
 
-void KeySig::ClearKeyAccidAttribChildren()
-{
-    ListOfObjects childList = this->GetList(this);
-    std::for_each(childList.begin(), childList.end(), [this](Object *child) {
-        if (child->IsAttribute()) this->DeleteChild(child);
-    });
-}
-
 void KeySig::GenerateKeyAccidAttribChildren()
 {
+    IsAttributeComparison isAttribute(KEYACCID);
+    this->DeleteChildrenByComparison(&isAttribute);
+
     if (this->HasEmptyList(this)) {
         for (int i = 0; i < this->GetAccidCount(true); ++i) {
             std::optional<KeyAccidInfo> info = this->GetKeyAccidInfoAt(i);
@@ -318,7 +314,6 @@ int KeySig::GetOctave(data_ACCIDENTAL_WRITTEN accidType, data_PITCHNAME pitch, C
 int KeySig::PrepareDataInitialization(FunctorParams *)
 {
     // Clear and regenerate attribute children
-    this->ClearKeyAccidAttribChildren();
     this->GenerateKeyAccidAttribChildren();
 
     return FUNCTOR_CONTINUE;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -763,7 +763,7 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
     ArrayOfObjects::iterator iter;
     for (iter = m_children.begin(); iter != m_children.end();) {
         if ((*comparison)(*iter)) {
-            delete *iter;
+            if (!m_isReferenceObject) delete *iter;
             iter = m_children.erase(iter);
             ++count;
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -757,6 +757,24 @@ bool Object::DeleteChild(Object *child)
     }
 }
 
+int Object::DeleteChildrenByComparison(Comparison *comparison)
+{
+    int count = 0;
+    ArrayOfObjects::iterator iter;
+    for (iter = m_children.begin(); iter != m_children.end();) {
+        if ((*comparison)(*iter)) {
+            delete *iter;
+            iter = m_children.erase(iter);
+            ++count;
+        }
+        else {
+            ++iter;
+        }
+    }
+    if (count > 0) this->Modify();
+    return count;
+}
+
 void Object::GenerateUuid()
 {
     m_uuid = m_classIdStr.at(0) + Object::GenerateRandUuid();


### PR DESCRIPTION
This PR removes KeySig::ClearKeyAccidAttribChildren because this method was problematic. `GetList` should not be used to modify the children of an object because it can (in theory) contain descendants that are not direct children of the object. Even though it was not the case with the KeySig attribute, I thought it would be better not to do it. With this PR, the clearing of the attribute objects is simply done every time they are updated.