### PR TITLE
Add support for `<symbol>` within `<dir>`

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -404,6 +404,12 @@
 		4D81351F2322C41800F59C01 /* keyaccid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D81351D2322C41800F59C01 /* keyaccid.cpp */; };
 		4D8135202322C41800F59C01 /* keyaccid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D81351D2322C41800F59C01 /* keyaccid.cpp */; };
 		4D8135212322C41800F59C01 /* keyaccid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D81351D2322C41800F59C01 /* keyaccid.cpp */; };
+		4D88AD09289673EB0006D7DA /* symbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D88AD08289673EA0006D7DA /* symbol.cpp */; };
+		4D88AD0A289673F40006D7DA /* symbol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D88AD07289673D50006D7DA /* symbol.h */; };
+		4D88AD0B289673F50006D7DA /* symbol.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D88AD07289673D50006D7DA /* symbol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4D88AD0C289674000006D7DA /* symbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D88AD08289673EA0006D7DA /* symbol.cpp */; };
+		4D88AD0D289674010006D7DA /* symbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D88AD08289673EA0006D7DA /* symbol.cpp */; };
+		4D88AD0E289674010006D7DA /* symbol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D88AD08289673EA0006D7DA /* symbol.cpp */; };
 		4D89F90C201771A700A4D336 /* num.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D89F90B201771A700A4D336 /* num.h */; };
 		4D89F90E201771AE00A4D336 /* num.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D89F90D201771AE00A4D336 /* num.cpp */; };
 		4D89F90F201771AE00A4D336 /* num.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D89F90D201771AE00A4D336 /* num.cpp */; };
@@ -1480,6 +1486,8 @@
 		4D798CBC1B8AEDBA007281CA /* drawinginterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = drawinginterface.cpp; path = src/drawinginterface.cpp; sourceTree = "<group>"; };
 		4D81351A2322C2CC00F59C01 /* keyaccid.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = keyaccid.h; path = include/vrv/keyaccid.h; sourceTree = "<group>"; };
 		4D81351D2322C41800F59C01 /* keyaccid.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = keyaccid.cpp; path = src/keyaccid.cpp; sourceTree = "<group>"; };
+		4D88AD07289673D50006D7DA /* symbol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = symbol.h; path = include/vrv/symbol.h; sourceTree = "<group>"; };
+		4D88AD08289673EA0006D7DA /* symbol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = symbol.cpp; path = src/symbol.cpp; sourceTree = "<group>"; };
 		4D89F90B201771A700A4D336 /* num.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = num.h; path = include/vrv/num.h; sourceTree = "<group>"; };
 		4D89F90D201771AE00A4D336 /* num.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = num.cpp; path = src/num.cpp; sourceTree = "<group>"; };
 		4D89F9112018A93200A4D336 /* svg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = svg.cpp; path = src/svg.cpp; sourceTree = "<group>"; };
@@ -1987,6 +1995,8 @@
 				4D6122BB1F77E1B900FC90A0 /* rend.h */,
 				4D89F9112018A93200A4D336 /* svg.cpp */,
 				4DB3D89F1F7E80DB00B5FC2B /* svg.h */,
+				4D88AD08289673EA0006D7DA /* symbol.cpp */,
+				4D88AD07289673D50006D7DA /* symbol.h */,
 				4DB726C41B8BB0E80040231B /* text.cpp */,
 				4DB726C71B8BB0F30040231B /* text.h */,
 				4DA144891C2AB28700CB7CEE /* textelement.cpp */,
@@ -2559,6 +2569,7 @@
 				4DB787662022F0BF00394520 /* jsonxx.h in Headers */,
 				E79C87C7269440800098FE85 /* lv.h in Headers */,
 				E79ADDC426BD1AE900527E4B /* runtimeclock.h in Headers */,
+				4D88AD0A289673F40006D7DA /* symbol.h in Headers */,
 				8F59294918854BF800FE51AD /* multirest.h in Headers */,
 				8F59294A18854BF800FE51AD /* note.h in Headers */,
 				8F59294B18854BF800FE51AD /* object.h in Headers */,
@@ -2737,6 +2748,7 @@
 				BB4C4B3822A932CF001F6AF0 /* trill.h in Headers */,
 				BB4C4B6422A932D7001F6AF0 /* mrpt2.h in Headers */,
 				BB4C4B5222A932D7001F6AF0 /* ftrem.h in Headers */,
