### PR TITLE
Rename Uuid into ID

### DIFF
--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -478,23 +478,23 @@ private:
 };
 
 //----------------------------------------------------------------------------
-// UuidComparison
+// IDComparison
 //----------------------------------------------------------------------------
 
 /**
- * This class evaluates if the object is of a certain ClassId has a certain Uuid
+ * This class evaluates if the object is of a certain ClassId has a certain ID
  */
-class UuidComparison : public ClassIdComparison {
+class IDComparison : public ClassIdComparison {
 
 public:
-    UuidComparison(ClassId classId, const std::string &uuid) : ClassIdComparison(classId) { m_uuid = uuid; }
+    IDComparison(ClassId classId, const std::string &uuid) : ClassIdComparison(classId) { m_uuid = uuid; }
 
-    void SetUuid(const std::string &uuid) { m_uuid = uuid; }
+    void SetID(const std::string &uuid) { m_uuid = uuid; }
 
     bool operator()(const Object *object) override
     {
         if (!MatchesType(object)) return false;
-        return object->GetUuid() == m_uuid;
+        return object->GetID() == m_uuid;
     }
 
 private:

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -494,7 +494,7 @@ public:
     bool operator()(const Object *object) override
     {
         if (!MatchesType(object)) return false;
-        return object->GetID() == m_id;
+        return (object->GetID() == m_id);
     }
 
 private:

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -487,18 +487,18 @@ private:
 class IDComparison : public ClassIdComparison {
 
 public:
-    IDComparison(ClassId classId, const std::string &uuid) : ClassIdComparison(classId) { m_uuid = uuid; }
+    IDComparison(ClassId classId, const std::string &id) : ClassIdComparison(classId) { m_id = id; }
 
-    void SetID(const std::string &uuid) { m_uuid = uuid; }
+    void SetID(const std::string &id) { m_id = id; }
 
     bool operator()(const Object *object) override
     {
         if (!MatchesType(object)) return false;
-        return object->GetID() == m_uuid;
+        return object->GetID() == m_id;
     }
 
 private:
-    std::string m_uuid;
+    std::string m_id;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/expansionmap.h
+++ b/include/vrv/expansionmap.h
@@ -48,7 +48,7 @@ public:
 private:
     bool UpdateIds(Object *object);
 
-    void GetUuidList(Object *object, std::vector<std::string> &idList);
+    void GetIDList(Object *object, std::vector<std::string> &idList);
 
     void GeneratePredictableIds(Object *source, Object *target);
 

--- a/include/vrv/expansionmap.h
+++ b/include/vrv/expansionmap.h
@@ -43,17 +43,17 @@ public:
      */
     void Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &existingList, Object *prevSection);
 
-    std::vector<std::string> GetExpansionIdsForElement(const std::string &xmlId);
+    std::vector<std::string> GetExpansionIDsForElement(const std::string &xmlId);
 
 private:
-    bool UpdateIds(Object *object);
+    bool UpdateIDs(Object *object);
 
     void GetIDList(Object *object, std::vector<std::string> &idList);
 
-    void GeneratePredictableIds(Object *source, Object *target);
+    void GeneratePredictableIDs(Object *source, Object *target);
 
     /** Ads an id string to an original/notated id */
-    bool AddExpandedIdToExpansionMap(const std::string &origXmlId, std::string newXmlId);
+    bool AddExpandedIDToExpansionMap(const std::string &origXmlId, std::string newXmlId);
 
 public:
     /** The expansion map indicates which xmlId has been repeated (expanded) elsewhere */

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -43,7 +43,7 @@ public:
     ///@}
     bool IsSupportedChild(Object *object) override;
 
-    Zone *FindZoneByUuid(std::string zoneId);
+    Zone *FindZoneByID(std::string zoneId);
     int GetMaxY();
     int GetMaxX();
 };

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -60,7 +60,7 @@ public:
      * Helpler for converting markup (from Note, Chord, Rest, MRest)
      */
     void ConvertFromAnalyticalMarkup(
-        AttFermataPresent *fermataPresent, const std::string &uuid, ConvertMarkupAnalyticalParams *params);
+        AttFermataPresent *fermataPresent, const std::string &id, ConvertMarkupAnalyticalParams *params);
 
     /**
      * Get the SMuFL glyph for the fermata based on type, shape or glyph.num

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1642,7 +1642,7 @@ public:
 
 /**
  * member 0: a pointer to the element inside Layer StaffDef
- * member 1: UUID of element to be found
+ * member 1: ID of element to be found
  **/
 
 class FindLayerIDWithinStaffDefParams : public FunctorParams {

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1647,9 +1647,9 @@ public:
 
 class FindLayerIDWithinStaffDefParams : public FunctorParams {
 public:
-    explicit FindLayerIDWithinStaffDefParams(const std::string &ID)
+    explicit FindLayerIDWithinStaffDefParams(const std::string &xmlId)
     {
-        m_uuid = ID;
+        m_uuid = xmlId;
         m_object = NULL;
     }
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1544,7 +1544,7 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// FindByUuidParams
+// FindByIDParams
 //----------------------------------------------------------------------------
 
 /**
@@ -1552,9 +1552,9 @@ public:
  * member 1: the pointer to pointer to the Object
  **/
 
-class FindByUuidParams : public FunctorParams {
+class FindByIDParams : public FunctorParams {
 public:
-    FindByUuidParams() { m_element = NULL; }
+    FindByIDParams() { m_element = NULL; }
     std::string m_uuid;
     const Object *m_element;
 };
@@ -1637,7 +1637,7 @@ public:
 };
 
 //----------------------------------------------------------------------------
-// FindLayerUuidWithinStaffDefParams
+// FindLayerIDWithinStaffDefParams
 //----------------------------------------------------------------------------
 
 /**
@@ -1645,11 +1645,11 @@ public:
  * member 1: UUID of element to be found
  **/
 
-class FindLayerUuidWithinStaffDefParams : public FunctorParams {
+class FindLayerIDWithinStaffDefParams : public FunctorParams {
 public:
-    explicit FindLayerUuidWithinStaffDefParams(const std::string &Uuid)
+    explicit FindLayerIDWithinStaffDefParams(const std::string &ID)
     {
-        m_uuid = Uuid;
+        m_uuid = ID;
         m_object = NULL;
     }
 
@@ -2233,9 +2233,9 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: MapOfLinkingInterfaceUuidPairs holds the interface / uuid pairs to match for links
- * member 1: MapOfLinkingInterfaceUuidPairs holds the interface / uuid pairs to match for sameas
- * member 2: MapOfNoteUuidPairs holds the note / uuid pairs to match for stem.sameas
+ * member 0: MapOfLinkingInterfaceIDPairs holds the interface / uuid pairs to match for links
+ * member 1: MapOfLinkingInterfaceIDPairs holds the interface / uuid pairs to match for sameas
+ * member 2: MapOfNoteIDPairs holds the note / uuid pairs to match for stem.sameas
  * member 3: bool* fillList for indicating whether the pairs have to be stacked or not
  *
  **/
@@ -2243,9 +2243,9 @@ public:
 class PrepareLinkingParams : public FunctorParams {
 public:
     PrepareLinkingParams() { m_fillList = true; }
-    MapOfLinkingInterfaceUuidPairs m_nextUuidPairs;
-    MapOfLinkingInterfaceUuidPairs m_sameasUuidPairs;
-    MapOfNoteUuidPairs m_stemSameasUuidPairs;
+    MapOfLinkingInterfaceIDPairs m_nextIDPairs;
+    MapOfLinkingInterfaceIDPairs m_sameasIDPairs;
+    MapOfNoteIDPairs m_stemSameasIDPairs;
     bool m_fillList;
 };
 
@@ -2291,14 +2291,14 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: ArrayOfInterfaceUuidPairs holds the interface / uuid pairs to match
+ * member 0: ArrayOfInterfaceIDPairs holds the interface / uuid pairs to match
  * member 1: bool* fillList for indicating whether the pairs have to be stacked or not
  **/
 
 class PreparePlistParams : public FunctorParams {
 public:
     PreparePlistParams() { m_fillList = true; }
-    ArrayOfPlistInterfaceUuidTuples m_interfaceUuidTuples;
+    ArrayOfPlistInterfaceIDTuples m_interfaceIDTuples;
     bool m_fillList;
 };
 
@@ -2651,8 +2651,8 @@ public:
     Functor *m_functorEnd;
     Transposer *m_transposer;
     std::string m_transposition;
-    std::string m_selectedMdivUuid;
-    std::list<std::string> m_currentMdivUuids;
+    std::string m_selectedMdivID;
+    std::list<std::string> m_currentMdivIDs;
     bool m_transposeToSoundingPitch;
     std::map<int, const KeySig *> m_keySigForStaffN;
     std::map<int, int> m_transposeIntervalForStaffN;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1548,14 +1548,14 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: the uuid we are looking for
+ * member 0: the id we are looking for
  * member 1: the pointer to pointer to the Object
  **/
 
 class FindByIDParams : public FunctorParams {
 public:
     FindByIDParams() { m_element = NULL; }
-    std::string m_uuid;
+    std::string m_id;
     const Object *m_element;
 };
 
@@ -1649,12 +1649,12 @@ class FindLayerIDWithinStaffDefParams : public FunctorParams {
 public:
     explicit FindLayerIDWithinStaffDefParams(const std::string &xmlId)
     {
-        m_uuid = xmlId;
+        m_id = xmlId;
         m_object = NULL;
     }
 
     Object *m_object;
-    std::string m_uuid;
+    std::string m_id;
 };
 
 //----------------------------------------------------------------------------
@@ -2233,9 +2233,9 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: MapOfLinkingInterfaceIDPairs holds the interface / uuid pairs to match for links
- * member 1: MapOfLinkingInterfaceIDPairs holds the interface / uuid pairs to match for sameas
- * member 2: MapOfNoteIDPairs holds the note / uuid pairs to match for stem.sameas
+ * member 0: MapOfLinkingInterfaceIDPairs holds the interface / id pairs to match for links
+ * member 1: MapOfLinkingInterfaceIDPairs holds the interface / id pairs to match for sameas
+ * member 2: MapOfNoteIDPairs holds the note / id pairs to match for stem.sameas
  * member 3: bool* fillList for indicating whether the pairs have to be stacked or not
  *
  **/
@@ -2291,7 +2291,7 @@ public:
 //----------------------------------------------------------------------------
 
 /**
- * member 0: ArrayOfInterfaceIDPairs holds the interface / uuid pairs to match
+ * member 0: ArrayOfInterfaceIDPairs holds the interface / id pairs to match
  * member 1: bool* fillList for indicating whether the pairs have to be stacked or not
  **/
 

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -217,9 +217,9 @@ public:
     bool HasFilter() const;
     void SetFirstPage(int page);
     void SetLastPage(int page);
-    void SetFirstMeasure(const std::string &uuid);
-    void SetLastMeasure(const std::string &uuid);
-    void SetMdiv(const std::string &uuid);
+    void SetFirstMeasure(const std::string &id);
+    void SetLastMeasure(const std::string &id);
+    void SetMdiv(const std::string &id);
     void ResetFilter();
     ///@}
 

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -513,7 +513,7 @@ private:
 
     /** @name Methods for converting members into MEI attributes. */
     ///@{
-    std::string UuidToMeiStr(Object *element);
+    std::string IDToMeiStr(Object *element);
     std::string DocTypeToStr(DocType type);
     ///@}
 
@@ -542,10 +542,10 @@ private:
     int m_firstPage;
     int m_currentPage;
     int m_lastPage;
-    std::string m_firstMeasureUuid;
-    std::string m_lastMeasureUuid;
+    std::string m_firstMeasureID;
+    std::string m_lastMeasureID;
     RangeMatchLocation m_measureFilterMatchLocation;
-    std::string m_mdivUuid;
+    std::string m_mdivID;
     MatchLocation m_mdivFilterMatchLocation;
     ///@}
 
@@ -827,7 +827,7 @@ private:
      * @name Various methods for reading / converting values.
      */
     ///@{
-    void SetMeiUuid(pugi::xml_node element, Object *object);
+    void SetMeiID(pugi::xml_node element, Object *object);
     DocType StrToDocType(std::string type);
     std::wstring LeftTrim(std::wstring str);
     std::wstring RightTrim(std::wstring str);

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -363,7 +363,7 @@ private:
      */
     ///@{
     ///@}
-    void GenerateUuid(pugi::xml_node node);
+    void GenerateID(pugi::xml_node node);
 
     /*
      * @name Helper method for meterSigGrp. Separates beat/beat-type into MeterSig and adds them to the MeterSigGrp.

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -276,9 +276,9 @@ public:
     int ResetData(FunctorParams *functorParams) override;
 
     /**
-     * See Object::FindElementInLayerStaffDefsByUUID
+     * See Object::FindElementInLayerStaffDefsByID
      */
-    int FindElementInLayerStaffDefsByUUID(FunctorParams *) const override;
+    int FindElementInLayerStaffDefsByID(FunctorParams *) const override;
 
     /**
      * @name See Object::GenerateMIDI

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -68,7 +68,7 @@ public:
     ///@}
 
     /**
-     * Set @corresp attribute to the UUID (or @corresp) of the object
+     * Set @corresp attribute to the ID (or @corresp) of the object
      */
     void AddBackLink(const Object *object);
 

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -102,7 +102,7 @@ protected:
     /**
      * Extract the fragment of the start or end @xml:id if given
      */
-    void SetUuidStr();
+    void SetIDStr();
 
 private:
     //
@@ -110,9 +110,9 @@ public:
     //
 private:
     Object *m_next;
-    std::string m_nextUuid;
+    std::string m_nextID;
     Object *m_sameas;
-    std::string m_sameasUuid;
+    std::string m_sameasID;
 };
 
 } // namespace vrv

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -243,7 +243,7 @@ public:
 
     /**
      * Resovle @stem.sameas links by instanciating Note::m_stemSameas (*Note).
-     * Called twice from Object::PrepareLinks. Once to fill uuid / note pairs,
+     * Called twice from Object::PrepareLinks. Once to fill id / note pairs,
      * and once to resolve the link. The link is bi-directional, which means
      * that both notes have their m_stemSameas pointer instanciated.
      */

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -169,7 +169,7 @@ public:
      * needs to be overridden in the child class - otherwise, it will crash.
      * Because this will create a problem if we don't check this (the parents will
      * one the same child...)
-     * ID: the uuid is copied, it needs to be reset later if this is not wished
+     * ID: the id is copied, it needs to be reset later if this is not wished
      */
     Object(const Object &object);
 
@@ -234,8 +234,8 @@ public:
      */
     virtual void CloneReset();
 
-    const std::string &GetID() const { return m_uuid; }
-    void SetID(std::string uuid);
+    const std::string &GetID() const { return m_id; }
+    void SetID(std::string id);
     void SwapID(Object *other);
     void ResetID();
 
@@ -411,13 +411,13 @@ public:
     bool HasDescendant(Object *child, int deepness = UNLIMITED_DEPTH) const;
 
     /**
-     * Look for a descendant with the specified uuid (returns NULL if not found)
+     * Look for a descendant with the specified id (returns NULL if not found)
      * This method is a wrapper for the Object::FindByID functor.
      */
     ///@{
-    Object *FindDescendantByID(const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    Object *FindDescendantByID(const std::string &id, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
     const Object *FindDescendantByID(
-        const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
+        const std::string &id, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
     ///@}
 
     /**
@@ -670,7 +670,7 @@ public:
     ///@{
 
     /**
-     * Find a Object with a specified uuid.
+     * Find a Object with a specified id.
      */
     virtual int FindByID(FunctorParams *functorParams) const;
 
@@ -1525,12 +1525,12 @@ public:
 
 private:
     /**
-     * Method for generating the uuid.
+     * Method for generating the id.
      */
     void GenerateID();
 
     /**
-     * Initialisation method taking the class id and a uuid prefix argument.
+     * Initialisation method taking the class id and a id prefix argument.
      */
     void Init(ClassId classId, const std::string &classIdStr);
 
@@ -1570,10 +1570,10 @@ private:
     ClassId m_classId;
 
     /**
-     * Members for storing / generating uuids
+     * Members for storing / generating ids
      */
     ///@{
-    std::string m_uuid;
+    std::string m_id;
     std::string m_classIdStr;
     ///@}
 
@@ -1636,7 +1636,7 @@ private:
     //----------------//
 
     /**
-     * A static counter for uuid generation.
+     * A static counter for id generation.
      */
     static thread_local unsigned long s_objectCounter;
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -169,7 +169,7 @@ public:
      * needs to be overridden in the child class - otherwise, it will crash.
      * Because this will create a problem if we don't check this (the parents will
      * one the same child...)
-     * UUID: the uuid is copied, is needs to be reset later if this is not wished
+     * ID: the uuid is copied, it needs to be reset later if this is not wished
      */
     Object(const Object &object);
 
@@ -735,9 +735,9 @@ public:
     virtual int FindSpannedLayerElements(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
-     * Look for element by UUID in StaffDef elements (Clef, KeySig, etc.) of all layers within
+     * Look for element by ID in StaffDef elements (Clef, KeySig, etc.) of all layers within
      */
-    virtual int FindElementInLayerStaffDefsByUUID(FunctorParams *) const { return FUNCTOR_CONTINUE; }
+    virtual int FindElementInLayerStaffDefsByID(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Retrieve the minimum left and maximum right for an alignment.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -235,7 +235,7 @@ public:
     virtual void CloneReset();
 
     const std::string &GetID() const { return m_id; }
-    void SetID(std::string id);
+    void SetID(const std::string &id) { m_id = id; }
     void SwapID(Object *other);
     void ResetID();
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -234,10 +234,10 @@ public:
      */
     virtual void CloneReset();
 
-    const std::string &GetUuid() const { return m_uuid; }
-    void SetUuid(std::string uuid);
-    void SwapUuid(Object *other);
-    void ResetUuid();
+    const std::string &GetID() const { return m_uuid; }
+    void SetID(std::string uuid);
+    void SwapID(Object *other);
+    void ResetID();
 
     /**
      * Methods for setting / getting comments
@@ -412,11 +412,11 @@ public:
 
     /**
      * Look for a descendant with the specified uuid (returns NULL if not found)
-     * This method is a wrapper for the Object::FindByUuid functor.
+     * This method is a wrapper for the Object::FindByID functor.
      */
     ///@{
-    Object *FindDescendantByUuid(const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
-    const Object *FindDescendantByUuid(
+    Object *FindDescendantByID(const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD);
+    const Object *FindDescendantByID(
         const std::string &uuid, int deepness = UNLIMITED_DEPTH, bool direction = FORWARD) const;
     ///@}
 
@@ -639,9 +639,9 @@ public:
     // Static methods //
     //----------------//
 
-    static void SeedUuid(unsigned int seed = 0);
+    static void SeedID(unsigned int seed = 0);
 
-    static std::string GenerateRandUuid();
+    static std::string GenerateRandID();
 
     static bool sortByUlx(Object *a, Object *b);
 
@@ -672,7 +672,7 @@ public:
     /**
      * Find a Object with a specified uuid.
      */
-    virtual int FindByUuid(FunctorParams *functorParams) const;
+    virtual int FindByID(FunctorParams *functorParams) const;
 
     /**
      * Find a Object with a Comparison functor.
@@ -1527,7 +1527,7 @@ private:
     /**
      * Method for generating the uuid.
      */
-    void GenerateUuid();
+    void GenerateID();
 
     /**
      * Initialisation method taking the class id and a uuid prefix argument.

--- a/include/vrv/plistinterface.h
+++ b/include/vrv/plistinterface.h
@@ -84,7 +84,7 @@ public:
 
 protected:
     /**
-     * Extract the fragment of the any uris given in @plist
+     * Extract the fragment of the any URIs given in @plist
      */
     void SetIDStrs();
 
@@ -107,7 +107,7 @@ private:
     ArrayOfConstObjects m_references;
 
     /**
-     * An array of parsed any uris stored as ids.
+     * An array of parsed any URIs stored as ids.
      * Filled in InterfacePreparePlist (backward and forward).
      */
     std::vector<std::string> m_ids;

--- a/include/vrv/plistinterface.h
+++ b/include/vrv/plistinterface.h
@@ -86,7 +86,7 @@ protected:
     /**
      * Extract the fragment of the any uris given in @plist
      */
-    void SetUuidStrs();
+    void SetIDStrs();
 
     /**
      * Method to be redefined in the child class if specific validation is required.

--- a/include/vrv/plistinterface.h
+++ b/include/vrv/plistinterface.h
@@ -48,7 +48,7 @@ public:
     void AddRefAllowDuplicate(const std::string &ref);
 
     /**
-     * Set a reference object when the uuid is found in the m_uuids.
+     * Set a reference object when the id is found in the m_ids.
      * Calls IsValidRef to check that the type of object is valid.
      */
     void SetRef(const Object *object);
@@ -107,10 +107,10 @@ private:
     ArrayOfConstObjects m_references;
 
     /**
-     * An array of parsed any uris stored as uuids.
+     * An array of parsed any uris stored as ids.
      * Filled in InterfacePreparePlist (backward and forward).
      */
-    std::vector<std::string> m_uuids;
+    std::vector<std::string> m_ids;
 };
 
 } // namespace vrv

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -120,7 +120,7 @@ protected:
     /**
      * Extract the fragment of the start or end @xml:id if given
      */
-    void SetUuidStr();
+    void SetIDStr();
 
 private:
     //
@@ -128,7 +128,7 @@ public:
     //
 protected:
     LayerElement *m_start;
-    std::string m_startUuid;
+    std::string m_startID;
 
 private:
 };
@@ -190,7 +190,7 @@ public:
     /**
      *
      */
-    void SetUuidStr();
+    void SetIDStr();
 
     /**
      * Check if the end points are temporally ordered
@@ -246,7 +246,7 @@ public:
     //
 private:
     LayerElement *m_end;
-    std::string m_endUuid;
+    std::string m_endID;
 };
 
 } // namespace vrv

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -86,6 +86,11 @@ public:
     std::string GetID() { return m_doc.GetID(); }
 
     /**
+     * @name Deprecated version, same as GetID()
+     */
+    std::string GetUuid();
+
+    /**
      * Get the resource path for the Toolkit instance.
      */
     std::string GetResourcePath() const;

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -83,7 +83,7 @@ public:
      *
      * @return The ID as as string
      */
-    std::string GetUuid() { return m_doc.GetUuid(); }
+    std::string GetID() { return m_doc.GetID(); }
 
     /**
      * Get the resource path for the Toolkit instance.

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -54,7 +54,7 @@ bool AreEqual(double dFirstVal, double dSecondVal);
 /**
  * Extract the uuid from a any uri string
  */
-std::string ExtractUuidFragment(std::string refUuid);
+std::string ExtractIDFragment(std::string refID);
 
 /**
  * Utility for converting UTF16 (std::wstring) to UTF-8

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -52,7 +52,7 @@ void LogString(std::string message, consoleLogLevel level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
- * Extract the id from any uri string
+ * Extract the ID from any URI
  */
 std::string ExtractIDFragment(std::string refID);
 

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -52,7 +52,7 @@ void LogString(std::string message, consoleLogLevel level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
- * Extract the id from a any uri string
+ * Extract the id from any uri string
  */
 std::string ExtractIDFragment(std::string refID);
 

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -52,7 +52,7 @@ void LogString(std::string message, consoleLogLevel level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
- * Extract the uuid from a any uri string
+ * Extract the id from a any uri string
  */
 std::string ExtractIDFragment(std::string refID);
 

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -329,11 +329,11 @@ typedef std::vector<BeamElementCoord *> ArrayOfBeamElementCoords;
 
 typedef std::vector<std::pair<int, int>> ArrayOfIntPairs;
 
-typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceUuidPairs;
+typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceIDPairs;
 
-typedef std::map<std::string, Note *> MapOfNoteUuidPairs;
+typedef std::map<std::string, Note *> MapOfNoteIDPairs;
 
-typedef std::vector<std::tuple<PlistInterface *, std::string, Object *>> ArrayOfPlistInterfaceUuidTuples;
+typedef std::vector<std::tuple<PlistInterface *, std::string, Object *>> ArrayOfPlistInterfaceIDTuples;
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -123,7 +123,7 @@ void Artic::SplitMultival(Object *parent)
     if (this->IsAttribute()) {
         this->IsAttribute(false);
         LogMessage("Multiple valued attribute @artic on '%s' permanently converted to <artic> elements",
-            parent->GetUuid().c_str());
+            parent->GetID().c_str());
     }
 }
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -398,7 +398,7 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingI
         if ((newDirection == STEMDIRECTION_down) && (m_uniformStemLength > 0)) m_uniformStemLength *= -1;
 
         LogWarning("Insufficient space to draw mixed beam, starting at '%s'. Drawing '%s' instead.",
-            m_beamElementCoordRefs.at(0)->m_element->GetUuid().c_str(),
+            m_beamElementCoordRefs.at(0)->m_element->GetID().c_str(),
             (beamInterface->m_drawingPlace == BEAMPLACE_above) ? "above" : "below");
     }
     else {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -605,7 +605,7 @@ int Chord::ConvertMarkupAnalytical(FunctorParams *functorParams)
 
     if (this->HasFermata()) {
         Fermata *fermata = new Fermata();
-        fermata->ConvertFromAnalyticalMarkup(this, this->GetUuid(), params);
+        fermata->ConvertFromAnalyticalMarkup(this, this->GetID(), params);
     }
 
     return FUNCTOR_CONTINUE;
@@ -932,7 +932,7 @@ int Chord::ResetData(FunctorParams *functorParams)
 int Chord::PrepareDataInitialization(FunctorParams *)
 {
     if (this->HasEmptyList(this)) {
-        LogWarning("Chord '%s' has no child note - a default note is added", this->GetUuid().c_str());
+        LogWarning("Chord '%s' has no child note - a default note is added", this->GetID().c_str());
         Note *rescueNote = new Note();
         this->AddChild(rescueNote);
     }

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -129,7 +129,7 @@ int ControlElement::AdjustXOverflow(FunctorParams *functorParams)
     // Something is probably not right if nothing found - maybe no @staff
     if (positioners.empty()) {
         LogDebug("Something was wrong when searching positioners for %s '%s'", this->GetClassName().c_str(),
-            this->GetUuid().c_str());
+            this->GetID().c_str());
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -584,7 +584,7 @@ void Doc::PrepareData()
         Functor processPlist(&Object::PrepareProcessPlist);
         this->Process(&processPlist, &preparePlistParams);
 
-        for (const auto &[plistInterface, uuid, objectReference] : preparePlistParams.m_interfaceIDTuples) {
+        for (const auto &[plistInterface, id, objectReference] : preparePlistParams.m_interfaceIDTuples) {
             plistInterface->SetRef(objectReference);
         }
         preparePlistParams.m_interfaceIDTuples.clear();
@@ -1379,10 +1379,10 @@ void Doc::TransposeDoc()
     }
     else if (m_options->m_transposeMdiv.IsSet()) {
         // Transpose mdivs individually
-        std::set<std::string> uuids = m_options->m_transposeMdiv.GetKeys();
-        for (const std::string &uuid : uuids) {
-            transposeParams.m_selectedMdivID = uuid;
-            transposeParams.m_transposition = m_options->m_transposeMdiv.GetStrValue({ uuid });
+        std::set<std::string> ids = m_options->m_transposeMdiv.GetKeys();
+        for (const std::string &id : ids) {
+            transposeParams.m_selectedMdivID = id;
+            transposeParams.m_transposition = m_options->m_transposeMdiv.GetStrValue({ id });
             this->Process(&transpose, &transposeParams, &transposeEnd);
         }
     }

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -554,22 +554,21 @@ void Doc::PrepareData()
     this->Process(&prepareLinking, &prepareLinkingParams);
 
     // If we have some left process again backward
-    if (!prepareLinkingParams.m_sameasUuidPairs.empty() || !prepareLinkingParams.m_stemSameasUuidPairs.empty()) {
+    if (!prepareLinkingParams.m_sameasIDPairs.empty() || !prepareLinkingParams.m_stemSameasIDPairs.empty()) {
         prepareLinkingParams.m_fillList = false;
         this->Process(&prepareLinking, &prepareLinkingParams, NULL, NULL, UNLIMITED_DEPTH, BACKWARD);
     }
 
     // If some are still there, then it is probably an issue in the encoding
-    if (!prepareLinkingParams.m_nextUuidPairs.empty()) {
-        LogWarning("%d element(s) with a @next could match the target", prepareLinkingParams.m_nextUuidPairs.size());
+    if (!prepareLinkingParams.m_nextIDPairs.empty()) {
+        LogWarning("%d element(s) with a @next could match the target", prepareLinkingParams.m_nextIDPairs.size());
     }
-    if (!prepareLinkingParams.m_sameasUuidPairs.empty()) {
-        LogWarning(
-            "%d element(s) with a @sameas could match the target", prepareLinkingParams.m_sameasUuidPairs.size());
+    if (!prepareLinkingParams.m_sameasIDPairs.empty()) {
+        LogWarning("%d element(s) with a @sameas could match the target", prepareLinkingParams.m_sameasIDPairs.size());
     }
-    if (!prepareLinkingParams.m_stemSameasUuidPairs.empty()) {
+    if (!prepareLinkingParams.m_stemSameasIDPairs.empty()) {
         LogWarning("%d element(s) with a @stem.sameas could match the target",
-            prepareLinkingParams.m_stemSameasUuidPairs.size());
+            prepareLinkingParams.m_stemSameasIDPairs.size());
     }
 
     /************ Resolve @plist ************/
@@ -580,21 +579,21 @@ void Doc::PrepareData()
     this->Process(&preparePlist, &preparePlistParams);
 
     // Process plist after all pairs has been collected
-    if (!preparePlistParams.m_interfaceUuidTuples.empty()) {
+    if (!preparePlistParams.m_interfaceIDTuples.empty()) {
         preparePlistParams.m_fillList = false;
         Functor processPlist(&Object::PrepareProcessPlist);
         this->Process(&processPlist, &preparePlistParams);
 
-        for (const auto &[plistInterface, uuid, objectReference] : preparePlistParams.m_interfaceUuidTuples) {
+        for (const auto &[plistInterface, uuid, objectReference] : preparePlistParams.m_interfaceIDTuples) {
             plistInterface->SetRef(objectReference);
         }
-        preparePlistParams.m_interfaceUuidTuples.clear();
+        preparePlistParams.m_interfaceIDTuples.clear();
     }
 
     // If some are still there, then it is probably an issue in the encoding
-    if (!preparePlistParams.m_interfaceUuidTuples.empty()) {
+    if (!preparePlistParams.m_interfaceIDTuples.empty()) {
         LogWarning(
-            "%d element(s) with a @plist could not match the target", preparePlistParams.m_interfaceUuidTuples.size());
+            "%d element(s) with a @plist could not match the target", preparePlistParams.m_interfaceIDTuples.size());
     }
 
     /************ Resolve cross staff ************/
@@ -1348,7 +1347,7 @@ void Doc::ConvertMarkupDoc(bool permanent)
                     std::vector<Note *>::iterator iter;
                     for (iter = convertMarkupAnalyticalParams.m_currentNotes.begin();
                          iter != convertMarkupAnalyticalParams.m_currentNotes.end(); ++iter) {
-                        LogWarning("Unable to match @tie of note '%s', skipping it", (*iter)->GetUuid().c_str());
+                        LogWarning("Unable to match @tie of note '%s', skipping it", (*iter)->GetID().c_str());
                     }
                 }
             }
@@ -1382,7 +1381,7 @@ void Doc::TransposeDoc()
         // Transpose mdivs individually
         std::set<std::string> uuids = m_options->m_transposeMdiv.GetKeys();
         for (const std::string &uuid : uuids) {
-            transposeParams.m_selectedMdivUuid = uuid;
+            transposeParams.m_selectedMdivID = uuid;
             transposeParams.m_transposition = m_options->m_transposeMdiv.GetStrValue({ uuid });
             this->Process(&transpose, &transposeParams, &transposeEnd);
         }
@@ -1390,7 +1389,7 @@ void Doc::TransposeDoc()
 
     if (m_options->m_transposeToSoundingPitch.GetValue()) {
         // Transpose to sounding pitch
-        transposeParams.m_selectedMdivUuid = "";
+        transposeParams.m_selectedMdivID = "";
         transposeParams.m_transposition = "";
         transposeParams.m_transposer->SetTransposition(0);
         transposeParams.m_transposeToSoundingPitch = true;
@@ -1404,7 +1403,7 @@ void Doc::ExpandExpansions()
     std::string expansionId = this->GetOptions()->m_expand.GetValue();
     if (expansionId.empty()) return;
 
-    Expansion *start = dynamic_cast<Expansion *>(this->FindDescendantByUuid(expansionId));
+    Expansion *start = dynamic_cast<Expansion *>(this->FindDescendantByID(expansionId));
     if (start == NULL) {
         LogMessage("Import MEI: expansion ID \"%s\" not found.", expansionId.c_str());
         return;
@@ -1418,7 +1417,7 @@ void Doc::ExpandExpansions()
     // Expansion *originalExpansion = new Expansion();
     // char rnd[35];
     // snprintf(rnd, 35, "expansion-notated-%016d", std::rand());
-    // originalExpansion->SetUuid(rnd);
+    // originalExpansion->SetID(rnd);
 
     // for (std::string ref : existingList) {
     //    originalExpansion->GetPlistInterface()->AddRef("#" + ref);
@@ -1426,7 +1425,7 @@ void Doc::ExpandExpansions()
 
     // start->GetParent()->InsertAfter(start, originalExpansion);
 
-    // std::cout << "[expand] original expansion xml:id=\"" << originalExpansion->GetUuid().c_str()
+    // std::cout << "[expand] original expansion xml:id=\"" << originalExpansion->GetID().c_str()
     //          << "\" plist={";
     // for (std::string s : existingList) std::cout << s.c_str() << ((s != existingList.back()) ? " " : "}.\n");
 

--- a/src/docselection.cpp
+++ b/src/docselection.cpp
@@ -130,12 +130,12 @@ void DocSelection::Set(Doc *doc)
         }
 
         if (m_selectionRangeStart == -1) {
-            selectionStartId = measures.front()->GetUuid();
+            selectionStartId = measures.front()->GetID();
         }
         else if (m_selectionRangeStart > 0 && m_selectionRangeStart <= (int)measures.size()) {
             ListOfObjects::const_iterator it = measures.begin();
             std::advance(it, m_selectionRangeStart - 1);
-            selectionStartId = (*it)->GetUuid();
+            selectionStartId = (*it)->GetID();
         }
         else {
             LogWarning("Measure range start for selection '%s' could not be found.", m_measureRange.c_str());
@@ -143,12 +143,12 @@ void DocSelection::Set(Doc *doc)
         }
 
         if (m_selectionRangeEnd == -1) {
-            selectionEndId = measures.back()->GetUuid();
+            selectionEndId = measures.back()->GetID();
         }
         else if (m_selectionRangeEnd > 0 && m_selectionRangeEnd <= (int)measures.size()) {
             ListOfObjects::const_iterator it = measures.begin();
             std::advance(it, m_selectionRangeEnd - 1);
-            selectionEndId = (*it)->GetUuid();
+            selectionEndId = (*it)->GetID();
         }
         else {
             LogWarning("Measure range end for selection '%s' could not be found.", m_measureRange.c_str());

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -269,8 +269,8 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
 {
     if (!m_doc->GetDrawingPage()) return false;
 
-    Object *start = m_doc->GetDrawingPage()->FindDescendantByUuid(startid);
-    Object *end = m_doc->GetDrawingPage()->FindDescendantByUuid(endid);
+    Object *start = m_doc->GetDrawingPage()->FindDescendantByID(startid);
+    Object *end = m_doc->GetDrawingPage()->FindDescendantByID(endid);
     // Check if both start and end elements exist
     if (!start || !end) {
         LogMessage("Elements start and end ids '%s' and '%s' could not be found", startid.c_str(), endid.c_str());
@@ -311,8 +311,8 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     interface->SetStartid("#" + startid);
     interface->SetEndid("#" + endid);
 
-    m_chainedId = element->GetUuid();
-    m_editInfo.import("uuid", element->GetUuid());
+    m_chainedId = element->GetID();
+    m_editInfo.import("uuid", element->GetID());
 
     return true;
 }
@@ -321,7 +321,7 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
 {
     if (!m_doc->GetDrawingPage()) return false;
 
-    Object *start = m_doc->GetDrawingPage()->FindDescendantByUuid(startid);
+    Object *start = m_doc->GetDrawingPage()->FindDescendantByID(startid);
     // Check if both start and end elements exist
     if (!start) {
         LogMessage("Element start id '%s' could not be found", startid.c_str());
@@ -357,8 +357,8 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     measure->AddChild(element);
     interface->SetStartid("#" + startid);
 
-    m_chainedId = element->GetUuid();
-    m_editInfo.import("uuid", element->GetUuid());
+    m_chainedId = element->GetID();
+    m_editInfo.import("uuid", element->GetID());
 
     return true;
 }
@@ -416,11 +416,11 @@ Object *EditorToolkitCMN::GetElement(std::string &elementId)
 
     // Try to get the element on the current drawing page
     if (m_doc->GetDrawingPage()) {
-        element = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+        element = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     }
     // If it wasn't there, try on the whole doc
     if (!element) {
-        element = m_doc->FindDescendantByUuid(elementId);
+        element = m_doc->FindDescendantByID(elementId);
     }
 
     return element;
@@ -440,7 +440,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         assert(currentChord);
         Note *note = new Note();
         currentChord->AddChild(note);
-        m_chainedId = note->GetUuid();
+        m_chainedId = note->GetID();
         return true;
     }
     else if (object->Is(NOTE)) {
@@ -451,7 +451,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         if (currentChord) {
             Note *note = new Note();
             currentChord->AddChild(note);
-            m_chainedId = note->GetUuid();
+            m_chainedId = note->GetID();
             return true;
         }
 
@@ -492,7 +492,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         }
         currentNote->ClearRelinquishedChildren();
 
-        m_chainedId = note->GetUuid();
+        m_chainedId = note->GetID();
         return true;
     }
     else if (object->Is(REST)) {
@@ -504,7 +504,7 @@ bool EditorToolkitCMN::InsertNote(Object *object)
         assert(parent);
         parent->ReplaceChild(rest, note);
         delete rest;
-        m_chainedId = note->GetUuid();
+        m_chainedId = note->GetID();
         return true;
     }
     return false;
@@ -543,13 +543,13 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             for (auto &artic : artics) {
                 artic->MoveItselfTo(otherNote);
             }
-            m_chainedId = chord->GetUuid();
+            m_chainedId = chord->GetID();
             delete chord;
             return true;
         }
         else if (count > 2) {
             chord->DeleteChild(note);
-            m_chainedId = chord->GetUuid();
+            m_chainedId = chord->GetID();
             return true;
         }
         // Handle cases of chords with one single note
@@ -585,7 +585,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             beam->DetachChild(otherElement->GetIdx());
             parent->ReplaceChild(beam, otherElement);
             delete beam;
-            m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetID();
             return true;
         }
         if (beam->IsFirstIn(beam, note)) {
@@ -595,7 +595,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             assert(parent);
             parent->InsertBefore(beam, rest);
             beam->DeleteChild(note);
-            m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetID();
             return true;
         }
         else if (beam->IsLastIn(beam, note)) {
@@ -605,7 +605,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             assert(parent);
             parent->InsertAfter(beam, rest);
             beam->DeleteChild(note);
-            m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetID();
             return true;
         }
         else {
@@ -613,7 +613,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
             rest->DurationInterface::operator=(*note);
             beam->ReplaceChild(note, rest);
             delete note;
-            m_chainedId = rest->GetUuid();
+            m_chainedId = rest->GetID();
             return true;
         }
     }
@@ -624,7 +624,7 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
         assert(parent);
         parent->ReplaceChild(note, rest);
         delete note;
-        m_chainedId = rest->GetUuid();
+        m_chainedId = rest->GetID();
         return true;
     }
 }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -230,11 +230,11 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
     }
 
     // Try to get the element on the current drawing page
-    Object *element = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *element = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
 
     // If it wasn't there, go back up to the whole doc
     if (!element) {
-        element = m_doc->FindDescendantByUuid(elementId);
+        element = m_doc->FindDescendantByID(elementId);
     }
     if (!element) {
         LogWarning("element is null");
@@ -608,7 +608,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         }
     }
     else {
-        staff = dynamic_cast<Staff *>(m_doc->FindDescendantByUuid(staffId));
+        staff = dynamic_cast<Staff *>(m_doc->FindDescendantByID(staffId));
     }
 
     Facsimile *facsimile = m_doc->GetFacsimile();
@@ -660,7 +660,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
                 parent->InsertChild(newStaff, i);
                 parent->Modify();
 
-                m_infoObject.import("uuid", newStaff->GetUuid());
+                m_infoObject.import("uuid", newStaff->GetID());
                 m_infoObject.import("status", status);
                 m_infoObject.import("message", message);
 
@@ -672,7 +672,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         parent->AddChild(newStaff);
         parent->Modify();
 
-        m_infoObject.import("uuid", newStaff->GetUuid());
+        m_infoObject.import("uuid", newStaff->GetID());
         m_infoObject.import("status", status);
         m_infoObject.import("message", message);
         return true;
@@ -818,10 +818,10 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             }
         }
         if (elementType == "nc") {
-            m_infoObject.import("uuid", nc->GetUuid());
+            m_infoObject.import("uuid", nc->GetID());
         }
         else {
-            m_infoObject.import("uuid", neume->GetUuid());
+            m_infoObject.import("uuid", neume->GetID());
         }
     }
     else if (elementType == "clef") {
@@ -868,7 +868,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         assert(surface);
         surface->AddChild(zone);
         layer->AddChild(clef);
-        m_infoObject.import("uuid", clef->GetUuid());
+        m_infoObject.import("uuid", clef->GetID());
         layer->ReorderByXPos();
 
         // ensure pitched elements associated with this clef keep their x,y positions
@@ -921,7 +921,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
             m_infoObject.import("message", "Failed to set pitch.");
             return false;
         }
-        m_infoObject.import("uuid", custos->GetUuid());
+        m_infoObject.import("uuid", custos->GetID());
     }
     else {
         delete zone;
@@ -943,7 +943,7 @@ bool EditorToolkitNeume::Merge(std::vector<std::string> elementIds)
 
     // Get the staves by element ID and fail if a staff does not exist.
     for (auto it = elementIds.begin(); it != elementIds.end(); ++it) {
-        Staff *obj = dynamic_cast<Staff *>(m_doc->GetDrawingPage()->FindDescendantByUuid(*it));
+        Staff *obj = dynamic_cast<Staff *>(m_doc->GetDrawingPage()->FindDescendantByID(*it));
         if (obj != NULL && obj->Is(STAFF)) {
             staves.push_back(obj);
         }
@@ -1018,7 +1018,7 @@ bool EditorToolkitNeume::Merge(std::vector<std::string> elementIds)
 
     fillLayer->ReorderByXPos();
 
-    m_infoObject.import("uuid", fillStaff->GetUuid());
+    m_infoObject.import("uuid", fillStaff->GetID());
     m_infoObject.import("status", "OK");
     m_infoObject.import("message", "");
 
@@ -1030,7 +1030,7 @@ bool EditorToolkitNeume::Merge(std::vector<std::string> elementIds)
 bool EditorToolkitNeume::Set(std::string elementId, std::string attrType, std::string attrValue)
 {
     if (!m_doc->GetDrawingPage()) return false;
-    Object *element = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *element = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     bool success = false;
     if (Att::SetAnalytical(element, attrType, attrValue))
         success = true;
@@ -1079,7 +1079,7 @@ bool EditorToolkitNeume::SetText(std::string elementId, std::string text)
         m_infoObject.import("message", "Could not find drawing page.");
         return false;
     }
-    Object *element = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *element = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     if (element == NULL) {
         LogWarning("No element with ID '%s' exists", elementId.c_str());
         m_infoObject.import("status", "FAILURE");
@@ -1153,7 +1153,7 @@ bool EditorToolkitNeume::SetText(std::string elementId, std::string text)
             success = true;
         }
         else {
-            success = SetText(syl->GetUuid(), text);
+            success = SetText(syl->GetID(), text);
         }
     }
     else {
@@ -1179,7 +1179,7 @@ bool EditorToolkitNeume::SetClef(std::string elementId, std::string shape)
     bool success = false;
     data_CLEFSHAPE clefShape = CLEFSHAPE_NONE;
     int shift = 0;
-    Clef *clef = vrv_cast<Clef *>(m_doc->GetDrawingPage()->FindDescendantByUuid(elementId));
+    Clef *clef = vrv_cast<Clef *>(m_doc->GetDrawingPage()->FindDescendantByID(elementId));
     assert(clef);
 
     if (shape == "C") {
@@ -1236,7 +1236,7 @@ bool EditorToolkitNeume::Split(std::string elementId, int x)
         m_infoObject.import("message", "Could not get the drawing page.");
         return false;
     }
-    Staff *staff = dynamic_cast<Staff *>(m_doc->GetDrawingPage()->FindDescendantByUuid(elementId));
+    Staff *staff = dynamic_cast<Staff *>(m_doc->GetDrawingPage()->FindDescendantByID(elementId));
     // Validate parameters
     if (staff == NULL) {
         LogError("Either no element exists with ID '%s' or it is not a staff.", elementId.c_str());
@@ -1267,8 +1267,8 @@ bool EditorToolkitNeume::Split(std::string elementId, int x)
         m_infoObject.import("message", "Failed to create a second staff.");
         return false;
     }
-    Staff *splitStaff = dynamic_cast<Staff *>(
-        m_doc->GetDrawingPage()->FindDescendantByUuid(m_infoObject.get<jsonxx::String>("uuid")));
+    Staff *splitStaff
+        = dynamic_cast<Staff *>(m_doc->GetDrawingPage()->FindDescendantByID(m_infoObject.get<jsonxx::String>("uuid")));
     assert(splitStaff);
     if (splitStaff == NULL) {
         LogError("Split staff is null");
@@ -1318,7 +1318,7 @@ bool EditorToolkitNeume::Split(std::string elementId, int x)
     layer->ClearRelinquishedChildren();
     m_infoObject.import("status", "OK");
     m_infoObject.import("message", "");
-    m_infoObject.import("uuid", splitStaff->GetUuid());
+    m_infoObject.import("uuid", splitStaff->GetID());
     return true;
 }
 
@@ -1330,7 +1330,7 @@ bool EditorToolkitNeume::Remove(std::string elementId)
         m_infoObject.import("message", "Could not get the drawing page.");
         return false;
     }
-    Object *obj = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *obj = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     assert(obj);
     bool result = false;
     bool isNeumeOrNc, isNc, isClef;
@@ -1358,7 +1358,7 @@ bool EditorToolkitNeume::Remove(std::string elementId)
         // y position of pitched elements (like neumes) is determined by their pitches
         // so when deleting a clef, the position on a page that a pitch value is associated with could change
         // so we need to change the pitch value of any elements whose clef is going to change
-        Clef *clef = vrv_cast<Clef *>(m_doc->GetDrawingPage()->FindDescendantByUuid(elementId));
+        Clef *clef = vrv_cast<Clef *>(m_doc->GetDrawingPage()->FindDescendantByID(elementId));
         assert(clef);
         ClassIdComparison ac(CLEF);
         Clef *previousClef = dynamic_cast<Clef *>(m_doc->GetDrawingPage()->FindPreviousChild(&ac, clef));
@@ -1412,7 +1412,7 @@ bool EditorToolkitNeume::Remove(std::string elementId)
         parent = parent->GetParent();
         if (obj->FindDescendantByType(NC) == NULL) {
             // Delete the empty neume
-            std::string neumeId = obj->GetUuid();
+            std::string neumeId = obj->GetID();
             result &= parent->DeleteChild(obj);
             if (!result) {
                 LogError("Failed to delete empty neume (%s)", neumeId.c_str());
@@ -1434,15 +1434,14 @@ bool EditorToolkitNeume::Remove(std::string elementId)
             if (li->HasPrecedes() || li->HasFollows()) {
                 std::string linkedID = (li->HasPrecedes() ? li->GetPrecedes() : li->GetFollows());
                 if (linkedID.compare(0, 1, "#") == 0) linkedID.erase(0, 1);
-                Syllable *linkedSyllable
-                    = vrv_cast<Syllable *>(m_doc->GetDrawingPage()->FindDescendantByUuid(linkedID));
+                Syllable *linkedSyllable = vrv_cast<Syllable *>(m_doc->GetDrawingPage()->FindDescendantByID(linkedID));
                 if (linkedSyllable != NULL) {
                     if (linkedSyllable->HasPrecedes()) linkedSyllable->SetPrecedes("");
                     if (linkedSyllable->HasFollows()) linkedSyllable->SetFollows("");
                 }
             }
             // Delete the syllable empty of neumes
-            std::string syllableId = obj->GetUuid();
+            std::string syllableId = obj->GetID();
             result &= parent->DeleteChild(obj);
             if (!result) {
                 LogError("Failed to delete empty syllable (%s)", syllableId.c_str());
@@ -1474,7 +1473,7 @@ bool EditorToolkitNeume::Resize(std::string elementId, int ulx, int uly, int lrx
         return false;
     }
 
-    Object *obj = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *obj = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     if (obj == NULL) {
         LogError("Object with ID '%s' not found.", elementId.c_str());
         m_infoObject.import("status", "FAILURE");
@@ -1576,7 +1575,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
     // Determine what the parents are
     for (auto it = elementIds.begin(); it != elementIds.end(); ++it) {
         // Verify that the children are of the same type
-        Object *el = m_doc->GetDrawingPage()->FindDescendantByUuid(*it);
+        Object *el = m_doc->GetDrawingPage()->FindDescendantByID(*it);
         if (el == NULL) {
             LogError("Could not get element with ID %s", it->c_str());
             m_infoObject.import("status", "FAILURE");
@@ -1584,11 +1583,11 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
             return false;
         }
         if (el->GetClassId() != elementClass) {
-            LogError("Element %s was of class %s. Expected class %s", el->GetUuid().c_str(), el->GetClassName().c_str(),
+            LogError("Element %s was of class %s. Expected class %s", el->GetID().c_str(), el->GetClassName().c_str(),
                 groupType.c_str());
             m_infoObject.import("status", "FAILURE");
             m_infoObject.import("message",
-                "Element " + el->GetUuid() + " was of class " + el->GetClassName() + " but expected class " + groupType
+                "Element " + el->GetID() + " was of class " + el->GetClassName() + " but expected class " + groupType
                     + ".");
             return false;
         }
@@ -1596,9 +1595,9 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
         // Get a set of parents and the number of children they have
         Object *par = el->GetParent();
         if (par == NULL) {
-            LogError("Parent of %s is null!", el->GetUuid().c_str());
+            LogError("Parent of %s is null!", el->GetID().c_str());
             m_infoObject.import("status", "FAILURE");
-            m_infoObject.import("message", "Parent of " + el->GetUuid() + " is null.");
+            m_infoObject.import("message", "Parent of " + el->GetID() + " is null.");
             return false;
         }
         if (doubleParent == NULL) {
@@ -1766,7 +1765,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
                 fi->SetZone(zone);
 
                 // syl->ResetFacsimile();
-                // syl->SetFacs(zone->GetUuid());
+                // syl->SetFacs(zone->GetID());
             }
         }
 
@@ -1929,7 +1928,7 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
         }
     }
 
-    m_infoObject.import("uuid", parent->GetUuid());
+    m_infoObject.import("uuid", parent->GetID());
     m_infoObject.import("status", status);
     m_infoObject.import("message", message);
     return true;
@@ -1962,7 +1961,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
         return false;
     }
     for (auto it = elementIds.begin(); it != elementIds.end(); ++it) {
-        Object *el = m_doc->GetDrawingPage()->FindDescendantByUuid(*it);
+        Object *el = m_doc->GetDrawingPage()->FindDescendantByID(*it);
 
         if (groupType == "neume") {
             // Keep the syl attached to the original syllable.
@@ -1972,7 +1971,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
             if (currentParent == NULL) {
                 fparent = el->GetFirstAncestor(SYLLABLE);
                 assert(fparent);
-                uuidArray << fparent->GetUuid();
+                uuidArray << fparent->GetID();
                 sparent = fparent->GetFirstAncestor(LAYER);
                 assert(sparent);
                 currentParent = vrv_cast<Syllable *>(fparent);
@@ -2068,7 +2067,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
                         delete zone;
                     }
                 }
-                uuidArray << newParent->GetUuid();
+                uuidArray << newParent->GetID();
                 sparent->AddChild(newParent);
                 sparent->ReorderByXPos();
             }
@@ -2088,7 +2087,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
             if (elementIds.begin() == it) {
                 fparent = el->GetFirstAncestor(NEUME);
                 assert(fparent);
-                uuidArray << fparent->GetUuid();
+                uuidArray << fparent->GetID();
                 sparent = fparent->GetFirstAncestor(SYLLABLE);
                 assert(sparent);
                 currentParent = vrv_cast<Neume *>(fparent);
@@ -2111,7 +2110,7 @@ bool EditorToolkitNeume::Ungroup(std::string groupType, std::vector<std::string>
 
                     el->MoveItselfTo(newParent);
                     fparent->ClearRelinquishedChildren();
-                    uuidArray << newParent->GetUuid();
+                    uuidArray << newParent->GetID();
                     sparent->AddChild(newParent);
                     sparent->ReorderByXPos();
 
@@ -2162,7 +2161,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
         m_infoObject.import("message", "Could not get the drawing page.");
         return false;
     }
-    Neume *el = dynamic_cast<Neume *>(m_doc->GetDrawingPage()->FindDescendantByUuid(elementId));
+    Neume *el = dynamic_cast<Neume *>(m_doc->GetDrawingPage()->FindDescendantByID(elementId));
     if (el == NULL) {
         LogError("Unable to find neume with id %s", elementId.c_str());
         m_infoObject.import("status", "FAILURE");
@@ -2252,7 +2251,7 @@ bool EditorToolkitNeume::ChangeGroup(std::string elementId, std::string contour)
         initialLry = newLry;
         prevNc = newNc;
     }
-    m_infoObject.import("uuid", el->GetUuid());
+    m_infoObject.import("uuid", el->GetID());
     m_infoObject.import("status", "OK");
     m_infoObject.import("message", "");
     return true;
@@ -2277,9 +2276,9 @@ bool EditorToolkitNeume::ToggleLigature(std::vector<std::string> elementIds, std
         return false;
     }
 
-    Nc *firstNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByUuid(firstNcId));
+    Nc *firstNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByID(firstNcId));
     assert(firstNc);
-    Nc *secondNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByUuid(secondNcId));
+    Nc *secondNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByID(secondNcId));
     assert(secondNc);
     Zone *zone = new Zone();
     // set ligature to false and update zone of second Nc
