### PR TITLE
Placement within staff for Dir and Hairpin

### DIFF
--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -379,7 +379,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 assert(turn);
                 yRel += turn->GetTurnHeight(doc, staffSize) / 2;
             }
-            else {
+            else if (!m_object->Is(HAIRPIN)) {
                 yRel += (this->GetContentY2() - this->GetContentY1()) / 2;
             }
             this->SetDrawingYRel(yRel);

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -379,7 +379,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 assert(turn);
                 yRel += turn->GetTurnHeight(doc, staffSize) / 2;
             }
-            else if (!m_object->Is(HAIRPIN)) {
+            else if (!m_object->Is({ DIR, HAIRPIN })) {
                 yRel += (this->GetContentY2() - this->GetContentY1()) / 2;
             }
             this->SetDrawingYRel(yRel);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -813,6 +813,10 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         if (place == STAFFREL_above) {
             overflowBoxes = &m_overflowAboveBBoxes;
         }
+        // Handle within placement (ignore collisions for certain classes)
+        if (place == STAFFREL_within) {
+            if (params->m_classId == HAIRPIN) continue;
+        }
         auto i = overflowBoxes->begin();
         auto end = overflowBoxes->end();
         while (i != end) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -815,8 +815,10 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         }
         // Handle within placement (ignore collisions for certain classes)
         if (place == STAFFREL_within) {
+            if (params->m_classId == DIR) continue;
             if (params->m_classId == HAIRPIN) continue;
         }
+
         auto i = overflowBoxes->begin();
         auto end = overflowBoxes->end();
         while (i != end) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1558,7 +1558,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
         dirTxt.SetPointSize(params.m_pointSize);
 
-        if (dir->GetPlace() == STAFFREL_between) {
+        if ((dir->GetPlace() == STAFFREL_between) || (dir->GetPlace() == STAFFREL_within)) {
             if (lineCount > 1) {
                 params.m_y += (m_doc->GetTextLineHeight(&dirTxt, false) * (lineCount - 1) / 2);
             }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -625,16 +625,10 @@ void View::DrawHairpin(
     // Now swap start/end for dim.
     if (form == hairpinLog_FORM_dim) BoundingBox::Swap(startY, endY);
 
-    int y1 = hairpin->GetDrawingY();
-    if (hairpin->GetPlace() != STAFFREL_between) {
-        y1 += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    }
-    int y2 = y1;
+    const int y1 = hairpin->GetDrawingY();
+    const int y2 = y1;
 
     /************** draw it **************/
-
-    y1 -= m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
-    y2 -= m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) / 2;
 
     if (graphic)
         dc->ResumeGraphic(graphic, graphic->GetID());

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -625,8 +625,18 @@ void View::DrawHairpin(
     // Now swap start/end for dim.
     if (form == hairpinLog_FORM_dim) BoundingBox::Swap(startY, endY);
 
-    const int y1 = hairpin->GetDrawingY();
-    const int y2 = y1;
+    int y1 = hairpin->GetDrawingY();
+    int y2 = y1;
+
+    // Improve alignment with dynamics
+    if (hairpin->GetPlace() != STAFFREL_within) {
+        int shiftY = -(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
+        if (hairpin->GetPlace() != STAFFREL_between) {
+            shiftY += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        }
+        y1 += shiftY;
+        y2 += shiftY;
+    }
 
     /************** draw it **************/
 


### PR DESCRIPTION
This PR adds support for placing Dir and Hairpin within the staff. Collisions are ignored in this case.
![HairpinWithin](https://user-images.githubusercontent.com/63608463/175043271-8d1ac74c-27e5-40d4-af4b-d9662ac2aa73.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Hairpin example with different widths</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-15</date>
         </pubStmt>
         <notesStmt>
            <annot>Short hairpin ends are not as wide as the ends of long hairpins.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="c" accid.ges="n" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="cres" place="within"/>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="d" accid.ges="n" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="8" oct="4" pname="e" accid.ges="n" />
                              <note dur="8" oct="4" pname="f" accid.ges="n" />
                           </beam>
                           <space dots="1" dur="2" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="0m+1.5000" form="dim" place="within" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

![DirWithin](https://user-images.githubusercontent.com/63608463/175043282-75549287-aa34-4af4-a310-675be93f8fe2.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Tests in space</title>
         </titleStmt>
         <pubStmt>
            <date>2017-04-27</date>
         </pubStmt>
         <notesStmt>
            <annot>Verovio appropriately places multiple directives, spacing them as desired.</annot>
            <annot type="warning">This isn't working as supposed in Safari due to <ref target="https://bugs.webkit.org/show_bug.cgi?id=112032">this bug</ref>.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="c">
                              <accid accid.ges="n" />
                           </note>
                        </layer>
                     </staff>
                     <dir place="within" staff="1" tstamp="1.000000">Allegro <rend>molto</rend>
                     </dir>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="d">
                              <accid accid.ges="n" />
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="e">
                              <accid accid.ges="n" />
                           </note>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

