### PR TITLE
Use VRV_UNSET

### DIFF
--- a/libmei/atts_analytical.cpp
+++ b/libmei/atts_analytical.cpp
@@ -393,7 +393,7 @@ AttPitchClass::~AttPitchClass()
 
 void AttPitchClass::ResetPitchClass()
 {
-    m_pclass = 0;
+    m_pclass = VRV_UNSET;
 }
 
 bool AttPitchClass::ReadPitchClass(pugi::xml_node element)
@@ -419,7 +419,7 @@ bool AttPitchClass::WritePitchClass(pugi::xml_node element)
 
 bool AttPitchClass::HasPclass() const
 {
-    return (m_pclass != 0);
+    return (m_pclass != VRV_UNSET);
 }
 
 /* include <attpclass> */

--- a/libmei/atts_cmn.cpp
+++ b/libmei/atts_cmn.cpp
@@ -270,7 +270,7 @@ AttBeamSecondary::~AttBeamSecondary()
 
 void AttBeamSecondary::ResetBeamSecondary()
 {
-    m_breaksec = 0;
+    m_breaksec = VRV_UNSET;
 }
 
 bool AttBeamSecondary::ReadBeamSecondary(pugi::xml_node element)
@@ -296,7 +296,7 @@ bool AttBeamSecondary::WriteBeamSecondary(pugi::xml_node element)
 
 bool AttBeamSecondary::HasBreaksec() const
 {
-    return (m_breaksec != 0);
+    return (m_breaksec != VRV_UNSET);
 }
 
 /* include <attbreaksec> */
@@ -1217,7 +1217,7 @@ AttNumbered::~AttNumbered()
 
 void AttNumbered::ResetNumbered()
 {
-    m_num = 0;
+    m_num = VRV_UNSET;
 }
 
 bool AttNumbered::ReadNumbered(pugi::xml_node element)
@@ -1243,7 +1243,7 @@ bool AttNumbered::WriteNumbered(pugi::xml_node element)
 
 bool AttNumbered::HasNum() const
 {
-    return (m_num != 0);
+    return (m_num != VRV_UNSET);
 }
 
 /* include <attnum> */

--- a/libmei/atts_figtable.cpp
+++ b/libmei/atts_figtable.cpp
@@ -41,8 +41,8 @@ AttTabular::~AttTabular()
 
 void AttTabular::ResetTabular()
 {
-    m_colspan = 0;
-    m_rowspan = 0;
+    m_colspan = VRV_UNSET;
+    m_rowspan = VRV_UNSET;
 }
 
 bool AttTabular::ReadTabular(pugi::xml_node element)
@@ -77,12 +77,12 @@ bool AttTabular::WriteTabular(pugi::xml_node element)
 
 bool AttTabular::HasColspan() const
 {
-    return (m_colspan != 0);
+    return (m_colspan != VRV_UNSET);
 }
 
 bool AttTabular::HasRowspan() const
 {
-    return (m_rowspan != 0);
+    return (m_rowspan != VRV_UNSET);
 }
 
 /* include <attrowspan> */

--- a/libmei/atts_frettab.cpp
+++ b/libmei/atts_frettab.cpp
@@ -87,7 +87,7 @@ AttNoteGesTab::~AttNoteGesTab()
 
 void AttNoteGesTab::ResetNoteGesTab()
 {
-    m_tabCourse = 0;
+    m_tabCourse = VRV_UNSET;
     m_tabFret = -1;
 }
 
@@ -123,7 +123,7 @@ bool AttNoteGesTab::WriteNoteGesTab(pugi::xml_node element)
 
 bool AttNoteGesTab::HasTabCourse() const
 {
-    return (m_tabCourse != 0);
+    return (m_tabCourse != VRV_UNSET);
 }
 
 bool AttNoteGesTab::HasTabFret() const

--- a/libmei/atts_gestural.cpp
+++ b/libmei/atts_gestural.cpp
@@ -180,9 +180,9 @@ AttDurationGestural::~AttDurationGestural()
 void AttDurationGestural::ResetDurationGestural()
 {
     m_durGes = DURATION_NONE;
-    m_dotsGes = -1;
+    m_dotsGes = VRV_UNSET;
     m_durMetrical = 0.0;
-    m_durPpq = 0;
+    m_durPpq = VRV_UNSET;
     m_durReal = 0.0;
     m_durRecip = "";
 }
@@ -260,7 +260,7 @@ bool AttDurationGestural::HasDurGes() const
 
 bool AttDurationGestural::HasDotsGes() const
 {
-    return (m_dotsGes != -1);
+    return (m_dotsGes != VRV_UNSET);
 }
 
 bool AttDurationGestural::HasDurMetrical() const