+				4D88AD0B289673F50006D7DA /* symbol.h in Headers */,
 				4D2E759022BC2B71004C51F0 /* course.h in Headers */,
 				BB4C4AA722A932A0001F6AF0 /* bboxdevicecontext.h in Headers */,
 				BB4C4AF822A932BC001F6AF0 /* reg.h in Headers */,
@@ -3262,6 +3274,7 @@
 				4D20740422A46BAA00E0765F /* atts_frettab.cpp in Sources */,
 				4DB787642022F0BB00394520 /* jsonxx.cc in Sources */,
 				4DEC4DBB21C8288900D1D273 /* choice.cpp in Sources */,
+				4D88AD0C289674000006D7DA /* symbol.cpp in Sources */,
 				4D64137F2035F68600BB630E /* mdiv.cpp in Sources */,
 				4D1694561E3A44F300569BF4 /* atts_pagebased.cpp in Sources */,
 				4D1694571E3A44F300569BF4 /* anchoredtext.cpp in Sources */,
@@ -3350,6 +3363,7 @@
 				4D79641F26C1621A0026288B /* pageelement.cpp in Sources */,
 				4DC12A811F741110000440E9 /* pgfoot.cpp in Sources */,
 				403BEFEF206C00B500D022D5 /* mrpt2.cpp in Sources */,
+				4D88AD09289673EB0006D7DA /* symbol.cpp in Sources */,
 				8F086EF6188539540037FD8E /* mensur.cpp in Sources */,
 				4026FBE4203C827E0076535E /* mnum.cpp in Sources */,
 				4DB726C51B8BB0E80040231B /* text.cpp in Sources */,
@@ -3701,6 +3715,7 @@
 				4DA3FCD419B61DB400CBDFE6 /* atts_cmn.cpp in Sources */,
 				4DC34BA919BC4A83006175CD /* accid.cpp in Sources */,
 				4DC34BAB19BC4A83006175CD /* custos.cpp in Sources */,
+				4D88AD0D289674010006D7DA /* symbol.cpp in Sources */,
 				4DEC4DB821C8270100D1D273 /* unclear.cpp in Sources */,
 				4D89F910201771AE00A4D336 /* num.cpp in Sources */,
 				4D4335D11ED4502C003BE1A9 /* atts_visual.cpp in Sources */,
@@ -3921,6 +3936,7 @@
 				BB4C4AA622A932A0001F6AF0 /* bboxdevicecontext.cpp in Sources */,
 				BB4C4BAD22A932EB001F6AF0 /* view_element.cpp in Sources */,
 				BB4C4B2522A932CF001F6AF0 /* fermata.cpp in Sources */,
+				4D88AD0E289674010006D7DA /* symbol.cpp in Sources */,
 				BB4C4BB322A932EB001F6AF0 /* view_slur.cpp in Sources */,
 				BB4C4B1922A932CF001F6AF0 /* anchoredtext.cpp in Sources */,
 				BB4C4AF322A932BC001F6AF0 /* rdg.cpp in Sources */,

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -17,6 +17,7 @@
 #include "object.h"
 #include "staffdef.h"
 #include "staffgrp.h"
