### PR TITLE
Engraving defaults for dashed barlines

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -652,8 +652,8 @@ public:
     OptionBool m_beamFrenchStyle;
     OptionDbl m_bracketThickness;
     OptionBool m_breaksNoWidow;
-    OptionDbl m_dashedBarlineDashLength;
-    OptionDbl m_dashedBarlineGapLength;
+    OptionDbl m_dashedBarLineDashLength;
+    OptionDbl m_dashedBarLineGapLength;
     OptionDbl m_dynamDist;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -652,6 +652,8 @@ public:
     OptionBool m_beamFrenchStyle;
     OptionDbl m_bracketThickness;
     OptionBool m_breaksNoWidow;
+    OptionDbl m_dashedBarlineDashLength;
+    OptionDbl m_dashedBarlineGapLength;
     OptionDbl m_dynamDist;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -535,11 +535,14 @@ protected:
      * Defined in view_graph.cpp
      */
     ///@{
-    void DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width, int dashLength = 0);
-    void DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int width, int dashLength = 0);
+    void DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width, int dashLength = 0, int gapLength = 0);
+    void DrawHorizontalLine(
+        DeviceContext *dc, int x1, int x2, int y1, int width, int dashLength = 0, int gapLength = 0);
     void DrawRoundedLine(DeviceContext *dc, int x1, int y1, int x2, int y2, int width);