@@ -270,7 +270,7 @@ bool AttDurationGestural::HasDurMetrical() const
 
 bool AttDurationGestural::HasDurPpq() const
 {
-    return (m_durPpq != 0);
+    return (m_durPpq != VRV_UNSET);
 }
 
 bool AttDurationGestural::HasDurReal() const
@@ -348,7 +348,7 @@ void AttNcGes::ResetNcGes()
 {
     m_octGes = -127;
     m_pnameGes = PITCHNAME_NONE;
-    m_pnum = 0;
+    m_pnum = VRV_UNSET;
 }
 
 bool AttNcGes::ReadNcGes(pugi::xml_node element)
@@ -402,7 +402,7 @@ bool AttNcGes::HasPnameGes() const
 
 bool AttNcGes::HasPnum() const
 {
-    return (m_pnum != 0);
+    return (m_pnum != VRV_UNSET);
 }
 
 /* include <attpnum> */
@@ -425,7 +425,7 @@ void AttNoteGes::ResetNoteGes()
     m_extremis = noteGes_EXTREMIS_NONE;
     m_octGes = -127;
     m_pnameGes = PITCHNAME_NONE;
-    m_pnum = 0;
+    m_pnum = VRV_UNSET;
 }
 
 bool AttNoteGes::ReadNoteGes(pugi::xml_node element)
@@ -493,7 +493,7 @@ bool AttNoteGes::HasPnameGes() const
 
 bool AttNoteGes::HasPnum() const
 {
-    return (m_pnum != 0);
+    return (m_pnum != VRV_UNSET);
 }
 
 /* include <attpnum> */

--- a/libmei/atts_mensural.cpp
+++ b/libmei/atts_mensural.cpp
@@ -87,8 +87,8 @@ AttMensuralLog::~AttMensuralLog()
 
 void AttMensuralLog::ResetMensuralLog()
 {
-    m_proportNum = -1;
-    m_proportNumbase = -1;
+    m_proportNum = VRV_UNSET;
+    m_proportNumbase = VRV_UNSET;
 }
 
 bool AttMensuralLog::ReadMensuralLog(pugi::xml_node element)
@@ -123,12 +123,12 @@ bool AttMensuralLog::WriteMensuralLog(pugi::xml_node element)
 
 bool AttMensuralLog::HasProportNum() const
 {
-    return (m_proportNum != -1);
+    return (m_proportNum != VRV_UNSET);
 }
 
 bool AttMensuralLog::HasProportNumbase() const
 {
-    return (m_proportNumbase != -1);
+    return (m_proportNumbase != VRV_UNSET);
 }
 
 /* include <attproport.numbase> */
@@ -361,7 +361,7 @@ AttRestVisMensural::~AttRestVisMensural()
 
 void AttRestVisMensural::ResetRestVisMensural()
 {
-    m_spaces = 0;
+    m_spaces = VRV_UNSET;
 }
 
 bool AttRestVisMensural::ReadRestVisMensural(pugi::xml_node element)
@@ -387,7 +387,7 @@ bool AttRestVisMensural::WriteRestVisMensural(pugi::xml_node element)
 
 bool AttRestVisMensural::HasSpaces() const
 {
-    return (m_spaces != 0);
+    return (m_spaces != VRV_UNSET);
 }
 
 /* include <attspaces> */

--- a/libmei/atts_midi.cpp
+++ b/libmei/atts_midi.cpp
@@ -44,7 +44,7 @@ void AttChannelized::ResetChannelized()
     m_midiChannel = -1;
     m_midiDuty = -1.0;
     m_midiPort = data_MIDIVALUE_NAME();
-    m_midiTrack = 0;
+    m_midiTrack = VRV_UNSET;
 }
 
 bool AttChannelized::ReadChannelized(pugi::xml_node element)
@@ -112,7 +112,7 @@ bool AttChannelized::HasMidiPort() const
 
 bool AttChannelized::HasMidiTrack() const
 {
-    return (m_midiTrack != 0);
+    return (m_midiTrack != VRV_UNSET);
 }
 
 /* include <attmidi.track> */
@@ -299,7 +299,7 @@ AttMidiNumber::~AttMidiNumber()
 
 void AttMidiNumber::ResetMidiNumber()
 {
-    m_num = 0;
+    m_num = VRV_UNSET;
 }
 
 bool AttMidiNumber::ReadMidiNumber(pugi::xml_node element)
