### PR TITLE
Const correctness for control elements

### DIFF
--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -77,7 +77,13 @@ public:
     void ClearBeamSegments();
     ////@}
 
-    BeamSpanSegment *GetSegmentForSystem(System *system);
+    /**
+     * Access the beam segments
+     */
+    ///@{
+    BeamSpanSegment *GetSegmentForSystem(const System *system);
+    const BeamSpanSegment *GetSegmentForSystem(const System *system) const;
+    ///@}
 
     //----------//
     // Functors //
@@ -105,18 +111,22 @@ public:
 
 private:
     // Helper for breaking one big spanning beamSpan into smaller beamSpans
-    bool AddSpanningSegment(Doc *doc, const SpanIndexVector &elements, int index, bool newSegment = true);
+    bool AddSpanningSegment(const Doc *doc, const SpanIndexVector &elements, int index, bool newSegment = true);
 
     // Helper to get element list for the beamSpan - elements are acquired from all layerElements that are located
     // in between start and end of the beamSpan
-    ArrayOfObjects GetBeamSpanElementList(Layer *layer, Staff *staff);
+    ArrayOfObjects GetBeamSpanElementList(Layer *layer, const Staff *staff);
 
 public:
     //
-    std::vector<BeamSpanSegment *> m_beamSegments;
-
 private:
-    //
+    /**
+     * Array of beam segments
+     */
+    std::vector<BeamSpanSegment *> m_beamSegments;
+    /**
+     * Array of beamed elements
+     */
     ArrayOfObjects m_beamedElements;
 };
 

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -172,14 +172,14 @@ public:
      * Return intersection between the bounding box and the curve represented by the FloatingPositioner.
      * The Object pointed by the FloatingPositioner is expected to be a SLUR or a TIE
      */
-    int Intersects(FloatingCurvePositioner *curve, Accessor type, int margin = 0) const;
+    int Intersects(const FloatingCurvePositioner *curve, Accessor type, int margin = 0) const;
 
     /**
      * Return intersection between the bounding box and the beam represented by the BeamDrawingInterface.
      * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
      * intersection.
      */
-    int Intersects(BeamDrawingInterface *beamInterface, Accessor type, int margin = 0) const;
+    int Intersects(const BeamDrawingInterface *beamInterface, Accessor type, int margin = 0) const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -170,7 +170,7 @@ public:
      * Diatonic step difference is take up to 2 points, so HasAdjacentNotesInStaff() needs to be called first, to make
      * sure there actually are adjacent notes.
      */
-    std::list<Note *> GetAdjacentNotesList(const Staff *staff, int loc);
+    std::list<const Note *> GetAdjacentNotesList(const Staff *staff, int loc) const;
 
     //----------//
     // Functors //

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -55,7 +55,7 @@ public:
      * Returns that placement accordingly - otherwise return the default passed as parameter.
      * Applied only for trill, mordent, and turn elements.
      */
-    data_STAFFREL GetLayerPlace(data_STAFFREL defaultValue);
+    data_STAFFREL GetLayerPlace(data_STAFFREL defaultValue) const;
 
     //----------//
     // Functors //

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -290,7 +290,7 @@ public:
      */
     ///@{
     void CalcInitialControlPointParams();
-    void CalcInitialControlPointParams(Doc *doc, float angle, int staffSize);
+    void CalcInitialControlPointParams(const Doc *doc, float angle, int staffSize);
     ///@}
 
     /**

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -71,7 +71,7 @@ public:
     /**
      * Return true if the dynam text is only composed of f, p, r, z, etc. letters (e.g. sfz)
      */
-    bool IsSymbolOnly();
+    bool IsSymbolOnly() const;
 
     /**
      * Return the SMuFL str for the dynamic symbol.
@@ -93,7 +93,7 @@ public:
     // Static methods //
     //----------------//
 
-    static bool GetSymbolsInStr(std::wstring &str, ArrayOfStringDynamTypePairs &tokens);
+    static bool GetSymbolsInStr(const std::wstring &str, ArrayOfStringDynamTypePairs &tokens);
 
     static bool IsSymbolOnly(const std::wstring &str);
 
@@ -116,7 +116,7 @@ public:
     //
 private:
     /** A cached version of the symbol str instanciated by IsSymbolOnly() */
-    std::wstring m_symbolStr;
+    mutable std::wstring m_symbolStr;
 };
 
 } // namespace vrv

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -57,7 +57,7 @@ public:
     ///@}
 
     /**
-     * Helpler for converting markup (from Note, Chord, Rest, MRest)
+     * Helper for converting markup (from Note, Chord, Rest, MRest)
      */
     void ConvertFromAnalyticalMarkup(
         AttFermataPresent *fermataPresent, const std::string &id, ConvertMarkupAnalyticalParams *params);

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -52,14 +52,23 @@ public:
     int GetDrawingY() const override;
     ///@}
 
+    /**
+     * @name Get and set the current positioner
+     */
+    ///@{
     void SetCurrentFloatingPositioner(FloatingPositioner *boundingBox);
-    FloatingPositioner *GetCurrentFloatingPositioner() const { return m_currentPositioner; }
+    FloatingPositioner *GetCurrentFloatingPositioner() { return m_currentPositioner; }
+    const FloatingPositioner *GetCurrentFloatingPositioner() const { return m_currentPositioner; }
+    ///@}
 
     /**
      * Look for the FloatingPositioner corresponding to the current one but for another object.
      * Return NULL if no current positioner or nothing found.
      */
-    FloatingPositioner *GetCorrespFloatingPositioner(FloatingObject *object);
+    ///@{
+    FloatingPositioner *GetCorrespFloatingPositioner(const FloatingObject *object);
+    const FloatingPositioner *GetCorrespFloatingPositioner(const FloatingObject *object) const;
+    ///@}
 
     /**
      * @name Get and set the drawing group for linking floating element horizontally.
@@ -191,28 +200,37 @@ public:
      */
     ///@{
     void SetObjectXY(Object *objectX, Object *objectY);
-    Object *GetObjectX() const { return m_objectX; }
-    Object *GetObjectY() const { return m_objectY; }
+    Object *GetObjectX() { return m_objectX; }
+    const Object *GetObjectX() const { return m_objectX; }
+    Object *GetObjectY() { return m_objectY; }
+    const Object *GetObjectY() const { return m_objectY; }
     ///@}
 
     /**
      * Getter for the FloatingObject (asserted, cannot be NULL)
      */
-    FloatingObject *GetObject() const { return m_object; }
+    ///@{
+    FloatingObject *GetObject() { return m_object; }
+    const FloatingObject *GetObject() const { return m_object; }
+    ///@}
 
     /**
      * Getter for the StaffAlignment (asserted, cannot be NULL)
      */
-    StaffAlignment *GetAlignment() const { return m_alignment; }
+    ///@{
+    StaffAlignment *GetAlignment() { return m_alignment; }
+    const StaffAlignment *GetAlignment() const { return m_alignment; }
+    ///@}
 
     /**
      * Getter for the spanning type
      */
-    char GetSpanningType() { return m_spanningType; }
+    char GetSpanningType() const { return m_spanningType; }
 
-    bool CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignment, BoundingBox *horizOverlapingBBox);
+    bool CalcDrawingYRel(Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlapingBBox);
 
-    int GetSpaceBelow(Doc *doc, StaffAlignment *staffAlignment, BoundingBox *horizOverlapingBBox);
+    int GetSpaceBelow(
+        const Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlapingBBox) const;
 
     data_STAFFREL GetDrawingPlace() const { return m_place; }
 
@@ -307,21 +325,22 @@ public:
     /**
      * Calculate the min or max Y for a set of points
      */
