### PR TITLE
Fix for extender line on Dynam with between place

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -661,6 +661,7 @@ public:
     OptionDbl m_dynamDist;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;
+    OptionDbl m_extenderLineMinSpace;
     OptionDbl m_fingeringScale;
     OptionString m_font;
     OptionDbl m_graceFactor;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1226,6 +1226,11 @@ Options::Options()
     m_engravingDefaultsFile.Init(JsonSource::FilePath, "");
     this->Register(&m_engravingDefaultsFile, "engravingDefaultsFile", &m_generalLayout);
 
+    m_extenderLineMinSpace.SetInfo(
+        "Extender line minimum space", "Minimum space required for extender line to be drawn");
+    m_extenderLineMinSpace.Init(1.5, 1.5, 10.0);
+    this->Register(&m_extenderLineMinSpace, "extenderLineMinSpace", &m_generalLayout);
+
     m_fingeringScale.SetInfo("Fingering scale", "The scale of fingering font compared to default font size");
     m_fingeringScale.Init(0.75, 0.25, 1);
     this->Register(&m_fingeringScale, "fingeringScale", &m_generalLayout);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1057,6 +1057,11 @@ int System::AdjustFloatingPositioners(FunctorParams *functorParams)
     params->m_classId = OBJECT;
     m_systemAligner.Process(params->m_functor, params);
 
+    adjustFloatingPositionerGrpsParams.m_classIds.clear();
+    adjustFloatingPositionerGrpsParams.m_classIds.push_back(DYNAM);
+    adjustFloatingPositionerGrpsParams.m_place = STAFFREL_between;
+    m_systemAligner.Process(&adjustFloatingPositionerGrps, &adjustFloatingPositionerGrpsParams);
+
     return FUNCTOR_SIBLINGS;
 }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1111,17 +1111,18 @@ void View::DrawControlElementConnector(
     const int width = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int y = element->GetDrawingY() + width / 2;
 
+    const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     // the length of the dash and the space between them - can be made a parameter
-    const int dashLength = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 4 / 3;
     const int dashSpace = m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) * 5 / 3;
-    const int halfDashLength = dashLength / 2;
+    const int minDashSpace = m_doc->GetOptions()->m_extenderLineMinSpace.GetValue() * unit;
+    const int halfDashLength = unit * 2 / 3;
 
     int dist = x2 - x1;
     int nbDashes = dist / dashSpace;
 
     int margin = dist / 2;
     // no dash if the distance is smaller than a dash length
-    if (dist < dashLength) {
+    if (dist < minDashSpace) {
         nbDashes = 0;
     }
     // at least one dash


### PR DESCRIPTION
- fixed invalid positioning of extender lines for Dynamics that have `between` place and are moved to next system
- added option to limit minimum space required for extender line to be drawn at the start of the system

closes #2987 

By default extender line is being drawn (but in correct position now), but with new option `--extender-line-min-space` this can be adjusted to prevent it being printed:
![image](https://user-images.githubusercontent.com/1819669/183370634-66e848c8-4ede-4040-b930-25448e808c38.png)
