### PR TITLE
Fix unisons with dots

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1866,7 +1866,8 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
                     else if ((currentNote->GetDrawingDur() > DUR_2) && (previousDuration > DUR_2)) {
                         isInUnison = true;
                     }
-                    if (currentNote->GetDots() == previousNote->GetDots()) {
+                    if ((currentNote->GetDots() == previousNote->GetDots())
+                        && (currentNote->GetDrawingDur() == previousDuration)) {
                         continue;
                     }
                     else {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1866,8 +1866,7 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
                     else if ((currentNote->GetDrawingDur() > DUR_2) && (previousDuration > DUR_2)) {
                         isInUnison = true;
                     }
-                    if ((currentNote->GetDots() == previousNote->GetDots())
-                        && (currentNote->GetDrawingDur() == previousDuration)) {
+                    if (isInUnison && (currentNote->GetDots() == previousNote->GetDots())) {
                         continue;
                     }
                     else {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1849,7 +1849,6 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
                 if (!isPreviousCoord || isEdgeElement || isChordElement) {
                     if ((currentNote->GetDrawingDur() == DUR_2) && (previousDuration == DUR_2)) {
                         isInUnison = true;
-                        continue;
                     }
                     else if ((!currentNote->IsGraceNote() && !currentNote->GetDrawingCueSize())
                         && (previousNote->IsGraceNote() || previousNote->GetDrawingCueSize())
@@ -1866,7 +1865,13 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
                     }
                     else if ((currentNote->GetDrawingDur() > DUR_2) && (previousDuration > DUR_2)) {
                         isInUnison = true;
+                    }
+                    if (currentNote->GetDots() == previousNote->GetDots()) {
                         continue;
+                    }
+                    else {
+                        isInUnison = false;
+                        horizontalMargin *= (currentNote->GetDots() > previousNote->GetDots()) ? 0 : -1;
                     }
                 }
                 else {


### PR DESCRIPTION
This PR fixes #2981 by shifting dotted notes in unisons.
![image](https://user-images.githubusercontent.com/7693447/180823765-fbb51477-b904-4893-93c7-d03016183dd1.png)

Also closes #2980.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Unisons with dots</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <persName role="funder">Enote GmbH</persName>
            </respStmt>
            <date isodate="2022-07-25">2022-07-25</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dots="1" dur="2" oct="5" pname="c" />
                           <note dots="1" dur="4" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <note dots="1" dur="2" oct="5" pname="c" />
                           <note dots="1" dur="4" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dots="1" dur="2" oct="5" pname="c" />
                           <note dots="1" dur="4" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <note dur="2" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="8" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="4" oct="5" pname="c" />
                           <note dur="8" oct="5" pname="c" />
                        </layer>
                        <layer n="2">
                           <note dots="1" dur="2" oct="5" pname="c" />
                           <note dots="1" dur="4" oct="5" pname="c" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
