### PR TITLE
Fix stem length on breaksec elements in beams

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -217,7 +217,7 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
 
             if (coord->m_beamRelativePlace == BEAMPLACE_below) {
                 y2 += stemmedInterface->GetStemDownNW(doc, staff->m_drawingStaffSize, beamInterface->m_cueSize).y;
-                stemAdjust = -stemWidth - stemOffset;
+                stemAdjust = -(beamInterface->m_beamWidthBlack + stemOffset);
             }
             else {
                 y2 += stemmedInterface->GetStemUpSE(doc, staff->m_drawingStaffSize, beamInterface->m_cueSize).y;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1819669/180463370-5668100f-d337-4f6e-b7a3-fb8ad379f692.png)

After:
![image](https://user-images.githubusercontent.com/1819669/180462378-9549f2da-656f-4e5c-9975-b54e2978939b.png)
