### PR TITLE
Fix for beamspan stems

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -179,7 +179,6 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
         }
 
         int stemAdjust = 0;
-        
         if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
             if (isStemSameas) {
                 // Move up according to the cut-outs

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -151,8 +151,6 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
     assert(doc);
     assert(beamInterface);
 
-    int y1, y2;
-
     const int stemWidth = doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
     for (auto coord : m_beamElementCoordRefs) {
         // All notes and chords get their stem value stored
@@ -165,7 +163,8 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
 
         assert(coord->m_closestNote);
 
-        y1 = coord->m_yBeam;
+        int y1 = coord->m_yBeam;
+        int y2 = coord->m_closestNote->GetDrawingY();
         bool isStemSameas = false;
 
         // With stem.sameas the y is not the beam one but the one of the other note
@@ -180,7 +179,7 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
         }
 
         int stemAdjust = 0;
-        y2 = coord->m_closestNote->GetDrawingY();
+        
         if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
             if (isStemSameas) {
                 // Move up according to the cut-outs

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -204,7 +204,7 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
             if (coord->m_partialFlagPlace == coord->m_beamRelativePlace) {
                 stemOffset = (coord->m_dur - DUR_8) * beamInterface->m_beamWidth;
                 const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
-                if (stemOffset && m_firstNoteOrChord && (m_firstNoteOrChord->m_yBeam ^ unit)) stemOffset -= unit / 2;
+                if (stemOffset && m_firstNoteOrChord && (m_firstNoteOrChord->m_yBeam % unit)) stemOffset -= unit / 2;
             }
             // handle cross-staff fTrem cases
             const auto [beams, beamsFloat] = beamInterface->GetFloatingBeamCount();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -205,6 +205,8 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
             int stemOffset = 0;
             if (coord->m_partialFlagPlace == coord->m_beamRelativePlace) {
                 stemOffset = (coord->m_dur - DUR_8) * beamInterface->m_beamWidth;
+                const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
+                if (stemOffset && m_firstNoteOrChord && (m_firstNoteOrChord->m_yBeam ^ unit)) stemOffset -= unit / 2;
             }
             // handle cross-staff fTrem cases
             const auto [beams, beamsFloat] = beamInterface->GetFloatingBeamCount();


### PR DESCRIPTION
This fixes an issue with some of the stems on cross-staff beamspans:
![image](https://user-images.githubusercontent.com/1819669/186357405-fa5fd028-6b02-4aaa-acfc-f3bc43b07d22.png)

After fix:
![image](https://user-images.githubusercontent.com/1819669/186357494-bdb4c5af-257d-45de-81a6-a7b3ef19f0aa.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Slurs with spanning beams</title>
            <respStmt />
         </titleStmt>
         <pubStmt>
            <date isodate="2022-07-12">2022-07-12</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m84yq1d">
            <score xml:id="s19n3ntg">
               <scoreDef xml:id="s6ugs6n">
                  <staffGrp xml:id="s16lym1x">
                     <staffGrp bar.thru="true">
                        <staffDef xml:id="s159axye" n="1" lines="5">
                           <clef xml:id="c8u5yb3" shape="G" line="2" />
                        </staffDef>
                        <staffDef xml:id="s1926zgx" n="2" lines="5">
                           <clef xml:id="csjdor0" shape="G" line="2" />
                        </staffDef>
                        <grpSym xml:id="ggo3kfo" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s6u1oc9">
                  <measure xml:id="m18a955r">
                     <staff xml:id="sgps2r1" n="1">
                        <layer xml:id="l13vjyyl" n="1">
                           <note xml:id="nx4sq2g" dur="16" staff="2" oct="5" pname="f" stem.dir="up" />
                           <note xml:id="n17igtg0" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid="f" />
                           <note xml:id="n1e9f64q" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="n1cojmad" dur="16" oct="6" pname="f" stem.dir="down" />
                           <note xml:id="n11h7ld9" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid="f" />
                           <note xml:id="nb2syjc" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid.ges="f" />
                           <note xml:id="n2fkm3m" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="nqg6e2s" dur="16" oct="6" pname="e" stem.dir="down" accid="f" />
                           <note xml:id="n1xigmo0" dur="16" staff="2" oct="5" pname="d" stem.dir="up" />
                           <note xml:id="n1oj6x9n" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                           <note xml:id="n4wdykt" dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                           <note xml:id="n1g20rnd" dur="16" oct="6" pname="d" stem.dir="down" />
                           <note xml:id="n14tgd9x" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                           <note xml:id="ngrc39q" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                           <note xml:id="nkj3d4z" dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                           <note xml:id="nll6y1l" dur="16" oct="6" pname="c" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff xml:id="s1amslu4" n="2">
                        <layer xml:id="lbjx4lf" n="2">
                           <note xml:id="n1ly2an" dur="4" oct="5" pname="f" stem.dir="down">
                              <artic xml:id="a1k3vnfp" artic="ten" />
                           </note>
                           <note xml:id="n8rk653" dur="4" oct="5" pname="e" stem.dir="down" accid="f">
                              <artic xml:id="a1equ1v3" artic="ten" />
                           </note>
                           <note xml:id="n18xznn2" dur="4" oct="5" pname="d" stem.dir="down">
                              <artic xml:id="a6o5l0z" artic="ten" />
                           </note>
                           <note xml:id="n1tnfpu3" dur="4" oct="5" pname="c" stem.dir="down">
                              <artic xml:id="a12idr4z" artic="ten" />
                           </note>
                        </layer>
                     </staff>
                     <beamSpan xml:id="bqgtx8n" startid="#nx4sq2g" endid="#n1cojmad" />
                     <slur xml:id="s1m3jnti" startid="#nx4sq2g" endid="#n1cojmad" curvedir="above" />
                     <beamSpan xml:id="bj6avl4" startid="#n11h7ld9" endid="#nqg6e2s" />
                     <slur xml:id="s163pkt0" startid="#n11h7ld9" endid="#nqg6e2s" curvedir="above" />
                     <beamSpan xml:id="bz32ve0" startid="#n1xigmo0" endid="#n1g20rnd" />
                     <slur xml:id="scnuf3e" startid="#n1xigmo0" endid="#n1g20rnd" curvedir="above" />
                     <beamSpan xml:id="b13bopbt" startid="#n14tgd9x" endid="#nll6y1l" />
                     <slur xml:id="so88il5" startid="#n14tgd9x" endid="#nll6y1l" curvedir="above" />
                  </measure>
                  <measure xml:id="mwp7iqm" right="dbl">
                     <staff xml:id="ss22r58" n="1">
                        <layer xml:id="l16ytpcw" n="1">
                           <note xml:id="nyursii" dur="16" staff="2" oct="5" pname="d" stem.dir="up" />
                           <note xml:id="n1ml8cji" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid="n" />
                           <note xml:id="n17s8jxg" dur="16" oct="5" pname="g" stem.dir="down" />
                           <note xml:id="n1d2fdxo" dur="16" oct="6" pname="d" stem.dir="down" />
                           <note xml:id="n1n9odzq" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                           <note xml:id="nupeob3" dur="16" staff="2" oct="5" pname="e" stem.dir="up" />
                           <note xml:id="n1ryzno9" dur="16" oct="5" pname="g" stem.dir="down" />
                           <note xml:id="n1v8xz9t" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="n8d99cr" dur="16" staff="2" oct="4" pname="b" stem.dir="up" />
                           <note xml:id="n1g8xtol" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                           <note xml:id="n1lh8awq" dur="16" oct="5" pname="g" stem.dir="down" />
                           <note xml:id="n1sdtbk0" dur="16" oct="6" pname="c" stem.dir="down" />
                           <note xml:id="nhhmpqg" dur="16" staff="2" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="nsjxxft" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                           <note xml:id="n1oqts8g" dur="16" oct="5" pname="e" stem.dir="down" />
                           <note xml:id="n14r47ne" dur="16" oct="5" pname="a" stem.dir="down" />
                        </layer>
                     </staff>
                     <staff xml:id="sec06s6" n="2">
                        <layer xml:id="l10op3pg" n="2">
                           <note xml:id="n1azs8o3" dur="4" oct="5" pname="d" stem.dir="down">
                              <artic xml:id="a1gfgq1" artic="ten" />
                           </note>
                           <note xml:id="nm640j0" dur="4" oct="5" pname="c" stem.dir="down">
                              <artic xml:id="a1hevtxn" artic="ten" />
                           </note>
                           <note xml:id="n1dqbam3" dur="4" oct="4" pname="b" stem.dir="down">
                              <artic xml:id="amq060e" artic="ten" />
                           </note>
                           <note xml:id="nf4q3yl" dur="4" oct="4" pname="a" stem.dir="down">
                              <artic xml:id="a6j3znf" artic="ten" />
                           </note>
                        </layer>
                     </staff>
                     <beamSpan xml:id="bb3zswg" startid="#nyursii" endid="#n1d2fdxo" />
                     <slur xml:id="s1kmqx8j" startid="#nyursii" endid="#n1d2fdxo" curvedir="above" />
                     <slur xml:id="s16e90gi" startid="#nyursii" endid="#n5r8tdx" curvedir="below" />
                     <beamSpan xml:id="b1o7ujfu" startid="#n1n9odzq" endid="#n1v8xz9t" />
                     <slur xml:id="slp0evj" startid="#n1n9odzq" endid="#n1v8xz9t" curvedir="above" />
                     <beamSpan xml:id="b1ckeh2o" startid="#n8d99cr" endid="#n1sdtbk0" />
                     <slur xml:id="s1wnnrto" startid="#n8d99cr" endid="#n1sdtbk0" curvedir="above" />
                     <beamSpan xml:id="b1ox85hz" startid="#nhhmpqg" endid="#n14r47ne" />
                     <slur xml:id="s1s0gpve" startid="#nhhmpqg" endid="#n14r47ne" curvedir="above" />
                  </measure>
               </section>
               <section xml:id="x6u1oc9">
                  <measure xml:id="x18a955r">
                     <staff xml:id="xgps2r1" n="1">
                        <layer xml:id="x13vjyyl" n="1">
                           <beam>
                              <note xml:id="xx4sq2g" dur="16" staff="2" oct="5" pname="f" stem.dir="up" />
                              <note xml:id="x17igtg0" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid="f" />
                              <note xml:id="x1e9f64q" dur="16" oct="6" pname="c" stem.dir="down" />
                              <note xml:id="x1cojmad" dur="16" oct="6" pname="f" stem.dir="down" />
                           </beam>
                           <beam>
                              <note xml:id="x11h7ld9" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid="f" />
                              <note xml:id="xb2syjc" dur="16" staff="2" oct="5" pname="a" stem.dir="up" accid.ges="f" />
                              <note xml:id="x2fkm3m" dur="16" oct="6" pname="c" stem.dir="down" />
                              <note xml:id="xqg6e2s" dur="16" oct="6" pname="e" stem.dir="down" accid="f" />
                           </beam>
                           <beam>
                              <note xml:id="x1xigmo0" dur="16" staff="2" oct="5" pname="d" stem.dir="up" />
                              <note xml:id="x1oj6x9n" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                              <note xml:id="x4wdykt" dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                              <note xml:id="x1g20rnd" dur="16" oct="6" pname="d" stem.dir="down" />
                           </beam>
                           <beam>
                              <note xml:id="x14tgd9x" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                              <note xml:id="xgrc39q" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid.ges="f" />
                              <note xml:id="xkj3d4z" dur="16" oct="5" pname="a" stem.dir="down" accid.ges="f" />
                              <note xml:id="xll6y1l" dur="16" oct="6" pname="c" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="x1amslu4" n="2">
                        <layer xml:id="xbjx4lf" n="2">
                           <note xml:id="x1ly2an" dur="4" oct="5" pname="f" stem.dir="down">
                              <artic xml:id="x1k3vnfp" artic="ten" />
                           </note>
                           <note xml:id="x8rk653" dur="4" oct="5" pname="e" stem.dir="down" accid="f">
                              <artic xml:id="x1equ1v3" artic="ten" />
                           </note>
                           <note xml:id="x18xznn2" dur="4" oct="5" pname="d" stem.dir="down">
                              <artic xml:id="x6o5l0z" artic="ten" />
                           </note>
                           <note xml:id="x1tnfpu3" dur="4" oct="5" pname="c" stem.dir="down">
                              <artic xml:id="x12idr4z" artic="ten" />
                           </note>
                        </layer>
                     </staff>
                     <slur xml:id="x1m3jnti" startid="#xx4sq2g" endid="#x1cojmad" curvedir="above" />
                     <slur xml:id="x163pkt0" startid="#x11h7ld9" endid="#xqg6e2s" curvedir="above" />
                     <slur xml:id="xcnuf3e" startid="#x1xigmo0" endid="#x1g20rnd" curvedir="above" />
                     <slur xml:id="xo88il5" startid="#x14tgd9x" endid="#xll6y1l" curvedir="above" />
                  </measure>
                  <measure xml:id="xwp7iqm" right="dbl">
                     <staff xml:id="xs22r58" n="1">
                        <layer xml:id="x16ytpcw" n="1">
                           <beam>
                              <note xml:id="xyursii" dur="16" staff="2" oct="5" pname="d" stem.dir="up" />
                              <note xml:id="x1ml8cji" dur="16" staff="2" oct="5" pname="e" stem.dir="up" accid="n" />
                              <note xml:id="x17s8jxg" dur="16" oct="5" pname="g" stem.dir="down" />
                              <note xml:id="x1d2fdxo" dur="16" oct="6" pname="d" stem.dir="down" />
                           </beam>
                           <beam>
                              <note xml:id="x1n9odzq" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                              <note xml:id="xupeob3" dur="16" staff="2" oct="5" pname="e" stem.dir="up" />
                              <note xml:id="x1ryzno9" dur="16" oct="5" pname="g" stem.dir="down" />
                              <note xml:id="x1v8xz9t" dur="16" oct="6" pname="c" stem.dir="down" />
                           </beam>
                           <beam>
                              <note xml:id="x8d99cr" dur="16" staff="2" oct="4" pname="b" stem.dir="up" />
                              <note xml:id="x1g8xtol" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                              <note xml:id="x1lh8awq" dur="16" oct="5" pname="g" stem.dir="down" />
                              <note xml:id="x1sdtbk0" dur="16" oct="6" pname="c" stem.dir="down" />
                           </beam>
                           <beam>
                              <note xml:id="xhhmpqg" dur="16" staff="2" oct="4" pname="a" stem.dir="up" />
                              <note xml:id="xsjxxft" dur="16" staff="2" oct="5" pname="c" stem.dir="up" />
                              <note xml:id="x1oqts8g" dur="16" oct="5" pname="e" stem.dir="down" />
                              <note xml:id="x14r47ne" dur="16" oct="5" pname="a" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="xec06s6" n="2">
                        <layer xml:id="x10op3pg" n="2">
                           <note xml:id="x1azs8o3" dur="4" oct="5" pname="d" stem.dir="down">
                              <artic xml:id="x1gfgq1" artic="ten" />
                           </note>
                           <note xml:id="xm640j0" dur="4" oct="5" pname="c" stem.dir="down">
                              <artic xml:id="x1hevtxn" artic="ten" />
                           </note>
                           <note xml:id="x1dqbam3" dur="4" oct="4" pname="b" stem.dir="down">
                              <artic xml:id="xmq060e" artic="ten" />
                           </note>
                           <note xml:id="xf4q3yl" dur="4" oct="4" pname="a" stem.dir="down">
                              <artic xml:id="x6j3znf" artic="ten" />
                           </note>
                        </layer>
                     </staff>
                     <slur xml:id="x1kmqx8j" startid="#xyursii" endid="#x1d2fdxo" curvedir="above" />
                     <slur xml:id="x16e90gi" startid="#xyursii" endid="#x5r8tdx" curvedir="below" />
                     <slur xml:id="xlp0evj" startid="#x1n9odzq" endid="#x1v8xz9t" curvedir="above" />
                     <slur xml:id="x1wnnrto" startid="#x8d99cr" endid="#x1sdtbk0" curvedir="above" />
                     <slur xml:id="x1s0gpve" startid="#xhhmpqg" endid="#x14r47ne" curvedir="above" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>