### PR TITLE
Const correctness for container elements

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1674,7 +1674,7 @@ public:
         m_object = NULL;
     }
 
-    Object *m_object;
+    const Object *m_object;
     std::string m_id;
 };
 

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -46,9 +46,11 @@ public:
      */
     ///@{
     void SetStartDef(StaffDef *start);
-    StaffDef *GetStartDef() const { return m_startDef; };
+    StaffDef *GetStartDef() { return m_startDef; }
+    const StaffDef *GetStartDef() const { return m_startDef; }
     void SetEndDef(StaffDef *end);
-    StaffDef *GetEndDef() const { return m_endDef; };
+    StaffDef *GetEndDef() { return m_endDef; }
+    const StaffDef *GetEndDef() const { return m_endDef; }
     ///@}
 
     /**

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -68,9 +68,10 @@ public:
      */
     int GetLayerIdx() const { return Object::GetIdx(); }
 
-    LayerElement *GetPrevious(LayerElement *element);
+    LayerElement *GetPrevious(const LayerElement *element);
+    const LayerElement *GetPrevious(const LayerElement *element) const;
     LayerElement *GetAtPos(int x);
-    LayerElement *Insert(LayerElement *element, int x); // return a pointer to the inserted element
+    const LayerElement *GetAtPos(int x) const;
 
     /**
      * Get the current clef for the test element.
@@ -79,7 +80,7 @@ public:
      * to know the clef in order to get the pitch.
      */
     ///@{
-    Clef *GetClef(LayerElement *test);
+    Clef *GetClef(const LayerElement *test);
     const Clef *GetClef(const LayerElement *test) const;
     ///@}
 
@@ -89,7 +90,7 @@ public:
      * Returns NULL if a clef cannot be found via this method.
      */
     ///@{
-    Clef *GetClefFacs(LayerElement *test);
+    Clef *GetClefFacs(const LayerElement *test);
     const Clef *GetClefFacs(const LayerElement *test) const;
     ///@}
 
@@ -171,38 +172,55 @@ public:
     void ResetStaffDefObjects();
 
     /**
-     * Set drawing clef, keysig and mensur if necessary and if available.
+     * Set drawing clef, keysig, mensur, metersig, metersiggrp if necessary and if available.
      */
+    ///@{
     void SetDrawingStaffDefValues(StaffDef *currentStaffDef);
 
     bool DrawKeySigCancellation() const { return m_drawKeySigCancellation; }
     void SetDrawKeySigCancellation(bool drawKeySigCancellation) { m_drawKeySigCancellation = drawKeySigCancellation; }
-    Clef *GetStaffDefClef() const { return m_staffDefClef; }
-    KeySig *GetStaffDefKeySig() const { return m_staffDefKeySig; }
-    Mensur *GetStaffDefMensur() const { return m_staffDefMensur; }
-    MeterSig *GetStaffDefMeterSig() const { return m_staffDefMeterSig; }
-    MeterSigGrp *GetStaffDefMeterSigGrp() const { return m_staffDefMeterSigGrp; }
+
+    Clef *GetStaffDefClef() { return m_staffDefClef; }
+    const Clef *GetStaffDefClef() const { return m_staffDefClef; }
+    KeySig *GetStaffDefKeySig() { return m_staffDefKeySig; }
+    const KeySig *GetStaffDefKeySig() const { return m_staffDefKeySig; }
+    Mensur *GetStaffDefMensur() { return m_staffDefMensur; }
+    const Mensur *GetStaffDefMensur() const { return m_staffDefMensur; }
+    MeterSig *GetStaffDefMeterSig() { return m_staffDefMeterSig; }
+    const MeterSig *GetStaffDefMeterSig() const { return m_staffDefMeterSig; }
+    MeterSigGrp *GetStaffDefMeterSigGrp() { return m_staffDefMeterSigGrp; }
+    const MeterSigGrp *GetStaffDefMeterSigGrp() const { return m_staffDefMeterSigGrp; }
+
     bool HasStaffDef() const
     {
         return (m_staffDefClef || m_staffDefKeySig || m_staffDefMensur || m_staffDefMeterSig || m_staffDefMeterSigGrp);
     }
+    ///@}
 
     /**
-     * Set drawing clef, keysig and mensur if necessary and if available.
+     * Set drawing caution clef, keysig, mensur, metersig if necessary and if available.
      */
