### PR TITLE
Const correctness for Doc and aligners

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -145,15 +145,15 @@ public:
     virtual ~FontInfo(){};
 
     // accessors and modifiers for the font elements
-    int GetPointSize() { return m_pointSize; }
-    data_FONTSTYLE GetStyle() { return m_style; }
-    data_FONTWEIGHT GetWeight() { return m_weight; }
-    bool GetUnderlined() { return m_underlined; }
-    bool GetSupSubScript() { return m_supSubScript; }
-    std::string GetFaceName() { return m_faceName; }
-    int GetFamily() { return m_family; }
-    int GetEncoding() { return m_encoding; }
-    float GetWidthToHeightRatio() { return m_widthToHeightRatio; }
+    int GetPointSize() const { return m_pointSize; }
+    data_FONTSTYLE GetStyle() const { return m_style; }
+    data_FONTWEIGHT GetWeight() const { return m_weight; }
+    bool GetUnderlined() const { return m_underlined; }
+    bool GetSupSubScript() const { return m_supSubScript; }
+    std::string GetFaceName() const { return m_faceName; }
+    int GetFamily() const { return m_family; }
+    int GetEncoding() const { return m_encoding; }
+    float GetWidthToHeightRatio() const { return m_widthToHeightRatio; }
 
     void SetPointSize(int pointSize) { m_pointSize = pointSize; }
     void SetStyle(data_FONTSTYLE style) { m_style = style; }

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -66,15 +66,11 @@ public:
     void ClearSelectionPages();
 
     /**
-     * Refreshes the views from Doc.
-     */
-    virtual void Refresh();
-
-    /**
      * Getter for the options
      */
     ///@{
-    Options *GetOptions() const { return m_options; }
+    Options *GetOptions() { return m_options; }
+    const Options *GetOptions() const { return m_options; }
     void SetOptions(Options *options) { (*m_options) = *options; }
     ///@}
 
@@ -119,7 +115,7 @@ public:
     /**
      * Check if the document has a page with the specified value
      */
-    bool HasPage(int pageIdx);
+    bool HasPage(int pageIdx) const;
 
     /**
      * Get all the Score in the visible Mdiv.
@@ -183,12 +179,12 @@ public:
      * The staff size must already be taken into account in the FontInfo
      */
     ///@{
-    int GetTextGlyphHeight(wchar_t code, FontInfo *font, bool graceSize) const;
-    int GetTextGlyphWidth(wchar_t code, FontInfo *font, bool graceSize) const;
-    int GetTextGlyphAdvX(wchar_t code, FontInfo *font, bool graceSize) const;
-    int GetTextGlyphDescender(wchar_t code, FontInfo *font, bool graceSize) const;
-    int GetTextLineHeight(FontInfo *font, bool graceSize) const;
-    int GetTextXHeight(FontInfo *font, bool graceSize) const;
+    int GetTextGlyphHeight(wchar_t code, const FontInfo *font, bool graceSize) const;
+    int GetTextGlyphWidth(wchar_t code, const FontInfo *font, bool graceSize) const;
+    int GetTextGlyphAdvX(wchar_t code, const FontInfo *font, bool graceSize) const;
+    int GetTextGlyphDescender(wchar_t code, const FontInfo *font, bool graceSize) const;
+    int GetTextLineHeight(const FontInfo *font, bool graceSize) const;
+    int GetTextXHeight(const FontInfo *font, bool graceSize) const;
     ///@}
 
     /**
@@ -207,9 +203,9 @@ public:
      */
     ///@{
     double GetLeftMargin(const ClassId classId) const;
-    double GetLeftMargin(Object *object) const;
+    double GetLeftMargin(const Object *object) const;
     double GetRightMargin(const ClassId classId) const;
-    double GetRightMargin(Object *object) const;
+    double GetRightMargin(const Object *object) const;
     double GetLeftPosition() const;
     double GetBottomMargin(const ClassId classId) const;
     double GetTopMargin(const ClassId classId) const;
