### PR TITLE
Vertical placement of mixed beams

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -125,7 +125,7 @@ private:
     int CalcBeamSlopeStep(
         const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep);
 
-    void CalcMixedBeamStem(const BeamDrawingInterface *beamInterface, int step);
+    void CalcMixedBeamPosition(const BeamDrawingInterface *beamInterface, int step);
 
     void CalcBeamPosition(const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -172,7 +172,7 @@ private:
 
     // Helper to check whether beam fits within certain bounds
     bool DoesBeamOverlap(
-        int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false) const;
+        int staffTop, int topOffset, int staffBottom, int bottomOffset, int unit, bool isCrossStaff = false) const;
 
     // Helper to calculate the minimal stem length of above/below notes
     std::pair<int, int> GetMinimalStemLength(const BeamDrawingInterface *beamInterface, bool hasFrenchStyle) const;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -171,14 +171,13 @@ private:
     void CalcSetValues();
 
     // Helper to check whether beam fits within certain bounds
-    bool DoesBeamOverlap(
-        int staffTop, int topOffset, int staffBottom, int bottomOffset, int unit, bool isCrossStaff = false) const;
+    bool DoesBeamOverlap(const BeamDrawingInterface *beamInterface, int topBorder, int bottomBorder, int unit) const;
 
     // Helper to calculate the vertical offset of the beam top/bottom w.r.t. the beam center
     std::pair<int, int> GetVerticalOffset(const BeamDrawingInterface *beamInterface) const;
 
     // Helper to calculate the minimal stem length of above/below notes
-    std::pair<int, int> GetMinimalStemLength(const BeamDrawingInterface *beamInterface, bool hasFrenchStyle) const;
+    std::pair<int, int> GetMinimalStemLength(const BeamDrawingInterface *beamInterface) const;
 
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly
     bool NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -165,9 +165,12 @@ private:
     // Helper to simply set the values of each BeamElementCoord according the the first position and the slope
     void CalcSetValues();
 
-    // Helper to check wheter beam fits within certain bounds
+    // Helper to check whether beam fits within certain bounds
     bool DoesBeamOverlap(
         int staffTop, int topOffset, int staffBottom, int bottomOffset, bool isCrossStaff = false) const;
+
+    // Helper to calculate the minimal stem length of above/below notes
+    std::pair<int, int> GetMinimalStemLength(const BeamDrawingInterface *beamInterface, bool hasFrenchStyle) const;
 
     // Helper to check mixed beam positioning compared to other elements (ledger lines, staff) and adjust it accordingly
     bool NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingInterface *beamInterface);

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -125,7 +125,7 @@ private:
     int CalcBeamSlopeStep(
         const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, int noteStep, bool &shortStep);
 
-    void CalcMixedBeamPosition(const BeamDrawingInterface *beamInterface, int step);
+    void CalcMixedBeamPosition(const BeamDrawingInterface *beamInterface, int step, int unit);
 
     void CalcBeamPosition(const Doc *doc, const Staff *staff, BeamDrawingInterface *beamInterface, bool isHorizontal);
 
@@ -154,6 +154,9 @@ private:
 
     // Helper to calculate max/min beam points for the relative beam place
     std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;
+
+    // Helper to calculate the vertical center of mixed beams
+    int CalcMixedBeamCenterY(int step, int unit) const;
 
     // Helper to calculate location and duration of the note that would be setting highest/lowest point for the beam
     std::pair<int, int> CalcStemDefiningNote(const Staff *staff, data_BEAMPLACE place) const;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -152,9 +152,6 @@ private:
     // Helper to set the stem values for tablature
     void CalcSetStemValuesTab(const Staff *staff, const Doc *doc, const BeamDrawingInterface *beamInterface);
 
-    // Helper to calculate max/min beam points for the relative beam place
-    std::pair<int, int> CalcBeamRelativeMinMax(data_BEAMPLACE place) const;
-
     // Helper to calculate the vertical center of mixed beams
     int CalcMixedBeamCenterY(int step, int unit) const;
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -171,7 +171,8 @@ private:
     void CalcSetValues();
 
     // Helper to check whether beam fits within certain bounds
