### PR TITLE
Const correctness for other elements

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -682,9 +682,9 @@
 		4DEC4D9221C81E0B00D1D273 /* del.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9121C81E0B00D1D273 /* del.cpp */; };
 		4DEC4D9321C81E0B00D1D273 /* del.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9121C81E0B00D1D273 /* del.cpp */; };
 		4DEC4D9421C81E0B00D1D273 /* del.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9121C81E0B00D1D273 /* del.cpp */; };
-		4DEC4D9621C81E3B00D1D273 /* expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expand.cpp */; };
-		4DEC4D9721C81E3B00D1D273 /* expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expand.cpp */; };
-		4DEC4D9821C81E3B00D1D273 /* expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expand.cpp */; };
+		4DEC4D9621C81E3B00D1D273 /* expan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expan.cpp */; };
+		4DEC4D9721C81E3B00D1D273 /* expan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expan.cpp */; };
+		4DEC4D9821C81E3B00D1D273 /* expan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expan.cpp */; };
 		4DEC4D9A21C81E6600D1D273 /* lem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9921C81E6600D1D273 /* lem.cpp */; };
 		4DEC4D9B21C81E6600D1D273 /* lem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9921C81E6600D1D273 /* lem.cpp */; };
 		4DEC4D9C21C81E6600D1D273 /* lem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9921C81E6600D1D273 /* lem.cpp */; };
@@ -1016,7 +1016,7 @@
 		BB4C4AEA22A932BC001F6AF0 /* del.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DEC4DC921C8295600D1D273 /* del.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BB4C4AEB22A932BC001F6AF0 /* editorial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DCA95D71A515D0E008AD7E9 /* editorial.cpp */; };
 		BB4C4AEC22A932BC001F6AF0 /* editorial.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DCA95DA1A515D33008AD7E9 /* editorial.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BB4C4AED22A932BC001F6AF0 /* expand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expand.cpp */; };
+		BB4C4AED22A932BC001F6AF0 /* expan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9521C81E3B00D1D273 /* expan.cpp */; };
 		BB4C4AEE22A932BC001F6AF0 /* expan.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DEC4DC721C8295500D1D273 /* expan.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BB4C4AEF22A932BC001F6AF0 /* lem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DEC4D9921C81E6600D1D273 /* lem.cpp */; };
 		BB4C4AF022A932BC001F6AF0 /* lem.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DEC4DD121C8295700D1D273 /* lem.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1588,7 +1588,7 @@
 		4DEC4D8121C804E000D1D273 /* app.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = app.cpp; path = src/app.cpp; sourceTree = "<group>"; };
 		4DEC4D8D21C81DEE00D1D273 /* damage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = damage.cpp; path = src/damage.cpp; sourceTree = "<group>"; };
 		4DEC4D9121C81E0B00D1D273 /* del.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = del.cpp; path = src/del.cpp; sourceTree = "<group>"; };
-		4DEC4D9521C81E3B00D1D273 /* expand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = expand.cpp; path = src/expand.cpp; sourceTree = "<group>"; };
+		4DEC4D9521C81E3B00D1D273 /* expan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = expan.cpp; path = src/expan.cpp; sourceTree = "<group>"; };
 		4DEC4D9921C81E6600D1D273 /* lem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = lem.cpp; path = src/lem.cpp; sourceTree = "<group>"; };
 		4DEC4D9D21C81E9400D1D273 /* orig.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = orig.cpp; path = src/orig.cpp; sourceTree = "<group>"; };
 		4DEC4DA121C81EB300D1D273 /* rdg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = rdg.cpp; path = src/rdg.cpp; sourceTree = "<group>"; };
@@ -1856,7 +1856,7 @@
 				4DEC4DC921C8295600D1D273 /* del.h */,
 				4DCA95D71A515D0E008AD7E9 /* editorial.cpp */,
 				4DCA95DA1A515D33008AD7E9 /* editorial.h */,
-				4DEC4D9521C81E3B00D1D273 /* expand.cpp */,
+				4DEC4D9521C81E3B00D1D273 /* expan.cpp */,
 				4DEC4DC721C8295500D1D273 /* expan.h */,
 				4DEC4D9921C81E6600D1D273 /* lem.cpp */,
 				4DEC4DD121C8295700D1D273 /* lem.h */,
@@ -3266,7 +3266,7 @@
 				4D1694561E3A44F300569BF4 /* atts_pagebased.cpp in Sources */,
 				4D1694571E3A44F300569BF4 /* anchoredtext.cpp in Sources */,
 				4DB3D8C51F83D0F900B5FC2B /* breath.cpp in Sources */,