-    int CalcMinMaxY(const Point points[4]);
+    int CalcMinMaxY(const Point points[4]) const;
 
     /**
      * Calculate the adjustment needed for an element for the curve not to overlap with it.
      * Discard will be true if the element already fits.
      */
     ///@{
-    int CalcAdjustment(BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
-    int CalcDirectionalAdjustment(
-        BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin = 0, bool horizontalOverlap = true);
+    int CalcAdjustment(
+        const BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true) const;
+    int CalcDirectionalAdjustment(const BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin = 0,
+        bool horizontalOverlap = true) const;
     // Refined version that returns the adjustments on the left and right hand side of the bounding box
     std::pair<int, int> CalcLeftRightAdjustment(
-        BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true);
-    std::pair<int, int> CalcDirectionalLeftRightAdjustment(
-        BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin = 0, bool horizontalOverlap = true);
+        const BoundingBox *boundingBox, bool &discard, int margin = 0, bool horizontalOverlap = true) const;
+    std::pair<int, int> CalcDirectionalLeftRightAdjustment(const BoundingBox *boundingBox, bool isCurveAbove,
+        bool &discard, int margin = 0, bool horizontalOverlap = true) const;
     ///@}
 
     /**
@@ -329,8 +348,8 @@ public:
      */
     ///@{
     void GetPoints(Point points[4]) const;
-    int GetThickness() { return m_thickness; }
-    curvature_CURVEDIR GetDir() { return m_dir; }
+    int GetThickness() const { return m_thickness; }
+    curvature_CURVEDIR GetDir() const { return m_dir; }
     ///@}
 
     /**
@@ -363,7 +382,8 @@ public:
      */
     ///@{
     void SetCrossStaff(Staff *crossStaff) { m_crossStaff = crossStaff; }
-    Staff *GetCrossStaff() const { return m_crossStaff; }
+    Staff *GetCrossStaff() { return m_crossStaff; }
+    const Staff *GetCrossStaff() const { return m_crossStaff; }
     bool IsCrossStaff() const { return m_crossStaff != NULL; }
     ///@}
 
@@ -378,7 +398,7 @@ public:
     /**
      * Calculate the requested staff space above and below
      */
-    std::pair<int, int> CalcRequestedStaffSpace(StaffAlignment *alignment);
+    std::pair<int, int> CalcRequestedStaffSpace(const StaffAlignment *alignment) const;
 
 private:
     //
@@ -399,7 +419,7 @@ private:
     ArrayOfCurveSpannedElements m_spannedElements;
 
     /** The cached min or max value (depending on the curvature) */
-    int m_cachedMinMaxY;
+    mutable int m_cachedMinMaxY;
 
     /** The cached values for x1 and x2 */
     std::pair<int, int> m_cachedX12;
@@ -429,7 +449,7 @@ public:
     virtual ~CurveSpannedElement(){};
 
     Point m_rotatedPoints[4];
-    BoundingBox *m_boundingBox;
+    const BoundingBox *m_boundingBox;
     bool m_discarded;
     bool m_isBelow;
 };

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1639,7 +1639,7 @@ public:
 
 class FindSpannedLayerElementsParams : public FunctorParams {
 public:
-    FindSpannedLayerElementsParams(TimeSpanningInterface *interface)
+    FindSpannedLayerElementsParams(const TimeSpanningInterface *interface)
     {
         m_interface = interface;
         m_minPos = 0;
@@ -1647,13 +1647,13 @@ public:
         m_minLayerN = 0;
         m_maxLayerN = 0;
     }
-    std::vector<LayerElement *> m_elements;
+    std::vector<const LayerElement *> m_elements;
     int m_minPos;
     int m_maxPos;
     std::set<int> m_staffNs;
     int m_minLayerN;
     int m_maxLayerN;
-    TimeSpanningInterface *m_interface;
+    const TimeSpanningInterface *m_interface;
     std::vector<ClassId> m_classIds;
 };
 

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -67,8 +67,8 @@ public:
     bool HasDrawingLength() const { return (m_drawingLength > 0); }
     ///@}
 
-    int CalcHeight(
-        Doc *doc, int staffSize, char spanningType, FloatingPositioner *leftHairpin, FloatingPositioner *rightHaipin);
+    int CalcHeight(const Doc *doc, int staffSize, char spanningType, const FloatingPositioner *leftHairpin,
+        const FloatingPositioner *rightHaipin) const;
 
     /**
      * @name Setter and getter for left and right links
@@ -76,15 +76,17 @@ public:
     ///@{
     void SetLeftLink(ControlElement *leftLink);
     ControlElement *GetLeftLink() { return m_leftLink; }
+    const ControlElement *GetLeftLink() const { return m_leftLink; }
     void SetRightLink(ControlElement *rightLink);
     ControlElement *GetRightLink() { return m_rightLink; }
+    const ControlElement *GetRightLink() const { return m_rightLink; }
     ///@}
 
     /**
      * Get left/right adjustments that needs to be done to the hairpin with set coordinates (leftX, rightX) for it not
      * to overlap with parent measure's barlines
      */
-    std::pair<int, int> GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX, int spanningType);
+    std::pair<int, int> GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX, int spanningType) const;
 
     //----------//
     // Functors //

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -403,7 +403,7 @@ public:
     /**
      * See Object::FindSpannedLayerElements
      */
-    int FindSpannedLayerElements(FunctorParams *functorParams) override;
+    int FindSpannedLayerElements(FunctorParams *functorParams) const override;
 
     /**
      * See Object::LayerCountInTimeSpan

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -33,7 +33,8 @@ public:
     std::string GetClassName() const override { return "Lv"; }
     ///@}
 
-    bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]) override;
+    bool CalculatePosition(
+        const Doc *doc, const Staff *staff, int x1, int x2, int spanningType, Point bezier[4]) override;
 
     //----------//
     // Functors //

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -279,7 +279,7 @@ public:
     /**
      * See Object::FindSpannedLayerElements
      */
-    int FindSpannedLayerElements(FunctorParams *functorParams) override;
+    int FindSpannedLayerElements(FunctorParams *functorParams) const override;
 
     /**
      * See Object::ConvertMarkupAnalytical

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -732,7 +732,7 @@ public:
     /**
      * Retrieve the layer elements spanned by two points
      */
-    virtual int FindSpannedLayerElements(FunctorParams *) { return FUNCTOR_CONTINUE; }
+    virtual int FindSpannedLayerElements(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
      * Look for element by ID in StaffDef elements (Clef, KeySig, etc.) of all layers within

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -77,7 +77,7 @@ public:
     /**
      * Get the pedal form based on the options and corresponding attributes from <pedal> and <scoreDef>
      */
-    pedalVis_FORM GetPedalForm(Doc *doc, System *system) const;
+    pedalVis_FORM GetPedalForm(const Doc *doc, const System *system) const;
 
     //----------//
     // Functors //

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -26,7 +26,7 @@ class Staff;
  * Contains the layer elements used for collision detection
  */
 struct SpannedElements {
-    std::vector<LayerElement *> elements;
+    std::vector<const LayerElement *> elements;
     std::set<int> layersN;
 };
 
@@ -162,7 +162,7 @@ public:
     /**
      * Calculate the initial slur bezier curve and store it in the curve positioner
      */
-    void CalcInitialCurve(Doc *doc, FloatingCurvePositioner *curve, NearEndCollision *nearEndCollision = NULL);
+    void CalcInitialCurve(const Doc *doc, FloatingCurvePositioner *curve, NearEndCollision *nearEndCollision = NULL);
 
     /**
      * Recalculate the spanned elements of the curve positioner
@@ -177,7 +177,10 @@ public:
     /**
      * Calculate the staff where the slur's floating curve positioner lives
      */
-    Staff *CalculateExtremalStaff(Staff *staff, int xMin, int xMax);
+    ///@{
+    Staff *CalculateExtremalStaff(const Staff *staff, int xMin, int xMax);
+    const Staff *CalculateExtremalStaff(const Staff *staff, int xMin, int xMax) const;
+    ///@}
 
     /**
      * Set the bezier control sides depending on the curve direction
@@ -188,12 +191,12 @@ public:
      * Slur adjustment
      */
     ///@{
-    void AdjustSlur(Doc *doc, FloatingCurvePositioner *curve, int unit);
+    void AdjustSlur(const Doc *doc, FloatingCurvePositioner *curve, int unit);
 
     void AdjustOuterSlur(
-        Doc *doc, FloatingCurvePositioner *curve, const ArrayOfFloatingCurvePositioners &innerCurves, int unit);
+        const Doc *doc, FloatingCurvePositioner *curve, const ArrayOfFloatingCurvePositioners &innerCurves, int unit);
 