@@ -355,11 +351,6 @@ public:
     void ExpandExpansions();
 
     /**
-     * To be implemented.
-     */
-    void RefreshViews(){};
-
-    /**
      * Set drawing values (page size, etc) when drawing a page.
      * By default, the page size of the document is taken.
      * If a page is given, the size of the page is taken.
@@ -377,9 +368,12 @@ public:
     /**
      * Getter to the drawPage. Normally, getting the page should
      * be done with Doc::SetDrawingPage. This is only a method for
-     * asserting that currently have the right page.
+     * asserting that we currently have the right page.
      */
-    Page *GetDrawingPage() const { return m_drawingPage; }
+    ///@{
+    Page *GetDrawingPage() { return m_drawingPage; }
+    const Page *GetDrawingPage() const { return m_drawingPage; }
+    ///@}
 
     /**
      * Return the width adjusted to the content of the current drawing page.
@@ -414,6 +408,7 @@ public:
     ///@{
     void SetFacsimile(Facsimile *facsimile) { m_facsimile = facsimile; }
     Facsimile *GetFacsimile() { return m_facsimile; }
+    const Facsimile *GetFacsimile() const { return m_facsimile; }
     bool HasFacsimile() const { return m_facsimile != NULL; }
     ///@}
 

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -129,9 +129,9 @@ public:
      * Returns (-)VRV_UNSET in nothing for the staff specified.
      * Uses Object::GetAlignmentLeftRight
      */
-    void GetLeftRight(
-        const std::vector<int> &staffNs, int &minLeft, int &maxRight, const std::vector<ClassId> &m_excludes = {});
-    void GetLeftRight(int staffN, int &minLeft, int &maxRight, const std::vector<ClassId> &m_excludes = {});
+    void GetLeftRight(const std::vector<int> &staffNs, int &minLeft, int &maxRight,
+        const std::vector<ClassId> &m_excludes = {}) const;
+    void GetLeftRight(int staffN, int &minLeft, int &maxRight, const std::vector<ClassId> &m_excludes = {}) const;
 
     /**
      * Returns the GraceAligner for the Alignment.
@@ -153,7 +153,10 @@ public:
      * Return the AlignmentReference holding the element.
      * If staffN is provided, uses the AlignmentReference->GetN() to accelerate the search.
      */
-    AlignmentReference *GetReferenceWithElement(LayerElement *element, int staffN = VRV_UNSET);
+    ///@{
+    AlignmentReference *GetReferenceWithElement(const LayerElement *element, int staffN = VRV_UNSET);
+    const AlignmentReference *GetReferenceWithElement(const LayerElement *element, int staffN = VRV_UNSET) const;
+    ///@}
 
     /**
      * Return pair of max and min Y value within alignment. Elements will be counted by alignment references.
@@ -165,6 +168,25 @@ public:
      * The Alignment has to have a AlignmentReference holding it.
      */
     void AddToAccidSpace(Accid *accid);
+
+    /**
+     * Return true if there is vertical overlap with accidentals from another alignment for specific staffN
+     */
+    bool HasAccidVerticalOverlap(const Alignment *otherAlignment, int staffN) const;
+
+    /**
+     * Return true if the alignment contains at least one reference with staffN
+     */
+    bool HasAlignmentReference(int staffN) const;
+
+    /**
+     * Return true if the alignment contains only references to timestamp attributes.
+     */
+    bool HasTimestampOnly() const;
+
+    //----------------//
+    // Static methods //
+    //----------------//
 
     /**
      * Compute "ideal" horizontal space to allow for a given time interval, ignoring the need
@@ -181,23 +203,8 @@ public:
      * flexible solution might be to get ideal spacing from a user-definable table, but using a
      * formula with parameters can come close and has other advantages.
      */
