### PR TITLE
Revert changes to DrawBarLine parameters

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -216,8 +216,8 @@ protected:
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
-    void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, bool eraseIntersections = false,
-        bool singleStaff = true);
+    void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
+        bool eraseIntersections = false, bool singleStaff = true);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerLines &lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -785,7 +785,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
                     yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
                     yBottom -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
                 }
-                this->DrawBarLine(dc, yTop, yBottom, barLine);
+                this->DrawBarLine(dc, yTop, yBottom, barLine, form);
                 if (barLine->HasRepetitionDots()) {
                     this->DrawBarLineDots(dc, staff, barLine);
                 }
@@ -856,7 +856,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         if (isLastMeasure && (barLine->GetPosition() == BarLinePosition::Right)) {
             eraseIntersections = false;
         }
-        this->DrawBarLine(dc, yTop, yBottom, barLine, eraseIntersections, singleStaff);
+        this->DrawBarLine(dc, yTop, yBottom, barLine, barLine->GetForm(), eraseIntersections, singleStaff);
 
         // Now we have a barthru barLine, but we have dots so we still need to go through each staff
         if (barLine->HasRepetitionDots()) {
@@ -879,13 +879,12 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
     }
 }
 
-void View::DrawBarLine(
-    DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, bool eraseIntersections, bool singleStaff)
+void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
+    bool eraseIntersections, bool singleStaff)
 {
     assert(dc);
     assert(barLine);
 
-    const data_BARRENDITION form = barLine->GetForm();
     Staff *staff = barLine->GetAncestorStaff(ANCESTOR_ONLY, false);
     const int staffSize = (staff) ? staff->m_drawingStaffSize : 100;
 


### PR DESCRIPTION
#2864 added regression to barLines:
![image](https://user-images.githubusercontent.com/1819669/172825642-06bd40d6-833a-4a51-9312-681b71bebce7.png)

This reverts part of the change to remove the problem:
![image](https://user-images.githubusercontent.com/1819669/172825718-c9b7bf2f-73b8-48cc-9d32-3c678cd8433a.png)
