### PR TITLE
Add support for MEI basic and new option for moving score definition encoding

### DIFF
--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -61,6 +61,14 @@ public:
     //----------//
 
     /**
+     * See Object::Save
+     */
+    ///@{
+    int Save(FunctorParams *functorParams) override;
+    int SaveEnd(FunctorParams *functorParams) override;
+    ///@}
+
+    /**
      * See Object::ConvertToPageBased
      */
     int ConvertToPageBased(FunctorParams *functorParams) override;

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1335,6 +1335,26 @@ public:
 };
 
 //----------------------------------------------------------------------------
+// ConvertMarkupScoreDefParams
+//----------------------------------------------------------------------------
+
+/**
+ * member 0: a pointer to the scoreDef we are moving the content from
+ * member 1: the doc
+ **/
+
+class ConvertMarkupScoreDefParams : public FunctorParams {
+public:
+    ConvertMarkupScoreDefParams(Doc *doc)
+    {
+        m_currentScoreDef = NULL;
+        m_doc = doc;
+    }
+    ScoreDef *m_currentScoreDef;
+    Doc *m_doc;
+};
+
+//----------------------------------------------------------------------------
 // ConvertToCastOffMensuralParams
 //----------------------------------------------------------------------------
 

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -49,6 +49,7 @@ class Object;
 class Page;
 class Pedal;
 class ScoreDef;
+class ScoreDefElement;
 class Slur;
 class Staff;
 class StaffAlignment;