-    void DrawVerticalSegmentedLine(DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength = 0);
-    void DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0);
+    void DrawVerticalSegmentedLine(
+        DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength = 0, int gapLength = 0);
+    void DrawHorizontalSegmentedLine(
+        DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength = 0, int gapLength = 0);
     void DrawSmuflCode(
         DeviceContext *dc, int x, int y, wchar_t code, int staffSize, bool dimin, bool setBBGlyph = false);
     void DrawThickBezierCurve(

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1157,7 +1157,7 @@ Options::Options()
     m_barLineSeparation.Init(0.8, 0.5, 2.0);
     this->Register(&m_barLineSeparation, "barLineSeparation", &m_generalLayout);
 
-    m_barLineWidth.SetInfo("Barline width", "The barLine width");
+    m_barLineWidth.SetInfo("Barline width", "The barline width");
     m_barLineWidth.Init(0.30, 0.10, 0.80);
     this->Register(&m_barLineWidth, "barLineWidth", &m_generalLayout);
 
@@ -1184,14 +1184,14 @@ Options::Options()
     this->Register(&m_breaksNoWidow, "breaksNoWidow", &m_generalLayout);
 
     // Optimized for five line staves
-    constexpr double dashedBarlineLengthDefault = 8.0 / 7.0;
-    m_dashedBarlineDashLength.SetInfo("Dashed barline dash length", "The dash length of dashed barlines");
-    m_dashedBarlineDashLength.Init(dashedBarlineLengthDefault, 0.1, 5.0);
-    this->Register(&m_dashedBarlineDashLength, "dashedBarlineDashLength", &m_generalLayout);
+    constexpr double dashedBarLineLengthDefault = 8.0 / 7.0;
+    m_dashedBarLineDashLength.SetInfo("Dashed barline dash length", "The dash length of dashed barlines");
+    m_dashedBarLineDashLength.Init(dashedBarLineLengthDefault, 0.1, 5.0);
+    this->Register(&m_dashedBarLineDashLength, "dashedBarLineDashLength", &m_generalLayout);
 
-    m_dashedBarlineGapLength.SetInfo("Dashed barline gap length", "The gap length of dashed barlines");
-    m_dashedBarlineGapLength.Init(dashedBarlineLengthDefault, 0.1, 5.0);
-    this->Register(&m_dashedBarlineGapLength, "dashedBarlineGapLength", &m_generalLayout);
+    m_dashedBarLineGapLength.SetInfo("Dashed barline gap length", "The gap length of dashed barlines");
+    m_dashedBarLineGapLength.Init(dashedBarLineLengthDefault, 0.1, 5.0);
+    this->Register(&m_dashedBarLineGapLength, "dashedBarLineGapLength", &m_generalLayout);
 
     m_dynamDist.SetInfo("Dynam dist", "The default distance from the staff for dynamic marks");
     m_dynamDist.Init(1.0, 0.5, 16.0);
@@ -1779,8 +1779,8 @@ void Options::Sync()
         { "thickBarlineThickness", &m_thickBarlineThickness }, //
         { "barlineSeparation", &m_barLineSeparation }, //
         { "repeatBarlineDotSeparation", &m_repeatBarLineDotSeparation }, //
-        { "dashedBarlineDashLength", &m_dashedBarlineDashLength }, //
-        { "dashedBarlineGapLength", &m_dashedBarlineGapLength }, //
+        { "dashedBarlineDashLength", &m_dashedBarLineDashLength }, //
+        { "dashedBarlineGapLength", &m_dashedBarLineGapLength }, //
         { "bracketThickness", &m_bracketThickness }, //
         { "subBracketThickness", &m_subBracketThickness }, //
         { "hairpinThickness", &m_hairpinThickness }, //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1184,11 +1184,11 @@ Options::Options()
     this->Register(&m_breaksNoWidow, "breaksNoWidow", &m_generalLayout);
 
     m_dashedBarlineDashLength.SetInfo("Dashed barline dash length", "The dash length of dashed barlines");
-    m_dashedBarlineDashLength.Init(1.0, 0.1, 5.0);
+    m_dashedBarlineDashLength.Init(0.57, 0.1, 2.0);
     this->Register(&m_dashedBarlineDashLength, "dashedBarlineDashLength", &m_generalLayout);
 
     m_dashedBarlineGapLength.SetInfo("Dashed barline gap length", "The gap length of dashed barlines");
-    m_dashedBarlineGapLength.Init(1.0, 0.1, 5.0);
+    m_dashedBarlineGapLength.Init(0.57, 0.1, 2.0);
     this->Register(&m_dashedBarlineGapLength, "dashedBarlineGapLength", &m_generalLayout);
 
     m_dynamDist.SetInfo("Dynam dist", "The default distance from the staff for dynamic marks");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1183,6 +1183,14 @@ Options::Options()
     m_breaksNoWidow.Init(false);
     this->Register(&m_breaksNoWidow, "breaksNoWidow", &m_generalLayout);
 
+    m_dashedBarlineDashLength.SetInfo("Dashed barline dash length", "The dash length of dashed barlines");
+    m_dashedBarlineDashLength.Init(1.0, 0.1, 5.0);
+    this->Register(&m_dashedBarlineDashLength, "dashedBarlineDashLength", &m_generalLayout);
+
+    m_dashedBarlineGapLength.SetInfo("Dashed barline gap length", "The gap length of dashed barlines");
+    m_dashedBarlineGapLength.Init(1.0, 0.1, 5.0);
+    this->Register(&m_dashedBarlineGapLength, "dashedBarlineGapLength", &m_generalLayout);
+
     m_dynamDist.SetInfo("Dynam dist", "The default distance from the staff for dynamic marks");
     m_dynamDist.Init(1.0, 0.5, 16.0);
     this->Register(&m_dynamDist, "dynamDist", &m_generalLayout);
@@ -1769,6 +1777,8 @@ void Options::Sync()
         { "thickBarlineThickness", &m_thickBarlineThickness }, //
         { "barlineSeparation", &m_barLineSeparation }, //
         { "repeatBarlineDotSeparation", &m_repeatBarLineDotSeparation }, //
+        { "dashedBarlineDashLength", &m_dashedBarlineDashLength }, //
+        { "dashedBarlineGapLength", &m_dashedBarlineGapLength }, //
         { "bracketThickness", &m_bracketThickness }, //
         { "subBracketThickness", &m_subBracketThickness }, //
         { "hairpinThickness", &m_hairpinThickness }, //

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1183,12 +1183,14 @@ Options::Options()
     m_breaksNoWidow.Init(false);
     this->Register(&m_breaksNoWidow, "breaksNoWidow", &m_generalLayout);
 
+    // Optimized for five line staves
+    constexpr double dashedBarlineLengthDefault = 8.0 / 7.0;
     m_dashedBarlineDashLength.SetInfo("Dashed barline dash length", "The dash length of dashed barlines");
-    m_dashedBarlineDashLength.Init(0.57, 0.1, 2.0);
+    m_dashedBarlineDashLength.Init(dashedBarlineLengthDefault, 0.1, 5.0);
     this->Register(&m_dashedBarlineDashLength, "dashedBarlineDashLength", &m_generalLayout);
 
     m_dashedBarlineGapLength.SetInfo("Dashed barline gap length", "The gap length of dashed barlines");
-    m_dashedBarlineGapLength.Init(0.57, 0.1, 2.0);
+    m_dashedBarlineGapLength.Init(dashedBarlineLengthDefault, 0.1, 5.0);
     this->Register(&m_dashedBarlineGapLength, "dashedBarlineGapLength", &m_generalLayout);
 
     m_dynamDist.SetInfo("Dynam dist", "The default distance from the staff for dynamic marks");

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -21,11 +21,11 @@
 
 namespace vrv {
 
-void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width, int dashLength)
+void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width, int dashLength, int gapLength)
 {
     assert(dc);
 
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength);
+    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
     dc->SetBrush(m_currentColour, AxSOLID);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x1), ToDeviceContextY(y2));
@@ -35,11 +35,11 @@ void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width
     return;
 }
 