+    ///@{
     void SetDrawingCautionValues(StaffDef *currentStaffDef);
 
     bool DrawCautionKeySigCancel() const { return m_drawCautionKeySigCancel; }
     void SetDrawCautionKeySigCancel(bool drawCautionKeySig) { m_drawCautionKeySigCancel = drawCautionKeySig; }
+
     Clef *GetCautionStaffDefClef() { return m_cautionStaffDefClef; }
+    const Clef *GetCautionStaffDefClef() const { return m_cautionStaffDefClef; }
     KeySig *GetCautionStaffDefKeySig() { return m_cautionStaffDefKeySig; }
+    const KeySig *GetCautionStaffDefKeySig() const { return m_cautionStaffDefKeySig; }
     Mensur *GetCautionStaffDefMensur() { return m_cautionStaffDefMensur; }
+    const Mensur *GetCautionStaffDefMensur() const { return m_cautionStaffDefMensur; }
     MeterSig *GetCautionStaffDefMeterSig() { return m_cautionStaffDefMeterSig; }
-    bool HasCautionStaffDef()
+    const MeterSig *GetCautionStaffDefMeterSig() const { return m_cautionStaffDefMeterSig; }
+
+    bool HasCautionStaffDef() const
     {
         return (
             m_cautionStaffDefClef || m_cautionStaffDefKeySig || m_cautionStaffDefMensur || m_cautionStaffDefMeterSig);
     }
+    ///@}
 
     /**
      * @name Setter and getter for the cross-staff flags

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -79,12 +79,6 @@ public:
     void AddChildBack(Object *object);
 
     /**
-     * Add a TimestampAttr to the measure.
-     * The TimestampAttr it not added as child of the measure but to the Measure::m_timestamps array.
-     */
-    void AddTimestamp(TimestampAttr *timestampAttr);
-
-    /**
      * Return true if the Measure has cached values for the horizontal layout
      */
     bool HasCachedHorizontalLayout() const { return (m_cachedWidth != VRV_UNSET); }
@@ -147,7 +141,7 @@ public:
      * Select drawing barlines based on the previous right and current left barlines (to avoid duplicated doubles or
      * singles). In certain cases drawn barlines would be simplified if they can be overlapped, e.g. single with dbl
      */
-    BarlineRenditionPair SelectDrawingBarLines(Measure *previous);
+    BarlineRenditionPair SelectDrawingBarLines(const Measure *previous) const;
 
     /**
      * Set the drawing barlines for the measure.
@@ -195,7 +189,7 @@ public:
     /**
      * Return the width of the right barline based on the barline form
      */
-    int GetRightBarLineWidth(Doc *doc);
+    int GetRightBarLineWidth(const Doc *doc) const;
 
     /**
      * Return the width of the measure, including the barLine width
@@ -221,13 +215,14 @@ public:
     /**
      * Calculates the section restart shift
      */
-    int GetSectionRestartShift(Doc *doc) const;
+    int GetSectionRestartShift(const Doc *doc) const;
 
     /**
      * @name Setter and getter of the drawing scoreDef
      */
     ///@{
-    ScoreDef *GetDrawingScoreDef() const { return m_drawingScoreDef; }
+    ScoreDef *GetDrawingScoreDef() { return m_drawingScoreDef; }
+    const ScoreDef *GetDrawingScoreDef() const { return m_drawingScoreDef; }
     void SetDrawingScoreDef(ScoreDef *drawingScoreDef);
     ///@}
 
@@ -235,7 +230,8 @@ public:
      * @name Setter and getter of the drawing ending
      */
     ///@{
-    Ending *GetDrawingEnding() const { return m_drawingEnding; }
+    Ending *GetDrawingEnding() { return m_drawingEnding; }
+    const Ending *GetDrawingEnding() const { return m_drawingEnding; }
     void SetDrawingEnding(Ending *ending) { m_drawingEnding = ending; }
     ///@}
 
@@ -248,13 +244,19 @@ public:
      * Return the top (first) visible staff in the measure (if any).
      * Takes into account system optimization
      */
+    ///@{
     Staff *GetTopVisibleStaff();
+    const Staff *GetTopVisibleStaff() const;
+    ///@}
 
     /**
      * Return the botoom (last) visible staff in the measure (if any).
      * Takes into account system optimization
      */
+    ///@{
     Staff *GetBottomVisibleStaff();