@@ -1341,17 +1342,23 @@ public:
 /**
  * member 0: a pointer to the scoreDef we are moving the content from
  * member 1: the doc
+ * member 2: the functor
+ * member 3: the end functor
  **/
 
 class ConvertMarkupScoreDefParams : public FunctorParams {
 public:
-    ConvertMarkupScoreDefParams(Doc *doc)
+    ConvertMarkupScoreDefParams(Doc *doc, Functor *functor, Functor *functorEnd)
     {
         m_currentScoreDef = NULL;
         m_doc = doc;
+        m_functor = functor;
+        m_functorEnd = functorEnd;
     }
-    ScoreDef *m_currentScoreDef;
+    ScoreDefElement *m_currentScoreDef;
     Doc *m_doc;
+    Functor *m_functor;
+    Functor *m_functorEnd;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2473,12 +2473,18 @@ public:
 
 /**
  * member 0: output stream
+ * member 1: flag for MEI basic output for filtering out editorial markup
  **/
 
 class SaveParams : public FunctorParams {
 public:
-    SaveParams(Output *output) { m_output = output; }
+    SaveParams(Output *output, bool basic)
+    {
+        m_output = output;
+        m_basic = basic;
+    }
     Output *m_output;
+    bool m_basic;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -261,7 +261,9 @@ private:
     void Reset();
 
     /**
-     *
+     * Helper checking if the object is tree object in score-based MEI
+     * For MEI basic output, also check object marked as attribute need to be kept as element
+     * of if some needs to be written as attributes
      */
     bool IsTreeObject(Object *object) const;
 

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -262,8 +262,8 @@ private:
 
     /**
      * Helper checking if the object is tree object in score-based MEI
-     * For MEI basic output, also check object marked as attribute need to be kept as element
-     * of if some needs to be written as attributes
+     * For MEI basic output, also check if objects marked as attribute need to be kept as element (e.g., accid)
+     * or if some need to be written as attributes (e.g. scoreDef/clef)
      */
     bool IsTreeObject(Object *object) const;
 
@@ -538,7 +538,7 @@ private:
     std::ostringstream m_streamStringOutput;
     int m_indent;
     bool m_scoreBasedMEI;
-    /** A flag indicating the we want to produce MEI basic */
+    /** A flag indicating that we want to produce MEI basic */
     bool m_basic;
     pugi::xml_node m_mei;
 

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -261,6 +261,11 @@ private:
     void Reset();
 
     /**
+     *
+     */
+    bool IsTreeObject(Object *object) const;
+
+    /**
      * Score based filtering
      */
     ///@{

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -211,6 +211,14 @@ public:
     ///@}
 
     /**
+     * @name Setter and getter for MEI basic output
+     */
+    ///@{
+    void SetBasic(bool basic) { m_basic = basic; }
+    bool GetBasic() const { return m_basic; }
+    ///@}
+
+    /**
      * Score based filtering by measure, page or mdiv
      */
     ///@{
@@ -523,6 +531,8 @@ private:
     std::ostringstream m_streamStringOutput;
     int m_indent;
     bool m_scoreBasedMEI;
+    /** A flag indicating the we want to produce MEI basic */
+    bool m_basic;
     pugi::xml_node m_mei;
 
     /** Current xml element */

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -89,8 +89,8 @@ public:
 
     /**
      * Try to convert a keySig content (keyAccid) to a @sig value
-     * This can work only of the content represent as standard accidental series
-     * Return and empty @sig when the content cannot be converted
+     * This can work only if the content represents a standard accidental series
+     * Return an empty @sig when the content cannot be converted
      */
     data_KEYSIGNATURE ConvertToSig() const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -88,6 +88,13 @@ public:
     ///@}
 
     /**
+     * Try to convert a keySig content (keyAccid) to a @sig value
+     * This can work only of the content represent as standard accidental series
+     * Return and empty @sig when the content cannot be converted
+     */
+    data_KEYSIGNATURE ConvertToSig() const;
+
+    /**
      * Fill the map of modified pitches
      */
     void FillMap(MapOfPitchAccid &mapOfPitchAccid) const;

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -805,6 +805,17 @@ public:
     virtual int ConvertMarkupArticEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
+     * Move scoreDef clef, keySig, meterSig and mensur to staffDef.
+     * When a staffDef already have one, it is not replaced.
+     */
+    virtual int ConvertMarkupScoreDef(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
+     * End Functor for Object::ConvertMarkupScoreDef
+     */
+    virtual int ConvertMarkupScoreDefEnd(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Save the content of any object by calling the appropriate FileOutputStream method.
      */
     virtual int Save(FunctorParams *functorParams);

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -806,7 +806,7 @@ public:
 
     /**
      * Move scoreDef clef, keySig, meterSig and mensur to staffDef.
-     * When a staffDef already have one, it is not replaced.
+     * When a staffDef already has one, it is not replaced.
      */
     virtual int ConvertMarkupScoreDef(FunctorParams *) { return FUNCTOR_CONTINUE; }
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -35,6 +35,7 @@ class FacsimileInterface;
 class PitchInterface;
 class PositionInterface;
 class Resources;
+class SaveParams;
 class ScoreDefInterface;
 class StemmedDrawingInterface;
 class TextDirInterface;
@@ -602,7 +603,7 @@ public:
      * Saves the object (and its children) using the specified output stream.
      * Creates functors that will parse the tree.
      */
-    virtual int Save(Output *output);
+    int SaveObject(SaveParams &saveParams);
 
     /**
      * Sort the child elements using std::stable_sort

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -608,6 +608,7 @@ public:
     OptionBool m_mensuralToMeasure;
     OptionDbl m_minLastJustification;
     OptionBool m_mmOutput;
+    OptionBool m_moveScoreDefinitionToStaff;
     OptionBool m_noJustification;
     OptionBool m_openControlEvents;
     OptionBool m_outputFormatRaw;

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -107,6 +107,11 @@ public:
     ///@}
 
     /**
+     * See Object::ConvertMarkupScoreDef
+     */
+    int ConvertMarkupScoreDef(FunctorParams *) override;
+
+    /**
      * See Object::CastOffPages
      */
     int CastOffPages(FunctorParams *functorParams) override;

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -102,6 +102,16 @@ public:
     // Functors //
     //----------//
 
+    /**
+     * See Object::ConvertMarkupScoreDef
+     */
+    int ConvertMarkupScoreDef(FunctorParams *) override;
+
+    /**
+     * See Object::ConvertMarkupScoreDef
+     */
+    int ConvertMarkupScoreDefEnd(FunctorParams *) override;
+
 private:
     //
 public:

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -594,7 +594,8 @@ enum {
     MARKUP_ANALYTICAL_TIE = 1,
     MARKUP_ANALYTICAL_FERMATA = 2,
     MARKUP_GRACE_ATTRIBUTE = 4,
-    MARKUP_ARTIC_MULTIVAL = 8
+    MARKUP_ARTIC_MULTIVAL = 8,
+    MARKUP_SCOREDEF_DEFINITIONS = 16
 };
 
 //----------------------------------------------------------------------------

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1353,6 +1353,15 @@ void Doc::ConvertMarkupDoc(bool permanent)
             }
         }
     }
+
+    if (m_markup & MARKUP_SCOREDEF_DEFINITIONS) {
+        LogMessage("Converting scoreDef markup...");
+        Functor convertMarkupScoreDef(&Object::ConvertMarkupScoreDef);
+        Functor convertMarkupScoreDefEnd(&Object::ConvertMarkupScoreDefEnd);
+        ConvertMarkupScoreDefParams convertMarkupScoreDefParams(
+            this, &convertMarkupScoreDef, &convertMarkupScoreDefEnd);
+        this->Process(&convertMarkupScoreDef, &convertMarkupScoreDefParams, &convertMarkupScoreDefEnd);
+    }
 }
 
 void Doc::TransposeDoc()

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -117,6 +117,34 @@ bool EditorialElement::IsSupportedChild(Object *child)
 // EditorialElement functor methods
 //----------------------------------------------------------------------------
 
