### PR TITLE
Fix missing schema

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -208,6 +208,15 @@ bool MEIOutput::Export()
 
         // schema processing instruction
         std::string schema;
+        if (this->IsPageBasedMEI()) {
+            schema = "https://www.verovio.org/schema/dev/mei-verovio.rng";
+        }
+        else if (this->GetBasic()) {
+            schema = "https://music-encoding.org/schema/dev/mei-basic.rng";
+        }
+        else {
+            schema = "https://music-encoding.org/schema/dev/mei-all.rng";
+        }
 
         decl = meiDoc.append_child(pugi::node_declaration);
         decl.set_name("xml-model");

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1383,12 +1383,6 @@ bool MEIOutput::WriteDoc(Doc *doc)
         pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
         pugi::xml_node date = pubStmt.append_child("date");
 
-        pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
-        pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
-        pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.append_child(pugi::node_pcdata)
-            .set_value(StringFormat("Encoded with Verovio version %s", GetVersion().c_str()).c_str());
-
         // date
         time_t t = time(0); // get time now
         struct tm *now = localtime(&t);
@@ -1396,8 +1390,17 @@ bool MEIOutput::WriteDoc(Doc *doc)
             now->tm_mday, now->tm_hour, now->tm_min, now->tm_sec);
         date.append_child(pugi::node_pcdata).set_value(dateStr.c_str());
 
-        // revisionDesc
-        if (!m_doc->GetOptions()->m_transpose.GetValue().empty()) this->WriteRevisionDesc(meiHead);
+        if (!this->GetBasic()) {
+            // encodingDesc
+            pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
+            pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
+            pugi::xml_node p1 = projectDesc.append_child("p");
+            p1.append_child(pugi::node_pcdata)
+                .set_value(StringFormat("Encoded with Verovio version %s", GetVersion().c_str()).c_str());
+
+            // revisionDesc
+            if (!m_doc->GetOptions()->m_transpose.GetValue().empty()) this->WriteRevisionDesc(meiHead);
+        }
     }
 
     // ---- music ----

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1189,6 +1189,15 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
         persName.append_attribute("role").set_value(creator.node().attribute("type").as_string());
     }
 
+    pugi::xpath_node_set dateSet = root.select_nodes("/score-partwise/identification/encoding/encoding-date");
+    for (pugi::xpath_node_set::const_iterator it = dateSet.begin(); it != dateSet.end(); ++it) {
+        pugi::xpath_node encodingDate = *it;
+        pugi::xml_node date = pubStmt.append_child("date");
+        date.text().set(encodingDate.node().text().as_string());
+        date.append_attribute("isodate").set_value(encodingDate.node().text().as_string());
+        date.append_attribute("type").set_value(encodingDate.node().name());
+    }
+
     // Convert rights into availability
     pugi::xpath_node_set rightsSet = root.select_nodes("/score-partwise/identification/rights");
     if (!rightsSet.empty()) {
@@ -1199,15 +1208,6 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
                 .append_child(pugi::node_pcdata)
                 .set_value(rights.node().text().as_string());
         }
-    }
-
-    pugi::xpath_node_set dateSet = root.select_nodes("/score-partwise/identification/encoding/encoding-date");
-    for (pugi::xpath_node_set::const_iterator it = dateSet.begin(); it != dateSet.end(); ++it) {
-        pugi::xpath_node encodingDate = *it;
-        pugi::xml_node date = pubStmt.append_child("date");
-        date.text().set(encodingDate.node().text().as_string());
-        date.append_attribute("isodate").set_value(encodingDate.node().text().as_string());
-        date.append_attribute("type").set_value(encodingDate.node().name());
     }
 
     pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");


### PR DESCRIPTION
This PR fixes the missing schema url in the processing instructions. 
Closes #2986
MEI Basic has no `encodingDesc`, so it shouldn't be added.