-void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int width, int dashLength)
+void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int width, int dashLength, int gapLength)
 {
     assert(dc);
 
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength);
+    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
     dc->SetBrush(m_currentColour, AxSOLID);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
@@ -63,21 +63,23 @@ void View::DrawRoundedLine(DeviceContext *dc, int x1, int y1, int x2, int y2, in
     return;
 }
 
-void View::DrawVerticalSegmentedLine(DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength)
+void View::DrawVerticalSegmentedLine(
+    DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength, int gapLength)
 {
     int i, start, end;
     for (i = 0; i < line.GetSegmentCount(); i++) {
         std::tie(start, end) = line.GetStartEnd(i);
-        this->DrawVerticalLine(dc, start, end, x1, width, dashLength);
+        this->DrawVerticalLine(dc, start, end, x1, width, dashLength, gapLength);
     }
 }
 
-void View::DrawHorizontalSegmentedLine(DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength)
+void View::DrawHorizontalSegmentedLine(
+    DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength, int gapLength)
 {
     int i, start, end;
     for (i = 0; i < line.GetSegmentCount(); i++) {
         std::tie(start, end) = line.GetStartEnd(i);
-        this->DrawHorizontalLine(dc, start, end, y1, width, dashLength);
+        this->DrawHorizontalLine(dc, start, end, y1, width, dashLength, gapLength);
     }
 }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -898,6 +898,13 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     // optimized for five line staves
     int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
     int dotLength = m_doc->GetDrawingUnit(staffSize) * 4 / 13;
+    int gapLength = dashLength;
+    if (m_options->m_dashedBarlineDashLength.IsSet()) {
+        dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineDashLength.GetValue();
+    }
+    if (m_options->m_dashedBarlineGapLength.IsSet()) {
+        gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineGapLength.GetValue();
+    }
 
     SegmentedLine line(yTop, yBottom);
     // We do not need to do this during layout calculation
@@ -934,7 +941,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
             this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth);
             break;
         case BARRENDITION_dashed: //
-            this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength);
+            this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength, gapLength);
             break;
         case BARRENDITION_dotted: //
             if (singleStaff) {
@@ -970,8 +977,8 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
             this->DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineWidth);
             break;
         case BARRENDITION_dbldashed:
-            this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength);
-            this->DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineWidth, dashLength);
+            this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dashLength, gapLength);
+            this->DrawVerticalSegmentedLine(dc, x2 + barLineWidth, line, barLineWidth, dashLength, gapLength);
             break;
         case BARRENDITION_dbldotted:
             this->DrawVerticalSegmentedLine(dc, x, line, barLineWidth, dotLength);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -895,16 +895,9 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int barLinesSum = barLineThickWidth + barLineWidth;
     int x2 = x + barLineSeparation;
 
-    // optimized for five line staves
-    int dashLength = m_doc->GetDrawingUnit(staffSize) * 16 / 13;
-    int dotLength = m_doc->GetDrawingUnit(staffSize) * 4 / 13;
-    int gapLength = dashLength;
-    if (m_options->m_dashedBarlineDashLength.IsSet()) {
-        dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineDashLength.GetValue();
-    }
-    if (m_options->m_dashedBarlineGapLength.IsSet()) {
-        gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineGapLength.GetValue();
-    }
+    const int dotLength = m_doc->GetDrawingUnit(staffSize) * 4 / 13;
+    const int dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineDashLength.GetValue();
+    const int gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineGapLength.GetValue();
 
     SegmentedLine line(yTop, yBottom);
     // We do not need to do this during layout calculation

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -896,8 +896,8 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     int x2 = x + barLineSeparation;
 
     const int dotLength = m_doc->GetDrawingUnit(staffSize) * 4 / 13;
-    const int dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineDashLength.GetValue();
-    const int gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarlineGapLength.GetValue();
+    const int dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarLineDashLength.GetValue();
+    const int gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarLineGapLength.GetValue();
 
     SegmentedLine line(yTop, yBottom);
     // We do not need to do this during layout calculation


### PR DESCRIPTION
With this PR we can set the dash or gap length of dashed barlines via engraving defaults/options.

The following example is rendered with:
`--engraving-defaults "{'dashedBarlineDashLength': 0.5, 'dashedBarlineGapLength': 0.25}"`