+#include "symbol.h"
 #include "timeinterface.h"
 
 namespace vrv {
@@ -534,6 +535,26 @@ public:
 
 protected:
     const Object *m_objectToExclude;
+};
+
+//----------------------------------------------------------------------------
+// VisibleSymbol
+//----------------------------------------------------------------------------
+/**
+ * This class evaluates if the object is a visible Symbol.
+ */
+class VisibleSymbol : public ClassIdComparison {
+
+public:
+    VisibleSymbol() : ClassIdComparison(SYMBOL) {}
+
+    bool operator()(const Object *object) override
+    {
+        if (!MatchesType(object)) return false;
+        const Symbol *symbol = vrv_cast<const Symbol *>(object);
+        assert(symbol);
+        return (symbol->m_visibility == Visible);
+    }
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -57,9 +57,13 @@ private:
 class ClassIdComparison : public Comparison {
 
 public:
-    ClassIdComparison(ClassId classId) { m_classId = classId; }
+    ClassIdComparison(ClassId classId)
+    {
+        m_classId = classId;
+        m_supportReverse = true;
+    }
 
-    bool operator()(const Object *object) override { return this->MatchesType(object); }
+    bool operator()(const Object *object) override { return Result(this->MatchesType(object)); }
 
     ClassId GetType() { return m_classId; }
 

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -69,6 +69,11 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
+     * Overwritten method for dir
+     */
+    void AddChild(Object *object) override;
+
+    /**
      * See FloatingObject::IsExtenderElement
      */
     bool IsExtenderElement() const override { return GetExtender() == BOOLEAN_true; }

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -142,6 +142,7 @@ class Surface;
 class Svg;
 class Syl;
 class Syllable;
+class Symbol;
 class System;
 class SystemElement;
 class SystemMilestoneEnd;
@@ -451,6 +452,7 @@ private:
     void WriteNum(pugi::xml_node currentNode, Num *num);
     void WriteRend(pugi::xml_node currentNode, Rend *rend);
     void WriteSvg(pugi::xml_node currentNode, Svg *svg);
+    void WriteSymbol(pugi::xml_node currentNode, Symbol *symbol);
     void WriteText(pugi::xml_node currentNode, Text *text);
     ///@}
 
@@ -752,6 +754,7 @@ private:
     bool ReadLb(Object *parent, pugi::xml_node lb);
     bool ReadRend(Object *parent, pugi::xml_node rend);
     bool ReadSvg(Object *parent, pugi::xml_node svg);
+    bool ReadSymbol(Object *parent, pugi::xml_node symbol);
     bool ReadText(Object *parent, pugi::xml_node text, bool trimLeft, bool trimRight);
     ///@}
 

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -8,7 +8,9 @@
 #ifndef __VRV_SYMBOL_H__
 #define __VRV_SYMBOL_H__
 
+#include "atts_externalsymbols.h"
 #include "atts_shared.h"
+#include "atts_visual.h"
 #include "object.h"
 
 namespace vrv {
@@ -20,7 +22,7 @@ namespace vrv {
 /**
  * This class models the MEI <symbol> element.
  */
-class Symbol : public Object {
+class Symbol : public Object, public AttColor, public AttExtSym {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -42,7 +42,14 @@ public:
 private:
     //
 public:
-    //
+    /**
+     * Holds the visibility (hidden or visible) for an symbol element.
+     * By default, a symbo elements is visible but it is make invisible when with mixed content
+     * The reason is that we cannot render SVG <g> within <text>.
+     * Symbol with text is not supported by Verovio.
+     */
+    VisibilityType m_visibility;
+
 private:
 };
 

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -9,7 +9,7 @@
 #define __VRV_SYMBOL_H__
 
 #include "atts_shared.h"
-#include "textelement.h"
+#include "object.h"
 
 namespace vrv {
 

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -1,0 +1,51 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        symbol.h
+// Author:      Laurent Pugin
+// Created:     2022
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_SYMBOL_H__
+#define __VRV_SYMBOL_H__
+
+#include "atts_shared.h"
+#include "textelement.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Symbol
+//----------------------------------------------------------------------------
+
+/**
+ * This class models the MEI <symbol> element.
+ */
+class Symbol : public Object {
+public:
+    /**
+     * @name Constructors, destructors, reset and class name methods
+     * Reset method reset all attribute classes
+     */
+    ///@{
+    Symbol();
+    virtual ~Symbol();
+    Object *Clone() const override { return new Symbol(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Symbol"; }
+    ///@}
+
+    /**
+     * Only supported elements will be actually added to the child list.
+     */
+    bool IsSupportedChild(Object *object) override;
+
+private:
+    //
+public:
+    //
+private:
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -41,6 +41,11 @@ public:
      */
     bool IsSupportedChild(Object *object) override;
 
+    /**
+     * Get the SMuFL glyph for the symbol based on glyph.num or glyph.name
+     */
+    wchar_t GetSymbolGlyph() const;
+
 private:
     //
 public:

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -70,6 +70,7 @@ class Staff;
 class Svg;
 class Syl;
 class Syllable;
+class Symbol;
 class System;
 class SystemElement;
 class Tempo;
@@ -383,6 +384,7 @@ protected:
     void DrawNum(DeviceContext *dc, Num *num, TextDrawingParams &params);
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
+    void DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
     void DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
 

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -385,7 +385,7 @@ protected:
     void DrawNum(DeviceContext *dc, Num *num, TextDrawingParams &params);
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
-    void DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params);
+    void DrawSymbol(DeviceContext *dc, Staff *staff, Symbol *symbol, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
     void DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
 

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -258,6 +258,7 @@ protected:
     void DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, Staff *staff, Measure *measure);
     void DrawTextChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
     void DrawFbChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
+    void DrawSymbolChildren(DeviceContext *dc, Object *parent, Staff *staff, TextDrawingParams &params);
     void DrawRunningChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
     ///@}
 

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -111,6 +111,7 @@ enum ClassId : uint16_t {
     STAFFGRP,
     SURFACE,
     SVG,
+    SYMBOL,
     SYSTEM,
     SYSTEM_ALIGNER,
     SYSTEM_ALIGNMENT,

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -22,6 +22,7 @@
 #include "scoredef.h"
 #include "section.h"
 #include "staff.h"
+#include "symbol.h"
 #include "system.h"
 #include "text.h"
 #include "textelement.h"
@@ -106,6 +107,9 @@ bool EditorialElement::IsSupportedChild(Object *child)
     }
     else if (child->Is(STAFFGRP)) {
         assert(dynamic_cast<Staff *>(child));
+    }
+    else if (child->Is(SYMBOL)) {
+        assert(dynamic_cast<Symbol *>(child));
     }
     else {
         return false;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -125,6 +125,7 @@
 #include "svg.h"
 #include "syl.h"
 #include "syllable.h"
+#include "symbol.h"
 #include "system.h"
 #include "systemmilestone.h"
 #include "tabdursym.h"
@@ -751,6 +752,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
     else if (object->Is(SVG)) {
         m_currentNode = m_currentNode.append_child("svg");
         this->WriteSvg(m_currentNode, vrv_cast<Svg *>(object));
+    }
+    else if (object->Is(SYMBOL)) {
+        m_currentNode = m_currentNode.append_child("symbol");
+        this->WriteSymbol(m_currentNode, vrv_cast<Symbol *>(object));
     }
     else if (object->Is(TEXT)) {
         this->WriteText(m_currentNode, vrv_cast<Text *>(object));
@@ -2828,6 +2833,13 @@ void MEIOutput::WriteSvg(pugi::xml_node currentNode, Svg *svg)
     }
 }
 
+void MEIOutput::WriteSymbol(pugi::xml_node currentNode, Symbol *symbol)
+{
+    assert(symbol);
+
+    this->WriteXmlId(currentNode, symbol);
+}
+
 void MEIOutput::WriteText(pugi::xml_node element, Text *text)
 {
     if (!text->GetText().empty()) {
@@ -3245,6 +3257,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
             return true;
         }
         else if (element == "rend") {
+            return true;
+        }
+        else if (element == "symbol") {
             return true;
         }
         else {
@@ -6605,6 +6620,9 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         else if (elementName == "svg") {
             success = this->ReadSvg(parent, xmlElement);
         }
+        else if (elementName == "symbol") {
+            success = this->ReadSymbol(parent, xmlElement);
+        }
         else if (xmlElement.text()) {
             bool trimLeft = (i == 0);
             bool trimRight = (!xmlElement.next_sibling());
@@ -6720,6 +6738,16 @@ bool MEIInput::ReadSvg(Object *parent, pugi::xml_node svg)
 
     parent->AddChild(vrvSvg);
     this->ReadUnsupportedAttr(svg, vrvSvg);
+    return true;
+}
+
+bool MEIInput::ReadSymbol(Object *parent, pugi::xml_node symbol)
+{
+    Symbol *vrvSymbol = new Symbol();
+    this->SetMeiID(symbol, vrvSymbol);
+
+    parent->AddChild(vrvSymbol);
+    this->ReadUnsupportedAttr(symbol, vrvSymbol);
     return true;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2837,6 +2837,9 @@ void MEIOutput::WriteSymbol(pugi::xml_node currentNode, Symbol *symbol)
 {
     assert(symbol);
 
+    symbol->WriteColor(currentNode);
+    symbol->WriteExtSym(currentNode);
+
     this->WriteXmlId(currentNode, symbol);
 }
 
@@ -6756,6 +6759,9 @@ bool MEIInput::ReadSymbol(Object *parent, pugi::xml_node symbol)
             meiElementName.c_str());
         vrvSymbol->m_visibility = Hidden;
     }
+
+    vrvSymbol->ReadColor(symbol);
+    vrvSymbol->ReadExtSym(symbol);
 
     parent->AddChild(vrvSymbol);
     this->ReadUnsupportedAttr(symbol, vrvSymbol);

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -32,6 +32,9 @@ Lb::Lb() : TextElement(LB, "lb-")
 
 Lb::~Lb() {}
 
-void Lb::Reset() {}
+void Lb::Reset()
+{
+    TextElement::Reset();
+}
 
 } // namespace vrv

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "editorial.h"
+#include "resources.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -47,6 +48,25 @@ void Symbol::Reset()
 bool Symbol::IsSupportedChild(Object *child)
 {
     return false;
+}
+
+wchar_t Symbol::GetSymbolGlyph() const
+{
+    const Resources *resources = this->GetDocResources();
+    if (!resources) return 0;
+
+    // If there is glyph.num, prioritize it
+    if (this->HasGlyphNum()) {
+        wchar_t code = this->GetGlyphNum();
+        if (NULL != resources->GetGlyph(code)) return code;
+    }
+    // If there is glyph.name (second priority)
+    else if (this->HasGlyphName()) {
+        wchar_t code = resources->GetGlyphCode(this->GetGlyphName());
+        if (NULL != resources->GetGlyph(code)) return code;
+    }
+
+    return 0;
 }
 
 } // namespace vrv

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -1,0 +1,44 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        symbol.cpp
+// Author:      Laurent Pugin
+// Created:     2022
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "symbol.h"
+
+//----------------------------------------------------------------------------
+
+#include <cassert>
+
+//----------------------------------------------------------------------------
+
+#include "editorial.h"
+#include "vrv.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Symbol
+//----------------------------------------------------------------------------
+
+static const ClassRegistrar<Symbol> s_factory("symbol", SYMBOL);
+
+Symbol::Symbol() : Object(SYMBOL, "symbol-")
+{
+    this->Reset();
+}
+
+Symbol::~Symbol() {}
+
+void Symbol::Reset()
+{
+    Object::Reset();
+}
+
+bool Symbol::IsSupportedChild(Object *child)
+{
+    return false;
+}
+
+} // namespace vrv

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -24,9 +24,12 @@ namespace vrv {
 
 static const ClassRegistrar<Symbol> s_factory("symbol", SYMBOL);
 
-Symbol::Symbol() : Object(SYMBOL, "symbol-")
+Symbol::Symbol() : Object(SYMBOL, "symbol-"), AttColor(), AttExtSym()
 {
     this->Reset();
+
+    this->RegisterAttClass(ATT_COLOR);
+    this->RegisterAttClass(ATT_EXTSYM);
 }
 
 Symbol::~Symbol() {}
@@ -34,6 +37,9 @@ Symbol::~Symbol() {}
 void Symbol::Reset()
 {
     Object::Reset();
+
+    this->ResetColor();
+    this->ResetExtSym();
 
     m_visibility = Visible;
 }

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -34,6 +34,8 @@ Symbol::~Symbol() {}
 void Symbol::Reset()
 {
     Object::Reset();
+
+    m_visibility = Visible;
 }
 
 bool Symbol::IsSupportedChild(Object *child)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1572,7 +1572,7 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
 
         VisibleSymbol visibleSymbol;
         if (dir->FindDescendantByComparison(&visibleSymbol)) {
-            // this->DrawDynamSymbolOnly(dc, *staffIter, dynam, dynamSymbol, alignment, params);
+            this->DrawSymbolChildren(dc, dir, *staffIter, params);
         }
         else {
             dc->SetBrush(m_currentColour, AxSOLID);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1570,16 +1570,21 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
             params.m_y -= m_doc->GetTextXHeight(&dirTxt, false) / 2;
         }
 
-        dc->SetBrush(m_currentColour, AxSOLID);
-        dc->SetFont(&dirTxt);
+        VisibleSymbol visibleSymbol;
+        if (dir->FindDescendantByComparison(&visibleSymbol)) {
+            // this->DrawDynamSymbolOnly(dc, *staffIter, dynam, dynamSymbol, alignment, params);
+        }
+        else {
+            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetFont(&dirTxt);
 
-        dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
-        DrawTextChildren(dc, dir, params);
-        dc->EndText();
+            dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
+            DrawTextChildren(dc, dir, params);
+            dc->EndText();
 
-        dc->ResetFont();
-        dc->ResetBrush();
-
+            dc->ResetFont();
+            dc->ResetBrush();
+        }
         this->DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1724,6 +1724,21 @@ void View::DrawFbChildren(DeviceContext *dc, Object *parent, TextDrawingParams &
     }
 }
 
+void View::DrawSymbolChildren(DeviceContext *dc, Object *parent, Staff *staff, TextDrawingParams &params)
+{
+    assert(dc);
+    assert(parent);
+
+    for (auto current : parent->GetChildren()) {
+        if (current->Is(SYMBOL)) {
+            this->DrawSymbol(dc, staff, dynamic_cast<Symbol *>(current), params);
+        }
+        else {
+            assert(false);
+        }
+    }
+}
+
 void View::DrawRunningChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params)
 {
     assert(dc);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1696,6 +1696,9 @@ void View::DrawTextChildren(DeviceContext *dc, Object *parent, TextDrawingParams
             // cast to EditorialElement check in DrawTextEditorialElement
             this->DrawTextEditorialElement(dc, dynamic_cast<EditorialElement *>(current), params);
         }
+        else if (current->Is(SYMBOL)) {
+            // assert(symbol->m_visibility == Hidden);
+        }
         else {
             assert(false);
         }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -27,6 +27,7 @@
 #include "options.h"
 #include "rend.h"
 #include "smufl.h"
+#include "staff.h"
 #include "svg.h"
 #include "symbol.h"
 #include "system.h"
@@ -450,12 +451,18 @@ void View::DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params)
     dc->EndGraphic(svg, this);
 }
 
-void View::DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params)
+void View::DrawSymbol(DeviceContext *dc, Staff *staff, Symbol *symbol, TextDrawingParams &params)
 {
     assert(dc);
     assert(symbol);
 
     dc->StartGraphic(symbol, "", symbol->GetID());
+
+    const wchar_t code = symbol->GetSymbolGlyph();
+
+    this->DrawSmuflCode(dc, params.m_x, params.m_y, code, staff->m_drawingStaffSize, false);
+
+    params.m_x += m_doc->GetGlyphAdvX(code, staff->m_drawingStaffSize, false);
 
     dc->EndGraphic(symbol, this);
 }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -28,6 +28,7 @@
 #include "rend.h"
 #include "smufl.h"
 #include "svg.h"
+#include "symbol.h"
 #include "system.h"
 #include "text.h"
 #include "vrv.h"
@@ -448,4 +449,15 @@ void View::DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params)
 
     dc->EndGraphic(svg, this);
 }
+
+void View::DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params)
+{
+    assert(dc);
+    assert(symbol);
+
+    dc->StartGraphic(symbol, "", symbol->GetID());
+
+    dc->EndGraphic(symbol, this);
+}
+
 } // namespace vrv