@@ -325,7 +325,7 @@ bool AttMidiNumber::WriteMidiNumber(pugi::xml_node element)
 
 bool AttMidiNumber::HasNum() const
 {
-    return (m_num != 0);
+    return (m_num != VRV_UNSET);
 }
 
 /* include <attnum> */
@@ -544,7 +544,7 @@ AttTimeBase::~AttTimeBase()
 
 void AttTimeBase::ResetTimeBase()
 {
-    m_ppq = 0;
+    m_ppq = VRV_UNSET;
 }
 
 bool AttTimeBase::ReadTimeBase(pugi::xml_node element)
@@ -570,7 +570,7 @@ bool AttTimeBase::WriteTimeBase(pugi::xml_node element)
 
 bool AttTimeBase::HasPpq() const
 {
-    return (m_ppq != 0);
+    return (m_ppq != VRV_UNSET);
 }
 
 /* include <attppq> */

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -271,7 +271,7 @@ AttAugmentDots::~AttAugmentDots()
 
 void AttAugmentDots::ResetAugmentDots()
 {
-    m_dots = -1;
+    m_dots = VRV_UNSET;
 }
 
 bool AttAugmentDots::ReadAugmentDots(pugi::xml_node element)
@@ -297,7 +297,7 @@ bool AttAugmentDots::WriteAugmentDots(pugi::xml_node element)
 
 bool AttAugmentDots::HasDots() const
 {
-    return (m_dots != -1);
+    return (m_dots != VRV_UNSET);
 }
 
 /* include <attdots> */
@@ -426,7 +426,7 @@ void AttBarring::ResetBarring()
 {
     m_barLen = 0.0;
     m_barMethod = BARMETHOD_NONE;
-    m_barPlace = 0;
+    m_barPlace = VRV_UNSET;
 }
 
 bool AttBarring::ReadBarring(pugi::xml_node element)
@@ -480,7 +480,7 @@ bool AttBarring::HasBarMethod() const
 
 bool AttBarring::HasBarPlace() const
 {
-    return (m_barPlace != 0);
+    return (m_barPlace != VRV_UNSET);
 }
 
 /* include <attbar.place> */
@@ -1143,10 +1143,10 @@ AttCoordinated::~AttCoordinated()
 
 void AttCoordinated::ResetCoordinated()
 {
-    m_ulx = 0;
-    m_uly = 0;
-    m_lrx = 0;
-    m_lry = 0;
+    m_ulx = VRV_UNSET;
+    m_uly = VRV_UNSET;
+    m_lrx = VRV_UNSET;
+    m_lry = VRV_UNSET;
     m_rotate = 0.0;
 }
 
@@ -1209,22 +1209,22 @@ bool AttCoordinated::WriteCoordinated(pugi::xml_node element)
 
 bool AttCoordinated::HasUlx() const
 {
-    return (m_ulx != 0);
+    return (m_ulx != VRV_UNSET);
 }
 
 bool AttCoordinated::HasUly() const
 {
-    return (m_uly != 0);
+    return (m_uly != VRV_UNSET);
 }
 
 bool AttCoordinated::HasLrx() const
 {
-    return (m_lrx != 0);
+    return (m_lrx != VRV_UNSET);
 }
 
 bool AttCoordinated::HasLry() const
 {
-    return (m_lry != 0);
+    return (m_lry != VRV_UNSET);
 }
 
 bool AttCoordinated::HasRotate() const
@@ -1799,8 +1799,8 @@ AttDurationDefault::~AttDurationDefault()
 void AttDurationDefault::ResetDurationDefault()
 {
     m_durDefault = DURATION_NONE;
-    m_numDefault = 0;
-    m_numbaseDefault = 0;
+    m_numDefault = VRV_UNSET;
+    m_numbaseDefault = VRV_UNSET;
 }
 
 bool AttDurationDefault::ReadDurationDefault(pugi::xml_node element)
@@ -1849,12 +1849,12 @@ bool AttDurationDefault::HasDurDefault() const
 
 bool AttDurationDefault::HasNumDefault() const
 {
-    return (m_numDefault != 0);
+    return (m_numDefault != VRV_UNSET);
 }
 
 bool AttDurationDefault::HasNumbaseDefault() const
 {
-    return (m_numbaseDefault != 0);
+    return (m_numbaseDefault != VRV_UNSET);
 }
 
 /* include <attnumbase.default> */
@@ -1920,8 +1920,8 @@ AttDurationRatio::~AttDurationRatio()
 
 void AttDurationRatio::ResetDurationRatio()
 {
-    m_num = -1;
-    m_numbase = -1;
+    m_num = VRV_UNSET;
+    m_numbase = VRV_UNSET;
 }
 
 bool AttDurationRatio::ReadDurationRatio(pugi::xml_node element)
