### PR TITLE
Use C++11 random library for ID generation

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -9,10 +9,10 @@
 #define __VRV_OBJECT_H__
 
 #include <cstdlib>
-#include <ctime>
 #include <functional>
 #include <iterator>
 #include <map>
+#include <random>
 #include <string>
 
 //----------------------------------------------------------------------------
@@ -1639,6 +1639,11 @@ private:
      * A static counter for uuid generation.
      */
     static thread_local unsigned long s_objectCounter;
+
+    /**
+     * Pseudo random number engine for ID generation
+     */
+    static thread_local std::mt19937 s_randomGenerator;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -94,7 +94,7 @@ std::string GetVersion();
  * Encode the integer value using the specified base (max is 62)
  * Base 36 uses 0-9 and a-z, base 62 also A-Z.
  */
-std::string BaseEncodeInt(int value, int base);
+std::string BaseEncodeInt(unsigned int value, unsigned int base);
 
 /**
  *

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -64,26 +64,26 @@ thread_local std::mt19937 Object::s_randomGenerator;
 
 Object::Object() : BoundingBox()
 {
-    this->Init(OBJECT, "m-");
     if (s_objectCounter++ == 0) {
         this->SeedUuid();
     }
+    this->Init(OBJECT, "m-");
 }
 
 Object::Object(ClassId classId) : BoundingBox()
 {
-    this->Init(classId, "m-");
     if (s_objectCounter++ == 0) {
         this->SeedUuid();
     }
+    this->Init(classId, "m-");
 }
 
 Object::Object(ClassId classId, const std::string &classIdStr) : BoundingBox()
 {
-    this->Init(classId, classIdStr);
     if (s_objectCounter++ == 0) {
         this->SeedUuid();
     }
+    this->Init(classId, classIdStr);
 }
 
 Object *Object::Clone() const

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -60,28 +60,29 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 thread_local unsigned long Object::s_objectCounter = 0;
+thread_local std::mt19937 Object::s_randomGenerator;
 
 Object::Object() : BoundingBox()
 {
-    Init(OBJECT, "m-");
+    this->Init(OBJECT, "m-");
     if (s_objectCounter++ == 0) {
-        SeedUuid();
+        this->SeedUuid();
     }
 }
 
 Object::Object(ClassId classId) : BoundingBox()
 {
-    Init(classId, "m-");
+    this->Init(classId, "m-");
     if (s_objectCounter++ == 0) {
-        SeedUuid();
+        this->SeedUuid();
     }
 }
 
 Object::Object(ClassId classId, const std::string &classIdStr) : BoundingBox()
 {
-    Init(classId, classIdStr);
+    this->Init(classId, classIdStr);
     if (s_objectCounter++ == 0) {
-        SeedUuid();
+        this->SeedUuid();
     }
 }
 
@@ -1205,16 +1206,17 @@ void Object::SeedUuid(unsigned int seed)
 {
     // Init random number generator for uuids
     if (seed == 0) {
-        std::srand((unsigned int)std::time(0));
+        std::random_device rd;
+        s_randomGenerator.seed(rd());
     }
     else {
-        std::srand(seed);
+        s_randomGenerator.seed(seed);
     }
 }
 
 std::string Object::GenerateRandUuid()
 {
-    int nr = std::rand();
+    unsigned int nr = s_randomGenerator();
 
     // char str[17];
     // snprintf(str, 17, "%016d", nr);

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -270,7 +270,7 @@ std::string GetVersion()
 
 static const std::string base62Chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-std::string BaseEncodeInt(int value, int base)
+std::string BaseEncodeInt(unsigned int value, unsigned int base)
 {
     assert(base > 10);
     assert(base < 63);


### PR DESCRIPTION
This PR replaces the C-style `rand()` used for ID generation by a generator from the C++11 random library. The main reasons for this change are thread safety (see [this post](https://stackoverflow.com/questions/6161322/using-stdlibs-rand-from-multiple-threads)) and higher quality random numbers (i.e. less likelihood of generating the same ID twice).