### PR TITLE
Fix issue with badly encoded sameas

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2637,16 +2637,14 @@ int LayerElement::InitOnsetOffset(FunctorParams *functorParams)
         // note->GetNoteOrChordDur(element), note->GetDiatonicPitch(), *midiTrack);
         // LogDebug("Oct %d - Pname %d - Accid %d", note->GetOct(), note->GetPname(), note->GetAccid());
 
-        Note *storeNote = note;
         // When we have a @sameas, do store the onset / offset values of the pointed note in the pointing note
-        if (this != element) {
-            storeNote = dynamic_cast<Note *>(this);
+        Note *storeNote = (this == element) ? note : dynamic_cast<Note *>(this);
+        if (storeNote) {
+            storeNote->SetScoreTimeOnset(params->m_currentScoreTime);
+            storeNote->SetRealTimeOnsetSeconds(params->m_currentRealTimeSeconds);
+            storeNote->SetScoreTimeOffset(params->m_currentScoreTime + incrementScoreTime);
+            storeNote->SetRealTimeOffsetSeconds(params->m_currentRealTimeSeconds + realTimeIncrementSeconds);
         }
-        assert(storeNote);
-        storeNote->SetScoreTimeOnset(params->m_currentScoreTime);
-        storeNote->SetRealTimeOnsetSeconds(params->m_currentRealTimeSeconds);
-        storeNote->SetScoreTimeOffset(params->m_currentScoreTime + incrementScoreTime);
-        storeNote->SetRealTimeOffsetSeconds(params->m_currentRealTimeSeconds + realTimeIncrementSeconds);
 
         // increase the currentTime accordingly, but only if not in a chord or tabGrp - checkit with note->IsChordTone()
         // or note->IsTabGrpNote()

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1907,6 +1907,12 @@ int Object::PrepareLinking(FunctorParams *functorParams)
     if (r2.first != params->m_sameasIDPairs.end()) {
         for (auto j = r2.first; j != r2.second; ++j) {
             j->second->SetSameasLink(this);
+            // Issue a warning if classes of object and sameas do not match
+            Object *owner = dynamic_cast<Object *>(j->second);
+            if (owner && (owner->GetClassId() != this->GetClassId())) {
+                LogWarning("%s with @xml:id %s has @sameas to an element of class %s.", owner->GetClassName().c_str(),
+                    owner->GetID().c_str(), this->GetClassName().c_str());
+            }
         }
         params->m_sameasIDPairs.erase(r2.first, r2.second);
     }


### PR DESCRIPTION
This PR fixes a crash during time map creation due to a badly encoded `@sameas`. It also adds a warning to better detect such encodings.