### PR TITLE
Improving the filtered export

### DIFF
--- a/src/att.cpp
+++ b/src/att.cpp
@@ -398,18 +398,19 @@ data_MEASUREBEAT Att::StrToMeasurebeat(std::string value, bool logWarning) const
 std::string Att::MetercountPairToStr(const data_METERCOUNT_pair &data) const
 {
     std::stringstream output;
-    for (const int count : data.first) {
-        output << count;
-        switch (data.second) {
-            case MeterCountSign::Slash: output << '\\'; break;
-            case MeterCountSign::Minus: output << '-'; break;
-            case MeterCountSign::Asterisk: output << '*'; break;
-            case MeterCountSign::Plus: output << '+'; break;
-            case MeterCountSign::None:
-            default: break;
+    for (auto iter = data.first.begin(); iter != data.first.end(); ++iter) {
+        output << *iter;
+        if (iter != std::prev(data.first.end())) {
+            switch (data.second) {
+                case MeterCountSign::Slash: output << '\\'; break;
+                case MeterCountSign::Minus: output << '-'; break;
+                case MeterCountSign::Asterisk: output << '*'; break;
+                case MeterCountSign::Plus: output << '+'; break;
+                case MeterCountSign::None:
+                default: break;
+            }
         }
     }
-
     return output.str();
 }
 
@@ -419,8 +420,8 @@ data_METERCOUNT_pair Att::StrToMetercountPair(const std::string &value) const
     std::sregex_token_iterator first{ value.begin(), value.end(), re, -1 }, last;
     std::vector<std::string> tokens{ first, last };
 
-    // Since there is currently no need for implementation of complex calculus within metersig, only one opperation will
-    // be supported in the meter count. Caclulation will be based on the first mathematical operator in the string
+    // Since there is currently no need for implementation of complex calculus within metersig, only one operation will
+    // be supported in the meter count. Calculation will be based on the first mathematical operator in the string
     MeterCountSign sign = MeterCountSign::None;
     const size_t pos = value.find_first_of("+-*/");
     if (pos != std::string::npos) {

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1292,8 +1292,9 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
     Staff *staff = vrv_cast<Staff *>(measure->FindDescendantByComparison(&matchN, 1));
     if (!staff) return;
     Layer *layer = vrv_cast<Layer *>(staff->FindDescendantByType(LAYER));
-    if (!layer || !layer->HasStaffDef()) return;
-    // Replace any element (clef, keysig, metersig, ...) by its current drawing element
+    if (!layer) return;
+
+    // Replace clef, keySig & mensur by its current drawing element
     if (layer->GetStaffDefClef()) {
         Object *clef = staffDef->GetChild(0, CLEF);
         if (clef) staffDef->DeleteChild(clef);
@@ -1309,6 +1310,8 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
         if (mensur) staffDef->DeleteChild(mensur);
         staffDef->AddChild(layer->GetStaffDefMensur()->Clone());
     }
+
+    // Replace meterSig & meterSigGrp by its current drawing element
     if (layer->GetStaffDefMeterSigGrp()) {
         Object *meterSigGrp = staffDef->GetChild(0, METERSIGGRP);
         if (meterSigGrp) {
@@ -1330,6 +1333,11 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
             if (meterSigGrp) staffDef->DeleteChild(meterSigGrp);
         }
         staffDef->AddChild(layer->GetStaffDefMeterSig()->Clone());
+    }
+    else if (!staffDef->FindDescendantByType(METERSIGGRP)) {
+        // Mark meter signatures invisible if no replacement was done
+        MeterSig *meterSig = vrv_cast<MeterSig *>(staffDef->GetChild(0, METERSIG));
+        if (meterSig) meterSig->SetForm(METERFORM_invis);
     }
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1312,6 +1312,7 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
     }
 
     // Replace meterSig & meterSigGrp by its current drawing element
+    bool meterSigReplaced = false;
     if (layer->GetStaffDefMeterSigGrp()) {
         Object *meterSigGrp = staffDef->GetChild(0, METERSIGGRP);
         if (meterSigGrp) {
@@ -1322,6 +1323,7 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
             if (meterSig) staffDef->DeleteChild(meterSig);
         }
         staffDef->AddChild(layer->GetStaffDefMeterSigGrp()->Clone());
+        meterSigReplaced = true;
     }
     if (layer->GetStaffDefMeterSig()) {
         Object *meterSig = staffDef->GetChild(0, METERSIG);
@@ -1333,11 +1335,16 @@ void MEIOutput::AdjustStaffDef(StaffDef *staffDef, Measure *measure)
             if (meterSigGrp) staffDef->DeleteChild(meterSigGrp);
         }
         staffDef->AddChild(layer->GetStaffDefMeterSig()->Clone());
+        meterSigReplaced = true;
     }
-    else if (!staffDef->FindDescendantByType(METERSIGGRP)) {
-        // Mark meter signatures invisible if no replacement was done
-        MeterSig *meterSig = vrv_cast<MeterSig *>(staffDef->GetChild(0, METERSIG));
-        if (meterSig) meterSig->SetForm(METERFORM_invis);
+
+    // Mark meter signatures invisible if no replacement was done
+    if (!meterSigReplaced) {
+        ListOfObjects objects = staffDef->FindAllDescendantsByType(METERSIG);
+        for (Object *object : objects) {
+            MeterSig *meterSig = vrv_cast<MeterSig *>(object);
+            meterSig->SetForm(METERFORM_invis);
+        }
     }
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1190,7 +1190,7 @@ bool MEIOutput::ProcessScoreBasedFilter(Object *object)
         }
     }
 
