### PR TITLE
Fix beam overlaps with other elements

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -342,9 +342,9 @@ public:
     std::pair<int, int> GetAdditionalBeamCount() const override;
 
     /**
-     * Return duration of beam part that are closest to the specified object X position
+     * Return duration of the beam part that is closest to the specified object X position
      */
-    int GetBeamPartDuration(const Object *object, bool ignoreRests = false) const;
+    int GetBeamPartDuration(const Object *object, bool includeRests = true) const;
 
     //----------//
     // Functors //
@@ -391,7 +391,7 @@ protected:
      * Return duration of beam part for specified X coordinate. Duration of two closest elements is taken for this
      * purpose.
      */
-    int GetBeamPartDuration(int x, bool ignoreRests = false) const;
+    int GetBeamPartDuration(int x, bool includeRests = true) const;
 
 private:
     /**

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -344,7 +344,7 @@ public:
     /**
      * Return duration of beam part that are closest to the specified object X position
      */
-    int GetBeamPartDuration(const Object *object) const;
+    int GetBeamPartDuration(const Object *object, bool ignoreRests = false) const;
 
     //----------//
     // Functors //
@@ -391,7 +391,7 @@ protected:
      * Return duration of beam part for specified X coordinate. Duration of two closest elements is taken for this
      * purpose.
      */