-    virtual int HorizontalSpaceForDuration(
+    static int HorizontalSpaceForDuration(
         double intervalTime, int maxActualDur, double spacingLinear, double spacingNonLinear);
-
-    /**
-     * Return true if there is vertical overlap with accidentals from another alignment for specific staffN
-     */
-    bool HasAccidVerticalOverlap(Alignment *otherAlignment, int staffN);
-
-    /**
-     * Return true if the alignment contains at least one reference with staffN
-     */
-    bool HasAlignmentReference(int staffN) const;
-
-    /**
-     * Return true if the alignment contains only references to timestamp attributes.
-     */
-    bool HasTimestampOnly() const;
 
     //----------//
     // Functors //
@@ -324,12 +331,12 @@ public:
     /**
      * See Object::AjustAccidX
      */
-    void AdjustAccidWithAccidSpace(Accid *accid, Doc *doc, int staffSize, std::vector<Accid *> &adjustedAccids);
+    void AdjustAccidWithAccidSpace(Accid *accid, const Doc *doc, int staffSize, std::vector<Accid *> &adjustedAccids);
 
     /**
      * Return true if one of objects overlaps with accidentals from current reference (i.e. if there are accidentals)
      */
-    bool HasAccidVerticalOverlap(const ArrayOfObjects *objects);
+    bool HasAccidVerticalOverlap(const ArrayOfConstObjects &objects) const;
 
     /**
      * Return true if the reference has elements from multiple layers.
@@ -502,16 +509,24 @@ public:
      * For each MeasureAligner, we keep and Alignment for the left position.
      * The Alignment time will be always -1.0 * DUR_MAX and will appear first in the list.
      */
-    Alignment *GetLeftAlignment() const { return m_leftAlignment; }
-    Alignment *GetLeftBarLineAlignment() const { return m_leftBarLineAlignment; }
+    ///@{
+    Alignment *GetLeftAlignment() { return m_leftAlignment; }
+    const Alignment *GetLeftAlignment() const { return m_leftAlignment; }
+    Alignment *GetLeftBarLineAlignment() { return m_leftBarLineAlignment; }
+    const Alignment *GetLeftBarLineAlignment() const { return m_leftBarLineAlignment; }
+    ///@}
 
     /**
      * Get right Alignment for the measure.
      * For each MeasureAligner, we keep and Alignment for the right position.
      * The Alignment time will be increased whenever necessary when values are added.
      */
-    Alignment *GetRightAlignment() const { return m_rightAlignment; }
-    Alignment *GetRightBarLineAlignment() const { return m_rightBarLineAlignment; }
+    ///@{
+    Alignment *GetRightAlignment() { return m_rightAlignment; }
+    const Alignment *GetRightAlignment() const { return m_rightAlignment; }
+    Alignment *GetRightBarLineAlignment() { return m_rightBarLineAlignment; }
+    const Alignment *GetRightBarLineAlignment() const { return m_rightBarLineAlignment; }
+    ///@}
 
     /**
      * Adjust the spacing of the measure looking at each tuple of start / end alignment and a distance.
@@ -530,7 +545,7 @@ public:
      * Adjust the spacing for the grace note group(s) of the alignment on staffN
      * The alignment need to be of ALIGNMENT_GRACENOTE type
      */
-    void AdjustGraceNoteSpacing(Doc *doc, Alignment *alignment, int staffN);
+    void AdjustGraceNoteSpacing(const Doc *doc, Alignment *alignment, int staffN);
 
     //----------//
     // Functors //
@@ -630,15 +645,15 @@ public:
      * Setting staffN as VRV_UNSET will look for and align all staves.
      */
     ///@{
-    int GetGraceGroupLeft(int staffN);
-    int GetGraceGroupRight(int staffN);
+    int GetGraceGroupLeft(int staffN) const;
+    int GetGraceGroupRight(int staffN) const;
     ///@{
 
     /**
      * Set an linear defaut position for each grace note
      * This is called from the CalcAlignmentXPos Functor.
      */
-    void SetGraceAligmentXPos(Doc *doc);
+    void SetGraceAlignmentXPos(const Doc *doc);
 
     //----------//
     // Functors //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -412,7 +412,7 @@ public:
      * Return true if the object has the child Object as descendant (reference of direct).
      * Processes in depth-first.
      */
-    bool HasDescendant(Object *child, int deepness = UNLIMITED_DEPTH) const;
+    bool HasDescendant(const Object *child, int deepness = UNLIMITED_DEPTH) const;
 
     /**
      * Look for a descendant with the specified id (returns NULL if not found)
@@ -747,7 +747,7 @@ public:
      * Retrieve the minimum left and maximum right for an alignment.
      * Used in GraceAligner::GetGraceGroupLeft and GraceAligner::GetGraceGroupRight.
      */
-    virtual int GetAlignmentLeftRight(FunctorParams *functorParams);
+    virtual int GetAlignmentLeftRight(FunctorParams *functorParams) const;
 
     /**
      * Go through all layer elements of the layer and return next/previous element relative to the specified

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -54,7 +54,10 @@ public:
      * Get bottom StaffAlignment for the system.
      * For each SystemAligner, we keep a StaffAlignment for the bottom position.
      */
-    StaffAlignment *GetBottomAlignment() const { return m_bottomAlignment; }
+    ///@{
+    StaffAlignment *GetBottomAlignment() { return m_bottomAlignment; }
+    const StaffAlignment *GetBottomAlignment() const { return m_bottomAlignment; }
+    ///@}
 
     /**
      * Get the StaffAlignment at index idx.
@@ -63,13 +66,16 @@ public:
      * If a staff is passed, it will be used for initializing m_staffN and m_staffSize of the aligner.
      * (no const since the bottom alignment is temporarily removed)
      */
-    StaffAlignment *GetStaffAlignment(int idx, Staff *staff, Doc *doc);
+    StaffAlignment *GetStaffAlignment(int idx, Staff *staff, const Doc *doc);
 
     /**
      * Get the StaffAlignment for the staffN.
      * Return NULL if not found.
      */
+    ///@{
     StaffAlignment *GetStaffAlignmentForStaffN(int staffN);
+    const StaffAlignment *GetStaffAlignmentForStaffN(int staffN) const;
+    ///@}
 
     /**
      * Get pointer to the parent system.
@@ -80,13 +86,13 @@ public:
     /**
      * Find all the positioners pointing to an object;
      */
-    void FindAllPositionerPointingTo(ArrayOfFloatingPositioners *positioners, FloatingObject *object);
+    void FindAllPositionerPointingTo(ArrayOfFloatingPositioners *positioners, const FloatingObject *object);
 
     /**
      * Find all the intersection points with a vertical line (top to bottom)
      */
     void FindAllIntersectionPoints(
-        SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin);
+        SegmentedLine &line, const BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin) const;
     /**
      * Get System Overflows
      */