@@ -1956,12 +1956,12 @@ bool AttDurationRatio::WriteDurationRatio(pugi::xml_node element)
 
 bool AttDurationRatio::HasNum() const
 {
-    return (m_num != -1);
+    return (m_num != VRV_UNSET);
 }
 
 bool AttDurationRatio::HasNumbase() const
 {
-    return (m_numbase != -1);
+    return (m_numbase != VRV_UNSET);
 }
 
 /* include <attnumbase> */
@@ -2272,7 +2272,7 @@ AttFiling::~AttFiling()
 
 void AttFiling::ResetFiling()
 {
-    m_nonfiling = 0;
+    m_nonfiling = VRV_UNSET;
 }
 
 bool AttFiling::ReadFiling(pugi::xml_node element)
@@ -2298,7 +2298,7 @@ bool AttFiling::WriteFiling(pugi::xml_node element)
 
 bool AttFiling::HasNonfiling() const
 {
-    return (m_nonfiling != 0);
+    return (m_nonfiling != VRV_UNSET);
 }
 
 /* include <attnonfiling> */
@@ -2318,7 +2318,7 @@ AttGrpSymLog::~AttGrpSymLog()
 
 void AttGrpSymLog::ResetGrpSymLog()
 {
-    m_level = 0;
+    m_level = VRV_UNSET;
 }
 
 bool AttGrpSymLog::ReadGrpSymLog(pugi::xml_node element)
@@ -2344,7 +2344,7 @@ bool AttGrpSymLog::WriteGrpSymLog(pugi::xml_node element)
 
 bool AttGrpSymLog::HasLevel() const
 {
-    return (m_level != 0);
+    return (m_level != VRV_UNSET);
 }
 
 /* include <attlevel> */
@@ -2839,7 +2839,7 @@ AttLayerIdent::~AttLayerIdent()
 
 void AttLayerIdent::ResetLayerIdent()
 {
-    m_layer = 0;
+    m_layer = VRV_UNSET;
 }
 
 bool AttLayerIdent::ReadLayerIdent(pugi::xml_node element)
@@ -2865,7 +2865,7 @@ bool AttLayerIdent::WriteLayerIdent(pugi::xml_node element)
 
 bool AttLayerIdent::HasLayer() const
 {
-    return (m_layer != 0);
+    return (m_layer != VRV_UNSET);
 }
 
 /* include <attlayer> */
@@ -2932,9 +2932,9 @@ AttLineRend::~AttLineRend()
 void AttLineRend::ResetLineRend()
 {
     m_lendsym = LINESTARTENDSYMBOL_NONE;
-    m_lendsymSize = 0;
+    m_lendsymSize = VRV_UNSET;
     m_lstartsym = LINESTARTENDSYMBOL_NONE;
-    m_lstartsymSize = 0;
+    m_lstartsymSize = VRV_UNSET;
 }
 
 bool AttLineRend::ReadLineRend(pugi::xml_node element)
@@ -2992,7 +2992,7 @@ bool AttLineRend::HasLendsym() const
 
 bool AttLineRend::HasLendsymSize() const
 {
-    return (m_lendsymSize != 0);
+    return (m_lendsymSize != VRV_UNSET);
 }
 
 bool AttLineRend::HasLstartsym() const
@@ -3002,7 +3002,7 @@ bool AttLineRend::HasLstartsym() const
 
 bool AttLineRend::HasLstartsymSize() const
 {
-    return (m_lstartsymSize != 0);
+    return (m_lstartsymSize != VRV_UNSET);
 }
 
 /* include <attlstartsym.size> */
@@ -3023,7 +3023,7 @@ AttLineRendBase::~AttLineRendBase()
 void AttLineRendBase::ResetLineRendBase()
 {
     m_lform = LINEFORM_NONE;
-    m_lsegs = 0;
+    m_lsegs = VRV_UNSET;
     m_lwidth = data_LINEWIDTH();
 }
 
@@ -3073,7 +3073,7 @@ bool AttLineRendBase::HasLform() const
 
 bool AttLineRendBase::HasLsegs() const
 {
-    return (m_lsegs != 0);
+    return (m_lsegs != VRV_UNSET);
 }
 
 bool AttLineRendBase::HasLwidth() const
@@ -3785,7 +3785,7 @@ void AttMeterSigLog::ResetMeterSigLog()
 {
     m_count = std::pair<std::vector<int>, MeterCountSign>();
     m_sym = METERSIGN_NONE;
-    m_unit = 0;
+    m_unit = VRV_UNSET;
 }
 
 bool AttMeterSigLog::ReadMeterSigLog(pugi::xml_node element)