-    int GetBeamPartDuration(int x) const;
+    int GetBeamPartDuration(int x, bool ignoreRests = false) const;
 
 private:
     /**

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -2076,7 +2076,7 @@ int Beam::GetBeamPartDuration(int x, bool includeRests) const
     reverseIt = std::find_if(reverseIt, m_beamSegment.m_beamElementCoordRefs.rend(),
         [includeRests](BeamElementCoord *coord) { return (!coord->m_element->Is(REST) || includeRests); });
     if (reverseIt != m_beamSegment.m_beamElementCoordRefs.rend()) return std::min((*it)->m_dur, (*reverseIt)->m_dur);
-    return (*it)->m_dur;    
+    return (*it)->m_dur;
 }
 
 int Beam::GetBeamPartDuration(const Object *object, bool includeRests) const

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -201,47 +201,35 @@ wchar_t Clef::GetClefGlyph(const data_NOTATIONTYPE notationtype) const
 
 int Clef::AdjustBeams(FunctorParams *functorParams)
 {
-    const std::map<data_CLEFSHAPE, std::pair<wchar_t, double>> topToMiddleProportions
-        = { { CLEFSHAPE_G, { SMUFL_E050_gClef, 0.6 } }, { CLEFSHAPE_C, { SMUFL_E05C_cClef, 0.5 } },
-              { CLEFSHAPE_F, { SMUFL_E062_fClef, 0.35 } } };
-
     AdjustBeamParams *params = vrv_params_cast<AdjustBeamParams *>(functorParams);
     assert(params);
     if (!params->m_beam) return FUNCTOR_SIBLINGS;
 
     Staff *staff = this->GetAncestorStaff();
-
-    auto currentShapeIter = topToMiddleProportions.find(this->GetShape());
-    if (currentShapeIter == topToMiddleProportions.end()) return FUNCTOR_CONTINUE;
-
-    // const int directionBias = (vrv_cast<Beam *>(params->m_beam)->m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
-    const int proportion = (params->m_directionBias > 0) ? 0 : -1;
-
-    // Y position differs for clef shapes, so we need to take into account only a part of the glyph height
-    // Proportion of the glyph about Y point is defined in the topToMiddleProportions map and used when
-    // left and right margins are calculated
+    // find number of beams at current position
+    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this) - DUR_4;
+    const int beamWidth = vrv_cast<Beam *>(params->m_beam)->m_beamWidth;
+    // find beam Y positions that are relevant to current clef
+    const int currentBeamYLeft = params->m_y1 + params->m_beamSlope * (this->GetContentLeft() - params->m_x1);
+    const int currentBeamYRight = params->m_y1 + params->m_beamSlope * (this->GetContentRight() - params->m_x1);
+    // get clef code and find its bounds on the staff (anchor point and top/bottom depending on the beam place)
+    const wchar_t clefCode = this->GetClefGlyph(staff->m_drawingNotationType);
     const int clefPosition = staff->GetDrawingY()
         - params->m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - this->GetLine());
-    const int clefGlyphHeight
-        = params->m_doc->GetGlyphHeight(currentShapeIter->second.first, staff->m_drawingStaffSize, true);
-    const int beamWidth = params->m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, false);
-    const int leftMargin = (clefPosition + clefGlyphHeight * (proportion + currentShapeIter->second.second)
-                               + (params->m_directionBias * beamWidth) - params->m_y1)
-        * params->m_directionBias;
-    const int rightMargin = (clefPosition + clefGlyphHeight * (proportion + currentShapeIter->second.second)
-                                + (params->m_directionBias * beamWidth) - params->m_y2)
-        * params->m_directionBias;
-
-    // If both sides of beam overlap with Clef, we need to get smaller margin, i.e. the one that would make one side not
-    // overlap anymore. For sloped beams this would generally mean that slope will avoid collision as well, for
-    // non-sloped ones it doesn't matter since both ends are at the same Y position
-    const bool bothSidesOverlap = ((leftMargin > params->m_overlapMargin) && (rightMargin > params->m_overlapMargin));
-    const int overlapMargin = bothSidesOverlap ? std::min(leftMargin, rightMargin) : std::max(leftMargin, rightMargin);
-    if ((overlapMargin >= params->m_overlapMargin)
-        && ((overlapMargin >= beamWidth / 2) || (leftMargin == rightMargin))) {
-        const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-        params->m_overlapMargin = (overlapMargin / staffOffset + (leftMargin == rightMargin ? 1 : 2)) * staffOffset
-            * params->m_directionBias;
+    const int clefBounds = clefPosition
+        + ((params->m_directionBias > 0) ? params->m_doc->GetGlyphTop(clefCode, staff->m_drawingStaffSize, false)
+                                         : params->m_doc->GetGlyphBottom(clefCode, staff->m_drawingStaffSize, false));
+    // calculate margins for the clef
+    const int leftMargin = params->m_directionBias * (currentBeamYLeft - clefBounds) - beams * beamWidth;
+    const int rightMargin = params->m_directionBias * (currentBeamYRight - clefBounds) - beams * beamWidth;
+    const int overlapMargin = std::min(leftMargin, rightMargin);
+    if (overlapMargin >= 0) return FUNCTOR_CONTINUE;
+    // calculate offset required for the beam
+    const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int unitChangeNumber = ((std::abs(overlapMargin) + 15) / staffOffset);
+    if (unitChangeNumber > 0) {
+        const int adjust = unitChangeNumber * staffOffset * params->m_directionBias;
+        if (std::abs(adjust) > std::abs(params->m_overlapMargin)) params->m_overlapMargin = adjust;
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -214,6 +214,8 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     const int currentBeamYRight = params->m_y1 + params->m_beamSlope * (this->GetContentRight() - params->m_x1);
     // get clef code and find its bounds on the staff (anchor point and top/bottom depending on the beam place)
     const wchar_t clefCode = this->GetClefGlyph(staff->m_drawingNotationType);
+    if (!clefCode) return FUNCTOR_SIBLINGS;
+
     const int clefPosition = staff->GetDrawingY()
         - params->m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - this->GetLine());
     const int clefBounds = clefPosition
@@ -225,10 +227,10 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     const int overlapMargin = std::min(leftMargin, rightMargin);
     if (overlapMargin >= 0) return FUNCTOR_CONTINUE;
     // calculate offset required for the beam
-    const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int unitChangeNumber = ((std::abs(overlapMargin) + 15) / staffOffset);
+    const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int unitChangeNumber = ((std::abs(overlapMargin) + unit / 6) / unit);
     if (unitChangeNumber > 0) {
-        const int adjust = unitChangeNumber * staffOffset * params->m_directionBias;
+        const int adjust = unitChangeNumber * unit * params->m_directionBias;
         if (std::abs(adjust) > std::abs(params->m_overlapMargin)) params->m_overlapMargin = adjust;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -526,7 +526,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
 
     // Calculate possible overlap for the rest with beams
     int leftMargin = 0, rightMargin = 0;
-    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this, true) - DUR_4;
+    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this, false) - DUR_4;
     const int beamWidth = vrv_cast<Beam *>(params->m_beam)->m_beamWidth;
     if (params->m_directionBias > 0) {
         leftMargin = params->m_y1 - beams * beamWidth - this->GetSelfTop();
@@ -570,10 +570,10 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
         }
     }
 
-    const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int unitChangeNumber = ((std::abs(overlapMargin) + 15) / staffOffset);
+    const int unit = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int unitChangeNumber = ((std::abs(overlapMargin) + unit / 6) / unit);
     if (unitChangeNumber > 0) {
-        const int adjust = unitChangeNumber * staffOffset * params->m_directionBias;
+        const int adjust = unitChangeNumber * unit * params->m_directionBias;
         if (std::abs(adjust) > std::abs(params->m_overlapMargin)) params->m_overlapMargin = adjust;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -526,7 +526,7 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
 
     // Calculate possible overlap for the rest with beams
     int leftMargin = 0, rightMargin = 0;
-    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this) - DUR_4;
+    const int beams = vrv_cast<Beam *>(params->m_beam)->GetBeamPartDuration(this, true) - DUR_4;
     const int beamWidth = vrv_cast<Beam *>(params->m_beam)->m_beamWidth;
     if (params->m_directionBias > 0) {
         leftMargin = params->m_y1 - beams * beamWidth - this->GetSelfTop();
@@ -571,8 +571,11 @@ int Rest::AdjustBeams(FunctorParams *functorParams)
     }
 
     const int staffOffset = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int unitChangeNumber = ((std::abs(overlapMargin)) / staffOffset - 1);
-    if (unitChangeNumber > 0) params->m_overlapMargin = unitChangeNumber * staffOffset * params->m_directionBias;
+    const int unitChangeNumber = ((std::abs(overlapMargin) + 15) / staffOffset);
+    if (unitChangeNumber > 0) {
+        const int adjust = unitChangeNumber * staffOffset * params->m_directionBias;
+        if (std::abs(adjust) > std::abs(params->m_overlapMargin)) params->m_overlapMargin = adjust;
+    }
 
     return FUNCTOR_CONTINUE;
 }


### PR DESCRIPTION
Fix for overlaps of beams with other elements within (rests, clefs, etc.)

Previous rendering:
![image](https://user-images.githubusercontent.com/1819669/180461001-27bba62f-0b95-4156-aeea-520cadedd3af.png)
![image](https://user-images.githubusercontent.com/1819669/180460651-3abb5168-fa48-43b0-ae44-9215e623dc83.png)

New rendering:
![image](https://user-images.githubusercontent.com/1819669/180461068-e8c5f562-b3e5-4569-875e-d1631daeaf55.png)
![image](https://user-images.githubusercontent.com/1819669/180460680-33d78681-ddbe-411b-83c5-630f122b0fa7.png)

Example is too long to be attached add it to body of PR :(