### PR TITLE
New methods for barline drawing

### DIFF
--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -13,6 +13,8 @@
 
 namespace vrv {
 
+class StaffDef;
+
 enum class BarLinePosition { None, Left, Right };
 
 //----------------------------------------------------------------------------
@@ -58,8 +60,20 @@ public:
     /**
      * @name Get and set the position
      */
+    ///@{
     BarLinePosition GetPosition() const { return m_position; }
     void SetPosition(BarLinePosition position) { m_position = position; }
+    ///@}
+
+    /**
+     * @name Collect AttBarring attributes
+     * @return First entry is true if the attribute was found, second entry contains the value
+     */
+    ///@{
+    std::pair<bool, double> GetLength(const StaffDef *staffDef) const;
+    std::pair<bool, data_BARMETHOD> GetMethod(const StaffDef *staffDef) const;
+    std::pair<bool, int> GetPlace(const StaffDef *staffDef) const;
+    ///@}
 
     //----------//
     // Functors //

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -14,6 +14,7 @@
 namespace vrv {
 
 class StaffDef;
+class StaffGrp;
 
 enum class BarLinePosition { None, Left, Right };
 
@@ -64,6 +65,11 @@ public:
     BarLinePosition GetPosition() const { return m_position; }
     void SetPosition(BarLinePosition position) { m_position = position; }
     ///@}
+
+    /**
+     * Check if the barline is drawn through
+     */
+    bool IsDrawnThrough(const StaffGrp *staffGrp) const;
 
     /**
      * @name Collect AttBarring attributes

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -185,18 +185,6 @@ public:
     // Static methods //
     //----------------//
 
-    /**
-     * Swap values.
-     * This is useful for example when switching to the device context world.
-     */
-    static void Swap(int &v1, int &v2);
-
-    /**
-     * Swap the points passed as reference.
-     * This is useful for example when calculating bezier positions.
-     */
-    static void SwapPoints(Point &p1, Point &p2);
-
     static std::pair<double, int> ApproximateBezierExtrema(
         const Point bezier[4], bool isMaxExtrema, int approximationSteps = BEZIER_APPROXIMATION);
 

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -386,8 +386,14 @@ protected:
 private:
     /**
      * An vector of line segments
+     * They always have increasing order and orientation
      */
     ArrayOfIntPairs m_segments;
+
+    /**
+     * Flag indicating the orientation of the original line
+     */
+    bool m_increasing;
 };
 
 } // namespace vrv

--- a/include/vrv/scoredefinterface.h
+++ b/include/vrv/scoredefinterface.h
@@ -28,6 +28,7 @@ namespace vrv {
  * It is not an abstract class but should not be instanciated directly.
  */
 class ScoreDefInterface : public Interface,
+                          public AttBarring,
                           public AttDurationDefault,
                           public AttLyricStyle,
                           public AttMeasureNumbers,

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -30,6 +30,7 @@ class LabelAbbr;
  */
 class StaffGrp : public Object,
                  public ObjectListInterface,
+                 public AttBarring,
                  public AttBasic,
                  public AttLabelled,
                  public AttNNumberLike,

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -203,7 +203,7 @@ protected:
     void DrawSystem(DeviceContext *dc, System *system);
     void DrawSystemList(DeviceContext *dc, System *system, const ClassId classId);
     void DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure, int x, BarLine *barLine = NULL,
-        bool isLastMeasure = false);
+        bool isLastMeasure = false, bool isLastSystem = false);
     void DrawStaffGrp(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, int x, bool topStaffGrp = false,
         bool abbreviations = false);
     void DrawStaffDef(DeviceContext *dc, Staff *staff, Measure *measure);
@@ -216,7 +216,7 @@ protected:
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
-        int &yBottomPrevious);
+        bool isLastSystem, int &yBottomPrevious);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
         bool inStaffSpace = false, bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -216,7 +216,7 @@ protected:
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
-        bool isLastSystem, bool isSingleStaff, int &yBottomPrevious);
+        bool isLastSystem, int &yBottomPrevious);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
         bool inStaffSpace = false, bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -217,7 +217,7 @@ protected:
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
-        bool eraseIntersections = false, bool singleStaff = true);
+        bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerLines &lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -217,7 +217,7 @@ protected:
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
-        bool eraseIntersections = false);
+        bool inStaffSpace = false, bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerLines &lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -216,7 +216,7 @@ protected:
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
-        bool isLastSystem, int &yBottomPrevious);
+        bool isLastSystem, bool isSingleStaff, int &yBottomPrevious);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
         bool inStaffSpace = false, bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -215,7 +215,8 @@ protected:
     void DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBracketSq(DeviceContext *dc, int x, int y1, int y2, int staffSize);
     void DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize);