-				4DEC4D9721C81E3B00D1D273 /* expand.cpp in Sources */,
+				4DEC4D9721C81E3B00D1D273 /* expan.cpp in Sources */,
 				4D766EFF20ACAD6D006875D8 /* neume.cpp in Sources */,
 				4D1694581E3A44F300569BF4 /* accid.cpp in Sources */,
 				4D1694591E3A44F300569BF4 /* custos.cpp in Sources */,
@@ -3284,7 +3284,7 @@
 				4D4FCD121F54570E0009C455 /* staffdef.cpp in Sources */,
 				8F086EE2188539540037FD8E /* verticalaligner.cpp in Sources */,
 				4DA0EAB922BB772C00A7EBEB /* atts_neumes.cpp in Sources */,
-				4DEC4D9621C81E3B00D1D273 /* expand.cpp in Sources */,
+				4DEC4D9621C81E3B00D1D273 /* expan.cpp in Sources */,
 				4D508C3026D4E64C00020F35 /* crc.cpp in Sources */,
 				8F086EE4188539540037FD8E /* barline.cpp in Sources */,
 				4DC12A7C1F740FB9000440E9 /* view_running.cpp in Sources */,
@@ -3503,7 +3503,7 @@
 				8F3DD36718854B410051330C /* verticalaligner.cpp in Sources */,
 				4D766F0220ACAD6E006875D8 /* nc.cpp in Sources */,
 				4DA0EABB22BB772C00A7EBEB /* atts_neumes.cpp in Sources */,
-				4DEC4D9821C81E3B00D1D273 /* expand.cpp in Sources */,
+				4DEC4D9821C81E3B00D1D273 /* expan.cpp in Sources */,
 				4DC12A651F73F898000440E9 /* pghead2.cpp in Sources */,
 				4DB3D8C81F83D10000B5FC2B /* dir.cpp in Sources */,
 				8F3DD36818854B410051330C /* doc.cpp in Sources */,
@@ -3883,7 +3883,7 @@
 				BDA81C27268B38A10065B802 /* metersiggrp.cpp in Sources */,
 				4D79643C26C6B3520026288B /* featureextractor.cpp in Sources */,
 				BB4C4BC022A932FC001F6AF0 /* MidiMessage.cpp in Sources */,
-				BB4C4AED22A932BC001F6AF0 /* expand.cpp in Sources */,
+				BB4C4AED22A932BC001F6AF0 /* expan.cpp in Sources */,
 				BB4C4B0F22A932C8001F6AF0 /* ending.cpp in Sources */,
 				BB4C4AB522A932A6001F6AF0 /* iomei.cpp in Sources */,
 				BB4C4B5922A932D7001F6AF0 /* ligature.cpp in Sources */,

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -32,7 +32,7 @@ public:
     ///@}
 
     /** Getter for level **/
-    EditorialLevel GetLevel() { return m_level; }
+    EditorialLevel GetLevel() const { return m_level; }
 
     /**
      * Add children to a apparatus.

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -33,7 +33,7 @@ public:
     ///@}
 
     /** Getter for level **/
-    EditorialLevel GetLevel() { return m_level; }
+    EditorialLevel GetLevel() const { return m_level; }
 
     /**
      * Add children to a apparatus.

--- a/include/vrv/expan.h
+++ b/include/vrv/expan.h
@@ -1,12 +1,12 @@
 /////////////////////////////////////////////////////////////////////////////
-// Name:        expand.h
+// Name:        expan.h
 // Author:      Laurent Pugin
 // Created:     2018
 // Copyright (c) Authors and others. All rights reserved.
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef __VRV_EXPAND_H__
-#define __VRV_EXPAND_H__
+#ifndef __VRV_EXPAN_H__
+#define __VRV_EXPAN_H__
 
 #include "atts_shared.h"
 #include "editorial.h"

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -43,9 +43,10 @@ public:
     ///@}
     bool IsSupportedChild(Object *object) override;
 
-    Zone *FindZoneByID(std::string zoneId);
-    int GetMaxY();
-    int GetMaxX();
+    Zone *FindZoneByID(const std::string &zoneId);
+    const Zone *FindZoneByID(const std::string &zoneId) const;
+    int GetMaxX() const;
+    int GetMaxY() const;
 };
 
 } // namespace vrv

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -38,7 +38,11 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual AreaPosInterface *GetAreaPosInterface() { return dynamic_cast<AreaPosInterface *>(this); }
+    AreaPosInterface *GetAreaPosInterface() override { return dynamic_cast<AreaPosInterface *>(this); }
+    const AreaPosInterface *GetAreaPosInterface() const override
+    {
+        return dynamic_cast<const AreaPosInterface *>(this);
+    }
     ///@}
 
     /**

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -43,7 +43,10 @@ public:
     /**
      * Return a pointer to the current text object.
      */
+    ///@{
     Text *GetCurrentText() { return &m_currentText; }
+    const Text *GetCurrentText() const { return &m_currentText; }
+    ///@}
 
 private:
     //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -127,6 +127,8 @@ public:
      * @name Getter to interfaces
      */
     ///@{