![DashedBarline](https://user-images.githubusercontent.com/63608463/178014002-63f96524-e1d5-40ff-ada9-4e8128b1b06c.png)
<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Barline example</title>
      </titleStmt>
      <pubStmt>
        <date>2018-05-29</date>
      </pubStmt>
      <seriesStmt>
        <title>Verovio test suite</title>
      </seriesStmt>
      <notesStmt>
        <annot>Verovio supports both various bar line types. Bar lines should be spaces approrpately</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="2.0.0" label="2">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef meter.count="2" meter.unit="4">
            <staffGrp bar.thru="false">
              <staffGrp symbol="bracket" bar.thru="true">
                <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s">
                  <label>Violino I</label>
                </staffDef>
                <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="2s">
                  <label>Violino II</label>
                </staffDef>
                <staffDef n="3" lines="5" clef.shape="C" clef.line="3" key.sig="2s">
                  <label>Viola</label>
                </staffDef>
                <staffDef n="4" lines="5" clef.shape="F" clef.line="4" key.sig="2s">
                  <label>Violoncello</label>
                </staffDef>
              </staffGrp>
            </staffGrp>
          </scoreDef>
          <section>
            <ending n="1">
              <measure left="dashed" right="dbldotted" metcon="false" n="44a-1">
                <staff n="1">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="2">
                  <layer n="1">
                    <beam>
                      <note xml:id="note_16590" dur="32" oct="4" pname="c" tstamp="1" accid.ges="s" />
                      <note dur="32" oct="4" pname="e" tstamp="1.125" />
                      <note dur="32" oct="4" pname="a" tstamp="1.25" />
                      <note dur="32" oct="4" pname="g" tstamp="1.375" accid="s" />
                    </beam>
                    <beam>
                      <note dur="32" oct="4" pname="g" tstamp="1.5" accid="n" />
                      <note dur="32" oct="4" pname="f" tstamp="1.625" accid.ges="s" />
                      <note dur="32" oct="4" pname="g" tstamp="1.75" accid.ges="n" />
                      <note xml:id="note_16641" dur="32" oct="4" pname="e" tstamp="1.875" />
                    </beam>
                  </layer>
                </staff>
                <staff n="3">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="4">
                  <layer n="1">
                    <note dur="8" oct="2" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <slur staff="2" startid="#note_16590" endid="#note_16641" />
              </measure>
            </ending>
            <ending n="2">
              <measure right="dbldashed" metcon="false" n="44a-2">
                <staff n="1">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="2">
                  <layer n="1">
                    <beam>
                      <note xml:id="note_16788" dur="32" oct="4" pname="c" tstamp="1" accid.ges="s" />
                      <note dur="32" oct="4" pname="e" tstamp="1.125" />
                      <note dur="32" oct="4" pname="f" tstamp="1.25" accid.ges="s" />
                      <note dur="32" oct="4" pname="g" tstamp="1.375" accid="s" />
                    </beam>
                    <beam>
                      <note dur="32" oct="4" pname="a" tstamp="1.5" />
                      <note dur="32" oct="4" pname="g" tstamp="1.625" accid.ges="s" />
                      <note dur="32" oct="4" pname="b" tstamp="1.75" />
                      <note xml:id="note_16839" dur="32" oct="4" pname="a" tstamp="1.875" />
                    </beam>
                  </layer>
                </staff>
                <staff n="3">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="4">
                  <layer n="1">
                    <note dur="8" oct="2" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <slur staff="2" startid="#note_16788" endid="#note_16839" />
              </measure>
            </ending>
            <measure metcon="false" n="44b">
              <staff n="1">
                <layer n="1">
                  <beam>
                    <note xml:id="note_16968" dur="8" oct="4" pname="a" tstamp="1">
                      <supplied>
                        <artic artic="stacc" />
                      </supplied>
                    </note>
                    <note dur="8" oct="4" pname="a" tstamp="1.5">
                      <supplied>
                        <artic artic="stacc" />
                      </supplied>
                    </note>
                  </beam>
                </layer>
              </staff>
              <staff n="2">
                <layer n="1">
                  <beam>
                    <note xml:id="note_17007" dur="32" oct="5" pname="c" tstamp="1" accid="n" />
                    <note dur="32" oct="5" pname="d" tstamp="1.125" />
                    <note dur="32" oct="5" pname="c" tstamp="1.25" accid.ges="n" />
                    <note dur="32" oct="4" pname="b" tstamp="1.375" />
                  </beam>
                  <beam>
                    <note dur="32" oct="4" pname="a" tstamp="1.5" />
                    <note dur="32" oct="4" pname="g" tstamp="1.625" accid="n" />
                    <note dur="32" oct="4" pname="f" tstamp="1.75" accid.ges="s" />
                    <note xml:id="note_17058" dur="32" oct="4" pname="e" tstamp="1.875" />
                  </beam>
                </layer>
              </staff>
              <staff n="3">
                <layer n="1">
                  <rest dur="4" tstamp="1" />
                </layer>
              </staff>
              <staff n="4">
                <layer n="1">
                  <rest dur="4" tstamp="1" />
                </layer>
              </staff>
              <dynam staff="1" startid="#note_16968">p</dynam>
              <dynam staff="2" startid="#note_17007">p</dynam>
              <slur staff="2" startid="#note_17007" endid="#note_17058" />
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>