-    void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure);
+    void DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
+        int &yBottomPrevious);
     void DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLine, data_BARRENDITION form,
         bool inStaffSpace = false, bool eraseIntersections = false);
     void DrawBarLineDots(DeviceContext *dc, Staff *staff, BarLine *barLine);

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -83,8 +83,8 @@ bool BarLine::HasRepetitionDots() const
 bool BarLine::IsDrawnThrough(const StaffGrp *staffGrp) const
 {
     while (staffGrp) {
-        if (staffGrp->GetBarThru() == BOOLEAN_true) {
-            return true;
+        if (staffGrp->HasBarThru()) {
+            return (staffGrp->GetBarThru() == BOOLEAN_true);
         }
         staffGrp = dynamic_cast<const StaffGrp *>(staffGrp->GetParent());
     }

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -21,6 +21,7 @@
 #include "measure.h"
 #include "staff.h"
 #include "staffdef.h"
+#include "staffgrp.h"
 #include "system.h"
 #include "vrv.h"
 
@@ -75,6 +76,17 @@ bool BarLine::HasRepetitionDots() const
     if (this->GetForm() == BARRENDITION_rptstart || this->GetForm() == BARRENDITION_rptend
         || this->GetForm() == BARRENDITION_rptboth) {
         return true;
+    }
+    return false;
+}
+
+bool BarLine::IsDrawnThrough(const StaffGrp *staffGrp) const
+{
+    while (staffGrp) {
+        if (staffGrp->GetBarThru() == BOOLEAN_true) {
+            return true;
+        }
+        staffGrp = dynamic_cast<const StaffGrp *>(staffGrp->GetParent());
     }
     return false;
 }

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -20,6 +20,7 @@
 #include "layer.h"
 #include "measure.h"
 #include "staff.h"
+#include "staffdef.h"
 #include "system.h"
 #include "vrv.h"
 
@@ -76,6 +77,81 @@ bool BarLine::HasRepetitionDots() const
         return true;
     }
     return false;