### PR DESCRIPTION
The PR add support for MEI `<symbol>` within `<dir>`. The symbols can make references to any of SMuFL glyphs supported by Verovio.

See https://github.com/rism-digital/verovio/issues/2976#issuecomment-1211608188 for the limitation of the current implementation.

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Symbol example</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2022-08-12"/>
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>Verovio supports symbols within directives.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.5.0" label="2">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef>
                        <staffGrp symbol="bracket">
                            <staffDef label="Violino I" n="1" lines="5" clef.shape="G" clef.line="2" key.sig="1f" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure n="1">
                            <staff n="1">
                                <layer n="1">
                                    <beam>
                                        <note dur="16" oct="4" pname="e" />
                                        <note dur="16" oct="4" pname="e" />
                                        <note dur="16" oct="4" pname="e" />
                                        <note dur="16" oct="4" pname="e" />
                                    </beam>
                                    <beam>
                                        <note dur="8" oct="4" pname="e" />
                                        <note dur="8" oct="4" pname="e" />
                                    </beam>
                                    <note dur="4" oct="4" pname="e" />
                                    <note dur="4" oct="4" pname="e" />
                                </layer>
                            </staff>
                            <dir tstamp="1" place="above">
                                <symbol glyph.auth="smufl" glyph.num="U+E530" color="red"></symbol>
                                <symbol glyph.auth="smufl" glyph.name="dynamicForte" color="green"></symbol>
                            </dir>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>

```
</details>

![image](https://user-images.githubusercontent.com/689412/184367898-c01cbed8-7bae-4f21-baa4-c4894b53192b.png)

Fixes #2976 