@@ -2357,7 +2356,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
         return false;
     }
 
-    Object *element = m_doc->GetDrawingPage()->FindDescendantByUuid(elementId);
+    Object *element = m_doc->GetDrawingPage()->FindDescendantByID(elementId);
     assert(element);
     if (element == NULL) {
         LogError("No element exists with ID '%s'.", elementId.c_str());
@@ -2443,7 +2442,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
         m_infoObject.import("status", "WARNING");
         m_infoObject.import("message", "Moving to the same staff as before.");
         m_infoObject.import("elementId", elementId);
-        m_infoObject.import("newStaffId", staff->GetUuid());
+        m_infoObject.import("newStaffId", staff->GetID());
         return true;
     }
 
@@ -2484,7 +2483,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
 
         // Adjust clefline
         if (!AdjustClefLineFromPosition(dynamic_cast<Clef *>(element), staff)) {
-            LogError("Could not adjust clef line of %s", element->GetUuid().c_str());
+            LogError("Could not adjust clef line of %s", element->GetID().c_str());
             m_infoObject.import("status", "FAILURE");
             m_infoObject.import("message", "Failed to set clef line from facsimile.");
             return false;
@@ -2513,11 +2512,11 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
         parent->ClearRelinquishedChildren();
         parent->ReorderByXPos();
         if (!AdjustPitchFromPosition(element)) {
-            LogError("Could not adjust pitch of %s", element->GetUuid().c_str());
+            LogError("Could not adjust pitch of %s", element->GetID().c_str());
             m_infoObject.import("status", "FAILURE");
             m_infoObject.import("message", "Failed to properly set pitch.");
-            m_infoObject.import("elementId", element->GetUuid());
-            m_infoObject.import("newStaffId", staff->GetUuid());
+            m_infoObject.import("elementId", element->GetID());
+            m_infoObject.import("newStaffId", staff->GetID());
             return false;
         }
     }
@@ -2525,7 +2524,7 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
     m_infoObject.import("status", "OK");
     m_infoObject.import("message", "");
     m_infoObject.import("elementId", elementId);
-    m_infoObject.import("newStaffId", staff->GetUuid());
+    m_infoObject.import("newStaffId", staff->GetID());
     return true;
 }
 
@@ -2817,7 +2816,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
             pi->SetPname(PITCHNAME_g);
         }
         else {
-            LogError("Clef %s does not have valid shape. Shape is %s", clef->GetUuid().c_str(), clef->GetShape());
+            LogError("Clef %s does not have valid shape. Shape is %s", clef->GetID().c_str(), clef->GetShape());
             return false;
         }
         pi->SetOct(3);
@@ -2845,7 +2844,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
         syl->FindAllDescendantsByComparison(&pitchedChildren, &ic);
 
         if (pitchedChildren.empty()) {
-            LogWarning("Syllable had no pitched children to reorder for syllable %s", obj->GetUuid().c_str());
+            LogWarning("Syllable had no pitched children to reorder for syllable %s", obj->GetID().c_str());
             return true;
         }
 
@@ -2867,7 +2866,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
             case CLEFSHAPE_F: pname = PITCHNAME_f; break;
             case CLEFSHAPE_G: pname = PITCHNAME_g; break;
             default:
-                LogError("Clef %s does not have valid shape. Shape is %s", clef->GetUuid().c_str(), clef->GetShape());
+                LogError("Clef %s does not have valid shape. Shape is %s", clef->GetID().c_str(), clef->GetShape());
                 return false;
         }
 
@@ -2876,7 +2875,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
         for (auto it = pitchedChildren.begin(); it != pitchedChildren.end(); ++it) {
             FacsimileInterface *fi = (*it)->GetFacsimileInterface();
             if (fi == NULL || !fi->HasFacs()) {
-                LogError("Could not adjust pitch: child %s does not have facsimile data", (*it)->GetUuid().c_str());
+                LogError("Could not adjust pitch: child %s does not have facsimile data", (*it)->GetID().c_str());
                 return false;
             }
 
@@ -2905,7 +2904,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
     else {
         LogError("AdjustPitchFromPosition should only be called on custos or syllables."
                  "It has been called on %s, whose id is %s",
-            obj->GetClassName().c_str(), obj->GetUuid().c_str());
+            obj->GetClassName().c_str(), obj->GetID().c_str());
         return false;
     }
 }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -43,19 +43,19 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
     const vrv::ArrayOfObjects &expansionSiblings = prevSect->GetParent()->GetChildren();
     std::vector<std::string> reductionList;
     for (auto o : expansionSiblings) {
-        if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetUuid());
+        if (o->Is(SECTION) || o->Is(ENDING) || o->Is(LEM) || o->Is(RDG)) reductionList.push_back(o->GetID());
     }
 
     for (std::string s : expansionList) {
         if (s.rfind("#", 0) == 0) s = s.substr(1, s.size() - 1); // remove trailing hash from reference
-        Object *currSect = prevSect->GetParent()->FindDescendantByUuid(s); // find section pointer of reference string
+        Object *currSect = prevSect->GetParent()->FindDescendantByID(s); // find section pointer of reference string
         if (!currSect) {
             return;
         }
         if (currSect->Is(EXPANSION)) { // if reference is itself an expansion, resolve it recursively
             // remove parent from reductionList, if expansion
             for (auto it = begin(reductionList); it != end(reductionList);) {
-                if ((*it).compare(currSect->GetParent()->GetUuid()) == 0)
+                if ((*it).compare(currSect->GetParent()->GetID()) == 0)
                     it = reductionList.erase(it);
                 else
                     ++it;
@@ -75,11 +75,11 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
 
                 // get IDs of old and new sections and add them to m_map
                 std::vector<std::string> oldIds;
-                oldIds.push_back(currSect->GetUuid());
-                this->GetUuidList(currSect, oldIds);
+                oldIds.push_back(currSect->GetID());
+                this->GetIDList(currSect, oldIds);
                 std::vector<std::string> clonedIds;
-                clonedIds.push_back(clonedObject->GetUuid());
-                this->GetUuidList(clonedObject, clonedIds);
+                clonedIds.push_back(clonedObject->GetID());
+                this->GetIDList(clonedObject, clonedIds);
                 for (int i = 0; (i < (int)oldIds.size()) && (i < (int)clonedIds.size()); i++) {
                     this->AddExpandedIdToExpansionMap(oldIds.at(i), clonedIds.at(i));
                 }
@@ -107,7 +107,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
     }
     // make unused sections hidden
     for (std::string r : reductionList) {
-        Object *currSect = prevSect->GetParent()->FindDescendantByUuid(r);
+        Object *currSect = prevSect->GetParent()->FindDescendantByID(r);
         assert(currSect);
         if (currSect->Is(ENDING) || currSect->Is(SECTION)) {
             SystemElement *tmp = dynamic_cast<SystemElement *>(currSect);
@@ -236,18 +236,18 @@ bool ExpansionMap::HasExpansionMap()
     return (m_map.empty()) ? false : true;
 }
 
-void ExpansionMap::GetUuidList(Object *object, std::vector<std::string> &idList)
+void ExpansionMap::GetIDList(Object *object, std::vector<std::string> &idList)
 {
     for (Object *o : object->GetChildren()) {
-        idList.push_back(o->GetUuid());
-        this->GetUuidList(o, idList);
+        idList.push_back(o->GetID());
+        this->GetIDList(o, idList);
     }
 }
 
 void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
 {
-    target->SetUuid(
-        source->GetUuid() + "-rend" + std::to_string(this->GetExpansionIdsForElement(source->GetUuid()).size() + 1));
+    target->SetID(
+        source->GetID() + "-rend" + std::to_string(this->GetExpansionIdsForElement(source->GetID()).size() + 1));
 
     ArrayOfObjects sourceObjects = source->GetChildren();
     ArrayOfObjects targetObjects = target->GetChildren();

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -71,7 +71,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
                 // clone current section/ending/rdg/lem and rename it, adding -"rend2" for the first repetition etc.
                 Object *clonedObject = currSect->Clone();
                 clonedObject->CloneReset();
-                this->GeneratePredictableIds(currSect, clonedObject);
+                this->GeneratePredictableIDs(currSect, clonedObject);
 
                 // get IDs of old and new sections and add them to m_map
                 std::vector<std::string> oldIds;
@@ -81,11 +81,11 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
                 clonedIds.push_back(clonedObject->GetID());
                 this->GetIDList(clonedObject, clonedIds);
                 for (int i = 0; (i < (int)oldIds.size()) && (i < (int)clonedIds.size()); i++) {
-                    this->AddExpandedIdToExpansionMap(oldIds.at(i), clonedIds.at(i));
+                    this->AddExpandedIDToExpansionMap(oldIds.at(i), clonedIds.at(i));
                 }
 
                 // go through cloned objects, find TimePointing/SpanningInterface, PListInterface, LinkingInterface
-                this->UpdateIds(clonedObject);
+                this->UpdateIDs(clonedObject);
 
                 assert(prevSect->GetParent());
                 prevSect->GetParent()->InsertAfter(prevSect, clonedObject);
@@ -120,7 +120,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
     }
 }
 
-bool ExpansionMap::UpdateIds(Object *object)
+bool ExpansionMap::UpdateIDs(Object *object)
 {
     for (Object *o : object->GetChildren()) {
         o->IsExpansion(true);
@@ -130,7 +130,7 @@ bool ExpansionMap::UpdateIds(Object *object)
             // @startid
             std::string oldStartId = interface->GetStartid();
             if (oldStartId.rfind("#", 0) == 0) oldStartId = oldStartId.substr(1, oldStartId.size() - 1);
-            std::string newStartId = this->GetExpansionIdsForElement(oldStartId).back();
+            std::string newStartId = this->GetExpansionIDsForElement(oldStartId).back();
             if (!newStartId.empty()) interface->SetStartid("#" + newStartId);
         }
         if (o->HasInterface(INTERFACE_TIME_SPANNING)) {
@@ -139,12 +139,12 @@ bool ExpansionMap::UpdateIds(Object *object)
             // @startid
             std::string oldStartId = interface->GetStartid();
             if (oldStartId.rfind("#", 0) == 0) oldStartId = oldStartId.substr(1, oldStartId.size() - 1);
-            std::string newStartId = this->GetExpansionIdsForElement(oldStartId).back();
+            std::string newStartId = this->GetExpansionIDsForElement(oldStartId).back();
             if (!newStartId.empty()) interface->SetStartid("#" + newStartId);
             // @endid
             oldStartId = interface->GetEndid();
             if (oldStartId.rfind("#", 0) == 0) oldStartId = oldStartId.substr(1, oldStartId.size() - 1);
-            std::string newEndId = this->GetExpansionIdsForElement(oldStartId).back();
+            std::string newEndId = this->GetExpansionIDsForElement(oldStartId).back();
             if (!newEndId.empty()) interface->SetEndid("#" + newEndId);
         }
         if (o->HasInterface(INTERFACE_PLIST)) {
@@ -154,7 +154,7 @@ bool ExpansionMap::UpdateIds(Object *object)
             xsdAnyURI_List newList;
             for (std::string oldRefString : oldList) {
                 if (oldRefString.rfind("#", 0) == 0) oldRefString = oldRefString.substr(1, oldRefString.size() - 1);
-                newList.push_back("#" + this->GetExpansionIdsForElement(oldRefString).back());
+                newList.push_back("#" + this->GetExpansionIDsForElement(oldRefString).back());
             }
             interface->SetPlist(newList);
         }
@@ -164,40 +164,40 @@ bool ExpansionMap::UpdateIds(Object *object)
             // @sameas
             std::string oldIdString = interface->GetSameas();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            std::string newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            std::string newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetSameas("#" + newIdString);
             // @next
             oldIdString = interface->GetNext();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetNext("#" + newIdString);
             // @prev
             oldIdString = interface->GetPrev();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetPrev("#" + newIdString);
             // @copyof
             oldIdString = interface->GetCopyof();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetCopyof("#" + newIdString);
             // @corresp
             oldIdString = interface->GetCorresp();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetCorresp("#" + newIdString);
             // @synch
             oldIdString = interface->GetSynch();
             if (oldIdString.rfind("#", 0) == 0) oldIdString = oldIdString.substr(1, oldIdString.size() - 1);
-            newIdString = this->GetExpansionIdsForElement(oldIdString).back();
+            newIdString = this->GetExpansionIDsForElement(oldIdString).back();
             if (!newIdString.empty()) interface->SetSynch("#" + newIdString);
         }
-        UpdateIds(o);
+        UpdateIDs(o);
     }
     return true;
 }
 
