### PR TITLE
Use LibMEI for version handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support for ES6 and improved npm package (@WolfgangDrescher)
 * Support for `@artic.ges` (@eNote-GmBH)
 * Support for transposition of scores without key signature (@eNote-GmBH)
-* Support for `dashedBarlineDashLength` and `dashedBarlineGapLength` in engraving defaults (@eNoteGmBH)
+* Support for `dashedBarlineDashLength` and `dashedBarlineGapLength` in engraving defaults (@eNote-GmBH)
 * Improved MIDI output with tuning, key signature and first verse (@eNote-GmBH)
 * Improved PAE output for measure rests
 * Improved mixed beam rendering (@eNote-GmBH)

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -893,7 +893,7 @@ private:
     /**
      * The version of the file being read
      */
-    MEIVersion m_version;
+    meiVersion_MEIVERSION m_version;
 
     /**
      * A flag indicating wheather we are reading page-based or score-based MEI

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -893,7 +893,7 @@ private:
     /**
      * The version of the file being read
      */
-    meiVersion_MEIVERSION m_version;
+    meiVersion_MEIVERSION m_meiversion;
 
     /**
      * A flag indicating wheather we are reading page-based or score-based MEI

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -42,8 +42,6 @@ namespace vrv {
 // Adds "-dev" in the version number - should be set to false for releases
 #define VERSION_DEV true
 
-enum MEIVersion { MEI_UNDEFINED = 0, MEI_2013, MEI_3_0_0, MEI_4_0_0, MEI_4_0_1, MEI_5_0_0_dev };
-
 //----------------------------------------------------------------------------
 // Cast redefinition
 //----------------------------------------------------------------------------

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -4615,7 +4615,7 @@ std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) 
         case meiVersion_MEIVERSION_3_0_0: value = "3.0.0"; break;
         case meiVersion_MEIVERSION_4_0_0: value = "4.0.0"; break;
         case meiVersion_MEIVERSION_4_0_1: value = "4.0.1"; break;
-        case meiVersion_MEIVERSION_4_0_1_rc1plusbasic: value = "4.0.1-rc1+basic"; break;
+        case meiVersion_MEIVERSION_5_0_0_devplusbasic: value = "5.0.0-dev+basic"; break;
         case meiVersion_MEIVERSION_5_0_0_dev: value = "5.0.0-dev"; break;
         default:
             LogWarning("Unknown value '%d' for att.meiVersion@meiversion", data);
@@ -4631,7 +4631,7 @@ meiVersion_MEIVERSION AttConverter::StrToMeiVersionMeiversion(const std::string 
     if (value == "3.0.0") return meiVersion_MEIVERSION_3_0_0;
     if (value == "4.0.0") return meiVersion_MEIVERSION_4_0_0;
     if (value == "4.0.1") return meiVersion_MEIVERSION_4_0_1;
-    if (value == "4.0.1-rc1+basic") return meiVersion_MEIVERSION_4_0_1_rc1plusbasic;
+    if (value == "5.0.0-dev+basic") return meiVersion_MEIVERSION_5_0_0_devplusbasic;
     if (value == "5.0.0-dev") return meiVersion_MEIVERSION_5_0_0_dev;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for att.meiVersion@meiversion", value.c_str());

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -4611,6 +4611,10 @@ std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) 
 {
     std::string value;
     switch (data) {
+        case meiVersion_MEIVERSION_2013: value = "2013"; break;
+        case meiVersion_MEIVERSION_3_0_0: value = "3.0.0"; break;
+        case meiVersion_MEIVERSION_4_0_0: value = "4.0.0"; break;
+        case meiVersion_MEIVERSION_4_0_1: value = "4.0.1"; break;
         case meiVersion_MEIVERSION_5_0_0_dev: value = "5.0.0-dev"; break;
         default:
             LogWarning("Unknown value '%d' for att.meiVersion@meiversion", data);
@@ -4622,6 +4626,10 @@ std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) 
 
 meiVersion_MEIVERSION AttConverter::StrToMeiVersionMeiversion(const std::string &value, bool logWarning) const
 {
+    if (value == "2013") return meiVersion_MEIVERSION_2013;
+    if (value == "3.0.0") return meiVersion_MEIVERSION_3_0_0;
+    if (value == "4.0.0") return meiVersion_MEIVERSION_4_0_0;
+    if (value == "4.0.1") return meiVersion_MEIVERSION_4_0_1;
     if (value == "5.0.0-dev") return meiVersion_MEIVERSION_5_0_0_dev;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for att.meiVersion@meiversion", value.c_str());

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -4615,6 +4615,7 @@ std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) 
         case meiVersion_MEIVERSION_3_0_0: value = "3.0.0"; break;
         case meiVersion_MEIVERSION_4_0_0: value = "4.0.0"; break;
         case meiVersion_MEIVERSION_4_0_1: value = "4.0.1"; break;
+        case meiVersion_MEIVERSION_4_0_1_rc1plusbasic: value = "4.0.1-rc1+basic"; break;
         case meiVersion_MEIVERSION_5_0_0_dev: value = "5.0.0-dev"; break;
         default:
             LogWarning("Unknown value '%d' for att.meiVersion@meiversion", data);
@@ -4630,6 +4631,7 @@ meiVersion_MEIVERSION AttConverter::StrToMeiVersionMeiversion(const std::string 
     if (value == "3.0.0") return meiVersion_MEIVERSION_3_0_0;
     if (value == "4.0.0") return meiVersion_MEIVERSION_4_0_0;
     if (value == "4.0.1") return meiVersion_MEIVERSION_4_0_1;
+    if (value == "4.0.1-rc1+basic") return meiVersion_MEIVERSION_4_0_1_rc1plusbasic;
     if (value == "5.0.0-dev") return meiVersion_MEIVERSION_5_0_0_dev;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for att.meiVersion@meiversion", value.c_str());

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -2142,7 +2142,7 @@ enum meiVersion_MEIVERSION {
     meiVersion_MEIVERSION_3_0_0,
     meiVersion_MEIVERSION_4_0_0,
     meiVersion_MEIVERSION_4_0_1,
-    meiVersion_MEIVERSION_4_0_1_rc1plusbasic,
+    meiVersion_MEIVERSION_5_0_0_devplusbasic,
     meiVersion_MEIVERSION_5_0_0_dev,
     meiVersion_MEIVERSION_MAX
 };

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -2142,6 +2142,7 @@ enum meiVersion_MEIVERSION {
     meiVersion_MEIVERSION_3_0_0,
     meiVersion_MEIVERSION_4_0_0,
     meiVersion_MEIVERSION_4_0_1,
+    meiVersion_MEIVERSION_4_0_1_rc1plusbasic,
     meiVersion_MEIVERSION_5_0_0_dev,
     meiVersion_MEIVERSION_MAX
 };

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -2138,6 +2138,10 @@ enum measurement_UNIT {
  */
 enum meiVersion_MEIVERSION {
     meiVersion_MEIVERSION_NONE = 0,
+    meiVersion_MEIVERSION_2013,
+    meiVersion_MEIVERSION_3_0_0,
+    meiVersion_MEIVERSION_4_0_0,
+    meiVersion_MEIVERSION_4_0_1,
     meiVersion_MEIVERSION_5_0_0_dev,
     meiVersion_MEIVERSION_MAX
 };

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -227,7 +227,7 @@ bool MEIOutput::Export()
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
         AttConverter converter;
         meiVersion_MEIVERSION meiVersion = meiVersion_MEIVERSION(meiVersion_MEIVERSION_MAX - 1);