+    const Staff *GetBottomVisibleStaff() const;
+    ///@}
 
     /**
      * Check if the measure encloses the given time (in millisecond)

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -87,11 +87,6 @@ public:
     int GetPageIdx() const { return Object::GetIdx(); }
 
     /**
-     * Return the position of the staff on the page, from top to bottom
-     */
-    int GetStaffPosOnPage(Staff *staff) const;
-
-    /**
      * Do the layout of the page, which means aligning its content horizontally
      * and vertically, and justify horizontally and vertically if wanted.
      * This will be done only if m_layoutDone is false or force is true.
@@ -209,7 +204,7 @@ private:
     /**
      * Check whether vertical justification is required for the current page
      */
-    bool IsJustificationRequired(Doc *doc);
+    bool IsJustificationRequired(const Doc *doc);
 
     //
 public:

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -144,20 +144,20 @@ public:
     /**
      * Replace the scoreDef with the content of the newScoreDef.
      */
-    void ReplaceDrawingValues(ScoreDef *newScoreDef);
+    void ReplaceDrawingValues(const ScoreDef *newScoreDef);
 
     /**
      * Replace the corresponding staffDef with the content of the newStaffDef.
      * Looks for the staffDef with the same m_n (@n) and replaces the attribute set.
      * Attribute set is provided by the ScoreOrStaffDefInterface.
      */
-    void ReplaceDrawingValues(StaffDef *newStaffDef);
+    void ReplaceDrawingValues(const StaffDef *newStaffDef);
 
     /**
      * Replace the corresponding staffGrp with the labels of the newStaffGrp.
      * Looks for the staffGrp with the same m_n (@n) and replaces label child
      */
-    void ReplaceDrawingLabels(StaffGrp *newStaffGrp);
+    void ReplaceDrawingLabels(const StaffGrp *newStaffGrp);
 
     /**
      * Replace the staffDef score attributes with the ones currently set as drawing values.
@@ -229,14 +229,14 @@ public:
     /**
      * Return the maximum staff size in the scoreDef (100 if empty)
      */
-    int GetMaxStaffSize();
+    int GetMaxStaffSize() const;
 
     bool IsSectionRestart() const;
 
     /**
      * @return True if a system start line will be drawn
      */
-    bool HasSystemStartLine();
+    bool HasSystemStartLine() const;
 
     //----------//
     // Functors //

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -237,7 +237,7 @@ private:
     SpannedElements CollectSpannedElements(const Staff *staff, int xMin, int xMax) const;
     // Filter and add layer elements spanned by the slur to the positioner
     void AddSpannedElements(
-        FloatingCurvePositioner *curve, const SpannedElements &elements, const Staff *staff, int xMin, int xMax);
+        FloatingCurvePositioner *curve, const SpannedElements &elements, Staff *staff, int xMin, int xMax);
     // Determine whether a layer element should lie above or below the slur
     bool IsElementBelow(const LayerElement *element, const Staff *startStaff, const Staff *endStaff) const;
     bool IsElementBelow(const FloatingPositioner *positioner, const Staff *startStaff, const Staff *endStaff) const;

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -98,7 +98,7 @@ public:
     /**
      * Return the drawing staff size for staff notation, including for tablature staves
      */
-    int GetDrawingStaffNotationSize();
+    int GetDrawingStaffNotationSize() const;
 
     /**
      * Check if the staff is currently visible.
@@ -128,21 +128,24 @@ public:
     /**
      * Calculate the yRel for the staff given a @loc value
      */
-    int CalcPitchPosYRel(Doc *doc, int loc);
+    int CalcPitchPosYRel(const Doc *doc, int loc) const;
 
     /**
      * Getter for the StaffAlignment
      */
-    StaffAlignment *GetAlignment() const { return m_staffAlignment; }
+    ///@{
+    StaffAlignment *GetAlignment() { return m_staffAlignment; }
+    const StaffAlignment *GetAlignment() const { return m_staffAlignment; }
+    ///@}
 
     /**
      * Return the ledger line arrays
      */
     ///@{
-    const ArrayOfLedgerLines &GetLedgerLinesAbove() { return m_ledgerLinesAbove; }
-    const ArrayOfLedgerLines &GetLedgerLinesAboveCue() { return m_ledgerLinesAboveCue; }
-    const ArrayOfLedgerLines &GetLedgerLinesBelow() { return m_ledgerLinesBelow; }
-    const ArrayOfLedgerLines &GetLedgerLinesBelowCue() { return m_ledgerLinesBelowCue; }
+    const ArrayOfLedgerLines &GetLedgerLinesAbove() const { return m_ledgerLinesAbove; }
+    const ArrayOfLedgerLines &GetLedgerLinesAboveCue() const { return m_ledgerLinesAboveCue; }
+    const ArrayOfLedgerLines &GetLedgerLinesBelow() const { return m_ledgerLinesBelow; }
+    const ArrayOfLedgerLines &GetLedgerLinesBelowCue() const { return m_ledgerLinesBelowCue; }
     ///@}
 
     /**
@@ -164,14 +167,14 @@ public:
      * Find the nearest unit position in the direction indicated by place.
      * The *Doc is the parent doc but passed as param in order to avoid look-up
      */
