### PR TITLE
Transpose without key signature

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2629,7 +2629,7 @@ public:
  * member 5: the mdiv selected for transposition
  * member 6: the list of current (nested) mdivs
  * member 7: transpose to sounding pitch by evaluating @trans.semi
- * member 8: true if the current scoreDef contains a KeySig (direct child or attribute)
+ * member 8: current KeySig for staff (ScoreDef key signatures are mapped to -1)
  * member 9: transposition interval for staff
  **/
 
@@ -2642,7 +2642,6 @@ public:
         m_functorEnd = functorEnd;
         m_transposer = transposer;
         m_transposeToSoundingPitch = false;
-        m_hasScoreDefKeySig = false;
     }
     Doc *m_doc;
     Functor *m_functor;
@@ -2652,7 +2651,7 @@ public:
     std::string m_selectedMdivUuid;
     std::list<std::string> m_currentMdivUuids;
     bool m_transposeToSoundingPitch;
-    bool m_hasScoreDefKeySig;
+    std::map<int, const KeySig *> m_keySigForStaffN;
     std::map<int, int> m_transposeIntervalForStaffN;
 };
 

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -369,7 +369,7 @@ private:
 
     TransPitch GetTransPitch();
 
-    void UpdateFromTransPitch(const TransPitch &tp);
+    void UpdateFromTransPitch(const TransPitch &tp, bool hasKeySig);
 
     /**
      * Return whether dots are overlapping with flag. Take into account flag height, its position as well

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -20,6 +20,8 @@
 #include "keyaccid.h"
 #include "scoredefinterface.h"
 #include "smufl.h"
+#include "staff.h"
+#include "staffdef.h"
 #include "transposition.h"
 #include "vrv.h"
 
@@ -329,11 +331,20 @@ int KeySig::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    if (!this->GetFirstAncestor(STAFFDEF)) {
-        params->m_hasScoreDefKeySig = true;
+    // Store current KeySig
+    int staffN = -1;
+    const StaffDef *staffDef = vrv_cast<StaffDef *>(this->GetFirstAncestor(STAFFDEF));
+    if (staffDef) {
+        staffN = staffDef->GetN();
     }
+    else {
+        const Staff *staff = this->GetAncestorStaff(ANCESTOR_ONLY, false);
+        if (staff) staffN = staff->GetN();
+    }
+    params->m_keySigForStaffN[staffN] = this;
 
-    int sig = this->GetFifthsInt();
+    // Transpose
+    const int sig = this->GetFifthsInt();
 
     int intervalClass = params->m_transposer->CircleOfFifthsToIntervalClass(sig);
     intervalClass = params->m_transposer->Transpose(intervalClass);

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -127,6 +127,7 @@ int Mdiv::Transpose(FunctorParams *functorParams)
     assert(params);
 
     params->m_currentMdivUuids.push_back(this->GetUuid());
+    params->m_keySigForStaffN.clear();
     params->m_transposeIntervalForStaffN.clear();
 
     return FUNCTOR_CONTINUE;

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -759,8 +759,6 @@ int ScoreDef::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    params->m_hasScoreDefKeySig = false;
-
     if (params->m_transposeToSoundingPitch) {
         // Set the transposition in order to transpose common key signatures
         // (i.e. encoded as ScoreDef attributes or direct KeySig children)
@@ -785,7 +783,8 @@ int ScoreDef::TransposeEnd(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    if (params->m_transposeToSoundingPitch && params->m_hasScoreDefKeySig) {
+    const bool hasScoreDefKeySig = (params->m_keySigForStaffN.count(-1) > 0);
+    if (params->m_transposeToSoundingPitch && hasScoreDefKeySig) {
         bool showWarning = false;
         // Check if some staves are untransposed
         const int mapEntryCount = static_cast<int>(params->m_transposeIntervalForStaffN.size());


### PR DESCRIPTION
This PR adds support for transposition of scores without key signature.

The following example has a key signature in staff 1, but no key signature in staff 2.

|  | Before | After |
| ----- | ------ | ----- |
| Untransposed | ![Before-Untransp](https://user-images.githubusercontent.com/63608463/172812377-fe3510e1-05c3-4877-b1fb-de9262b2936c.png) | ![After-Untransp](https://user-images.githubusercontent.com/63608463/172812410-607dc33a-b12b-42b0-825c-b715b515d223.png) |
| Transposed to D | ![Before-Transp](https://user-images.githubusercontent.com/63608463/172812591-e790f5b7-d6bb-4129-a151-b27308f7d12f.png) | ![After-Transp](https://user-images.githubusercontent.com/63608463/172812637-a428963f-49b6-48c0-90ce-9ac4b52c169a.png) |
| Transposed to F | ![Before-Transp-F](https://user-images.githubusercontent.com/63608463/172815581-6c510e2b-8a53-4c6e-b4e0-4f60d3c20a66.png) | ![After-Transp-F](https://user-images.githubusercontent.com/63608463/172815626-caf5305d-fbd4-4dcf-bfd7-fbf4db93f663.png) |


<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="400">
                  <staffGrp symbol="bracket">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0">
                        <label />
                     </staffDef>
                     <staffDef n="2" lines="5" clef.shape="G" clef.line="2">
                        <label />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="c" />
                            <note dur="4" oct="4" pname="d" />
                            <note dur="4" oct="4" pname="e" />
                            <note dur="4" oct="4" pname="f" />
                          </beam>
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="f" />
                            <note dur="4" oct="4" pname="e" />
                            <note dur="4" oct="4" pname="d" />
                          </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="c" />
                            <note dur="4" oct="4" pname="d" />
                            <note dur="4" oct="4" pname="e" />
                            <note dur="4" oct="4" pname="f" />
                          </beam>
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="f" />
                            <note dur="4" oct="4" pname="e" />
                            <note dur="4" oct="4" pname="d" />
                          </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="a" />
                            <note dur="4" oct="4" pname="b" />
                            <note dur="4" oct="5" pname="c" />
                          </beam>
                          <beam>
                            <note dur="4" oct="5" pname="d" />
                            <note dur="4" oct="5" pname="c" />
                            <note dur="4" oct="4" pname="b" />
                            <note dur="4" oct="4" pname="a" />
                          </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="a" />
                            <note dur="4" oct="4" pname="b" />
                            <note dur="4" oct="5" pname="c" />
                          </beam>
                          <beam>
                            <note dur="4" oct="5" pname="d" />
                            <note dur="4" oct="5" pname="c" />
                            <note dur="4" oct="4" pname="b" />
                            <note dur="4" oct="4" pname="a" />
                          </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="c" />
                            <note dur="4" oct="4" pname="d" accid="s" />
                            <note dur="4" oct="4" pname="e" accid="f" />
                            <note dur="4" oct="4" pname="f" />
                          </beam>
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="f" />
                            <note dur="4" oct="4" pname="e" accid="n" />
                            <note dur="4" oct="4" pname="d" accid.ges="s" />
                          </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                          <beam>
                            <note dur="4" oct="4" pname="c" />
                            <note dur="4" oct="4" pname="d" accid="s" />
                            <note dur="4" oct="4" pname="e" accid="f" />
                            <note dur="4" oct="4" pname="f" />
                          </beam>
                          <beam>
                            <note dur="4" oct="4" pname="g" />
                            <note dur="4" oct="4" pname="f" />
                            <note dur="4" oct="4" pname="e" accid="n" />
                            <note dur="4" oct="4" pname="d" accid.ges="s" />
                          </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

 