-        if (this->GetBasic()) meiVersion = meiVersion_MEIVERSION_4_0_1_rc1plusbasic;
+        if (this->GetBasic()) meiVersion = meiVersion_MEIVERSION_5_0_0_devplusbasic;
         m_mei.append_attribute("meiversion") = (converter.MeiVersionMeiversionToStr(meiVersion)).c_str();
 
         // If the document is mensural, we have to undo the mensural (segments) cast off

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -238,9 +238,9 @@ bool MEIOutput::Export()
 
         m_mei = meiDoc.append_child("mei");
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
-        AttMeiVersion att;
+        AttConverter converter;
         meiVersion_MEIVERSION meiVersion = meiVersion_MEIVERSION(meiVersion_MEIVERSION_MAX - 1);
-        m_mei.append_attribute("meiversion") = (att.AttConverter::MeiVersionMeiversionToStr(meiVersion)).c_str();
+        m_mei.append_attribute("meiversion") = (converter.MeiVersionMeiversionToStr(meiVersion)).c_str();
 
         // If the document is mensural, we have to undo the mensural (segments) cast off
         m_doc->ConvertToCastOffMensuralDoc(false);
@@ -3603,8 +3603,8 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
 
     if (root.attribute("meiversion")) {
         std::string version = std::string(root.attribute("meiversion").value());
-        AttMeiVersion att;
-        m_meiversion = att.AttConverter::StrToMeiVersionMeiversion(version);
+        AttConverter converter;
+        m_meiversion = converter.StrToMeiVersionMeiversion(version);
     }
     else {
         // default to MEI 5

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -207,19 +207,6 @@ bool MEIOutput::Export()
 
         // schema processing instruction
         std::string schema;
-        std::string version;
-        if (this->IsPageBasedMEI()) {
-            schema = "https://www.verovio.org/schema/dev/mei-verovio.rng";
-            version = "5.0.0-dev";
-        }
-        else if (this->GetBasic()) {
-            schema = "https://music-encoding.org/schema/dev/mei-basic.rng";
-            version = "4.0.1-rc1+basic";
-        }
-        else {
-            schema = "https://music-encoding.org/schema/dev/mei-all.rng";
-            version = "5.0.0-dev";
-        }
 
         decl = meiDoc.append_child(pugi::node_declaration);
         decl.set_name("xml-model");
@@ -240,6 +227,7 @@ bool MEIOutput::Export()
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
         AttConverter converter;
         meiVersion_MEIVERSION meiVersion = meiVersion_MEIVERSION(meiVersion_MEIVERSION_MAX - 1);
+        if (this->GetBasic()) meiVersion = meiVersion_MEIVERSION_4_0_1_rc1plusbasic;
         m_mei.append_attribute("meiversion") = (converter.MeiVersionMeiversionToStr(meiVersion)).c_str();
 
         // If the document is mensural, we have to undo the mensural (segments) cast off

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -238,7 +238,9 @@ bool MEIOutput::Export()
 
         m_mei = meiDoc.append_child("mei");
         m_mei.append_attribute("xmlns") = "http://www.music-encoding.org/ns/mei";
-        m_mei.append_attribute("meiversion") = version.c_str();
+        AttMeiVersion att;
+        meiVersion_MEIVERSION meiVersion = meiVersion_MEIVERSION(meiVersion_MEIVERSION_MAX - 1);
+        m_mei.append_attribute("meiversion") = (att.AttConverter::MeiVersionMeiversionToStr(meiVersion)).c_str();
 
         // If the document is mensural, we have to undo the mensural (segments) cast off
         m_doc->ConvertToCastOffMensuralDoc(false);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3149,7 +3149,7 @@ MEIInput::MEIInput(Doc *doc) : Input(doc)
 {
     m_hasScoreDef = false;
     m_readingScoreBased = false;
-    m_version = MEI_UNDEFINED;
+    m_version = meiVersion_MEIVERSION_NONE;
 }
 
 MEIInput::~MEIInput() {}
@@ -3601,26 +3601,13 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
 
     if (root.attribute("meiversion")) {
         std::string version = std::string(root.attribute("meiversion").value());
-        if (version == "5.0.0-dev" || version == "4.0.1-rc1+basic") {
-            m_version = MEI_5_0_0_dev;
-        }
-        else if (version == "4.0.1") {
-            m_version = MEI_4_0_1;
-        }
-        else if (version == "4.0.0") {
-            m_version = MEI_4_0_0;
-        }
-        else if (version == "3.0.0") {
-            m_version = MEI_3_0_0;
-        }
-        else if (version == "2013") {
-            m_version = MEI_2013;
-        }
+        AttMeiVersion att;
+        m_version = att.AttConverter::StrToMeiVersionMeiversion(version);
     }
     else {
         // default to MEI 5
         LogWarning("No meiversion found, falling back to MEI5 (dev)");
-        m_version = MEI_5_0_0_dev;
+        m_version = meiVersion_MEIVERSION_5_0_0_dev;
     }
 
     // only try to handle meiHead if we have a full MEI document
@@ -3699,7 +3686,7 @@ bool MEIInput::ReadDoc(pugi::xml_node root)
     // Old page-based files. We skip the mdiv and load the pages element.
     // The mdiv and score boundaries are added by UpgradePageTo_5_0_0.
     // This work only for single page files
-    else if (m_selectedMdiv.child("pages") && (m_version == MEI_2013)) {
+    else if (m_selectedMdiv.child("pages") && (m_version == meiVersion_MEIVERSION_2013)) {
         pages = m_selectedMdiv.child("pages");
         m_readingScoreBased = false;
     }
@@ -3829,7 +3816,7 @@ bool MEIInput::ReadPage(Object *parent, pugi::xml_node page)
     Page *vrvPage = new Page();
     this->SetMeiID(page, vrvPage);
 
-    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
         UpgradePageTo_3_0_0(vrvPage, m_doc);
     }
 
@@ -3874,7 +3861,7 @@ bool MEIInput::ReadPage(Object *parent, pugi::xml_node page)
         vrvPage->Process(&applyPPUFactor, &applyPPUFactorParams);
     }
 
