### PR TITLE
add support for artic.ges

### DIFF
--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -9,6 +9,7 @@
 #define __VRV_ARTIC_H__
 
 #include "atts_externalsymbols.h"
+#include "atts_gestural.h"
 #include "atts_shared.h"
 #include "layerelement.h"
 
@@ -20,6 +21,7 @@ namespace vrv {
 
 class Artic : public LayerElement,
               public AttArticulation,
+              public AttArticulationGestural,
               public AttColor,
               public AttEnclosingChars,
               public AttExtSym,

--- a/libmei/atts_gestural.cpp
+++ b/libmei/atts_gestural.cpp
@@ -87,14 +87,14 @@ AttArticulationGestural::~AttArticulationGestural()
 
 void AttArticulationGestural::ResetArticulationGestural()
 {
-    m_articGes = ARTICULATION_NONE;
+    m_articGes = std::vector<data_ARTICULATION>();
 }
 
 bool AttArticulationGestural::ReadArticulationGestural(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("artic.ges")) {
-        this->SetArticGes(StrToArticulation(element.attribute("artic.ges").value()));
+        this->SetArticGes(StrToArticulationList(element.attribute("artic.ges").value()));
         element.remove_attribute("artic.ges");
         hasAttribute = true;
     }
@@ -105,7 +105,7 @@ bool AttArticulationGestural::WriteArticulationGestural(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasArticGes()) {
-        element.append_attribute("artic.ges") = ArticulationToStr(this->GetArticGes()).c_str();
+        element.append_attribute("artic.ges") = ArticulationListToStr(this->GetArticGes()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -113,7 +113,7 @@ bool AttArticulationGestural::WriteArticulationGestural(pugi::xml_node element)
 
 bool AttArticulationGestural::HasArticGes() const
 {
-    return (m_articGes != ARTICULATION_NONE);
+    return (m_articGes != std::vector<data_ARTICULATION>());
 }
 
 /* include <attartic.ges> */
@@ -817,7 +817,7 @@ bool Att::SetGestural(Object *element, const std::string &attrType, const std::s
         AttArticulationGestural *att = dynamic_cast<AttArticulationGestural *>(element);
         assert(att);
         if (attrType == "artic.ges") {
-            att->SetArticGes(att->StrToArticulation(attrValue));
+            att->SetArticGes(att->StrToArticulationList(attrValue));
             return true;
         }
     }
@@ -978,7 +978,7 @@ void Att::GetGestural(const Object *element, ArrayOfStrAttr *attributes)
         const AttArticulationGestural *att = dynamic_cast<const AttArticulationGestural *>(element);
         assert(att);
         if (att->HasArticGes()) {
-            attributes->push_back({ "artic.ges", att->ArticulationToStr(att->GetArticGes()) });
+            attributes->push_back({ "artic.ges", att->ArticulationListToStr(att->GetArticGes()) });
         }
     }
     if (element->HasAttClass(ATT_BENDGES)) {

--- a/libmei/atts_gestural.h
+++ b/libmei/atts_gestural.h
@@ -85,14 +85,14 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetArticGes(data_ARTICULATION articGes_) { m_articGes = articGes_; }
-    data_ARTICULATION GetArticGes() const { return m_articGes; }
+    void SetArticGes(data_ARTICULATION_List articGes_) { m_articGes = articGes_; }
+    data_ARTICULATION_List GetArticGes() const { return m_articGes; }
     bool HasArticGes() const;
     ///@}
 
 private:
     /** Records performed articulation that differs from the written value. **/
-    data_ARTICULATION m_articGes;
+    data_ARTICULATION_List m_articGes;
 
     /* include <attartic.ges> */
 };

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -42,12 +42,14 @@ static const ClassRegistrar<Artic> s_factory("artic", ARTIC);
 Artic::Artic()
     : LayerElement(ARTIC, "artic-")
     , AttArticulation()
+    , AttArticulationGestural()
     , AttColor()
     , AttEnclosingChars()
     , AttExtSym()
     , AttPlacementRelEvent()
 {
     this->RegisterAttClass(ATT_ARTICULATION);
+    this->RegisterAttClass(ATT_ARTICULATIONGESTURAL);
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
     this->RegisterAttClass(ATT_EXTSYM);
@@ -62,6 +64,7 @@ void Artic::Reset()
 {
     LayerElement::Reset();
     this->ResetArticulation();
+    this->ResetArticulationGestural();
     this->ResetColor();
     this->ResetEnclosingChars();
     this->ResetExtSym();

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2170,6 +2170,7 @@ void MEIOutput::WriteArtic(pugi::xml_node currentNode, Artic *artic)
 
     this->WriteLayerElement(currentNode, artic);
     artic->WriteArticulation(currentNode);
+    artic->WriteArticulationGestural(currentNode);
     artic->WriteColor(currentNode);
     artic->WriteEnclosingChars(currentNode);
     artic->WriteExtSym(currentNode);
@@ -5817,6 +5818,7 @@ bool MEIInput::ReadArtic(Object *parent, pugi::xml_node artic)
     this->ReadLayerElement(artic, vrvArtic);
 
     vrvArtic->ReadArticulation(artic);
+    vrvArtic->ReadArticulationGestural(artic);
     vrvArtic->ReadColor(artic);
     vrvArtic->ReadEnclosingChars(artic);
     vrvArtic->ReadExtSym(artic);


### PR DESCRIPTION
This PR adds basic support for `arctic.ges` as asked in #2881.
The corresponding PR for the change in LibMEI can be found in https://github.com/rism-digital/libmei/pull/12.