@@ -108,7 +114,7 @@ private:
      * Return above spacing type for passed staff.
      * Calculates spacings if required.
      */
-    SpacingType GetAboveSpacingType(Staff *staff);
+    SpacingType GetAboveSpacingType(const Staff *staff);
     /**
      * Calculates above spacing type for staffDef
      */
@@ -178,7 +184,10 @@ public:
      * Look for the first FloatingPositioner corresponding to the FloatingObject of the ClassId.
      * Return NULL if not found and does not create anything.
      */
+    ///@{
     FloatingPositioner *FindFirstFloatingPositioner(ClassId classId);
+    const FloatingPositioner *FindFirstFloatingPositioner(ClassId classId) const;
+    ///@}
 
     /**
      * Find all FloatingPositioner corresponding to a FloatingObject with given ClassId.
@@ -199,16 +208,19 @@ public:
      * Used for accessing the staff @n, the size, etc.
      */
     ///@{
-    Staff *GetStaff() const { return m_staff; }
-    void SetStaff(Staff *staff, Doc *doc, SystemAligner::SpacingType spacingType);
+    Staff *GetStaff() { return m_staff; }
+    const Staff *GetStaff() const { return m_staff; }
+    void SetStaff(Staff *staff, const Doc *doc, SystemAligner::SpacingType spacingType);
     ///@}
 
     /**
      * @name Setter and getter of the system pointer to which the Alignment is belong to.
      */
     ///@{
-    System *GetParentSystem() const { return m_system; }
+    System *GetParentSystem() { return m_system; }
+    const System *GetParentSystem() const { return m_system; }
     void SetParentSystem(System *system);
+    ///@}
 
     /**
      * Returns the staff size (100 if no staff object is refered to)
@@ -290,7 +302,7 @@ public:
      * Find all the intersection points with a vertical line (top to bottom)
      */
     void FindAllIntersectionPoints(
-        SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin);
+        SegmentedLine &line, const BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin) const;
 
     void ReAdjustFloatingPositionersGrps(AdjustFloatingPositionerGrpsParams *params,
         const ArrayOfFloatingPositioners &positioners, ArrayOfIntPairs &grpIdYRel);