+    virtual AreaPosInterface *GetAreaPosInterface() { return NULL; }
+    virtual const AreaPosInterface *GetAreaPosInterface() const { return NULL; }
     virtual BeamDrawingInterface *GetBeamDrawingInterface() { return NULL; }
     virtual const BeamDrawingInterface *GetBeamDrawingInterface() const { return NULL; }
     virtual DurationInterface *GetDurationInterface() { return NULL; }

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -23,6 +23,7 @@
 
 namespace vrv {
 
+class AreaPosInterface;
 class Doc;
 class DurationInterface;
 class EditorialElement;

--- a/include/vrv/pagemilestone.h
+++ b/include/vrv/pagemilestone.h
@@ -36,14 +36,12 @@ public:
     std::string GetClassName() const override { return "PageMilestoneEnd"; }
     ///@}
 
-    // void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }
-    // Measure *GetMeasure() { return m_drawingMeasure; }
-
     /**
      * @name Get the corresponding milestone start
      */
     ///@{
-    Object *GetStart() const { return m_start; }
+    Object *GetStart() { return m_start; }
+    const Object *GetStart() const { return m_start; }
     std::string GetStartClassName() const { return m_startClassName; }
     ///@}
 
@@ -121,7 +119,8 @@ public:
     ///@{
     void SetEnd(PageMilestoneEnd *end);
     PageMilestoneEnd *GetEnd() { return m_end; }
-    bool IsPageMilestone() { return (m_end != NULL); }
+    const PageMilestoneEnd *GetEnd() const { return m_end; }
+    bool IsPageMilestone() const { return (m_end != NULL); }
     ///@}
 
     /**

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -37,7 +37,7 @@ public:
      */
     int GetTotalHeight(const Doc *doc) const override;
 
-    bool GenerateFromMEIHeader(pugi::xml_document &header);
+    bool GenerateFromMEIHeader(const pugi::xml_document &header);
 
     //----------//
     // Functors //

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -45,7 +45,11 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual AreaPosInterface *GetAreaPosInterface() { return dynamic_cast<AreaPosInterface *>(this); }
+    AreaPosInterface *GetAreaPosInterface() override { return dynamic_cast<AreaPosInterface *>(this); }
+    const AreaPosInterface *GetAreaPosInterface() const override
+    {
+        return dynamic_cast<const AreaPosInterface *>(this);
+    }
     ///@}
 
     /**

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -76,6 +76,7 @@ public:
     ///@{
     void SetDrawingPage(Page *page);
     Page *GetDrawingPage() { return m_drawingPage; }
+    const Page *GetDrawingPage() const { return m_drawingPage; }
     ///@}
 
     /**
@@ -117,7 +118,7 @@ public:
     /**
      * Set the current page number by looking for a <num label="page">#</num> element.
      */
-    void SetCurrentPageNum(Page *currentPage);
+    void SetCurrentPageNum(const Page *currentPage);
 
     /**
      * Load the footer from the resources (footer.svg)
@@ -164,7 +165,7 @@ private:
     /**
      *
      */
-    int GetAlignmentPos(data_HORIZONTALALIGNMENT h, data_VERTICALALIGNMENT v);
+    int GetAlignmentPos(data_HORIZONTALALIGNMENT h, data_VERTICALALIGNMENT v) const;
 
 public:
     //

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -49,7 +49,10 @@ public:
     /**
      * Getter for the score/scoreDef
      */
+    ///@{
     ScoreDef *GetScoreDef() { return &m_scoreDef; }
+    const ScoreDef *GetScoreDef() const { return &m_scoreDef; }
+    ///@}
 
     /**
      * Helper looking at the parent Doc and set its scoreDef as current one.

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -35,7 +35,7 @@ public:
     ///@}
 
     /** Getter for level **/
-    EditorialLevel GetLevel() { return m_level; }
+    EditorialLevel GetLevel() const { return m_level; }
 
     /**
      * Add children to a apparatus.

--- a/include/vrv/systemmilestone.h
+++ b/include/vrv/systemmilestone.h
@@ -21,7 +21,7 @@ class Object;
 //----------------------------------------------------------------------------
 
 /**
- * This class models an end milestone element milesoneEnd at the system level.
+ * This class models an end milestone element at the system level.
  */
 class SystemMilestoneEnd : public SystemElement {
 public:
@@ -38,12 +38,14 @@ public:
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }
     Measure *GetMeasure() { return m_drawingMeasure; }
+    const Measure *GetMeasure() const { return m_drawingMeasure; }
 
     /**
      * @name Get the corresponding milestone start
      */
     ///@{
     Object *GetStart() { return m_start; }
+    const Object *GetStart() const { return m_start; }
     std::string GetStartClassName() const { return m_startClassName; }
     ///@}
 
@@ -113,6 +115,7 @@ public:
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }
     Measure *GetMeasure() { return m_drawingMeasure; }
