### PR TITLE
Create symbol string for Accid and KeyAccid 

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -118,9 +118,9 @@ public:
     /**
      * Create the SMuFL string based on various properties
      */
-    static std::wstring CreateSymbolStr(const Resources *resources, data_ACCIDENTAL_WRITTEN accid,
-        data_ENCLOSURE enclosure = ENCLOSURE_NONE, data_NOTATIONTYPE notationType = NOTATIONTYPE_NONE,
-        data_HEXNUM glyphNum = 0, std::string glyphName = "");
+    static std::wstring CreateSymbolStr(data_ACCIDENTAL_WRITTEN accid, data_ENCLOSURE enclosure = ENCLOSURE_NONE,
+        data_NOTATIONTYPE notationType = NOTATIONTYPE_NONE, const Resources *resources = NULL, data_HEXNUM glyphNum = 0,
+        std::string glyphName = "");
 
     //----------//
     // Functors //

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -85,7 +85,7 @@ public:
      * Retrieve SMuFL string for the accidental.
      * This will include brackets
      */
-    std::wstring GetSymbolStr(const data_NOTATIONTYPE notationType) const;
+    std::wstring GetSymbolStr(data_NOTATIONTYPE notationType) const;
 
     /**
      * Adjust X position of accid in relation to other element
@@ -113,7 +113,14 @@ public:
     /**
      * @name Method used for drawing accidentals on ornaments
      */
-    static wchar_t GetAccidGlyph(data_ACCIDENTAL_WRITTEN);
+    static wchar_t GetAccidGlyph(data_ACCIDENTAL_WRITTEN accid);
+
+    /**
+     * Create the SMuFL string based on various properties
+     */
+    static std::wstring CreateSymbolStr(const Resources *resources, data_ACCIDENTAL_WRITTEN accid,
+        data_ENCLOSURE enclosure = ENCLOSURE_NONE, data_NOTATIONTYPE notationType = NOTATIONTYPE_NONE,
+        data_HEXNUM glyphNum = 0, std::string glyphName = "");
 
     //----------//
     // Functors //

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_KEYACCID_H__
 #define __VRV_KEYACCID_H__
 
+#include "atts_externalsymbols.h"
 #include "atts_gestural.h"
 #include "layerelement.h"
 #include "pitchinterface.h"
@@ -27,7 +28,8 @@ class KeyAccid : public LayerElement,
                  public PositionInterface,
                  public AttAccidental,
                  public AttColor,
