### PR TITLE
Option for compound dynamics glyph usage

### DIFF
--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -77,7 +77,7 @@ public:
      * Return the SMuFL str for the dynamic symbol.
      * Call IsSymbolOnly first to check.
      */
-    std::wstring GetSymbolStr() const;
+    std::wstring GetSymbolStr(const bool singleGlyphs) const;
 
     /**
      * See FloatingObject::IsExtenderElement
@@ -97,7 +97,7 @@ public:
 
     static bool IsSymbolOnly(const std::wstring &str);
 
-    static std::wstring GetSymbolStr(const std::wstring &str);
+    static std::wstring GetSymbolStr(const std::wstring &str, const bool singleGlyphs);
 
     //----------//
     // Functors //

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -659,6 +659,7 @@ public:
     OptionDbl m_dashedBarLineDashLength;
     OptionDbl m_dashedBarLineGapLength;
     OptionDbl m_dynamDist;
+    OptionBool m_dynamSingleGlyphs;
     OptionJson m_engravingDefaults;
     OptionJson m_engravingDefaultsFile;
     OptionDbl m_extenderLineMinSpace;

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -14,6 +14,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "doc.h"
 #include "editorial.h"
 #include "functorparams.h"
 #include "hairpin.h"
@@ -97,9 +98,9 @@ bool Dynam::IsSymbolOnly() const
     return false;
 }
 
-std::wstring Dynam::GetSymbolStr() const
+std::wstring Dynam::GetSymbolStr(const bool singleGlyphs) const
 {
-    return Dynam::GetSymbolStr(m_symbolStr);
+    return Dynam::GetSymbolStr(m_symbolStr, singleGlyphs);
 }
 
 std::pair<wchar_t, wchar_t> Dynam::GetEnclosingGlyphs() const
@@ -174,69 +175,71 @@ bool Dynam::IsSymbolOnly(const std::wstring &str)
     return false;
 }
 
-std::wstring Dynam::GetSymbolStr(const std::wstring &str)
+std::wstring Dynam::GetSymbolStr(const std::wstring &str, const bool singleGlyphs)
 {
     std::wstring dynam;
-    if (str == L"p")
-        dynam.push_back(SMUFL_E520_dynamicPiano);
-    else if (str == L"m")
-        dynam.push_back(SMUFL_E521_dynamicMezzo);
-    else if (str == L"f")
-        dynam.push_back(SMUFL_E522_dynamicForte);
-    else if (str == L"r")
-        dynam.push_back(SMUFL_E523_dynamicRinforzando);
-    else if (str == L"s")
-        dynam.push_back(SMUFL_E524_dynamicSforzando);
-    else if (str == L"z")
-        dynam.push_back(SMUFL_E525_dynamicZ);
-    else if (str == L"n")
-        dynam.push_back(SMUFL_E526_dynamicNiente);
-    else if (str == L"pppppp")
-        dynam.push_back(SMUFL_E527_dynamicPPPPPP);
-    else if (str == L"ppppp")
-        dynam.push_back(SMUFL_E528_dynamicPPPPP);
-    else if (str == L"pppp")
-        dynam.push_back(SMUFL_E529_dynamicPPPP);
-    else if (str == L"ppp")
-        dynam.push_back(SMUFL_E52A_dynamicPPP);
-    else if (str == L"pp")
-        dynam.push_back(SMUFL_E52B_dynamicPP);
-    else if (str == L"mp")
-        dynam.push_back(SMUFL_E52C_dynamicMP);
-    else if (str == L"mf")
-        dynam.push_back(SMUFL_E52D_dynamicMF);
-    else if (str == L"pf")
-        dynam.push_back(SMUFL_E52E_dynamicPF);
-    else if (str == L"ff")
-        dynam.push_back(SMUFL_E52F_dynamicFF);
-    else if (str == L"fff")
-        dynam.push_back(SMUFL_E530_dynamicFFF);
-    else if (str == L"ffff")
-        dynam.push_back(SMUFL_E531_dynamicFFFF);
-    else if (str == L"fffff")
-        dynam.push_back(SMUFL_E532_dynamicFFFFF);
-    else if (str == L"ffffff")
-        dynam.push_back(SMUFL_E533_dynamicFFFFFF);
-    else if (str == L"fp")
-        dynam.push_back(SMUFL_E534_dynamicFortePiano);
-    else if (str == L"fz")
-        dynam.push_back(SMUFL_E535_dynamicForzando);
-    else if (str == L"sf")
-        dynam.push_back(SMUFL_E536_dynamicSforzando1);
-    else if (str == L"sfp")
-        dynam.push_back(SMUFL_E537_dynamicSforzandoPiano);
-    else if (str == L"sfpp")
-        dynam.push_back(SMUFL_E538_dynamicSforzandoPianissimo);
-    else if (str == L"sfz")
-        dynam.push_back(SMUFL_E539_dynamicSforzato);
-    else if (str == L"sfzp")
-        dynam.push_back(SMUFL_E53A_dynamicSforzatoPiano);
-    else if (str == L"sffz")
-        dynam.push_back(SMUFL_E53B_dynamicSforzatoFF);
-    else if (str == L"rf")
-        dynam.push_back(SMUFL_E53C_dynamicRinforzando1);
-    else if (str == L"rfz")
-        dynam.push_back(SMUFL_E53D_dynamicRinforzando2);
+    if (!singleGlyphs) {
+        if (str == L"p")
+            dynam.push_back(SMUFL_E520_dynamicPiano);
+        else if (str == L"m")
+            dynam.push_back(SMUFL_E521_dynamicMezzo);
+        else if (str == L"f")
+            dynam.push_back(SMUFL_E522_dynamicForte);
+        else if (str == L"r")
+            dynam.push_back(SMUFL_E523_dynamicRinforzando);
+        else if (str == L"s")
+            dynam.push_back(SMUFL_E524_dynamicSforzando);
+        else if (str == L"z")
+            dynam.push_back(SMUFL_E525_dynamicZ);
+        else if (str == L"n")
+            dynam.push_back(SMUFL_E526_dynamicNiente);
+        else if (str == L"pppppp")
+            dynam.push_back(SMUFL_E527_dynamicPPPPPP);
+        else if (str == L"ppppp")
+            dynam.push_back(SMUFL_E528_dynamicPPPPP);
+        else if (str == L"pppp")
+            dynam.push_back(SMUFL_E529_dynamicPPPP);
+        else if (str == L"ppp")
+            dynam.push_back(SMUFL_E52A_dynamicPPP);
+        else if (str == L"pp")
+            dynam.push_back(SMUFL_E52B_dynamicPP);
+        else if (str == L"mp")
+            dynam.push_back(SMUFL_E52C_dynamicMP);
+        else if (str == L"mf")
+            dynam.push_back(SMUFL_E52D_dynamicMF);
+        else if (str == L"pf")
+            dynam.push_back(SMUFL_E52E_dynamicPF);
+        else if (str == L"ff")
+            dynam.push_back(SMUFL_E52F_dynamicFF);
+        else if (str == L"fff")
+            dynam.push_back(SMUFL_E530_dynamicFFF);
+        else if (str == L"ffff")
+            dynam.push_back(SMUFL_E531_dynamicFFFF);
+        else if (str == L"fffff")
+            dynam.push_back(SMUFL_E532_dynamicFFFFF);
+        else if (str == L"ffffff")
+            dynam.push_back(SMUFL_E533_dynamicFFFFFF);
+        else if (str == L"fp")
+            dynam.push_back(SMUFL_E534_dynamicFortePiano);
+        else if (str == L"fz")
+            dynam.push_back(SMUFL_E535_dynamicForzando);
+        else if (str == L"sf")
+            dynam.push_back(SMUFL_E536_dynamicSforzando1);
+        else if (str == L"sfp")
+            dynam.push_back(SMUFL_E537_dynamicSforzandoPiano);
+        else if (str == L"sfpp")
+            dynam.push_back(SMUFL_E538_dynamicSforzandoPianissimo);
+        else if (str == L"sfz")
+            dynam.push_back(SMUFL_E539_dynamicSforzato);
+        else if (str == L"sfzp")
+            dynam.push_back(SMUFL_E53A_dynamicSforzatoPiano);
+        else if (str == L"sffz")
+            dynam.push_back(SMUFL_E53B_dynamicSforzatoFF);
+        else if (str == L"rf")
+            dynam.push_back(SMUFL_E53C_dynamicRinforzando1);
+        else if (str == L"rfz")
+            dynam.push_back(SMUFL_E53D_dynamicRinforzando2);
+    }
 
     if (!dynam.empty()) return dynam;
 

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -14,7 +14,6 @@
 
 //----------------------------------------------------------------------------
 
-#include "doc.h"
 #include "editorial.h"
 #include "functorparams.h"
 #include "hairpin.h"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1217,6 +1217,10 @@ Options::Options()
     m_dynamDist.Init(1.0, 0.5, 16.0);
     this->Register(&m_dynamDist, "dynamDist", &m_generalLayout);
 
+    m_dynamSingleGlyphs.SetInfo("Dynam single glyphs", "Don't use SMuFL's predefined dynamics glyph combinations");
+    m_dynamSingleGlyphs.Init(false);
+    this->Register(&m_dynamSingleGlyphs, "dynamSingleGlyphs", &m_generalLayout);
+
     m_engravingDefaults.SetInfo("Engraving defaults", "Json describing defaults for engraving SMuFL elements");
     m_engravingDefaults.Init(JsonSource::String, "{}");
     this->Register(&m_engravingDefaults, "engravingDefaults", &m_generalLayout);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1604,10 +1604,6 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
     dc->StartGraphic(dynam, "", dynam->GetID());
 
     bool isSymbolOnly = dynam->IsSymbolOnly();
-    std::wstring dynamSymbol;
-    if (isSymbolOnly) {
-        dynamSymbol = dynam->GetSymbolStr();
-    }
 
     FontInfo dynamTxt;
     if (!dc->UseGlobalStyling()) {
@@ -1655,6 +1651,8 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
         // If the dynamic is a symbol (pp, mf, etc.) draw it as one SMuFL string. This will not take into account
         // editorial element within the dynam as it would with text. Also, it is center only if it is a symbol.
         if (isSymbolOnly) {
+            const bool singleGlyphs = m_doc->GetOptions()->m_dynamSingleGlyphs.GetValue();
+            std::wstring dynamSymbol = dynam->GetSymbolStr(singleGlyphs);
             this->DrawDynamSymbolOnly(dc, *staffIter, dynam, dynamSymbol, alignment, params);
         }
         else {

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -71,6 +71,8 @@ void View::DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParam
 {
     assert(dc);
 
+    const bool singleGlyphs = m_doc->GetOptions()->m_dynamSingleGlyphs.GetValue();
+
     if (rend && rend->HasFontfam()) {
         this->DrawTextString(dc, str, params);
         return;
@@ -96,7 +98,7 @@ void View::DrawDynamString(DeviceContext *dc, std::wstring str, TextDrawingParam
             first = false;
 
             if (token.second) {
-                std::wstring smuflStr = Dynam::GetSymbolStr(token.first);
+                std::wstring smuflStr = Dynam::GetSymbolStr(token.first, singleGlyphs);
                 FontInfo vrvTxt;
                 vrvTxt.SetFaceName("VerovioText");
                 vrvTxt.SetStyle(FONTSTYLE_normal);


### PR DESCRIPTION
This PR adds another option to switch from using SMuFL's pre-defined compound dynamics glyphs to using single glyphs for rendering.