### PR TITLE
fix barLine attribute error

### DIFF
--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -378,7 +378,7 @@ AttBarLineLog::~AttBarLineLog()
 
 void AttBarLineLog::ResetBarLineLog()
 {
-    m_form = BARRENDITION_single;
+    m_form = BARRENDITION_NONE;
 }
 
 bool AttBarLineLog::ReadBarLineLog(pugi::xml_node element)
@@ -404,7 +404,7 @@ bool AttBarLineLog::WriteBarLineLog(pugi::xml_node element)
 
 bool AttBarLineLog::HasForm() const
 {
-    return (m_form != BARRENDITION_single);
+    return (m_form != BARRENDITION_NONE);
 }
 
 /* include <attform> */


### PR DESCRIPTION
This is a tiny fix setting the default for bar rendition back to `BARRENDITION_NONE`. No additional change is needed, as we always draw `single` bar lines as default.

The problem was, that encoded single bar lines didn't turn up in the SVG as `data-form` when you use 
`--svg-additional-attribute "barLine@form"`

```xml
<measure left="rptstart" right="single">
   <staff n="1">
      <layer n="1">
         <mRest />
      </layer>
   </staff>
</measure>
```

![image](https://user-images.githubusercontent.com/7693447/185400684-ab8f1af5-88b3-489e-b3df-0c188442cfdc.png)

(A separate PR will be made for LibMEI.)