+int EditorialElement::Save(FunctorParams *functorParams)
+{
+    SaveParams *params = vrv_params_cast<SaveParams *>(functorParams);
+    assert(params);
+
+    // When writing MEI basic, only visible elements within editorial markup a saved
+    if (params->m_basic && this->m_visibility == Hidden) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return Object::Save(functorParams);
+    }
+}
+
+int EditorialElement::SaveEnd(FunctorParams *functorParams)
+{
+    SaveParams *params = vrv_params_cast<SaveParams *>(functorParams);
+    assert(params);
+
+    // Same as above
+    if (params->m_basic && this->m_visibility == Hidden) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return Object::SaveEnd(functorParams);
+    }
+}
+
 int EditorialElement::ConvertToPageBased(FunctorParams *functorParams)
 {
     ConvertToPageBasedParams *params = vrv_params_cast<ConvertToPageBasedParams *>(functorParams);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -899,6 +899,9 @@ bool MEIOutput::WriteObjectInternalEnd(Object *object)
         m_currentNode.append_child(pugi::node_comment).set_value(object->GetClosingComment().c_str());
     }
 
+    if (object->Is(DOC)) return true;
+
+    assert(!m_nodeStack.empty());
     m_nodeStack.pop_back();
     m_currentNode = m_nodeStack.back();
 
@@ -960,6 +963,11 @@ void MEIOutput::Reset()
 
     m_streamStringOutput.str("");
     m_streamStringOutput.clear();
+}
+
+bool MEIOutput::IsTreeObject(Object *object) const
+{
+    return !object->Is({ PAGES, PAGE, SYSTEM, SYSTEM_MILESTONE_END, PAGE_MILESTONE_END });
 }
 
 bool MEIOutput::HasValidFilter() const
@@ -1117,7 +1125,7 @@ bool MEIOutput::ProcessScoreBasedFilter(Object *object)
         }
     }
 