-    if (this->IsTreeObject(object)) {
+    if (this->IsTreeObject(object) && !object->Is({ SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
         m_objectStack.push_back(object);
     }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1083,7 +1083,16 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     assert(staff);
 
     MeterSigGrp *meterSigGrp = layer->GetStaffDefMeterSigGrp();
-    const ListOfObjects &childList = meterSigGrp->GetList(meterSigGrp);
+    ListOfObjects childList = meterSigGrp->GetList(meterSigGrp);
+
+    // Ignore invisible meter signatures and those without count
+    childList.erase(std::remove_if(childList.begin(), childList.end(),
+                        [](Object *object) {
+                            MeterSig *meterSig = vrv_cast<MeterSig *>(object);
+                            assert(meterSig);
+                            return ((meterSig->GetForm() == METERFORM_invis) || !meterSig->HasCount());
+                        }),
+        childList.end());
 
     const int glyphSize = staff->GetDrawingStaffNotationSize();
 
@@ -1094,10 +1103,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     for (auto iter = childList.begin(); iter != childList.end(); ++iter) {
         MeterSig *meterSig = vrv_cast<MeterSig *>(*iter);
         assert(meterSig);
-
-        if (meterSig->HasCount()) {
-            this->DrawMeterSig(dc, meterSig, staff, offset);
-        }
+        this->DrawMeterSig(dc, meterSig, staff, offset);
 
         const int y = staff->GetDrawingY() - unit * (staff->m_drawingLines - 1);
         const int x = meterSig->GetDrawingX() + offset;


### PR DESCRIPTION
This PR improves the filtered score based export and fixes some issues:
- The filtered export was broken by the changes [for basic MEI export](https://github.com/rism-digital/verovio/pull/2950). Exporting a single measure or mdiv from an MEI with multiple mdivs led to invalid MEI.
- When exporting a measure or page that starts in the middle of an mdiv, the time signature at the begin is now suppressed:
```xml
<staffDef n="1" lines="5" ppq="4" meter.count="3" meter.unit="4" meter.form="invis" clef.shape="G" clef.line="2">
```
<details>
<summary>Show SVG example</summary>

![Chopin-part_001](https://user-images.githubusercontent.com/63608463/185898450-a1c327d8-5d82-42d9-935a-92736f077b1d.svg)
</details>

- Add support for drawing MeterSigGrp with invisible MeterSig children.
- Fix an issue when writing the `count` attribute: `2+3` was stringified into `"2+3+"`