-    int GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place);
+    int GetNearestInterStaffPosition(int y, const Doc *doc, data_STAFFREL place) const;
 
     /**
      * Set staff parameters based on
      * facsimile information (if it
      * exists).
      */
-    virtual void SetFromFacsimile(Doc *doc);
+    void SetFromFacsimile(Doc *doc);
 
     //----------//
     // Functors //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -104,7 +104,7 @@ public:
      * Check if the staff is currently visible.
      * Looks for the parent system and its current drawing scoreDef
      */
-    bool DrawingIsVisible();
+    bool DrawingIsVisible() const;
 
     /**
      * @name Get notation type

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -68,7 +68,10 @@ public:
     /**
      * Get first and last staffDef of the staff group without visibility optimization set to hidden
      */
+    ///@{
     std::pair<StaffDef *, StaffDef *> GetFirstLastStaffDef();
+    std::pair<const StaffDef *, const StaffDef *> GetFirstLastStaffDef() const;
+    ///@}
 
     /**
      * Return the maximum staff size in the staffGrp (100 if empty)

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -83,7 +83,8 @@ public:
      */
     ///@{
     void SetGroupSymbol(GrpSym *grpSym);
-    GrpSym *GetGroupSymbol() const { return m_groupSymbol; }
+    GrpSym *GetGroupSymbol() { return m_groupSymbol; }
+    const GrpSym *GetGroupSymbol() const { return m_groupSymbol; }
     ///@}
 
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -112,12 +112,13 @@ public:
      * Check if the notes between the start and end have mixed drawing stem directions.
      * The start and end element are expected to be on the same staff and same layer.
      */
-    bool HasMixedDrawingStemDir(LayerElement *start, LayerElement *end);
+    bool HasMixedDrawingStemDir(const LayerElement *start, const LayerElement *end) const;
 
     /**
      * Get preferred curve direction based on the starting and ending point of the slur
      */
-    curvature_CURVEDIR GetPreferredCurveDirection(LayerElement *start, LayerElement *end, Slur *slur);
+    curvature_CURVEDIR GetPreferredCurveDirection(
+        const LayerElement *start, const LayerElement *end, const Slur *slur) const;
 
     /**
      * @name Setter and getter of the drawing visible flag
@@ -131,7 +132,7 @@ public:
      * Add an object to the drawing list but only if necessary.
      * Check types but also links (dynam, dir) and extensions (trill).
      */
-    void AddToDrawingListIfNeccessary(Object *object);
+    void AddToDrawingListIfNecessary(Object *object);
 
     /**
      * @name Check if the system is the first or last in page or of a selection or of an mdiv by looking at the next
@@ -149,7 +150,7 @@ public:
     /**
      * Estimate the justification ratio from the castoff system widths and the desired page width
      */
-    double EstimateJustificationRatio(Doc *doc);
+    double EstimateJustificationRatio(const Doc *doc) const;
 
     /**
      * Convert mensural MEI into cast-off (measure) segments looking at the barLine objects.

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -103,7 +103,8 @@ public:
      * @name Setter and getter of the drawing scoreDef
      */
     ///@{
-    ScoreDef *GetDrawingScoreDef() const { return m_drawingScoreDef; }
+    ScoreDef *GetDrawingScoreDef() { return m_drawingScoreDef; }
+    const ScoreDef *GetDrawingScoreDef() const { return m_drawingScoreDef; }
     void SetDrawingScoreDef(ScoreDef *drawingScoreDef);
     ///@}
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -174,27 +174,37 @@ bool Layer::IsSupportedChild(Object *child)
     return true;
 }
 
