### PR TITLE
More JavaScript and npm package improvements 

### DIFF
--- a/emscripten/npm/README.md
+++ b/emscripten/npm/README.md
@@ -4,24 +4,66 @@ Verovio is a fast, portable and lightweight library for engraving [Music Encodin
 
 See it running in the [MEI Viewer](http://www.verovio.org/mei-viewer.xhtml) and check out the [tutorial](http://www.verovio.org/tutorial.xhtml) for its web integration and for enabling user interaction.
 
-## Usage
+
+## Basic usage
 
 ```javascript
-var verovio = require( 'verovio' );
-var fs = require( 'fs' );
+const verovio = require('verovio');
+const fs = require('fs');
 
 /* Wait for verovio to load */
 verovio.module.onRuntimeInitialized = function ()
 {
-    /* create the toolkit instance */
-    var vrvToolkit = new verovio.toolkit();
-    /* read the MEI file */
-	mei = fs.readFileSync("hello.mei");
-    /* load the MEI data as string into the toolkit */
+   // create the toolkit instance
+   const vrvToolkit = new verovio.toolkit();
+   // read the MEI file
+	mei = fs.readFileSync('hello.mei');
+   // load the MEI data as string into the toolkit
 	vrvToolkit.loadData(mei.toString());
-    /* render the fist page as SVG */
+   // render the fist page as SVG
 	svg = vrvToolkit.renderToSVG(1, {});
-    /* save the SVG into a file */
-	fs.writeFileSync("hello.svg", svg);
+   // save the SVG into a file
+	fs.writeFileSync('hello.svg', svg);
 }
 ```
+
+
+## Usage with ESM
+
+This package also provides an ESM version which can be used with a modularized build of the Verovio module. Use `.mjs` as file extension when using this directly in Node.js or set `"type": "module"` in your `package.json`.
+
+```js
+import createVerovioModule from 'verovio/wasm';
+import { VerovioToolkit } from 'verovio/esm';
+import fs from 'node:fs';
+
+createVerovioModule().then(VerovioModule => {
+   const verovioToolkit = new VerovioToolkit(VerovioModule);
+   const score = fs.readFileSync('hello.mei').toString();
+   verovioToolkit.loadData(score);
+   const data = verovioToolkit.renderToSVG(1, {});
+   console.log(data);
+});
+```
+
+This is the recommended way to use Verovio when creating a website or web app with bundlers like webpack or Vite or when using JavaScript frameworks like React or Vue.js.
+
+
+## Usage with CommonJS
+
+Alternatively this package also exports a version compatible with CommonJS
+
+```js
+const createVerovioModule = require('verovio/wasm');
+const { VerovioToolkit } = require('verovio/esm');
+```
+
+
+# Humdrum support
+
+Since version 3.11.0 the npm package provides an additional module with Humdrum support:
+
+```js
+import createVerovioModule from 'verovio/wasm-hum';
+```
+

--- a/emscripten/npm/package.json
+++ b/emscripten/npm/package.json
@@ -5,7 +5,7 @@
   "main": "dist/verovio-toolkit-wasm.js",
   "exports": {
     ".": "./dist/verovio-toolkit-wasm.js",
-    "./next": {
+    "./esm": {
       "import": "./dist/verovio.mjs",
       "require": "./dist/verovio.cjs"
     },

--- a/emscripten/npm/package.json
+++ b/emscripten/npm/package.json
@@ -12,7 +12,9 @@
     "./wasm": "./dist/verovio-module.js",
     "./wasm-hum": "./dist/verovio-module-hum.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rollup --config",
     "prebundle": "rollup --config rollup.config.prebundle.js"

--- a/emscripten/npm/src/prebundle-module.js
+++ b/emscripten/npm/src/prebundle-module.js
@@ -7,6 +7,12 @@ class VerovioToolkitDefaultModule extends VerovioToolkit {
     }
 };
 
+// Assign Module to window to prevent breaking changes.
+// Deprecated, use verovio.module instead.
+if (typeof window !== 'undefined') {
+    window.Module = DefaultVerovioModule;
+}
+
 export default {
     module: DefaultVerovioModule,
     toolkit: VerovioToolkitDefaultModule,

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -193,16 +193,10 @@ export class VerovioToolkit {
 VerovioToolkit.instances = [];
 
 
-
-
-/***************************************************************************************************************************/
-
 // If the window object is defined (if we are not within a WebWorker)...
-if ((typeof window !== 'undefined') && (window.addEventListener))
-{
+if ((typeof window !== 'undefined') && (window.addEventListener)) {
     // Add a listener that will delete the object (if necessary) when the page is closed
-    window.addEventListener('unload', function()
-    {
+    window.addEventListener('unload', () => {
         VerovioToolkit.instances.forEach((instance) => {
             instance.destroy();
         });

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -11,11 +11,11 @@ export class VerovioToolkit {
         this.proxy = createEmscriptenProxy(this.VerovioModule);
         this.ptr = this.proxy.constructor();
         console.debug('Creating toolkit instance');
-        VerovioToolkit.instances.push(this.ptr);
+        VerovioToolkit.instances.push(this);
     }
 
     destroy() {
-        VerovioToolkit.instances.splice(VerovioToolkit.instances.indexOf(this.ptr), 1);
+        VerovioToolkit.instances.splice(VerovioToolkit.instances.findIndex(i => i.ptr === this.ptr), 1);
         console.debug('Deleting toolkit instance');
         this.proxy.destructor(this.ptr);
     }
@@ -203,9 +203,8 @@ if ((typeof window !== 'undefined') && (window.addEventListener))
     // Add a listener that will delete the object (if necessary) when the page is closed
     window.addEventListener('unload', function()
     {
-        for (var i = 0; i < VerovioToolkit.instances.length; i++)
-        {
-            this.proxy.destructor(instances[i]);
-        }
+        VerovioToolkit.instances.forEach((instance) => {
+            instance.destroy();
+        });
     });
 }

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -6,7 +6,7 @@ export class VerovioToolkit {
     constructor(VerovioModule) {
         this.VerovioModule = VerovioModule;
         if (!this.VerovioModule) {
-            throw new Error('VerovioToolkit could not find emscripten module.');
+            throw new Error('VerovioToolkit needs VerovioModule passed as argument to the constructor.');
         }
         this.proxy = createEmscriptenProxy(this.VerovioModule);
         this.ptr = this.proxy.constructor();


### PR DESCRIPTION
Changes since #2937:

* Added export of Module on global `window.Module` variable for backwards compatibility
* Fixed `VerovioToolkit.destroy()` and `window.unload` event
* Improved error message if no module is passed to the VerovioToolkit constructor
* Changed export name from `verovio/next` to `verovio/esm`
* Added documentation and ESM examples in `README.md`