-    bool DoesBeamOverlap(const BeamDrawingInterface *beamInterface, int topBorder, int bottomBorder, int unit) const;
+    bool DoesBeamOverlap(
+        const BeamDrawingInterface *beamInterface, int topBorder, int bottomBorder, int minStemLength) const;
 
     // Helper to calculate the vertical offset of the beam top/bottom w.r.t. the beam center
     std::pair<int, int> GetVerticalOffset(const BeamDrawingInterface *beamInterface) const;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -174,6 +174,9 @@ private:
     bool DoesBeamOverlap(
         int staffTop, int topOffset, int staffBottom, int bottomOffset, int unit, bool isCrossStaff = false) const;
 
+    // Helper to calculate the vertical offset of the beam top/bottom w.r.t. the beam center
+    std::pair<int, int> GetVerticalOffset(const BeamDrawingInterface *beamInterface) const;
+
     // Helper to calculate the minimal stem length of above/below notes
     std::pair<int, int> GetMinimalStemLength(const BeamDrawingInterface *beamInterface, bool hasFrenchStyle) const;
 

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -97,6 +97,11 @@ public:
     void CalcNoteHeadShiftForStemSameas(Beam *sameasBeam, data_BEAMPLACE place);
     ///@}
 
+    /**
+     * Request staff space for mixed beams if minimal stem length is too short
+     */
+    void RequestStaffSpace(const Doc *doc, const BeamDrawingInterface *beamInterface);
+
 private:
     // Helper to adjust stem length to extend only towards outmost subbeam (if option "--beam-french-style" is set)
     void AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterface);

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -651,6 +651,7 @@ public:
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
     OptionBool m_beamMixedPreserve;
+    OptionDbl m_beamMixedStemMin;
     OptionDbl m_bracketThickness;
     OptionBool m_breaksNoWidow;
     OptionDbl m_dynamDist;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -647,9 +647,10 @@ public:
 
     OptionDbl m_barLineSeparation;
     OptionDbl m_barLineWidth;
+    OptionBool m_beamFrenchStyle;
     OptionInt m_beamMaxSlope;
     OptionInt m_beamMinSlope;
-    OptionBool m_beamFrenchStyle;
+    OptionBool m_beamMixedPreserve;
     OptionDbl m_bracketThickness;
     OptionBool m_breaksNoWidow;
     OptionDbl m_dynamDist;

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -173,11 +173,6 @@ public:
      */
     virtual void SetFromFacsimile(Doc *doc);
 
-    /**
-     * Set beam adjustment for the corresponding staff alignment
-     */
-    void SetAlignmentBeamAdjustment(int adjust);
-
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -293,14 +293,6 @@ public:
         const ArrayOfFloatingPositioners &positioners, ArrayOfIntPairs &grpIdYRel);
 
     /**
-     * @name Set/get for the beam adjust
-     */
-    ///@{
-    void SetBeamAdjust(int beamAdjust) { m_beamAdjust = beamAdjust; }
-    int GetBeamAdjust() const { return m_beamAdjust; }
-    ///@}
-
-    /**
      * Find overflow for the alignments taking bracket group elements into account
      */
     void AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous, int spacing);
@@ -409,9 +401,6 @@ private:
     int m_scoreDefClefOverflowAbove;
     int m_scoreDefClefOverflowBelow;
     ///@}