@@ -3839,7 +3839,7 @@ bool AttMeterSigLog::HasSym() const
 
 bool AttMeterSigLog::HasUnit() const
 {
-    return (m_unit != 0);
+    return (m_unit != VRV_UNSET);
 }
 
 /* include <attunit> */
@@ -3860,7 +3860,7 @@ AttMeterSigDefaultLog::~AttMeterSigDefaultLog()
 void AttMeterSigDefaultLog::ResetMeterSigDefaultLog()
 {
     m_meterCount = std::pair<std::vector<int>, MeterCountSign>();
-    m_meterUnit = 0;
+    m_meterUnit = VRV_UNSET;
     m_meterSym = METERSIGN_NONE;
 }
 
@@ -3910,7 +3910,7 @@ bool AttMeterSigDefaultLog::HasMeterCount() const
 
 bool AttMeterSigDefaultLog::HasMeterUnit() const
 {
-    return (m_meterUnit != 0);
+    return (m_meterUnit != VRV_UNSET);
 }
 
 bool AttMeterSigDefaultLog::HasMeterSym() const
@@ -3937,7 +3937,7 @@ void AttMmTempo::ResetMmTempo()
 {
     m_mm = 0.0;
     m_mmUnit = DURATION_NONE;
-    m_mmDots = 0;
+    m_mmDots = VRV_UNSET;
 }
 
 bool AttMmTempo::ReadMmTempo(pugi::xml_node element)
@@ -3991,7 +3991,7 @@ bool AttMmTempo::HasMmUnit() const
 
 bool AttMmTempo::HasMmDots() const
 {
-    return (m_mmDots != 0);
+    return (m_mmDots != VRV_UNSET);
 }
 
 /* include <attmm.dots> */
@@ -4057,7 +4057,7 @@ AttNInteger::~AttNInteger()
 
 void AttNInteger::ResetNInteger()
 {
-    m_n = -1;
+    m_n = VRV_UNSET;
 }
 
 bool AttNInteger::ReadNInteger(pugi::xml_node element)
@@ -4083,7 +4083,7 @@ bool AttNInteger::WriteNInteger(pugi::xml_node element)
 
 bool AttNInteger::HasN() const
 {
-    return (m_n != -1);
+    return (m_n != VRV_UNSET);
 }
 
 /* include <attn> */
@@ -5734,7 +5734,7 @@ AttSequence::~AttSequence()
 
 void AttSequence::ResetSequence()
 {
-    m_seq = 0;
+    m_seq = VRV_UNSET;
 }
 
 bool AttSequence::ReadSequence(pugi::xml_node element)
@@ -5760,7 +5760,7 @@ bool AttSequence::WriteSequence(pugi::xml_node element)
 
 bool AttSequence::HasSeq() const
 {
-    return (m_seq != 0);
+    return (m_seq != VRV_UNSET);
 }
 
 /* include <attseq> */
@@ -6055,7 +6055,7 @@ AttStaffDefLog::~AttStaffDefLog()
 
 void AttStaffDefLog::ResetStaffDefLog()
 {
-    m_lines = 0;
+    m_lines = VRV_UNSET;
 }
 
 bool AttStaffDefLog::ReadStaffDefLog(pugi::xml_node element)
@@ -6081,7 +6081,7 @@ bool AttStaffDefLog::WriteStaffDefLog(pugi::xml_node element)
 
 bool AttStaffDefLog::HasLines() const
 {
-    return (m_lines != 0);
+    return (m_lines != VRV_UNSET);
 }
 
 /* include <attlines> */
@@ -7214,8 +7214,8 @@ AttTransposition::~AttTransposition()
 
 void AttTransposition::ResetTransposition()
 {
-    m_transDiat = VRV_UNSET;
-    m_transSemi = VRV_UNSET;
+    m_transDiat = 0.0;
+    m_transSemi = 0.0;
 }
 
 bool AttTransposition::ReadTransposition(pugi::xml_node element)
@@ -7250,12 +7250,12 @@ bool AttTransposition::WriteTransposition(pugi::xml_node element)
 
 bool AttTransposition::HasTransDiat() const
 {
-    return (m_transDiat != VRV_UNSET);
+    return (m_transDiat != 0.0);
 }
 
 bool AttTransposition::HasTransSemi() const
 {
-    return (m_transSemi != VRV_UNSET);
+    return (m_transSemi != 0.0);
 }
 
 /* include <atttrans.semi> */