-LayerElement *Layer::GetPrevious(LayerElement *element)
+LayerElement *Layer::GetPrevious(const LayerElement *element)
+{
+    return const_cast<LayerElement *>(std::as_const(*this).GetPrevious(element));
+}
+
+const LayerElement *Layer::GetPrevious(const LayerElement *element) const
 {
     this->ResetList(this);
     if (!element || this->HasEmptyList(this)) return NULL;
 
-    return dynamic_cast<LayerElement *>(this->GetListPrevious(element));
+    return dynamic_cast<const LayerElement *>(this->GetListPrevious(element));
 }
 
 LayerElement *Layer::GetAtPos(int x)
 {
-    Object *first = this->GetFirst();
+    return const_cast<LayerElement *>(std::as_const(*this).GetAtPos(x));
+}
+
+const LayerElement *Layer::GetAtPos(int x) const
+{
+    const Object *first = this->GetFirst();
     if (!first || !first->IsLayerElement()) return NULL;
 
-    LayerElement *element = vrv_cast<LayerElement *>(first);
+    const LayerElement *element = vrv_cast<const LayerElement *>(first);
     assert(element);
     if (element->GetDrawingX() > x) return NULL;
 
-    Object *next;
+    const Object *next;
     while ((next = this->GetNext())) {
         if (!next->IsLayerElement()) continue;
-        LayerElement *nextLayerElement = vrv_cast<LayerElement *>(next);
+        const LayerElement *nextLayerElement = vrv_cast<const LayerElement *>(next);
         assert(nextLayerElement);
         if (nextLayerElement->GetDrawingX() > x) return element;
         element = nextLayerElement;
@@ -203,7 +213,7 @@ LayerElement *Layer::GetAtPos(int x)
     return element;
 }
 
-Clef *Layer::GetClef(LayerElement *test)
+Clef *Layer::GetClef(const LayerElement *test)
 {
     return const_cast<Clef *>(std::as_const(*this).GetClef(test));
 }
@@ -234,7 +244,7 @@ const Clef *Layer::GetClef(const LayerElement *test) const
     return this->GetCurrentClef();
 }
 
-Clef *Layer::GetClefFacs(LayerElement *test)
+Clef *Layer::GetClefFacs(const LayerElement *test)
 {
     return const_cast<Clef *>(std::as_const(*this).GetClefFacs(test));
 }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -285,7 +285,7 @@ int Measure::GetRightBarLineXRel() const
     return 0;
 }
 
