### PR TITLE
Allow for stems on chords without duration

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -717,7 +717,7 @@ int Chord::CalcStem(FunctorParams *functorParams)
     params->m_staff = staff;
     params->m_layer = layer;
     params->m_interface = this;
-    params->m_dur = this->GetActualDur();
+    params->m_dur = this->GetNoteOrChordDur(this);
     params->m_isGraceNote = this->IsGraceNote();
     params->m_isStemSameasSecondary = false;
 
@@ -855,11 +855,12 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
     currentStem->AttGraced::operator=(*this);
     currentStem->AttStems::operator=(*this);
     currentStem->AttStemsCmn::operator=(*this);
-    if (this->GetActualDur() < DUR_2 || (this->GetStemVisible() == BOOLEAN_false)) {
+    int duration = this->GetNoteOrChordDur(this);
+    if ((duration < DUR_2) || (this->GetStemVisible() == BOOLEAN_false)) {
         currentStem->IsVirtual(true);
     }
 
-    if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->GetAncestorFTrem()) {
+    if ((duration > DUR_4) && !this->IsInBeam() && !this->GetAncestorFTrem()) {
         // We should have a stem at this stage
         assert(currentStem);
         if (!currentFlag) {

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -199,13 +199,13 @@ int DurationInterface::GetNoteOrChordDur(const LayerElement *element) const
 {
     if (element->Is(CHORD)) {
         int duration = this->GetActualDur();
-        const Chord *chord = vrv_cast<const Chord *>(element);
         if (duration != DUR_NONE) return duration;
 
+        const Chord *chord = vrv_cast<const Chord *>(element);
         for (const Note *note : { chord->GetTopNote(), chord->GetBottomNote() }) {
-            const int noteDur = note->GetActualDur();
-            if (noteDur != DUR_NONE) {
-                return noteDur;
+            duration = note->GetActualDur();
+            if (duration != DUR_NONE) {
+                return duration;
             }
         }        
     }

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -198,7 +198,16 @@ int DurationInterface::CalcActualDur(data_DURATION dur) const
 int DurationInterface::GetNoteOrChordDur(const LayerElement *element) const
 {
     if (element->Is(CHORD)) {
-        return this->GetActualDur();
+        int duration = this->GetActualDur();
+        const Chord *chord = vrv_cast<const Chord *>(element);
+        if (duration != DUR_NONE) return duration;
+
+        for (const Note *note : { chord->GetTopNote(), chord->GetBottomNote() }) {
+            const int noteDur = note->GetActualDur();
+            if (noteDur != DUR_NONE) {
+                return noteDur;
+            }
+        }        
     }
     else if (element->Is(NOTE)) {
         const Note *note = vrv_cast<const Note *>(element);


### PR DESCRIPTION
Changed code to check for duration of chord children if chord doesn't have one.
![image](https://user-images.githubusercontent.com/1819669/176467358-e3e0f36a-7c25-4c44-b799-78d56154ddad.png)

<details><summary>Example:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>44 Duos: No.23 Wedding Song</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <resp>Prepared by</resp>
               <persName>Zoltán Kőmíves</persName>
            </respStmt>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.mode="minor" key.pname="d">
                        <label>Violin I.</label>
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="8">
                     <staff n="1">
                        <layer n="1">
                           
                              <chord>
                                 <note dur="8" oct="5" pname="d" />
                                 <note dur="8" oct="4" pname="d">
                                    <artic artic="acc" />
                                 </note>
                              </chord>
                              <chord>
                                 <note dur="8" oct="4" pname="a" />
                                 <note dur="8" oct="4" pname="f" accid="s">
                                    <artic artic="dot" />
                                 </note>
                              </chord>
                           <rest dur="4" />
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="9">
                     <staff n="1">
                        <layer n="1">
                           <rest dur="2" />
                           <chord>
                              <note dur="2" oct="4" pname="a" />
                              <note dur="2" oct="4" pname="g" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>