### PR TITLE
Improve position of the notes with notehead shapes

### DIFF
--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -205,6 +205,11 @@ public:
     int CalcStem(FunctorParams *functorParams) override;
 
     /**
+     * See Object::CalcChordNoteHeads
+     */
+    int CalcChordNoteHeads(FunctorParams *functorParams) override;
+
+    /**
      * See Object::CalcDots
      */
     int CalcDots(FunctorParams *functorParams) override;

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -193,10 +193,6 @@ public:
     int m_beamWidthWhite;
     int m_fractionSize;
 
-    // position x for the stem (normal and cue-sized)
-    int m_stemXAbove[2];
-    int m_stemXBelow[2];
-
     /**
      * An array of coordinates for each element
      **/

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1130,6 +1130,27 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// CalcChordNoteHeadsParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: the doc
+ * member 1: diameter of the anchoring note of the chord
+ **/
+
+class CalcChordNoteHeadsParams : public FunctorParams {
+public:
+    CalcChordNoteHeadsParams(Doc *doc)
+    {
+        m_doc = doc;
+        m_diameter = 0;
+    }
+
+    Doc *m_doc;
+    int m_diameter;
+};
+
+//----------------------------------------------------------------------------
 // CastOffEncodingParams
 //----------------------------------------------------------------------------
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -588,20 +588,6 @@ void BeamSegment::CalcBeamInit(
             beamInterface->m_beamWidthBlack = beamInterface->m_beamWidthBlack * 2 / 5;
             beamInterface->m_beamWidthWhite = beamInterface->m_beamWidthWhite * 3 / 5;
         }
