### PR TITLE
Skip layout for MIDI and timemap output

### DIFF
--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -634,6 +634,13 @@ public:
     ///@{
 
     /**
+     * Skip the layout on load to speed up MIDI or timemap output
+     *
+     * @ingroup nodoc
+     */
+    void SkipLayoutOnLoad(bool value);
+
+    /**
      * Render the page to the deviceContext
      *
      * Page number is 1-based.
@@ -757,6 +764,8 @@ private:
     FileFormat m_outputTo;
 
     Options *m_options;
+
+    bool m_skipLayoutOnLoad;
 
     /**
      * The C buffer string.

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -742,7 +742,7 @@ bool Toolkit::LoadData(const std::string &data)
     // to be converted
     if (m_doc.GetType() == Transcription || m_doc.GetType() == Facs) breaks = BREAKS_none;
 
-    if (breaks != BREAKS_none) {
+    if (!m_skipLayoutOnLoad && (breaks != BREAKS_none)) {
         if (input->GetLayoutInformation() == LAYOUT_ENCODED
             && (breaks == BREAKS_encoded || breaks == BREAKS_line || breaks == BREAKS_smart)) {
             if (breaks == BREAKS_encoded) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -84,6 +84,8 @@ Toolkit::Toolkit(bool initFont)
 
     m_options = m_doc.GetOptions();
 
+    m_skipLayoutOnLoad = false;
+
     m_editorToolkit = NULL;
 
 #ifndef NO_RUNTIME
@@ -790,6 +792,11 @@ bool Toolkit::LoadData(const std::string &data)
 #endif
 
     return true;
+}
+
+void Toolkit::SkipLayoutOnLoad(bool value)
+{
+    m_skipLayoutOnLoad = value;
 }
 
 std::string Toolkit::GetMEI(const std::string &jsonOptions)

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -472,6 +472,11 @@ int main(int argc, char **argv)
         outfile = removeExtension(outfile);
     }
 
+    // Skip the layout for MIDI and timemap output
+    if ((outformat == "midi") || (outformat == "timemap")) {
+        toolkit.SkipLayoutOnLoad(true);
+    }
+
     // Load the std input or load the file
     if (!((toolkit.GetOutputTo() == vrv::HUMDRUM) && (toolkit.GetInputFrom() == vrv::MEI))) {
         if (infile == "-") {


### PR DESCRIPTION
This PR introduces skipping the layout for midi and timemap output in the Verovio command line tool. This speeds up the total runtime of MIDI/timemap generation by a factor between 1,4 and 1,9 (depending on the size of the piece and the complexity of the layout).