### PR TITLE
Support MEI input/output of Stem

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -401,6 +401,7 @@ private:
     void WriteProport(pugi::xml_node currentNode, Proport *proport);
     void WriteRest(pugi::xml_node currentNode, Rest *rest);
     void WriteSpace(pugi::xml_node currentNode, Space *space);
+    void WriteStem(pugi::xml_node currentNode, Stem *stem);
     void WriteSyllable(pugi::xml_node currentNode, Syllable *syllable);
     void WriteTabDurSym(pugi::xml_node currentNode, TabDurSym *tabDurSym);
     void WriteTabGrp(pugi::xml_node currentNode, TabGrp *tabGrp);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -700,6 +700,7 @@ private:
     bool ReadProport(Object *parent, pugi::xml_node proport);
     bool ReadRest(Object *parent, pugi::xml_node rest);
     bool ReadSpace(Object *parent, pugi::xml_node space);
+    bool ReadStem(Object *parent, pugi::xml_node stem);
     bool ReadSyl(Object *parent, pugi::xml_node syl);
     bool ReadSyllable(Object *parent, pugi::xml_node syllable);
     bool ReadTabDurSym(Object *parent, pugi::xml_node tabDurSym);

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -9,8 +9,7 @@
 #define __VRV_STEM_H__
 
 #include "atts_cmn.h"