-
-    // Value to store required beam adjustment for cross-staff beams
-    int m_beamAdjust = 0;
 
     /**
      * The list of overflowing bounding boxes (e.g, LayerElement or FloatingPositioner)

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -249,6 +249,8 @@ public:
     int GetRequestedSpaceAbove() const { return m_requestedSpaceAbove; }
     void SetRequestedSpaceBelow(int space);
     int GetRequestedSpaceBelow() const { return m_requestedSpaceBelow; }
+    void SetRequestedSpacing(int spacing) { m_requestedSpacing = spacing; }
+    int GetRequestedSpacing() const { return m_requestedSpacing; }
     int GetStaffHeight() const { return m_staffHeight; }
     void SetScoreDefClefOverflowAbove(int overflowAbove) { m_scoreDefClefOverflowAbove = overflowAbove; }
     int GetScoreDefClefOverflowAbove() const { return m_scoreDefClefOverflowAbove; }
@@ -402,6 +404,7 @@ private:
     int m_overlap;
     int m_requestedSpaceAbove;
     int m_requestedSpaceBelow;
+    int m_requestedSpacing;
     int m_staffHeight;
     int m_scoreDefClefOverflowAbove;
     int m_scoreDefClefOverflowBelow;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -306,7 +306,7 @@ bool BeamSegment::DoesBeamOverlap(
 
     // Check for minimal stem length
     const auto [minLengthAbove, minLengthBelow] = this->GetMinimalStemLength(beamInterface);
-    return (std::min(minLengthAbove, minLengthBelow) < 4 * unit);
+    return (std::min(minLengthAbove, minLengthBelow) < 3 * unit);
 }
 
 std::pair<int, int> BeamSegment::GetVerticalOffset(const BeamDrawingInterface *beamInterface) const

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -843,7 +843,7 @@ bool BeamSegment::CalcBeamSlope(const Staff *staff, const Doc *doc, BeamDrawingI
         if ((step <= unit) || (step > unit * 2)) {
             step = unit * 2;
         }
-        this->CalcMixedBeamStem(beamInterface, step);
+        this->CalcMixedBeamPosition(beamInterface, step);
     }
 
     m_beamSlope = BoundingBox::CalcSlope(Point(m_firstNoteOrChord->m_x, m_firstNoteOrChord->m_yBeam),
@@ -915,7 +915,7 @@ int BeamSegment::CalcBeamSlopeStep(
     return step;
 }
 
-void BeamSegment::CalcMixedBeamStem(const BeamDrawingInterface *beamInterface, int step)
+void BeamSegment::CalcMixedBeamPosition(const BeamDrawingInterface *beamInterface, int step)
 {
     // In cases, when both first and last notes/chords of the beam have same relative places (i.e. they have same stem
     // direction and/or same staff), - we don't need additional calculations
@@ -941,7 +941,7 @@ void BeamSegment::CalcMixedBeamStem(const BeamDrawingInterface *beamInterface, i
     // Calculate midpoint for the beam, taking into account highest and lowest points, as well as number of additional
     // beams above and below main beam. Start position of the beam is then further adjusted based on the step size to
     // make sure that beam is truly centered
-    const int midPoint = (highestPoint + lowestPoint + (up - down) * beamInterface->m_beamWidth) / 2;
+    const int midPoint = (highestPoint + lowestPoint + (down - up) * beamInterface->m_beamWidth) / 2;
     const bool isSlopeUp = (m_firstNoteOrChord->m_beamRelativePlace == m_lastNoteOrChord->m_beamRelativePlace)
         ? (m_beamSlope > 0)
         : (m_lastNoteOrChord->m_beamRelativePlace == BEAMPLACE_below);
@@ -1356,7 +1356,7 @@ void BeamSegment::CalcHorizontalBeam(const Doc *doc, const Staff *staff, const B
 {
 
     if (beamInterface->m_drawingPlace == BEAMPLACE_mixed) {
-        this->CalcMixedBeamStem(beamInterface, 0);
+        this->CalcMixedBeamPosition(beamInterface, 0);
     }
     else {
         int maxLength = (beamInterface->m_drawingPlace == BEAMPLACE_above) ? VRV_UNSET : -VRV_UNSET;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -441,30 +441,7 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingI
             (beamInterface->m_drawingPlace == BEAMPLACE_above) ? "above" : "below");
     }
     else {
-        int adjust = 0;
-        std::for_each(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
-            if (!coord->m_element || !coord->m_element->Is({ NOTE, CHORD })) return;
-            int elemY = coord->m_element->GetDrawingY();
-            const int diff = std::abs(elemY - coord->m_yBeam);
-            assert(coord->m_stem);
-            if (coord->m_stem->GetDrawingStemDir() == STEMDIRECTION_down) {
-                if (elemY <= coord->m_yBeam + topOffset) {
-                    if (diff > adjust) adjust = diff + topOffset;
-                }
-            }
-            else if (coord->m_stem->GetDrawingStemDir() == STEMDIRECTION_up) {
-                if (elemY >= coord->m_yBeam - bottomOffset) {
-                    if (diff > adjust) adjust = diff + bottomOffset;
-                }
-            }
-        });
-        // Set adjustment for the staf here
-        if (beamInterface->m_crossStaffContent->GetN() < staff->GetN()) {
-            beamInterface->m_crossStaffContent->SetAlignmentBeamAdjustment(adjust);
-        }
-        else {
-            staff->SetAlignmentBeamAdjustment(adjust);
-        }
+        // Cross staff beams request staff space, see BeamSegment::RequestStaffSpace(...)
         return false;
     }
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -943,11 +943,6 @@ void BeamSegment::CalcMixedBeamPosition(const BeamDrawingInterface *beamInterfac
         : (m_lastNoteOrChord->m_beamRelativePlace == BEAMPLACE_below);
     m_firstNoteOrChord->m_yBeam = isSlopeUp ? centerY - step / 2 : centerY + step / 2;
     m_lastNoteOrChord->m_yBeam = isSlopeUp ? m_firstNoteOrChord->m_yBeam + step : m_firstNoteOrChord->m_yBeam - step;
-    if ((abs(m_firstNoteOrChord->m_yBeam - m_firstNoteOrChord->m_element->GetDrawingY()) < beamInterface->m_beamWidth)
-        || (abs(m_lastNoteOrChord->m_yBeam - m_lastNoteOrChord->m_element->GetDrawingY())
-            < beamInterface->m_beamWidth)) {
-        std::swap(m_lastNoteOrChord->m_yBeam, m_firstNoteOrChord->m_yBeam);
-    }
 }
 
 void BeamSegment::CalcBeamPosition(
@@ -1266,22 +1261,6 @@ void BeamSegment::CalcBeamStemLength(const Staff *staff, data_BEAMPLACE place, b
             }
         }
     }
-}
-
-std::pair<int, int> BeamSegment::CalcBeamRelativeMinMax(data_BEAMPLACE place) const
-{
-    int highestPoint = VRV_UNSET;
-    int lowestPoint = VRV_UNSET;
-    std::for_each(m_beamElementCoordRefs.begin(), m_beamElementCoordRefs.end(), [&](BeamElementCoord *coord) {
-        if (coord->m_beamRelativePlace == place) {
-            if ((highestPoint == VRV_UNSET) || (coord->m_yBeam > highestPoint)) highestPoint = coord->m_yBeam;
-            if ((lowestPoint == VRV_UNSET) || (coord->m_yBeam < lowestPoint)) {
-                lowestPoint = coord->m_yBeam;
-            }
-        }
-    });
-
-    return { highestPoint, lowestPoint };
 }
 
 int BeamSegment::CalcMixedBeamCenterY(int step, int unit) const

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -377,6 +377,10 @@ bool BeamSegment::NeedToResetPosition(Staff *staff, const Doc *doc, BeamDrawingI
     }
 
     // CASE 2: SINGLE STAFF BEAMS
+    if (doc->GetOptions()->m_beamMixedPreserve.GetValue()) {
+        return false;
+    }
+
     const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     auto [topOffset, bottomOffset] = this->GetVerticalOffset(beamInterface);
 

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -306,7 +306,7 @@ bool BeamSegment::DoesBeamOverlap(
 
     // Check for minimal stem length
     const auto [minLengthAbove, minLengthBelow] = this->GetMinimalStemLength(beamInterface);
-    return (std::min(minLengthAbove, minLengthBelow) < 3.5 * unit);
+    return (std::min(minLengthAbove, minLengthBelow) < 4 * unit);
 }
 
 std::pair<int, int> BeamSegment::GetVerticalOffset(const BeamDrawingInterface *beamInterface) const

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -312,9 +312,7 @@ bool BeamSegment::DoesBeamOverlap(
 std::pair<int, int> BeamSegment::GetVerticalOffset(const BeamDrawingInterface *beamInterface) const
 {
     const auto [topBeams, bottomBeams] = beamInterface->GetAdditionalBeamCount();
-    double multiplier = 1.0;
-    if (const Object *obj = dynamic_cast<const Object *>(beamInterface); obj && obj->Is(FTREM)) multiplier = 0.5;
-    const int topOffset = multiplier * topBeams * beamInterface->m_beamWidth;
+    const int topOffset = topBeams * beamInterface->m_beamWidth;
     const int bottomOffset = bottomBeams * beamInterface->m_beamWidth;
     return { topOffset, bottomOffset };
 }

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -104,7 +104,7 @@ void FTrem::FilterList(ListOfConstObjects &childList) const
 
 std::pair<int, int> FTrem::GetAdditionalBeamCount() const
 {
-    return { std::max(this->GetBeams(), this->GetBeamsFloat()), 0 };
+    return { 0, std::max(this->GetBeams(), this->GetBeamsFloat()) };
 }
 
 std::pair<int, int> FTrem::GetFloatingBeamCount() const

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -132,7 +132,10 @@ int FTrem::AdjustBeams(FunctorParams *functorParams)
     }
 
     if (!params->m_beam) {
-        if (m_drawingPlace != BEAMPLACE_mixed) {
+        if (m_drawingPlace == BEAMPLACE_mixed) {
+            m_beamSegment.RequestStaffSpace(params->m_doc, this);
+        }
+        else {
             params->m_beam = this;
             params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
             params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1178,6 +1178,11 @@ Options::Options()
     m_beamMixedPreserve.Init(false);
     this->Register(&m_beamMixedPreserve, "beamMixedPreserve", &m_generalLayout);
 
+    m_beamMixedStemMin.SetInfo(
+        "Minimal stem length of mixed beams", "The minimal stem length in MEI units used to draw mixed beams");
+    m_beamMixedStemMin.Init(3.5, 1.0, 8.0);
+    this->Register(&m_beamMixedStemMin, "beamMixedStemMin", &m_generalLayout);
+
     m_bracketThickness.SetInfo("Bracket thickness", "The thickness of the system bracket");
     m_bracketThickness.Init(1.0, 0.5, 2.0);
     this->Register(&m_bracketThickness, "bracketThickness", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1161,6 +1161,11 @@ Options::Options()
     m_barLineWidth.Init(0.30, 0.10, 0.80);
     this->Register(&m_barLineWidth, "barLineWidth", &m_generalLayout);
 
+    m_beamFrenchStyle.SetInfo(
+        "French style of beams", "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
+    m_beamFrenchStyle.Init(false);
+    this->Register(&m_beamFrenchStyle, "beamFrenchStyle", &m_generalLayout);
+
     m_beamMaxSlope.SetInfo("Beam max slope", "The maximum beam slope");
     m_beamMaxSlope.Init(10, 0, 20);
     this->Register(&m_beamMaxSlope, "beamMaxSlope", &m_generalLayout);
@@ -1169,10 +1174,9 @@ Options::Options()
     m_beamMinSlope.Init(0, 0, 0);
     this->Register(&m_beamMinSlope, "beamMinSlope", &m_generalLayout);
 
-    m_beamFrenchStyle.SetInfo(
-        "French style of beams", "For notes in beams, stems will stop at first outermost sub-beam without crossing it");
-    m_beamFrenchStyle.Init(false);
-    this->Register(&m_beamFrenchStyle, "beamFrenchStyle", &m_generalLayout);
+    m_beamMixedPreserve.SetInfo("Preserve mixed beams", "Mixed beams will be drawn even if there is not enough space");
+    m_beamMixedPreserve.Init(false);
+    this->Register(&m_beamMixedPreserve, "beamMixedPreserve", &m_generalLayout);
 
     m_bracketThickness.SetInfo("Bracket thickness", "The thickness of the system bracket");
     m_bracketThickness.Init(1.0, 0.5, 2.0);

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -379,11 +379,6 @@ int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
     }
 }
 
-void Staff::SetAlignmentBeamAdjustment(int adjust)
-{
-    if (m_staffAlignment) m_staffAlignment->SetBeamAdjust(adjust);
-}
-
 //----------------------------------------------------------------------------
 // LedgerLine
 //----------------------------------------------------------------------------

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -548,10 +548,6 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
     // Add a margin but not for the bottom aligner
     if (m_staff) overflowSum += doc->GetBottomMargin(STAFF) * unit;
 
-    if (const int adjust = prevAlignment->GetBeamAdjust()) {
-        overflowSum += adjust;
-    }
-
     return overflowSum;
 }
 

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1106,9 +1106,10 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
     // Calculate the overlap from requested staff space
     const int currentStaffDistance
         = params->m_previous->GetYRel() - params->m_previous->GetStaffHeight() - this->GetYRel();
-    const int requestedSpace = std::max(this->GetRequestedSpaceAbove(), params->m_previous->GetRequestedSpaceBelow());
-    if ((requestedSpace > 0) && (spacing < (currentStaffDistance + requestedSpace))) {
-        this->SetOverlap(currentStaffDistance + requestedSpace - spacing);
+    int requestedSpace = std::max(this->GetRequestedSpaceAbove(), params->m_previous->GetRequestedSpaceBelow());
+    if (spacing > currentStaffDistance) requestedSpace += currentStaffDistance - spacing;
+    if (requestedSpace > 0) {
+        this->SetOverlap(requestedSpace);
     }
 
     // This is the bottom alignment (or something is wrong) - this is all we need to do

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -261,6 +261,7 @@ StaffAlignment::StaffAlignment() : Object(STAFF_ALIGNMENT)
     m_overlap = 0;
     m_requestedSpaceAbove = 0;
     m_requestedSpaceBelow = 0;
+    m_requestedSpacing = 0;
     m_scoreDefClefOverflowAbove = 0;
     m_scoreDefClefOverflowBelow = 0;
 }
@@ -1103,13 +1104,12 @@ int StaffAlignment::AdjustStaffOverlap(FunctorParams *functorParams)
 
     this->AdjustBracketGroupSpacing(params->m_doc, params->m_previous, spacing);
 
-    // Calculate the overlap from requested staff space
+    // Calculate the requested spacing
     const int currentStaffDistance
         = params->m_previous->GetYRel() - params->m_previous->GetStaffHeight() - this->GetYRel();
-    int requestedSpace = std::max(this->GetRequestedSpaceAbove(), params->m_previous->GetRequestedSpaceBelow());
-    if (spacing > currentStaffDistance) requestedSpace += currentStaffDistance - spacing;
+    const int requestedSpace = std::max(this->GetRequestedSpaceAbove(), params->m_previous->GetRequestedSpaceBelow());
     if (requestedSpace > 0) {
-        this->SetOverlap(requestedSpace);
+        this->SetRequestedSpacing(currentStaffDistance + requestedSpace);
     }
 
     // This is the bottom alignment (or something is wrong) - this is all we need to do
@@ -1181,7 +1181,8 @@ int StaffAlignment::AdjustYPos(FunctorParams *functorParams)
     assert(params);
 
     const int defaultSpacing = this->GetMinimumSpacing(params->m_doc);
-    const int minSpacing = this->CalcMinimumRequiredSpacing(params->m_doc);
+    int minSpacing = this->CalcMinimumRequiredSpacing(params->m_doc);
+    minSpacing = std::max(this->GetRequestedSpacing(), minSpacing);
 
     if (minSpacing > defaultSpacing) {
         params->m_cumulatedShift += minSpacing - defaultSpacing;


### PR DESCRIPTION
This PR addresses the vertical positioning of mixed beams. We

1. Request staff space in order to enforce minimal stem lengths for mixed cross staff beams.
2. Improve the vertical beam placement for mixed beams by maximising the minimal stem length on both sides of the beam.

The change improves several examples in the test library, such as:

**beams-050**
<img width="1155" alt="beams-050" src="https://user-images.githubusercontent.com/63608463/176955681-85f5a0d0-a4c2-44a3-89bc-c0cd4d3c2930.png">

**cross-staff-007**
<img width="401" alt="cross-staff-007" src="https://user-images.githubusercontent.com/63608463/176955745-61ef0249-aba7-49ed-9add-5a4d9849c58c.png">

**cross-staff-009**
<img width="405" alt="cross-staff-009" src="https://user-images.githubusercontent.com/63608463/176955836-72fca028-7383-435d-bcbb-6db9ceda104b.png">

**cross-staff-014**
<img width="285" alt="cross-staff-014" src="https://user-images.githubusercontent.com/63608463/176955921-5655ec3b-3d69-4bbe-ab15-a078464d5de0.png">


