### PR TITLE
Check slur boundary for beamSpan

### DIFF
--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -257,6 +257,10 @@ private:
     std::pair<int, int> CalcBrokenLoc(const Staff *staff, int startLoc, int endLoc) const;
     // Check if the slur resembles portato
     PortatoSlurType IsPortatoSlur(const Doc *doc, const Note *startNote, const Chord *startChord) const;
+    // Check if the slur starts or ends on a beam
+    bool StartsOnBeam() const { return this->HasBoundaryOnBeam(true); }
+    bool EndsOnBeam() const { return this->HasBoundaryOnBeam(false); }
+    bool HasBoundaryOnBeam(bool isStart) const;
     ///@}
 
     /**


### PR DESCRIPTION
Previously slurs weren't aware of spanning beams:

![Bildschirmfoto 2022-07-22 um 11 25 08](https://user-images.githubusercontent.com/7693447/180408992-a9749402-d5ae-47c1-be88-f46b9a81bb38.png)

This change improves the bounderies check:

![image](https://user-images.githubusercontent.com/7693447/180409551-5cb8464c-6dbc-458b-ac9e-dbfccef80251.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Slurs with spanning beams</title>
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2022-07-12">2022-07-12</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m84yq1d">
            <score xml:id="s19n3ntg">
               <scoreDef xml:id="s6ugs6n">
                  <staffGrp xml:id="s16lym1x">
                     <staffGrp bar.thru="true">
                        <staffDef xml:id="s159axye" n="1" lines="5">
                           <clef xml:id="c8u5yb3" shape="G" line="2" />
                        </staffDef>
                        <staffDef xml:id="s1926zgx" n="2" lines="5">
                           <clef xml:id="csjdor0" shape="G" line="2" />
                        </staffDef>
                        <grpSym xml:id="ggo3kfo" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s6u1oc9">
                  <measure xml:id="m18a955r">
                     <staff xml:id="sgps2r1" n="1">
                        <layer xml:id="l13vjyyl" n="1">
                           <note xml:id="nx4sq2g" dur="16" staff="2" oct="5" pname="f" stem.dir="up" />
                           <note xml:id="n17igtg0" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid="f" />
                           <note xml:id="n1e9f64q" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="n1cojmad" dur="16" oct="6" pname="f" stem.dir="down" />
                           <note xml:id="n11h7ld9" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid="f" />
                           <note xml:id="nb2syjc" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid.ges="f" />
                           <note xml:id="n2fkm3m" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="nqg6e2s" dur="16" oct="6" pname="e" stem.dir="down" accid="f" />
                        </layer>
                     </staff>
                     <staff xml:id="s1amslu4" n="2">
                        <layer xml:id="lbjx4lf" n="2">
                           <note xml:id="n1ly2an" dur="4" oct="5" pname="f" stem.dir="down">
                              <artic xml:id="a1k3vnfp" artic="ten" />
                           </note>
                           <note xml:id="n8rk653" dur="4" oct="5" pname="e" stem.dir="down" accid="f">
                              <artic xml:id="a1equ1v3" artic="ten" />
                           </note>
                        </layer>
                     </staff>
                     <beamSpan xml:id="bqgtx8n" startid="#nx4sq2g" endid="#n1cojmad" />
                     <slur xml:id="s1m3jnti" startid="#nx4sq2g" endid="#n1cojmad" curvedir="above" />
                     <beamSpan xml:id="bj6avl4" startid="#n11h7ld9" endid="#nqg6e2s" />
                     <slur xml:id="s163pkt0" startid="#n11h7ld9" endid="#nqg6e2s" curvedir="above" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```