-    float GetAdjustedSlurAngle(Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir);
+    float GetAdjustedSlurAngle(const Doc *doc, Point &p1, Point &p2, curvature_CURVEDIR curveDir) const;
     ///@}
 
     //----------//
@@ -216,14 +219,14 @@ private:
      */
     ///@{
     // Get layer by only considering the slur boundary
-    std::pair<Layer *, LayerElement *> GetBoundaryLayer();
+    std::pair<const Layer *, const LayerElement *> GetBoundaryLayer() const;
     // Get cross staff by only considering the slur boundary
-    Staff *GetBoundaryCrossStaff();
+    const Staff *GetBoundaryCrossStaff() const;
     // Determine curve direction for the slurs that start at grace note
     curvature_CURVEDIR GetGraceCurveDirection() const;
     // Get preferred curve direction based on various conditions
     curvature_CURVEDIR GetPreferredCurveDirection(
-        data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur);
+        data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter, bool isGraceToNoteSlur) const;
     ///@}
 
     /**
@@ -231,13 +234,13 @@ private:
      */
     ///@{
     // Determine layer elements spanned by the slur
-    SpannedElements CollectSpannedElements(Staff *staff, int xMin, int xMax);
+    SpannedElements CollectSpannedElements(const Staff *staff, int xMin, int xMax) const;
     // Filter and add layer elements spanned by the slur to the positioner
     void AddSpannedElements(
-        FloatingCurvePositioner *curve, const SpannedElements &elements, Staff *staff, int xMin, int xMax);
+        FloatingCurvePositioner *curve, const SpannedElements &elements, const Staff *staff, int xMin, int xMax);
     // Determine whether a layer element should lie above or below the slur
-    bool IsElementBelow(LayerElement *element, Staff *startStaff, Staff *endStaff) const;
-    bool IsElementBelow(FloatingPositioner *positioner, Staff *startStaff, Staff *endStaff) const;
+    bool IsElementBelow(const LayerElement *element, const Staff *startStaff, const Staff *endStaff) const;
+    bool IsElementBelow(const FloatingPositioner *positioner, const Staff *startStaff, const Staff *endStaff) const;
     ///@}
 
     /**
@@ -245,14 +248,15 @@ private:
      */
     ///@{
     // Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
-    std::pair<Point, Point> CalcEndPoints(Doc *doc, Staff *staff, NearEndCollision *nearEndCollision, int x1, int x2,
-        curvature_CURVEDIR drawingCurveDir, char spanningType);
+    std::pair<Point, Point> CalcEndPoints(const Doc *doc, const Staff *staff, NearEndCollision *nearEndCollision,
+        int x1, int x2, curvature_CURVEDIR drawingCurveDir, char spanningType) const;
     // Retrieve the start and end note locations of the slur
-    std::pair<int, int> GetStartEndLocs(Note *startNote, Chord *startChord, Note *endNote, Chord *endChord) const;
+    std::pair<int, int> GetStartEndLocs(
+        const Note *startNote, const Chord *startChord, const Note *endNote, const Chord *endChord) const;
     // Calculate the break location at system start/end and the pitch difference
-    std::pair<int, int> CalcBrokenLoc(Staff *staff, int startLoc, int endLoc) const;
+    std::pair<int, int> CalcBrokenLoc(const Staff *staff, int startLoc, int endLoc) const;
     // Check if the slur resembles portato
-    PortatoSlurType IsPortatoSlur(Doc *doc, Note *startNote, Chord *startChord) const;
+    PortatoSlurType IsPortatoSlur(const Doc *doc, const Note *startNote, const Chord *startChord) const;
     ///@}
 
     /**
@@ -290,7 +294,7 @@ private:
 
     // Solve the constraints for vertical control point adjustment
     std::pair<int, int> SolveControlPointConstraints(
-        const std::list<ControlPointConstraint> &constraints, double symmetry = 0.0);
+        const std::list<ControlPointConstraint> &constraints, double symmetry = 0.0) const;
 
     // Improve the slur shape by adjusting the control point heights
     void AdjustSlurShape(BezierCurve &bezierCurve, curvature_CURVEDIR dir, int unit);

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -66,7 +66,7 @@ public:
      * @name Get the X drawing position
      */
     ///@{
-    int GetDrawingXRelativeToStaff(int staffN);
+    int GetDrawingXRelativeToStaff(int staffN) const;
 
     //----------//
     // Functors //

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -82,8 +82,8 @@ public:
 
 private:
     // Update tie positioning based overlaps with accidentals in cases with enharmonic ties
-    bool AdjustEnharmonicTies(const Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], const Note *startNote,
-        const Note *endNote, curvature_CURVEDIR drawingCurveDir);
+    bool AdjustEnharmonicTies(const Doc *doc, const FloatingCurvePositioner *curve, Point bezier[4],
+        const Note *startNote, const Note *endNote, curvature_CURVEDIR drawingCurveDir) const;
 
     // Calculate initial position X position and return stem direction of the startNote
     void CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *startParentChord,
@@ -92,12 +92,12 @@ private:
 
     // Helper function to get preferred curve direction based on the number of conditions (like note direction, position
     // on the staff, etc.)
-    curvature_CURVEDIR GetPreferredCurveDirection(
-        Layer *layer, Note *note, Chord *startParentChord, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter);
+    curvature_CURVEDIR GetPreferredCurveDirection(const Layer *layer, const Note *note, const Chord *startParentChord,
+        data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter) const;
 
     // Update tie positioning based on the overlaps with possible layerElements such as dots/flags
-    void UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], LayerElement *durElement,
-        Note *startNote, int height, curvature_CURVEDIR drawingCurveDir);
+    void UpdateTiePositioning(const FloatingCurvePositioner *curve, Point bezier[4], const LayerElement *durElement,
+        const Note *startNote, int height, curvature_CURVEDIR drawingCurveDir) const;
 
 public:
     //

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -60,13 +60,14 @@ public:
     }
     ///@}
 
-    virtual bool CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
+    virtual bool CalculatePosition(
+        const Doc *doc, const Staff *staff, int x1, int x2, int spanningType, Point bezier[4]);
 
     /**
      * Calculate starting/ending point for the ties in the chords with adjacent notes
      */
-    int CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
-        curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint);
+    int CalculateAdjacentChordXOffset(const Doc *doc, const Staff *staff, const Chord *parentChord, const Note *note,
+        curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint) const;
 
     //----------//
     // Functors //
