### PR TITLE
Adjust semitone shift during MIDI output 

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1714,16 +1714,17 @@ using MIDIChordSequence = std::list<MIDIChord>;
  * member 1: int: the midi track number
  * member 2: int: the midi channel number
  * member 3: double: the score time from the start of the music to the start of the current measure
- * member 4: int: the semi tone transposition for the current track
- * member 5: double with the current tempo
- * member 6: the last (non grace) note that was performed
- * member 7: expanded notes due to ornaments and tremolandi
- * member 8: deferred notes which start slightly later
- * member 9: grace note sequence
- * member 10: flag indicating whether the last grace note/chord was accented
- * member 11: flag indicating whether cue notes should be included
- * member 12: the functor
- * member 13: Tablature held notes indexed by (course - 1)
+ * member 4: the current staff number
+ * member 5: the semi tone transposition for the current track
+ * member 6: double with the current tempo
+ * member 7: the last (non grace) note that was performed
+ * member 8: expanded notes due to ornaments and tremolandi
+ * member 9: deferred notes which start slightly later
+ * member 10: grace note sequence
+ * member 11: flag indicating whether the last grace note/chord was accented
+ * member 12: flag indicating whether cue notes should be included
+ * member 13: the functor
+ * member 14: Tablature held notes indexed by (course - 1)
  **/
 
 class GenerateMIDIParams : public FunctorParams {
@@ -1734,6 +1735,7 @@ public:
         m_midiTrack = 1;
         m_midiChannel = 0;
         m_totalTime = 0.0;
+        m_staffN = 0;
         m_transSemi = 0;
         m_currentTempo = MIDI_TEMPO;
         m_lastNote = NULL;
@@ -1745,6 +1747,7 @@ public:
     int m_midiTrack;
     int m_midiChannel;
     double m_totalTime;
+    int m_staffN;
     int m_transSemi;
     double m_currentTempo;
     Note *m_lastNote;

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -85,6 +85,11 @@ public:
     int PrepareDuration(FunctorParams *functorParams) override;
 
     /**
+     * See Object::GenerateMIDI
+     */
+    int GenerateMIDI(FunctorParams *functorParams) override;
+
+    /**
      * See Object::Transpose
      */
     int Transpose(FunctorParams *functorParams) override;

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -7214,8 +7214,8 @@ AttTransposition::~AttTransposition()
 
 void AttTransposition::ResetTransposition()
 {
-    m_transDiat = 0.0;
-    m_transSemi = 0.0;
+    m_transDiat = VRV_UNSET;
+    m_transSemi = VRV_UNSET;
 }
 
 bool AttTransposition::ReadTransposition(pugi::xml_node element)
@@ -7250,12 +7250,12 @@ bool AttTransposition::WriteTransposition(pugi::xml_node element)
 
 bool AttTransposition::HasTransDiat() const
 {
-    return (m_transDiat != 0.0);
+    return (m_transDiat != VRV_UNSET);
 }
 
 bool AttTransposition::HasTransSemi() const
 {
-    return (m_transSemi != 0.0);
+    return (m_transSemi != VRV_UNSET);
 }
 
 /* include <atttrans.semi> */

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -418,6 +418,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             GenerateMIDIParams generateMIDIParams(midiFile, &generateMIDI);
             generateMIDIParams.m_midiChannel = midiChannel;
             generateMIDIParams.m_midiTrack = midiTrack;
+            generateMIDIParams.m_staffN = staves->first;
             generateMIDIParams.m_transSemi = transSemi;
             generateMIDIParams.m_currentTempo = tempo;
             generateMIDIParams.m_deferredNotes = initMIDIParams.m_deferredNotes;

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -197,6 +197,19 @@ int StaffDef::PrepareDuration(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int StaffDef::GenerateMIDI(FunctorParams *functorParams)
+{
+    GenerateMIDIParams *params = vrv_params_cast<GenerateMIDIParams *>(functorParams);
+    assert(params);
+
+    if (this->GetN() == params->m_staffN) {
+        // Update the semitone transposition
+        if (this->HasTransSemi()) params->m_transSemi = this->GetTransSemi();
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 int StaffDef::Transpose(FunctorParams *functorParams)
 {
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);


### PR DESCRIPTION
This PR adds adjustment of the semitone shift provided by `@trans.semi` during MIDI output. 
The PR includes a small update of LibMEI [with changes for default values](https://github.com/rism-digital/libmei/pull/10).
![SemitoneShift](https://user-images.githubusercontent.com/63608463/173009806-bd8acd8b-4576-43ed-963e-c7c55dacbdc8.png)
<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title></title>
         </titleStmt>
         <pubStmt>
            <date isodate="2022-05-24">2022-05-24</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>For the bottom two staves, the chord should visually look the same as on the top staff.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.9.0" label="0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" trans.diat="1" trans.semi="2">
                        <clef shape="G" line="2" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                        </layer>
                     </staff>
                     <dir staff="1" tstamp="1" place="above">in D</dir>
                  </measure>
                  <scoreDef>
                     <staffGrp>
                        <staffDef n="1" lines="5" trans.diat="-1" trans.semi="-2">
                           <clef shape="G" line="2" />
                           <meterSig count="4" unit="4" />
                        </staffDef>
                     </staffGrp>
                  </scoreDef>
                     <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                        </layer>
                     </staff>
                     <dir staff="1" tstamp="1" place="above">in B♭</dir>
                  </measure>
                  <scoreDef>
                     <staffGrp>
                        <staffDef n="1" lines="5" trans.diat="0" trans.semi="0">
                           <clef shape="G" line="2" />
                           <meterSig count="4" unit="4" />
                        </staffDef>
                     </staffGrp>
                  </scoreDef>
                     <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="e" accid.ges="n" />
                              <note oct="4" pname="g" accid.ges="n" />
                           </chord>
                        </layer>
                     </staff>
                     <dir staff="1" tstamp="1" place="above">in C</dir>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