@@ -298,7 +310,7 @@ public:
     /**
      * Find overflow for the alignments taking bracket group elements into account
      */
-    void AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous, int spacing);
+    void AdjustBracketGroupSpacing(const Doc *doc, const StaffAlignment *previous, int spacing);
 
     //----------//
     // Functors //

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -168,11 +168,6 @@ bool Doc::IsSupportedChild(Object *child)
     return true;
 }
 
-void Doc::Refresh()
-{
-    RefreshViews();
-}
-
 bool Doc::GenerateDocumentScoreDef()
 {
     Measure *measure = dynamic_cast<Measure *>(this->FindDescendantByType(MEASURE));
@@ -1474,9 +1469,9 @@ void Doc::ExpandExpansions()
     // }
 }
 
-bool Doc::HasPage(int pageIdx)
+bool Doc::HasPage(int pageIdx) const
 {
-    Pages *pages = this->GetPages();
+    const Pages *pages = this->GetPages();
     assert(pages);
     return ((pageIdx >= 0) && (pageIdx < pages->GetChildCount()));
 }
@@ -1601,7 +1596,7 @@ int Doc::GetGlyphTop(wchar_t code, int staffSize, bool graceSize) const
     return this->GetGlyphBottom(code, staffSize, graceSize) + this->GetGlyphHeight(code, staffSize, graceSize);
 }
 
-int Doc::GetTextGlyphHeight(wchar_t code, FontInfo *font, bool graceSize) const
+int Doc::GetTextGlyphHeight(wchar_t code, const FontInfo *font, bool graceSize) const
 {
     assert(font);
 
@@ -1615,7 +1610,7 @@ int Doc::GetTextGlyphHeight(wchar_t code, FontInfo *font, bool graceSize) const
     return h;
 }
 
-int Doc::GetTextGlyphWidth(wchar_t code, FontInfo *font, bool graceSize) const
+int Doc::GetTextGlyphWidth(wchar_t code, const FontInfo *font, bool graceSize) const
 {
     assert(font);
 
@@ -1629,7 +1624,7 @@ int Doc::GetTextGlyphWidth(wchar_t code, FontInfo *font, bool graceSize) const
     return w;
 }
 
-int Doc::GetTextGlyphAdvX(wchar_t code, FontInfo *font, bool graceSize) const
+int Doc::GetTextGlyphAdvX(wchar_t code, const FontInfo *font, bool graceSize) const
 {
     assert(font);
 
@@ -1642,7 +1637,7 @@ int Doc::GetTextGlyphAdvX(wchar_t code, FontInfo *font, bool graceSize) const
     return advX;
 }
 
-int Doc::GetTextGlyphDescender(wchar_t code, FontInfo *font, bool graceSize) const
+int Doc::GetTextGlyphDescender(wchar_t code, const FontInfo *font, bool graceSize) const
 {
     assert(font);
 
@@ -1656,7 +1651,7 @@ int Doc::GetTextGlyphDescender(wchar_t code, FontInfo *font, bool graceSize) con
     return y;
 }
 
-int Doc::GetTextLineHeight(FontInfo *font, bool graceSize) const
+int Doc::GetTextLineHeight(const FontInfo *font, bool graceSize) const
 {
     int descender = -this->GetTextGlyphDescender(L'q', font, graceSize);
     int height = this->GetTextGlyphHeight(L'I', font, graceSize);
@@ -1667,7 +1662,7 @@ int Doc::GetTextLineHeight(FontInfo *font, bool graceSize) const
     return lineHeight;
 }
 
-int Doc::GetTextXHeight(FontInfo *font, bool graceSize) const
+int Doc::GetTextXHeight(const FontInfo *font, bool graceSize) const
 {
     return this->GetTextGlyphHeight('x', font, graceSize);
 }
@@ -1808,12 +1803,12 @@ double Doc::GetLeftMargin(const ClassId classId) const
     return m_options->m_defaultLeftMargin.GetValue();
 }
 