-    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
         UpgradePageTo_5_0_0(vrvPage);
     }
 
@@ -4293,7 +4280,7 @@ bool MEIInput::ReadSystemChildren(Object *parent, pugi::xml_node parentNode)
                     assert(system);
                     unmeasured = new Measure(false);
                     m_doc->SetMensuralMusicOnly(true);
-                    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+                    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
                         UpgradeMeasureTo_3_0_0(unmeasured, system);
                     }
                     system->AddChild(unmeasured);
@@ -4423,7 +4410,7 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
         vrvMensur->SetColor(mensuralVis.GetMensurColor());
         vrvMensur->SetOrient(mensuralVis.GetMensurOrient());
 
-        if (m_version < MEI_5_0_0_dev) {
+        if (m_version < meiVersion_MEIVERSION_5_0_0_dev) {
             UpgradeMensurTo_5_0_0(element, vrvMensur);
         }
 
@@ -4468,7 +4455,7 @@ bool MEIInput::ReadScoreDef(Object *parent, pugi::xml_node scoreDef)
     }
     this->ReadScoreDefElement(scoreDef, vrvScoreDef);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeScoreDefElementTo_4_0_0(scoreDef, vrvScoreDef);
     }
 
@@ -4556,7 +4543,7 @@ bool MEIInput::ReadStaffGrp(Object *parent, pugi::xml_node staffGrp)
     StaffGrp *vrvStaffGrp = new StaffGrp();
     this->SetMeiID(staffGrp, vrvStaffGrp);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeStaffGrpTo_4_0_0(staffGrp, vrvStaffGrp);
     }
 