+}
+
+std::pair<bool, double> BarLine::GetLength(const StaffDef *staffDef) const
+{
+    // First check the parent measure
+    const Measure *measure = dynamic_cast<const Measure *>(this->GetParent());
+    if (measure && measure->HasBarLen()) {
+        return { true, measure->GetBarLen() };
+    }
+
+    // Then check the staffDef and its ancestors
+    const Object *object = staffDef;
+    while (object) {
+        if (object->HasAttClass(ATT_BARRING)) {
+            const AttBarring *att = dynamic_cast<const AttBarring *>(object);
+            assert(att);
+            if (att->HasBarLen()) {
+                return { true, att->GetBarLen() };
+            }
+        }
+        if (object->Is(SCOREDEF)) break;
+        object = object->GetParent();
+    }
+
+    return { false, 0.0 };
+}
+
+std::pair<bool, data_BARMETHOD> BarLine::GetMethod(const StaffDef *staffDef) const
+{
+    // First check the parent measure
+    const Measure *measure = dynamic_cast<const Measure *>(this->GetParent());
+    if (measure && measure->HasBarMethod()) {
+        return { true, measure->GetBarMethod() };
+    }
+
+    // Then check the staffDef and its ancestors
+    const Object *object = staffDef;
+    while (object) {
+        if (object->HasAttClass(ATT_BARRING)) {
+            const AttBarring *att = dynamic_cast<const AttBarring *>(object);
+            assert(att);
+            if (att->HasBarMethod()) {
+                return { true, att->GetBarMethod() };
+            }
+        }
+        if (object->Is(SCOREDEF)) break;
+        object = object->GetParent();
+    }
+
+    return { false, BARMETHOD_NONE };
+}
+
+std::pair<bool, int> BarLine::GetPlace(const StaffDef *staffDef) const
+{
+    // First check the parent measure
+    const Measure *measure = dynamic_cast<const Measure *>(this->GetParent());
+    if (measure && measure->HasBarPlace()) {
+        return { true, measure->GetBarPlace() };
+    }
+
+    // Then check the staffDef and its ancestors
+    const Object *object = staffDef;
+    while (object) {
+        if (object->HasAttClass(ATT_BARRING)) {
+            const AttBarring *att = dynamic_cast<const AttBarring *>(object);
+            assert(att);
+            if (att->HasBarPlace()) {
+                return { true, att->GetBarPlace() };
+            }
+        }
+        if (object->Is(SCOREDEF)) break;
+        object = object->GetParent();
+    }
+
+    return { false, 0 };
 }
 
 //----------------------------------------------------------------------------

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -795,20 +795,6 @@ int BoundingBox::Intersects(const BeamDrawingInterface *beamInterface, Accessor 
 // Static methods for BoundingBox
 //----------------------------------------------------------------------------
 
-void BoundingBox::SwapPoints(Point &p1, Point &p2)
-{
-    Point tmp = p1;
-    p1 = p2;
-    p2 = tmp;
-}
-
-void BoundingBox::Swap(int &v1, int &v2)
-{
-    int tmp = v1;
-    v1 = v2;
-    v2 = tmp;
-}
-
 Point BoundingBox::CalcPositionAfterRotation(Point point, float alpha, Point center)
 {
     if (point == center) return point;
@@ -1153,7 +1139,7 @@ SegmentedLine::SegmentedLine(int start, int end)
 {
     m_increasing = (start <= end);
     if (!m_increasing) {
-        BoundingBox::Swap(start, end);
+        std::swap(start, end);
     }
     m_segments.push_back({ start, end });
 }
@@ -1179,7 +1165,7 @@ void SegmentedLine::AddGap(int start, int end)
 
     // Internally segments always have increasing order and orientation
     if (start > end) {
-        BoundingBox::Swap(start, end);
+        std::swap(start, end);
     }
 
     // nothing to do

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -1151,7 +1151,8 @@ int BoundingBox::RectBottomOverlap(const Point rect1[2], const Point rect2[2], i
 
 SegmentedLine::SegmentedLine(int start, int end)
 {
-    if (start > end) {
+    m_increasing = (start <= end);
+    if (!m_increasing) {
         BoundingBox::Swap(start, end);
     }
     m_segments.push_back({ start, end });
@@ -1162,13 +1163,21 @@ std::pair<int, int> SegmentedLine::GetStartEnd(int idx) const
     assert(idx >= 0);
     assert(idx < this->GetSegmentCount());
 
-    return { m_segments.at(idx).first, m_segments.at(idx).second };
+    if (m_increasing) {
+        return { m_segments.at(idx).first, m_segments.at(idx).second };
+    }
+    else {
+        // Read the segment array "backwards"
+        idx = this->GetSegmentCount() - 1 - idx;
+        return { m_segments.at(idx).second, m_segments.at(idx).first };
+    }
 }
 
 void SegmentedLine::AddGap(int start, int end)
 {
     assert(start != end);
 
+    // Internally segments always have increasing order and orientation
     if (start > end) {
         BoundingBox::Swap(start, end);
     }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1659,6 +1659,7 @@ void MEIOutput::WriteStaffGrp(pugi::xml_node currentNode, StaffGrp *staffGrp)
     assert(staffGrp);
 
     this->WriteXmlId(currentNode, staffGrp);
+    staffGrp->WriteBarring(currentNode);
     staffGrp->WriteBasic(currentNode);
     staffGrp->WriteLabelled(currentNode);
     staffGrp->WriteNNumberLike(currentNode);
@@ -2811,6 +2812,7 @@ void MEIOutput::WriteScoreDefInterface(pugi::xml_node element, ScoreDefInterface
 {
     assert(interface);
 
+    interface->WriteBarring(element);
     interface->WriteDurationDefault(element);
     interface->WriteLyricStyle(element);
     interface->WriteMidiTempo(element);
@@ -4482,6 +4484,7 @@ bool MEIInput::ReadStaffGrp(Object *parent, pugi::xml_node staffGrp)
         UpgradeStaffGrpTo_4_0_0(staffGrp, vrvStaffGrp);
     }
 
+    vrvStaffGrp->ReadBarring(staffGrp);
     vrvStaffGrp->ReadBasic(staffGrp);
     vrvStaffGrp->ReadLabelled(staffGrp);
     vrvStaffGrp->ReadNNumberLike(staffGrp);
@@ -6693,6 +6696,7 @@ bool MEIInput::ReadPositionInterface(pugi::xml_node element, PositionInterface *
 
 bool MEIInput::ReadScoreDefInterface(pugi::xml_node element, ScoreDefInterface *interface)
 {
+    interface->ReadBarring(element);
     interface->ReadDurationDefault(element);
     interface->ReadLyricStyle(element);
     interface->ReadMidiTempo(element);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -889,7 +889,8 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
                     staffGrp->AddChild(grpSym);
                 }
                 const std::string groupBarline = xpathNode.node().child("group-barline").text().as_string();
-                staffGrp->SetBarThru(ConvertWordToBool(groupBarline));
+                if (!groupBarline.empty()) staffGrp->SetBarThru((groupBarline == "no") ? BOOLEAN_false : BOOLEAN_true);
+                if (groupBarline == "Mensurstrich") staffGrp->SetBarMethod(BARMETHOD_mensur);
                 // now stack it
                 const std::string groupName
                     = GetContentOfChild(xpathNode.node(), "group-name[not(@print-object='no')]");

--- a/src/scoredefinterface.cpp
+++ b/src/scoredefinterface.cpp
@@ -25,6 +25,7 @@ namespace vrv {
 
 ScoreDefInterface::ScoreDefInterface()
     : Interface()
+    , AttBarring()
     , AttDurationDefault()
     , AttLyricStyle()
     , AttMeasureNumbers()
@@ -34,6 +35,7 @@ ScoreDefInterface::ScoreDefInterface()
     , AttSpacing()
     , AttSystems()
 {
+    this->RegisterInterfaceAttClass(ATT_BARRING);
     this->RegisterInterfaceAttClass(ATT_DURATIONDEFAULT);
     this->RegisterInterfaceAttClass(ATT_LYRICSTYLE);
     this->RegisterInterfaceAttClass(ATT_MEASURENUMBERS);
@@ -52,6 +54,7 @@ ScoreDefInterface::~ScoreDefInterface() {}
 
 void ScoreDefInterface::Reset()
 {
+    this->ResetBarring();
     this->ResetDurationDefault();
     this->ResetLyricStyle();
     this->ResetMeasureNumbers();

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -33,6 +33,7 @@ static const ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
 StaffGrp::StaffGrp()
     : Object(STAFFGRP, "staffgrp-")
     , ObjectListInterface()
+    , AttBarring()
     , AttBasic()
     , AttLabelled()
     , AttNNumberLike()
@@ -40,6 +41,7 @@ StaffGrp::StaffGrp()
     , AttStaffGrpVis()
     , AttTyped()
 {
+    this->RegisterAttClass(ATT_BARRING);
     this->RegisterAttClass(ATT_BASIC);
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);
@@ -55,6 +57,7 @@ StaffGrp::~StaffGrp() {}
 void StaffGrp::Reset()
 {
     Object::Reset();
+    this->ResetBarring();
     this->ResetBasic();
     this->ResetLabelled();
     this->ResetNNumberLike();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -623,7 +623,7 @@ void View::DrawHairpin(
     }
 
     // Now swap start/end for dim.
-    if (form == hairpinLog_FORM_dim) BoundingBox::Swap(startY, endY);
+    if (form == hairpinLog_FORM_dim) std::swap(startY, endY);
 
     int y1 = hairpin->GetDrawingY();
     int y2 = y1;

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -87,7 +87,7 @@ void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y
 {
     assert(dc); // DC cannot be NULL
 
-    BoundingBox::Swap(y1, y2);
+    std::swap(y1, y2);
 
     dc->SetPen(m_currentColour, lineThickness, AxSOLID);
     dc->SetBrush(m_currentColour, AxTRANSPARENT);
@@ -109,7 +109,7 @@ void View::DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, in
 {
     assert(dc); // DC cannot be NULL
 
-    BoundingBox::Swap(y1, y2);
+    std::swap(y1, y2);
 
     // dc->SetPen(m_currentColour, 0, AxSOLID );
     // dc->SetBrush(AxWHITE, AxTRANSPARENT);
@@ -128,7 +128,7 @@ void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int
 {
     assert(dc); // DC cannot be NULL
 
-    BoundingBox::Swap(y1, y2);
+    std::swap(y1, y2);
 
     const int penWidth = lineThickness;
     dc->SetPen(m_currentColour, penWidth, AxSOLID);
@@ -157,7 +157,7 @@ void View::DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2,
 {
     assert(dc);
 
-    BoundingBox::Swap(y1, y2);
+    std::swap(y1, y2);
 
     dc->SetPen(m_currentColour, 0, AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -243,16 +243,16 @@ void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line,
 {
     if (line.GetSegmentCount() > 1) return;
 
-    const auto [start, end] = line.GetStartEnd(0);
+    const auto [top, bottom] = line.GetStartEnd(0);
     const int radius = std::max(barlineWidth, 2);
-    int drawingPosition = start + interval / 2;
+    int drawingPosition = top - interval / 2;
 
     dc->SetPen(m_currentColour, 0, AxSOLID);
     dc->SetBrush(m_currentColour, AxSOLID);
 
-    while (drawingPosition < end) {
+    while (drawingPosition > bottom) {
         dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(drawingPosition), radius);
-        drawingPosition += interval;
+        drawingPosition -= interval;
     }
 
     dc->ResetPen();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -790,17 +790,19 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         int yLength = staff->GetDrawingY() - yBottom;
 
         // Adjust barline start and length
-        if (measure->HasBarPlace()) {
+        const auto [hasPlace, place] = barLine->GetPlace(staffDef);
+        if (hasPlace) {
             // bar.place counts upwards (note order).
-            yBottom += measure->GetBarPlace() * unit;
+            yBottom += place * unit;
         }
         else if (staffDef->GetLines() <= 1) {
             // Make sure barlines are visible with a single line
             yBottom -= 2 * unit;
         }
 
-        if (measure->HasBarLen()) {
-            yLength = measure->GetBarLen() * unit;
+        const auto [hasLength, length] = barLine->GetLength(staffDef);
+        if (hasLength) {
+            yLength = length * unit;
         }
         else if (staffDef->GetLines() <= 1) {
             yLength = 4 * unit;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -747,9 +747,13 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
             continue;
         }
 
+        // Determine the staff def
         if (!child->Is(STAFFDEF)) continue;
         StaffDef *staffDef = vrv_cast<StaffDef *>(child);
         assert(staffDef);
+        if (staffDef->GetDrawingVisibility() == OPTIMIZATION_HIDDEN) {
+            continue;
+        }
 
         // Determine the barline form
         data_BARRENDITION form = barLine->GetForm();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -660,7 +660,7 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     y1 -= penWidth;
     y2 += penWidth;
     x += penWidth;
-    BoundingBox::Swap(y1, y2);
+    std::swap(y1, y2);
 
     const int fact = m_doc->GetDrawingBeamWhiteWidth(staffSize, false) + m_doc->GetDrawingStemWidth(staffSize);
     const int xdec = ToDeviceContextX(fact);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -817,7 +817,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         bool drawOutsideStaff = methodMensur || (!methodTakt && barlineThrough);
         bool drawTaktstrichAbove = methodTakt;
         bool drawTaktstrichBelow = false;
-        if (isLastMeasure && isLastSystem) {
+        if ((isLastMeasure && isLastSystem) || barLine->HasRepetitionDots()) {
             drawInsideStaff = true;
             drawTaktstrichAbove = false;
             drawTaktstrichBelow = false;
@@ -826,7 +826,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // Now draw the barline part inside the staff
         if (drawInsideStaff) {
             this->DrawBarLine(dc, yTop, yBottom, barLine, form);
-            if (!methodTakt && barLine->HasRepetitionDots()) {
+            if (barLine->HasRepetitionDots()) {
                 this->DrawBarLineDots(dc, staff, barLine);
             }
         }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -786,23 +786,30 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
             drawnPrevious = false;
             continue;
         }
+        const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
         // For the bottom position we need to take into account the number of lines and the staff size
-        int yBottom = staff->GetDrawingY()
-            - (staffDef->GetLines() - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        int yBottom = staff->GetDrawingY() - 2 * (staffDef->GetLines() - 1) * unit;
+        int yLength = staff->GetDrawingY() - yBottom;
+
+        // Adjust barline start and length
         if (measure->HasBarPlace()) {
             // bar.place counts upwards (note order).
-            yBottom += measure->GetBarPlace() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            yBottom += measure->GetBarPlace() * unit;
         }
-        int yTop = staff->GetDrawingY();
+        else if (staffDef->GetLines() <= 1) {
+            // Make sure barlines are visible with a single line
+            yBottom -= 2 * unit;
+        }
+
         if (measure->HasBarLen()) {
-            yTop = yBottom + (measure->GetBarLen() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
+            yLength = measure->GetBarLen() * unit;
         }
-        // Make sure barlines are visible with a single line
-        if (staffDef->GetLines() <= 1) {
-            yTop = yBottom + m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
-            yBottom -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+        else if (staffDef->GetLines() <= 1) {
+            yLength = 4 * unit;
         }
+
+        const int yTop = yBottom + yLength;
 
         // Now draw the barline in the staff
         this->DrawBarLine(dc, yTop, yBottom, barLine, form, false, true);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -875,11 +875,8 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
     const int barLinesSum = barLineThickWidth + barLineWidth;
     int x2 = x + barLineSeparation;
 
-    const int dotLength = m_doc->GetDrawingUnit(staffSize) * 4 / 13;
-    const int dashLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarLineDashLength.GetValue();
-    const int gapLength = m_doc->GetDrawingUnit(staffSize) * m_options->m_dashedBarLineGapLength.GetValue();
-    // optimized for five line staves
-    const int dashLength = unit * 8 / 7;
+    const int dashLength = unit * m_options->m_dashedBarLineDashLength.GetValue();
+    const int gapLength = unit * m_options->m_dashedBarLineGapLength.GetValue();
     if (inStaffSpace && ((form == BARRENDITION_dashed) || (form == BARRENDITION_dbldashed))) {
         // Dashed lines in staff space should start with a gap
         yTop -= dashLength;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -305,6 +305,7 @@ void View::DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure,
     if (!staffGrp) {
         return;
     }
+    const bool isSingleStaff = (staffGrp->GetListSize(staffGrp) == 1);
 
     if (barLine == NULL) {
         // Draw the first staffGrp and from there its children recursively
@@ -313,7 +314,7 @@ void View::DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure,
     else {
         dc->StartGraphic(barLine, "", barLine->GetID());
         int yBottomPrevious = VRV_UNSET;
-        this->DrawBarLines(dc, measure, staffGrp, barLine, isLastMeasure, isLastSystem, yBottomPrevious);
+        this->DrawBarLines(dc, measure, staffGrp, barLine, isLastMeasure, isLastSystem, isSingleStaff, yBottomPrevious);
         dc->EndGraphic(barLine, this);
     }
 
@@ -722,7 +723,7 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
 }
 
 void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
-    bool isLastSystem, int &yBottomPrevious)
+    bool isLastSystem, bool isSingleStaff, int &yBottomPrevious)
 {
     assert(dc);
     assert(measure);
@@ -741,7 +742,8 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // Recursive call for staff group
         if (child->Is(STAFFGRP)) {
             StaffGrp *childStaffGrp = vrv_cast<StaffGrp *>(child);
-            this->DrawBarLines(dc, measure, childStaffGrp, barLine, isLastMeasure, isLastSystem, yBottomPrevious);
+            this->DrawBarLines(
+                dc, measure, childStaffGrp, barLine, isLastMeasure, isLastSystem, isSingleStaff, yBottomPrevious);
             continue;
         }
 
@@ -817,6 +819,10 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         bool drawOutsideStaff = methodMensur || (!methodTakt && barlineThrough);
         bool drawTaktstrichAbove = methodTakt;
         bool drawTaktstrichBelow = false;
+        if (methodMensur && isSingleStaff) {
+            drawTaktstrichAbove = true;
+            drawTaktstrichBelow = true;
+        }
         if ((isLastMeasure && isLastSystem) || barLine->HasRepetitionDots()) {
             drawInsideStaff = true;
             drawTaktstrichAbove = false;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -305,7 +305,6 @@ void View::DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure,
     if (!staffGrp) {
         return;
     }
-    const bool isSingleStaff = (staffGrp->GetListSize(staffGrp) == 1);
 
     if (barLine == NULL) {
         // Draw the first staffGrp and from there its children recursively
@@ -314,7 +313,7 @@ void View::DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure,
     else {
         dc->StartGraphic(barLine, "", barLine->GetID());
         int yBottomPrevious = VRV_UNSET;
-        this->DrawBarLines(dc, measure, staffGrp, barLine, isLastMeasure, isLastSystem, isSingleStaff, yBottomPrevious);
+        this->DrawBarLines(dc, measure, staffGrp, barLine, isLastMeasure, isLastSystem, yBottomPrevious);
         dc->EndGraphic(barLine, this);
     }
 
@@ -723,7 +722,7 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
 }
 
 void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, BarLine *barLine, bool isLastMeasure,
-    bool isLastSystem, bool isSingleStaff, int &yBottomPrevious)
+    bool isLastSystem, int &yBottomPrevious)
 {
     assert(dc);
     assert(measure);
@@ -742,8 +741,7 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
         // Recursive call for staff group
         if (child->Is(STAFFGRP)) {
             StaffGrp *childStaffGrp = vrv_cast<StaffGrp *>(child);
-            this->DrawBarLines(
-                dc, measure, childStaffGrp, barLine, isLastMeasure, isLastSystem, isSingleStaff, yBottomPrevious);
+            this->DrawBarLines(dc, measure, childStaffGrp, barLine, isLastMeasure, isLastSystem, yBottomPrevious);
             continue;
         }
 
@@ -820,13 +818,9 @@ void View::DrawBarLines(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp,
 
         // Determine which parts to draw
         bool drawInsideStaff = !methodMensur && !methodTakt;
-        bool drawOutsideStaff = methodMensur || (!methodTakt && barlineThrough);
-        bool drawTaktstrichAbove = methodTakt;
-        bool drawTaktstrichBelow = false;
-        if (methodMensur && isSingleStaff) {
-            drawTaktstrichAbove = true;
-            drawTaktstrichBelow = true;
-        }
+        bool drawOutsideStaff = !methodTakt && barlineThrough;
+        bool drawTaktstrichAbove = (methodMensur && !barlineThrough) || methodTakt;
+        bool drawTaktstrichBelow = methodMensur && !barlineThrough;
         if ((isLastMeasure && isLastSystem) || barLine->HasRepetitionDots()) {
             drawInsideStaff = true;
             drawTaktstrichAbove = false;


### PR DESCRIPTION
This PR enhances the drawing of barlines.

**(1)** We restructure the code for barline drawing removing the case distinction on `@bar.thru` . Now we always use recursion and barlines are drawn segment wise over several staves.

**(2)** Barlines are always drawn from top to bottom. They restart on the top of each staff. The default dash/gap length for dashed barlines is chosen such that 4 dashes appear symmetrically on the five-line staff. Double dotted barlines are drawn with real dots. This partially (?!) resolves #2958 .

<img width="1441" alt="Dashed" src="https://user-images.githubusercontent.com/63608463/178275836-645d4246-bc6b-4fff-b580-e11145d36c63.png">

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title>Barline example</title>
      </titleStmt>
      <pubStmt>
        <date>2018-05-29</date>
      </pubStmt>
      <seriesStmt>
        <title>Verovio test suite</title>
      </seriesStmt>
      <notesStmt>
        <annot>Verovio supports both various bar line types. Bar lines should be spaces approrpately</annot>
      </notesStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application version="2.0.0" label="2">
          <name>Verovio</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef meter.count="2" meter.unit="4">
            <staffGrp bar.thru="false">
              <staffGrp symbol="bracket" bar.thru="true">
                <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="2s">
                  <label>Violino I</label>
                </staffDef>
                <staffDef n="2" lines="5" clef.shape="G" clef.line="2" key.sig="2s">
                  <label>Violino II</label>
                </staffDef>
                <staffDef n="3" lines="5" clef.shape="C" clef.line="3" key.sig="2s">
                  <label>Viola</label>
                </staffDef>
                <staffDef n="4" lines="5" clef.shape="F" clef.line="4" key.sig="2s">
                  <label>Violoncello</label>
                </staffDef>
              </staffGrp>
            </staffGrp>
          </scoreDef>
          <section>
            <ending n="1">
              <measure left="dashed" right="dbldotted" metcon="false" n="44a-1">
                <staff n="1">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="2">
                  <layer n="1">
                    <beam>
                      <note xml:id="note_16590" dur="32" oct="4" pname="c" tstamp="1" accid.ges="s" />
                      <note dur="32" oct="4" pname="e" tstamp="1.125" />
                      <note dur="32" oct="4" pname="a" tstamp="1.25" />
                      <note dur="32" oct="4" pname="g" tstamp="1.375" accid="s" />
                    </beam>
                    <beam>
                      <note dur="32" oct="4" pname="g" tstamp="1.5" accid="n" />
                      <note dur="32" oct="4" pname="f" tstamp="1.625" accid.ges="s" />
                      <note dur="32" oct="4" pname="g" tstamp="1.75" accid.ges="n" />
                      <note xml:id="note_16641" dur="32" oct="4" pname="e" tstamp="1.875" />
                    </beam>
                  </layer>
                </staff>
                <staff n="3">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="4">
                  <layer n="1">
                    <note dur="8" oct="2" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <slur staff="2" startid="#note_16590" endid="#note_16641" />
              </measure>
            </ending>
            <ending n="2">
              <measure right="dbldashed" metcon="false" n="44a-2">
                <staff n="1">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="2">
                  <layer n="1">
                    <beam>
                      <note xml:id="note_16788" dur="32" oct="4" pname="c" tstamp="1" accid.ges="s" />
                      <note dur="32" oct="4" pname="e" tstamp="1.125" />
                      <note dur="32" oct="4" pname="f" tstamp="1.25" accid.ges="s" />
                      <note dur="32" oct="4" pname="g" tstamp="1.375" accid="s" />
                    </beam>
                    <beam>
                      <note dur="32" oct="4" pname="a" tstamp="1.5" />
                      <note dur="32" oct="4" pname="g" tstamp="1.625" accid.ges="s" />
                      <note dur="32" oct="4" pname="b" tstamp="1.75" />
                      <note xml:id="note_16839" dur="32" oct="4" pname="a" tstamp="1.875" />
                    </beam>
                  </layer>
                </staff>
                <staff n="3">
                  <layer n="1">
                    <note dur="8" oct="4" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <staff n="4">
                  <layer n="1">
                    <note dur="8" oct="2" pname="a" tstamp="1" />
                    <rest dur="8" tstamp="1.5" />
                  </layer>
                </staff>
                <slur staff="2" startid="#note_16788" endid="#note_16839" />
              </measure>
            </ending>
            <measure metcon="false" n="44b">
              <staff n="1">
                <layer n="1">
                  <beam>
                    <note xml:id="note_16968" dur="8" oct="4" pname="a" tstamp="1">
                      <supplied>
                        <artic artic="stacc" />
                      </supplied>
                    </note>
                    <note dur="8" oct="4" pname="a" tstamp="1.5">
                      <supplied>
                        <artic artic="stacc" />
                      </supplied>
                    </note>
                  </beam>
                </layer>
              </staff>
              <staff n="2">
                <layer n="1">
                  <beam>
                    <note xml:id="note_17007" dur="32" oct="5" pname="c" tstamp="1" accid="n" />
                    <note dur="32" oct="5" pname="d" tstamp="1.125" />
                    <note dur="32" oct="5" pname="c" tstamp="1.25" accid.ges="n" />
                    <note dur="32" oct="4" pname="b" tstamp="1.375" />
                  </beam>
                  <beam>
                    <note dur="32" oct="4" pname="a" tstamp="1.5" />
                    <note dur="32" oct="4" pname="g" tstamp="1.625" accid="n" />
                    <note dur="32" oct="4" pname="f" tstamp="1.75" accid.ges="s" />
                    <note xml:id="note_17058" dur="32" oct="4" pname="e" tstamp="1.875" />
                  </beam>
                </layer>
              </staff>
              <staff n="3">
                <layer n="1">
                  <rest dur="4" tstamp="1" />
                </layer>
              </staff>
              <staff n="4">
                <layer n="1">
                  <rest dur="4" tstamp="1" />
                </layer>
              </staff>
              <dynam staff="1" startid="#note_16968">p</dynam>
              <dynam staff="2" startid="#note_17007">p</dynam>
              <slur staff="2" startid="#note_17007" endid="#note_17058" />
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

**(3)** We add support for notation type _mensur_ and _takt_ . Repetition barlines will be drawn as before and an ordinary barline occurs after the last measure of the mdiv.

<img width="1092" alt="NotationTypes" src="https://user-images.githubusercontent.com/63608463/178277161-b6c07391-f749-4731-84db-cc466e3508f6.png">

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Score and barlines example</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2017-05-09">2017-05-09</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Verovio supports the score parameters defined in the "scoreDef", "staffGrp" and "staffDef" elements with some of their
					attributes. Verovio also supports various types of barline for the "measure" elements. It also supports the "scale" attribute on
					the "staffDef" element.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="1.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffGrp bar.thru="true" bar.method="mensur">
                        <grpSym symbol="bracket" />
                        <staffDef n="1" scale="66.00%" lines="5" clef.shape="G" clef.line="2" />
                        <staffGrp>
                           <grpSym symbol="brace" />
                           <staffDef n="2" scale="66.00%" lines="5" clef.shape="G" clef.line="2" />
                           <staffDef n="3" scale="66.00%" lines="5" clef.shape="G" clef.line="2" />
                        </staffGrp>
                     </staffGrp>
                     <staffDef n="4" lines="5" clef.shape="G" clef.line="2" bar.method="takt" />
                     <staffGrp bar.thru="true">
                        <grpSym symbol="brace" />
                        <staffDef n="5" lines="5" clef.shape="G" clef.line="2" />
                        <staffDef n="6" lines="5" clef.shape="F" clef.line="4" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
                  <measure right="dbl" n="3">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
                  <measure right="rptstart" n="4">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
                  <measure right="rptboth" n="5">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
                  <measure right="rptend" n="6">
                     <staff n="1">
                        <layer n="1" />
                     </staff>
                     <staff n="2">
                        <layer n="1" />
                     </staff>
                     <staff n="3">
                        <layer n="1" />
                     </staff>
                     <staff n="4">
                        <layer n="1" />
                     </staff>
                     <staff n="5">
                        <layer n="1" />
                     </staff>
                     <staff n="6">
                        <layer n="1" />
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

**(4)** Notation type _mensur_ is rendered differently depending on whether `@bar.thru` is set or not.

<img width="1432" alt="Mensural" src="https://user-images.githubusercontent.com/63608463/178277441-028b3a96-5c2c-4c29-91ed-605492251a1b.png">

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt><date isodate="2022-05-06" type="encoding-date">2022-05-06</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef bar.method="mensur">
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="4" trans.diat="6.000000" trans.semi="10.000000">
                        <instrDef midi.channel="0" midi.instrnum="56" midi.volume="78.00%" />
                        <clef shape="G" line="2" />
                        <keySig sig="4s" />
                        <meterSig count="3" unit="4" />
                     </staffDef>
                     <staffGrp>
                        <staffGrp bar.thru="true">
                           <grpSym symbol="bracket" />
                           <instrDef midi.channel="2" midi.instrnum="19" midi.volume="78.00%" />
                           <staffGrp>
                              <grpSym symbol="brace" />
                              <staffDef n="2" lines="5" ppq="4">
                                 <clef shape="G" line="2" />
                                 <keySig sig="2s" />
                                 <meterSig count="3" unit="4" />
                              </staffDef>
                              <staffDef n="3" lines="5" ppq="4">
                                 <clef shape="F" line="4" />
                                 <keySig sig="2s" />
                                 <meterSig count="3" unit="4" />
                              </staffDef>
                           </staffGrp>
                           <staffDef n="4" lines="5" ppq="4">
                              <clef shape="F" line="4" />
                              <keySig sig="2s" />
                              <meterSig count="3" unit="4" />
                           </staffDef>
                        </staffGrp>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="0">
                     <mNum />
                     <staff n="1">
                        <layer n="1">
                           <rest dur.ppq="4" dur="4" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <note dur.ppq="4" dur="4" oct="4" pname="a" stem.dir="up" />
                        </layer>
                     </staff>
                     <staff n="3">
                        <layer n="5">
                           <rest dur.ppq="4" dur="4" />
                        </layer>
                     </staff>
                     <staff n="4">
                        <layer n="9">
                           <rest dur.ppq="4" dur="4" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <chord dur.ppq="4" dur="4" stem.dir="up">
                              <note oct="4" pname="f" accid.ges="s" />
                              <note oct="4" pname="a" />
                              <note oct="5" pname="d" />
                           </chord>
                           <beam>
                              <chord dur.ppq="2" dur="8" stem.dir="down">
                                 <note oct="5" pname="d" />
                                 <note oct="5" pname="f" accid.ges="s" />
                              </chord>
                              <chord dur.ppq="2" dur="8" stem.dir="down">
                                 <note oct="5" pname="c" accid.ges="s" />
                                 <note oct="5" pname="e" />
                              </chord>
                           </beam>
                           <note dur.ppq="4" dur="4" oct="5" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="3">
                        <layer n="5">
                           <chord dur.ppq="4" dur="4" stem.dir="up">
                              <note oct="2" pname="d" />
                              <note oct="3" pname="d" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="d" />
                              <note oct="4" pname="d" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="d" />
                              <note oct="4" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="4">
                        <layer n="9">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <chord dur.ppq="4" dur="4" stem.dir="up">
                              <note oct="5" pname="e" />
                              <note oct="5" pname="a" />
                           </chord>
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                              <note dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                           </beam>
                           <note dur.ppq="4" dur="4" oct="5" pname="d" stem.dir="up" />
                        </layer>
                        <layer n="2">
                           <note dur.ppq="4" dur="4" oct="4" pname="a" stem.dir="down" />
                           <note dur.ppq="4" dur="4" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                           <note xml:id="ns357g7" dur.ppq="4" dur="4" oct="5" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="3">
                        <layer n="5">
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="c" accid.ges="s" />
                              <note oct="4" pname="c" accid.ges="s" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="2" pname="a" />
                              <note oct="3" pname="a" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="2" pname="b" />
                              <note oct="3" pname="b" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="4">
                        <layer n="9">
                           <mRest />
                        </layer>
                     </staff>
                     <tie startid="#ns357g7" endid="#nr4q7wk" />
                  </measure>
                  <measure n="3">
                     <staff n="1">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                              <note dur.ppq="2" dur="8" oct="5" pname="d" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                              <note dur.ppq="2" dur="8" oct="5" pname="g" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                              <note dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer n="2">
                           <note xml:id="nr4q7wk" dur.ppq="4" dur="4" oct="5" pname="d" stem.dir="down" />
                           <note dur.ppq="8" dur="2" oct="5" pname="c" stem.dir="down" accid.ges="s" />
                        </layer>
                     </staff>
                     <staff n="3">
                        <layer n="5">
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="g" />
                              <note oct="3" pname="b" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="g" />
                              <note oct="3" pname="a" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="2" pname="a" />
                              <note oct="3" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="4">
                        <layer n="9">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="4">
                     <staff n="1">
                        <layer n="1">
                           <mRest />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <chord dur.ppq="4" dur="4" stem.dir="up">
                              <note oct="5" pname="d" />
                              <note oct="5" pname="f" accid.ges="s" />
                           </chord>
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="d" stem.dir="up" />
                              <note dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                           </beam>
                           <beam>
                              <note dur.ppq="2" dur="8" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                              <note dur.ppq="2" dur="8" oct="5" pname="a" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer n="2">
                           <note dur.ppq="4" dur="4" oct="4" pname="a" stem.dir="down" />
                           <note dur.ppq="4" dur="4" oct="4" pname="a" stem.dir="down" />
                           <note dur.ppq="4" dur="4" oct="5" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff n="3">
                        <layer n="5">
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="f" accid.ges="s" />
                              <note oct="4" pname="d" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="d" />
                              <note oct="3" pname="f" accid.ges="s" />
                           </chord>
                           <chord dur.ppq="4" dur="4" stem.dir="down">
                              <note oct="3" pname="f" accid.ges="s" />
                              <note oct="4" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                     <staff n="4">
                        <layer n="9">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