-bool ExpansionMap::AddExpandedIdToExpansionMap(const std::string &origXmlId, std::string newXmlId)
+bool ExpansionMap::AddExpandedIDToExpansionMap(const std::string &origXmlId, std::string newXmlId)
 {
     auto list = m_map.find(origXmlId);
     if (list != m_map.end()) {
@@ -219,7 +219,7 @@ bool ExpansionMap::AddExpandedIdToExpansionMap(const std::string &origXmlId, std
     return true;
 }
 
-std::vector<std::string> ExpansionMap::GetExpansionIdsForElement(const std::string &xmlId)
+std::vector<std::string> ExpansionMap::GetExpansionIDsForElement(const std::string &xmlId)
 {
     try {
         return m_map.at(xmlId);
@@ -244,10 +244,10 @@ void ExpansionMap::GetIDList(Object *object, std::vector<std::string> &idList)
     }
 }
 
-void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
+void ExpansionMap::GeneratePredictableIDs(Object *source, Object *target)
 {
     target->SetID(
-        source->GetID() + "-rend" + std::to_string(this->GetExpansionIdsForElement(source->GetID()).size() + 1));
+        source->GetID() + "-rend" + std::to_string(this->GetExpansionIDsForElement(source->GetID()).size() + 1));
 
     ArrayOfObjects sourceObjects = source->GetChildren();
     ArrayOfObjects targetObjects = target->GetChildren();
@@ -255,7 +255,7 @@ void ExpansionMap::GeneratePredictableIds(Object *source, Object *target)
 
     unsigned i = 0;
     for (Object *s : sourceObjects) {
-        this->GeneratePredictableIds(s, targetObjects.at(i++));
+        this->GeneratePredictableIDs(s, targetObjects.at(i++));
     }
 }
 

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -45,9 +45,9 @@ bool Facsimile::IsSupportedChild(Object *object)
     return true;
 }
 
-Zone *Facsimile::FindZoneByUuid(std::string zoneId)
+Zone *Facsimile::FindZoneByID(std::string zoneId)
 {
-    return dynamic_cast<Zone *>(this->FindDescendantByUuid(zoneId));
+    return dynamic_cast<Zone *>(this->FindDescendantByID(zoneId));
 }
 
 int Facsimile::GetMaxX()

--- a/src/facsimileinterface.cpp
+++ b/src/facsimileinterface.cpp
@@ -93,7 +93,7 @@ void FacsimileInterface::SetZone(Zone *zone)
     if (m_zone != NULL) {
         Object *parent = m_zone->GetParent();
         if (!parent->DeleteChild(m_zone)) {
-            printf("Failed to delete zone with ID %s\n", m_zone->GetUuid().c_str());
+            printf("Failed to delete zone with ID %s\n", m_zone->GetID().c_str());
         }
     }
     m_zone = zone;
@@ -101,7 +101,7 @@ void FacsimileInterface::SetZone(Zone *zone)
         this->SetFacs("");
     }
     else {
-        this->SetFacs("#" + m_zone->GetUuid());
+        this->SetFacs("#" + m_zone->GetID());
     }
 }
 

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -61,10 +61,10 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
         if (note->GetScoreTimeTiedDuration() == -1.0) {
             // Check if we need to add it to the previous interval ids
             const int intervalsIdsSize = (int)m_intervalsIds.size();
-            if (intervalsIdsSize > 0) m_intervalsIds.get<jsonxx::Array>(intervalsIdsSize - 1) << note->GetUuid();
+            if (intervalsIdsSize > 0) m_intervalsIds.get<jsonxx::Array>(intervalsIdsSize - 1) << note->GetID();
             // Same for pitch ids
             const int pitchesIdsSize = (int)m_pitchesIds.size();
-            if (pitchesIdsSize > 0) m_pitchesIds.get<jsonxx::Array>(pitchesIdsSize - 1) << note->GetUuid();
+            if (pitchesIdsSize > 0) m_pitchesIds.get<jsonxx::Array>(pitchesIdsSize - 1) << note->GetID();
             m_previousNotes.push_back(note);
             return;
         }
@@ -107,7 +107,7 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
         m_pitchesChromatic << pitch.str();
         m_pitchesDiatonic << pname;
         jsonxx::Array pitchesIds;
-        pitchesIds << note->GetUuid();
+        pitchesIds << note->GetID();
         m_pitchesIds << jsonxx::Value(pitchesIds);
 
         // We have a previous note (or more with tied notes), so we can calculate an interval
@@ -119,8 +119,8 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
                 = StringFormat("%d", note->GetDiatonicPitch() - m_previousNotes.front()->GetDiatonicPitch());
             m_intervalsDiatonic << intervalDiatonic;
             jsonxx::Array intervalsIds;
-            for (auto previousNote : m_previousNotes) intervalsIds << previousNote->GetUuid();
-            intervalsIds << note->GetUuid();
+            for (auto previousNote : m_previousNotes) intervalsIds << previousNote->GetID();
+            intervalsIds << note->GetID();
             m_intervalsIds << jsonxx::Value(intervalsIds);
         }
         m_previousNotes.clear();

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -57,7 +57,7 @@ void Fermata::Reset()
 }
 
 void Fermata::ConvertFromAnalyticalMarkup(
-    AttFermataPresent *fermataPresent, const std::string &uuid, ConvertMarkupAnalyticalParams *params)
+    AttFermataPresent *fermataPresent, const std::string &id, ConvertMarkupAnalyticalParams *params)
 {
     this->SetPlace(Att::StaffrelBasicToStaffrel(fermataPresent->GetFermata()));
     if (params->m_permanent) {
@@ -66,7 +66,7 @@ void Fermata::ConvertFromAnalyticalMarkup(
     else {
         this->IsAttribute(true);
     }
-    this->SetStartid("#" + uuid);
+    this->SetStartid("#" + id);
     params->m_controlEvents.push_back(this);
 }
 

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -102,22 +102,22 @@ int GrpSym::ScoreDefSetGrpSym(FunctorParams *)
         ScoreDef *scoreDef = vrv_cast<ScoreDef *>(this->GetParent());
         assert(scoreDef);
 
-        const std::string startId = ExtractUuidFragment(this->GetStartid());
-        const std::string endId = ExtractUuidFragment(this->GetEndid());
+        const std::string startId = ExtractIDFragment(this->GetStartid());
+        const std::string endId = ExtractIDFragment(this->GetEndid());
         const int level = this->GetLevel();
 
-        UuidComparison compare(STAFFDEF, startId);
+        IDComparison compare(STAFFDEF, startId);
         StaffDef *start = vrv_cast<StaffDef *>(scoreDef->FindDescendantByComparison(&compare, level));
-        compare.SetUuid(endId);
+        compare.SetID(endId);
         StaffDef *end = vrv_cast<StaffDef *>(scoreDef->FindDescendantByComparison(&compare, level));
 
         if (!start || !end) {
-            LogWarning("Could not find startid/endid on level %d for <'%s'>", level, this->GetUuid().c_str());
+            LogWarning("Could not find startid/endid on level %d for <'%s'>", level, this->GetID().c_str());
             return FUNCTOR_CONTINUE;
         }
 
         if (start->GetParent() != end->GetParent()) {
-            LogWarning("<'%s'> has mismatching parents for startid:<'%s'> and endid:<'%s'>", this->GetUuid().c_str(),
+            LogWarning("<'%s'> has mismatching parents for startid:<'%s'> and endid:<'%s'>", this->GetID().c_str(),
                 startId.c_str(), endId.c_str());
             return FUNCTOR_CONTINUE;
         }

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -218,7 +218,7 @@ int Harm::AdjustHarmGrpsSpacing(FunctorParams *functorParams)
     // Something is probably not right if nothing found - maybe no @staff
     if (positioners.empty()) {
         LogDebug("Something was wrong when searching positioners for %s '%s'", this->GetClassName().c_str(),
-            this->GetUuid().c_str());
+            this->GetID().c_str());
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -362,7 +362,7 @@ void ABCInput::AddChordSymbol(LayerElement *element)
 
     // there should always only be one element in the harmony stack
     if (!m_harmStack.empty() && !m_harmStack.back()->HasStartid()) {
-        m_harmStack.back()->SetStartid("#" + element->GetUuid());
+        m_harmStack.back()->SetStartid("#" + element->GetID());
         m_harmStack.clear();
     }
 
@@ -375,11 +375,11 @@ void ABCInput::AddDynamic(LayerElement *element)
 
     for (auto it = m_dynam.begin(); it != m_dynam.end(); ++it) {
         Dynam *dynam = new Dynam();
-        dynam->SetStartid("#" + element->GetUuid());
+        dynam->SetStartid("#" + element->GetID());
         Text *text = new Text();
         text->SetText(UTF8to16(*it));
         dynam->AddChild(text);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), dynam));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), dynam));
     }
 
     m_dynam.clear();
@@ -390,9 +390,9 @@ void ABCInput::AddFermata(LayerElement *element)
     assert(element);
 
     Fermata *fermata = new Fermata();
-    fermata->SetStartid("#" + element->GetUuid());
+    fermata->SetStartid("#" + element->GetID());
     fermata->SetPlace(m_fermata);
-    m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), fermata));
+    m_controlElements.push_back(std::make_pair(m_layer->GetID(), fermata));
 
     m_fermata = STAFFREL_NONE;
 }
@@ -401,36 +401,36 @@ void ABCInput::AddOrnaments(LayerElement *element)
 {
     assert(element);
 
-    std::string refId = "#" + element->GetUuid();
+    std::string refId = "#" + element->GetID();
     // note->SetOrnam(m_ornam);
     if (m_ornam.find("m") != std::string::npos) {
         Mordent *mordent = new Mordent();
         mordent->SetStartid(refId);
         mordent->SetForm(mordentLog_FORM_lower);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), mordent));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), mordent));
     }
     if (m_ornam.find("M") != std::string::npos) {
         Mordent *mordent = new Mordent();
         mordent->SetStartid(refId);
         mordent->SetForm(mordentLog_FORM_upper);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), mordent));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), mordent));
     }
     if (m_ornam.find("s") != std::string::npos) {
         Turn *turn = new Turn();
         turn->SetStartid(refId);
         turn->SetForm(turnLog_FORM_lower);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), turn));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), turn));
     }
     if (m_ornam.find("S") != std::string::npos) {
         Turn *turn = new Turn();
         turn->SetStartid(refId);
         turn->SetForm(turnLog_FORM_upper);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), turn));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), turn));
     }
     if (m_ornam.find("T") != std::string::npos) {
         Trill *trill = new Trill();
         trill->SetStartid(refId);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), trill));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), trill));
     }
 
     m_ornam.clear();
@@ -446,7 +446,7 @@ void ABCInput::AddTie()
         Tie *tie = new Tie();
         tie->SetStartid(m_ID);
         m_tieStack.push_back(tie);
-        m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), tie));
+        m_controlElements.push_back(std::make_pair(m_layer->GetID(), tie));
     }
 }
 
@@ -454,7 +454,7 @@ void ABCInput::StartSlur()
 {
     Slur *openSlur = new Slur();
     m_slurStack.push_back(openSlur);
-    m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), openSlur));
+    m_controlElements.push_back(std::make_pair(m_layer->GetID(), openSlur));
 }
 
 void ABCInput::EndSlur()
@@ -907,7 +907,7 @@ void ABCInput::CreateWorkEntry()
     // <work> //
     pugi::xml_node work = m_workList.append_child("work");
     work.append_attribute("n").set_value(m_mdiv->GetN().c_str());