-double Doc::GetLeftMargin(Object *object) const
+double Doc::GetLeftMargin(const Object *object) const
 {
     assert(object);
     const ClassId id = object->GetClassId();
     if (id == BARLINE) {
-        BarLine *barLine = vrv_cast<BarLine *>(object);
+        const BarLine *barLine = vrv_cast<const BarLine *>(object);
         switch (barLine->GetPosition()) {
             case BarLinePosition::None: return m_options->m_leftMarginBarLine.GetValue();
             case BarLinePosition::Left: return m_options->m_leftMarginLeftBarLine.GetValue();
@@ -1845,12 +1840,12 @@ double Doc::GetRightMargin(const ClassId classId) const
     return m_options->m_defaultRightMargin.GetValue();
 }
 
-double Doc::GetRightMargin(Object *object) const
+double Doc::GetRightMargin(const Object *object) const
 {
     assert(object);
     const ClassId id = object->GetClassId();
     if (id == BARLINE) {
-        BarLine *barLine = vrv_cast<BarLine *>(object);
+        const BarLine *barLine = vrv_cast<const BarLine *>(object);
         switch (barLine->GetPosition()) {
             case BarLinePosition::None: return m_options->m_rightMarginBarLine.GetValue();
             case BarLinePosition::Left: return m_options->m_rightMarginLeftBarLine.GetValue();
@@ -1990,7 +1985,7 @@ Page *Doc::SetDrawingPage(int pageIdx)
     m_drawingBeamWhiteWidth = m_options->m_unit.GetValue() / 2;
 
     // values for fonts
-    m_drawingSmuflFontSize = CalcMusicFontSize();
+    m_drawingSmuflFontSize = this->CalcMusicFontSize();
     m_drawingLyricFontSize = m_options->m_unit.GetValue() * m_options->m_lyricSize.GetValue();
     m_fingeringFontSize = m_drawingLyricFontSize * m_options->m_fingeringScale.GetValue();
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -545,7 +545,7 @@ Object *Object::DetachChild(int idx)
     return child;
 }
 
-bool Object::HasDescendant(Object *child, int deepness) const
+bool Object::HasDescendant(const Object *child, int deepness) const
 {
     ArrayOfObjects::const_iterator iter;
 
@@ -2224,7 +2224,7 @@ int Object::ScoreDefSetCurrent(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
-int Object::GetAlignmentLeftRight(FunctorParams *functorParams)
+int Object::GetAlignmentLeftRight(FunctorParams *functorParams) const
 {
     GetAlignmentLeftRightParams *params = vrv_params_cast<GetAlignmentLeftRightParams *>(functorParams);
     assert(params);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -51,7 +51,7 @@ void SystemAligner::Reset()
     m_bottomAlignment = this->GetStaffAlignment(0, NULL, NULL);
 }
 
-StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc)
+StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, const Doc *doc)
 {
     ArrayOfObjects &children = this->GetChildrenForModification();
 
@@ -86,9 +86,14 @@ StaffAlignment *SystemAligner::GetStaffAlignment(int idx, Staff *staff, Doc *doc
 
 StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN)
 {
-    StaffAlignment *alignment = NULL;
+    return const_cast<StaffAlignment *>(std::as_const(*this).GetStaffAlignmentForStaffN(staffN));
+}
+
+const StaffAlignment *SystemAligner::GetStaffAlignmentForStaffN(int staffN) const
+{
+    const StaffAlignment *alignment = NULL;
     for (int i = 0; i < this->GetChildCount(); ++i) {
-        alignment = vrv_cast<StaffAlignment *>(this->GetChild(i));
+        alignment = vrv_cast<const StaffAlignment *>(this->GetChild(i));
         assert(alignment);
 
         if ((alignment->GetStaff()) && (alignment->GetStaff()->GetN() == staffN)) return alignment;
@@ -105,7 +110,7 @@ System *SystemAligner::GetSystem()
     return m_system;
 }
 
-void SystemAligner::FindAllPositionerPointingTo(ArrayOfFloatingPositioners *positioners, FloatingObject *object)
+void SystemAligner::FindAllPositionerPointingTo(ArrayOfFloatingPositioners *positioners, const FloatingObject *object)
 {
     assert(positioners);
 
@@ -123,11 +128,11 @@ void SystemAligner::FindAllPositionerPointingTo(ArrayOfFloatingPositioners *posi
 }
 
 void SystemAligner::FindAllIntersectionPoints(
-    SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin)
+    SegmentedLine &line, const BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin) const
 {
-    StaffAlignment *alignment = NULL;
+    const StaffAlignment *alignment = NULL;
     for (const auto child : this->GetChildren()) {
-        alignment = vrv_cast<StaffAlignment *>(child);
+        alignment = vrv_cast<const StaffAlignment *>(child);
         assert(alignment);
         alignment->FindAllIntersectionPoints(line, boundingBox, classIds, margin);
     }
@@ -182,13 +187,13 @@ void SystemAligner::SetSpacing(const ScoreDef *scoreDef)
     }
 }
 
-SystemAligner::SpacingType SystemAligner::GetAboveSpacingType(Staff *staff)
+SystemAligner::SpacingType SystemAligner::GetAboveSpacingType(const Staff *staff)
 {
     if (!staff) return SpacingType::None;
 
     if (m_spacingTypes.empty()) {
-        System *system = dynamic_cast<System *>(staff->GetFirstAncestor(SYSTEM));
-        ScoreDef *scoreDef = system ? system->GetDrawingScoreDef() : NULL;
+        const System *system = vrv_cast<const System *>(staff->GetFirstAncestor(SYSTEM));
+        const ScoreDef *scoreDef = system ? system->GetDrawingScoreDef() : NULL;
         this->SetSpacing(scoreDef);
     }
 
@@ -306,7 +311,7 @@ void StaffAlignment::SortPositioners()
     }
 }
 
-void StaffAlignment::SetStaff(Staff *staff, Doc *doc, SystemAligner::SpacingType spacingType)
+void StaffAlignment::SetStaff(Staff *staff, const Doc *doc, SystemAligner::SpacingType spacingType)
 {
     m_staff = staff;
     m_spacingType = spacingType;
@@ -327,7 +332,7 @@ int StaffAlignment::GetStaffSize() const
 
 const AttSpacing *StaffAlignment::GetAttSpacing() const
 {
-    System *system = this->GetParentSystem();
+    const System *system = this->GetParentSystem();
     assert(system);
 
     return system->GetDrawingScoreDef();
@@ -552,7 +557,7 @@ int StaffAlignment::CalcMinimumRequiredSpacing(const Doc *doc) const
     return overflowSum;
 }
 
-void StaffAlignment::AdjustBracketGroupSpacing(Doc *doc, StaffAlignment *previous, int spacing)
+void StaffAlignment::AdjustBracketGroupSpacing(const Doc *doc, const StaffAlignment *previous, int spacing)
 {
     if (!previous) return;
 
@@ -622,6 +627,11 @@ void StaffAlignment::SetCurrentFloatingPositioner(
 
 FloatingPositioner *StaffAlignment::FindFirstFloatingPositioner(ClassId classId)
 {
+    return const_cast<FloatingPositioner *>(std::as_const(*this).FindFirstFloatingPositioner(classId));
+}
+
+const FloatingPositioner *StaffAlignment::FindFirstFloatingPositioner(ClassId classId) const
+{
     auto item = std::find_if(m_floatingPositioners.begin(), m_floatingPositioners.end(),
         [classId](FloatingPositioner *positioner) { return positioner->GetObject()->GetClassId() == classId; });
     if (item != m_floatingPositioners.end()) {
@@ -654,7 +664,7 @@ const FloatingPositioner *StaffAlignment::GetCorrespFloatingPositioner(const Flo
 }
 
 void StaffAlignment::FindAllIntersectionPoints(
-    SegmentedLine &line, BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin)
+    SegmentedLine &line, const BoundingBox &boundingBox, const std::vector<ClassId> &classIds, int margin) const
 {
     for (const auto positioner : m_floatingPositioners) {
         assert(positioner->GetObject());


### PR DESCRIPTION
The last PR in a series to improve const correctness. This time the Doc and aligners are considered - adding const to relevant member functions and arguments. No changes in behaviour are expected.