@@ -81,12 +82,13 @@ public:
 
 private:
     // Update tie positioning based overlaps with accidentals in cases with enharmonic ties
-    bool AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote, Note *endNote,
-        curvature_CURVEDIR drawingCurveDir);
+    bool AdjustEnharmonicTies(const Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], const Note *startNote,
+        const Note *endNote, curvature_CURVEDIR drawingCurveDir);
 
     // Calculate initial position X position and return stem direction of the startNote
-    void CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
-        bool isOuterChordNote, Point &startPoint, Point &endPoint, curvature_CURVEDIR drawingCurveDir);
+    void CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *startParentChord,
+        const Chord *endParentChord, int spanningType, bool isOuterChordNote, Point &startPoint, Point &endPoint,
+        curvature_CURVEDIR drawingCurveDir) const;
 
     // Helper function to get preferred curve direction based on the number of conditions (like note direction, position
     // on the staff, etc.)

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -62,7 +62,7 @@ public:
     /**
      * Get the turn height ignoring slash
      */
-    int GetTurnHeight(Doc *doc, int staffSize) const;
+    int GetTurnHeight(const Doc *doc, int staffSize) const;
 
     //----------//
     // Functors //

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -189,7 +189,10 @@ public:
      * Look for the FloatingPositioner corresponding to the FloatingObject.
      * Return NULL if not found and does not create anything.
      */
-    FloatingPositioner *GetCorrespFloatingPositioner(FloatingObject *object);
+    ///@{
+    FloatingPositioner *GetCorrespFloatingPositioner(const FloatingObject *object);
+    const FloatingPositioner *GetCorrespFloatingPositioner(const FloatingObject *object) const;
+    ///@}
 
     /**
      * @name Setter and getter of the staff from which the alignment is created alignment.
@@ -223,8 +226,8 @@ public:
      * value.
      */
     ///@{