-#include "atts_shared.h"
-#include "atts_visual.h"
+#include "atts_mensural.h"
 #include "layerelement.h"
 
 namespace vrv {
@@ -22,9 +21,9 @@ class Flag;
 //----------------------------------------------------------------------------
 
 /**
- * This class models a stem as a layer element part and has not direct MEI equivlatent.
+ * This class models a stem as a layer element part and as MEI <stem> element.
  */
-class Stem : public LayerElement, public AttGraced, public AttStems, public AttStemsCmn {
+class Stem : public LayerElement, public AttGraced, public AttStemVis, public AttVisibility {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods
@@ -47,13 +46,17 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
-     * @name Setter and getter for darwing stem direction and length
+     * @name Setter and getter for the drawing stem direction, length and modifier
      */
     ///@{
     data_STEMDIRECTION GetDrawingStemDir() const { return m_drawingStemDir; }
     void SetDrawingStemDir(data_STEMDIRECTION drawingStemDir) { m_drawingStemDir = drawingStemDir; }
     int GetDrawingStemLen() const { return m_drawingStemLen; }
     void SetDrawingStemLen(int drawingStemLen) { m_drawingStemLen = drawingStemLen; }
+    // Since Stem does not inherit from AttStems we override LayerElement::GetDrawingStemMod()
+    data_STEMMODIFIER GetDrawingStemMod() const override { return m_drawingStemMod; }
+    bool HasDrawingStemMod() const { return (m_drawingStemMod != STEMMODIFIER_NONE); }
+    void SetDrawingStemMod(data_STEMMODIFIER mod) { m_drawingStemMod = mod; }
     int GetDrawingStemAdjust() const { return m_drawingStemAdjust; }
     void SetDrawingStemAdjust(int drawingStemAdjust) { m_drawingStemAdjust = drawingStemAdjust; }
     int GetStemModRelY() const { return m_stemModRelY; }
@@ -126,6 +129,10 @@ private:
      * The drawing length of stem
      */
     int m_drawingStemLen;
+    /**
+     * The drawing modifier of the stem
+     */
+    data_STEMMODIFIER m_drawingStemMod;
     /**
      * Relative Y position for the stem modifier
      */

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -95,14 +95,6 @@ public:
     int CalcStem(FunctorParams *functorParams) override;
 
     /**
-     * Overwritten version of Save that avoids anything to be written
-     */
-    ///@{
-    int Save(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
-    int SaveEnd(FunctorParams *functorParams) override { return FUNCTOR_CONTINUE; }
-    ///@}
-
-    /**
      * See Object::ResetData
      */
     int ResetData(FunctorParams *functorParams) override;

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -46,6 +46,11 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
+     * Fill the attributes from the AttStems attribute of the parent note/chord
+     */
+    void FillAttributes(const AttStems &attSource);
+
+    /**
      * @name Setter and getter for the drawing stem direction, length and modifier
      */
     ///@{

--- a/libmei/atts_mensural.cpp
+++ b/libmei/atts_mensural.cpp
@@ -408,7 +408,7 @@ AttStemVis::~AttStemVis()
 void AttStemVis::ResetStemVis()
 {
     m_pos = STEMPOSITION_NONE;
-    m_len = 0.0;
+    m_len = -1.0;
     m_form = STEMFORM_mensural_NONE;
     m_dir = STEMDIRECTION_NONE;
     m_flagPos = FLAGPOS_mensural_NONE;
@@ -488,7 +488,7 @@ bool AttStemVis::HasPos() const
 
 bool AttStemVis::HasLen() const
 {
-    return (m_len != 0.0);
+    return (m_len != -1.0);
 }
 
 bool AttStemVis::HasForm() const

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -6469,7 +6469,7 @@ AttStems::~AttStems()
 void AttStems::ResetStems()
 {
     m_stemDir = STEMDIRECTION_NONE;
-    m_stemLen = -1;
+    m_stemLen = -1.0;
     m_stemMod = STEMMODIFIER_NONE;
     m_stemPos = STEMPOSITION_NONE;
     m_stemSameas = "";
@@ -6569,7 +6569,7 @@ bool AttStems::HasStemDir() const
 
 bool AttStems::HasStemLen() const
 {
-    return (m_stemLen != -1);
+    return (m_stemLen != -1.0);
 }
 
 bool AttStems::HasStemMod() const

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1807,7 +1807,7 @@ data_STEMDIRECTION BeamElementCoord::GetStemDir() const
     // m_stem is not necssary set, so we need to look at the Note / Chord original value
     // Example: IsInBeam called in Note::PrepareLayerElementParts when reaching the first note of the beam
     if (m_stem) {
-        return m_stem->GetStemDir();
+        return m_stem->GetDir();
     }
 
     if (!m_element) {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -851,12 +851,12 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
 
     if (!currentStem) {
         currentStem = new Stem();
+        currentStem->IsAttribute(true);
         this->AddChild(currentStem);
     }
     currentStem->AttGraced::operator=(*this);
-    // TODO: CONVERT ATTRIBUTES
-    // currentStem->AttStems::operator=(*this);
-    // currentStem->AttStemsCmn::operator=(*this);
+    currentStem->FillAttributes(*this);
+
     int duration = this->GetNoteOrChordDur(this);
     if ((duration < DUR_2) || (this->GetStemVisible() == BOOLEAN_false)) {
         currentStem->IsVirtual(true);

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -735,8 +735,8 @@ int Chord::CalcStem(FunctorParams *functorParams)
     data_STEMDIRECTION layerStemDir;
     data_STEMDIRECTION stemDir = STEMDIRECTION_NONE;
 
-    if (stem->HasStemDir()) {
-        stemDir = stem->GetStemDir();
+    if (stem->HasDir()) {
+        stemDir = stem->GetDir();
     }
     else if ((layerStemDir = layer->GetDrawingStemDir(this)) != STEMDIRECTION_NONE) {
         stemDir = layerStemDir;
@@ -854,8 +854,9 @@ int Chord::PrepareLayerElementParts(FunctorParams *functorParams)
         this->AddChild(currentStem);
     }
     currentStem->AttGraced::operator=(*this);
-    currentStem->AttStems::operator=(*this);
-    currentStem->AttStemsCmn::operator=(*this);
+    // TODO: CONVERT ATTRIBUTES
+    // currentStem->AttStems::operator=(*this);
+    // currentStem->AttStemsCmn::operator=(*this);
     int duration = this->GetNoteOrChordDur(this);
     if ((duration < DUR_2) || (this->GetStemVisible() == BOOLEAN_false)) {
         currentStem->IsVirtual(true);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -681,6 +681,12 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         m_currentNode = m_currentNode.append_child("space");
         this->WriteSpace(m_currentNode, vrv_cast<Space *>(object));
     }
+    else if (object->Is(STEM)) {
+        if (!object->IsAttribute()) {
+            m_currentNode = m_currentNode.append_child("stem");
+            this->WriteStem(m_currentNode, vrv_cast<Stem *>(object));
+        }
+    }
     else if (object->Is(SYL)) {
         m_currentNode = m_currentNode.append_child("syl");
         this->WriteSyl(m_currentNode, vrv_cast<Syl *>(object));
@@ -2624,6 +2630,16 @@ void MEIOutput::WriteSpace(pugi::xml_node currentNode, Space *space)
 
     this->WriteLayerElement(currentNode, space);
     this->WriteDurationInterface(currentNode, space);
+}
+
+void MEIOutput::WriteStem(pugi::xml_node currentNode, Stem *stem)
+{
+    assert(stem);
+
+    this->WriteLayerElement(currentNode, stem);
+    stem->WriteGraced(currentNode);
+    stem->WriteStemVis(currentNode);
+    stem->WriteVisibility(currentNode);
 }
 
 void MEIOutput::WriteTabDurSym(pugi::xml_node currentNode, TabDurSym *tabDurSym)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -118,6 +118,7 @@
 #include "staff.h"
 #include "staffdef.h"
 #include "staffgrp.h"
+#include "stem.h"
 #include "subst.h"
 #include "supplied.h"
 #include "surface.h"
@@ -3474,6 +3475,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         else if (element == "plica") {
             return true;
         }
+        else if (element == "stem") {
+            return true;
+        }
         else if (element == "syl") {
             return true;
         }
@@ -5802,6 +5806,9 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         else if (elementName == "space") {
             success = this->ReadSpace(parent, xmlElement);
         }
+        else if (elementName == "stem") {
+            success = this->ReadStem(parent, xmlElement);
+        }
         else if (elementName == "syl") {
             success = this->ReadSyl(parent, xmlElement);
         }
@@ -6428,6 +6435,20 @@ bool MEIInput::ReadSpace(Object *parent, pugi::xml_node space)
 
     parent->AddChild(vrvSpace);
     this->ReadUnsupportedAttr(space, vrvSpace);
+    return true;
+}
+
+bool MEIInput::ReadStem(Object *parent, pugi::xml_node stem)
+{
+    Stem *vrvStem = new Stem();
+    this->ReadLayerElement(stem, vrvStem);
+
+    vrvStem->ReadGraced(stem);
+    vrvStem->ReadStemVis(stem);
+    vrvStem->ReadVisibility(stem);
+
+    parent->AddChild(vrvStem);
+    this->ReadUnsupportedAttr(stem, vrvStem);
     return true;
 }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1303,12 +1303,12 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
     if (!this->IsChordTone() && !this->IsMensuralDur() && !this->IsTabGrpNote()) {
         if (!currentStem) {
             currentStem = new Stem();
+            currentStem->IsAttribute(true);
             this->AddChild(currentStem);
         }
         currentStem->AttGraced::operator=(*this);
-        // TODO: CONVERT ATTRIBUTES
-        // currentStem->AttStems::operator=(*this);
-        // currentStem->AttStemsCmn::operator=(*this);
+        currentStem->FillAttributes(*this);
+
         if (this->GetActualDur() < DUR_2 || (this->GetStemVisible() == BOOLEAN_false)) {
             currentStem->IsVirtual(true);
         }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1077,8 +1077,8 @@ int Note::CalcStem(FunctorParams *functorParams)
     if (this->HasStemSameasNote()) {
         stemDir = this->CalcStemDirForSameasNote(params->m_verticalCenter);
     }
-    else if (stem->HasStemDir()) {
-        stemDir = stem->GetStemDir();
+    else if (stem->HasDir()) {
+        stemDir = stem->GetDir();
     }
     else if (this->IsGraceNote()) {
         stemDir = STEMDIRECTION_up;
@@ -1306,8 +1306,9 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
             this->AddChild(currentStem);
         }
         currentStem->AttGraced::operator=(*this);
-        currentStem->AttStems::operator=(*this);
-        currentStem->AttStemsCmn::operator=(*this);
+        // TODO: CONVERT ATTRIBUTES
+        // currentStem->AttStems::operator=(*this);
+        // currentStem->AttStemsCmn::operator=(*this);
         if (this->GetActualDur() < DUR_2 || (this->GetStemVisible() == BOOLEAN_false)) {
             currentStem->IsVirtual(true);
         }

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -66,6 +66,25 @@ bool Stem::IsSupportedChild(Object *child)
     return true;
 }
 
+void Stem::FillAttributes(const AttStems &attSource)
+{
+    if (attSource.HasStemDir()) {
+        this->SetDir(attSource.GetStemDir());
+    }
+    if (attSource.HasStemLen()) {
+        this->SetLen(attSource.GetStemLen());
+    }
+    if (attSource.HasStemPos()) {
+        this->SetPos(attSource.GetStemPos());
+    }
+    if (attSource.HasStemMod()) {
+        this->SetDrawingStemMod(attSource.GetStemMod());
+    }
+    if (attSource.HasStemVisible()) {
+        this->SetVisible(attSource.GetStemVisible());
+    }
+}
+
 int Stem::CompareToElementPosition(const Doc *doc, const LayerElement *otherElement, int margin) const
 {
     const Staff *staff = this->GetAncestorStaff();

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -30,11 +30,11 @@ namespace vrv {
 
 static const ClassRegistrar<Note> s_factory("stem", STEM);
 
-Stem::Stem() : LayerElement(STEM, "stem-"), AttGraced(), AttStems(), AttStemsCmn()
+Stem::Stem() : LayerElement(STEM, "stem-"), AttGraced(), AttStemVis(), AttVisibility()
 {
     this->RegisterAttClass(ATT_GRACED);
-    this->RegisterAttClass(ATT_STEMS);
-    this->RegisterAttClass(ATT_STEMSCMN);
+    this->RegisterAttClass(ATT_STEMVIS);
+    this->RegisterAttClass(ATT_VISIBILITY);
 
     this->Reset();
 }
@@ -45,8 +45,8 @@ void Stem::Reset()
 {
     LayerElement::Reset();
     this->ResetGraced();
-    this->ResetStems();
-    this->ResetStemsCmn();
+    this->ResetStemVis();
+    this->ResetVisibility();
 
     m_drawingStemDir = STEMDIRECTION_NONE;
     m_drawingStemLen = 0;
@@ -157,7 +157,7 @@ void Stem::AdjustFlagPlacement(const Doc *doc, Flag *flag, int staffSize, int ve
 int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) const
 {
     // if stem length is explicitly set - exit
-    if (this->HasStemLen()) return 0;
+    if (this->HasLen()) return 0;
 
     const int staffSize = staff->m_drawingStaffSize;
     const int unit = doc->GetDrawingUnit(staffSize);
@@ -166,7 +166,7 @@ int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) cons
     if (bTrem) {
         stemMod = bTrem->GetDrawingStemMod();
     }
-    else if (this->HasStemMod() && (this->GetStemMod() < 8)) {
+    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < 8)) {
         stemMod = this->GetDrawingStemMod();
     }
     if ((stemMod == STEMMODIFIER_NONE) || (stemMod == STEMMODIFIER_none)) return 0;
@@ -227,8 +227,8 @@ int Stem::CalcStem(FunctorParams *functorParams)
     const int unit = params->m_doc->GetDrawingUnit(staffSize);
     int baseStem = 0;
     // Use the given one if any
-    if (this->HasStemLen()) {
-        baseStem = this->GetStemLen() * -unit;
+    if (this->HasLen()) {
+        baseStem = this->GetLen() * -unit;
     }
     // Do not adjust the baseStem for stem sameas notes (its length is in m_chordStemLength)
     else if (!params->m_isStemSameasSecondary) {
@@ -240,10 +240,10 @@ int Stem::CalcStem(FunctorParams *functorParams)
     // Even if a stem length is given we add the length of the chord content (however only if not 0)
     // Also, the given stem length is understood as being measured from the center of the note.
     // This means that it will be adjusted according to the note head (see below
-    if (!params->m_staff || !this->HasStemLen() || (this->GetStemLen() != 0)) {
+    if (!params->m_staff || !this->HasLen() || (this->GetLen() != 0)) {
         Point p;
         if (this->GetDrawingStemDir() == STEMDIRECTION_up) {
-            if (this->GetStemPos() == STEMPOSITION_left) {
+            if (this->GetPos() == STEMPOSITION_left) {
                 p = params->m_interface->GetStemDownNW(params->m_doc, staffSize, drawingCueSize);
                 p.x += stemShift;
             }
@@ -255,7 +255,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
             this->SetDrawingStemLen(baseStem + params->m_chordStemLength + stemShotening);
         }
         else {
-            if (this->GetStemPos() == STEMPOSITION_right) {
+            if (this->GetPos() == STEMPOSITION_right) {
                 p = params->m_interface->GetStemUpSE(params->m_doc, staffSize, drawingCueSize);
                 p.x -= stemShift;
             }
@@ -294,11 +294,11 @@ int Stem::CalcStem(FunctorParams *functorParams)
 
     // Do not adjust the length with stem sameas notes or if given in the encoding
     // however, the stem will be extend with the SMuFL extension from 32th - this can be improved
-    if (params->m_isStemSameasSecondary || this->HasStemLen()) {
-        if ((this->GetStemLen() == 0) && flag) flag->m_drawingNbFlags = 0;
+    if (params->m_isStemSameasSecondary || this->HasLen()) {
+        if ((this->GetLen() == 0) && flag) flag->m_drawingNbFlags = 0;
         return FUNCTOR_CONTINUE;
     }
-    if ((this->GetStemVisible() == BOOLEAN_false) && flag) {
+    if ((this->GetVisible() == BOOLEAN_false) && flag) {
         flag->m_drawingNbFlags = 0;
         return FUNCTOR_CONTINUE;
     }
@@ -366,7 +366,7 @@ void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
     if (bTrem) {
         stemMod = bTrem->GetDrawingStemMod();
     }
-    else if (this->HasStemMod() && (this->GetStemMod() < 8)) {
+    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < 8)) {
         stemMod = this->GetDrawingStemMod();
     }
     if ((stemMod == STEMMODIFIER_NONE) || (stemMod == STEMMODIFIER_none)) return;

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -135,6 +135,7 @@ int TabDurSym::PrepareLayerElementParts(FunctorParams *functorParams)
 
     if (!currentStem) {
         currentStem = new Stem();
+        currentStem->IsAttribute(true);
         this->AddChild(currentStem);
     }
     this->SetDrawingStem(currentStem);

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -203,8 +203,8 @@ int TabDurSym::CalcStem(FunctorParams *functorParams)
     // Up by default with tablature
     data_STEMDIRECTION stemDir = STEMDIRECTION_up;
 
-    if (stem->HasStemDir()) {
-        stemDir = stem->GetStemDir();
+    if (stem->HasDir()) {
+        stemDir = stem->GetDir();
     }
     else if ((layerStemDir = params->m_layer->GetDrawingStemDir()) != STEMDIRECTION_NONE) {
         stemDir = layerStemDir;


### PR DESCRIPTION
This PR adds support for reading and writing `Stem` in MEI. To achieve this `Stem` now derives from `AttStemVis` and when constructing attribute stems we convert from `AttStems`, the base class of `Note/Chord`.

There is a [related PR on LibMEI](https://github.com/rism-digital/libmei/pull/17) that adjusts default values of stem length attributes.

Example:
```xml
<note dur="4" oct="4" pname="c" accid.ges="n" >
   <stem len="3.0" dir="down" pos="right"/>
</note>
```
![Bildschirmfoto 2022-07-15 um 17 03 42](https://user-images.githubusercontent.com/63608463/179251405-50c51a66-a886-4d65-a3a2-0a5a2b508ae9.png)

<details>
<summary>Show full MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Stem length adjustment</title>
         </titleStmt>
         <pubStmt>
            <date>2017-05-17</date>
         </pubStmt>
         <notesStmt>
            <annot>The length of stems can be individually adjusted using the "stem.len" attribute.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="1.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="end" n="0">
                     <staff n="1">
                        <layer n="1">
                          <note dur="4" oct="4" pname="c" accid.ges="n" >
                            <stem len="3.0" dir="down" pos="right"/>
                          </note>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>