@@ -7519,7 +7519,7 @@ AttVerticalGroup::~AttVerticalGroup()
 
 void AttVerticalGroup::ResetVerticalGroup()
 {
-    m_vgrp = 0;
+    m_vgrp = VRV_UNSET;
 }
 
 bool AttVerticalGroup::ReadVerticalGroup(pugi::xml_node element)
@@ -7545,7 +7545,7 @@ bool AttVerticalGroup::WriteVerticalGroup(pugi::xml_node element)
 
 bool AttVerticalGroup::HasVgrp() const
 {
-    return (m_vgrp != 0);
+    return (m_vgrp != VRV_UNSET);
 }
 
 /* include <attvgrp> */

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -7214,20 +7214,20 @@ AttTransposition::~AttTransposition()
 
 void AttTransposition::ResetTransposition()
 {
-    m_transDiat = 0.0;
-    m_transSemi = 0.0;
+    m_transDiat = VRV_UNSET;
+    m_transSemi = VRV_UNSET;
 }
 
 bool AttTransposition::ReadTransposition(pugi::xml_node element)
 {
     bool hasAttribute = false;
     if (element.attribute("trans.diat")) {
-        this->SetTransDiat(StrToDbl(element.attribute("trans.diat").value()));
+        this->SetTransDiat(StrToInt(element.attribute("trans.diat").value()));
         element.remove_attribute("trans.diat");
         hasAttribute = true;
     }
     if (element.attribute("trans.semi")) {
-        this->SetTransSemi(StrToDbl(element.attribute("trans.semi").value()));
+        this->SetTransSemi(StrToInt(element.attribute("trans.semi").value()));
         element.remove_attribute("trans.semi");
         hasAttribute = true;
     }
@@ -7238,11 +7238,11 @@ bool AttTransposition::WriteTransposition(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasTransDiat()) {
-        element.append_attribute("trans.diat") = DblToStr(this->GetTransDiat()).c_str();
+        element.append_attribute("trans.diat") = IntToStr(this->GetTransDiat()).c_str();
         wroteAttribute = true;
     }
     if (this->HasTransSemi()) {
-        element.append_attribute("trans.semi") = DblToStr(this->GetTransSemi()).c_str();
+        element.append_attribute("trans.semi") = IntToStr(this->GetTransSemi()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -7250,12 +7250,12 @@ bool AttTransposition::WriteTransposition(pugi::xml_node element)
 
 bool AttTransposition::HasTransDiat() const
 {
-    return (m_transDiat != 0.0);
+    return (m_transDiat != VRV_UNSET);
 }
 
 bool AttTransposition::HasTransSemi() const
 {
-    return (m_transSemi != 0.0);
+    return (m_transSemi != VRV_UNSET);
 }
 
 /* include <atttrans.semi> */
@@ -9571,11 +9571,11 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
         AttTransposition *att = dynamic_cast<AttTransposition *>(element);
         assert(att);
         if (attrType == "trans.diat") {
-            att->SetTransDiat(att->StrToDbl(attrValue));
+            att->SetTransDiat(att->StrToInt(attrValue));
             return true;
         }
         if (attrType == "trans.semi") {
-            att->SetTransSemi(att->StrToDbl(attrValue));
+            att->SetTransSemi(att->StrToInt(attrValue));
             return true;
         }
     }
@@ -10925,10 +10925,10 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttTransposition *att = dynamic_cast<const AttTransposition *>(element);
         assert(att);
         if (att->HasTransDiat()) {
-            attributes->push_back({ "trans.diat", att->DblToStr(att->GetTransDiat()) });
+            attributes->push_back({ "trans.diat", att->IntToStr(att->GetTransDiat()) });
         }
         if (att->HasTransSemi()) {
-            attributes->push_back({ "trans.semi", att->DblToStr(att->GetTransSemi()) });
+            attributes->push_back({ "trans.semi", att->IntToStr(att->GetTransSemi()) });
         }
     }
     if (element->HasAttClass(ATT_TUPLETPRESENT)) {

--- a/libmei/atts_shared.h
+++ b/libmei/atts_shared.h
@@ -5459,20 +5459,20 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetTransDiat(double transDiat_) { m_transDiat = transDiat_; }
-    double GetTransDiat() const { return m_transDiat; }
+    void SetTransDiat(int transDiat_) { m_transDiat = transDiat_; }
+    int GetTransDiat() const { return m_transDiat; }
     bool HasTransDiat() const;
     //
-    void SetTransSemi(double transSemi_) { m_transSemi = transSemi_; }
-    double GetTransSemi() const { return m_transSemi; }
+    void SetTransSemi(int transSemi_) { m_transSemi = transSemi_; }
+    int GetTransSemi() const { return m_transSemi; }
     bool HasTransSemi() const;
     ///@}
 
 private:
     /** Records the amount of diatonic pitch shift, **/
-    double m_transDiat;
+    int m_transDiat;
     /** Records the amount of pitch shift in semitones, **/
-    double m_transSemi;
+    int m_transSemi;
 
     /* include <atttrans.semi> */
 };

--- a/libmei/atts_visual.cpp
+++ b/libmei/atts_visual.cpp
@@ -89,7 +89,7 @@ void AttArpegVis::ResetArpegVis()
 {
     m_arrow = BOOLEAN_NONE;
     m_arrowShape = LINESTARTENDSYMBOL_NONE;
-    m_arrowSize = 0;
+    m_arrowSize = VRV_UNSET;
     m_arrowColor = "";
     m_arrowFillcolor = "";
     m_lineForm = LINEFORM_NONE;
@@ -183,7 +183,7 @@ bool AttArpegVis::HasArrowShape() const
 
 bool AttArpegVis::HasArrowSize() const
 {
-    return (m_arrowSize != 0);
+    return (m_arrowSize != VRV_UNSET);
 }
 
 bool AttArpegVis::HasArrowColor() const
@@ -225,7 +225,7 @@ void AttBarLineVis::ResetBarLineVis()
 {
     m_len = 0.0;
     m_method = BARMETHOD_NONE;
-    m_place = 0;
+    m_place = VRV_UNSET;
 }
 
 bool AttBarLineVis::ReadBarLineVis(pugi::xml_node element)
@@ -279,7 +279,7 @@ bool AttBarLineVis::HasMethod() const
 
 bool AttBarLineVis::HasPlace() const
 {
-    return (m_place != 0);
+    return (m_place != VRV_UNSET);
 }
 
 /* include <attplace> */
@@ -589,8 +589,8 @@ AttFTremVis::~AttFTremVis()
 
 void AttFTremVis::ResetFTremVis()
 {
-    m_beams = 0;
-    m_beamsFloat = -1;
+    m_beams = VRV_UNSET;
+    m_beamsFloat = VRV_UNSET;
     m_floatGap = VRV_UNSET;
 }
 
@@ -635,12 +635,12 @@ bool AttFTremVis::WriteFTremVis(pugi::xml_node element)
 
 bool AttFTremVis::HasBeams() const
 {
-    return (m_beams != 0);
+    return (m_beams != VRV_UNSET);
 }
 
 bool AttFTremVis::HasBeamsFloat() const
 {
-    return (m_beamsFloat != -1);
+    return (m_beamsFloat != VRV_UNSET);
 }
 
 bool AttFTremVis::HasFloatGap() const
@@ -1081,9 +1081,9 @@ void AttLineVis::ResetLineVis()
     m_form = LINEFORM_NONE;
     m_width = data_LINEWIDTH();
     m_endsym = LINESTARTENDSYMBOL_NONE;
-    m_endsymSize = 0;
+    m_endsymSize = VRV_UNSET;
     m_startsym = LINESTARTENDSYMBOL_NONE;
-    m_startsymSize = 0;
+    m_startsymSize = VRV_UNSET;
 }
 
 bool AttLineVis::ReadLineVis(pugi::xml_node element)
@@ -1169,7 +1169,7 @@ bool AttLineVis::HasEndsym() const
 
 bool AttLineVis::HasEndsymSize() const
 {
-    return (m_endsymSize != 0);
+    return (m_endsymSize != VRV_UNSET);
 }
 
 bool AttLineVis::HasStartsym() const
@@ -1179,7 +1179,7 @@ bool AttLineVis::HasStartsym() const
 
 bool AttLineVis::HasStartsymSize() const
 {
-    return (m_startsymSize != 0);
+    return (m_startsymSize != VRV_UNSET);
 }
 
 /* include <attstartsym.size> */
@@ -1354,11 +1354,11 @@ void AttMensuralVis::ResetMensuralVis()
     m_mensurColor = "";
     m_mensurDot = BOOLEAN_NONE;
     m_mensurForm = mensuralVis_MENSURFORM_NONE;
-    m_mensurLoc = 0;
+    m_mensurLoc = VRV_UNSET;
     m_mensurOrient = ORIENTATION_NONE;
     m_mensurSign = MENSURATIONSIGN_NONE;
     m_mensurSize = data_FONTSIZE();
-    m_mensurSlash = 0;
+    m_mensurSlash = VRV_UNSET;
 }
 
 bool AttMensuralVis::ReadMensuralVis(pugi::xml_node element)