-    work.append_attribute("data").set_value(StringFormat("#%s", m_mdiv->GetUuid().c_str()).c_str());
+    work.append_attribute("data").set_value(StringFormat("#%s", m_mdiv->GetID().c_str()).c_str());
     for (auto it = m_title.begin(); it != m_title.end(); ++it) {
         pugi::xml_node title = work.append_child("title");
         title.text().set((it->first).c_str());
@@ -954,8 +954,8 @@ void ABCInput::FlushControlElements(Score *score, Section *section)
     Layer *layer = NULL;
     Measure *measure = NULL;
     for (auto iter = m_controlElements.begin(); iter != m_controlElements.end(); ++iter) {
-        if (!measure || (layer && layer->GetUuid() != iter->first)) {
-            layer = dynamic_cast<Layer *>(section->FindDescendantByUuid(iter->first));
+        if (!measure || (layer && layer->GetID() != iter->first)) {
+            layer = dynamic_cast<Layer *>(section->FindDescendantByID(iter->first));
         }
         if (!layer) {
             LogWarning("ABC import: Element '%s' could not be assigned to layer '%s'",
@@ -1010,7 +1010,7 @@ void ABCInput::InitScoreAndSection(Score *&score, Section *&section)
     // start with a new page
     if (m_linebreak != '\0') {
         Pb *pb = new Pb();
-        pb->SetUuid(StringFormat("abcLine%02d", m_lineNum + 1));
+        pb->SetID(StringFormat("abcLine%02d", m_lineNum + 1));
         section->AddChild(pb);
     }
     // calculate default unit note length
@@ -1329,7 +1329,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
         else if (pitch.find(toupper(musicCode.at(i))) != std::string::npos) {
             int oct = 0;
             Note *note = new Note;
-            m_ID = note->GetUuid();
+            m_ID = note->GetID();
 
             // accidentals
             if (i >= 1) {
@@ -1501,7 +1501,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
         // spaces
         else if (musicCode.at(i) == 'x') {
             Space *space = new Space();
-            m_ID = space->GetUuid();
+            m_ID = space->GetID();
 
             // add chord symbols
             if (!m_harmStack.empty()) {
@@ -1573,7 +1573,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
         // rests
         else if (musicCode.at(i) == 'z') {
             Rest *rest = new Rest();
-            m_ID = rest->GetUuid();
+            m_ID = rest->GetID();
 
             // add chord symbols
             if (!m_harmStack.empty()) {
@@ -1671,7 +1671,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
             text->SetText(UTF8to16(chordSymbol));
             harm->AddChild(text);
             m_harmStack.push_back(harm);
-            m_controlElements.push_back(std::make_pair(m_layer->GetUuid(), harm));
+            m_controlElements.push_back(std::make_pair(m_layer->GetID(), harm));
         }
 
         // suppressing score line-breaks
@@ -1736,7 +1736,7 @@ void ABCInput::readMusicCode(const std::string &musicCode, Section *section)
     if (sysBreak && (m_linebreak != '\0') && !(section->GetLast())->Is(SB)) {
         AddLayerElement();
         Sb *sb = new Sb();
-        sb->SetUuid(StringFormat("abcLine%02d", m_lineNum + 1));
+        sb->SetID(StringFormat("abcLine%02d", m_lineNum + 1));
         section->AddChild(sb);
     }
 }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -23891,7 +23891,7 @@ void HumdrumInput::processTieStart(Note *note, hum::HTp token, const std::string
     hum::HumNum endtime = timestamp + token->getDuration();
     int track = token->getTrack();
     int rtrack = m_rkern[track];
-    std::string noteuuid = note->GetID();
+    std::string noteid = note->GetID();
     int cl = m_currentlayer;
     int pitch = hum::Convert::kernToMidiNoteNumber(tstring);
 
@@ -23900,7 +23900,7 @@ void HumdrumInput::processTieStart(Note *note, hum::HTp token, const std::string
 
     ss[rtrack].tiestarts.emplace_back();
     ss[rtrack].tiestarts.back().setStart(
-        noteuuid, m_measure, cl, tstring, pitch, timestamp, endtime, subindex, token, metertop, meterbot);
+        noteid, m_measure, cl, tstring, pitch, timestamp, endtime, subindex, token, metertop, meterbot);
 
     if (m_signifiers.above) {
         std::string marker = "[";
@@ -23948,7 +23948,7 @@ void HumdrumInput::processTieEnd(Note *note, hum::HTp token, const std::string &
     hum::HumNum timestamp = token->getDurationFromStart();
     int track = token->getTrack();
     int staffindex = m_rkern[track];
-    std::string noteuuid = note->GetID();
+    std::string noteid = note->GetID();
     bool disjunct = token->find("]]") != std::string::npos;
     if (token->find("__") != std::string::npos) {
         disjunct = true;
@@ -24028,7 +24028,7 @@ void HumdrumInput::processTieEnd(Note *note, hum::HTp token, const std::string &
         hum::HumNum endtime = starttime + duration;
 
         Tie *tie = found->setEndAndInsert(
-            noteuuid, m_measure, layer, tstring, pitch, starttime, endtime, subindex, token, metertop, meterbot);
+            noteid, m_measure, layer, tstring, pitch, starttime, endtime, subindex, token, metertop, meterbot);
 
         int startindex = found->getStartSubindex();
         if (starttoken) {

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -9815,9 +9815,9 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         if (diff > 0) {
                             std::string letter;
                             letter.push_back('a' + diff);
-                            std::string uid = clef->GetID();
-                            uid += letter;
-                            clef->SetID(uid);
+                            std::string id = clef->GetID();
+                            id += letter;
+                            clef->SetID(id);
                         }
                         if (spaceSplitToken != NULL) {
                             // Add the second part of a split invisible rest:
@@ -9826,9 +9826,9 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                                 embedQstampInClass(irest, spaceSplitToken, *spaceSplitToken);
                             }
                             setLocationId(irest, spaceSplitToken);
-                            std::string uid = irest->GetID();
-                            uid += "b";
-                            irest->SetID(uid);
+                            std::string id = irest->GetID();
+                            id += "b";
+                            irest->SetID(id);
                             appendElement(elements, pointers, irest);
                             // convertRhythm(irest, spaceSplitToken);
                             setRhythmFromDuration(irest, remainingSplitDur);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -1420,7 +1420,7 @@ void HumdrumInput::processHangingTieEnd(
         int cl = m_currentlayer;
         int metertop = ss[staffindex].meter_top;
         hum::HumNum meterbot = ss[staffindex].meter_bottom;
-        std::string noteid = note->GetUuid();
+        std::string noteid = note->GetID();
         int pitch = hum::Convert::kernToMidiNoteNumber(tstring);
 
         hum::HumNum starttime = token->getDurationFromStart();
@@ -8461,7 +8461,7 @@ void HumdrumInput::suppressBufferedClef(int index)
         return;
     }
 
-    badclef->SetSameas("#" + goodclef->GetUuid());
+    badclef->SetSameas("#" + goodclef->GetID());
 }
 
 //////////////////////////////
@@ -8486,12 +8486,12 @@ bool HumdrumInput::convertStaffLayer(int track, int startline, int endline, int 
         if (layerdata[0]->size() > 0) {
             setLocationIdNSuffix(m_layer, layerdata[0], layerindex + 1);
             // Start the Layer at startline rather than line of first token in layer.
-            std::string id = m_layer->GetUuid();
+            std::string id = m_layer->GetID();
             hum::HumRegex hre;
             std::string replacement = "L";
             replacement += to_string(startline + 1);
             hre.replaceDestructive(id, replacement, "L\\d+");
-            m_layer->SetUuid(id);
+            m_layer->SetID(id);
         }
     }
 
@@ -9014,13 +9014,13 @@ void HumdrumInput::handleGroupStarts(const std::vector<humaux::HumdrumBeamAndTup
             }
             checkBeamWith(beam, tgs, layerdata, layerindex);
             setBeamLocationId(beam, tgs, layerdata, layerindex);
-            std::string id = beam->GetUuid();
+            std::string id = beam->GetID();
             layerdata[layerindex]->setValue("auto", "beamid", id);
         }
         else {
             beam = insertBeam(elements, pointers, tg);
             setBeamLocationId(beam, tgs, layerdata, layerindex);
-            std::string id = beam->GetUuid();
+            std::string id = beam->GetID();
             layerdata[layerindex]->setValue("auto", "beamid", id);
             bool status = checkForBeamSameas(beam, layerdata, layerindex);
             if (status) {
@@ -9043,7 +9043,7 @@ void HumdrumInput::handleGroupStarts(const std::vector<humaux::HumdrumBeamAndTup
     else if (tg.beamstart) {
         beam = insertBeam(elements, pointers, tg);
         setBeamLocationId(beam, tgs, layerdata, layerindex);
-        std::string id = beam->GetUuid();
+        std::string id = beam->GetID();
         layerdata[layerindex]->setValue("auto", "beamid", id);
         bool status = checkForBeamSameas(beam, layerdata, layerindex);
         if (status) {
@@ -9073,7 +9073,7 @@ void HumdrumInput::handleGroupStarts(const std::vector<humaux::HumdrumBeamAndTup
         }
         checkBeamWith(beam, tgs, layerdata, layerindex);
         setBeamLocationId(beam, tgs, layerdata, layerindex);
-        std::string id = beam->GetUuid();
+        std::string id = beam->GetID();
         layerdata[layerindex]->setValue("auto", "beamid", id);
     }
 }
@@ -9434,7 +9434,7 @@ bool HumdrumInput::checkForLayerJoin(int staffindex, int layerindex)
             // Two layers have same note/rest content so make the second layer
             // a sameas of the first layer:
        Layer *&layer = m_layer;
-            std::string id = layer->GetUuid();
+            std::string id = layer->GetID();
             hum::HumRegex hre;
             hre.replaceDestructive(id, "N1", "N\\d+");
             // m_layer->SetSameas("#" + id);
@@ -9815,9 +9815,9 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         if (diff > 0) {
                             std::string letter;
                             letter.push_back('a' + diff);
-                            std::string uid = clef->GetUuid();
+                            std::string uid = clef->GetID();
                             uid += letter;
-                            clef->SetUuid(uid);
+                            clef->SetID(uid);
                         }
                         if (spaceSplitToken != NULL) {
                             // Add the second part of a split invisible rest:
@@ -9826,9 +9826,9 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                                 embedQstampInClass(irest, spaceSplitToken, *spaceSplitToken);
                             }
                             setLocationId(irest, spaceSplitToken);
-                            std::string uid = irest->GetUuid();
+                            std::string uid = irest->GetID();
                             uid += "b";
-                            irest->SetUuid(uid);
+                            irest->SetID(uid);
                             appendElement(elements, pointers, irest);
                             // convertRhythm(irest, spaceSplitToken);
                             setRhythmFromDuration(irest, remainingSplitDur);
@@ -10672,8 +10672,8 @@ void HumdrumInput::addSlur(FTrem *ftrem, hum::HTp start, hum::HTp ending)
         return;
     }
 
-    std::string firstid = ftrem->GetChild(0)->GetUuid();
-    std::string secondid = ftrem->GetChild(1)->GetUuid();
+    std::string firstid = ftrem->GetChild(0)->GetID();
+    std::string secondid = ftrem->GetChild(1)->GetID();
 
     // should also deal with chord notes in ID.
     int endline = ending->getLineNumber();
@@ -11027,7 +11027,7 @@ void HumdrumInput::handleLigature(hum::HTp token)
     id += "F" + to_string(startfield);
     id += "-L" + to_string(stopline);
     id += "F" + to_string(stopfield);
-    ligature->SetUuid(id);
+    ligature->SetID(id);
 
     // not considering if notes are in chords (which they should not)
     std::string startid = getLocationId("note", firstnote);
@@ -11095,7 +11095,7 @@ void HumdrumInput::handleColoration(hum::HTp token)
     id += "F" + to_string(startfield);
     id += "-L" + to_string(stopline);
     id += "F" + to_string(stopfield);
-    coloration->SetUuid(id);
+    coloration->SetID(id);
 
     // not considering if notes are in chords (which they should not)
     std::string startid;
@@ -11257,7 +11257,7 @@ void HumdrumInput::convertMensuralToken(
             // of a compound ligature
             Ligature *ligature = new Ligature();
             std::string id = getLocationId("ligature", token);
-            ligature->SetUuid(id);
+            ligature->SetID(id);
             ligature->SetForm(LIGATUREFORM_recta);
             appendElement(elements, pointers, ligature);
             elements.push_back("ligature");
@@ -11274,7 +11274,7 @@ void HumdrumInput::convertMensuralToken(
             ss[staffindex].ligature_obliqua = true;
             Ligature *ligature = new Ligature();
             std::string id = getLocationId("ligature", token);
-            ligature->SetUuid(id);
+            ligature->SetID(id);
             ligature->SetForm(LIGATUREFORM_obliqua);
             appendElement(elements, pointers, ligature);
             elements.push_back("ligature");
@@ -11285,7 +11285,7 @@ void HumdrumInput::convertMensuralToken(
             // contain an obliqua, which will be handled above.
             Ligature *ligature = new Ligature();
             std::string id = getLocationId("ligature", token);
-            ligature->SetUuid(id);
+            ligature->SetID(id);
             ligature->SetForm(LIGATUREFORM_recta);
             appendElement(elements, pointers, ligature);
             elements.push_back("ligature");
@@ -11715,10 +11715,10 @@ template <class ELEMENT> void HumdrumInput::addArticulations(ELEMENT element, hu
                 setLocationId(artic, token);
             }
             if (counts.at(i)) {
-                std::string id = artic->GetUuid();
+                std::string id = artic->GetID();
                 id += "N";
                 id += to_string(j + 1);
-                artic->SetUuid(id);
+                artic->SetID(id);
             }
             if (!color.empty()) {
                 artic->SetColor(color);
@@ -19286,13 +19286,13 @@ void HumdrumInput::handleOttavaMark(hum::HTp token, Note *note)
             ss[staffindex].ottavameasure->AddChild(octave);
             setStaff(octave, staffindex + 1);
             octave->SetDis(OCTAVE_DIS_8);
-            octave->SetStartid("#" + ss[staffindex].ottavanotestart->GetUuid());
+            octave->SetStartid("#" + ss[staffindex].ottavanotestart->GetID());
             std::string endid = getEndIdForOttava(token);
             if (endid != "") {
                 octave->SetEndid("#" + endid);
             }
             else {
-                octave->SetEndid("#" + ss[staffindex].ottavanoteend->GetUuid());
+                octave->SetEndid("#" + ss[staffindex].ottavanoteend->GetID());
             }
             octave->SetDisPlace(STAFFREL_basic_above);
         }
@@ -19309,13 +19309,13 @@ void HumdrumInput::handleOttavaMark(hum::HTp token, Note *note)
             ss[staffindex].ottavadownmeasure->AddChild(octave);
             setStaff(octave, staffindex + 1);
             octave->SetDis(OCTAVE_DIS_8);
-            octave->SetStartid("#" + ss[staffindex].ottavadownnotestart->GetUuid());
+            octave->SetStartid("#" + ss[staffindex].ottavadownnotestart->GetID());
             std::string endid = getEndIdForOttava(token);
             if (endid != "") {
                 octave->SetEndid("#" + endid);
             }
             else {
-                octave->SetEndid("#" + ss[staffindex].ottavadownnoteend->GetUuid());
+                octave->SetEndid("#" + ss[staffindex].ottavadownnoteend->GetID());
             }
             octave->SetDisPlace(STAFFREL_basic_below);
         }
@@ -19332,14 +19332,14 @@ void HumdrumInput::handleOttavaMark(hum::HTp token, Note *note)
             ss[staffindex].ottava2measure->AddChild(octave);
             setStaff(octave, staffindex + 1);
             octave->SetDis(OCTAVE_DIS_15);
-            octave->SetStartid("#" + ss[staffindex].ottava2notestart->GetUuid());
-            octave->SetEndid("#" + ss[staffindex].ottava2noteend->GetUuid());
+            octave->SetStartid("#" + ss[staffindex].ottava2notestart->GetID());
+            octave->SetEndid("#" + ss[staffindex].ottava2noteend->GetID());
             std::string endid = getEndIdForOttava(token);
             if (endid != "") {
                 octave->SetEndid("#" + endid);
             }
             else {
-                octave->SetEndid("#" + ss[staffindex].ottava2noteend->GetUuid());
+                octave->SetEndid("#" + ss[staffindex].ottava2noteend->GetID());
             }
             octave->SetDisPlace(STAFFREL_basic_above);
         }
@@ -19356,13 +19356,13 @@ void HumdrumInput::handleOttavaMark(hum::HTp token, Note *note)
             ss[staffindex].ottava2downmeasure->AddChild(octave);
             setStaff(octave, staffindex + 1);
             octave->SetDis(OCTAVE_DIS_15);
-            octave->SetStartid("#" + ss[staffindex].ottava2downnotestart->GetUuid());
+            octave->SetStartid("#" + ss[staffindex].ottava2downnotestart->GetID());
             std::string endid = getEndIdForOttava(token);
             if (endid != "") {
                 octave->SetEndid("#" + endid);
             }
             else {
-                octave->SetEndid("#" + ss[staffindex].ottava2downnoteend->GetUuid());
+                octave->SetEndid("#" + ss[staffindex].ottava2downnoteend->GetID());
             }
             octave->SetDisPlace(STAFFREL_basic_below);
         }
@@ -19920,7 +19920,7 @@ void HumdrumInput::convertChord(Chord *chord, hum::HTp token, int staffindex)
 
     checkForAutoStem(chord, token);
 
-    token->setValue("MEI", "xml:id", chord->GetUuid());
+    token->setValue("MEI", "xml:id", chord->GetID());
     int index = (int)m_measures.size() - 1;
     token->setValue("MEI", "measureIndex", index);
 
@@ -20453,7 +20453,7 @@ void HumdrumInput::convertRest(Rest *rest, hum::HTp token, int subtoken, int sta
         appendTypeTag(rest, "phraseStop");
     }
 
-    token->setValue("MEI", "xml:id", rest->GetUuid());
+    token->setValue("MEI", "xml:id", rest->GetID());
     int index = (int)m_measures.size() - 1;
     token->setValue("MEI", "measureIndex", index);
 }
@@ -21227,7 +21227,7 @@ void HumdrumInput::convertNote(Note *note, hum::HTp token, int staffadj, int sta
 
     // maybe organize by sub-token index, but consider as chord for now
     if (!chordQ) {
-        token->setValue("MEI", "xml:id", note->GetUuid());
+        token->setValue("MEI", "xml:id", note->GetID());
         int index = (int)m_measures.size() - 1;
         token->setValue("MEI", "measureIndex", index);
     }
@@ -21975,9 +21975,9 @@ template <class ELEMENT> void HumdrumInput::convertVerses(ELEMENT element, hum::
 
             for (int m = 0; m < (int)contents.size(); m++) {
                 if (m > 0) {
-                    std::string id = syls[0]->GetUuid();
+                    std::string id = syls[0]->GetID();
                     id += "S" + to_string(m + 1);
-                    syls[m]->SetUuid(id);
+                    syls[m]->SetID(id);
                 }
                 bool spacer = false;
                 if ((contents.size() == 1) && (contents[0].size() == 1)) {
@@ -22444,13 +22444,13 @@ void HumdrumInput::addBreath(hum::HTp token, Object *parent)
             // have to use @startid.  Maybe allow @tstamp, since
             // @startid will probably shift to the correct grace note
             // position.
-            std::string id = "#" + parent->GetUuid();
+            std::string id = "#" + parent->GetID();
             breath->SetStartid(id);
         }
         else if (!token->empty() && (token->at(0) == '=')) {
             // barline breath
             if (parent) {
-                std::string id = "#" + parent->GetUuid();
+                std::string id = "#" + parent->GetID();
                 breath->SetStartid(id);
             }
             else {
@@ -22604,7 +22604,7 @@ void HumdrumInput::addFermata(hum::HTp token, Object *parent)
             // have to use @startid.  Maybe allow @tstamp, since
             // @startid will probably shift to the correct grace note
             // position.
-            std::string id = "#" + parent->GetUuid();
+            std::string id = "#" + parent->GetID();
             fermata->SetStartid(id);
             if (fermata2) {
                 fermata2->SetStartid(id);
@@ -22613,7 +22613,7 @@ void HumdrumInput::addFermata(hum::HTp token, Object *parent)
         else if (!token->empty() && (token->at(0) == '=')) {
             // barline fermata
             if (parent) {
-                std::string id = "#" + parent->GetUuid();
+                std::string id = "#" + parent->GetID();
                 fermata->SetStartid(id);
                 if (fermata2) {
                     fermata2->SetStartid(id);
@@ -22630,7 +22630,7 @@ void HumdrumInput::addFermata(hum::HTp token, Object *parent)
         else {
             hum::HumNum tstamp = getMeasureTstamp(token, staff - 1);
             if (parent) {
-                std::string id = "#" + parent->GetUuid();
+                std::string id = "#" + parent->GetID();
                 fermata->SetStartid(id);
                 if (fermata2) {
                     fermata2->SetStartid(id);
@@ -22721,8 +22721,8 @@ void HumdrumInput::addArpeggio(Object *object, hum::HTp token)
         appendElement(m_measure, arpeg);
         // no staff attachment, or list both endpoint staves or all staves involved?
         setLocationId(arpeg, token);
-        // arpeg->SetStartid("#" + object->GetUuid());
-        std::string firstid = object->GetUuid();
+        // arpeg->SetStartid("#" + object->GetID());
+        std::string firstid = object->GetID();
         std::string secondid;
         if (earp->find(" ") != std::string::npos) {
             secondid = getLocationId("chord", earp);
@@ -23095,7 +23095,7 @@ void HumdrumInput::addTurn(Object *linked, hum::HTp token)
         turn->SetTstamp(tstamp.getFloat());
     }
     else {
-        turn->SetStartid("#" + linked->GetUuid());
+        turn->SetStartid("#" + linked->GetID());
     }
 
     if (invertedQ) {
@@ -23891,7 +23891,7 @@ void HumdrumInput::processTieStart(Note *note, hum::HTp token, const std::string
     hum::HumNum endtime = timestamp + token->getDuration();
     int track = token->getTrack();
     int rtrack = m_rkern[track];
-    std::string noteuuid = note->GetUuid();
+    std::string noteuuid = note->GetID();
     int cl = m_currentlayer;
     int pitch = hum::Convert::kernToMidiNoteNumber(tstring);
 
@@ -23948,7 +23948,7 @@ void HumdrumInput::processTieEnd(Note *note, hum::HTp token, const std::string &
     hum::HumNum timestamp = token->getDurationFromStart();
     int track = token->getTrack();
     int staffindex = m_rkern[track];
-    std::string noteuuid = note->GetUuid();
+    std::string noteuuid = note->GetID();
     bool disjunct = token->find("]]") != std::string::npos;
     if (token->find("__") != std::string::npos) {
         disjunct = true;
@@ -24383,7 +24383,7 @@ void HumdrumInput::setupSystemMeasure(int startline, int endline)
         endingid = "label-" + endingid;
         setN(m_currentending, endnum, m_sectionlabels[startline]);
         // sanitize id if not valid:
-        m_currentending->SetUuid(endingid);
+        m_currentending->SetID(endingid);
         if (m_sections.size() > 1) {
             // assuming the ending does not start at beginning
             // of music.
@@ -24403,7 +24403,7 @@ void HumdrumInput::setupSystemMeasure(int startline, int endline)
         if (m_measure) {
             m_currentsection->AddChild(m_measure);
         }
-        m_currentsection->SetUuid(m_lastsection);
+        m_currentsection->SetID(m_lastsection);
         m_sections.back()->AddChild(m_currentsection);
         m_sections.push_back(m_currentsection);
     }
@@ -24839,7 +24839,7 @@ void HumdrumInput::setupMeiDocument()
     Section *section = new Section();
     hum::HTp starting = infile.getTrackStart(1);
     if (starting) {
-        section->SetUuid(getLocationId(section, starting, -1));
+        section->SetID(getLocationId(section, starting, -1));
         storeExpansionLists(section, starting);
     }
     m_sections.push_back(section);
@@ -25226,12 +25226,12 @@ std::string HumdrumInput::GetMeiString()
 
 void HumdrumInput::setLocationId(Object *object, hum::HTp token, int subtoken)
 {
-    object->SetUuid(getLocationId(object, token, subtoken));
+    object->SetID(getLocationId(object, token, subtoken));
 }
 
 void HumdrumInput::setLocationId(Object *object, int lineindex, int fieldindex, int subtokenindex)
 {
-    object->SetUuid(getLocationId(object, lineindex, fieldindex, subtokenindex));
+    object->SetID(getLocationId(object, lineindex, fieldindex, subtokenindex));
 }
 
 ///////////////////////////////////
@@ -25317,7 +25317,7 @@ void HumdrumInput::setLocationIdNSuffix(Object *object, hum::HTp token, int numb
     id += "-L" + to_string(line);
     id += "F" + to_string(field);
     id += "N" + to_string(number);
-    object->SetUuid(id);
+    object->SetID(id);
 }
 
 /////////////////////////////
@@ -25422,7 +25422,7 @@ void HumdrumInput::setBeamLocationId(Object *object, const std::vector<humaux::H
         id += "F" + to_string(endfield);
     }
 
-    object->SetUuid(id);
+    object->SetID(id);
 }
 
 /////////////////////////////
@@ -25461,7 +25461,7 @@ void HumdrumInput::setTupletLocationId(Object *object, const std::vector<humaux:
         id += "F" + to_string(endfield);
     }
 
-    object->SetUuid(id);
+    object->SetID(id);
 }
 
 /////////////////////////////
@@ -25501,7 +25501,7 @@ void HumdrumInput::setTieLocationId(Object *object, hum::HTp tiestart, int sinde
         id += "S" + to_string(eindex + 1);
     }
 
-    object->SetUuid(id);
+    object->SetID(id);
 }
 
 /////////////////////////////
@@ -25552,7 +25552,7 @@ void HumdrumInput::setSlurLocationId(
         id += to_string(slurendnumber);
     }
 
-    object->SetUuid(id);
+    object->SetID(id);
 }
 
 //////////////////////////////
@@ -26363,7 +26363,7 @@ template <class ELEMENT> void HumdrumInput::storeExpansionList(ELEMENT *parent, 
     }
 
     Expansion *exp = new Expansion();
-    exp->SetUuid(getLocationId(exp, etok, -1));
+    exp->SetID(getLocationId(exp, etok, -1));
     parent->AddChild(exp);
     if (!variant.empty()) {
         exp->SetType(variant);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -919,21 +919,21 @@ void MEIOutput::SetLastPage(int page)
     m_hasFilter = true;
 }
 
-void MEIOutput::SetFirstMeasure(const std::string &uuid)
+void MEIOutput::SetFirstMeasure(const std::string &id)
 {
-    m_firstMeasureID = uuid;
+    m_firstMeasureID = id;
     m_hasFilter = true;
 }
 
-void MEIOutput::SetLastMeasure(const std::string &uuid)
+void MEIOutput::SetLastMeasure(const std::string &id)
 {
-    m_lastMeasureID = uuid;
+    m_lastMeasureID = id;
     m_hasFilter = true;
 }
 
-void MEIOutput::SetMdiv(const std::string &uuid)
+void MEIOutput::SetMdiv(const std::string &id)
 {
-    m_mdivID = uuid;
+    m_mdivID = id;
     m_hasFilter = true;
 }
 
@@ -1277,7 +1277,7 @@ bool MEIOutput::AdjustLabel(Label *label)
 std::string MEIOutput::IDToMeiStr(Object *element)
 {
     std::string out = element->GetID();
-    // LogDebug("uuid: %s", out.c_str());
+    // LogDebug("id: %s", out.c_str());
     return out;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -921,19 +921,19 @@ void MEIOutput::SetLastPage(int page)
 
 void MEIOutput::SetFirstMeasure(const std::string &uuid)
 {
-    m_firstMeasureUuid = uuid;
+    m_firstMeasureID = uuid;
     m_hasFilter = true;
 }
 
 void MEIOutput::SetLastMeasure(const std::string &uuid)
 {
-    m_lastMeasureUuid = uuid;
+    m_lastMeasureID = uuid;
     m_hasFilter = true;
 }
 
 void MEIOutput::SetMdiv(const std::string &uuid)
 {
-    m_mdivUuid = uuid;
+    m_mdivID = uuid;
     m_hasFilter = true;
 }
 
@@ -942,9 +942,9 @@ void MEIOutput::ResetFilter()
     m_hasFilter = false;
     m_firstPage = 1;
     m_lastPage = m_doc->GetPageCount();
-    m_firstMeasureUuid = "";
-    m_lastMeasureUuid = "";
-    m_mdivUuid = "";
+    m_firstMeasureID = "";
+    m_lastMeasureID = "";
+    m_mdivID = "";
 }
 
 void MEIOutput::Reset()
@@ -968,13 +968,13 @@ bool MEIOutput::HasValidFilter() const
 
     // Verify measure filter
     Object *firstMeasure = NULL;
-    if (!m_firstMeasureUuid.empty()) {
-        firstMeasure = m_doc->FindDescendantByUuid(m_firstMeasureUuid);
+    if (!m_firstMeasureID.empty()) {
+        firstMeasure = m_doc->FindDescendantByID(m_firstMeasureID);
         if (!firstMeasure || !firstMeasure->Is(MEASURE)) return false;
     }
     Object *lastMeasure = NULL;
-    if (!m_lastMeasureUuid.empty()) {
-        lastMeasure = m_doc->FindDescendantByUuid(m_lastMeasureUuid);
+    if (!m_lastMeasureID.empty()) {
+        lastMeasure = m_doc->FindDescendantByID(m_lastMeasureID);
         if (!lastMeasure || !lastMeasure->Is(MEASURE)) return false;
     }
     if (firstMeasure && lastMeasure && (firstMeasure != lastMeasure)) {
@@ -984,8 +984,8 @@ bool MEIOutput::HasValidFilter() const
     }
 
     // Verify mdiv filter
-    if (!m_mdivUuid.empty()) {
-        Object *mdiv = m_doc->FindDescendantByUuid(m_mdivUuid);
+    if (!m_mdivID.empty()) {
+        Object *mdiv = m_doc->FindDescendantByID(m_mdivID);
         if (!mdiv || !mdiv->Is(MDIV)) return false;
     }
 
@@ -1029,24 +1029,24 @@ void MEIOutput::UpdatePageFilter(Object *object)
 void MEIOutput::UpdateMeasureFilter(Object *object)
 {
     // Update measure range
-    if (m_firstMeasureUuid.empty() && (m_measureFilterMatchLocation == RangeMatchLocation::BeforeStart)) {
+    if (m_firstMeasureID.empty() && (m_measureFilterMatchLocation == RangeMatchLocation::BeforeStart)) {
         m_measureFilterMatchLocation = RangeMatchLocation::BetweenStartEnd;
     }
     if (object->Is(MEASURE)) {
         switch (m_measureFilterMatchLocation) {
             case RangeMatchLocation::BeforeStart:
-                if (!m_firstMeasureUuid.empty() && (object->GetUuid() == m_firstMeasureUuid)) {
+                if (!m_firstMeasureID.empty() && (object->GetID() == m_firstMeasureID)) {
                     m_measureFilterMatchLocation = RangeMatchLocation::AtStart;
                 }
                 break;
             case RangeMatchLocation::AtStart:
-                if (m_lastMeasureUuid.empty()) {
+                if (m_lastMeasureID.empty()) {
                     m_measureFilterMatchLocation = RangeMatchLocation::BetweenStartEnd;
                 }
-                else if (object->GetUuid() == m_lastMeasureUuid) {
+                else if (object->GetID() == m_lastMeasureID) {
                     m_measureFilterMatchLocation = RangeMatchLocation::AtEnd;
                 }
-                else if (m_firstMeasureUuid == m_lastMeasureUuid) {
+                else if (m_firstMeasureID == m_lastMeasureID) {
                     m_measureFilterMatchLocation = RangeMatchLocation::AfterEnd;
                 }
                 else {
@@ -1054,7 +1054,7 @@ void MEIOutput::UpdateMeasureFilter(Object *object)
                 }
                 break;
             case RangeMatchLocation::BetweenStartEnd:
-                if (!m_lastMeasureUuid.empty() && (object->GetUuid() == m_lastMeasureUuid)) {
+                if (!m_lastMeasureID.empty() && (object->GetID() == m_lastMeasureID)) {
                     m_measureFilterMatchLocation = RangeMatchLocation::AtEnd;
                 }
                 break;
@@ -1067,22 +1067,22 @@ void MEIOutput::UpdateMeasureFilter(Object *object)
 void MEIOutput::UpdateMdivFilter(Object *object)
 {
     // Update mdiv
-    if (m_mdivUuid.empty() && (m_mdivFilterMatchLocation == MatchLocation::Before)) {
+    if (m_mdivID.empty() && (m_mdivFilterMatchLocation == MatchLocation::Before)) {
         m_mdivFilterMatchLocation = MatchLocation::Here;
     }
     if (object->Is(MDIV)) {
         switch (m_mdivFilterMatchLocation) {
             case MatchLocation::Before:
-                if (!m_mdivUuid.empty() && (object->GetUuid() == m_mdivUuid)) {
+                if (!m_mdivID.empty() && (object->GetID() == m_mdivID)) {
                     m_mdivFilterMatchLocation = MatchLocation::Here;
                 }
                 break;
             case MatchLocation::Here:
                 // Mdivs can contain mdivs as children
                 // => have to check whether we are still in the subtree of the filtered mdiv
-                if (!m_mdivUuid.empty()) {
+                if (!m_mdivID.empty()) {
                     const bool noneMatchingStackElements = std::none_of(m_objectStack.cbegin(), m_objectStack.cend(),
-                        [this](Object *object) { return (object->GetUuid() == m_mdivUuid); });
+                        [this](Object *object) { return (object->GetID() == m_mdivID); });
                     if (noneMatchingStackElements) {
                         m_mdivFilterMatchLocation = MatchLocation::After;
                     }
@@ -1274,9 +1274,9 @@ bool MEIOutput::AdjustLabel(Label *label)
     return false;
 }
 
-std::string MEIOutput::UuidToMeiStr(Object *element)
+std::string MEIOutput::IDToMeiStr(Object *element)
 {
-    std::string out = element->GetUuid();
+    std::string out = element->GetID();
     // LogDebug("uuid: %s", out.c_str());
     return out;
 }
@@ -1288,7 +1288,7 @@ void MEIOutput::WriteXmlId(pugi::xml_node currentNode, Object *object)
         if (it == m_referredObjects.end()) return;
         m_referredObjects.erase(it);
     }
-    currentNode.append_attribute("xml:id") = UuidToMeiStr(object).c_str();
+    currentNode.append_attribute("xml:id") = IDToMeiStr(object).c_str();
 }
 
 bool MEIOutput::WriteDoc(Doc *doc)
@@ -1491,7 +1491,7 @@ void MEIOutput::WritePageMilestoneEnd(pugi::xml_node currentNode, PageMilestoneE
     assert(milestoneEnd && milestoneEnd->GetStart());
 
     this->WritePageElement(currentNode, milestoneEnd);
-    currentNode.append_attribute("startid") = ("#" + UuidToMeiStr(milestoneEnd->GetStart())).c_str();
+    currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
     std::string meiElementName = milestoneEnd->GetStart()->GetClassName();
     std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
     currentNode.append_attribute("type") = meiElementName.c_str();
@@ -1527,7 +1527,7 @@ void MEIOutput::WriteSystemMilestoneEnd(pugi::xml_node currentNode, SystemMilest
     assert(milestoneEnd && milestoneEnd->GetStart());
 
     this->WriteSystemElement(currentNode, milestoneEnd);
-    currentNode.append_attribute("startid") = ("#" + UuidToMeiStr(milestoneEnd->GetStart())).c_str();
+    currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
     std::string meiElementName = milestoneEnd->GetStart()->GetClassName();
     std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
     currentNode.append_attribute("type") = meiElementName.c_str();
@@ -3695,7 +3695,7 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
 bool MEIInput::ReadPages(Object *parent, pugi::xml_node pages)
 {
     Pages *vrvPages = new Pages();
-    this->SetMeiUuid(pages, vrvPages);
+    this->SetMeiID(pages, vrvPages);
 
     vrvPages->ReadLabelled(pages);
     vrvPages->ReadNNumberLike(pages);
@@ -3752,7 +3752,7 @@ bool MEIInput::ReadPages(Object *parent, pugi::xml_node pages)
 bool MEIInput::ReadPage(Object *parent, pugi::xml_node page)
 {
     Page *vrvPage = new Page();
-    this->SetMeiUuid(page, vrvPage);
+    this->SetMeiID(page, vrvPage);
 
     if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
         UpgradePageTo_3_0_0(vrvPage, m_doc);
@@ -3854,22 +3854,22 @@ bool MEIInput::ReadPageMilestoneEnd(Object *parent, pugi::xml_node milestoneEnd)
     }
 
     // Find the element pointing to it
-    std::string startUuid = milestoneEnd.attribute("startid").value();
-    Object *start = m_doc->FindDescendantByUuid(ExtractUuidFragment(startUuid));
+    std::string startID = milestoneEnd.attribute("startid").value();
+    Object *start = m_doc->FindDescendantByID(ExtractIDFragment(startID));
     if (!start) {
-        LogError("Could not find start element '%s' for milestoneEnd", startUuid.c_str());
+        LogError("Could not find start element '%s' for milestoneEnd", startID.c_str());
         return false;
     }
 
     // Check that it is a page milestone
     PageMilestoneInterface *interface = dynamic_cast<PageMilestoneInterface *>(start);
     if (!interface) {
-        LogError("The start element  '%s' is not a page milestone element", startUuid.c_str());
+        LogError("The start element  '%s' is not a page milestone element", startID.c_str());
         return false;
     }
 
     PageMilestoneEnd *vrvElementEnd = new PageMilestoneEnd(start);
-    this->SetMeiUuid(milestoneEnd, vrvElementEnd);
+    this->SetMeiID(milestoneEnd, vrvElementEnd);
     interface->SetEnd(vrvElementEnd);
 
     parent->AddChild(vrvElementEnd);
@@ -3879,7 +3879,7 @@ bool MEIInput::ReadPageMilestoneEnd(Object *parent, pugi::xml_node milestoneEnd)
 bool MEIInput::ReadMdiv(Object *parent, pugi::xml_node mdiv, bool isVisible)
 {
     Mdiv *vrvMdiv = new Mdiv();
-    this->SetMeiUuid(mdiv, vrvMdiv);
+    this->SetMeiID(mdiv, vrvMdiv);
 
     vrvMdiv->ReadLabelled(mdiv);
     vrvMdiv->ReadNNumberLike(mdiv);
@@ -3936,7 +3936,7 @@ bool MEIInput::ReadMdivChildren(Object *parent, pugi::xml_node parentNode, bool 
 bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
 {
     Score *vrvScore = new Score();
-    this->SetMeiUuid(score, vrvScore);
+    this->SetMeiID(score, vrvScore);
 
     vrvScore->ReadLabelled(score);
     vrvScore->ReadNNumberLike(score);
@@ -3996,7 +3996,7 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
 bool MEIInput::ReadSection(Object *parent, pugi::xml_node section)
 {
     Section *vrvSection = new Section();
-    this->SetMeiUuid(section, vrvSection);
+    this->SetMeiID(section, vrvSection);
 
     vrvSection->ReadNNumberLike(section);
     vrvSection->ReadSectionVis(section);
@@ -4085,7 +4085,7 @@ bool MEIInput::ReadSectionChildren(Object *parent, pugi::xml_node parentNode)
 
 bool MEIInput::ReadSystemElement(pugi::xml_node element, SystemElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     object->ReadTyped(element);
 
     return true;
@@ -4158,7 +4158,7 @@ bool MEIInput::ReadSystem(Object *parent, pugi::xml_node system)
     assert(dynamic_cast<Page *>(parent));
 
     System *vrvSystem = new System();
-    this->SetMeiUuid(system, vrvSystem);
+    this->SetMeiID(system, vrvSystem);
     vrvSystem->ReadTyped(system);
 
     if (system.attribute("system.leftmar")) {
@@ -4257,22 +4257,22 @@ bool MEIInput::ReadSystemMilestoneEnd(Object *parent, pugi::xml_node milestoneEn
     }
 
     // Find the element pointing to it
-    std::string startUuid = milestoneEnd.attribute("startid").value();
-    Object *start = m_doc->FindDescendantByUuid(ExtractUuidFragment(startUuid));
+    std::string startID = milestoneEnd.attribute("startid").value();
+    Object *start = m_doc->FindDescendantByID(ExtractIDFragment(startID));
     if (!start) {
-        LogError("Could not find start element '%s' for milestoneEnd", startUuid.c_str());
+        LogError("Could not find start element '%s' for milestoneEnd", startID.c_str());
         return false;
     }
 
     // Check that it is a page milestone
     SystemMilestoneInterface *interface = dynamic_cast<SystemMilestoneInterface *>(start);
     if (!interface) {
-        LogError("The start element  '%s' is not a system milestone element", startUuid.c_str());
+        LogError("The start element  '%s' is not a system milestone element", startID.c_str());
         return false;
     }
 
     SystemMilestoneEnd *vrvElementEnd = new SystemMilestoneEnd(start);
-    this->SetMeiUuid(milestoneEnd, vrvElementEnd);
+    this->SetMeiID(milestoneEnd, vrvElementEnd);
     interface->SetEnd(vrvElementEnd);
 
     parent->AddChild(vrvElementEnd);
@@ -4281,7 +4281,7 @@ bool MEIInput::ReadSystemMilestoneEnd(Object *parent, pugi::xml_node milestoneEn
 
 bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     object->ReadMeasureNumbers(element);
     object->ReadSpacing(element);
     object->ReadSystems(element);
@@ -4472,7 +4472,7 @@ bool MEIInput::ReadStaffGrp(Object *parent, pugi::xml_node staffGrp)
     assert(dynamic_cast<ScoreDef *>(parent) || dynamic_cast<StaffGrp *>(parent));
 
     StaffGrp *vrvStaffGrp = new StaffGrp();
-    this->SetMeiUuid(staffGrp, vrvStaffGrp);
+    this->SetMeiID(staffGrp, vrvStaffGrp);
 
     if (m_version < MEI_4_0_0) {
         UpgradeStaffGrpTo_4_0_0(staffGrp, vrvStaffGrp);
@@ -4552,7 +4552,7 @@ bool MEIInput::ReadStaffGrpChildren(Object *parent, pugi::xml_node parentNode)
 
 bool MEIInput::ReadRunningElement(pugi::xml_node element, RunningElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     object->ReadHorizontalAlign(element);
     object->ReadTyped(element);
 
@@ -4562,7 +4562,7 @@ bool MEIInput::ReadRunningElement(pugi::xml_node element, RunningElement *object
 bool MEIInput::ReadGrpSym(Object *parent, pugi::xml_node grpSym)
 {
     GrpSym *vrvGrpSym = new GrpSym();
-    this->SetMeiUuid(grpSym, vrvGrpSym);
+    this->SetMeiID(grpSym, vrvGrpSym);
 
     vrvGrpSym->ReadColor(grpSym);
     vrvGrpSym->ReadGrpSymLog(grpSym);
@@ -4755,7 +4755,7 @@ bool MEIInput::ReadTuning(Object *parent, pugi::xml_node tuning)
     assert(dynamic_cast<StaffDef *>(parent) || dynamic_cast<EditorialElement *>(parent));
 
     Tuning *vrvTuning = new Tuning();
-    this->SetMeiUuid(tuning, vrvTuning);
+    this->SetMeiID(tuning, vrvTuning);
 
     parent->AddChild(vrvTuning);
     vrvTuning->ReadCourseLog(tuning);
@@ -4788,7 +4788,7 @@ bool MEIInput::ReadCourse(Object *parent, pugi::xml_node course)
     assert(dynamic_cast<Tuning *>(parent) || dynamic_cast<EditorialElement *>(parent));
 
     Course *vrvCourse = new Course();
-    this->SetMeiUuid(course, vrvCourse);
+    this->SetMeiID(course, vrvCourse);
 
     parent->AddChild(vrvCourse);
     vrvCourse->ReadAccidental(course);
@@ -4804,7 +4804,7 @@ bool MEIInput::ReadCourse(Object *parent, pugi::xml_node course)
 bool MEIInput::ReadInstrDef(Object *parent, pugi::xml_node instrDef)
 {
     InstrDef *vrvInstrDef = new InstrDef();
-    this->SetMeiUuid(instrDef, vrvInstrDef);
+    this->SetMeiID(instrDef, vrvInstrDef);
 
     if (m_version < MEI_4_0_0) {
         if (instrDef.attribute("midi.volume")) {
@@ -4825,7 +4825,7 @@ bool MEIInput::ReadInstrDef(Object *parent, pugi::xml_node instrDef)
 bool MEIInput::ReadLabel(Object *parent, pugi::xml_node label)
 {
     Label *vrvLabel = new Label();
-    this->SetMeiUuid(label, vrvLabel);
+    this->SetMeiID(label, vrvLabel);
 
     parent->AddChild(vrvLabel);
     this->ReadUnsupportedAttr(label, vrvLabel);
@@ -4835,7 +4835,7 @@ bool MEIInput::ReadLabel(Object *parent, pugi::xml_node label)
 bool MEIInput::ReadLabelAbbr(Object *parent, pugi::xml_node labelAbbr)
 {
     LabelAbbr *vrvLabelAbbr = new LabelAbbr();
-    this->SetMeiUuid(labelAbbr, vrvLabelAbbr);
+    this->SetMeiID(labelAbbr, vrvLabelAbbr);
 
     parent->AddChild(vrvLabelAbbr);
     this->ReadUnsupportedAttr(labelAbbr, vrvLabelAbbr);
@@ -4845,7 +4845,7 @@ bool MEIInput::ReadLabelAbbr(Object *parent, pugi::xml_node labelAbbr)
 bool MEIInput::ReadLayerDef(Object *parent, pugi::xml_node layerDef)
 {
     LayerDef *vrvLayerDef = new LayerDef();
-    this->SetMeiUuid(layerDef, vrvLayerDef);
+    this->SetMeiID(layerDef, vrvLayerDef);
 
     vrvLayerDef->ReadLabelled(layerDef);
     vrvLayerDef->ReadNInteger(layerDef);
@@ -4892,7 +4892,7 @@ bool MEIInput::ReadMeasure(Object *parent, pugi::xml_node measure)
         LogWarning("Mixing mensural and non mensural music is not supported. Trying to go ahead...");
         m_doc->SetMensuralMusicOnly(false);
     }
-    this->SetMeiUuid(measure, vrvMeasure);
+    this->SetMeiID(measure, vrvMeasure);
 
     vrvMeasure->ReadBarring(measure);
     vrvMeasure->ReadMeasureLog(measure);
@@ -5034,7 +5034,7 @@ bool MEIInput::ReadMeterSigGrp(Object *parent, pugi::xml_node meterSigGrp)
     assert(dynamic_cast<ScoreDef *>(parent) || dynamic_cast<StaffDef *>(parent) || dynamic_cast<Layer *>(parent));
 
     MeterSigGrp *vrvMeterSigGrp = new MeterSigGrp();
-    this->SetMeiUuid(meterSigGrp, vrvMeterSigGrp);
+    this->SetMeiID(meterSigGrp, vrvMeterSigGrp);
     this->ReadLinkingInterface(meterSigGrp, vrvMeterSigGrp);
     vrvMeterSigGrp->ReadBasic(meterSigGrp);
     vrvMeterSigGrp->ReadLabelled(meterSigGrp);
@@ -5071,7 +5071,7 @@ bool MEIInput::ReadMeterSigGrpChildren(Object *parent, pugi::xml_node parentNode
 
 bool MEIInput::ReadControlElement(pugi::xml_node element, ControlElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     this->ReadLinkingInterface(element, object);
     object->ReadLabelled(element);
     object->ReadTyped(element);
@@ -5504,7 +5504,7 @@ bool MEIInput::ReadTurn(Object *parent, pugi::xml_node turn)
 bool MEIInput::ReadFb(Object *parent, pugi::xml_node fb)
 {
     Fb *vrvFb = new Fb();
-    this->SetMeiUuid(fb, vrvFb);
+    this->SetMeiID(fb, vrvFb);
 
     parent->AddChild(vrvFb);
     this->ReadUnsupportedAttr(fb, vrvFb);
@@ -5542,7 +5542,7 @@ bool MEIInput::ReadFbChildren(Object *parent, pugi::xml_node parentNode)
 bool MEIInput::ReadStaff(Object *parent, pugi::xml_node staff)
 {
     Staff *vrvStaff = new Staff();
-    this->SetMeiUuid(staff, vrvStaff);
+    this->SetMeiID(staff, vrvStaff);
 
     vrvStaff->ReadFacsimile(staff);
     vrvStaff->ReadNInteger(staff);
@@ -5598,7 +5598,7 @@ bool MEIInput::ReadStaffChildren(Object *parent, pugi::xml_node parentNode)
 bool MEIInput::ReadLayer(Object *parent, pugi::xml_node layer)
 {
     Layer *vrvLayer = new Layer();
-    this->SetMeiUuid(layer, vrvLayer);
+    this->SetMeiID(layer, vrvLayer);
 
     vrvLayer->ReadCue(layer);
     vrvLayer->ReadNInteger(layer);
@@ -5774,7 +5774,7 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
 
 bool MEIInput::ReadLayerElement(pugi::xml_node element, LayerElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     this->ReadLinkingInterface(element, object);
     object->ReadLabelled(element);
     object->ReadTyped(element);
@@ -6079,7 +6079,7 @@ bool MEIInput::ReadKeySig(Object *parent, pugi::xml_node keySig)
 bool MEIInput::ReadLigature(Object *parent, pugi::xml_node ligature)
 {
     Ligature *vrvLigature = new Ligature();
-    this->SetMeiUuid(ligature, vrvLigature);
+    this->SetMeiID(ligature, vrvLigature);
 
     vrvLigature->ReadLigatureVis(ligature);
 
@@ -6514,7 +6514,7 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
 
 bool MEIInput::ReadTextElement(pugi::xml_node element, TextElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
     object->ReadLabelled(element);
     object->ReadTyped(element);
 
@@ -6580,7 +6580,7 @@ bool MEIInput::ReadRend(Object *parent, pugi::xml_node rend)
     vrvRend->ReadWhitespace(rend);
 
     if (vrvRend->GetFirstAncestor(REND) && (vrvRend->HasHalign() || vrvRend->HasValign())) {
-        LogWarning("@halign or @valign in nested <rend> element <rend> %s will be ignored", vrvRend->GetUuid().c_str());
+        LogWarning("@halign or @valign in nested <rend> element <rend> %s will be ignored", vrvRend->GetID().c_str());
         // Eventually to be added to unsupported attributes?
         vrvRend->SetHalign(HORIZONTALALIGNMENT_NONE);
         vrvRend->SetValign(VERTICALALIGNMENT_NONE);
@@ -6594,13 +6594,13 @@ bool MEIInput::ReadRend(Object *parent, pugi::xml_node rend)
 bool MEIInput::ReadSvg(Object *parent, pugi::xml_node svg)
 {
     Svg *vrvSvg = new Svg();
-    this->SetMeiUuid(svg, vrvSvg);
+    this->SetMeiID(svg, vrvSvg);
 
     if (std::string(svg.name()) == "svg") {
         vrvSvg->Set(svg);
     }
     else {
-        LogWarning("No svg content found for <fig> %s", parent->GetUuid().c_str());
+        LogWarning("No svg content found for <fig> %s", parent->GetID().c_str());
     }
 
     parent->AddChild(vrvSvg);
@@ -6785,7 +6785,7 @@ bool MEIInput::ReadEditorialElement(Object *parent, pugi::xml_node current, Edit
 
 bool MEIInput::ReadEditorialElement(pugi::xml_node element, EditorialElement *object)
 {
-    this->SetMeiUuid(element, object);
+    this->SetMeiID(element, object);
 
     object->ReadLabelled(element);
     object->ReadTyped(element);
@@ -7287,7 +7287,7 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
     }
 
     Tuplet *tuplet = new Tuplet();
-    this->SetMeiUuid(tupletSpan, tuplet);
+    this->SetMeiID(tupletSpan, tuplet);
 
     LayerElement *start = NULL;
     LayerElement *end = NULL;
@@ -7337,15 +7337,15 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
 
     // position (pitch)
     if (tupletSpan.attribute("startid")) {
-        std::string refId = ExtractUuidFragment(tupletSpan.attribute("startid").value());
-        start = dynamic_cast<LayerElement *>(measure->FindDescendantByUuid(refId));
+        std::string refId = ExtractIDFragment(tupletSpan.attribute("startid").value());
+        start = dynamic_cast<LayerElement *>(measure->FindDescendantByID(refId));
         if (!start) {
             LogWarning("Element with @startid '%s' not found when trying to read the <tupletSpan>", refId.c_str());
         }
     }
     if (tupletSpan.attribute("endid")) {
-        std::string refId = ExtractUuidFragment(tupletSpan.attribute("endid").value());
-        end = dynamic_cast<LayerElement *>(measure->FindDescendantByUuid(refId));
+        std::string refId = ExtractIDFragment(tupletSpan.attribute("endid").value());
+        end = dynamic_cast<LayerElement *>(measure->FindDescendantByID(refId));
         if (!end) {
             LogWarning("Element with @endid '%s' not found when trying to read the <tupletSpan>", refId.c_str());
         }
@@ -7359,7 +7359,7 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
     LayerElement *endChild = dynamic_cast<LayerElement *>(end->GetLastAncestorNot(LAYER));
 
     if (!startChild || !endChild || (startChild->GetParent() != endChild->GetParent())) {
-        LogWarning("Start and end elements for <tupletSpan> '%s' not in the same layer", tuplet->GetUuid().c_str());
+        LogWarning("Start and end elements for <tupletSpan> '%s' not in the same layer", tuplet->GetID().c_str());
         delete tuplet;
         return false;
     }
@@ -7369,7 +7369,7 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
 
     int startIdx = startChild->GetIdx();
     int endIdx = endChild->GetIdx();
-    // LogDebug("%d %d %s!", startIdx, endIdx, start->GetUuid().c_str());
+    // LogDebug("%d %d %s!", startIdx, endIdx, start->GetID().c_str());
     int i;
     for (i = endIdx; i >= startIdx; i--) {
         LayerElement *element = dynamic_cast<LayerElement *>(parentLayer->DetachChild(i));
@@ -7381,7 +7381,7 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
     return true;
 }
 
-void MEIInput::SetMeiUuid(pugi::xml_node element, Object *object)
+void MEIInput::SetMeiID(pugi::xml_node element, Object *object)
 {
     if (!m_comment.empty()) {
         object->SetComment(m_comment);
@@ -7392,7 +7392,7 @@ void MEIInput::SetMeiUuid(pugi::xml_node element, Object *object)
         return;
     }
 
-    object->SetUuid(element.attribute("xml:id").value());
+    object->SetID(element.attribute("xml:id").value());
     element.remove_attribute("xml:id");
 }
 
@@ -7715,7 +7715,7 @@ bool MEIInput::ReadSurface(Facsimile *parent, pugi::xml_node surface)
 {
     assert(parent);
     Surface *vrvSurface = new Surface();
-    this->SetMeiUuid(surface, vrvSurface);
+    this->SetMeiID(surface, vrvSurface);
     vrvSurface->ReadCoordinated(surface);
     vrvSurface->ReadTyped(surface);
 
@@ -7735,7 +7735,7 @@ bool MEIInput::ReadZone(Surface *parent, pugi::xml_node zone)
 {
     assert(parent);
     Zone *vrvZone = new Zone();
-    this->SetMeiUuid(zone, vrvZone);
+    this->SetMeiID(zone, vrvZone);
     vrvZone->ReadCoordinated(zone);
     vrvZone->ReadTyped(zone);
     parent->AddChild(vrvZone);
@@ -7747,7 +7747,7 @@ bool MEIInput::ReadFacsimile(Doc *doc, pugi::xml_node facsimile)
     assert(doc);
     Facsimile *vrvFacsimile = new Facsimile();
     // Read xmlId (if present)
-    this->SetMeiUuid(facsimile, vrvFacsimile);
+    this->SetMeiID(facsimile, vrvFacsimile);
     // Read children
     for (pugi::xml_node child = facsimile.first_child(); child; child = child.next_sibling()) {
         if (strcmp(child.name(), "surface") == 0) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -285,7 +285,7 @@ void MusicXmlInput::InsertClefToLayer(Staff *staff, Layer *layer, Clef *clef, in
         }
         else {
             clefToAdd = new Clef();
-            clefToAdd->SetSameas("#" + clef->GetUuid());
+            clefToAdd->SetSameas("#" + clef->GetID());
         }
 
         // In case scoreOnset is 0 - add clef before the first element
@@ -371,7 +371,7 @@ void MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
     // add this measure to `m_endingStack` if within an ending
     if (!m_endingStack.empty()) {
         if (m_endingStack.back().second.m_endingType == "start"
-            && m_endingStack.back().first.back()->GetUuid() != measure->GetUuid()) {
+            && m_endingStack.back().first.back()->GetID() != measure->GetID()) {
             m_endingStack.back().first.push_back(measure);
         }
     }
@@ -512,9 +512,9 @@ void MusicXmlInput::FillSpace(Layer *layer, int dur)
     }
 }
 
-void MusicXmlInput::GenerateUuid(pugi::xml_node node)
+void MusicXmlInput::GenerateID(pugi::xml_node node)
 {
-    std::string uuid = StringFormat("%s-%s", node.name(), Object::GenerateRandUuid().c_str()).c_str();
+    std::string uuid = StringFormat("%s-%s", node.name(), Object::GenerateRandID().c_str()).c_str();
     std::transform(uuid.begin(), uuid.end(), uuid.begin(), ::tolower);
     node.append_attribute("xml:id").set_value(uuid.c_str());
 }
@@ -524,7 +524,7 @@ void MusicXmlInput::GenerateUuid(pugi::xml_node node)
 
 void MusicXmlInput::OpenTie(Note *note, Tie *tie)
 {
-    tie->SetStartid("#" + note->GetUuid());
+    tie->SetStartid("#" + note->GetID());
     m_tieStack.push_back({ tie, note });
 }
 
@@ -543,7 +543,7 @@ void MusicXmlInput::OpenSlur(Measure *measure, short int number, Slur *slur, cur
     // try to match open slur with slur stops within that measure
     for (auto iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
         if ((iter->second.m_number == number) && ((iter->second.m_measureNum).compare(measure->GetN()) == 0)) {
-            slur->SetEndid("#" + iter->first->GetUuid());
+            slur->SetEndid("#" + iter->first->GetID());
             slur->SetCurvedir(CombineCurvedir(dir, iter->second.m_curvedir));
             m_slurStopStack.erase(iter);
             return;
@@ -560,7 +560,7 @@ void MusicXmlInput::CloseSlur(Measure *measure, short int number, LayerElement *
     std::vector<std::pair<Slur *, musicxml::OpenSlur>>::reverse_iterator riter;
     for (riter = m_slurStack.rbegin(); riter != m_slurStack.rend(); ++riter) {
         if (riter->second.m_number == number) {
-            riter->first->SetEndid("#" + element->GetUuid());
+            riter->first->SetEndid("#" + element->GetID());
             riter->first->SetCurvedir(CombineCurvedir(riter->second.m_curvedir, dir));
             m_slurStack.erase(std::next(riter).base());
             return;
@@ -575,7 +575,7 @@ void MusicXmlInput::CloseBeamSpan(Staff *staff, Layer *layer, LayerElement *elem
 {
     for (auto riter = m_beamspanStack.rbegin(); riter != m_beamspanStack.rend(); ++riter) {
         if ((riter->second.first == staff->GetN()) || (riter->second.second == layer->GetN())) {
-            riter->first->SetEndid("#" + element->GetUuid());
+            riter->first->SetEndid("#" + element->GetID());
             m_beamspanStack.erase(std::next(riter).base());
             return;
         }
@@ -1012,7 +1012,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             }
             // create the staffDef(s)
             StaffGrp *partStaffGrp = new StaffGrp();
-            partStaffGrp->SetUuid(partId.c_str());
+            partStaffGrp->SetID(partId.c_str());
             const short int nbStaves
                 = ReadMusicXmlPartAttributesAsStaffDef(partFirstMeasure.node(), partStaffGrp, staffOffset);
             // if we have more than one staff in the part we create a new staffGrp
@@ -1089,9 +1089,9 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             // <ending>
             std::vector<Measure *>::iterator jter;
             for (jter = measureList.begin(); jter != measureList.end(); ++jter) {
-                logString = logString + (*jter)->GetUuid().c_str();
+                logString = logString + (*jter)->GetID().c_str();
                 // remove other measures from <section> that are not already removed above (first measure)
-                if ((*jter)->GetUuid() != measureList.front()->GetUuid()) {
+                if ((*jter)->GetID() != measureList.front()->GetID()) {
                     int idx = section->GetChildIndex(*jter);
                     section->DetachChild(idx);
                 }
@@ -1126,19 +1126,19 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         for (auto iter = m_slurStopStack.begin(); iter != m_slurStopStack.end(); ++iter) {
             LogWarning("MusicXML import: slur ending for element '%s' could not be "
                        "matched to a start element",
-                iter->first->GetUuid().c_str());
+                iter->first->GetID().c_str());
         }
         m_slurStopStack.clear();
     }
     if (!m_glissStack.empty()) {
         for (auto iter = m_glissStack.begin(); iter != m_glissStack.end(); ++iter) {
-            LogWarning("MusicXML import: gliss for '%s' could not be closed", (*iter)->GetUuid().c_str());
+            LogWarning("MusicXML import: gliss for '%s' could not be closed", (*iter)->GetID().c_str());
         }
         m_glissStack.clear();
     }
     if (!m_trillStack.empty()) { // open trills without ending
         for (auto iter = m_trillStack.begin(); iter != m_trillStack.end(); ++iter) {
-            LogWarning("MusicXML import: trill extender for '%s' could not be ended", iter->first->GetUuid().c_str());
+            LogWarning("MusicXML import: trill extender for '%s' could not be ended", iter->first->GetID().c_str());
         }
         m_trillStack.clear();
     }
@@ -1210,16 +1210,16 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     }
 
     pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
-    GenerateUuid(encodingDesc);
+    GenerateID(encodingDesc);
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
-    GenerateUuid(appInfo);
+    GenerateID(appInfo);
     pugi::xml_node app = appInfo.append_child("application");
-    GenerateUuid(app);
+    GenerateID(app);
     pugi::xml_node appName = app.append_child("name");
-    GenerateUuid(appName);
+    GenerateID(appName);
     appName.append_child(pugi::node_pcdata).set_value("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    GenerateUuid(appText);
+    GenerateID(appText);
     appText.append_child(pugi::node_pcdata).set_value("Transcoded from MusicXML");
 
     // isodate and version
@@ -1279,7 +1279,7 @@ short int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(
                 staffDef = new StaffDef();
                 staffDef->SetN(i + 1 + staffOffset);
                 if (nbStaves == 1) {
-                    staffDef->SetUuid(staffGrp->GetUuid());
+                    staffDef->SetID(staffGrp->GetID());
                     if (m_label) staffDef->AddChild(m_label);
                     if (m_labelAbbr) staffDef->AddChild(m_labelAbbr);
                     if (m_instrdef) staffDef->AddChild(m_instrdef);
@@ -1457,7 +1457,7 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
     if ((time.select_nodes("beats").size() > 1) || time.select_node("interchangeable")) {
         MeterSigGrp *meterSigGrp = new MeterSigGrp();
         if (time.attribute("id")) {
-            meterSigGrp->SetUuid(time.attribute("id").as_string());
+            meterSigGrp->SetID(time.attribute("id").as_string());
         }
         pugi::xpath_node interchangeable = time.select_node("interchangeable");
         meterSigGrp->SetFunc(interchangeable ? meterSigGrpLog_FUNC_interchanging : meterSigGrpLog_FUNC_mixed);
@@ -1471,7 +1471,7 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
     else {
         MeterSig *meterSig = new MeterSig();
         if (time.attribute("id")) {
-            meterSig->SetUuid(time.attribute("id").as_string());
+            meterSig->SetID(time.attribute("id").as_string());
         }
         const std::string symbol = time.attribute("symbol").as_string();
         if (!symbol.empty()) {
@@ -1552,13 +1552,13 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, shor
     if (!m_openDashesStack.empty()) { // open dashes without ending
         for (auto iter = m_openDashesStack.begin(); iter != m_openDashesStack.end(); ++iter) {
             LogWarning(
-                "MusicXML import: dashes/extender lines for '%s' could not be closed", iter->first->GetUuid().c_str());
+                "MusicXML import: dashes/extender lines for '%s' could not be closed", iter->first->GetID().c_str());
         }
         m_openDashesStack.clear();
     }
     if (!m_bracketStack.empty()) { // open brackets without ending
         for (auto iter = m_bracketStack.begin(); iter != m_bracketStack.end(); ++iter) {
-            LogWarning("MusicXML import: bracketSpan for '%s' could not be closed", iter->first->GetUuid().c_str());
+            LogWarning("MusicXML import: bracketSpan for '%s' could not be closed", iter->first->GetID().c_str());
         }
         m_bracketStack.clear();
     }
@@ -1579,7 +1579,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
     assert(measure);
 
     const std::string measureNum = node.attribute("number").as_string();
-    if (node.attribute("id")) measure->SetUuid(node.attribute("id").as_string());
+    if (node.attribute("id")) measure->SetID(node.attribute("id").as_string());
     if (measure != NULL) measure->SetN(measureNum);
 
     bool implicit = node.attribute("implicit").as_bool();
@@ -1676,7 +1676,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
             if (iter->second->GetPname() == (*jter)->GetPname() && iter->second->GetOct() == (*jter)->GetOct()
                 && (iter->second->GetScoreTimeOnset() < (*jter)->GetScoreTimeOnset()
                     && (*jter)->GetScoreTimeOnset() < lastScoreTimeOnset)) {
-                iter->first->SetEndid("#" + (*jter)->GetUuid());
+                iter->first->SetEndid("#" + (*jter)->GetID());
                 lastScoreTimeOnset = (*jter)->GetScoreTimeOnset();
                 tieMatched = true;
             }
@@ -1888,7 +1888,7 @@ void MusicXmlInput::ReadMusicXmlBarLine(pugi::xml_node node, Measure *measure, c
         else {
             fermata->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 1.0);
         }
-        if (xmlFermata.attribute("id")) fermata->SetUuid(xmlFermata.attribute("id").as_string());
+        if (xmlFermata.attribute("id")) fermata->SetID(xmlFermata.attribute("id").as_string());
 
         if (fermataCounter < 2) {
             fermata->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
@@ -1965,7 +1965,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         dir->SetTstamp(timeStamp - 1.0);
         dir->SetType("coda");
         dir->SetStaff(dir->AttStaffIdent::StrToXsdPositiveIntegerList("1"));
-        if (xmlCoda.attribute("id")) dir->SetUuid(xmlCoda.attribute("id").as_string());
+        if (xmlCoda.attribute("id")) dir->SetID(xmlCoda.attribute("id").as_string());
         Rend *rend = new Rend;
         rend->SetFontname("VerovioText");
         rend->SetFontstyle(FONTSTYLE_normal);
@@ -2209,7 +2209,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             hairpin->SetColor(wedge->node().attribute("color").as_string());
             hairpin->SetPlace(hairpin->AttPlacementRelStaff::StrToStaffrel(placeStr.c_str()));
             hairpin->SetTstamp(timeStamp);
-            if (wedge->node().attribute("id")) hairpin->SetUuid(wedge->node().attribute("id").as_string());
+            if (wedge->node().attribute("id")) hairpin->SetID(wedge->node().attribute("id").as_string());
             if (staffNode) {
                 hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(
                     std::to_string(staffNode.text().as_int() + staffOffset)));
@@ -2261,7 +2261,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                         octave->SetEndid(m_ID);
                     }
                     else {
-                        LogWarning("MusicXML import: octave for '%s' could not be closed", octave->GetUuid().c_str());
+                        LogWarning("MusicXML import: octave for '%s' could not be closed", octave->GetID().c_str());
                     }
                 }
             }
@@ -2391,7 +2391,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         dir->SetTstamp(timeStamp - 1.0);
         dir->SetType("segno");
         dir->SetStaff(dir->AttStaffIdent::StrToXsdPositiveIntegerList("1"));
-        if (xmlSegno.attribute("id")) dir->SetUuid(xmlSegno.attribute("id").as_string());
+        if (xmlSegno.attribute("id")) dir->SetID(xmlSegno.attribute("id").as_string());
         Rend *rend = new Rend;
         rend->SetFontname("VerovioText");
         rend->SetFontstyle(FONTSTYLE_normal);
@@ -2644,7 +2644,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 space->SetDurPpq(duration);
                 if (dots > 0) space->SetDots(dots);
                 if (!noteID.empty()) {
-                    space->SetUuid(noteID);
+                    space->SetID(noteID);
                 }
                 // set @staff attribute, if existing and different from parent staff number
                 if (noteStaffNum > 0 && noteStaffNum + staffOffset != staff->GetN())
@@ -2655,7 +2655,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             else {
                 MSpace *mSpace = new MSpace();
                 if (!noteID.empty()) {
-                    mSpace->SetUuid(noteID);
+                    mSpace->SetID(noteID);
                 }
                 AddLayerElement(layer, mSpace);
             }
@@ -2679,7 +2679,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 if (!stepStr.empty()) mRest->SetPloc(ConvertStepToPitchName(stepStr));
                 if (!octaveStr.empty()) mRest->SetOloc(std::stoi(octaveStr));
                 if (!noteID.empty()) {
-                    mRest->SetUuid(noteID);
+                    mRest->SetID(noteID);
                 }
                 AddLayerElement(layer, mRest, duration);
             }
@@ -2706,7 +2706,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 if (!stepStr.empty()) rest->SetPloc(ConvertStepToPitchName(stepStr));
                 if (!octaveStr.empty()) rest->SetOloc(std::stoi(octaveStr));
                 if (!noteID.empty()) {
-                    rest->SetUuid(noteID);
+                    rest->SetID(noteID);
                 }
                 // set @staff attribute, if existing and different from parent staff number
                 if (noteStaffNum > 0 && noteStaffNum + staffOffset != staff->GetN())
@@ -2722,7 +2722,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         note->SetVisible(ConvertWordToBool(node.attribute("print-object").as_string()));
         note->SetColor(node.attribute("color").as_string());
         if (!noteID.empty()) {
-            note->SetUuid(noteID);
+            note->SetID(noteID);
         }
         note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
         // set @staff attribute, if existing and different from parent staff number
@@ -2918,7 +2918,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         // beamspan
         if (!readBeamsAndTuplets) {
             BeamSpan *meiBeamSpan = new BeamSpan();
-            meiBeamSpan->SetStartid("#" + element->GetUuid());
+            meiBeamSpan->SetStartid("#" + element->GetID());
             m_controlElements.push_back({ measureNum, meiBeamSpan });
             m_beamspanStack.push_back({ meiBeamSpan, { staff->GetN(), layer->GetN() } });
         }
@@ -3047,8 +3047,8 @@ void MusicXmlInput::ReadMusicXmlNote(
                 meiSlur->SetColor(slur.attribute("color").as_string());
                 // lineform
                 meiSlur->SetLform(meiSlur->AttCurveRend::StrToLineform(slur.attribute("line-type").as_string()));
-                if (slur.attribute("id")) meiSlur->SetUuid(slur.attribute("id").as_string());
-                meiSlur->SetStartid("#" + note->GetUuid());
+                if (slur.attribute("id")) meiSlur->SetID(slur.attribute("id").as_string());
+                meiSlur->SetStartid("#" + note->GetID());
                 // add it to the stack
                 m_controlElements.push_back({ measureNum, meiSlur });
                 OpenSlur(measure, slurNumber, meiSlur, dir);
@@ -3179,7 +3179,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     // add duration to measure time
     if (!nextIsChord) m_durTotal += duration;
 
-    m_ID = "#" + element->GetUuid();
+    m_ID = "#" + element->GetID();
 
     // breath marks
     pugi::xpath_node xmlBreath = notations.node().select_node("articulations/breath-mark");
@@ -3212,7 +3212,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         m_controlElements.push_back({ measureNum, dynam });
         dynam->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         dynam->SetStartid(m_ID);
-        if (xmlDynam.attribute("id")) dynam->SetUuid(xmlDynam.attribute("id").as_string());
+        if (xmlDynam.attribute("id")) dynam->SetID(xmlDynam.attribute("id").as_string());
         // place
         dynam->SetPlace(dynam->AttPlacementRelStaff::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         int defaultY = xmlDynam.attribute("default-y").as_int();
@@ -3239,7 +3239,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         m_controlElements.push_back({ measureNum, fermata });
         fermata->SetStartid(m_ID);
         fermata->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
-        if (xmlFermata.attribute("id")) fermata->SetUuid(xmlFermata.attribute("id").as_string());
+        if (xmlFermata.attribute("id")) fermata->SetID(xmlFermata.attribute("id").as_string());
         ShapeFermata(fermata, xmlFermata);
     }
 
@@ -3251,7 +3251,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         Text *text = new Text();
         text->SetText(UTF8to16(fingText));
         m_controlElements.push_back({ measureNum, fing });
-        const std::string startID = note ? ("#" + note->GetUuid()) : m_ID;
+        const std::string startID = note ? ("#" + note->GetID()) : m_ID;
         fing->SetStartid(startID);
         fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
         fing->SetPlace(fing->AttPlacementRelStaff::StrToStaffrel(xmlFing.node().attribute("placement").as_string()));
@@ -3263,7 +3263,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     for (pugi::xpath_node_set::const_iterator it = glissandi.begin(); it != glissandi.end(); ++it) {
         std::string noteID = m_ID;
         // prevent from using chords or tabGrps
-        if (element->Is(CHORD) || element->Is(TABGRP)) noteID = "#" + element->GetChild(0)->GetUuid();
+        if (element->Is(CHORD) || element->Is(TABGRP)) noteID = "#" + element->GetChild(0)->GetID();
         pugi::xml_node xmlGlissando = it->node();
         if (HasAttributeWithValue(xmlGlissando, "type", "start")) {
             Gliss *gliss = new Gliss();
@@ -3274,7 +3274,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             gliss->SetStartid(noteID);
             gliss->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
             gliss->SetType(xmlGlissando.name());
-            if (xmlGlissando.attribute("id")) gliss->SetUuid(xmlGlissando.attribute("id").as_string());
+            if (xmlGlissando.attribute("id")) gliss->SetID(xmlGlissando.attribute("id").as_string());
             m_glissStack.push_back(gliss);
         }
         else if (!m_glissStack.empty()) {
@@ -3459,7 +3459,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             for (auto iter = m_ArpeggioStack.begin(); iter != m_ArpeggioStack.end(); ++iter) {
                 if (iter->second.m_arpegN == arpegN && onset == iter->second.m_timeStamp) {
                     // don't add other chord notes, because the chord is already referenced.
-                    if (!isChord) iter->first->GetPlistInterface()->AddRef("#" + element->GetUuid());
+                    if (!isChord) iter->first->GetPlistInterface()->AddRef("#" + element->GetID());
                     added = true; // so that no new Arpeg gets created below
                     break;
                 }
@@ -3467,7 +3467,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         }
         if (!added) {
             Arpeg *arpeggio = new Arpeg();
-            arpeggio->GetPlistInterface()->AddRef("#" + element->GetUuid());
+            arpeggio->GetPlistInterface()->AddRef("#" + element->GetID());
             // color
             arpeggio->SetColor(xmlArpeggiate.node().attribute("color").as_string());
             // direction (up/down) and in MEI arrow
@@ -3711,7 +3711,7 @@ void MusicXmlInput::ReadMusicXmlBeamStart(const pugi::xml_node &node, const pugi
     }
 
     Beam *beam = new Beam();
-    if (beamStart.attribute("id")) beam->SetUuid(beamStart.attribute("id").as_string());
+    if (beamStart.attribute("id")) beam->SetID(beamStart.attribute("id").as_string());
     if (beamStart.attribute("fan")) beam->SetForm(ConvertBeamFanToForm(beamStart.attribute("fan").as_string()));
     AddLayerElement(layer, beam);
     m_elementStackMap.at(layer).push_back(beam);
@@ -3726,7 +3726,7 @@ void MusicXmlInput::ReadMusicXmlTies(
     const std::string tieType = xmlTie.node().attribute("type").as_string();
     if ("stop" == tieType) { // add to stack if (endTie) or if pitch/oct match to open tie on m_tieStack
         if (!m_tieStack.empty() && note->IsEnharmonicWith(m_tieStack.back().second)) {
-            m_tieStack.back().first->SetEndid("#" + note->GetUuid());
+            m_tieStack.back().first->SetEndid("#" + note->GetID());
             m_tieStack.pop_back();
         }
         else {
@@ -3744,7 +3744,7 @@ void MusicXmlInput::ReadMusicXmlTies(
         // placement and orientation
         tie->SetCurvedir(InferCurvedir(xmlTie.node()));
         tie->SetLform(tie->AttCurveRend::StrToLineform(xmlTie.node().attribute("line-type").as_string()));
-        if (xmlTie.node().attribute("id")) tie->SetUuid(xmlTie.node().attribute("id").as_string());
+        if (xmlTie.node().attribute("id")) tie->SetID(xmlTie.node().attribute("id").as_string());
         // add it to the stack
         m_controlElements.push_back({ measureNum, tie });
         OpenTie(note, tie);
@@ -3757,12 +3757,12 @@ void MusicXmlInput::ReadMusicXmlTies(
         // placement and orientation
         lv->SetCurvedir(InferCurvedir(xmlTie.node()));
         lv->SetLform(lv->AttCurveRend::StrToLineform(xmlTie.node().attribute("line-type").as_string()));
-        if (xmlTie.node().attribute("id")) lv->SetUuid(xmlTie.node().attribute("id").as_string());
+        if (xmlTie.node().attribute("id")) lv->SetID(xmlTie.node().attribute("id").as_string());
         // add it to the stack
         m_controlElements.push_back({ measureNum, lv });
         // set startid to the current note and set second timestamp (endpoint) right away, since we're going to link
         // <lv> not to another element, but to timestamp
-        lv->SetStartid("#" + note->GetUuid());
+        lv->SetStartid("#" + note->GetID());
         double tstamp = std::min(static_cast<double>(m_layerEndTimes[layer]), m_durTotal + 2.0);
         tstamp = std::max(tstamp, m_durTotal + 1.25);
         lv->SetTstamp2({ 0, tstamp * (double)m_meterUnit / (4.0 * m_ppq) + 1 });
@@ -3777,7 +3777,7 @@ Clef *MusicXmlInput::ConvertClef(const pugi::xml_node &clef)
         meiClef->SetColor(clef.attribute("color").as_string());
         meiClef->SetVisible(ConvertWordToBool(clef.attribute("print-object").as_string()));
         if (clef.attribute("id")) {
-            meiClef->SetUuid(clef.attribute("id").as_string());
+            meiClef->SetID(clef.attribute("id").as_string());
         }
         meiClef->SetShape(meiClef->AttClefShape::StrToClefshape(GetContent(clefSign).substr(0, 4)));
 
@@ -3826,7 +3826,7 @@ KeySig *MusicXmlInput::ConvertKey(const pugi::xml_node &key)
     KeySig *keySig = new KeySig();
     keySig->SetVisible(ConvertWordToBool(key.attribute("print-object").as_string()));
     if (key.attribute("id")) {
-        keySig->SetUuid(key.attribute("id").as_string());
+        keySig->SetID(key.attribute("id").as_string());
     }
     if (key.child("fifths")) {
         short int fifths = key.child("fifths").text().as_int();

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -514,9 +514,9 @@ void MusicXmlInput::FillSpace(Layer *layer, int dur)
 
 void MusicXmlInput::GenerateID(pugi::xml_node node)
 {
-    std::string uuid = StringFormat("%s-%s", node.name(), Object::GenerateRandID().c_str()).c_str();
-    std::transform(uuid.begin(), uuid.end(), uuid.begin(), ::tolower);
-    node.append_attribute("xml:id").set_value(uuid.c_str());
+    std::string id = StringFormat("%s-%s", node.name(), Object::GenerateRandID().c_str()).c_str();
+    std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+    node.append_attribute("xml:id").set_value(id.c_str());
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -1903,7 +1903,7 @@ void PAEInput::parseNote(pae::Note *note)
 
         if (note->fermata) {
             Fermata *fermata = new Fermata();
-            fermata->SetStartid("#" + rest->GetUuid());
+            fermata->SetStartid("#" + rest->GetID());
             m_measure->AddChild(fermata);
         }
 
@@ -1941,24 +1941,24 @@ void PAEInput::parseNote(pae::Note *note)
 
         if (note->fermata) {
             Fermata *fermata = new Fermata();
-            fermata->SetStartid("#" + mnote->GetUuid());
+            fermata->SetStartid("#" + mnote->GetID());
             m_measure->AddChild(fermata);
         }
 
         if (note->trill) {
             Trill *trill = new Trill();
-            trill->SetStartid("#" + mnote->GetUuid());
+            trill->SetStartid("#" + mnote->GetID());
             m_measure->AddChild(trill);
         }
 
         if (m_tie != NULL) {
-            m_tie->SetEndid("#" + mnote->GetUuid());
+            m_tie->SetEndid("#" + mnote->GetID());
             m_tie = NULL;
         }
 
         if (note->tie) {
             m_tie = new Tie();
-            m_tie->SetStartid("#" + mnote->GetUuid());
+            m_tie->SetStartid("#" + mnote->GetID());
             m_measure->AddChild(m_tie);
         }
 
@@ -3504,7 +3504,7 @@ bool PAEInput::ConvertTrill()
             token.m_char = 0;
             if (note) {
                 Trill *trill = new Trill();
-                trill->SetStartid("#" + note->GetUuid());
+                trill->SetStartid("#" + note->GetID());
                 token.m_object = trill;
             }
             else {
@@ -3562,7 +3562,7 @@ bool PAEInput::ConvertFermata()
                 if (token.m_char == ')') {
                     Fermata *fermata = new Fermata();
                     fermataToken->m_object = fermata;
-                    fermata->SetStartid("#" + fermataTarget->GetUuid());
+                    fermata->SetStartid("#" + fermataTarget->GetID());
                     fermataToken->m_char = 0;
                     token.m_char = 0;
                     fermataToken = NULL;
@@ -4173,7 +4173,7 @@ bool PAEInput::ConvertTie()
                     }
                 }
                 else {
-                    tie->SetEndid("#" + tokenNote->GetUuid());
+                    tie->SetEndid("#" + tokenNote->GetID());
                     tie = NULL;
                 }
             }
@@ -4191,7 +4191,7 @@ bool PAEInput::ConvertTie()
                 // Keep a pointer to the token in case this is a ligature
                 tieToken = &token;
                 tie = new Tie();
-                tie->SetStartid("#" + note->GetUuid());
+                tie->SetStartid("#" + note->GetID());
                 token.m_object = tie;
             }
             else {
@@ -4338,14 +4338,14 @@ bool PAEInput::ConvertAccidGes()
             assert(note);
             Accid *accid = vrv_cast<Accid *>(note->FindDescendantByType(ACCID));
 
-            std::string noteUuid = note->GetUuid();
+            std::string noteID = note->GetID();
             if (!accid) {
                 // Enc tied note with a prevous note with an accidental
-                if (ties.count(noteUuid)) {
+                if (ties.count(noteID)) {
                     Accid *tieAccid = new Accid();
                     note->AddChild(tieAccid);
-                    tieAccid->SetAccidGes(Att::AccidentalWrittenToGestural(ties[noteUuid]));
-                    ties.erase(noteUuid);
+                    tieAccid->SetAccidGes(Att::AccidentalWrittenToGestural(ties[noteID]));
+                    ties.erase(noteID);
                 }
                 // Nothing in front of the note, but something in the list - make it an accid.ges
                 else if ((currentAccids.count(note->GetPname()) != 0)) {
@@ -4379,7 +4379,7 @@ bool PAEInput::ConvertAccidGes()
                     = (accid->HasAccid()) ? accid->GetAccid() : Att::AccidentalGesturalToWritten(accid->GetAccidGes());
                 Tie *tie = vrv_cast<Tie *>(token.m_object);
                 assert(tie);
-                ties[ExtractUuidFragment(tie->GetEndid())] = accidWritten;
+                ties[ExtractIDFragment(tie->GetEndid())] = accidWritten;
             }
         }
         // Reset the last note unless we have a fermata or a trill

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -183,8 +183,8 @@ void KeySig::GenerateKeyAccidAttribChildren()
         }
     }
     else if (this->HasSig()) {
-        LogWarning("Attribute key signature is ignored, since KeySig '%s' contains KeyAccid children.",
-            this->GetUuid().c_str());
+        LogWarning(
+            "Attribute key signature is ignored, since KeySig '%s' contains KeyAccid children.", this->GetID().c_str());
     }
 }
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -796,19 +796,19 @@ int Layer::FindElementInLayerStaffDefsByID(FunctorParams *functorParams) const
 
     if (!this->HasStaffDef()) return FUNCTOR_SIBLINGS;
     // Get corresponding elements from the layer
-    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetID() == params->m_uuid)) {
+    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetID() == params->m_id)) {
         params->m_object = this->GetStaffDefClef();
     }
-    else if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetID() == params->m_uuid)) {
+    else if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetID() == params->m_id)) {
         params->m_object = this->GetStaffDefKeySig();
     }
-    else if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetID() == params->m_uuid)) {
+    else if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetID() == params->m_id)) {
         params->m_object = this->GetStaffDefMensur();
     }
-    else if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetID() == params->m_uuid)) {
+    else if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetID() == params->m_id)) {
         params->m_object = this->GetStaffDefMeterSig();
     }
-    else if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetID() == params->m_uuid)) {
+    else if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetID() == params->m_id)) {
         params->m_object = this->GetStaffDefMeterSigGrp();
     }
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -601,7 +601,7 @@ int Layer::ConvertToCastOffMensural(FunctorParams *functorParams)
     params->m_targetLayer->ClearChildren();
     params->m_targetLayer->CloneReset();
     // Keep the xml:id of the layer in the first segment
-    params->m_targetLayer->SwapUuid(this);
+    params->m_targetLayer->SwapID(this);
     assert(params->m_targetStaff);
     params->m_targetStaff->AddChild(params->m_targetLayer);
 
@@ -791,24 +791,24 @@ int Layer::InitOnsetOffset(FunctorParams *functorParams)
 
 int Layer::FindElementInLayerStaffDefsByUUID(FunctorParams *functorParams) const
 {
-    FindLayerUuidWithinStaffDefParams *params = vrv_params_cast<FindLayerUuidWithinStaffDefParams *>(functorParams);
+    FindLayerIDWithinStaffDefParams *params = vrv_params_cast<FindLayerIDWithinStaffDefParams *>(functorParams);
     assert(params);
 
     if (!this->HasStaffDef()) return FUNCTOR_SIBLINGS;
     // Get corresponding elements from the layer
-    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetUuid() == params->m_uuid)) {
+    if (this->GetStaffDefClef() && (this->GetStaffDefClef()->GetID() == params->m_uuid)) {
         params->m_object = this->GetStaffDefClef();
     }
-    else if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetUuid() == params->m_uuid)) {
+    else if (this->GetStaffDefKeySig() && (this->GetStaffDefKeySig()->GetID() == params->m_uuid)) {
         params->m_object = this->GetStaffDefKeySig();
     }
-    else if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetUuid() == params->m_uuid)) {
+    else if (this->GetStaffDefMensur() && (this->GetStaffDefMensur()->GetID() == params->m_uuid)) {
         params->m_object = this->GetStaffDefMensur();
     }
-    else if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetUuid() == params->m_uuid)) {
+    else if (this->GetStaffDefMeterSig() && (this->GetStaffDefMeterSig()->GetID() == params->m_uuid)) {
         params->m_object = this->GetStaffDefMeterSig();
     }
-    else if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetUuid() == params->m_uuid)) {
+    else if (this->GetStaffDefMeterSigGrp() && (this->GetStaffDefMeterSigGrp()->GetID() == params->m_uuid)) {
         params->m_object = this->GetStaffDefMeterSigGrp();
     }
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -789,7 +789,7 @@ int Layer::InitOnsetOffset(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Layer::FindElementInLayerStaffDefsByUUID(FunctorParams *functorParams) const
+int Layer::FindElementInLayerStaffDefsByID(FunctorParams *functorParams) const
 {
     FindLayerIDWithinStaffDefParams *params = vrv_params_cast<FindLayerIDWithinStaffDefParams *>(functorParams);
     assert(params);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1175,7 +1175,7 @@ int LayerElement::AlignHorizontally(FunctorParams *functorParams)
     AlignHorizontallyParams *params = vrv_params_cast<AlignHorizontallyParams *>(functorParams);
     assert(params);
 
-    // if (m_alignment) LogDebug("Element %s %s", this->GetUuid().c_str(), this->GetClassName().c_str());
+    // if (m_alignment) LogDebug("Element %s %s", this->GetID().c_str(), this->GetClassName().c_str());
     assert(!m_alignment);
 
     if (this->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
@@ -2240,7 +2240,7 @@ int LayerElement::PrepareCrossStaff(FunctorParams *functorParams)
     m_crossStaff = dynamic_cast<Staff *>(params->m_currentMeasure->FindDescendantByComparison(&comparisonFirst, 1));
     if (!m_crossStaff) {
         LogWarning("Could not get the cross staff reference '%d' for element '%s'", crossElement->GetStaff().at(0),
-            this->GetUuid().c_str());
+            this->GetID().c_str());
         return FUNCTOR_CONTINUE;
     }
 
@@ -2248,7 +2248,7 @@ int LayerElement::PrepareCrossStaff(FunctorParams *functorParams)
     // Check if we have a cross-staff to itself...
     if (m_crossStaff == parentStaff) {
         LogWarning("The cross staff reference '%d' for element '%s' seems to be identical to the parent staff",
-            crossElement->GetStaff().at(0), this->GetUuid().c_str());
+            crossElement->GetStaff().at(0), this->GetID().c_str());
         m_crossStaff = NULL;
         return FUNCTOR_CONTINUE;
     }
@@ -2269,7 +2269,7 @@ int LayerElement::PrepareCrossStaff(FunctorParams *functorParams)
     if (!m_crossLayer) {
         // Nothing we can do
         LogWarning("Could not get the layer with cross-staff reference '%d' for element '%s'",
-            crossElement->GetStaff().at(0), this->GetUuid().c_str());
+            crossElement->GetStaff().at(0), this->GetID().c_str());
         m_crossStaff = NULL;
     }
 

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -37,9 +37,9 @@ void LinkingInterface::Reset()
     this->ResetLinking();
 
     m_next = NULL;
-    m_nextUuid = "";
+    m_nextID = "";
     m_sameas = NULL;
-    m_sameasUuid = "";
+    m_sameasID = "";
 }
 
 void LinkingInterface::SetNextLink(Object *next)
@@ -54,13 +54,13 @@ void LinkingInterface::SetSameasLink(Object *sameas)
     m_sameas = sameas;
 }
 
-void LinkingInterface::SetUuidStr()
+void LinkingInterface::SetIDStr()
 {
     if (this->HasNext()) {
-        m_nextUuid = ExtractUuidFragment(this->GetNext());
+        m_nextID = ExtractIDFragment(this->GetNext());
     }
     if (this->HasSameas()) {
-        m_sameasUuid = ExtractUuidFragment(this->GetSameas());
+        m_sameasID = ExtractIDFragment(this->GetSameas());
     }
 }
 
@@ -78,7 +78,7 @@ const Measure *LinkingInterface::GetNextMeasure() const
 void LinkingInterface::AddBackLink(const Object *object)
 {
     const LinkingInterface *linking = object->GetLinkingInterface();
-    std::string corresp = "#" + object->GetUuid();
+    std::string corresp = "#" + object->GetID();
     if (linking && linking->HasCorresp()) {
         corresp = linking->GetCorresp();
     }
@@ -99,13 +99,13 @@ int LinkingInterface::InterfacePrepareLinking(FunctorParams *functorParams, Obje
         return FUNCTOR_CONTINUE;
     }
 
-    this->SetUuidStr();
+    this->SetIDStr();
 
-    if (!m_nextUuid.empty()) {
-        params->m_nextUuidPairs.insert({ m_nextUuid, this });
+    if (!m_nextID.empty()) {
+        params->m_nextIDPairs.insert({ m_nextID, this });
     }
-    if (!m_sameasUuid.empty()) {
-        params->m_sameasUuidPairs.insert({ m_sameasUuid, this });
+    if (!m_sameasID.empty()) {
+        params->m_sameasIDPairs.insert({ m_sameasID, this });
     }
 
     return FUNCTOR_CONTINUE;
@@ -142,9 +142,9 @@ int LinkingInterface::InterfacePrepareStaffCurrentTimeSpanning(FunctorParams *fu
 int LinkingInterface::InterfaceResetData(FunctorParams *functorParams, Object *object)
 {
     m_next = NULL;
-    m_nextUuid = "";
+    m_nextID = "";
     m_sameas = NULL;
-    m_sameasUuid = "";
+    m_sameasID = "";
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -126,7 +126,7 @@ int Mdiv::Transpose(FunctorParams *functorParams)
     TransposeParams *params = vrv_params_cast<TransposeParams *>(functorParams);
     assert(params);
 
-    params->m_currentMdivUuids.push_back(this->GetUuid());
+    params->m_currentMdivIDs.push_back(this->GetID());
     params->m_keySigForStaffN.clear();
     params->m_transposeIntervalForStaffN.clear();
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -420,7 +420,7 @@ std::vector<Staff *> Measure::GetFirstStaffGrpStaves(ScoreDef *scoreDef)
         AttNIntegerComparison matchN(STAFF, *iter);
         Staff *staff = dynamic_cast<Staff *>(this->FindDescendantByComparison(&matchN, 1));
         if (!staff) {
-            // LogDebug("Staff with @n '%d' not found in measure '%s'", *iter, measure->GetUuid().c_str());
+            // LogDebug("Staff with @n '%d' not found in measure '%s'", *iter, measure->GetID().c_str());
             continue;
         }
         staves.push_back(staff);
@@ -1298,7 +1298,7 @@ int Measure::CastOffToSelection(FunctorParams *functorParams)
     CastOffToSelectionParams *params = vrv_params_cast<CastOffToSelectionParams *>(functorParams);
     assert(params);
 
-    const bool startSelection = (!params->m_isSelection && this->GetUuid() == params->m_start);
+    const bool startSelection = (!params->m_isSelection && this->GetID() == params->m_start);
 
     if (startSelection) {
         params->m_page = new Page();
@@ -1308,7 +1308,7 @@ int Measure::CastOffToSelection(FunctorParams *functorParams)
         params->m_isSelection = true;
     }
 
-    const bool endSelection = (params->m_isSelection && this->GetUuid() == params->m_end);
+    const bool endSelection = (params->m_isSelection && this->GetID() == params->m_end);
 
     MoveItselfTo(params->m_currentSystem);
 
@@ -1462,7 +1462,7 @@ int Measure::PrepareTimePointingEnd(FunctorParams *functorParams)
 
     if (!params->m_timePointingInterfaces.empty()) {
         LogWarning("%d time pointing element(s) could not be matched in measure %s",
-            params->m_timePointingInterfaces.size(), this->GetUuid().c_str());
+            params->m_timePointingInterfaces.size(), this->GetID().c_str());
     }
 
     ListOfPointingInterClassIdPairs::iterator iter = params->m_timePointingInterfaces.begin();

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -64,7 +64,7 @@ int MRest::ConvertMarkupAnalytical(FunctorParams *functorParams)
 
     if (this->HasFermata()) {
         Fermata *fermata = new Fermata();
-        fermata->ConvertFromAnalyticalMarkup(this, this->GetUuid(), params);
+        fermata->ConvertFromAnalyticalMarkup(this, this->GetID(), params);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -570,15 +570,15 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
     // First pass we fill m_stemSameasIDPairs
     if (params->m_fillList) {
         if (this->HasStemSameas()) {
-            std::string uuidTarget = ExtractIDFragment(this->GetStemSameas());
-            params->m_stemSameasIDPairs[uuidTarget] = this;
+            std::string idTarget = ExtractIDFragment(this->GetStemSameas());
+            params->m_stemSameasIDPairs[idTarget] = this;
         }
     }
     // Second pass we resolve links
     else {
-        const std::string uuid = this->GetID();
-        if (params->m_stemSameasIDPairs.count(uuid)) {
-            Note *noteStemSameas = params->m_stemSameasIDPairs.at(uuid);
+        const std::string id = this->GetID();
+        if (params->m_stemSameasIDPairs.count(id)) {
+            Note *noteStemSameas = params->m_stemSameasIDPairs.at(id);
             // Instanciate the bi-directional references and mark the roles as unset
             this->SetStemSameasNote(noteStemSameas);
             this->m_stemSameasRole = SAMEAS_UNSET;
@@ -599,7 +599,7 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
                     beamStemSameas->SetStemSameasBeam(thisBeam);
                 }
             }
-            params->m_stemSameasIDPairs.erase(uuid);
+            params->m_stemSameasIDPairs.erase(id);
         }
     }
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -567,18 +567,18 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
 {
     assert(params);
 
-    // First pass we fill m_stemSameasUuidPairs
+    // First pass we fill m_stemSameasIDPairs
     if (params->m_fillList) {
         if (this->HasStemSameas()) {
-            std::string uuidTarget = ExtractUuidFragment(this->GetStemSameas());
-            params->m_stemSameasUuidPairs[uuidTarget] = this;
+            std::string uuidTarget = ExtractIDFragment(this->GetStemSameas());
+            params->m_stemSameasIDPairs[uuidTarget] = this;
         }
     }
     // Second pass we resolve links
     else {
-        const std::string uuid = this->GetUuid();
-        if (params->m_stemSameasUuidPairs.count(uuid)) {
-            Note *noteStemSameas = params->m_stemSameasUuidPairs.at(uuid);
+        const std::string uuid = this->GetID();
+        if (params->m_stemSameasIDPairs.count(uuid)) {
+            Note *noteStemSameas = params->m_stemSameasIDPairs.at(uuid);
             // Instanciate the bi-directional references and mark the roles as unset
             this->SetStemSameasNote(noteStemSameas);
             this->m_stemSameasRole = SAMEAS_UNSET;
@@ -599,7 +599,7 @@ void Note::ResolveStemSameas(PrepareLinkingParams *params)
                     beamStemSameas->SetStemSameasBeam(thisBeam);
                 }
             }
-            params->m_stemSameasUuidPairs.erase(uuid);
+            params->m_stemSameasIDPairs.erase(uuid);
         }
     }
 }
@@ -922,12 +922,12 @@ int Note::ConvertMarkupAnalytical(FunctorParams *functorParams)
                 if (!params->m_permanent) {
                     tie->IsAttribute(true);
                 }
-                tie->SetStartid("#" + (*iter)->GetUuid());
-                tie->SetEndid("#" + this->GetUuid());
+                tie->SetStartid("#" + (*iter)->GetID());
+                tie->SetEndid("#" + this->GetID());
                 params->m_controlEvents.push_back(tie);
             }
             else {
-                LogWarning("Expected @tie median or terminal in note '%s', skipping it", this->GetUuid().c_str());
+                LogWarning("Expected @tie median or terminal in note '%s', skipping it", this->GetID().c_str());
             }
             iter = params->m_currentNotes.erase(iter);
             // we are done for this note
@@ -948,7 +948,7 @@ int Note::ConvertMarkupAnalytical(FunctorParams *functorParams)
 
     if (this->HasFermata()) {
         Fermata *fermata = new Fermata();
-        fermata->ConvertFromAnalyticalMarkup(this, this->GetUuid(), params);
+        fermata->ConvertFromAnalyticalMarkup(this, this->GetID(), params);
     }
 
     return FUNCTOR_CONTINUE;
@@ -1351,7 +1351,7 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
     if (this->GetDots() > 0) {
         if (chord && (chord->GetDots() == this->GetDots())) {
             LogWarning(
-                "Note '%s' with a @dots attribute with the same value as its chord parent", this->GetUuid().c_str());
+                "Note '%s' with a @dots attribute with the same value as its chord parent", this->GetID().c_str());
         }
         if (!currentDots) {
             currentDots = new Dots();

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -110,7 +110,7 @@ Object::Object(const Object &object) : BoundingBox(object)
     m_attClasses = object.m_attClasses;
     m_interfaces = object.m_interfaces;
     // New uuid
-    this->GenerateUuid();
+    this->GenerateID();
     // For now do not copy them
     // m_unsupported = object.m_unsupported;
 
@@ -158,7 +158,7 @@ Object &Object::operator=(const Object &object)
         m_attClasses = object.m_attClasses;
         m_interfaces = object.m_interfaces;
         // New uuid
-        this->GenerateUuid();
+        this->GenerateID();
         // For now do now copy them
         // m_unsupported = object.m_unsupported;
         LinkingInterface *link = this->GetLinkingInterface();
@@ -202,7 +202,7 @@ void Object::Init(ClassId classId, const std::string &classIdStr)
     m_comment = "";
     m_closingComment = "";
 
-    this->GenerateUuid();
+    this->GenerateID();
 
     this->Reset();
 }
@@ -353,17 +353,17 @@ void Object::MoveItselfTo(Object *targetParent)
     targetParent->AddChild(relinquishedObject);
 }
 
-void Object::SetUuid(std::string uuid)
+void Object::SetID(std::string uuid)
 {
     m_uuid = uuid;
 }
 
-void Object::SwapUuid(Object *other)
+void Object::SwapID(Object *other)
 {
     assert(other);
-    std::string swapUuid = this->GetUuid();
-    this->SetUuid(other->GetUuid());
-    other->SetUuid(swapUuid);
+    std::string swapID = this->GetID();
+    this->SetID(other->GetID());
+    other->SetID(swapID);
 }
 
 void Object::ClearChildren()
@@ -588,18 +588,18 @@ void Object::ClearRelinquishedChildren()
     }
 }
 
-Object *Object::FindDescendantByUuid(const std::string &uuid, int deepness, bool direction)
+Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool direction)
 {
-    return const_cast<Object *>(std::as_const(*this).FindDescendantByUuid(uuid, deepness, direction));
+    return const_cast<Object *>(std::as_const(*this).FindDescendantByID(uuid, deepness, direction));
 }
 
-const Object *Object::FindDescendantByUuid(const std::string &uuid, int deepness, bool direction) const
+const Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool direction) const
 {
-    Functor findByUuid(&Object::FindByUuid);
-    FindByUuidParams findbyUuidParams;
-    findbyUuidParams.m_uuid = uuid;
-    this->Process(&findByUuid, &findbyUuidParams, NULL, NULL, deepness, direction, true);
-    return findbyUuidParams.m_element;
+    Functor findByID(&Object::FindByID);
+    FindByIDParams findbyIDParams;
+    findbyIDParams.m_uuid = uuid;
+    this->Process(&findByID, &findbyIDParams, NULL, NULL, deepness, direction, true);
+    return findbyIDParams.m_element;
 }
 
 Object *Object::FindDescendantByType(ClassId classId, int deepness, bool direction)
@@ -776,14 +776,14 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
     return count;
 }
 
-void Object::GenerateUuid()
+void Object::GenerateID()
 {
-    m_uuid = m_classIdStr.at(0) + Object::GenerateRandUuid();
+    m_uuid = m_classIdStr.at(0) + Object::GenerateRandID();
 }
 
-void Object::ResetUuid()
+void Object::ResetID()
 {
-    GenerateUuid();
+    GenerateID();
 }
 
 void Object::SetParent(Object *parent)
@@ -1202,7 +1202,7 @@ Object *Object::FindPreviousChild(Comparison *comp, Object *start)
 // Static methods for Object
 //----------------------------------------------------------------------------
 
-void Object::SeedUuid(unsigned int seed)
+void Object::SeedID(unsigned int seed)
 {
     // Init random number generator for uuids
     if (seed == 0) {
@@ -1214,7 +1214,7 @@ void Object::SeedUuid(unsigned int seed)
     }
 }
 
-std::string Object::GenerateRandUuid()
+std::string Object::GenerateRandID()
 {
     unsigned int nr = s_randomGenerator();
 
@@ -1274,10 +1274,10 @@ bool Object::sortByUlx(Object *a, Object *b)
 
     if (fa == NULL || fb == NULL) {
         if (fa == NULL) {
-            LogMessage("No available facsimile interface for %s", a->GetUuid().c_str());
+            LogMessage("No available facsimile interface for %s", a->GetID().c_str());
         }
         if (fb == NULL) {
-            LogMessage("No available facsimile interface for %s", b->GetUuid().c_str());
+            LogMessage("No available facsimile interface for %s", b->GetID().c_str());
         }
         return false;
     }
@@ -1649,9 +1649,9 @@ int Object::AddLayerElementToFlatList(FunctorParams *functorParams) const
     return FUNCTOR_CONTINUE;
 }
 
-int Object::FindByUuid(FunctorParams *functorParams) const
+int Object::FindByID(FunctorParams *functorParams) const
 {
-    FindByUuidParams *params = vrv_params_cast<FindByUuidParams *>(functorParams);
+    FindByIDParams *params = vrv_params_cast<FindByIDParams *>(functorParams);
     assert(params);
 
     if (params->m_element) {
@@ -1659,7 +1659,7 @@ int Object::FindByUuid(FunctorParams *functorParams) const
         return FUNCTOR_STOP;
     }
 
-    if (params->m_uuid == this->GetUuid()) {
+    if (params->m_uuid == this->GetID()) {
         params->m_element = this;
         // LogDebug("Found it!");
         return FUNCTOR_STOP;
@@ -1864,9 +1864,9 @@ int Object::PrepareFacsimile(FunctorParams *functorParams)
         FacsimileInterface *interface = this->GetFacsimileInterface();
         assert(interface);
         if (interface->HasFacs()) {
-            std::string facsUuid = (interface->GetFacs().compare(0, 1, "#") == 0 ? interface->GetFacs().substr(1)
-                                                                                 : interface->GetFacs());
-            Zone *zone = params->m_facsimile->FindZoneByUuid(facsUuid);
+            std::string facsID = (interface->GetFacs().compare(0, 1, "#") == 0 ? interface->GetFacs().substr(1)
+                                                                               : interface->GetFacs());
+            Zone *zone = params->m_facsimile->FindZoneByID(facsID);
             if (zone != NULL) {
                 interface->SetZone(zone);
             }
@@ -1900,22 +1900,22 @@ int Object::PrepareLinking(FunctorParams *functorParams)
     }
 
     // @next
-    std::string uuid = this->GetUuid();
-    auto r1 = params->m_nextUuidPairs.equal_range(uuid);
-    if (r1.first != params->m_nextUuidPairs.end()) {
+    std::string uuid = this->GetID();
+    auto r1 = params->m_nextIDPairs.equal_range(uuid);
+    if (r1.first != params->m_nextIDPairs.end()) {
         for (auto i = r1.first; i != r1.second; ++i) {
             i->second->SetNextLink(this);
         }
-        params->m_nextUuidPairs.erase(r1.first, r1.second);
+        params->m_nextIDPairs.erase(r1.first, r1.second);
     }
 
     // @sameas
-    auto r2 = params->m_sameasUuidPairs.equal_range(uuid);
-    if (r2.first != params->m_sameasUuidPairs.end()) {
+    auto r2 = params->m_sameasIDPairs.equal_range(uuid);
+    if (r2.first != params->m_sameasIDPairs.end()) {
         for (auto j = r2.first; j != r2.second; ++j) {
             j->second->SetSameasLink(this);
         }
-        params->m_sameasUuidPairs.erase(r2.first, r2.second);
+        params->m_sameasIDPairs.erase(r2.first, r2.second);
     }
     return FUNCTOR_CONTINUE;
 }
@@ -1941,10 +1941,10 @@ int Object::PrepareProcessPlist(FunctorParams *functorParams)
 
     if (!this->IsLayerElement()) return FUNCTOR_CONTINUE;
 
-    std::string uuid = this->GetUuid();
-    auto i = std::find_if(params->m_interfaceUuidTuples.begin(), params->m_interfaceUuidTuples.end(),
+    std::string uuid = this->GetID();
+    auto i = std::find_if(params->m_interfaceIDTuples.begin(), params->m_interfaceIDTuples.end(),
         [&uuid](std::tuple<PlistInterface *, std::string, Object *> tuple) { return (std::get<1>(tuple) == uuid); });
-    if (i != params->m_interfaceUuidTuples.end()) {
+    if (i != params->m_interfaceIDTuples.end()) {
         std::get<2>(*i) = this;
     }
 
@@ -2360,7 +2360,7 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
         int overflowAbove = above->CalcOverflowAbove(current);
         int staffSize = above->GetStaffSize();
         if (overflowAbove > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
-            // LogMessage("%s top overflow: %d", current->GetUuid().c_str(), overflowAbove);
+            // LogMessage("%s top overflow: %d", current->GetID().c_str(), overflowAbove);
             if (isScoreDefClef) {
                 above->SetScoreDefClefOverflowAbove(overflowAbove);
             }
@@ -2375,7 +2375,7 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
         int overflowBelow = below->CalcOverflowBelow(current);
         int staffSize = below->GetStaffSize();
         if (overflowBelow > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
-            // LogMessage("%s bottom overflow: %d", current->GetUuid().c_str(), overflowBelow);
+            // LogMessage("%s bottom overflow: %d", current->GetID().c_str(), overflowBelow);
             if (isScoreDefClef) {
                 below->SetScoreDefClefOverflowBelow(overflowBelow);
             }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -109,7 +109,7 @@ Object::Object(const Object &object) : BoundingBox(object)
     // Also copy attribute classes
     m_attClasses = object.m_attClasses;
     m_interfaces = object.m_interfaces;
-    // New uuid
+    // New id
     this->GenerateID();
     // For now do not copy them
     // m_unsupported = object.m_unsupported;
@@ -157,7 +157,7 @@ Object &Object::operator=(const Object &object)
         // Also copy attribute classes
         m_attClasses = object.m_attClasses;
         m_interfaces = object.m_interfaces;
-        // New uuid
+        // New id
         this->GenerateID();
         // For now do now copy them
         // m_unsupported = object.m_unsupported;
@@ -353,9 +353,9 @@ void Object::MoveItselfTo(Object *targetParent)
     targetParent->AddChild(relinquishedObject);
 }
 
-void Object::SetID(std::string uuid)
+void Object::SetID(std::string id)
 {
-    m_uuid = uuid;
+    m_id = id;
 }
 
 void Object::SwapID(Object *other)
@@ -588,16 +588,16 @@ void Object::ClearRelinquishedChildren()
     }
 }
 
-Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool direction)
+Object *Object::FindDescendantByID(const std::string &id, int deepness, bool direction)
 {
-    return const_cast<Object *>(std::as_const(*this).FindDescendantByID(uuid, deepness, direction));
+    return const_cast<Object *>(std::as_const(*this).FindDescendantByID(id, deepness, direction));
 }
 
-const Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool direction) const
+const Object *Object::FindDescendantByID(const std::string &id, int deepness, bool direction) const
 {
     Functor findByID(&Object::FindByID);
     FindByIDParams findByIDParams;
-    findByIDParams.m_uuid = uuid;
+    findByIDParams.m_id = id;
     this->Process(&findByID, &findByIDParams, NULL, NULL, deepness, direction, true);
     return findByIDParams.m_element;
 }
@@ -778,7 +778,7 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
 
 void Object::GenerateID()
 {
-    m_uuid = m_classIdStr.at(0) + Object::GenerateRandID();
+    m_id = m_classIdStr.at(0) + Object::GenerateRandID();
 }
 
 void Object::ResetID()
@@ -1204,7 +1204,7 @@ Object *Object::FindPreviousChild(Comparison *comp, Object *start)
 
 void Object::SeedID(unsigned int seed)
 {
-    // Init random number generator for uuids
+    // Init random number generator for ids
     if (seed == 0) {
         std::random_device rd;
         s_randomGenerator.seed(rd());
@@ -1659,12 +1659,12 @@ int Object::FindByID(FunctorParams *functorParams) const
         return FUNCTOR_STOP;
     }
 
-    if (params->m_uuid == this->GetID()) {
+    if (params->m_id == this->GetID()) {
         params->m_element = this;
         // LogDebug("Found it!");
         return FUNCTOR_STOP;
     }
-    // LogDebug("Still looking for uuid...");
+    // LogDebug("Still looking for id...");
     return FUNCTOR_CONTINUE;
 }
 
@@ -1900,8 +1900,8 @@ int Object::PrepareLinking(FunctorParams *functorParams)
     }
 
     // @next
-    std::string uuid = this->GetID();
-    auto r1 = params->m_nextIDPairs.equal_range(uuid);
+    std::string id = this->GetID();
+    auto r1 = params->m_nextIDPairs.equal_range(id);
     if (r1.first != params->m_nextIDPairs.end()) {
         for (auto i = r1.first; i != r1.second; ++i) {
             i->second->SetNextLink(this);
@@ -1910,7 +1910,7 @@ int Object::PrepareLinking(FunctorParams *functorParams)
     }
 
     // @sameas
-    auto r2 = params->m_sameasIDPairs.equal_range(uuid);
+    auto r2 = params->m_sameasIDPairs.equal_range(id);
     if (r2.first != params->m_sameasIDPairs.end()) {
         for (auto j = r2.first; j != r2.second; ++j) {
             j->second->SetSameasLink(this);
@@ -1941,9 +1941,9 @@ int Object::PrepareProcessPlist(FunctorParams *functorParams)
 
     if (!this->IsLayerElement()) return FUNCTOR_CONTINUE;
 
-    std::string uuid = this->GetID();
+    std::string id = this->GetID();
     auto i = std::find_if(params->m_interfaceIDTuples.begin(), params->m_interfaceIDTuples.end(),
-        [&uuid](std::tuple<PlistInterface *, std::string, Object *> tuple) { return (std::get<1>(tuple) == uuid); });
+        [&id](std::tuple<PlistInterface *, std::string, Object *> tuple) { return (std::get<1>(tuple) == id); });
     if (i != params->m_interfaceIDTuples.end()) {
         std::get<2>(*i) = this;
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -596,10 +596,10 @@ Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool d
 const Object *Object::FindDescendantByID(const std::string &uuid, int deepness, bool direction) const
 {
     Functor findByID(&Object::FindByID);
-    FindByIDParams findbyIDParams;
-    findbyIDParams.m_uuid = uuid;
-    this->Process(&findByID, &findbyIDParams, NULL, NULL, deepness, direction, true);
-    return findbyIDParams.m_element;
+    FindByIDParams findByIDParams;
+    findByIDParams.m_uuid = uuid;
+    this->Process(&findByID, &findByIDParams, NULL, NULL, deepness, direction, true);
+    return findByIDParams.m_element;
 }
 
 Object *Object::FindDescendantByType(ClassId classId, int deepness, bool direction)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -353,11 +353,6 @@ void Object::MoveItselfTo(Object *targetParent)
     targetParent->AddChild(relinquishedObject);
 }
 
-void Object::SetID(std::string id)
-{
-    m_id = id;
-}
-
 void Object::SwapID(Object *other)
 {
     assert(other);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -65,7 +65,7 @@ thread_local std::mt19937 Object::s_randomGenerator;
 Object::Object() : BoundingBox()
 {
     if (s_objectCounter++ == 0) {
-        this->SeedUuid();
+        this->SeedID();
     }
     this->Init(OBJECT, "m-");
 }
@@ -73,7 +73,7 @@ Object::Object() : BoundingBox()
 Object::Object(ClassId classId) : BoundingBox()
 {
     if (s_objectCounter++ == 0) {
-        this->SeedUuid();
+        this->SeedID();
     }
     this->Init(classId, "m-");
 }
@@ -81,7 +81,7 @@ Object::Object(ClassId classId) : BoundingBox()
 Object::Object(ClassId classId, const std::string &classIdStr) : BoundingBox()
 {
     if (s_objectCounter++ == 0) {
-        this->SeedUuid();
+        this->SeedID();
     }
     this->Init(classId, classIdStr);
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1476,7 +1476,7 @@ Options::Options()
     this->Register(&m_transpose, "transpose", &m_selectors);
 
     m_transposeMdiv.SetInfo(
-        "Transpose individual mdivs", "Json mapping the mdiv uuids to the corresponding transposition");
+        "Transpose individual mdivs", "Json mapping the mdiv ids to the corresponding transposition");
     m_transposeMdiv.Init(JsonSource::String, "{}");
     this->Register(&m_transposeMdiv, "transposeMdiv", &m_selectors);
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -50,7 +50,7 @@ void Page::Reset()
     m_score = NULL;
     m_scoreEnd = NULL;
     m_layoutDone = false;
-    this->ResetUuid();
+    this->ResetID();
 
     // by default we have no values and use the document ones
     m_pageHeight = -1;

--- a/src/pagemilestone.cpp
+++ b/src/pagemilestone.cpp
@@ -164,7 +164,7 @@ int PageMilestoneEnd::Transpose(FunctorParams *functorParams)
     assert(params);
 
     if (this->m_start && this->m_start->Is(MDIV)) {
-        params->m_currentMdivUuids.pop_back();
+        params->m_currentMdivIDs.pop_back();
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -56,7 +56,7 @@ bool Pages::IsSupportedChild(Object *child)
 
 void Pages::ConvertFrom(Score *score)
 {
-    score->SwapUuid(this);
+    score->SwapID(this);
     this->AttLabelled::operator=(*score);
     this->AttNNumberLike::operator=(*score);
 }

--- a/src/plistinterface.cpp
+++ b/src/plistinterface.cpp
@@ -77,14 +77,14 @@ ArrayOfObjects PlistInterface::GetRefs()
 
 void PlistInterface::SetIDStrs()
 {
-    assert(m_uuids.empty() && m_references.empty());
+    assert(m_ids.empty() && m_references.empty());
 
     xsdAnyURI_List list = this->GetPlist();
     xsdAnyURI_List::iterator iter;
     for (iter = list.begin(); iter != list.end(); ++iter) {
-        std::string uuid = ExtractIDFragment(*iter);
-        if (!uuid.empty()) {
-            m_uuids.push_back(uuid);
+        std::string id = ExtractIDFragment(*iter);
+        if (!id.empty()) {
+            m_ids.push_back(id);
         }
         else {
             LogError("Cannot parse the anyURI '%s'", (*iter).c_str());
@@ -109,7 +109,7 @@ int PlistInterface::InterfacePreparePlist(FunctorParams *functorParams, Object *
     this->SetIDStrs();
 
     std::vector<std::string>::iterator iter;
-    for (iter = m_uuids.begin(); iter != m_uuids.end(); ++iter) {
+    for (iter = m_ids.begin(); iter != m_ids.end(); ++iter) {
         params->m_interfaceIDTuples.push_back(std::make_tuple(this, *iter, (Object *)NULL));
     }
 
@@ -118,7 +118,7 @@ int PlistInterface::InterfacePreparePlist(FunctorParams *functorParams, Object *
 
 int PlistInterface::InterfaceResetData(FunctorParams *functorParams, Object *object)
 {
-    m_uuids.clear();
+    m_ids.clear();
     m_references.clear();
 
     return FUNCTOR_CONTINUE;

--- a/src/plistinterface.cpp
+++ b/src/plistinterface.cpp
@@ -75,14 +75,14 @@ ArrayOfObjects PlistInterface::GetRefs()
     return result;
 }
 
-void PlistInterface::SetUuidStrs()
+void PlistInterface::SetIDStrs()
 {
     assert(m_uuids.empty() && m_references.empty());
 
     xsdAnyURI_List list = this->GetPlist();
     xsdAnyURI_List::iterator iter;
     for (iter = list.begin(); iter != list.end(); ++iter) {
-        std::string uuid = ExtractUuidFragment(*iter);
+        std::string uuid = ExtractIDFragment(*iter);
         if (!uuid.empty()) {
             m_uuids.push_back(uuid);
         }
@@ -106,11 +106,11 @@ int PlistInterface::InterfacePreparePlist(FunctorParams *functorParams, Object *
         return FUNCTOR_CONTINUE;
     }
 
-    this->SetUuidStrs();
+    this->SetIDStrs();
 
     std::vector<std::string>::iterator iter;
     for (iter = m_uuids.begin(); iter != m_uuids.end(); ++iter) {
-        params->m_interfaceUuidTuples.push_back(std::make_tuple(this, *iter, (Object *)NULL));
+        params->m_interfaceIDTuples.push_back(std::make_tuple(this, *iter, (Object *)NULL));
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -584,7 +584,7 @@ int Rest::ConvertMarkupAnalytical(FunctorParams *functorParams)
 
     if (this->HasFermata()) {
         Fermata *fermata = new Fermata();
-        fermata->ConvertFromAnalyticalMarkup(this, this->GetUuid(), params);
+        fermata->ConvertFromAnalyticalMarkup(this, this->GetID(), params);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -304,9 +304,9 @@ int Score::Transpose(FunctorParams *functorParams)
     }
 
     // Check whether we are in the selected mdiv
-    if (!params->m_selectedMdivUuid.empty()
-        && (std::find(params->m_currentMdivUuids.begin(), params->m_currentMdivUuids.end(), params->m_selectedMdivUuid)
-            == params->m_currentMdivUuids.end())) {
+    if (!params->m_selectedMdivID.empty()
+        && (std::find(params->m_currentMdivIDs.begin(), params->m_currentMdivIDs.end(), params->m_selectedMdivID)
+            == params->m_currentMdivIDs.end())) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -400,7 +400,7 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
         if (newStaffDef->HasLabel()) staffDef->SetLabel(newStaffDef->GetLabel());
     }
     else {
-        LogWarning("StaffDef with xml:id '%s' could not be found", newStaffDef->GetUuid().c_str());
+        LogWarning("StaffDef with xml:id '%s' could not be found", newStaffDef->GetID().c_str());
     }
 }
 

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -349,7 +349,7 @@ void Staff::SetFromFacsimile(Doc *doc)
     if (!this->HasFacs()) return;
     if (this->GetZone() == NULL) {
         assert(doc);
-        Zone *zone = doc->GetFacsimile()->FindZoneByUuid(this->GetFacs());
+        Zone *zone = doc->GetFacsimile()->FindZoneByID(this->GetFacs());
         assert(zone);
         this->SetZone(zone);
     }
@@ -443,7 +443,7 @@ int Staff::ConvertToCastOffMensural(FunctorParams *functorParams)
     params->m_targetStaff->ClearChildren();
     params->m_targetStaff->CloneReset();
     // Keep the xml:id of the staff in the first staff segment
-    params->m_targetStaff->SwapUuid(this);
+    params->m_targetStaff->SwapID(this);
     assert(params->m_targetMeasure);
     params->m_targetMeasure->AddChild(params->m_targetStaff);
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -70,7 +70,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
 
     m_outdata.clear();
 
-    m_glyphPostfixId = Object::GenerateRandUuid();
+    m_glyphPostfixId = Object::GenerateRandID();
 }
 
 SvgDeviceContext::~SvgDeviceContext() {}
@@ -1133,7 +1133,7 @@ void SvgDeviceContext::DrawSvgBoundingBox(Object *object, View *view)
             m_currentNode = m_pageNode;
         }
 
-        StartGraphic(object, "bounding-box", "bbox-" + object->GetUuid(), true, true);
+        StartGraphic(object, "bounding-box", "bbox-" + object->GetID(), true, true);
 
         if (box->HasSelfBB()) {
             this->DrawSvgBoundingBoxRectangle(view->ToDeviceContextX(object->GetDrawingX() + box->GetSelfX1()),
@@ -1184,7 +1184,7 @@ void SvgDeviceContext::DrawSvgBoundingBox(Object *object, View *view)
 
         if (drawContentBB) {
             if (object->HasContentBB()) {
-                StartGraphic(object, "content-bounding-box", "cbbox-" + object->GetUuid(), true, true);
+                StartGraphic(object, "content-bounding-box", "cbbox-" + object->GetID(), true, true);
                 if (object->HasContentBB()) {
                     this->DrawSvgBoundingBoxRectangle(
                         view->ToDeviceContextX(object->GetDrawingX() + box->GetContentX1()),

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -157,7 +157,7 @@ int Syl::PrepareLyrics(FunctorParams *functorParams)
         else if (params->m_currentSyl->GetCon() == sylLog_CON_u) {
             if (params->m_currentSyl->GetStart() == params->m_penultimateNoteOrChord)
                 LogWarning("Syllable with underline extender under one single note '%s'",
-                    params->m_currentSyl->GetStart()->GetUuid().c_str());
+                    params->m_currentSyl->GetStart()->GetID().c_str());
             else
                 params->m_currentSyl->SetEnd(params->m_penultimateNoteOrChord);
         }
@@ -221,8 +221,8 @@ bool Syl::CreateDefaultZone(Doc *doc)
         int ulx, uly, lrx, lry;
         if (syllable->GenerateZoneBounds(&ulx, &uly, &lrx, &lry)) {
             if (ulx == 0 || uly == 0 || lrx == 0 || lry == 0) {
-                LogWarning("Zero value when generating bbox from %s: (%d, %d, %d, %d)", syllable->GetUuid().c_str(),
-                    ulx, uly, lrx, lry);
+                LogWarning("Zero value when generating bbox from %s: (%d, %d, %d, %d)", syllable->GetID().c_str(), ulx,
+                    uly, lrx, lry);
             }
             zone->SetUlx(ulx);
             zone->SetUly(uly + offsetUly);
@@ -230,8 +230,7 @@ bool Syl::CreateDefaultZone(Doc *doc)
             zone->SetLry(lry + offsetLry);
         }
         else {
-            LogWarning(
-                "Failed to create zone for %s of type %s", this->GetUuid().c_str(), this->GetClassName().c_str());
+            LogWarning("Failed to create zone for %s of type %s", this->GetID().c_str(), this->GetClassName().c_str());
             delete zone;
             return false;
         }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -182,7 +182,7 @@ bool System::SetCurrentFloatingPositioner(
     StaffAlignment *alignment = m_systemAligner.GetStaffAlignmentForStaffN(staffN);
     if (!alignment) {
         LogError("Staff @n='%d' for rendering control event %s %s not found", staffN, object->GetClassName().c_str(),
-            object->GetUuid().c_str());
+            object->GetID().c_str());
         return false;
     }
     alignment->SetCurrentFloatingPositioner(object, objectX, objectY, spanningType);
@@ -1217,9 +1217,9 @@ int System::Transpose(FunctorParams *functorParams)
     assert(params);
 
     // Check whether we are in the selected mdiv
-    if (!params->m_selectedMdivUuid.empty()
-        && (std::find(params->m_currentMdivUuids.begin(), params->m_currentMdivUuids.end(), params->m_selectedMdivUuid)
-            == params->m_currentMdivUuids.end())) {
+    if (!params->m_selectedMdivID.empty()
+        && (std::find(params->m_currentMdivIDs.begin(), params->m_currentMdivIDs.end(), params->m_selectedMdivID)
+            == params->m_currentMdivIDs.end())) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -46,7 +46,7 @@ void TimePointInterface::Reset()
     this->ResetTimestampLogical();
 
     m_start = NULL;
-    m_startUuid = "";
+    m_startID = "";
 }
 
 void TimePointInterface::SetStart(LayerElement *start)
@@ -57,8 +57,8 @@ void TimePointInterface::SetStart(LayerElement *start)
 
 bool TimePointInterface::SetStartOnly(LayerElement *element)
 {
-    // LogDebug("%s - %s - %s", element->GetUuid().c_str(), m_startUuid.c_str(), m_endUuid.c_str() );
-    if (!m_start && !m_startUuid.empty() && (element->GetUuid() == m_startUuid)) {
+    // LogDebug("%s - %s - %s", element->GetID().c_str(), m_startID.c_str(), m_endID.c_str() );
+    if (!m_start && !m_startID.empty() && (element->GetID() == m_startID)) {
         this->SetStart(element);
         return true;
     }
@@ -74,10 +74,10 @@ void TimePointInterface::AddStaff(int n)
     }
 }
 
-void TimePointInterface::SetUuidStr()
+void TimePointInterface::SetIDStr()
 {
     if (this->HasStartid()) {
-        m_startUuid = ExtractUuidFragment(this->GetStartid());
+        m_startID = ExtractIDFragment(this->GetStartid());
     }
 }
 
@@ -155,7 +155,7 @@ std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Objec
         AttNIntegerComparison comparison(STAFF, *iter);
         Staff *staff = dynamic_cast<Staff *>(measure->FindDescendantByComparison(&comparison, 1));
         if (!staff) {
-            // LogDebug("Staff with @n '%d' not found in measure '%s'", *iter, measure->GetUuid().c_str());
+            // LogDebug("Staff with @n '%d' not found in measure '%s'", *iter, measure->GetID().c_str());
             continue;
         }
         if (!staff->DrawingIsVisible()) {
@@ -171,7 +171,7 @@ bool TimePointInterface::VerifyMeasure(const Object *owner) const
     assert(owner);
     if (m_start && (owner->GetFirstAncestor(MEASURE) != this->GetStartMeasure())) {
         LogWarning("%s '%s' is not encoded in the measure of its start '%s'. This may cause improper rendering.",
-            owner->GetClassName().c_str(), owner->GetUuid().c_str(), m_start->GetUuid().c_str());
+            owner->GetClassName().c_str(), owner->GetID().c_str(), m_start->GetID().c_str());
         return false;
     }
     return true;
@@ -198,7 +198,7 @@ void TimeSpanningInterface::Reset()
     this->ResetTimestamp2Logical();
 
     m_end = NULL;
-    m_endUuid = "";
+    m_endID = "";
 }
 
 void TimeSpanningInterface::SetEnd(LayerElement *end)
@@ -207,21 +207,21 @@ void TimeSpanningInterface::SetEnd(LayerElement *end)
     m_end = end;
 }
 
-void TimeSpanningInterface::SetUuidStr()
+void TimeSpanningInterface::SetIDStr()
 {
-    TimePointInterface::SetUuidStr();
+    TimePointInterface::SetIDStr();
     if (this->HasEndid()) {
-        m_endUuid = ExtractUuidFragment(this->GetEndid());
+        m_endID = ExtractIDFragment(this->GetEndid());
     }
 }
 
 bool TimeSpanningInterface::SetStartAndEnd(LayerElement *element)
 {
-    // LogDebug("%s - %s - %s", element->GetUuid().c_str(), m_startUuid.c_str(), m_endUuid.c_str() );
-    if (!m_start && !m_startUuid.empty() && (element->GetUuid() == m_startUuid)) {
+    // LogDebug("%s - %s - %s", element->GetID().c_str(), m_startID.c_str(), m_endID.c_str() );
+    if (!m_start && !m_startID.empty() && (element->GetID() == m_startID)) {
         this->SetStart(element);
     }
-    else if (!m_end && !m_endUuid.empty() && (element->GetUuid() == m_endUuid)) {
+    else if (!m_end && !m_endID.empty() && (element->GetID() == m_endID)) {
         this->SetEnd(element);
     }
     return (m_start && m_end);
@@ -351,7 +351,7 @@ int TimePointInterface::InterfacePrepareTimestamps(FunctorParams *functorParams,
     if (this->HasStart()) {
         if (this->HasTstamp())
             LogWarning("%s with @xml:id %s has both a @startid and an @tstamp; @tstamp is ignored",
-                object->GetClassName().c_str(), object->GetUuid().c_str());
+                object->GetClassName().c_str(), object->GetID().c_str());
         return FUNCTOR_CONTINUE;
     }
     else if (!this->HasTstamp()) {
@@ -367,7 +367,7 @@ int TimePointInterface::InterfacePrepareTimestamps(FunctorParams *functorParams,
 int TimePointInterface::InterfaceResetData(FunctorParams *functorParams, Object *object)
 {
     m_start = NULL;
-    m_startUuid = "";
+    m_startID = "";
     return FUNCTOR_CONTINUE;
 }
 
@@ -378,7 +378,7 @@ int TimePointInterface::InterfacePrepareTimePointing(FunctorParams *functorParam
 
     if (!this->HasStartid()) return FUNCTOR_CONTINUE;
 
-    this->SetUuidStr();
+    this->SetIDStr();
     params->m_timePointingInterfaces.push_back({ this, object->GetClassId() });
 
     return FUNCTOR_CONTINUE;
@@ -397,7 +397,7 @@ int TimeSpanningInterface::InterfacePrepareTimeSpanning(FunctorParams *functorPa
         return FUNCTOR_CONTINUE;
     }
 
-    this->SetUuidStr();
+    this->SetIDStr();
     params->m_timeSpanningInterfaces.push_back({ this, object });
 
     return FUNCTOR_CONTINUE;
@@ -412,10 +412,10 @@ int TimeSpanningInterface::InterfacePrepareTimestamps(FunctorParams *functorPara
     if (this->HasEndid()) {
         if (this->HasTstamp2())
             LogWarning("%s with @xml:id %s has both a @endid and an @tstamp2; @tstamp2 is ignored",
-                object->GetClassName().c_str(), object->GetUuid().c_str());
+                object->GetClassName().c_str(), object->GetID().c_str());
         if ((this->GetStartid() == this->GetEndid()) && !object->Is(OCTAVE)) {
             LogWarning("%s with @xml:id %s will not get rendered as it has identical values in @startid and @endid",
-                object->GetClassName().c_str(), object->GetUuid().c_str());
+                object->GetClassName().c_str(), object->GetID().c_str());
         }
         return TimePointInterface::InterfacePrepareTimestamps(functorParams, object);
     }
@@ -446,7 +446,7 @@ int TimeSpanningInterface::InterfacePrepareStaffCurrentTimeSpanning(FunctorParam
 int TimeSpanningInterface::InterfaceResetData(FunctorParams *functorParams, Object *object)
 {
     m_end = NULL;
-    m_endUuid = "";
+    m_endID = "";
     // Special case where we have interface inheritance
     return TimePointInterface::InterfaceResetData(functorParams, object);
 }

--- a/src/timemap.cpp
+++ b/src/timemap.cpp
@@ -72,8 +72,8 @@ void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
         startEntry->qstamp = scoreTimeStart;
 
         // Store the element ID in list to turn on at given time - note or rest
-        if (!isRest) startEntry->notesOn.push_back(object->GetUuid());
-        if (isRest) startEntry->restsOn.push_back(object->GetUuid());
+        if (!isRest) startEntry->notesOn.push_back(object->GetID());
+        if (isRest) startEntry->restsOn.push_back(object->GetID());
 
         // Also add the tempo the
         startEntry->tempo = params->m_currentTempo;
@@ -90,8 +90,8 @@ void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
         endEntry->qstamp = scoreTimeEnd;
 
         // Store the element ID in list to turn off at given time - notes or rest
-        if (!isRest) endEntry->notesOff.push_back(object->GetUuid());
-        if (isRest) endEntry->restsOff.push_back(object->GetUuid());
+        if (!isRest) endEntry->notesOff.push_back(object->GetID());
+        if (isRest) endEntry->restsOff.push_back(object->GetID());
     }
     else if (object->Is(MEASURE)) {
 
@@ -112,7 +112,7 @@ void Timemap::AddEntry(Object *object, GenerateTimemapParams *params)
         startEntry->qstamp = scoreTimeStart;
 
         // Add the measureOn
-        startEntry->measureOn = measure->GetUuid();
+        startEntry->measureOn = measure->GetID();
     }
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -115,6 +115,13 @@ Toolkit::~Toolkit()
 #endif
 }
 
+std::string Toolkit::GetUuid()
+{
+    LogWarning("Toolkit function GetUuid() is deprecated; use GetID() instead.");
+
+    return this->GetID();
+}
+
 std::string Toolkit::GetResourcePath() const
 {
     return m_doc.GetResources().GetPath();

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -465,7 +465,7 @@ bool Toolkit::LoadData(const std::string &data)
     if (m_options->m_xmlIdChecksum.GetValue()) {
         crcInit();
         unsigned int cr = crcFast((unsigned char *)data.c_str(), (int)data.size());
-        Object::SeedUuid(cr);
+        Object::SeedID(cr);
     }
 
 #ifndef NO_HUMDRUM_SUPPORT
@@ -1029,7 +1029,7 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
             else if (iter->first == "xmlIdSeed") {
                 if (json.has<jsonxx::Number>("xmlIdSeed")) {
                     m_options->m_xmlIdSeed.SetValue(json.get<jsonxx::Number>("xmlIdSeed"));
-                    Object::SeedUuid(m_options->m_xmlIdSeed.GetValue());
+                    Object::SeedID(m_options->m_xmlIdSeed.GetValue());
                 }
             }
             // Deprecated option
@@ -1138,23 +1138,23 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
 
     // Try to get the element on the current drawing page - it is usually the case and fast
     if (m_doc.GetDrawingPage()) {
-        element = m_doc.GetDrawingPage()->FindDescendantByUuid(xmlId);
+        element = m_doc.GetDrawingPage()->FindDescendantByID(xmlId);
     }
     // If it wasn't there, try on the whole doc
     if (!element) {
-        element = m_doc.FindDescendantByUuid(xmlId);
+        element = m_doc.FindDescendantByID(xmlId);
     }
     // If not found again, try looking in the layer staffdefs
     if (!element) {
-        Functor findByUuid(&Object::FindElementInLayerStaffDefsByUUID);
-        FindLayerUuidWithinStaffDefParams params(xmlId);
+        Functor findByID(&Object::FindElementInLayerStaffDefsByUUID);
+        FindLayerIDWithinStaffDefParams params(xmlId);
         // Check drawing page elements first
         if (m_doc.GetDrawingPage()) {
-            m_doc.GetDrawingPage()->Process(&findByUuid, &params);
+            m_doc.GetDrawingPage()->Process(&findByID, &params);
             element = params.m_object;
         }
         if (!element) {
-            m_doc.Process(&findByUuid, &params);
+            m_doc.Process(&findByID, &params);
             element = params.m_object;
         }
         // If element is found within layer staffdef - check for the linking interface @corresp attribute to find
@@ -1163,13 +1163,13 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
             // If element has @corresp set, try finding its origin
             const LinkingInterface *link = element->GetLinkingInterface();
             if (link && link->HasCorresp()) {
-                const std::string correspId = ExtractUuidFragment(link->GetCorresp());
-                Object *origin = m_doc.FindDescendantByUuid(correspId);
+                const std::string correspId = ExtractIDFragment(link->GetCorresp());
+                Object *origin = m_doc.FindDescendantByID(correspId);
                 // if no original element was found, try searching through scoredef in score (only for certain elements)
                 if (!origin && element->Is({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
                     Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
                     if (page && page->m_score) {
-                        origin = page->m_score->GetScoreDef()->FindDescendantByUuid(correspId);
+                        origin = page->m_score->GetScoreDef()->FindDescendantByID(correspId);
                     }
                 }
                 if (origin) element = origin;
@@ -1247,7 +1247,7 @@ std::string Toolkit::GetVersion()
 void Toolkit::ResetXmlIdSeed(int seed)
 {
     m_options->m_xmlIdSeed.SetValue(seed);
-    Object::SeedUuid(m_options->m_xmlIdSeed.GetValue());
+    Object::SeedID(m_options->m_xmlIdSeed.GetValue());
 }
 
 void Toolkit::ResetLogBuffer()
@@ -1571,26 +1571,26 @@ std::string Toolkit::GetElementsAtTime(int millisec)
     // Fill the JSON object
     for (auto const item : notesOrRests) {
         if (item->Is(NOTE)) {
-            noteArray << item->GetUuid();
+            noteArray << item->GetID();
             Note *note = vrv_cast<Note *>(item);
             assert(note);
             Chord *chord = note->IsChordTone();
             if (chord) chords.push_back(chord);
         }
         else if (item->Is(REST)) {
-            restArray << item->GetUuid();
+            restArray << item->GetID();
         }
     }
     chords.unique();
     for (auto const item : chords) {
-        chordArray << item->GetUuid();
+        chordArray << item->GetID();
     }
 
     o << "notes" << noteArray;
     o << "chords" << chordArray;
     o << "rests" << restArray;
     o << "page" << pageNo;
-    o << "measure" << measure->GetUuid();
+    o << "measure" << measure->GetID();
 
     return o.json();
 }
@@ -1636,7 +1636,7 @@ std::string Toolkit::GetDescriptiveFeatures(const std::string &options)
 
 int Toolkit::GetPageWithElement(const std::string &xmlId)
 {
-    Object *element = m_doc.FindDescendantByUuid(xmlId);
+    Object *element = m_doc.FindDescendantByID(xmlId);
     if (!element) {
         return 0;
     }
@@ -1651,7 +1651,7 @@ int Toolkit::GetTimeForElement(const std::string &xmlId)
 {
     this->ResetLogBuffer();
 
-    Object *element = m_doc.FindDescendantByUuid(xmlId);
+    Object *element = m_doc.FindDescendantByID(xmlId);
 
     if (!element) {
         LogWarning("Element '%s' not found", xmlId.c_str());
@@ -1699,7 +1699,7 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
 {
     this->ResetLogBuffer();
 
-    Object *element = m_doc.FindDescendantByUuid(xmlId);
+    Object *element = m_doc.FindDescendantByID(xmlId);
     jsonxx::Object o;
 
     if (!element) {
@@ -1753,7 +1753,7 @@ std::string Toolkit::GetMIDIValuesForElement(const std::string &xmlId)
 {
     this->ResetLogBuffer();
 
-    Object *element = m_doc.FindDescendantByUuid(xmlId);
+    Object *element = m_doc.FindDescendantByID(xmlId);
 
     if (!element) {
         LogWarning("Element '%s' not found", xmlId.c_str());

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1153,7 +1153,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
     }
     // If not found again, try looking in the layer staffdefs
     if (!element) {
-        Functor findByID(&Object::FindElementInLayerStaffDefsByUUID);
+        Functor findByID(&Object::FindElementInLayerStaffDefsByID);
         FindLayerIDWithinStaffDefParams params(xmlId);
         // Check drawing page elements first
         if (m_doc.GetDrawingPage()) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1198,7 +1198,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
 std::string Toolkit::GetNotatedIdForElement(const std::string &xmlId)
 {
     if (m_doc.m_expansionMap.HasExpansionMap())
-        return m_doc.m_expansionMap.GetExpansionIdsForElement(xmlId).front();
+        return m_doc.m_expansionMap.GetExpansionIDsForElement(xmlId).front();
     else
         return xmlId;
 }
@@ -1207,7 +1207,7 @@ std::string Toolkit::GetExpansionIdsForElement(const std::string &xmlId)
 {
     jsonxx::Array a;
     if (m_doc.m_expansionMap.HasExpansionMap()) {
-        for (std::string id : m_doc.m_expansionMap.GetExpansionIdsForElement(xmlId)) {
+        for (std::string id : m_doc.m_expansionMap.GetExpansionIDsForElement(xmlId)) {
             a << id;
         }
     }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -193,7 +193,7 @@ SystemAligner::SpacingType SystemAligner::GetAboveSpacingType(Staff *staff)
 
     auto iter = m_spacingTypes.find(staff->GetN());
     if (iter == m_spacingTypes.end()) {
-        LogWarning("No spacing type found matching @n=%d for '<%s>'", staff->GetN(), staff->GetUuid().c_str());
+        LogWarning("No spacing type found matching @n=%d for '<%s>'", staff->GetN(), staff->GetID().c_str());
         return SpacingType::None;
     }
 
@@ -782,7 +782,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             int overflowAbove = 0;
             if (!skipAbove) overflowAbove = this->CalcOverflowAbove(*iter);
             if (overflowAbove > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
-                // LogMessage("%sparams->m_doc top overflow: %d", this->GetUuid().c_str(), overflowAbove);
+                // LogMessage("%sparams->m_doc top overflow: %d", this->GetID().c_str(), overflowAbove);
                 this->SetOverflowAbove(overflowAbove);
                 m_overflowAboveBBoxes.push_back(*iter);
             }
@@ -790,7 +790,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             int overflowBelow = 0;
             if (!skipBelow) overflowBelow = this->CalcOverflowBelow(*iter);
             if (overflowBelow > params->m_doc->GetDrawingStaffLineWidth(staffSize) / 2) {
-                // LogMessage("%s bottom overflow: %d", this->GetUuid().c_str(), overflowBelow);
+                // LogMessage("%s bottom overflow: %d", this->GetID().c_str(), overflowBelow);
                 this->SetOverflowBelow(overflowBelow);
                 m_overflowBelowBBoxes.push_back(*iter);
             }

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -67,7 +67,7 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     /******************************************************************/
     // Start the Beam graphic and draw the children
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     /******************************************************************/
     // Draw the children
@@ -116,7 +116,7 @@ void View::DrawFTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     /******************************************************************/
     // Start the grahic
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     /******************************************************************/
     // Draw the children
@@ -429,10 +429,10 @@ void View::DrawBeamSpan(DeviceContext *dc, BeamSpan *beamSpan, System *system, O
 
     // Draw segments for the beamSpan
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
-        dc->StartGraphic(beamSpan, "", beamSpan->GetUuid(), false);
+        dc->StartGraphic(beamSpan, "", beamSpan->GetID(), false);
     }
 
     BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -79,7 +79,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
     if (element->Is(
             { BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION, SLUR, TIE })) {
         // create placeholder
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
         system->AddToDrawingList(element);
     }
@@ -412,8 +412,8 @@ bool View::HasValidTimeSpanningOrder(DeviceContext *dc, Object *element, LayerEl
         // To avoid showing the same warning multiple times, display a warning only during actual drawing
         if (!dc->Is(BBOX_DEVICE_CONTEXT) && (m_currentPage == vrv_cast<Page *>(start->GetFirstAncestor(PAGE)))) {
             LogWarning("%s '%s' is ignored, since start '%s' does not occur temporally before end '%s'.",
-                element->GetClassName().c_str(), element->GetUuid().c_str(), start->GetUuid().c_str(),
-                end->GetUuid().c_str());
+                element->GetClassName().c_str(), element->GetID().c_str(), start->GetID().c_str(),
+                end->GetID().c_str());
         }
         return false;
     }
@@ -466,10 +466,10 @@ void View::DrawBracketSpan(
     }
 
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
-        dc->StartGraphic(bracketSpan, "", bracketSpan->GetUuid(), false);
+        dc->StartGraphic(bracketSpan, "", bracketSpan->GetID(), false);
     }
 
     int bracketSize = 2 * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
@@ -637,9 +637,9 @@ void View::DrawHairpin(
     y2 -= m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
 
     if (graphic)
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     else
-        dc->StartGraphic(hairpin, "", hairpin->GetUuid(), false);
+        dc->StartGraphic(hairpin, "", hairpin->GetID(), false);
     // dc->DeactivateGraphic();
 
     const double hairpinThickness
@@ -712,9 +712,9 @@ void View::DrawOctave(
     /************** draw it **************/
 
     if (graphic)
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     else
-        dc->StartGraphic(octave, "", octave->GetUuid(), false);
+        dc->StartGraphic(octave, "", octave->GetID(), false);
 
     const bool altSymbols = m_doc->GetOptions()->m_octaveAlternativeSymbols.GetValue();
     int code = SMUFL_E511_ottavaAlta;
@@ -909,7 +909,7 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
     /************** draw it **************/
 
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
         dc->StartGraphic(pitchInflection, "spanning-pinflection", "");
@@ -951,9 +951,9 @@ void View::DrawTie(DeviceContext *dc, Tie *tie, int x1, int x2, Staff *staff, ch
     }
 
     if (graphic)
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     else
-        dc->StartGraphic(tie, "", tie->GetUuid(), false);
+        dc->StartGraphic(tie, "", tie->GetID(), false);
 
     // set pen width and calculate tie thickness coefficient to adjust tie width in according to it
     const int thickness
@@ -1009,10 +1009,10 @@ void View::DrawPedalLine(
     }
 
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
-        dc->StartGraphic(pedal, "", pedal->GetUuid(), false);
+        dc->StartGraphic(pedal, "", pedal->GetID(), false);
     }
 
     const int bracketSize = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
@@ -1068,9 +1068,9 @@ void View::DrawTrillExtension(
     /************** draw it **************/
 
     if (graphic)
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     else
-        dc->StartGraphic(trill, "", trill->GetUuid(), false);
+        dc->StartGraphic(trill, "", trill->GetID(), false);
 
     this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, SMUFL_E59D_ornamentZigZagLineNoRightEnd, 0,
         SMUFL_E59E_ornamentZigZagLineWithRightEnd);
@@ -1137,10 +1137,10 @@ void View::DrawControlElementConnector(
     /************** draw it **************/
 
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
-        dc->StartGraphic(element, "", element->GetUuid(), false);
+        dc->StartGraphic(element, "", element->GetID(), false);
     }
 
     bool deactivate = true;
@@ -1204,10 +1204,10 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
     // temporary object in order not to reset the Syl bounding box.
     F fConnector;
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else
-        dc->StartGraphic(&fConnector, "", f->GetUuid(), false);
+        dc->StartGraphic(&fConnector, "", f->GetID(), false);
 
     dc->DeactivateGraphic();
 
@@ -1278,10 +1278,10 @@ void View::DrawSylConnector(
     // temporary object in order not to reset the Syl bounding box.
     Syl sylConnector;
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else
-        dc->StartGraphic(&sylConnector, "", syl->GetUuid(), false);
+        dc->StartGraphic(&sylConnector, "", syl->GetID(), false);
 
     dc->DeactivateGraphic();
 
@@ -1388,7 +1388,7 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
 
     const arpegLog_ORDER order = arpeg->GetOrder();
     if (order == arpegLog_ORDER_nonarp) {
-        dc->StartGraphic(arpeg, "", arpeg->GetUuid());
+        dc->StartGraphic(arpeg, "", arpeg->GetID());
         const int offset = unit / 2;
         const int thickness = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
         this->DrawSquareBracket(dc, true, x - unit, bottom - offset, length + 2 * offset, unit, thickness, thickness);
@@ -1410,7 +1410,7 @@ void View::DrawArpeg(DeviceContext *dc, Arpeg *arpeg, Measure *measure, System *
 
         Point orig(x, y);
 
-        dc->StartGraphic(arpeg, "", arpeg->GetUuid());
+        dc->StartGraphic(arpeg, "", arpeg->GetID());
 
         // Smufl glyphs are horizontal - Rotate them counter clockwise
         const int angle = -90;
@@ -1459,7 +1459,7 @@ void View::DrawArpegEnclosing(DeviceContext *dc, Arpeg *arpeg, Staff *staff, wch
         const int horizontalThickness = ((arpeg->GetEnclose() == ENCLOSURE_brack) ? 2 : 1) * verticalThickness;
 
         // Draw the brackets
-        dc->StartGraphic(arpeg, "", arpeg->GetUuid());
+        dc->StartGraphic(arpeg, "", arpeg->GetID());
         this->DrawEnclosingBrackets(
             dc, x, y, height, width, offset, bracketWidth, horizontalThickness, verticalThickness);
         dc->EndGraphic(arpeg, this);
@@ -1479,7 +1479,7 @@ void View::DrawBreath(DeviceContext *dc, Breath *breath, Measure *measure, Syste
     // Cannot draw a breath that has no start position
     if (!breath->GetStart()) return;
 
-    dc->StartGraphic(breath, "", breath->GetUuid());
+    dc->StartGraphic(breath, "", breath->GetID());
 
     int x = breath->GetStart()->GetDrawingX() + breath->GetStart()->GetDrawingRadius(m_doc);
 
@@ -1521,7 +1521,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
     // Cannot draw a dir that has no start position
     if (!dir->GetStart()) return;
 
-    dc->StartGraphic(dir, "", dir->GetUuid());
+    dc->StartGraphic(dir, "", dir->GetID());
 
     FontInfo dirTxt;
     if (!dc->UseGlobalStyling()) {
@@ -1597,7 +1597,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
     // Cannot draw dynamics that have no start position
     if (!dynam->GetStart()) return;
 
-    dc->StartGraphic(dynam, "", dynam->GetUuid());
+    dc->StartGraphic(dynam, "", dynam->GetID());
 
     bool isSymbolOnly = dynam->IsSymbolOnly();
     std::wstring dynamSymbol;
@@ -1725,7 +1725,7 @@ void View::DrawFb(DeviceContext *dc, Staff *staff, Fb *fb, TextDrawingParams &pa
     assert(dc);
     assert(fb);
 
-    dc->StartGraphic(fb, "", fb->GetUuid());
+    dc->StartGraphic(fb, "", fb->GetID());
 
     FontInfo *fontDim = m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize);
     const int lineHeight = m_doc->GetTextLineHeight(fontDim, false);
@@ -1773,7 +1773,7 @@ void View::DrawFermata(DeviceContext *dc, Fermata *fermata, Measure *measure, Sy
 
     const bool drawingCueSize = false;
 
-    dc->StartGraphic(fermata, "", fermata->GetUuid());
+    dc->StartGraphic(fermata, "", fermata->GetID());
 
     const wchar_t code = fermata->GetFermataGlyph();
     wchar_t enclosingFront, enclosingBack;
@@ -1845,7 +1845,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
     // Cannot draw a fing that has no start position
     if (!fing->GetStart()) return;
 
-    dc->StartGraphic(fing, "", fing->GetUuid());
+    dc->StartGraphic(fing, "", fing->GetID());
 
     FontInfo fingTxt;
     if (!dc->UseGlobalStyling()) {
@@ -1975,10 +1975,10 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
     }
 
     if (graphic) {
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     }
     else {
-        dc->StartGraphic(gliss, "", gliss->GetUuid(), false);
+        dc->StartGraphic(gliss, "", gliss->GetID(), false);
     }
 
     switch (gliss->GetLform()) {
@@ -2021,7 +2021,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
     // Cannot draw a harmony indication that has no start position
     if (!harm->GetStart()) return;
 
-    dc->StartGraphic(harm, "", harm->GetUuid());
+    dc->StartGraphic(harm, "", harm->GetID());
 
     FontInfo harmTxt;
     if (!dc->UseGlobalStyling()) {
@@ -2085,7 +2085,7 @@ void View::DrawMordent(DeviceContext *dc, Mordent *mordent, Measure *measure, Sy
     // Cannot draw a mordent that has no start position
     if (!mordent->GetStart()) return;
 
-    dc->StartGraphic(mordent, "", mordent->GetUuid());
+    dc->StartGraphic(mordent, "", mordent->GetID());
 
     const int x = mordent->GetStart()->GetDrawingX() + mordent->GetStart()->GetDrawingRadius(m_doc);
 
@@ -2192,7 +2192,7 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
     // just as without a dir attribute
     if (!pedal->HasDir()) return;
 
-    dc->StartGraphic(pedal, "", pedal->GetUuid());
+    dc->StartGraphic(pedal, "", pedal->GetID());
 
     pedalVis_FORM form = pedal->GetPedalForm(m_doc, system);
 
@@ -2259,7 +2259,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
     // Reh should be drawn at measure start
     if (!reh->GetStart()) return;
 
-    dc->StartGraphic(reh, "", reh->GetUuid());
+    dc->StartGraphic(reh, "", reh->GetID());
 
     FontInfo rehTxt;
     if (!dc->UseGlobalStyling()) {
@@ -2332,7 +2332,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
     // Cannot draw a tempo that has no start position
     if (!tempo->GetStart()) return;
 
-    dc->StartGraphic(tempo, "", tempo->GetUuid());
+    dc->StartGraphic(tempo, "", tempo->GetID());
 
     FontInfo tempoTxt;
     if (!dc->UseGlobalStyling()) {
@@ -2394,7 +2394,7 @@ void View::DrawTrill(DeviceContext *dc, Trill *trill, Measure *measure, System *
     // Cannot draw a trill that has no start position
     if (!trill->GetStart()) return;
 
-    dc->StartGraphic(trill, "", trill->GetUuid());
+    dc->StartGraphic(trill, "", trill->GetID());
 
     int x = trill->GetStart()->GetDrawingX();
 
@@ -2468,7 +2468,7 @@ void View::DrawTurn(DeviceContext *dc, Turn *turn, Measure *measure, System *sys
     // Cannot draw a turn that has no start position
     if (!turn->GetStart()) return;
 
-    dc->StartGraphic(turn, "", turn->GetUuid());
+    dc->StartGraphic(turn, "", turn->GetID());
 
     int x = turn->GetStart()->GetDrawingX() + turn->GetStart()->GetDrawingRadius(m_doc);
 
@@ -2549,26 +2549,26 @@ void View::DrawSystemElement(DeviceContext *dc, SystemElement *element, System *
         SystemMilestoneEnd *elementEnd = vrv_cast<SystemMilestoneEnd *>(element);
         assert(elementEnd);
         assert(elementEnd->GetStart());
-        dc->StartGraphic(element, elementEnd->GetStart()->GetUuid(), element->GetUuid());
+        dc->StartGraphic(element, elementEnd->GetStart()->GetID(), element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(ENDING)) {
         // Create placeholder - A graphic for the end milestone will be created
         // but only if it is on a different system - See View::DrawEnding
         // The Ending is added to the System drawing list by View::DrawMeasure
-        dc->StartGraphic(element, "systemMilestone", element->GetUuid());
+        dc->StartGraphic(element, "systemMilestone", element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(PB)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(SB)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(SECTION)) {
-        dc->StartGraphic(element, "systemMilestone", element->GetUuid());
+        dc->StartGraphic(element, "systemMilestone", element->GetID());
         dc->EndGraphic(element, this);
     }
 }
@@ -2658,9 +2658,9 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     }
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START))
-        dc->ResumeGraphic(ending, ending->GetUuid());
+        dc->ResumeGraphic(ending, ending->GetID());
     else
-        dc->StartGraphic(ending, "", ending->GetUuid(), false);
+        dc->StartGraphic(ending, "", ending->GetID(), false);
 
     std::vector<Staff *>::iterator staffIter;
     std::vector<Staff *> staffList;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -74,7 +74,7 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     assert(measure);
 
     if (element->HasSameas()) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         element->SetEmptyBB();
         dc->EndGraphic(element, this);
         return;
@@ -204,12 +204,12 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
         this->DrawTuplet(dc, element, layer, staff, measure);
     }
     else if (element->Is(TUPLET_BRACKET)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
         layer->AddToDrawingList(element);
     }
     else if (element->Is(TUPLET_NUM)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
         layer->AddToDrawingList(element);
     }
@@ -242,13 +242,13 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     // This can happen with accid within note with only accid.ges
     // We still create an graphic in the output
     if (!accid->HasAccid() || staff->IsTablature()) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         accid->SetEmptyBB();
         dc->EndGraphic(element, this);
         return;
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     const data_NOTATIONTYPE notationType = staff->m_drawingNotationType;
     std::wstring accidStr = accid->GetSymbolStr(notationType);
@@ -376,7 +376,7 @@ void View::DrawArtic(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     }
 
     // Draw glyph including possible enclosing brackets
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     if (enclosingFront) {
         int xCorrEncl = std::max(xCorr, m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 2 / 3);
@@ -413,7 +413,7 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
         return;
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     const int yTop = staff->GetDrawingY();
     const int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
@@ -439,7 +439,7 @@ void View::DrawBeatRpt(DeviceContext *dc, LayerElement *element, Layer *layer, S
     BeatRpt *beatRpt = vrv_cast<BeatRpt *>(element);
     assert(beatRpt);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     const int staffSize = staff->m_drawingStaffSize;
     const int xSymbol = element->GetDrawingX();
@@ -484,7 +484,7 @@ void View::DrawBTrem(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         return;
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawLayerChildren(dc, bTrem, layer, staff, measure);
 
@@ -609,7 +609,7 @@ void View::DrawClef(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         return;
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawSmuflCode(dc, x, y, sym, staff->m_drawingStaffSize, false);
 
@@ -664,7 +664,7 @@ void View::DrawCustos(DeviceContext *dc, LayerElement *element, Layer *layer, St
     Custos *custos = vrv_cast<Custos *>(element);
     assert(custos);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     // Select glyph to use for this custos
     const int sym = custos->GetCustosGlyph(staff->m_drawingNotationType);
@@ -736,7 +736,7 @@ void View::DrawDot(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     Dot *dot = vrv_cast<Dot *>(element);
     assert(dot);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     if (dot->m_drawingPreviousElement && dot->m_drawingPreviousElement->IsInLigature()) {
         this->DrawDotInLigature(dc, element, layer, staff, measure);
@@ -775,7 +775,7 @@ void View::DrawDots(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     Dots *dots = vrv_cast<Dots *>(element);
     assert(dots);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     for (const auto &mapEntry : dots->GetMapOfDotLocs()) {
         const Staff *dotStaff = (mapEntry.first) ? mapEntry.first : staff;
@@ -800,17 +800,17 @@ void View::DrawDurationElement(DeviceContext *dc, LayerElement *element, Layer *
     assert(measure);
 
     if (dynamic_cast<Chord *>(element)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         this->DrawChord(dc, element, layer, staff, measure);
         dc->EndGraphic(element, this);
     }
     else if (dynamic_cast<Note *>(element)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         this->DrawNote(dc, element, layer, staff, measure);
         dc->EndGraphic(element, this);
     }
     else if (dynamic_cast<Rest *>(element)) {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
         this->DrawRest(dc, element, layer, staff, measure);
         dc->EndGraphic(element, this);
     }
@@ -833,7 +833,7 @@ void View::DrawFlag(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     int x = flag->GetDrawingX() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
     int y = flag->GetDrawingY();
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     wchar_t code = flag->GetFlagGlyph(stem->GetDrawingStemDir());
     this->DrawSmuflCode(dc, x, y, code, staff->GetDrawingStaffNotationSize(), flag->GetDrawingCueSize());
@@ -849,7 +849,7 @@ void View::DrawGraceGrp(DeviceContext *dc, LayerElement *element, Layer *layer, 
     assert(staff);
     assert(measure);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     // basically nothing to do here
     this->DrawLayerChildren(dc, element, layer, staff, measure);
@@ -871,7 +871,7 @@ void View::DrawHalfmRpt(DeviceContext *dc, LayerElement *element, Layer *layer, 
     int x = halfmRpt->GetDrawingX();
     x += m_doc->GetGlyphWidth(SMUFL_E500_repeat1Bar, staff->m_drawingStaffSize, false) / 2;
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawMRptPart(dc, x, SMUFL_E500_repeat1Bar, 0, false, staff);
 
@@ -925,7 +925,7 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     int clefLocOffset = layer->GetClefLocOffset(element);
     int loc;
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     // Show cancellation if showchange is true (false by default) or if C major
     if ((keySig->GetScoreDefRole() != SCOREDEF_SYSTEM)
@@ -992,7 +992,7 @@ void View::DrawKeyAccid(DeviceContext *dc, KeyAccid *keyAccid, Staff *staff, Cle
     const int loc = keyAccid->CalcStaffLoc(clef, clefLocOffset);
     const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 
-    dc->StartCustomGraphic("keyAccid", "", keyAccid->GetUuid());
+    dc->StartCustomGraphic("keyAccid", "", keyAccid->GetID());
 
     this->DrawSmuflString(dc, x, y, symbolStr, HORIZONTALALIGNMENT_left, staff->m_drawingStaffSize, false);
 
@@ -1011,7 +1011,7 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
     wchar_t enclosingFront, enclosingBack;
     std::tie(enclosingFront, enclosingBack) = meterSig->GetEnclosingGlyphs(hasSmallEnclosing);
 
-    dc->StartGraphic(meterSig, "", meterSig->GetUuid());
+    dc->StartGraphic(meterSig, "", meterSig->GetID());
 
     int y = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
     int x = meterSig->GetDrawingX() + horizOffset;
@@ -1053,7 +1053,7 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     MRest *mRest = vrv_cast<MRest *>(element);
     assert(mRest);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     mRest->CenterDrawingX();
 
@@ -1105,7 +1105,7 @@ void View::DrawMRpt(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     mRpt->CenterDrawingX();
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawMRptPart(dc, element->GetDrawingX(), SMUFL_E500_repeat1Bar, 0, false, staff);
 
@@ -1145,7 +1145,7 @@ void View::DrawMRpt2(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     mRpt2->CenterDrawingX();
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawMRptPart(dc, element->GetDrawingX(), SMUFL_E501_repeat2Bars, 2, true, staff);
 
@@ -1163,7 +1163,7 @@ void View::DrawMSpace(DeviceContext *dc, LayerElement *element, Layer *layer, St
     // MSpace *mSpace = vrv_cast<MSpace *>(element);
     // assert(mSpace);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     // nothing to draw here
     dc->EndGraphic(element, this);
 }
@@ -1181,7 +1181,7 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
 
     multiRest->CenterDrawingX();
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     int measureWidth = measure->GetInnerWidth();
     int xCentered = multiRest->GetDrawingX();
@@ -1300,7 +1300,7 @@ void View::DrawMultiRpt(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     multiRpt->CenterDrawingX();
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawMRptPart(dc, element->GetDrawingX(), SMUFL_E501_repeat2Bars, multiRpt->GetNum(), true, staff);
 
@@ -1346,7 +1346,7 @@ void View::DrawNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         int drawingDur = note->GetDrawingDur();
         if (drawingDur == DUR_NONE) {
             if (note->IsInBeam() && !dc->Is(BBOX_DEVICE_CONTEXT)) {
-                LogWarning("Missing duration for note '%s' in beam", note->GetUuid().c_str());
+                LogWarning("Missing duration for note '%s' in beam", note->GetID().c_str());
             }
             drawingDur = DUR_4;
         }
@@ -1425,7 +1425,7 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     int drawingDur = rest->GetActualDur();
     if (drawingDur == DUR_NONE) {
         if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
-            LogWarning("Missing duration for rest '%s'", rest->GetUuid().c_str());
+            LogWarning("Missing duration for rest '%s'", rest->GetID().c_str());
         }
         drawingDur = DUR_4;
     }
@@ -1487,7 +1487,7 @@ void View::DrawSpace(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     assert(staff);
     assert(measure);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     dc->DrawPlaceholder(ToDeviceContextX(element->GetDrawingX()), ToDeviceContextY(element->GetDrawingY()));
     dc->EndGraphic(element, this);
 }
@@ -1506,7 +1506,7 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     // Do not draw virtual (e.g., whole note) stems
     if (stem->IsVirtual()) return;
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawFilledRectangle(dc, stem->GetDrawingX() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
         stem->GetDrawingY(), stem->GetDrawingX() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2,
@@ -1615,7 +1615,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
 
     syl->SetDrawingYRel(this->GetSylYRel(syl->m_drawingVerse, staff));
 
-    dc->StartGraphic(syl, "", syl->GetUuid());
+    dc->StartGraphic(syl, "", syl->GetID());
     dc->DeactivateGraphicY();
 
     dc->SetBrush(m_currentColour, AxSOLID);
@@ -1722,7 +1722,7 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         dc->SetBrush(m_currentColour, AxSOLID);
         dc->SetFont(&labelTxt);
 
-        dc->StartGraphic(graphic, "", graphic->GetUuid());
+        dc->StartGraphic(graphic, "", graphic->GetID());
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), HORIZONTALALIGNMENT_right);
         this->DrawTextChildren(dc, graphic, params);
@@ -1734,7 +1734,7 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         dc->ResetBrush();
     }
 
-    dc->StartGraphic(verse, "", verse->GetUuid());
+    dc->StartGraphic(verse, "", verse->GetID());
 
     this->DrawLayerChildren(dc, verse, layer, staff, measure);
 

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -160,7 +160,7 @@ void View::DrawMensur(DeviceContext *dc, LayerElement *element, Layer *layer, St
         }
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawSmuflCode(dc, x, y, code, staff->m_drawingStaffSize, false);
 
@@ -323,7 +323,7 @@ void View::DrawLigature(DeviceContext *dc, LayerElement *element, Layer *layer, 
     Ligature *ligature = vrv_cast<Ligature *>(element);
     assert(ligature);
 
-    dc->StartGraphic(ligature, "", ligature->GetUuid());
+    dc->StartGraphic(ligature, "", ligature->GetID());
 
     // Draw children (notes)
     this->DrawLayerChildren(dc, ligature, layer, staff, measure);
@@ -531,7 +531,7 @@ void View::DrawPlica(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int shortStem = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     shortStem *= (!isMensuralBlack) ? 3.5 : 2.5;
 
-    dc->StartGraphic(plica, "", plica->GetUuid());
+    dc->StartGraphic(plica, "", plica->GetID());
 
     if (isLonga) {
         if (up) {
@@ -603,7 +603,7 @@ void View::DrawProport(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     Proport *proport = dynamic_cast<Proport *>(element);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     int y = staff->GetDrawingY() - (m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 4);
     int x = element->GetDrawingX();

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -44,7 +44,7 @@ void View::DrawSyllable(DeviceContext *dc, LayerElement *element, Layer *layer, 
     /******************************************************************/
     // Start the Beam graphic and draw the children
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     /******************************************************************/
     // Draw the children
@@ -71,7 +71,7 @@ void View::DrawNc(DeviceContext *dc, LayerElement *element, Layer *layer, Staff 
     };
     std::vector<drawingParams> params;
     params.push_back(drawingParams());
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     /******************************************************************/
 
@@ -215,7 +215,7 @@ void View::DrawNeume(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     /******************************************************************/
     // Start the Neume graphic and draw the children
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     this->DrawLayerChildren(dc, neume, layer, staff, measure);
     dc->EndGraphic(element, this);
 }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -169,17 +169,17 @@ void View::DrawPageElement(DeviceContext *dc, PageElement *element)
         PageMilestoneEnd *elementEnd = vrv_cast<PageMilestoneEnd *>(element);
         assert(elementEnd);
         assert(elementEnd->GetStart());
-        dc->StartGraphic(element, elementEnd->GetStart()->GetUuid(), element->GetUuid());
+        dc->StartGraphic(element, elementEnd->GetStart()->GetID(), element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(MDIV)) {
         // When the mdiv is not visible, then there is no start / end element
         std::string elementStart = (element->IsMilestoneElement()) ? "pageMilestone" : "";
-        dc->StartGraphic(element, elementStart, element->GetUuid());
+        dc->StartGraphic(element, elementStart, element->GetID());
         dc->EndGraphic(element, this);
     }
     else if (element->Is(SCORE)) {
-        dc->StartGraphic(element, "pageMilestone", element->GetUuid());
+        dc->StartGraphic(element, "pageMilestone", element->GetID());
         dc->EndGraphic(element, this);
     }
 }
@@ -193,7 +193,7 @@ void View::DrawSystem(DeviceContext *dc, System *system)
     assert(dc);
     assert(system);
 
-    dc->StartGraphic(system, "", system->GetUuid());
+    dc->StartGraphic(system, "", system->GetID());
 
     Measure *firstMeasure = dynamic_cast<Measure *>(system->FindDescendantByType(MEASURE, 1));
 
@@ -311,7 +311,7 @@ void View::DrawScoreDef(
         this->DrawStaffGrp(dc, measure, staffGrp, x, true, !scoreDef->DrawLabels());
     }
     else {
-        dc->StartGraphic(barLine, "", barLine->GetUuid());
+        dc->StartGraphic(barLine, "", barLine->GetID());
         this->DrawBarLines(dc, measure, staffGrp, barLine, isLastMeasure);
         dc->EndGraphic(barLine, this);
     }
@@ -451,7 +451,7 @@ void View::DrawGrpSym(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, i
         return;
     }
 
-    dc->StartGraphic(groupSymbol, "", groupSymbol->GetUuid());
+    dc->StartGraphic(groupSymbol, "", groupSymbol->GetID());
 
     const int staffSize = staffGrp->GetMaxStaffSize();
     int yTop = first->GetDrawingY();
@@ -565,7 +565,7 @@ void View::DrawLabels(
     dc->SetBrush(m_currentColour, AxSOLID);
     dc->SetFont(&labelTxt);
 
-    dc->StartGraphic(graphic, "", graphic->GetUuid());
+    dc->StartGraphic(graphic, "", graphic->GetID());
 
     dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), HORIZONTALALIGNMENT_right);
     this->DrawTextChildren(dc, graphic, params);
@@ -1041,7 +1041,7 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
 
     // This is a special case where we do not draw (SVG, Bounding boxes, etc.) the measure for unmeasured music
     if (measure->IsMeasuredMusic()) {
-        dc->StartGraphic(measure, "", measure->GetUuid());
+        dc->StartGraphic(measure, "", measure->GetID());
     }
 
     if (m_drawingScoreDef.GetMnumVisible() != BOOLEAN_false) {
@@ -1115,7 +1115,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
 
     const int unit = m_doc->GetDrawingUnit(glyphSize);
     int offset = 0;
-    dc->StartGraphic(meterSigGrp, "", meterSigGrp->GetUuid());
+    dc->StartGraphic(meterSigGrp, "", meterSigGrp->GetID());
     // Draw meterSigGrp by alternating meterSig and plus sign (when required)
     for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         MeterSig *meterSig = vrv_cast<MeterSig *>(*iter);
@@ -1151,7 +1151,7 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
     Staff *staff = measure->GetTopVisibleStaff();
     if (staff) {
 
-        dc->StartGraphic(mnum, "", mnum->GetUuid());
+        dc->StartGraphic(mnum, "", mnum->GetID());
 
         FontInfo mnumTxt;
         if (!dc->UseGlobalStyling()) {
@@ -1216,7 +1216,7 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
         return;
     }
 
-    dc->StartGraphic(staff, "", staff->GetUuid());
+    dc->StartGraphic(staff, "", staff->GetID());
 
     if (m_doc->GetType() == Facs) {
         staff->SetFromFacsimile(m_doc);
@@ -1373,7 +1373,7 @@ void View::DrawStaffDef(DeviceContext *dc, Staff *staff, Measure *measure)
     if (!layer || !layer->HasStaffDef()) return;
 
     // StaffDef staffDef;
-    // dc->StartGraphic(&staffDef, "", staffDef.GetUuid());
+    // dc->StartGraphic(&staffDef, "", staffDef.GetID());
 
     // draw the scoreDef if required
     if (layer->GetStaffDefClef()) {
@@ -1406,7 +1406,7 @@ void View::DrawStaffDefCautionary(DeviceContext *dc, Staff *staff, Measure *meas
     if (!layer || !layer->HasCautionStaffDef()) return;
 
     // StaffDef staffDef;
-    // dc->StartGraphic(&staffDef, "cautionary", staffDef.GetUuid());
+    // dc->StartGraphic(&staffDef, "cautionary", staffDef.GetID());
 
     // draw the scoreDef if required
     if (layer->GetCautionStaffDefClef()) {
@@ -1489,7 +1489,7 @@ void View::DrawLayer(DeviceContext *dc, Layer *layer, Staff *staff, Measure *mea
 
     // Now start to draw the layer content
 
-    dc->StartGraphic(layer, "", layer->GetUuid());
+    dc->StartGraphic(layer, "", layer->GetID());
 
     this->DrawLayerChildren(dc, layer, layer, staff, measure);
 
@@ -1793,7 +1793,7 @@ void View::DrawSystemEditorialElement(DeviceContext *dc, EditorialElement *eleme
     std::string elementStart;
     if (element->IsMilestoneElement()) elementStart = "systemElementStart";
 
-    dc->StartGraphic(element, elementStart, element->GetUuid());
+    dc->StartGraphic(element, elementStart, element->GetID());
     // EditorialElements at the system level that are visible have no children
     // if (element->m_visibility == Visible) {
     //    DrawSystemChildren(dc, element, system);
@@ -1815,7 +1815,7 @@ void View::DrawMeasureEditorialElement(DeviceContext *dc, EditorialElement *elem
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_MEASURE));
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawMeasureChildren(dc, element, measure, system);
     }
@@ -1836,7 +1836,7 @@ void View::DrawStaffEditorialElement(DeviceContext *dc, EditorialElement *elemen
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_STAFF));
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawStaffChildren(dc, element, staff, measure);
     }
@@ -1858,7 +1858,7 @@ void View::DrawLayerEditorialElement(
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_LAYER));
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawLayerChildren(dc, element, layer, staff, measure);
     }
@@ -1879,7 +1879,7 @@ void View::DrawTextEditorialElement(DeviceContext *dc, EditorialElement *element
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_TEXT));
     }
 
-    dc->StartTextGraphic(element, "", element->GetUuid());
+    dc->StartTextGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawTextChildren(dc, element, params);
     }
@@ -1900,7 +1900,7 @@ void View::DrawFbEditorialElement(DeviceContext *dc, EditorialElement *element, 
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_FB));
     }
 
-    dc->StartTextGraphic(element, "", element->GetUuid());
+    dc->StartTextGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawFbChildren(dc, element, params);
     }
@@ -1921,7 +1921,7 @@ void View::DrawRunningEditorialElement(DeviceContext *dc, EditorialElement *elem
         assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_RUNNING));
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
     if (element->m_visibility == Visible) {
         this->DrawRunningChildren(dc, element, params);
     }
@@ -1933,10 +1933,10 @@ void View::DrawAnnot(DeviceContext *dc, EditorialElement *element, bool isTextEl
     assert(element);
 
     if (isTextElement) {
-        dc->StartTextGraphic(element, "", element->GetUuid());
+        dc->StartTextGraphic(element, "", element->GetID());
     }
     else {
-        dc->StartGraphic(element, "", element->GetUuid());
+        dc->StartGraphic(element, "", element->GetID());
     }
 
     Annot *annot = vrv_cast<Annot *>(element);

--- a/src/view_running.cpp
+++ b/src/view_running.cpp
@@ -52,7 +52,7 @@ void View::DrawPgHeader(DeviceContext *dc, RunningElement *pgHeader)
     assert(dc);
     assert(pgHeader);
 
-    dc->StartGraphic(pgHeader, "", pgHeader->GetUuid());
+    dc->StartGraphic(pgHeader, "", pgHeader->GetID());
 
     FontInfo pgHeadTxt;
 

--- a/src/view_slur.cpp
+++ b/src/view_slur.cpp
@@ -49,9 +49,9 @@ void View::DrawSlur(DeviceContext *dc, Slur *slur, int x1, int x2, Staff *staff,
     curve->GetPoints(points);
 
     if (graphic)
-        dc->ResumeGraphic(graphic, graphic->GetUuid());
+        dc->ResumeGraphic(graphic, graphic->GetID());
     else
-        dc->StartGraphic(slur, "", slur->GetUuid(), false);
+        dc->StartGraphic(slur, "", slur->GetID(), false);
 
     int penStyle = AxSOLID;
     switch (slur->GetLform()) {

--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -57,7 +57,7 @@ void View::DrawTabClef(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     y -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     this->DrawSmuflCode(dc, x, y, sym, glyphSize, false);
 
@@ -77,7 +77,7 @@ void View::DrawTabGrp(DeviceContext *dc, LayerElement *element, Layer *layer, St
     TabGrp *tabGrp = dynamic_cast<TabGrp *>(element);
     assert(tabGrp);
 
-    dc->StartGraphic(tabGrp, "", tabGrp->GetUuid());
+    dc->StartGraphic(tabGrp, "", tabGrp->GetID());
 
     // Draw children (rhyhtm, notes)
     this->DrawLayerChildren(dc, tabGrp, layer, staff, measure);
@@ -98,7 +98,7 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
     // TabGrp *tabGrp = note->IsTabGrpNote();
     // assert(tabGrp);
 
-    dc->StartGraphic(note, "", note->GetUuid());
+    dc->StartGraphic(note, "", note->GetID());
 
     int x = element->GetDrawingX();
     int y = element->GetDrawingY();
@@ -167,7 +167,7 @@ void View::DrawTabDurSym(DeviceContext *dc, LayerElement *element, Layer *layer,
     TabGrp *tabGrp = dynamic_cast<TabGrp *>(tabDurSym->GetFirstAncestor(TABGRP));
     assert(tabGrp);
 
-    dc->StartGraphic(tabDurSym, "", tabDurSym->GetUuid());
+    dc->StartGraphic(tabDurSym, "", tabDurSym->GetID());
 
     int x = element->GetDrawingX();
     int y = element->GetDrawingY();

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -43,7 +43,7 @@ void View::DrawF(DeviceContext *dc, F *f, TextDrawingParams &params)
     assert(dc);
     assert(f);
 
-    dc->StartTextGraphic(f, "", f->GetUuid());
+    dc->StartTextGraphic(f, "", f->GetID());
 
     this->DrawTextChildren(dc, f, params);
 
@@ -261,7 +261,7 @@ void View::DrawLb(DeviceContext *dc, Lb *lb, TextDrawingParams &params)
     assert(dc);
     assert(lb);
 
-    dc->StartTextGraphic(lb, "", lb->GetUuid());
+    dc->StartTextGraphic(lb, "", lb->GetID());
 
     FontInfo *currentFont = dc->GetFont();
 
@@ -276,7 +276,7 @@ void View::DrawNum(DeviceContext *dc, Num *num, TextDrawingParams &params)
     assert(dc);
     assert(num);
 
-    dc->StartTextGraphic(num, "", num->GetUuid());
+    dc->StartTextGraphic(num, "", num->GetID());
 
     Text *currentText = num->GetCurrentText();
     if (currentText && (currentText->GetText().length() > 0)) {
@@ -294,7 +294,7 @@ void View::DrawFig(DeviceContext *dc, Fig *fig, TextDrawingParams &params)
     assert(dc);
     assert(fig);
 
-    dc->StartGraphic(fig, "", fig->GetUuid());
+    dc->StartGraphic(fig, "", fig->GetID());
 
     Svg *svg = dynamic_cast<Svg *>(fig->FindDescendantByType(SVG));
     if (svg) {
@@ -311,7 +311,7 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
     assert(dc);
     assert(rend);
 
-    dc->StartTextGraphic(rend, "", rend->GetUuid());
+    dc->StartTextGraphic(rend, "", rend->GetID());
 
     if (params.m_laidOut) {
         if (params.m_alignment == HORIZONTALALIGNMENT_NONE) {
@@ -397,7 +397,7 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
     const Resources *resources = dc->GetResources();
     assert(resources);
 
-    dc->StartTextGraphic(text, "", text->GetUuid());
+    dc->StartTextGraphic(text, "", text->GetID());
 
     resources->SelectTextFont(dc->GetFont()->GetWeight(), dc->GetFont()->GetStyle());
 
@@ -441,7 +441,7 @@ void View::DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params)
     assert(dc);
     assert(svg);
 
-    dc->StartGraphic(svg, "", svg->GetUuid());
+    dc->StartGraphic(svg, "", svg->GetID());
 
     dc->DrawSvgShape(
         ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), svg->GetWidth(), svg->GetHeight(), svg->Get());

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -65,7 +65,7 @@ void View::DrawTuplet(DeviceContext *dc, LayerElement *element, Layer *layer, St
         tuplet->CalcDrawingBracketAndNumPos(m_doc->GetOptions()->m_tupletNumHead.GetValue());
     }
 
-    dc->StartGraphic(element, "", element->GetUuid());
+    dc->StartGraphic(element, "", element->GetID());
 
     // Draw the inner elements
     this->DrawLayerChildren(dc, tuplet, layer, staff, measure);
@@ -101,7 +101,7 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     const int lineWidth
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
 
-    dc->ResumeGraphic(tupletBracket, tupletBracket->GetUuid());
+    dc->ResumeGraphic(tupletBracket, tupletBracket->GetID());
 
     const int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
     const int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
@@ -188,7 +188,7 @@ void View::DrawTupletNum(DeviceContext *dc, LayerElement *element, Layer *layer,
     // adjust the baseline (to be improved with slanted brackets
     y -= m_doc->GetGlyphHeight(notes.back(), glyphSize, drawingCueSize) / 2;
 
-    dc->ResumeGraphic(tupletNum, tupletNum->GetUuid());
+    dc->ResumeGraphic(tupletNum, tupletNum->GetID());
 
     this->DrawSmuflString(dc, x, y, notes, HORIZONTALALIGNMENT_left, glyphSize, drawingCueSize);
 

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -220,13 +220,13 @@ bool AreEqual(double dFirstVal, double dSecondVal)
     return std::fabs(dFirstVal - dSecondVal) < 1E-3;
 }
 
-std::string ExtractUuidFragment(std::string refUuid)
+std::string ExtractIDFragment(std::string refID)
 {
-    size_t pos = refUuid.find_last_of("#");
-    if ((pos != std::string::npos) && (pos < refUuid.length() - 1)) {
-        refUuid = refUuid.substr(pos + 1);
+    size_t pos = refID.find_last_of("#");
+    if ((pos != std::string::npos) && (pos < refID.length() - 1)) {
+        refID = refID.substr(pos + 1);
     }
-    return refUuid;
+    return refID;
 }
 
 std::string UTF16to8(const std::wstring &in)

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -383,7 +383,7 @@ int main(int argc, char **argv)
             case 'x':
                 seed = atoi(optarg);
                 options->m_xmlIdSeed.SetValue(seed);
-                vrv::Object::SeedUuid(seed);
+                vrv::Object::SeedID(seed);
                 break;
 
             case 'z':


### PR DESCRIPTION
In this PR we rename all occurences of `uuid/Uuid/UUID` in the codebase into `id/ID`. I guess the change was motivated by the discussion in #2904 . For compatibility we keep a version of `GetUuid` in the toolkit, but this now displays a warning that the function is deprecated.