-    int CalcOverflowAbove(BoundingBox *box);
-    int CalcOverflowBelow(BoundingBox *box);
+    int CalcOverflowAbove(const BoundingBox *box) const;
+    int CalcOverflowBelow(const BoundingBox *box) const;
     ///@}
 
     /**

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -82,19 +82,25 @@ void BeamSpan::ClearBeamSegments()
     m_beamSegments.clear();
 }
 
-BeamSpanSegment *BeamSpan::GetSegmentForSystem(System *system)
+BeamSpanSegment *BeamSpan::GetSegmentForSystem(const System *system)
+{
+    return const_cast<BeamSpanSegment *>(std::as_const(*this).GetSegmentForSystem(system));
+}
+
+const BeamSpanSegment *BeamSpan::GetSegmentForSystem(const System *system) const
 {
     assert(system);
 
     for (auto segment : m_beamSegments) {
         // make sure to process only segments for current system
-        Measure *segmentSystem = segment->GetMeasure();
-        if (segmentSystem && vrv_cast<System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system) return segment;
+        const Measure *segmentSystem = segment->GetMeasure();
+        if (segmentSystem && vrv_cast<const System *>(segmentSystem->GetFirstAncestor(SYSTEM)) == system)
+            return segment;
     }
     return NULL;
 }
 
-ArrayOfObjects BeamSpan::GetBeamSpanElementList(Layer *layer, Staff *staff)
+ArrayOfObjects BeamSpan::GetBeamSpanElementList(Layer *layer, const Staff *staff)
 {
     // find all elements between startId and endId of the beamSpan
     ClassIdsComparison classIds({ NOTE, CHORD });
@@ -145,7 +151,7 @@ ArrayOfObjects BeamSpan::GetBeamSpanElementList(Layer *layer, Staff *staff)
     return beamSpanElements;
 }
 
-bool BeamSpan::AddSpanningSegment(Doc *doc, const SpanIndexVector &elements, int index, bool newSegment)
+bool BeamSpan::AddSpanningSegment(const Doc *doc, const SpanIndexVector &elements, int index, bool newSegment)
 {
     Layer *layer = vrv_cast<Layer *>((*elements.at(index).first)->GetFirstAncestor(LAYER));
     Staff *staff = vrv_cast<Staff *>((*elements.at(index).first)->GetFirstAncestor(STAFF));

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -571,7 +571,7 @@ bool BoundingBox::Encloses(const Point point) const
     return true;
 }
 
-int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int margin) const
+int BoundingBox::Intersects(const FloatingCurvePositioner *curve, Accessor type, int margin) const
 {
     assert(curve);
     assert(curve->GetObject());
@@ -721,7 +721,7 @@ int BoundingBox::Intersects(FloatingCurvePositioner *curve, Accessor type, int m
     return 0;
 }
 
-int BoundingBox::Intersects(BeamDrawingInterface *beamInterface, Accessor type, const int margin) const
+int BoundingBox::Intersects(const BeamDrawingInterface *beamInterface, Accessor type, const int margin) const
 {
     assert(beamInterface);
     assert(beamInterface->HasCoords());

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -550,16 +550,16 @@ int Chord::AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElemen
     return 0;
 }
 
-std::list<Note *> Chord::GetAdjacentNotesList(const Staff *staff, int loc)
+std::list<const Note *> Chord::GetAdjacentNotesList(const Staff *staff, int loc) const
 {
-    const ListOfObjects &notes = this->GetList(this);
+    const ListOfConstObjects &notes = this->GetList(this);
 
-    std::list<Note *> adjacentNotes;
-    for (Object *obj : notes) {
-        Note *note = vrv_cast<Note *>(obj);
+    std::list<const Note *> adjacentNotes;
+    for (const Object *obj : notes) {
+        const Note *note = vrv_cast<const Note *>(obj);
         assert(note);
 
-        Staff *noteStaff = note->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+        const Staff *noteStaff = note->GetAncestorStaff(RESOLVE_CROSS_STAFF);
         if (noteStaff != staff) continue;
 
         const int locDiff = note->GetDrawingLoc() - loc;

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -74,18 +74,18 @@ data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment() const
     return rend->GetHalign();
 }
 
-data_STAFFREL ControlElement::GetLayerPlace(data_STAFFREL defaultValue)
+data_STAFFREL ControlElement::GetLayerPlace(data_STAFFREL defaultValue) const
 {
     // Do this only for the following elements
     if (!this->Is({ TRILL, MORDENT, TURN })) return defaultValue;
 
-    TimePointInterface *interface = this->GetTimePointInterface();
+    const TimePointInterface *interface = this->GetTimePointInterface();
     assert(interface);
 
-    LayerElement *start = interface->GetStart();
+    const LayerElement *start = interface->GetStart();
     if (!start || start->Is(TIMESTAMP_ATTR)) return defaultValue;
 
-    Layer *layer = vrv_cast<Layer *>(start->GetFirstAncestor(LAYER));
+    const Layer *layer = vrv_cast<const Layer *>(start->GetFirstAncestor(LAYER));
     // We are only looking that the element cross-staff. We could use LayerElement::GetCrossStaff(Layer  *&)
     if (start->m_crossLayer) layer = start->m_crossLayer;
     assert(layer);

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -43,7 +43,7 @@ void BezierCurve::CalcInitialControlPointParams()
     this->SetControlHeight(0);
 }
 
-void BezierCurve::CalcInitialControlPointParams(Doc *doc, float angle, int staffSize)
+void BezierCurve::CalcInitialControlPointParams(const Doc *doc, float angle, int staffSize)
 {
     // Note: For convex curves (both control points on the same side) we assume that the curve is rotated
     // such that p1.y == p2.y, but for curves with mixed curvature we assume that the curve is unrotated

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -86,7 +86,7 @@ bool Dynam::IsSupportedChild(Object *child)
     return true;
 }
 
-bool Dynam::IsSymbolOnly()
+bool Dynam::IsSymbolOnly() const
 {
     m_symbolStr = L"";
     std::wstring str = this->GetText(this);
@@ -118,7 +118,7 @@ std::pair<wchar_t, wchar_t> Dynam::GetEnclosingGlyphs() const
 // Static methods for Dynam
 //----------------------------------------------------------------------------
 
-bool Dynam::GetSymbolsInStr(std::wstring &str, ArrayOfStringDynamTypePairs &tokens)
+bool Dynam::GetSymbolsInStr(const std::wstring &str, ArrayOfStringDynamTypePairs &tokens)
 {
     tokens.clear();
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -697,7 +697,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
         // For selected types use the cut out boundary
         int boxTopY = boundingBox->GetTopBy(type);
         if (boundingBox->Is(ACCID)) {
-            const Resources *resources = vrv_cast<Object *>(boundingBox)->GetDocResources();
+            const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxTopY = boundingBox->GetCutOutTop(*resources);
             }
@@ -734,7 +734,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
         // For selected types use the cut out boundary
         int boxBottomY = boundingBox->GetBottomBy(type);
         if (boundingBox->Is(ACCID)) {
-            const Resources *resources = vrv_cast<Object *>(boundingBox)->GetDocResources();
+            const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxBottomY = boundingBox->GetCutOutBottom(*resources);
             }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -131,7 +131,12 @@ void FloatingObject::SetCurrentFloatingPositioner(FloatingPositioner *boundingBo
     m_currentPositioner = boundingBox;
 }
 
-FloatingPositioner *FloatingObject::GetCorrespFloatingPositioner(FloatingObject *object)
+FloatingPositioner *FloatingObject::GetCorrespFloatingPositioner(const FloatingObject *object)
+{
+    return const_cast<FloatingPositioner *>(std::as_const(*this).GetCorrespFloatingPositioner(object));
+}
+
+const FloatingPositioner *FloatingObject::GetCorrespFloatingPositioner(const FloatingObject *object) const
 {
     if (!object || !m_currentPositioner) return NULL;
 
@@ -348,7 +353,8 @@ void FloatingPositioner::SetDrawingYRel(int drawingYRel, bool force)
     }
 }
 
-bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignment, BoundingBox *horizOverlapingBBox)
+bool FloatingPositioner::CalcDrawingYRel(
+    Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlapingBBox)
 {
     assert(doc);
     assert(staffAlignment);
@@ -392,7 +398,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
         }
     }
     else {
-        FloatingCurvePositioner *curve = dynamic_cast<FloatingCurvePositioner *>(horizOverlapingBBox);
+        const FloatingCurvePositioner *curve = dynamic_cast<const FloatingCurvePositioner *>(horizOverlapingBBox);
         if (curve) {
             assert(curve->m_object);
         }
@@ -408,7 +414,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(vrv_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
+                const int shift = this->Intersects(vrv_cast<const Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
@@ -416,7 +422,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             }
             yRel = -staffAlignment->CalcOverflowAbove(horizOverlapingBBox) + this->GetContentY1() - margin;
 
-            Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            const Object *object = dynamic_cast<const Object *>(horizOverlapingBBox);
             // For elements, that can have extender lines, we need to make sure that they continue in next system on the
             // same height, as they were before (even if there are no overlapping elements in subsequent measures)
             if (isExtender) {
@@ -441,7 +447,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
                 return true;
             }
             else if (horizOverlapingBBox->Is(BEAM) && !isExtender) {
-                const int shift = this->Intersects(vrv_cast<Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
+                const int shift = this->Intersects(vrv_cast<const Beam *>(horizOverlapingBBox), CONTENT, unit / 2);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
                 }
@@ -450,7 +456,7 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
             yRel = staffAlignment->CalcOverflowBelow(horizOverlapingBBox) + staffAlignment->GetStaffHeight()
                 + this->GetContentY2() + margin;
 
-            Object *object = dynamic_cast<Object *>(horizOverlapingBBox);
+            const Object *object = dynamic_cast<const Object *>(horizOverlapingBBox);
             // For elements, that can have extender lines, we need to make sure that they continue in next system on the
             // same height, as they were before (even if there are no overlapping elements in subsequent measures)
             if (isExtender) {
@@ -470,13 +476,14 @@ bool FloatingPositioner::CalcDrawingYRel(Doc *doc, StaffAlignment *staffAlignmen
     return true;
 }
 
-int FloatingPositioner::GetSpaceBelow(Doc *doc, StaffAlignment *staffAlignment, BoundingBox *horizOverlapingBBox)
+int FloatingPositioner::GetSpaceBelow(
+    const Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlapingBBox) const
 {
     if (m_place != STAFFREL_between) return VRV_UNSET;
 
     int staffSize = staffAlignment->GetStaffSize();
 
-    FloatingCurvePositioner *curve = dynamic_cast<FloatingCurvePositioner *>(horizOverlapingBBox);
+    const FloatingCurvePositioner *curve = dynamic_cast<const FloatingCurvePositioner *>(horizOverlapingBBox);
     if (curve) {
         assert(curve->m_object);
     }
@@ -590,7 +597,7 @@ void FloatingCurvePositioner::MoveBackVertical(int distance)
     m_points[3].y += distance;
 }
 
-int FloatingCurvePositioner::CalcMinMaxY(const Point points[4])
+int FloatingCurvePositioner::CalcMinMaxY(const Point points[4]) const
 {
     assert(this->GetObject());
     assert(this->GetObject()->Is({ LV, PHRASE, SLUR, TIE }));
@@ -607,7 +614,8 @@ int FloatingCurvePositioner::CalcMinMaxY(const Point points[4])
     return m_cachedMinMaxY;
 }
 
-int FloatingCurvePositioner::CalcAdjustment(BoundingBox *boundingBox, bool &discard, int margin, bool horizontalOverlap)
+int FloatingCurvePositioner::CalcAdjustment(
+    const BoundingBox *boundingBox, bool &discard, int margin, bool horizontalOverlap) const
 {
     int leftAdjustment, rightAdjustment;
     std::tie(leftAdjustment, rightAdjustment)
@@ -616,7 +624,7 @@ int FloatingCurvePositioner::CalcAdjustment(BoundingBox *boundingBox, bool &disc
 }
 
 int FloatingCurvePositioner::CalcDirectionalAdjustment(
-    BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin, bool horizontalOverlap)
+    const BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin, bool horizontalOverlap) const
 {
     int leftAdjustment, rightAdjustment;
     std::tie(leftAdjustment, rightAdjustment)
@@ -625,14 +633,14 @@ int FloatingCurvePositioner::CalcDirectionalAdjustment(
 }
 
 std::pair<int, int> FloatingCurvePositioner::CalcLeftRightAdjustment(
-    BoundingBox *boundingBox, bool &discard, int margin, bool horizontalOverlap)
+    const BoundingBox *boundingBox, bool &discard, int margin, bool horizontalOverlap) const
 {
     return this->CalcDirectionalLeftRightAdjustment(
         boundingBox, (this->GetDir() == curvature_CURVEDIR_above), discard, margin, horizontalOverlap);
 }
 
 std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
-    BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin, bool horizontalOverlap)
+    const BoundingBox *boundingBox, bool isCurveAbove, bool &discard, int margin, bool horizontalOverlap) const
 {
     assert(boundingBox);
     assert(boundingBox->HasSelfBB());
@@ -757,14 +765,14 @@ void FloatingCurvePositioner::GetPoints(Point points[4]) const
     points[3].y += currentY;
 }
 
-std::pair<int, int> FloatingCurvePositioner::CalcRequestedStaffSpace(StaffAlignment *alignment)
+std::pair<int, int> FloatingCurvePositioner::CalcRequestedStaffSpace(const StaffAlignment *alignment) const
 {
     assert(alignment);
 
-    TimeSpanningInterface *interface = this->GetObject()->GetTimeSpanningInterface();
+    const TimeSpanningInterface *interface = this->GetObject()->GetTimeSpanningInterface();
     if (interface) {
-        Staff *startStaff = interface->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
-        Staff *endStaff = interface->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
+        const Staff *startStaff = interface->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
+        const Staff *endStaff = interface->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
 
         if (startStaff && endStaff) {
             const int startStaffN = startStaff->GetN();

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -67,8 +67,8 @@ void Hairpin::Reset()
     m_drawingLength = 0;
 }
 
-int Hairpin::CalcHeight(
-    Doc *doc, int staffSize, char spanningType, FloatingPositioner *leftPositioner, FloatingPositioner *rightPositioner)
+int Hairpin::CalcHeight(const Doc *doc, int staffSize, char spanningType, const FloatingPositioner *leftPositioner,
+    const FloatingPositioner *rightPositioner) const
 {
     assert(doc);
 
@@ -88,9 +88,9 @@ int Hairpin::CalcHeight(
 
     // Second of a <>
     if ((this->GetForm() == hairpinLog_FORM_dim) && m_leftLink && m_leftLink->Is(HAIRPIN)) {
-        // Do no adjust height when previous hairpin is not a full hairpin
+        // Don't adjust height when previous hairpin is not a full hairpin
         if (!leftPositioner || (leftPositioner->GetSpanningType() != SPANNING_START_END)) return endY;
-        Hairpin *left = vrv_cast<Hairpin *>(m_leftLink);
+        const Hairpin *left = vrv_cast<const Hairpin *>(m_leftLink);
         assert(left);
         // Take into account its length only if the left one is actually a <
         if (left->GetForm() == hairpinLog_FORM_cres) {
@@ -100,9 +100,9 @@ int Hairpin::CalcHeight(
 
     // First of a <>
     if ((this->GetForm() == hairpinLog_FORM_cres) && m_rightLink && m_rightLink->Is(HAIRPIN)) {
-        // Do no adjust height when next hairpin is not a full hairpin
+        // Don't adjust height when next hairpin is not a full hairpin
         if (!rightPositioner || (rightPositioner->GetSpanningType() != SPANNING_START_END)) return endY;
-        Hairpin *right = vrv_cast<Hairpin *>(m_rightLink);
+        const Hairpin *right = vrv_cast<const Hairpin *>(m_rightLink);
         assert(right);
         // Take into account its length only if the right one is actually a >
         if (right->GetForm() == hairpinLog_FORM_dim) {
@@ -158,17 +158,17 @@ void Hairpin::SetRightLink(ControlElement *rightLink)
     rightLink->SetDrawingGrpId(grpId);
 }
 
-std::pair<int, int> Hairpin::GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX, int spanningType)
+std::pair<int, int> Hairpin::GetBarlineOverlapAdjustment(int doubleUnit, int leftX, int rightX, int spanningType) const
 {
-    Measure *startMeasure = vrv_cast<Measure *>(this->GetStart()->GetFirstAncestor(MEASURE));
-    Measure *endMeasure = vrv_cast<Measure *>(this->GetEnd()->GetFirstAncestor(MEASURE));
+    const Measure *startMeasure = vrv_cast<const Measure *>(this->GetStart()->GetFirstAncestor(MEASURE));
+    const Measure *endMeasure = vrv_cast<const Measure *>(this->GetEnd()->GetFirstAncestor(MEASURE));
 
     if (!startMeasure || !endMeasure) return { 0, 0 };
 
     // Calculate adjustment that needs to be made for hairpin not to touch the left barline. We take doubleUnit for the
     // default margin to consider them overlapping, which is adjusted in case we have wider barline on the left
     int leftAdjustment = 0;
-    BarLine *leftBarline = startMeasure->GetLeftBarLine();
+    const BarLine *leftBarline = startMeasure->GetLeftBarLine();
     if (leftBarline && (spanningType == SPANNING_START_END || spanningType == SPANNING_START)) {
         int margin = doubleUnit;
         const int leftBarlineX = leftBarline->GetDrawingX();
@@ -182,16 +182,16 @@ std::pair<int, int> Hairpin::GetBarlineOverlapAdjustment(int doubleUnit, int lef
     // be selected - when processing start of the spanning hairpin, we should check for the last measure of the current
     // system, instead of the endMeasure
     int rightAdjustment = 0;
-    BarLine *rightBarline = NULL;
+    const BarLine *rightBarline = NULL;
     if (spanningType == SPANNING_START_END || spanningType == SPANNING_END) {
         rightBarline = endMeasure->GetRightBarLine();
     }
     else if (spanningType == SPANNING_START) {
-        System *startSystem = vrv_cast<System *>(this->GetStart()->GetFirstAncestor(SYSTEM));
+        const System *startSystem = vrv_cast<const System *>(this->GetStart()->GetFirstAncestor(SYSTEM));
         if (startSystem) {
             ClassIdComparison cmp(MEASURE);
-            Measure *measure
-                = vrv_cast<Measure *>(startSystem->FindDescendantByComparison(&cmp, UNLIMITED_DEPTH, BACKWARD));
+            const Measure *measure
+                = vrv_cast<const Measure *>(startSystem->FindDescendantByComparison(&cmp, UNLIMITED_DEPTH, BACKWARD));
             if (measure) rightBarline = measure->GetRightBarLine();
         }
     }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2502,7 +2502,7 @@ int LayerElement::LayerElementsInTimeSpan(FunctorParams *functorParams) const
     return this->Is(CHORD) ? FUNCTOR_SIBLINGS : FUNCTOR_CONTINUE;
 }
 
-int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
+int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams) const
 {
     FindSpannedLayerElementsParams *params = vrv_params_cast<FindSpannedLayerElementsParams *>(functorParams);
     assert(params);
@@ -2517,17 +2517,17 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
         && (this->GetContentLeft() < params->m_maxPos)) {
 
         // We skip the start or end of the slur
-        LayerElement *start = params->m_interface->GetStart();
-        LayerElement *end = params->m_interface->GetEnd();
+        const LayerElement *start = params->m_interface->GetStart();
+        const LayerElement *end = params->m_interface->GetEnd();
         if ((this == start) || (this == end)) {
             return FUNCTOR_CONTINUE;
         }
 
         // Skip if neither parent staff nor cross staff matches the given staff number
         if (!params->m_staffNs.empty()) {
-            Staff *staff = this->GetAncestorStaff();
+            const Staff *staff = this->GetAncestorStaff();
             if (params->m_staffNs.find(staff->GetN()) == params->m_staffNs.end()) {
-                Layer *layer = NULL;
+                const Layer *layer = NULL;
                 staff = this->GetCrossStaff(layer);
                 if (!staff || (params->m_staffNs.find(staff->GetN()) == params->m_staffNs.end())) {
                     return FUNCTOR_CONTINUE;
@@ -2546,15 +2546,15 @@ int LayerElement::FindSpannedLayerElements(FunctorParams *functorParams)
 
         // Skip elements aligned at start/end, but on a different staff
         if ((this->GetAlignment() == start->GetAlignment()) && !start->Is(TIMESTAMP_ATTR)) {
-            Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
-            Staff *startStaff = start->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+            const Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+            const Staff *startStaff = start->GetAncestorStaff(RESOLVE_CROSS_STAFF);
             if (staff->GetN() != startStaff->GetN()) {
                 return FUNCTOR_CONTINUE;
             }
         }
         if ((this->GetAlignment() == end->GetAlignment()) && !end->Is(TIMESTAMP_ATTR)) {
-            Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
-            Staff *endStaff = end->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+            const Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+            const Staff *endStaff = end->GetAncestorStaff(RESOLVE_CROSS_STAFF);
             if (staff->GetN() != endStaff->GetN()) {
                 return FUNCTOR_CONTINUE;
             }

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -35,7 +35,7 @@ void Lv::Reset()
     Tie::Reset();
 }
 
-bool Lv::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
+bool Lv::CalculatePosition(const Doc *doc, const Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
 {
     if (spanningType != SPANNING_START_END) {
         //  this makes no sense

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -675,7 +675,7 @@ std::vector<std::pair<LayerElement *, LayerElement *>> Measure::GetInternalTieEn
 // Measure functor methods
 //----------------------------------------------------------------------------
 
-int Measure::FindSpannedLayerElements(FunctorParams *functorParams)
+int Measure::FindSpannedLayerElements(FunctorParams *functorParams) const
 {
     FindSpannedLayerElementsParams *params = vrv_params_cast<FindSpannedLayerElementsParams *>(functorParams);
     assert(params);

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -88,7 +88,7 @@ wchar_t Pedal::GetPedalGlyph() const
     return (this->GetFunc() == "sostenuto") ? SMUFL_E659_keyboardPedalSost : SMUFL_E650_keyboardPedalPed;
 }
 
-pedalVis_FORM Pedal::GetPedalForm(Doc *doc, System *system) const
+pedalVis_FORM Pedal::GetPedalForm(const Doc *doc, const System *system) const
 {
     const std::map<option_PEDALSTYLE, pedalVis_FORM> option2PedalVis = { { PEDALSTYLE_line, pedalVis_FORM_line },
         { PEDALSTYLE_pedstar, pedalVis_FORM_pedstar }, { PEDALSTYLE_altpedstar, pedalVis_FORM_altpedstar } };

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -283,7 +283,7 @@ curvature_CURVEDIR System::GetPreferredCurveDirection(LayerElement *start, Layer
 
     curvature_CURVEDIR preferredDirection = curvature_CURVEDIR_NONE;
     for (auto element : findSpannedLayerElementsParams.m_elements) {
-        Layer *layer = vrv_cast<Layer *>((element)->GetFirstAncestor(LAYER));
+        const Layer *layer = vrv_cast<const Layer *>((element)->GetFirstAncestor(LAYER));
         assert(layer);
         if (layer == layerStart) continue;
 

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -69,7 +69,7 @@ bool Tempo::IsSupportedChild(Object *child)
     return true;
 }
 
-int Tempo::GetDrawingXRelativeToStaff(int staffN)
+int Tempo::GetDrawingXRelativeToStaff(int staffN) const
 {
     int m_relativeX = 0;
     if (m_drawingXRels.find(staffN) != m_drawingXRels.end()) {

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -75,10 +75,10 @@ void Tie::Reset()
     this->ResetCurveRend();
 }
 
-bool Tie::AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], Note *startNote,
-    Note *endNote, curvature_CURVEDIR drawingCurveDir)
+bool Tie::AdjustEnharmonicTies(const Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], const Note *startNote,
+    const Note *endNote, curvature_CURVEDIR drawingCurveDir)
 {
-    ListOfObjects objects = endNote->FindAllDescendantsByType(ACCID);
+    ListOfConstObjects objects = endNote->FindAllDescendantsByType(ACCID);
     if (objects.empty()) return false;
 
     int overlap = 0;
@@ -138,7 +138,7 @@ bool Tie::AdjustEnharmonicTies(Doc *doc, FloatingCurvePositioner *curve, Point b
     return true;
 }
 
-bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
+bool Tie::CalculatePosition(const Doc *doc, const Staff *staff, int x1, int x2, int spanningType, Point bezier[4])
 {
     if (!doc || !staff) return false;
 
@@ -211,7 +211,7 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
 
     /************** x positions **************/
 