@@ -1462,7 +1462,7 @@ bool AttMensuralVis::HasMensurForm() const
 
 bool AttMensuralVis::HasMensurLoc() const
 {
-    return (m_mensurLoc != 0);
+    return (m_mensurLoc != VRV_UNSET);
 }
 
 bool AttMensuralVis::HasMensurOrient() const
@@ -1482,7 +1482,7 @@ bool AttMensuralVis::HasMensurSize() const
 
 bool AttMensuralVis::HasMensurSlash() const
 {
-    return (m_mensurSlash != 0);
+    return (m_mensurSlash != VRV_UNSET);
 }
 
 /* include <attmensur.slash> */
@@ -1747,7 +1747,7 @@ AttQuilismaVis::~AttQuilismaVis()
 
 void AttQuilismaVis::ResetQuilismaVis()
 {
-    m_waves = 0;
+    m_waves = VRV_UNSET;
 }
 
 bool AttQuilismaVis::ReadQuilismaVis(pugi::xml_node element)
@@ -1773,7 +1773,7 @@ bool AttQuilismaVis::WriteQuilismaVis(pugi::xml_node element)
 
 bool AttQuilismaVis::HasWaves() const
 {
-    return (m_waves != 0);
+    return (m_waves != VRV_UNSET);
 }
 
 /* include <attwaves> */

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -84,7 +84,7 @@ double DurationInterface::GetInterfaceAlignmentDuration(int num, int numBase) co
     double duration = DUR_MAX / pow(2.0, (double)(noteDur - 2.0)) * numBase / num;
 
     int noteDots = (this->HasDotsGes()) ? this->GetDotsGes() : this->GetDots();
