### PR TITLE
Reset alignment on MeterSigGrp

### DIFF
--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -644,6 +644,10 @@ int Layer::ResetHorizontalAlignment(FunctorParams *functorParams)
     if (this->GetStaffDefMeterSig()) {
         this->GetStaffDefMeterSig()->ResetHorizontalAlignment(functorParams);
     }
+    if (this->GetStaffDefMeterSigGrp()) {
+        Functor resetHorizontalAlignment(&Object::ResetHorizontalAlignment);
+        this->GetStaffDefMeterSigGrp()->Process(&resetHorizontalAlignment, NULL);
+    }
 
     if (this->GetCautionStaffDefClef()) {
         this->GetCautionStaffDefClef()->ResetHorizontalAlignment(functorParams);


### PR DESCRIPTION
This PR properly resets the horizontal alignment for MeterSigGrp. This fixes a crash that we recently observed and was caused by a failed assertion in `LayerElement::AlignHorizontally`.