### PR TITLE
keep last system despite condensing

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -596,6 +596,7 @@ public:
     OptionDbl m_breaksSmartSb;
     OptionIntMap m_condense;
     OptionBool m_condenseFirstPage;
+    OptionBool m_condenseNotLastSystem;
     OptionBool m_condenseTempoPages;
     OptionBool m_evenNoteSpacing;
     OptionString m_expand;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -962,6 +962,11 @@ Options::Options()
     m_condenseFirstPage.Init(false);
     this->Register(&m_condenseFirstPage, "condenseFirstPage", &m_general);
 
+    m_condenseNotLastSystem.SetInfo(
+        "Condense not last system", "When condensing a score never condense the last system");
+    m_condenseNotLastSystem.Init(false);
+    this->Register(&m_condenseNotLastSystem, "condenseNotLastSystem", &m_general);
+
     m_condenseTempoPages.SetInfo(
         "Condense tempo pages", "When condensing a score also condense pages with a tempo change");
     m_condenseTempoPages.Init(false);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -497,7 +497,7 @@ int System::ScoreDefOptimize(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
     }
-    
+
     if (this->IsLastOfMdiv()) {
         this->IsDrawingOptimized(false);
         return FUNCTOR_SIBLINGS;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -497,6 +497,11 @@ int System::ScoreDefOptimize(FunctorParams *functorParams)
             return FUNCTOR_SIBLINGS;
         }
     }
+    
+    if (this->IsLastOfMdiv()) {
+        this->IsDrawingOptimized(false);
+        return FUNCTOR_SIBLINGS;
+    }
 
     params->m_currentScoreDef = this->GetDrawingScoreDef();
     assert(params->m_currentScoreDef);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -499,8 +499,9 @@ int System::ScoreDefOptimize(FunctorParams *functorParams)
     }
 
     if (this->IsLastOfMdiv()) {
-        this->IsDrawingOptimized(false);
-        return FUNCTOR_SIBLINGS;
+        if (params->m_doc->GetOptions()->m_condenseNotLastSystem.GetValue()) {
+            return FUNCTOR_SIBLINGS;
+        }
     }
 
     params->m_currentScoreDef = this->GetDrawingScoreDef();


### PR DESCRIPTION
This small addition makes sure the last system of a score is always shown. 
Closes #2949