### PR TITLE
Minor code fixes

### DIFF
--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -204,6 +204,10 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     AdjustBeamParams *params = vrv_params_cast<AdjustBeamParams *>(functorParams);
     assert(params);
     if (!params->m_beam) return FUNCTOR_SIBLINGS;
+    // ignore elements that start before/after the beam
+    if (this->GetDrawingX() < params->m_x1) return FUNCTOR_CONTINUE;
+    const int beamRight = params->m_x1 + (params->m_y2 - params->m_y1) / params->m_beamSlope;
+    if (this->GetDrawingX() > beamRight) return FUNCTOR_CONTINUE;
 
     Staff *staff = this->GetAncestorStaff();
     // find number of beams at current position

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1118,6 +1118,9 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
         noteheadShift = params->m_diameter - diameter;
     }
 
+    // Nothing to do for notes that are not in a cluster and without base diameter for the chord
+    if (!params->m_diameter && !m_cluster) return FUNCTOR_SIBLINGS;
+
     /************** notehead direction **************/
 
     bool flippedNotehead = false;


### PR DESCRIPTION
Two code fixes for the changes in the recent PRs:
#2978 introduced problem with beam avoiding clef that is not inside of it:
![image](https://user-images.githubusercontent.com/1819669/180957677-12e11d3c-3195-44a5-98ba-6e1653bcf989.png)
This is now fixed:
![image](https://user-images.githubusercontent.com/1819669/180957730-082a88e3-8e29-4198-9e06-62d2d717be17.png)

#2936 broke some of the cases with @sameas stems:
![image](https://user-images.githubusercontent.com/1819669/180958051-8d8843a9-f45c-4582-91b5-47f1896a1129.png)
This is fixed as well:
![image](https://user-images.githubusercontent.com/1819669/180957963-743c2653-9fbe-4af1-9b73-29c80c1ba1fe.png)