@@ -4754,7 +4741,7 @@ bool MEIInput::ReadStaffDef(Object *parent, pugi::xml_node staffDef)
     StaffDef *vrvStaffDef = new StaffDef();
     this->ReadScoreDefElement(staffDef, vrvStaffDef);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeScoreDefElementTo_4_0_0(staffDef, vrvStaffDef);
         UpgradeStaffDefTo_4_0_0(staffDef, vrvStaffDef);
     }
@@ -4889,7 +4876,7 @@ bool MEIInput::ReadInstrDef(Object *parent, pugi::xml_node instrDef)
     InstrDef *vrvInstrDef = new InstrDef();
     this->SetMeiID(instrDef, vrvInstrDef);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (instrDef.attribute("midi.volume")) {
             const float midiValue = instrDef.attribute("midi.volume").as_float();
             instrDef.attribute("midi.volume").set_value(StringFormat("%.2f%%", midiValue / 127 * 100).c_str());
@@ -4984,7 +4971,7 @@ bool MEIInput::ReadMeasure(Object *parent, pugi::xml_node measure)
     vrvMeasure->ReadPointing(measure);
     vrvMeasure->ReadTyped(measure);
 
-    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
         UpgradeMeasureTo_5_0_0(measure);
     }
 
@@ -5401,7 +5388,7 @@ bool MEIInput::ReadMordent(Object *parent, pugi::xml_node mordent)
     Mordent *vrvMordent = new Mordent();
     this->ReadControlElement(mordent, vrvMordent);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeMordentTo_4_0_0(mordent, vrvMordent);
     }
 
@@ -5568,7 +5555,7 @@ bool MEIInput::ReadTurn(Object *parent, pugi::xml_node turn)
     Turn *vrvTurn = new Turn();
     this->ReadControlElement(turn, vrvTurn);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeTurnTo_4_0_0(turn, vrvTurn);
     }
 
@@ -5632,7 +5619,7 @@ bool MEIInput::ReadStaff(Object *parent, pugi::xml_node staff)
     vrvStaff->ReadTyped(staff);
     vrvStaff->ReadVisibility(staff);
 
-    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
         UpgradeStaffTo_5_0_0(staff);
     }
 