-    if (noteDots != -1) {
+    if (noteDots != VRV_UNSET) {
         duration = 2 * duration - (duration / pow(2, noteDots));
     }
     // LogDebug("Duration %d; Dot %d; Alignment %f", noteDur, this->GetDots(), duration);

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1226,15 +1226,15 @@ int Alignment::AdjustDotsEnd(FunctorParams *functorParams)
                 if (dot->HorizontalSelfOverlap(element, thirdUnit)
                     && dot->VerticalSelfOverlap(element, 2 * thirdUnit)) {
                     if (element->Is({ CHORD, NOTE })) {
-                        if (dynamic_cast<AttAugmentDots *>(element)->GetDots() <= 0) continue;
+                        if (dynamic_cast<AttAugmentDots *>(element)->GetDots() < 1) continue;
                         overlapElements.emplace(dot, element);
                     }
                     else if (Object *chord = element->GetFirstAncestor(CHORD, UNLIMITED_DEPTH); chord) {
-                        if (vrv_cast<Chord *>(chord)->GetDots() <= 0) continue;
+                        if (vrv_cast<Chord *>(chord)->GetDots() < 1) continue;
                         overlapElements.emplace(dot, vrv_cast<LayerElement *>(chord));
                     }
                     else if (Object *note = element->GetFirstAncestor(NOTE, UNLIMITED_DEPTH); note) {
-                        if (vrv_cast<Note *>(note)->GetDots() <= 0) continue;
+                        if (vrv_cast<Note *>(note)->GetDots() < 1) continue;
                         overlapElements.emplace(dot, vrv_cast<LayerElement *>(note));
                     }
                 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1211,7 +1211,7 @@ int Note::CalcDots(FunctorParams *functorParams)
         assert(dots);
 
         // Stem up, shorter than 4th and not in beam
-        if ((this->GetDots() != 0) && (params->m_chordStemDir == STEMDIRECTION_up) && (this->GetDrawingDur() > DUR_4)
+        if ((this->GetDots() > 0) && (params->m_chordStemDir == STEMDIRECTION_up) && (this->GetDrawingDur() > DUR_4)
             && !this->IsInBeam()) {
             // Shift according to the flag width if the top note is not flipped
             if ((this == chord->GetTopNote()) && !this->GetFlippedNotehead()) {

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -225,7 +225,7 @@ int StaffDef::Transpose(FunctorParams *functorParams)
         // Determine and store the transposition interval (based on keySig)
         if (keySig && this->HasTransSemi() && this->HasN()) {
             const int fifths = keySig->GetFifthsInt();
-            int semitones = static_cast<int>(std::round(this->GetTransSemi()));
+            int semitones = this->GetTransSemi();
             // Factor out octave transpositions
             const int sign = (semitones >= 0) ? +1 : -1;
             semitones = sign * (std::abs(semitones) % 24);


### PR DESCRIPTION
This PR switches to use VRV_UNSET for all integer attribute values as default by updating LibMEI. Corresponds to /rism-digital/libmei/pull/18.