### PR TITLE
Remove DrawMensuralRest

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -83,7 +83,7 @@ public:
      */
     ///@{
     wchar_t GetRestGlyph() const;
-    wchar_t GetRestGlyph(int duration) const;
+    wchar_t GetRestGlyph(const int duration) const;
     ///@}
 
     /**

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -495,7 +495,6 @@ protected:
     ///@{
     void DrawMensur(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
-    void DrawMensuralRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawDotInLigature(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawPlica(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawProport(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -269,7 +269,7 @@ wchar_t Rest::GetRestGlyph(const int duration) const
             case DUR_1024: return SMUFL_E4ED_rest1024th; break;
         }
     }
-    
+
     return 0;
 }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -240,21 +240,36 @@ wchar_t Rest::GetRestGlyph(const int duration) const
         if (NULL != resources->GetGlyph(code)) return code;
     }
 
-    switch (duration) {
-        case DUR_LG: return SMUFL_E4E1_restLonga; break;
-        case DUR_BR: return SMUFL_E4E2_restDoubleWhole; break;
-        case DUR_1: return SMUFL_E4E3_restWhole; break;
-        case DUR_2: return SMUFL_E4E4_restHalf; break;
-        case DUR_4: return SMUFL_E4E5_restQuarter; break;
-        case DUR_8: return SMUFL_E4E6_rest8th; break;
-        case DUR_16: return SMUFL_E4E7_rest16th; break;
-        case DUR_32: return SMUFL_E4E8_rest32nd; break;
-        case DUR_64: return SMUFL_E4E9_rest64th; break;
-        case DUR_128: return SMUFL_E4EA_rest128th; break;
-        case DUR_256: return SMUFL_E4EB_rest256th; break;
-        case DUR_512: return SMUFL_E4EC_rest512th; break;
-        case DUR_1024: return SMUFL_E4ED_rest1024th; break;
+    if (this->IsMensuralDur()) {
+        switch (duration) {
+            case DUR_MX: return SMUFL_E9F0_mensuralRestMaxima; break;
+            case DUR_LG: return SMUFL_E9F2_mensuralRestLongaImperfecta; break;
+            case DUR_BR: return SMUFL_E9F3_mensuralRestBrevis; break;
+            case DUR_1: return SMUFL_E9F4_mensuralRestSemibrevis; break;
+            case DUR_2: return SMUFL_E9F5_mensuralRestMinima; break;
+            case DUR_4: return SMUFL_E9F6_mensuralRestSemiminima; break;
+            case DUR_8: return SMUFL_E9F7_mensuralRestFusa; break;
+            case DUR_16: return SMUFL_E9F8_mensuralRestSemifusa; break;
+        }
     }
+    else {
+        switch (duration) {
+            case DUR_LG: return SMUFL_E4E1_restLonga; break;
+            case DUR_BR: return SMUFL_E4E2_restDoubleWhole; break;
+            case DUR_1: return SMUFL_E4E3_restWhole; break;
+            case DUR_2: return SMUFL_E4E4_restHalf; break;
+            case DUR_4: return SMUFL_E4E5_restQuarter; break;
+            case DUR_8: return SMUFL_E4E6_rest8th; break;
+            case DUR_16: return SMUFL_E4E7_rest16th; break;
+            case DUR_32: return SMUFL_E4E8_rest32nd; break;
+            case DUR_64: return SMUFL_E4E9_rest64th; break;
+            case DUR_128: return SMUFL_E4EA_rest128th; break;
+            case DUR_256: return SMUFL_E4EB_rest256th; break;
+            case DUR_512: return SMUFL_E4EC_rest512th; break;
+            case DUR_1024: return SMUFL_E4ED_rest1024th; break;
+        }
+    }
+    
     return 0;
 }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1406,11 +1406,6 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     Rest *rest = vrv_cast<Rest *>(element);
     assert(rest);
 
-    if (rest->IsMensuralDur()) {
-        this->DrawMensuralRest(dc, element, layer, staff, measure);
-        return;
-    }
-
     if (rest->m_crossStaff) staff = rest->m_crossStaff;
 
     const bool drawingCueSize = rest->GetDrawingCueSize();

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -24,7 +24,6 @@
 #include "options.h"
 #include "plica.h"
 #include "proport.h"
-#include "rest.h"
 #include "smufl.h"
 #include "staff.h"
 #include "vrv.h"
@@ -85,38 +84,6 @@ void View::DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *lay
     /************ Draw children (verse / syl) ************/
 
     this->DrawLayerChildren(dc, note, layer, staff, measure);
-}
-
-void View::DrawMensuralRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)
-{
-    assert(dc);
-    assert(element);
-    assert(layer);
-    assert(staff);
-    assert(measure);
-
-    wchar_t charCode;
-
-    Rest *rest = vrv_cast<Rest *>(element);
-    assert(rest);
-
-    const bool drawingCueSize = rest->GetDrawingCueSize();
-    const int drawingDur = rest->GetActualDur();
-    const int x = element->GetDrawingX();
-    const int y = element->GetDrawingY();
-
-    switch (drawingDur) {
-        case DUR_MX: charCode = SMUFL_E9F0_mensuralRestMaxima; break;
-        case DUR_LG: charCode = SMUFL_E9F2_mensuralRestLongaImperfecta; break;
-        case DUR_BR: charCode = SMUFL_E9F3_mensuralRestBrevis; break;
-        case DUR_1: charCode = SMUFL_E9F4_mensuralRestSemibrevis; break;
-        case DUR_2: charCode = SMUFL_E9F5_mensuralRestMinima; break;
-        case DUR_4: charCode = SMUFL_E9F6_mensuralRestSemiminima; break;
-        case DUR_8: charCode = SMUFL_E9F7_mensuralRestFusa; break;
-        case DUR_16: charCode = SMUFL_E9F8_mensuralRestSemifusa; break;
-        default: charCode = 0; // This should never happen
-    }
-    this->DrawSmuflCode(dc, x, y, charCode, staff->m_drawingStaffSize, drawingCueSize);
 }
 
 void View::DrawMensur(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)


### PR DESCRIPTION
Since we use glyphs for mensural rest we no longer need a separate function for drawing them. 
This PR removes `DrawMensuralRest` and moves glyph selection into `GetRestGlyph`.

No changes in behaviour are expected.