-                 public AttEnclosingChars {
+                 public AttEnclosingChars,
+                 public AttExtSym {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -55,7 +55,7 @@ public:
      * Retrieve SMuFL string for the accidental.
      * This will include brackets
      */
-    std::wstring GetSymbolStr() const;
+    std::wstring GetSymbolStr(data_NOTATIONTYPE notationType) const;
 
     /**
      * Determine the staff location

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -225,8 +225,6 @@ wchar_t Accid::GetAccidGlyph(data_ACCIDENTAL_WRITTEN accid)
 std::wstring Accid::CreateSymbolStr(data_ACCIDENTAL_WRITTEN accid, data_ENCLOSURE enclosure,
     data_NOTATIONTYPE notationType, const Resources *resources, data_HEXNUM glyphNum, std::string glyphName)
 {
-    if (accid == ACCIDENTAL_WRITTEN_NONE) return L"";
-
     wchar_t code = 0;
 
     if (resources) {
@@ -243,6 +241,8 @@ std::wstring Accid::CreateSymbolStr(data_ACCIDENTAL_WRITTEN accid, data_ENCLOSUR
     }
 
     if (!code) {
+        if (accid == ACCIDENTAL_WRITTEN_NONE) return L"";
+
         switch (notationType) {
             case NOTATIONTYPE_mensural:
             case NOTATIONTYPE_mensural_black:

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -75,7 +75,7 @@ void Accid::Reset()
 
 std::wstring Accid::GetSymbolStr(data_NOTATIONTYPE notationType) const
 {
-    return Accid::CreateSymbolStr(this->GetDocResources(), this->GetAccid(), this->GetEnclose(), notationType,
+    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose(), notationType, this->GetDocResources(),
         this->GetGlyphNum(), this->GetGlyphName());
 }
 
@@ -222,23 +222,24 @@ wchar_t Accid::GetAccidGlyph(data_ACCIDENTAL_WRITTEN accid)
     return 0;
 }
 
-std::wstring Accid::CreateSymbolStr(const Resources *resources, data_ACCIDENTAL_WRITTEN accid, data_ENCLOSURE enclosure,
-    data_NOTATIONTYPE notationType, data_HEXNUM glyphNum, std::string glyphName)
+std::wstring Accid::CreateSymbolStr(data_ACCIDENTAL_WRITTEN accid, data_ENCLOSURE enclosure,
+    data_NOTATIONTYPE notationType, const Resources *resources, data_HEXNUM glyphNum, std::string glyphName)
 {
     if (accid == ACCIDENTAL_WRITTEN_NONE) return L"";
-    if (!resources) return L"";
 
     wchar_t code = 0;
 
-    // If there is glyph.num, prioritize it
-    if (glyphNum != 0) {
-        code = glyphNum;
-        if (NULL == resources->GetGlyph(code)) code = 0;
-    }
-    // If there is glyph.name (second priority)
-    else if (!glyphName.empty()) {
-        code = resources->GetGlyphCode(glyphName);
-        if (NULL == resources->GetGlyph(code)) code = 0;
+    if (resources) {
+        // If there is glyph.num, prioritize it
+        if (glyphNum != 0) {
+            code = glyphNum;
+            if (NULL == resources->GetGlyph(code)) code = 0;
+        }
+        // If there is glyph.name (second priority)
+        else if (!glyphName.empty()) {
+            code = resources->GetGlyphCode(glyphName);
+            if (NULL == resources->GetGlyph(code)) code = 0;
+        }
     }
 
     if (!code) {
@@ -259,20 +260,18 @@ std::wstring Accid::CreateSymbolStr(const Resources *resources, data_ACCIDENTAL_
     }
 
     std::wstring symbolStr;
-    if (enclosure != ENCLOSURE_NONE) {
-        if (enclosure == ENCLOSURE_brack) {
+    switch (enclosure) {
+        case ENCLOSURE_brack:
             symbolStr.push_back(SMUFL_E26C_accidentalBracketLeft);
             symbolStr.push_back(code);
             symbolStr.push_back(SMUFL_E26D_accidentalBracketRight);
-        }
-        else {
+            break;
+        case ENCLOSURE_paren:
             symbolStr.push_back(SMUFL_E26A_accidentalParensLeft);
             symbolStr.push_back(code);
             symbolStr.push_back(SMUFL_E26B_accidentalParensRight);
-        }
-    }
-    else {
-        symbolStr.push_back(code);
+            break;
+        default: symbolStr.push_back(code); break;
     }
     return symbolStr;
 }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2323,6 +2323,7 @@ void MEIOutput::WriteKeyAccid(pugi::xml_node currentNode, KeyAccid *keyAccid)
     keyAccid->WriteAccidental(currentNode);
     keyAccid->WriteColor(currentNode);
     keyAccid->WriteEnclosingChars(currentNode);
+    keyAccid->WriteExtSym(currentNode);
 }
 
 void MEIOutput::WriteKeySig(pugi::xml_node currentNode, KeySig *keySig)
@@ -6053,6 +6054,7 @@ bool MEIInput::ReadKeyAccid(Object *parent, pugi::xml_node keyAccid)
     vrvKeyAccid->ReadAccidental(keyAccid);
     vrvKeyAccid->ReadColor(keyAccid);
     vrvKeyAccid->ReadEnclosingChars(keyAccid);
+    vrvKeyAccid->ReadExtSym(keyAccid);
 
     parent->AddChild(vrvKeyAccid);
     this->ReadUnsupportedAttr(keyAccid, vrvKeyAccid);

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -61,30 +61,7 @@ void KeyAccid::Reset()
 
 std::wstring KeyAccid::GetSymbolStr() const
 {
-    if (!this->HasAccid()) return L"";
-
-    wchar_t symc = Accid::GetAccidGlyph(this->GetAccid());
-    std::wstring symbolStr;
-
-    if (this->HasEnclose()) {
-        switch (this->GetEnclose()) {
-            case ENCLOSURE_brack:
-                symbolStr.push_back(SMUFL_E26C_accidentalBracketLeft);
-                symbolStr.push_back(symc);
-                symbolStr.push_back(SMUFL_E26D_accidentalBracketRight);
-                break;
-            case ENCLOSURE_paren:
-                symbolStr.push_back(SMUFL_E26A_accidentalParensLeft);
-                symbolStr.push_back(symc);
-                symbolStr.push_back(SMUFL_E26B_accidentalParensRight);
-                break;
-            default: symbolStr.push_back(symc);
-        }
-    }
-    else {
-        symbolStr.push_back(symc);
-    }
-    return symbolStr;
+    return Accid::CreateSymbolStr(this->GetDocResources(), this->GetAccid(), this->GetEnclose());
 }
 
 int KeyAccid::CalcStaffLoc(Clef *clef, int clefLocOffset) const

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -59,9 +59,9 @@ void KeyAccid::Reset()
     this->ResetEnclosingChars();
 }
 
-std::wstring KeyAccid::GetSymbolStr() const
+std::wstring KeyAccid::GetSymbolStr(data_NOTATIONTYPE notationType) const
 {
-    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose());
+    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose(), notationType);
 }
 
 int KeyAccid::CalcStaffLoc(Clef *clef, int clefLocOffset) const

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -36,6 +36,7 @@ KeyAccid::KeyAccid()
     , AttAccidental()
     , AttColor()
     , AttEnclosingChars()
+    , AttExtSym()
 {
 
     this->RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
@@ -43,6 +44,7 @@ KeyAccid::KeyAccid()
     this->RegisterAttClass(ATT_ACCIDENTAL);
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
+    this->RegisterAttClass(ATT_EXTSYM);
 
     this->Reset();
 }
@@ -57,11 +59,13 @@ void KeyAccid::Reset()
     this->ResetAccidental();
     this->ResetColor();
     this->ResetEnclosingChars();
+    this->ResetExtSym();
 }
 
 std::wstring KeyAccid::GetSymbolStr(data_NOTATIONTYPE notationType) const
 {
-    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose(), notationType);
+    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose(), notationType, this->GetDocResources(),
+        this->GetGlyphNum(), this->GetGlyphName());
 }
 
 int KeyAccid::CalcStaffLoc(Clef *clef, int clefLocOffset) const

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -61,7 +61,7 @@ void KeyAccid::Reset()
 
 std::wstring KeyAccid::GetSymbolStr() const
 {
-    return Accid::CreateSymbolStr(this->GetDocResources(), this->GetAccid(), this->GetEnclose());
+    return Accid::CreateSymbolStr(this->GetAccid(), this->GetEnclose());
 }
 
 int KeyAccid::CalcStaffLoc(Clef *clef, int clefLocOffset) const

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -988,7 +988,7 @@ void View::DrawMeterSig(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
 void View::DrawKeyAccid(DeviceContext *dc, KeyAccid *keyAccid, Staff *staff, Clef *clef, int clefLocOffset, int &x)
 {
-    const std::wstring symbolStr = keyAccid->GetSymbolStr();
+    const std::wstring symbolStr = keyAccid->GetSymbolStr(staff->m_drawingNotationType);
     const int loc = keyAccid->CalcStaffLoc(clef, clefLocOffset);
     const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(m_doc, loc);
 


### PR DESCRIPTION
This PR unifies the creation of the symbol string for Accid and KeyAccid by directing the work to a static function.

As an application we enable mensural notation and support for `@glyph.num / @glyph.name` for KeyAccid.

<img width="402" alt="Mensural" src="https://user-images.githubusercontent.com/63608463/176688568-f36ae4dc-2496-4477-8347-3dbc785e067e.png">
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Mensural accidentals</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2021-11-15">2021-11-15</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio uses appropriate glyphs for accidentals in mensural notation.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.7.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" notationtype="mensural" lines="5" key.sig="2f">
                        <clef shape="C" line="1" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <note dur="semibrevis" oct="4" pname="f">
                           <accid accid="s" />
                        </note>
                        <note dur="semibrevis" oct="4" pname="b">
                           <accid accid="n" />
                        </note>
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<img width="378" alt="GlyphNumName" src="https://user-images.githubusercontent.com/63608463/176688785-4d728457-db6d-4fb9-a5c3-d988693ac017.png">
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Non-standard key signatures</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
            <date isodate="2019-09-09">9 Sep 2019</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio renders non-standard key signatures encoded with keyAccid.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.2.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="400" key.mode="aeolian" key.sig="5f" keysig.showchange="false">
                  <staffGrp bar.thru="false">
                     <staffDef n="1" lines="5" meter.count="4" meter.unit="2">
                        <label>Canto</label>
                        <labelAbbr>C</labelAbbr>
                        <clef shape="G" line="2" visible="false" />
                        <keySig>
                           <keyAccid pname="b" glyph.num="U+E444" />
                           <keyAccid pname="f" glyph.name="accidentalBuyukMucennebSharp" />
                        </keySig>
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure type="m--1">
                     <staff n="1">
                        <layer n="1">
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