-    if (!object->Is({ PAGES, PAGE, SYSTEM, SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
+    if (this->IsTreeObject(object)) {
         m_objectStack.push_back(object);
     }
 
@@ -1127,7 +1135,7 @@ bool MEIOutput::ProcessScoreBasedFilter(Object *object)
 bool MEIOutput::ProcessScoreBasedFilterEnd(Object *object)
 {
     // Pop current object or merged boundary from stack
-    if (!m_objectStack.empty()) {
+    if (this->IsTreeObject(object) && !m_objectStack.empty()) {
         m_objectStack.pop_back();
     }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3596,7 +3596,7 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
 
     if (root.attribute("meiversion")) {
         std::string version = std::string(root.attribute("meiversion").value());
-        if (version == "5.0.0-dev") {
+        if (version == "5.0.0-dev" || version == "4.0.1-rc1+basic") {
             m_version = MEI_5_0_0_dev;
         }
         else if (version == "4.0.1") {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2404,7 +2404,9 @@ void MEIOutput::WriteKeySig(pugi::xml_node currentNode, KeySig *keySig)
         attKeySigDefaultAnl.SetKeyPname(keySig->GetPname());
         attKeySigDefaultAnl.WriteKeySigDefaultAnl(currentNode);
         AttKeySigDefaultLog attKeySigDefaultLog;
-        attKeySigDefaultLog.SetKeySig(keySig->GetSig());
+        // If there is no @sig, try to build it from the keyAccid children.
+        const data_KEYSIGNATURE sig = (keySig->HasSig()) ? keySig->GetSig() : keySig->ConvertToSig();
+        attKeySigDefaultLog.SetKeySig(sig);
         attKeySigDefaultLog.WriteKeySigDefaultLog(currentNode);
         AttKeySigDefaultVis attKeySigDefaultVis;
         attKeySigDefaultVis.SetKeysigShow(keySig->GetVisible());

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -154,6 +154,7 @@ MEIOutput::MEIOutput(Doc *doc) : Output(doc)
 {
     m_indent = 5;
     m_scoreBasedMEI = false;
+    m_basic = false;
     m_ignoreHeader = false;
     m_removeIds = false;
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4467,6 +4467,12 @@ bool MEIInput::ReadScoreDef(Object *parent, pugi::xml_node scoreDef)
         UpgradeScoreDefElementTo_4_0_0(scoreDef, vrvScoreDef);
     }
 
+    if (m_doc->GetOptions()->m_moveScoreDefinitionToStaff.GetValue()) {
+        if (vrvScoreDef->HasClefInfo() || vrvScoreDef->HasKeySigInfo() || vrvScoreDef->HasMeterSigGrpInfo()
+            || vrvScoreDef->HasMeterSigInfo() || vrvScoreDef->HasMensurInfo())
+            m_doc->SetMarkup(MARKUP_SCOREDEF_DEFINITIONS);
+    }
+
     this->ReadScoreDefInterface(scoreDef, vrvScoreDef);
     vrvScoreDef->ReadDistances(scoreDef);
     vrvScoreDef->ReadEndings(scoreDef);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -227,7 +227,8 @@ bool MEIOutput::Export()
         m_doc->ConvertToCastOffMensuralDoc(false);
 
         // this starts the call of all the functors
-        m_doc->Save(this);
+        SaveParams saveParams(this, this->GetBasic());
+        m_doc->SaveObject(saveParams);
 
         // Redo the mensural segment cast of if necessary
         m_doc->ConvertToCastOffMensuralDoc(true);
@@ -842,7 +843,8 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         }
         else {
             // Save the main scoreDef
-            m_doc->GetCurrentScoreDef()->Save(this);
+            SaveParams saveParams(this, this->GetBasic());
+            m_doc->GetCurrentScoreDef()->SaveObject(saveParams);
         }
     }
 
@@ -1196,11 +1198,13 @@ void MEIOutput::WriteCustomScoreDef()
         }
 
         // Save the adjusted score def and delete it afterwards
-        scoreDef->Save(this);
+        SaveParams saveParams(this, this->GetBasic());
+        scoreDef->SaveObject(saveParams);
         delete scoreDef;
     }
     else {
-        m_doc->GetCurrentScoreDef()->Save(this);
+        SaveParams saveParams(this, this->GetBasic());
+        m_doc->GetCurrentScoreDef()->SaveObject(saveParams);
     }
 }
 

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -25,6 +25,7 @@
 #include "doc.h"
 #include "dot.h"
 #include "fermata.h"
+#include "functorparams.h"
 #include "gracegrp.h"
 #include "keyaccid.h"
 #include "keysig.h"
@@ -73,11 +74,12 @@ bool PAEOutput::Export(std::string &output)
     m_currentDots = -1;
     m_grace = false;
 
-    m_doc->GetCurrentScoreDef()->Save(this);
+    SaveParams saveParams(this, false);
+    m_doc->GetCurrentScoreDef()->SaveObject(saveParams);
 
     m_docScoreDef = false;
 
-    m_doc->Save(this);
+    m_doc->SaveObject(saveParams);
 
     output = m_streamStringOutput.str();
 

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -243,7 +243,7 @@ data_KEYSIGNATURE KeySig::ConvertToSig() const
     data_KEYSIGNATURE sig = std::make_pair(-1, ACCIDENTAL_WRITTEN_NONE);
     const ListOfConstObjects &childList = this->GetList(this);
     if (childList.size() > 1) {
-        data_ACCIDENTAL_WRITTEN accidType = ACCIDENTAL_WRITTEN_n;
+        data_ACCIDENTAL_WRITTEN accidType = ACCIDENTAL_WRITTEN_NONE;
         bool isCommon = true;
         int pos = 0;
         for (auto &child : childList) {
@@ -255,14 +255,14 @@ data_KEYSIGNATURE KeySig::ConvertToSig() const
                 continue;
             }
             // We have not a key sig type at this stage
-            if (accidType == ACCIDENTAL_WRITTEN_n) {
+            if (accidType == ACCIDENTAL_WRITTEN_NONE) {
                 if (curType == ACCIDENTAL_WRITTEN_s || curType == ACCIDENTAL_WRITTEN_f) {
                     accidType = curType;
                 }
             }
-            else if (accidType != curType) {
+            if (accidType != curType) {
                 LogWarning("All the keySig content cannot be converted to @sig because the accidental type is not a "
-                           "flat or a sharp or mixes them");
+                           "flat or a sharp, or mixes them");
                 break;
             }
             if (accidType == ACCIDENTAL_WRITTEN_f && s_pnameForFlats[pos] != keyAccid->GetPname()) {

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -243,19 +243,28 @@ data_KEYSIGNATURE KeySig::ConvertToSig() const
     data_KEYSIGNATURE sig = std::make_pair(-1, ACCIDENTAL_WRITTEN_NONE);
     const ListOfConstObjects &childList = this->GetList(this);
     if (childList.size() > 1) {
-        const KeyAccid *firstKeyAccid = vrv_cast<const KeyAccid *>(childList.front());
-        assert(firstKeyAccid);
-        const data_ACCIDENTAL_WRITTEN accidType = firstKeyAccid->GetAccid();
-        if (accidType != ACCIDENTAL_WRITTEN_f && accidType != ACCIDENTAL_WRITTEN_s) {
-            LogWarning(
-                "KeySig content cannot be converted to @sig because this accidental type is not a flat or a sharp");
-            return sig;
-        }
+        data_ACCIDENTAL_WRITTEN accidType = ACCIDENTAL_WRITTEN_n;
         bool isCommon = true;
         int pos = 0;
         for (auto &child : childList) {
             const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
             assert(keyAccid);
+            data_ACCIDENTAL_WRITTEN curType = keyAccid->GetAccid();
+            if (curType == ACCIDENTAL_WRITTEN_n) {
+                // Skip naturals encoded explicitly
+                continue;
+            }
+            // We have not a key sig type at this stage
+            if (accidType == ACCIDENTAL_WRITTEN_n) {
+                if (curType == ACCIDENTAL_WRITTEN_s || curType == ACCIDENTAL_WRITTEN_f) {
+                    accidType = curType;
+                }
+            }
+            else if (accidType != curType) {
+                LogWarning("All the keySig content cannot be converted to @sig because the accidental type is not a "
+                           "flat or a sharp or mixes them");
+                break;
+            }
             if (accidType == ACCIDENTAL_WRITTEN_f && s_pnameForFlats[pos] != keyAccid->GetPname()) {
                 isCommon = false;
                 break;
@@ -270,7 +279,7 @@ data_KEYSIGNATURE KeySig::ConvertToSig() const
             LogWarning("KeySig content cannot be converted to @sig because the accidental series is not standard");
             return sig;
         }
-        sig = std::make_pair((int)childList.size(), accidType);
+        sig = std::make_pair(pos, accidType);
     }
     return sig;
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1157,10 +1157,8 @@ bool Object::FiltersApply(const Filters *filters, Object *object) const
     return filters ? filters->Apply(object) : true;
 }
 
-int Object::Save(Output *output)
+int Object::SaveObject(SaveParams &saveParams)
 {
-    SaveParams saveParams(output);
-
     Functor save(&Object::Save);
     // Special case where we want to process all objects
     save.m_visibleOnly = false;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1012,6 +1012,11 @@ Options::Options()
     m_mmOutput.Init(false);
     this->Register(&m_mmOutput, "mmOutput", &m_general);
 
+    m_moveScoreDefinitionToStaff.SetInfo("Move score definition to staff",
+        "Move score definition (clef, keySig, meterSig, etc.) from scoreDef to staffDef");
+    m_moveScoreDefinitionToStaff.Init(false);
+    this->Register(&m_moveScoreDefinitionToStaff, "moveScoreDefinitionToStaff", &m_general);
+
     m_noJustification.SetInfo("No justification", "Do not justify the system");
     m_noJustification.Init(false);
     this->Register(&m_noJustification, "noJustification", &m_general);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -913,7 +913,8 @@ Options::Options()
     m_scale.SetShortOption('s', false);
     m_baseOptions.AddOption(&m_scale);
 
-    m_outputTo.SetInfo("Output to", "Select output format to: \"mei\", \"pb-mei\", \"svg\", or \"midi\"");
+    m_outputTo.SetInfo(
+        "Output to", "Select output format to: \"mei\", \"mei-pb\", \"mei-basic\", \"svg\", or \"midi\"");
     m_outputTo.Init("svg");
     m_outputTo.SetKey("outputTo");
     m_outputTo.SetShortOption('t', true);

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -404,18 +404,22 @@ int RunningElement::PrepareDataInitialization(FunctorParams *)
 
 int RunningElement::Save(FunctorParams *functorParams)
 {
-    if (this->IsGenerated())
+    if (this->IsGenerated()) {
         return FUNCTOR_SIBLINGS;
-    else
+    }
+    else {
         return Object::Save(functorParams);
+    }
 }
 
 int RunningElement::SaveEnd(FunctorParams *functorParams)
 {
-    if (this->IsGenerated())
+    if (this->IsGenerated()) {
         return FUNCTOR_SIBLINGS;
-    else
+    }
+    else {
         return Object::SaveEnd(functorParams);
+    }
 }
 
 int RunningElement::AlignVertically(FunctorParams *functorParams)

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -205,6 +205,17 @@ int Score::AdjustGraceXPos(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Score::ConvertMarkupScoreDef(FunctorParams *functorParams)
+{
+    ConvertMarkupScoreDefParams *params = vrv_params_cast<ConvertMarkupScoreDefParams *>(functorParams);
+    assert(params);
+
+    // Evaluate functor on scoreDef
+    this->GetScoreDef()->Process(params->m_functor, params, params->m_functorEnd);
+
+    return FUNCTOR_CONTINUE;
+}
+
 int Score::ConvertToPageBased(FunctorParams *functorParams)
 {
     ConvertToPageBasedParams *params = vrv_params_cast<ConvertToPageBasedParams *>(functorParams);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -639,6 +639,22 @@ bool ScoreDef::HasSystemStartLine()
 // Functors methods
 //----------------------------------------------------------------------------
 
+int ScoreDefElement::ConvertMarkupScoreDef(FunctorParams *functorParams)
+{
+    ConvertMarkupScoreDefParams *params = vrv_params_cast<ConvertMarkupScoreDefParams *>(functorParams);
+    assert(params);
+
+    return FUNCTOR_SIBLINGS;
+}
+
+int ScoreDefElement::ConvertMarkupScoreDefEnd(FunctorParams *functorParams)
+{
+    ConvertMarkupScoreDefParams *params = vrv_params_cast<ConvertMarkupScoreDefParams *>(functorParams);
+    assert(params);
+
+    return FUNCTOR_SIBLINGS;
+}
+
 int ScoreDef::ResetHorizontalAlignment(FunctorParams *functorParams)
 {
     m_drawingLabelsWidth = 0;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -163,7 +163,11 @@ bool Toolkit::SetOutputTo(std::string const &outputTo)
     else if (outputTo == "mei-basic") {
         m_outputTo = MEI;
     }
+    else if (outputTo == "mei-pb") {
+        m_outputTo = MEI;
+    }
     else if (outputTo == "pb-mei") {
+        LogWarning("Output to 'pb-mei' is deprecaded, use 'mei-pb' instead.");
         m_outputTo = MEI;
     }
     else if (outputTo == "midi") {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -160,6 +160,9 @@ bool Toolkit::SetOutputTo(std::string const &outputTo)
     else if (outputTo == "mei") {
         m_outputTo = MEI;
     }
+    else if (outputTo == "mei-basic") {
+        m_outputTo = MEI;
+    }
     else if (outputTo == "pb-mei") {
         m_outputTo = MEI;
     }
@@ -809,6 +812,7 @@ void Toolkit::SkipLayoutOnLoad(bool value)
 std::string Toolkit::GetMEI(const std::string &jsonOptions)
 {
     bool scoreBased = true;
+    bool basic = false;
     bool ignoreHeader = false;
     bool removeIds = m_options->m_removeIds.GetValue();
     int firstPage = 0;
@@ -826,6 +830,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
         }
         else {
             if (json.has<jsonxx::Boolean>("scoreBased")) scoreBased = json.get<jsonxx::Boolean>("scoreBased");
+            if (json.has<jsonxx::Boolean>("basic")) basic = json.get<jsonxx::Boolean>("basic");
             if (json.has<jsonxx::Boolean>("ignoreHeader")) ignoreHeader = json.get<jsonxx::Boolean>("ignoreHeader");
             if (json.has<jsonxx::Boolean>("removeIds")) removeIds = json.get<jsonxx::Boolean>("removeIds");
             if (json.has<jsonxx::Number>("firstPage")) firstPage = json.get<jsonxx::Number>("firstPage");
@@ -859,6 +864,7 @@ std::string Toolkit::GetMEI(const std::string &jsonOptions)
 
     MEIOutput meioutput(&m_doc);
     meioutput.SetScoreBasedMEI(scoreBased);
+    meioutput.SetBasic(basic);
 
     int indent = (m_options->m_outputIndentTab.GetValue()) ? -1 : m_options->m_outputIndent.GetValue();
     meioutput.SetIndent(indent);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -167,7 +167,7 @@ bool Toolkit::SetOutputTo(std::string const &outputTo)
         m_outputTo = MEI;
     }
     else if (outputTo == "pb-mei") {
-        LogWarning("Output to 'pb-mei' is deprecaded, use 'mei-pb' instead.");
+        LogWarning("Output to 'pb-mei' is deprecated, use 'mei-pb' instead.");
         m_outputTo = MEI;
     }
     else if (outputTo == "midi") {

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
 
     if (outformat == "pb-mei") {
         outformat = "mei-pb";
-        vrv::LogWarning("Output to 'pb-mei' is deprecaded, use 'mei-pb' instead.");
+        vrv::LogWarning("Output to 'pb-mei' is deprecated, use 'mei-pb' instead.");
     }
     if ((outformat != "svg") && (outformat != "mei") && (outformat != "mei-basic") && (outformat != "mei-pb")
         && (outformat != "midi") && (outformat != "timemap") && (outformat != "humdrum") && (outformat != "hum")

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -447,10 +447,11 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    if ((outformat != "svg") && (outformat != "mei") && (outformat != "midi") && (outformat != "timemap")
-        && (outformat != "humdrum") && (outformat != "hum") && (outformat != "pae") && (outformat != "pb-mei")) {
+    if ((outformat != "svg") && (outformat != "mei") && (outformat != "mei-basic") && (outformat != "midi")
+        && (outformat != "timemap") && (outformat != "humdrum") && (outformat != "hum") && (outformat != "pae")
+        && (outformat != "pb-mei")) {
         std::cerr << "Output format (" << outformat
-                  << ") can only be 'mei', 'pb-mei', 'svg', 'midi', 'humdrum' or 'pae'." << std::endl;
+                  << ") can only be 'mei', 'mei-basic', 'pb-mei', 'svg', 'midi', 'humdrum' or 'pae'." << std::endl;
         exit(1);
     }
 
@@ -702,11 +703,13 @@ int main(int argc, char **argv)
         }
     }
     else {
-        const char *scoreBased = (outformat == "mei") ? "true" : "false";
+        const char *scoreBased = (outformat == "pb-mei") ? "false" : "true";
+        const char *basic = (outformat == "mei-basic") ? "true" : "false";
         const char *removeIds = (options->m_removeIds.GetValue()) ? "true" : "false";
         outfile += ".mei";
         if (all_pages) {
-            std::string params = vrv::StringFormat("{'scoreBased': %s, 'removeIds': %s}", scoreBased, removeIds);
+            std::string params
+                = vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'removeIds': %s}", scoreBased, basic, removeIds);
             if (std_output) {
                 std::string output;
                 std::cout << toolkit.GetMEI(params);
@@ -719,8 +722,8 @@ int main(int argc, char **argv)
             }
         }
         else {
-            std::string params
-                = vrv::StringFormat("{'scoreBased': %s, 'pageNo': %d, 'removeIds': %s}", scoreBased, page, removeIds);
+            std::string params = vrv::StringFormat(
+                "{'scoreBased': %s, 'basic': %s, 'pageNo': %d, 'removeIds': %s}", scoreBased, basic, page, removeIds);
             if (std_output) {
                 std::cout << toolkit.GetMEI(params);
             }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -447,11 +447,15 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    if ((outformat != "svg") && (outformat != "mei") && (outformat != "mei-basic") && (outformat != "midi")
-        && (outformat != "timemap") && (outformat != "humdrum") && (outformat != "hum") && (outformat != "pae")
-        && (outformat != "pb-mei")) {
+    if (outformat == "pb-mei") {
+        outformat = "mei-pb";
+        vrv::LogWarning("Output to 'pb-mei' is deprecaded, use 'mei-pb' instead.");
+    }
+    if ((outformat != "svg") && (outformat != "mei") && (outformat != "mei-basic") && (outformat != "mei-pb")
+        && (outformat != "midi") && (outformat != "timemap") && (outformat != "humdrum") && (outformat != "hum")
+        && (outformat != "pae")) {
         std::cerr << "Output format (" << outformat
-                  << ") can only be 'mei', 'mei-basic', 'pb-mei', 'svg', 'midi', 'humdrum' or 'pae'." << std::endl;
+                  << ") can only be 'mei', 'mei-basic', 'mei-pb', 'svg', 'midi', 'humdrum' or 'pae'." << std::endl;
         exit(1);
     }
 
@@ -703,7 +707,7 @@ int main(int argc, char **argv)
         }
     }
     else {
-        const char *scoreBased = (outformat == "pb-mei") ? "false" : "true";
+        const char *scoreBased = (outformat == "mei-pb") ? "false" : "true";
         const char *basic = (outformat == "mei-basic") ? "true" : "false";
         const char *removeIds = (options->m_removeIds.GetValue()) ? "true" : "false";
         outfile += ".mei";


### PR DESCRIPTION
The PR add a `mei-basic` output format that performs some conversion to MEI basic when saving to MEI. The internal data remains untouched because the conversion is performed only in the writing process.

The conversion includes:
* Removing of the editorial markup. When there is some parallel segmentation in the data, only one (the visible) subtree is written to the ouput
* Moving `@accid` and `@artic` to `./accid` and `./artic`
* Moving `./clef`, `./keySig`, `./meterSig` within `scoreDef` and `staffDef` as corresponding attributes

At this stage, no check or removing of unsupported elements or attributes is performed

### Option to move score definition to staff

The PR also introduces a new `--move-score-definition-to-staff` option that moves all the clef, keySig, meterSigGrp, meterSig and mensur elements to the staffDef level when loading a file. This option can be used in conjunction with MEI basic output to have MEI files that follow the same encoding structure.