-
-        beamInterface->m_stemXAbove[0] = 0;
-        beamInterface->m_stemXAbove[1] = 0;
-        beamInterface->m_stemXBelow[0] = 0;
-        beamInterface->m_stemXBelow[1] = 0;
-    }
-    else {
-        // x-offset values for stem bases, dx[y] where y = element->m_cueSize
-        beamInterface->m_stemXAbove[0] = doc->GetGlyphWidth(SMUFL_E0A4_noteheadBlack, staff->m_drawingStaffSize, false)
-            - (doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
-        beamInterface->m_stemXAbove[1] = doc->GetGlyphWidth(SMUFL_E0A4_noteheadBlack, staff->m_drawingStaffSize, true)
-            - (doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
-        beamInterface->m_stemXBelow[0] = (doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
-        beamInterface->m_stemXBelow[1] = (doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
     }
 
     beamInterface->m_beamWidth = beamInterface->m_beamWidthBlack + beamInterface->m_beamWidthWhite;
@@ -1821,8 +1807,9 @@ void BeamElementCoord::SetDrawingStemDir(data_STEMDIRECTION stemDir, const Staff
 
     m_stem->SetDrawingStemDir(stemDir);
     m_yBeam = m_element->GetDrawingY();
-    m_x += (STEMDIRECTION_up == stemDir) ? interface->m_stemXAbove[interface->m_cueSize]
-                                         : interface->m_stemXBelow[interface->m_cueSize];
+    m_x += (STEMDIRECTION_up == stemDir)
+        ? 2 * m_element->GetDrawingRadius(doc) - doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2
+        : doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
 
     if (m_tabDurSym && !m_closestNote) {
         m_yBeam = m_tabDurSym->GetDrawingY();

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -755,6 +755,28 @@ int Chord::CalcStem(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Chord::CalcChordNoteHeads(FunctorParams *functorParams)
+{
+    CalcChordNoteHeadsParams *params = vrv_params_cast<CalcChordNoteHeadsParams *>(functorParams);
+    assert(params);
+
+    Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+
+    if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
+        if (this->IsInBeam()) {
+            params->m_diameter = 2 * this->GetDrawingRadius(params->m_doc);
+        }
+        else {
+            const Note *bottomNote = this->GetBottomNote();
+            const wchar_t code = bottomNote->GetNoteheadGlyph(this->GetActualDur());
+            params->m_diameter = params->m_doc->GetGlyphWidth(
+                code, staff->m_drawingStaffSize, this->GetDrawingCueSize() ? bottomNote->GetDrawingCueSize() : false);
+        }
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
 MapOfNoteLocs Chord::CalcNoteLocations(NotePredicate predicate) const
 {
     const ListOfConstObjects &notes = this->GetList(this);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -762,6 +762,7 @@ int Chord::CalcChordNoteHeads(FunctorParams *functorParams)
 
     Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
 
+    params->m_diameter = 0;
     if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
         if (this->IsInBeam()) {
             params->m_diameter = 2 * this->GetDrawingRadius(params->m_doc);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1101,7 +1101,9 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
 
     const int diameter = 2 * this->GetDrawingRadius(params->m_doc);
     int noteheadShift = 0;
-    if (this->GetDrawingStemDir() == STEMDIRECTION_up) noteheadShift = params->m_diameter - diameter;
+    if ((this->GetDrawingStemDir() == STEMDIRECTION_up) && (params->m_diameter)) {
+        noteheadShift = params->m_diameter - diameter;
+    }
 
     /************** notehead direction **************/
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -351,7 +351,7 @@ Point Note::GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const
     int defaultYShift = doc->GetDrawingUnit(staffSize) / 4;
     if (isCueSize) defaultYShift = doc->GetCueSize(defaultYShift);
     // x default is always set to the right for now
-    int defaultXShift = doc->GetGlyphWidth(SMUFL_E0A3_noteheadHalf, staffSize, isCueSize);
+    int defaultXShift = doc->GetGlyphWidth(this->GetNoteheadGlyph(this->GetActualDur()), staffSize, isCueSize);
     Point p(defaultXShift, defaultYShift);
 
     // Here we should get the notehead value
@@ -1093,37 +1093,15 @@ int Note::CalcStem(FunctorParams *functorParams)
 
 int Note::CalcChordNoteHeads(FunctorParams *functorParams)
 {
-    FunctorDocParams *params = vrv_params_cast<FunctorDocParams *>(functorParams);
+    CalcChordNoteHeadsParams *params = vrv_params_cast<CalcChordNoteHeadsParams *>(functorParams);
     assert(params);
 
     Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     const int staffSize = staff->m_drawingStaffSize;
 
-    bool mixedCue = false;
-    if (Chord *chord = this->IsChordTone(); chord != NULL) {
-        mixedCue = (chord->GetDrawingCueSize() != this->GetDrawingCueSize());
-    }
-
-    // Nothing to do for notes that are not in a cluster and without cue mixing
-    if (!m_cluster && !mixedCue) return FUNCTOR_SIBLINGS;
-
-    int diameter = 2 * this->GetDrawingRadius(params->m_doc);
-
-    // If chord consists partially of cue notes we may have to shift the noteheads
-    int cueShift = 0;
-    if (mixedCue && (this->GetDrawingStemDir() == STEMDIRECTION_up)) {
-        const double cueScaling = params->m_doc->GetCueScaling();
-        assert(cueScaling > 0.0);
-
-        if (this->GetDrawingCueSize()) {
-            // Note is cue and chord is not
-            cueShift = (1.0 / cueScaling - 1.0) * diameter; // shift to the right
-        }
-        else {
-            // Chord is cue and note is not
-            cueShift = (cueScaling - 1.0) * diameter; // shift to the left
-        }
-    }
+    const int diameter = 2 * this->GetDrawingRadius(params->m_doc);
+    int noteheadShift = 0;
+    if (this->GetDrawingStemDir() == STEMDIRECTION_up) noteheadShift = params->m_diameter - diameter;
 
     /************** notehead direction **************/
 
@@ -1156,7 +1134,7 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
             this->SetDrawingXRel(-diameter + params->m_doc->GetDrawingStemWidth(staffSize));
         }
     }
-    this->SetDrawingXRel(this->GetDrawingXRel() + cueShift);
+    this->SetDrawingXRel(this->GetDrawingXRel() + noteheadShift);
 
     this->SetFlippedNotehead(flippedNotehead);
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -225,7 +225,7 @@ void Page::LayOutTranscription(bool force)
     Functor calcStem(&Object::CalcStem);
     this->Process(&calcStem, &calcStemParams);
 
-    FunctorDocParams calcChordNoteHeadsParams(doc);
+    CalcChordNoteHeadsParams calcChordNoteHeadsParams(doc);
     Functor calcChordNoteHeads(&Object::CalcChordNoteHeads);
     this->Process(&calcChordNoteHeads, &calcChordNoteHeadsParams);
 
@@ -324,7 +324,7 @@ void Page::ResetAligners()
     Functor calcStem(&Object::CalcStem);
     this->Process(&calcStem, &calcStemParams);
 
-    FunctorDocParams calcChordNoteHeadsParams(doc);
+    CalcChordNoteHeadsParams calcChordNoteHeadsParams(doc);
     Functor calcChordNoteHeads(&Object::CalcChordNoteHeads);
     this->Process(&calcChordNoteHeads, &calcChordNoteHeadsParams);
 


### PR DESCRIPTION
- improve position of the notes with @head.shape in beams and chords
- change code to be more generic and work for both normal and cue notes

closes #2910 

![image](https://user-images.githubusercontent.com/1819669/174578112-a3082bb0-f964-4800-8039-274c25f40cfd.png)