@@ -5862,7 +5849,7 @@ bool MEIInput::ReadLayerElement(pugi::xml_node element, LayerElement *object)
     object->ReadLabelled(element);
     object->ReadTyped(element);
 
-    if ((m_doc->GetType() == Transcription) && (m_version == MEI_2013)) {
+    if ((m_doc->GetType() == Transcription) && (m_version == meiVersion_MEIVERSION_2013)) {
         UpgradeLayerElementTo_5_0_0(element);
     }
 
@@ -5954,7 +5941,7 @@ bool MEIInput::ReadBeatRpt(Object *parent, pugi::xml_node beatRpt)
     vrvBeatRpt->ReadBeatRptLog(beatRpt);
     vrvBeatRpt->ReadBeatRptVis(beatRpt);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeBeatRptTo_4_0_0(beatRpt, vrvBeatRpt);
     }
 
@@ -5983,7 +5970,7 @@ bool MEIInput::ReadChord(Object *parent, pugi::xml_node chord)
     Chord *vrvChord = new Chord();
     this->ReadLayerElement(chord, vrvChord);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (chord.attribute("size")) {
             chord.remove_attribute("size");
             chord.append_attribute("cue").set_value("true");
@@ -6089,7 +6076,7 @@ bool MEIInput::ReadFTrem(Object *parent, pugi::xml_node fTrem)
     FTrem *vrvFTrem = new FTrem();
     this->ReadLayerElement(fTrem, vrvFTrem);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeFTremTo_4_0_0(fTrem, vrvFTrem);
     }
 
@@ -6178,7 +6165,7 @@ bool MEIInput::ReadMensur(Object *parent, pugi::xml_node mensur)
     Mensur *vrvMensur = new Mensur();
     this->ReadLayerElement(mensur, vrvMensur);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (mensur.attribute("size")) {
             mensur.remove_attribute("size");
             mensur.append_attribute("cue").set_value("true");
@@ -6193,7 +6180,7 @@ bool MEIInput::ReadMensur(Object *parent, pugi::xml_node mensur)
     vrvMensur->ReadSlashCount(mensur);
     vrvMensur->ReadStaffLoc(mensur);
 
-    if (m_version < MEI_5_0_0_dev) {
+    if (m_version < meiVersion_MEIVERSION_5_0_0_dev) {
         UpgradeMensurTo_5_0_0(mensur, vrvMensur);
     }
 
@@ -6222,7 +6209,7 @@ bool MEIInput::ReadMRest(Object *parent, pugi::xml_node mRest)
     this->ReadLayerElement(mRest, vrvMRest);
     this->ReadPositionInterface(mRest, vrvMRest);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (mRest.attribute("size")) {
             mRest.remove_attribute("size");
             mRest.append_attribute("cue").set_value("true");
@@ -6238,7 +6225,7 @@ bool MEIInput::ReadMRest(Object *parent, pugi::xml_node mRest)
         m_doc->SetMarkup(MARKUP_ANALYTICAL_FERMATA);
     }
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         // as mRest has no durationInterface we simply delete dur.ges on upgrade
         if (mRest.attribute("dur.ges")) mRest.remove_attribute("dur.ges");
     }
@@ -6347,7 +6334,7 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
     Note *vrvNote = new Note();
     this->ReadLayerElement(note, vrvNote);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (note.attribute("size")) {
             note.remove_attribute("size");
             note.append_attribute("cue").set_value("true");
@@ -6399,7 +6386,7 @@ bool MEIInput::ReadRest(Object *parent, pugi::xml_node rest)
     Rest *vrvRest = new Rest();
     this->ReadLayerElement(rest, vrvRest);
 
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         if (rest.attribute("size")) {
             rest.remove_attribute("size");
             rest.append_attribute("cue").set_value("true");
@@ -6717,7 +6704,7 @@ bool MEIInput::ReadAreaPosInterface(pugi::xml_node element, AreaPosInterface *in
 
 bool MEIInput::ReadDurationInterface(pugi::xml_node element, DurationInterface *interface)
 {
-    if (m_version < MEI_4_0_0) {
+    if (m_version < meiVersion_MEIVERSION_4_0_0) {
         UpgradeDurGesTo_4_0_0(element, interface);
     }
 


### PR DESCRIPTION
As Verovio supports different MEI versions it seems natural to have them all in the Verovio customization. This way we can handle the `meiversion` by using the `AttConverter`.
A corresponding PR for LibMEI will be opened.