### PR TITLE
Update action and test time maps

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -32,10 +32,10 @@ jobs:
   ###################################################
   build_python:
     name: Build the test suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: FranzDiebold/github-env-vars-action@v1.2.1
+      - uses: FranzDiebold/github-env-vars-action@v2.4.0
       - name: Get Short SHA
         run: |
           echo "SHORT_SHA=`echo ${{ github.event.pull_request.head.sha }} | cut -c1-7`" >> $GITHUB_ENV

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -64,7 +64,7 @@ jobs:
           ls -alh ${{ env.OUTPUT_DIR }}
           sudo apt-get install openresolv wireguard
           sudo echo "${{ secrets.VPN_CONFIGURATION }}" > wg0.conf
-          python3 -m pip install diffimg lxml xmldiff cairosvg
+          python3 -m pip install diffimg jsondiff lxml xmldiff cairosvg
 
       - name: Checkout the dev branch
         uses: actions/checkout@v2

--- a/doc/test-suite-diff.py
+++ b/doc/test-suite-diff.py
@@ -6,9 +6,9 @@ import lxml.etree as etree
 import PIL.Image as Image
 import PIL.ImageChops as ImageChops
 import PIL.ImageOps as ImageOps
-import xmldiff.main as main
 from diffimg import diff as pngdiff
 from jsondiff import diff as jsondiff
+from xmldiff.main import diff_trees as xmldiff
 
 ns = {'svg': 'http://www.w3.org/2000/svg'}
 
@@ -201,7 +201,7 @@ if __name__ == "__main__":
                 root2.remove(e)
 
             # unused for now
-            diff = main.diff_trees(root1, root2)
+            diff = xmldiff(root1, root2)
             if (len(diff) > 0):
                 print(f'Node diff: {len(diff)}')
 

--- a/doc/test-suite-diff.py
+++ b/doc/test-suite-diff.py
@@ -7,7 +7,7 @@ import PIL.Image as Image
 import PIL.ImageChops as ImageChops
 import PIL.ImageOps as ImageOps
 from diffimg import diff as pngdiff
-from jsondiff import diff as jsondiff
+from jsondiff import similarity as jsondiff
 from xmldiff.main import diff_trees as xmldiff
 
 ns = {'svg': 'http://www.w3.org/2000/svg'}
@@ -137,7 +137,7 @@ if __name__ == "__main__":
 
             timeMap1 = json.load(open(jsonFile1, 'r'))
             timeMap2 = json.load(open(jsonFile2, 'r'))
-            if jsondiff(timeMap1, timeMap2):
+            if jsondiff(timeMap1, timeMap2) != 1:
                 print(f'{name} produced a changed time map')
 
             diffValue = pngdiff(pngFile1, pngFile2, delete_diff_file=True)

--- a/doc/test-suite-diff.py
+++ b/doc/test-suite-diff.py
@@ -1,14 +1,14 @@
 import argparse
 import json
 import os
-import sys
 
-import diffimg
 import lxml.etree as etree
 import PIL.Image as Image
 import PIL.ImageChops as ImageChops
 import PIL.ImageOps as ImageOps
 import xmldiff.main as main
+from diffimg import diff as pngdiff
+from jsondiff import diff as jsondiff
 
 ns = {'svg': 'http://www.w3.org/2000/svg'}
 
@@ -128,12 +128,19 @@ if __name__ == "__main__":
             name, ext = os.path.splitext(item2)
             pngFile1 = os.path.join(path_in1, item1, name + '.png')
             pngFile2 = os.path.join(path_in2, item1, name + '.png')
+            jsonFile1 = os.path.join(path_in1, item1, name + '.json')
+            jsonFile2 = os.path.join(path_in2, item1, name + '.json')
             pngFileOut = os.path.join(path_out, item1, name + '.png')
             pngFile1Out = os.path.join(path_out, item1, name + '.after.png')
             pngFile2Out = os.path.join(path_out, item1, name + '.before.png')
             print(f'Comparing {name}')
 
-            diffValue = diffimg.diff(pngFile1, pngFile2, delete_diff_file=True)
+            timeMap1 = json.load(open(jsonFile1, 'r'))
+            timeMap2 = json.load(open(jsonFile2, 'r'))
+            if jsondiff(timeMap1, timeMap2):
+                print(f'{name} produced a changed time map')
+
+            diffValue = pngdiff(pngFile1, pngFile2, delete_diff_file=True)
             if (diffValue > (args.threshold / 100.0)):
                 print(f'Img diff: {diffValue}')
                 row = etree.SubElement(table, 'tr')

--- a/doc/test-suite.py
+++ b/doc/test-suite.py
@@ -1,5 +1,6 @@
 # This script it expected to be run from ./bindings/python
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -81,7 +82,9 @@ if __name__ == '__main__':
 
             # filenames (input MEI/XML and output SVG)
             inputFile = os.path.join(path1, item1, item2)
-            print(inputFile)
+            options.update({"xmlIdSeed": int(hashlib.sha256(
+                inputFile.encode("utf-8")).hexdigest(), 16) % 10**9})
+            print(f'Rendering {item2}')
             name, ext = os.path.splitext(item2)
             svgFile = os.path.join(path2, item1, name + '.svg')
             pngFile = os.path.join(path2, item1, name + '.png')

--- a/doc/test-suite.py
+++ b/doc/test-suite.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
                 "overflow=\"inherit\"", "overflow=\"visible\"")
             ET.ElementTree(ET.fromstring(svgString)).write(svgFile)
             cairosvg.svg2png(bytestring=svgString, scale=2, write_to=pngFile)
-            tk.resetOptions()
             # create time map
             tk.renderToTimemapFile(timeMapFile)
+            tk.resetOptions()
             options.clear()


### PR DESCRIPTION
This PR updates the GitHub Action to use Ubuntu 22.04 (which comes with Python 3.10.0). 

The test suite run now seeds the random generator to produce stable IDs and creates a timemap that can also be compared. For now it throws just an info if the timemap changes, but we can extend it if we want to add a deeper insight to the generated HTML.