-int Measure::GetRightBarLineWidth(Doc *doc)
+int Measure::GetRightBarLineWidth(const Doc *doc) const
 {
     const BarLine *barline = this->GetRightBarLine();
     if (!barline) return 0;
@@ -366,13 +366,13 @@ int Measure::GetInnerCenterX() const
 
 int Measure::GetDrawingOverflow()
 {
-    Functor adjustXOverlfow(&Object::AdjustXOverflow);
-    Functor adjustXOverlfowEnd(&Object::AdjustXOverflowEnd);
+    Functor adjustXOverflow(&Object::AdjustXOverflow);
+    Functor adjustXOverflowEnd(&Object::AdjustXOverflowEnd);
     AdjustXOverflowParams adjustXOverflowParams(0);
     adjustXOverflowParams.m_currentSystem = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
     assert(adjustXOverflowParams.m_currentSystem);
     adjustXOverflowParams.m_lastMeasure = this;
-    this->Process(&adjustXOverlfow, &adjustXOverflowParams, &adjustXOverlfowEnd);
+    this->Process(&adjustXOverflow, &adjustXOverflowParams, &adjustXOverflowEnd);
     if (!adjustXOverflowParams.m_currentWidest) return 0;
 
     int measureRightX = this->GetDrawingX() + this->GetWidth();
@@ -380,7 +380,7 @@ int Measure::GetDrawingOverflow()
     return std::max(0, overflow);
 }
 
-int Measure::GetSectionRestartShift(Doc *doc) const
+int Measure::GetSectionRestartShift(const Doc *doc) const
 {
     if (this->IsFirstInSystem()) {
         return 0;
@@ -431,10 +431,15 @@ std::vector<Staff *> Measure::GetFirstStaffGrpStaves(ScoreDef *scoreDef)
 
 Staff *Measure::GetTopVisibleStaff()
 {
-    Staff *staff = NULL;
-    ListOfObjects staves = this->FindAllDescendantsByType(STAFF, false);
+    return const_cast<Staff *>(std::as_const(*this).GetTopVisibleStaff());
+}
+
+const Staff *Measure::GetTopVisibleStaff() const
+{
+    const Staff *staff = NULL;
+    ListOfConstObjects staves = this->FindAllDescendantsByType(STAFF, false);
     for (auto &child : staves) {
-        staff = vrv_cast<Staff *>(child);
+        staff = vrv_cast<const Staff *>(child);
         assert(staff);
         if (staff->DrawingIsVisible()) {
             break;
@@ -446,10 +451,15 @@ Staff *Measure::GetTopVisibleStaff()
 
 Staff *Measure::GetBottomVisibleStaff()
 {
-    Staff *bottomStaff = NULL;
-    ListOfObjects staves = this->FindAllDescendantsByType(STAFF, false);
+    return const_cast<Staff *>(std::as_const(*this).GetBottomVisibleStaff());
+}
+
+const Staff *Measure::GetBottomVisibleStaff() const
+{
+    const Staff *bottomStaff = NULL;
+    ListOfConstObjects staves = this->FindAllDescendantsByType(STAFF, false);
     for (const auto child : staves) {
-        Staff *staff = vrv_cast<Staff *>(child);
+        const Staff *staff = vrv_cast<const Staff *>(child);
         assert(staff);
         if (!staff->DrawingIsVisible()) {
             continue;
@@ -492,7 +502,7 @@ data_BARRENDITION Measure::GetDrawingRightBarLineByStaffN(int staffN) const
     return this->GetDrawingRightBarLine();
 }
 
-Measure::BarlineRenditionPair Measure::SelectDrawingBarLines(Measure *previous)
+Measure::BarlineRenditionPair Measure::SelectDrawingBarLines(const Measure *previous) const
 {
     // Barlines are stored in the map in the following format:
     // previous measure right -> current measure left -> expected barlines (previous, current)

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -666,9 +666,9 @@ void Page::JustifyVertically()
     }
 }
 
-bool Page::IsJustificationRequired(Doc *doc)
+bool Page::IsJustificationRequired(const Doc *doc)
 {
-    Pages *pages = doc->GetPages();
+    const Pages *pages = doc->GetPages();
     assert(pages);
 
     const int childSystems = this->GetChildCount(SYSTEM);
@@ -676,7 +676,7 @@ bool Page::IsJustificationRequired(Doc *doc)
     if (pages->GetLast() == this) {
         const int idx = this->GetIdx();
         if (idx > 0) {
-            Page *previousPage = dynamic_cast<Page *>(pages->GetPrevious(this));
+            const Page *previousPage = dynamic_cast<const Page *>(pages->GetPrevious(this));
             assert(previousPage);
             const int previousJustifiableHeight = previousPage->m_drawingJustifiableHeight;
             const int previousJustificationSum = previousPage->m_justificationSum;

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -289,7 +289,7 @@ bool ScoreDef::IsSupportedChild(Object *child)
     return true;
 }
 
-void ScoreDef::ReplaceDrawingValues(ScoreDef *newScoreDef)
+void ScoreDef::ReplaceDrawingValues(const ScoreDef *newScoreDef)
 {
     assert(newScoreDef);
 
@@ -297,11 +297,11 @@ void ScoreDef::ReplaceDrawingValues(ScoreDef *newScoreDef)
     m_setAsDrawing = true;
 
     int redrawFlags = 0;
-    Clef const *clef = NULL;
-    KeySig const *keySig = NULL;
+    const Clef *clef = NULL;
+    const KeySig *keySig = NULL;
     Mensur *mensur = NULL;
     MeterSig *meterSig = NULL;
-    MeterSigGrp *meterSigGrp = NULL;
+    const MeterSigGrp *meterSigGrp = NULL;
 
     if (newScoreDef->HasClefInfo()) {
         redrawFlags |= StaffDefRedrawFlags::REDRAW_CLEF;
@@ -337,7 +337,7 @@ void ScoreDef::ReplaceDrawingValues(ScoreDef *newScoreDef)
     this->SetRedrawFlags(redrawFlags);
 }
 
-void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
+void ScoreDef::ReplaceDrawingValues(const StaffDef *newStaffDef)
 {
     assert(newStaffDef);
 
@@ -348,12 +348,12 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
     if (staffDef) {
         if (newStaffDef->HasClefInfo()) {
             staffDef->SetDrawClef(true);
-            Clef const *clef = newStaffDef->GetClef();
+            const Clef *clef = newStaffDef->GetClef();
             staffDef->SetCurrentClef(clef);
         }
         if (newStaffDef->HasKeySigInfo()) {
             staffDef->SetDrawKeySig(true);
-            KeySig const *keySig = newStaffDef->GetKeySig();
+            const KeySig *keySig = newStaffDef->GetKeySig();
             staffDef->SetCurrentKeySig(keySig);
         }
         if (newStaffDef->HasMensurInfo()) {
@@ -412,7 +412,7 @@ void ScoreDef::ReplaceDrawingValues(StaffDef *newStaffDef)
     }
 }
 
-void ScoreDef::ReplaceDrawingLabels(StaffGrp *newStaffGrp)
+void ScoreDef::ReplaceDrawingLabels(const StaffGrp *newStaffGrp)
 {
     assert(newStaffGrp);
 
@@ -614,9 +614,9 @@ const PgHead2 *ScoreDef::GetPgHead2() const
     return dynamic_cast<const PgHead2 *>(this->FindDescendantByType(PGHEAD2));
 }
 
-int ScoreDef::GetMaxStaffSize()
+int ScoreDef::GetMaxStaffSize() const
 {
-    StaffGrp *staffGrp = dynamic_cast<StaffGrp *>(this->FindDescendantByType(STAFFGRP));
+    const StaffGrp *staffGrp = vrv_cast<const StaffGrp *>(this->FindDescendantByType(STAFFGRP));
     return (staffGrp) ? staffGrp->GetMaxStaffSize() : 100;
 }
 
@@ -630,9 +630,9 @@ bool ScoreDef::IsSectionRestart() const
     return (section && (section->GetRestart() == BOOLEAN_true));
 }
 
-bool ScoreDef::HasSystemStartLine()
+bool ScoreDef::HasSystemStartLine() const
 {
-    StaffGrp *staffGrp = vrv_cast<StaffGrp *>(this->FindDescendantByType(STAFFGRP));
+    const StaffGrp *staffGrp = vrv_cast<const StaffGrp *>(this->FindDescendantByType(STAFFGRP));
     if (staffGrp) {
         auto [firstDef, lastDef] = staffGrp->GetFirstLastStaffDef();
         if ((firstDef && lastDef && (firstDef != lastDef)) || staffGrp->GetFirst(GRPSYM)) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -325,7 +325,7 @@ SpannedElements Slur::CollectSpannedElements(const Staff *staff, int xMin, int x
 }
 
 void Slur::AddSpannedElements(
-    FloatingCurvePositioner *curve, const SpannedElements &spanned, const Staff *staff, int xMin, int xMax)
+    FloatingCurvePositioner *curve, const SpannedElements &spanned, Staff *staff, int xMin, int xMax)
 {
     Staff *startStaff = this->GetStart()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);
     Staff *endStaff = this->GetEnd()->GetAncestorStaff(RESOLVE_CROSS_STAFF, false);

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -187,13 +187,13 @@ int Staff::GetDrawingStaffNotationSize()
     return (this->IsTablature()) ? m_drawingStaffSize / TABLATURE_STAFF_RATIO : m_drawingStaffSize;
 }
 
-bool Staff::DrawingIsVisible()
+bool Staff::DrawingIsVisible() const
 {
-    System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
+    const System *system = vrv_cast<const System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     assert(system->GetDrawingScoreDef());
 
-    StaffDef *staffDef = system->GetDrawingScoreDef()->GetStaffDef(this->GetN());
+    const StaffDef *staffDef = system->GetDrawingScoreDef()->GetStaffDef(this->GetN());
     assert(staffDef);
     return (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN);
 }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -182,7 +182,7 @@ void Staff::AdjustDrawingStaffSize()
     }
 }
 
-int Staff::GetDrawingStaffNotationSize()
+int Staff::GetDrawingStaffNotationSize() const
 {
     return (this->IsTablature()) ? m_drawingStaffSize / TABLATURE_STAFF_RATIO : m_drawingStaffSize;
 }
@@ -228,7 +228,7 @@ bool Staff::IsTabWithStemsOutside() const
     return (!this->IsTabGuitar() || !m_drawingStaffDef->HasType() || m_drawingStaffDef->GetType() != "stems.within");
 }
 
-int Staff::CalcPitchPosYRel(Doc *doc, int loc)
+int Staff::CalcPitchPosYRel(const Doc *doc, int loc) const
 {
     assert(doc);
 
@@ -363,7 +363,7 @@ bool Staff::IsOnStaffLine(int y, const Doc *doc) const
     return ((y - this->GetDrawingY()) % (2 * doc->GetDrawingUnit(m_drawingStaffSize)) == 0);
 }
 
-int Staff::GetNearestInterStaffPosition(int y, Doc *doc, data_STAFFREL place)
+int Staff::GetNearestInterStaffPosition(int y, const Doc *doc, data_STAFFREL place) const
 {
     assert(doc);
 

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -138,15 +138,21 @@ int StaffGrp::GetMaxStaffSize() const
 
 std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
 {
-    const ListOfObjects &staffDefs = this->GetList(this);
+    const auto [firstDef, lastDef] = std::as_const(*this).GetFirstLastStaffDef();
+    return { const_cast<StaffDef *>(firstDef), const_cast<StaffDef *>(lastDef) };
+}
+
+std::pair<const StaffDef *, const StaffDef *> StaffGrp::GetFirstLastStaffDef() const
+{
+    const ListOfConstObjects &staffDefs = this->GetList(this);
     if (staffDefs.empty()) {
         return { NULL, NULL };
     }
 
-    StaffDef *firstDef = NULL;
-    ListOfObjects::const_iterator iter;
+    const StaffDef *firstDef = NULL;
+    ListOfConstObjects::const_iterator iter;
     for (iter = staffDefs.begin(); iter != staffDefs.end(); ++iter) {
-        StaffDef *staffDef = vrv_cast<StaffDef *>(*iter);
+        const StaffDef *staffDef = vrv_cast<const StaffDef *>(*iter);
         assert(staffDef);
         if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
             firstDef = staffDef;
@@ -154,10 +160,10 @@ std::pair<StaffDef *, StaffDef *> StaffGrp::GetFirstLastStaffDef()
         }
     }
 
-    StaffDef *lastDef = NULL;
-    ListOfObjects::const_reverse_iterator riter;
+    const StaffDef *lastDef = NULL;
+    ListOfConstObjects::const_reverse_iterator riter;
     for (riter = staffDefs.rbegin(); riter != staffDefs.rend(); ++riter) {
-        StaffDef *staffDef = vrv_cast<StaffDef *>(*riter);
+        const StaffDef *staffDef = vrv_cast<const StaffDef *>(*riter);
         assert(staffDef);
         if (staffDef->GetDrawingVisibility() != OPTIMIZATION_HIDDEN) {
             lastDef = staffDef;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1141,7 +1141,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
 {
     jsonxx::Object o;
 
-    Object *element = NULL;
+    const Object *element = NULL;
 
     // Try to get the element on the current drawing page - it is usually the case and fast
     if (m_doc.GetDrawingPage()) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -97,13 +97,13 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
         Dir *dir = vrv_cast<Dir *>(element);
         assert(dir);
         this->DrawDir(dc, dir, measure, system);
-        system->AddToDrawingListIfNeccessary(dir);
+        system->AddToDrawingListIfNecessary(dir);
     }
     else if (element->Is(DYNAM)) {
         Dynam *dynam = vrv_cast<Dynam *>(element);
         assert(dynam);
         this->DrawDynam(dc, dynam, measure, system);
-        system->AddToDrawingListIfNeccessary(dynam);
+        system->AddToDrawingListIfNecessary(dynam);
     }
     else if (element->Is(FERMATA)) {
         Fermata *fermata = vrv_cast<Fermata *>(element);
@@ -129,7 +129,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
         Pedal *pedal = vrv_cast<Pedal *>(element);
         assert(pedal);
         this->DrawPedal(dc, pedal, measure, system);
-        system->AddToDrawingListIfNeccessary(pedal);
+        system->AddToDrawingListIfNecessary(pedal);
     }
     else if (element->Is(REH)) {
         Reh *reh = vrv_cast<Reh *>(element);
@@ -145,7 +145,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
         Trill *trill = vrv_cast<Trill *>(element);
         assert(trill);
         this->DrawTrill(dc, trill, measure, system);
-        system->AddToDrawingListIfNeccessary(trill);
+        system->AddToDrawingListIfNecessary(trill);
     }
     else if (element->Is(TURN)) {
         Turn *turn = vrv_cast<Turn *>(element);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1224,7 +1224,7 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
     this->DrawStaffDefCautionary(dc, staff, measure);
 
     for (auto &spanningElement : staff->m_timeSpanningElements) {
-        system->AddToDrawingListIfNeccessary(spanningElement);
+        system->AddToDrawingListIfNecessary(spanningElement);
     }
 
     dc->EndGraphic(staff, this);


### PR DESCRIPTION
This PR improves const correctness for container elements by adding `const` to relevant member functions and arguments. No changes in behaviour are expected.