-    CalculateXPosition(doc, staff, startParentChord, endParentChord, spanningType, isOuterChordNote, startPoint,
+    this->CalculateXPosition(doc, staff, startParentChord, endParentChord, spanningType, isOuterChordNote, startPoint,
         endPoint, drawingCurveDir);
 
     /************** y position **************/
@@ -273,8 +273,8 @@ bool Tie::CalculatePosition(Doc *doc, Staff *staff, int x1, int x2, int spanning
     return true;
 }
 
-int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChord, Note *note,
-    curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint)
+int Tie::CalculateAdjacentChordXOffset(const Doc *doc, const Staff *staff, const Chord *parentChord, const Note *note,
+    curvature_CURVEDIR drawingCurveDir, int initialX, bool isStartPoint) const
 {
     assert(parentChord);
     const int drawingUnit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
@@ -289,7 +289,7 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
             if ((curvature_CURVEDIR_below == drawingCurveDir) && (note == parentChord->GetBottomNote())) {
                 return defaultX;
             }
-            Stem *stem = parentChord->GetDrawingStem();
+            const Stem *stem = parentChord->GetDrawingStem();
             if (stem && !stem->IsVirtual()) {
                 return stem->GetContentRight() + 2 * radius + drawingUnit / 2;
             }
@@ -299,7 +299,8 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
         }
         else {
             if (!note) return defaultX;
-            const std::list<Note *> adjacentNotes = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
+            const std::list<const Note *> adjacentNotes
+                = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
             for (const auto adjacentNote : adjacentNotes) {
                 if (adjacentNote->GetDrawingX() > note->GetDrawingX()) {
                     if ((drawingCurveDir == curvature_CURVEDIR_above)
@@ -324,7 +325,7 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
             if ((curvature_CURVEDIR_above == drawingCurveDir) && (note == parentChord->GetTopNote())) {
                 return defaultX;
             }
-            Stem *stem = parentChord->GetDrawingStem();
+            const Stem *stem = parentChord->GetDrawingStem();
             if (stem && !stem->IsVirtual()) {
                 return stem->GetContentLeft() - 2 * radius - drawingUnit / 2;
             }
@@ -334,7 +335,8 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
         }
         else {
             if (!note) return defaultX;
-            const std::list<Note *> adjacentNotes = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
+            const std::list<const Note *> adjacentNotes
+                = parentChord->GetAdjacentNotesList(staff, note->GetDrawingLoc());
             for (const auto adjacentNote : adjacentNotes) {
                 if (adjacentNote->GetDrawingX() < note->GetDrawingX()) {
                     if ((drawingCurveDir == curvature_CURVEDIR_above)
@@ -352,11 +354,12 @@ int Tie::CalculateAdjacentChordXOffset(Doc *doc, Staff *staff, Chord *parentChor
     }
 }
 
-void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Chord *endParentChord, int spanningType,
-    bool isOuterChordNote, Point &startPoint, Point &endPoint, curvature_CURVEDIR drawingCurveDir)
+void Tie::CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *startParentChord,
+    const Chord *endParentChord, int spanningType, bool isOuterChordNote, Point &startPoint, Point &endPoint,
+    curvature_CURVEDIR drawingCurveDir) const
 {
-    Note *startNote = dynamic_cast<Note *>(this->GetStart());
-    Note *endNote = dynamic_cast<Note *>(this->GetEnd());
+    const Note *startNote = dynamic_cast<const Note *>(this->GetStart());
+    const Note *endNote = dynamic_cast<const Note *>(this->GetEnd());
 
     const int drawingUnit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     bool isShortTie = false;
@@ -390,7 +393,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
                 startPoint.x += r1 + drawingUnit / 2;
             }
             // endPoint
-            Staff *endStaff = staff;
+            const Staff *endStaff = staff;
             if (endParentChord) endStaff = endParentChord->GetAncestorStaff();
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(
@@ -405,7 +408,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
                 startPoint.x += drawingUnit;
             }
             else {
-                Dots *dots = vrv_cast<Dots *>(startParentChord->FindDescendantByType(DOTS));
+                const Dots *dots = vrv_cast<const Dots *>(startParentChord->FindDescendantByType(DOTS));
                 assert(dots);
                 startPoint.x = dots->GetDrawingX() + (1 + startParentChord->GetDots()) * drawingUnit;
             }
@@ -435,7 +438,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
             }
         }
         if (startParentChord && !isOuterChordNote && (startParentChord->GetDots() > 0)) {
-            Dots *dots = vrv_cast<Dots *>(startParentChord->FindDescendantByType(DOTS));
+            const Dots *dots = vrv_cast<const Dots *>(startParentChord->FindDescendantByType(DOTS));
             assert(dots);
             startPoint.x = dots->GetDrawingX() + (1 + startParentChord->GetDots()) * drawingUnit;
         }
@@ -450,7 +453,7 @@ void Tie::CalculateXPosition(Doc *doc, Staff *staff, Chord *startParentChord, Ch
         }
         if (!isShortTie) {
             // endPoint
-            Staff *endStaff = staff;
+            const Staff *endStaff = staff;
             if (endParentChord) endStaff = endParentChord->GetAncestorStaff();
             if (endParentChord && endParentChord->HasAdjacentNotesInStaff(endStaff)) {
                 endPoint.x = this->CalculateAdjacentChordXOffset(

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -75,8 +75,8 @@ void Tie::Reset()
     this->ResetCurveRend();
 }
 
-bool Tie::AdjustEnharmonicTies(const Doc *doc, FloatingCurvePositioner *curve, Point bezier[4], const Note *startNote,
-    const Note *endNote, curvature_CURVEDIR drawingCurveDir)
+bool Tie::AdjustEnharmonicTies(const Doc *doc, const FloatingCurvePositioner *curve, Point bezier[4],
+    const Note *startNote, const Note *endNote, curvature_CURVEDIR drawingCurveDir) const
 {
     ListOfConstObjects objects = endNote->FindAllDescendantsByType(ACCID);
     if (objects.empty()) return false;
@@ -466,8 +466,8 @@ void Tie::CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *st
     }
 }
 
-curvature_CURVEDIR Tie::GetPreferredCurveDirection(
-    Layer *layer, Note *note, Chord *startParentChord, data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter)
+curvature_CURVEDIR Tie::GetPreferredCurveDirection(const Layer *layer, const Note *note, const Chord *startParentChord,
+    data_STEMDIRECTION noteStemDir, bool isAboveStaffCenter) const
 {
     data_STEMDIRECTION layerStemDir;
     curvature_CURVEDIR drawingCurveDir = curvature_CURVEDIR_above;
@@ -504,10 +504,10 @@ curvature_CURVEDIR Tie::GetPreferredCurveDirection(
     return drawingCurveDir;
 }
 
-void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], LayerElement *durElement,
-    Note *startNote, int drawingUnit, curvature_CURVEDIR drawingCurveDir)
+void Tie::UpdateTiePositioning(const FloatingCurvePositioner *curve, Point bezier[4], const LayerElement *durElement,
+    const Note *startNote, int drawingUnit, curvature_CURVEDIR drawingCurveDir) const
 {
-    ListOfObjects objects;
+    ListOfConstObjects objects;
     ClassIdsComparison cmp({ DOT, DOTS, FLAG });
     durElement->FindAllDescendantsByComparison(&objects, &cmp);
 
@@ -527,13 +527,13 @@ void Tie::UpdateTiePositioning(FloatingCurvePositioner *curve, Point bezier[4], 
             // chord gets separate BB
             int oppositeOverlap = 0;
             // calculate position for the tie in case there is overlap with FLAG in the future
-            dotsPosition
-                = object->GetDrawingX() + (1 + dynamic_cast<AttAugmentDots *>(durElement)->GetDots()) * drawingUnit;
+            dotsPosition = object->GetDrawingX()
+                + (1 + dynamic_cast<const AttAugmentDots *>(durElement)->GetDots()) * drawingUnit;
             if (durElement->Is(CHORD)) {
                 // If this is chord, we need to make sure that ties is compared agains relative dot. Since all dots have
                 // one BB and this action is done for outer ties only, we can safely take height of the BB to determine
                 // margin for adjustment calculation
-                Chord *parentChord = vrv_cast<Chord *>(durElement);
+                const Chord *parentChord = vrv_cast<const Chord *>(durElement);
                 int offset = (object->GetSelfRight() - object->GetSelfLeft()) / parentChord->GetDots();
                 if ((drawingCurveDir == curvature_CURVEDIR_above) && (startNote != parentChord->GetTopNote())) {
                     margin = object->GetSelfBottom() - object->GetSelfTop() + offset;

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -79,7 +79,7 @@ wchar_t Turn::GetTurnGlyph() const
     return (this->GetForm() == turnLog_FORM_lower) ? SMUFL_E568_ornamentTurnInverted : SMUFL_E567_ornamentTurn;
 }
 
-int Turn::GetTurnHeight(Doc *doc, int staffSize) const
+int Turn::GetTurnHeight(const Doc *doc, int staffSize) const
 {
     assert(doc);
 

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -436,20 +436,20 @@ double StaffAlignment::GetJustificationFactor(const Doc *doc) const
     return justificationFactor;
 }
 
-int StaffAlignment::CalcOverflowAbove(BoundingBox *box)
+int StaffAlignment::CalcOverflowAbove(const BoundingBox *box) const
 {
     if (box->Is(FLOATING_POSITIONER)) {
-        FloatingPositioner *positioner = vrv_cast<FloatingPositioner *>(box);
+        const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(box);
         assert(positioner);
         return positioner->GetContentTop() - this->GetYRel();
     }
     return box->GetSelfTop() - this->GetYRel();
 }
 
-int StaffAlignment::CalcOverflowBelow(BoundingBox *box)
+int StaffAlignment::CalcOverflowBelow(const BoundingBox *box) const
 {
     if (box->Is(FLOATING_POSITIONER)) {
-        FloatingPositioner *positioner = vrv_cast<FloatingPositioner *>(box);
+        const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(box);
         assert(positioner);
         return -(positioner->GetContentBottom() + m_staffHeight - this->GetYRel());
     }
@@ -640,7 +640,12 @@ ArrayOfFloatingPositioners StaffAlignment::FindAllFloatingPositioners(ClassId cl
     return positioners;
 }
 
-FloatingPositioner *StaffAlignment::GetCorrespFloatingPositioner(FloatingObject *object)
+FloatingPositioner *StaffAlignment::GetCorrespFloatingPositioner(const FloatingObject *object)
+{
+    return const_cast<FloatingPositioner *>(std::as_const(*this).GetCorrespFloatingPositioner(object));
+}
+
+const FloatingPositioner *StaffAlignment::GetCorrespFloatingPositioner(const FloatingObject *object) const
 {
     auto item = std::find_if(m_floatingPositioners.begin(), m_floatingPositioners.end(),
         [object](FloatingPositioner *positioner) { return positioner->GetObject() == object; });


### PR DESCRIPTION
This PR improves const correctness for control elements by adding `const` to relevant member functions and arguments. No changes in behaviour are expected.