+    const Measure *GetMeasure() const { return m_drawingMeasure; }
 
     /**
      * @name Set and get the first LayerElement
@@ -121,7 +124,8 @@ public:
     ///@{
     void SetEnd(SystemMilestoneEnd *end);
     SystemMilestoneEnd *GetEnd() { return m_end; }
-    bool IsSystemMilestone() { return (m_end != NULL); }
+    const SystemMilestoneEnd *GetEnd() const { return m_end; }
+    bool IsSystemMilestone() const { return (m_end != NULL); }
     ///@}
 
     /**

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -39,8 +39,8 @@ public:
     void Reset() override;
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
-    int GetLogicalUly();
-    int GetLogicalLry();
+    int GetLogicalUly() const;
+    int GetLogicalLry() const;
 
 protected:
     //

--- a/src/expan.cpp
+++ b/src/expan.cpp
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////
-// Name:        expand.cpp
+// Name:        expan.cpp
 // Author:      Laurent Pugin
 // Created:     2018
 // Copyright (c) Authors and others. All rights reserved.

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -44,31 +44,36 @@ bool Facsimile::IsSupportedChild(Object *object)
     return true;
 }
 
-Zone *Facsimile::FindZoneByID(std::string zoneId)
+Zone *Facsimile::FindZoneByID(const std::string &zoneId)
 {
     return dynamic_cast<Zone *>(this->FindDescendantByID(zoneId));
 }
 
-int Facsimile::GetMaxX()
+const Zone *Facsimile::FindZoneByID(const std::string &zoneId) const
 {
-    ListOfObjects surfaces = this->FindAllDescendantsByType(SURFACE);
+    return dynamic_cast<const Zone *>(this->FindDescendantByID(zoneId));
+}
+
+int Facsimile::GetMaxX() const
+{
+    ListOfConstObjects surfaces = this->FindAllDescendantsByType(SURFACE);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {
-        Surface *surface = vrv_cast<Surface *>(*iter);
+        const Surface *surface = vrv_cast<const Surface *>(*iter);
         assert(surface);
         max = (surface->GetMaxX() > max) ? surface->GetMaxX() : max;
     }
     return max;
 }
 
-int Facsimile::GetMaxY()
+int Facsimile::GetMaxY() const
 {
-    ListOfObjects surfaces = this->FindAllDescendantsByType(SURFACE);
+    ListOfConstObjects surfaces = this->FindAllDescendantsByType(SURFACE);
 
     int max = 0;
     for (auto iter = surfaces.begin(); iter != surfaces.end(); ++iter) {
-        Surface *surface = vrv_cast<Surface *>(*iter);
+        const Surface *surface = vrv_cast<const Surface *>(*iter);
         assert(surface);
         max = (surface->GetMaxY() > max) ? surface->GetMaxY() : max;
     }

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -51,7 +51,7 @@ int PgHead::GetTotalHeight(const Doc *doc) const
     return height;
 }
 
-bool PgHead::GenerateFromMEIHeader(pugi::xml_document &header)
+bool PgHead::GenerateFromMEIHeader(const pugi::xml_document &header)
 {
     pugi::xpath_node node;
     pugi::xpath_node_set nodeSet;

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -298,7 +298,7 @@ bool RunningElement::AdjustRunningElementYPos()
     return true;
 }
 
-int RunningElement::GetAlignmentPos(data_HORIZONTALALIGNMENT h, data_VERTICALALIGNMENT v)
+int RunningElement::GetAlignmentPos(data_HORIZONTALALIGNMENT h, data_VERTICALALIGNMENT v) const
 {
     int pos = 0;
     switch (h) {
@@ -316,7 +316,7 @@ int RunningElement::GetAlignmentPos(data_HORIZONTALALIGNMENT h, data_VERTICALALI
     return pos;
 }
 
-void RunningElement::SetCurrentPageNum(Page *currentPage)
+void RunningElement::SetCurrentPageNum(const Page *currentPage)
 {
     assert(currentPage);
 

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -47,12 +47,12 @@ void Zone::ShiftByXY(int xDiff, int yDiff)
     this->SetLry(this->GetLry() + yDiff);
 }
 
-int Zone::GetLogicalUly()
+int Zone::GetLogicalUly() const
 {
     return (this->GetUly());
 }
 
-int Zone::GetLogicalLry()
+int Zone::GetLogicalLry() const
 {
     return (this->GetLry());
 }


### PR DESCRIPTION
This PR improves const correctness for various other element classes (i.e. _editorial, facs, running, system, page_ and _text elements_) by adding `const` to relevant member functions and arguments.
Additionally, we unify the file names for the _Expan class_.

No changes in behaviour are expected.