### PR TITLE
Allow multiple stems

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -505,8 +505,7 @@ protected:
      * Defined in view_mensural.cpp
      */
     ///@{
-    void DrawMensuralStem(DeviceContext *dc, Note *note, Staff *staff, data_STEMDIRECTION dir, int radius, int xn,
-        int originY, int heightY = 0);
+    void DrawMensuralStem(DeviceContext *dc, Note *note, Staff *staff, data_STEMDIRECTION dir, int xn, int originY);
     void DrawMaximaToBrevis(DeviceContext *dc, int y, LayerElement *element, Layer *layer, Staff *staff);
     void DrawProportFigures(DeviceContext *dc, int x, int y, int num, int numBase, Staff *staff);
     void DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -629,7 +629,7 @@ private:
     /**
      * Internal method to find stem direction for notes of mensural notation
      */
-    data_STEMDIRECTION GetMensuralStemDirection(Layer *layer, Note *note, int verticalCenter);
+    data_STEMDIRECTION GetMensuralStemDir(Layer *layer, Note *note, int verticalCenter);
 
 public:
     /** Document */

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1302,7 +1302,7 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
     Chord *chord = this->IsChordTone();
     if (currentStem) currentFlag = dynamic_cast<Flag *>(currentStem->GetFirst(FLAG));
 
-    if (!this->IsChordTone() && !this->IsMensuralDur() && !this->IsTabGrpNote()) {
+    if (!this->IsChordTone() && !this->IsTabGrpNote()) {
         if (!currentStem) {
             currentStem = new Stem();
             currentStem->IsAttribute(true);
@@ -1324,8 +1324,11 @@ int Note::PrepareLayerElementParts(FunctorParams *functorParams)
         }
     }
 
+    // We don't care about flags or dots in mensural notes
+    if (this->IsMensuralDur()) return FUNCTOR_CONTINUE;
+
     if ((this->GetActualDur() > DUR_4) && !this->IsInBeam() && !this->GetAncestorFTrem() && !this->IsChordTone()
-        && !this->IsMensuralDur() && !this->IsTabGrpNote()) {
+        && !this->IsTabGrpNote()) {
         // We should have a stem at this stage
         assert(currentStem);
         if (!currentFlag) {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1029,8 +1029,8 @@ int Note::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_SIBLINGS;
     }
 
-    // We currently have no stem object with mensural notes
-    // We also have no stem  with tab because it belongs to tabDurSym in this case
+    // We do not need to calc stems for mensural notes
+    // We have no stem with tab because it belongs to tabDurSym in this case
     if (this->IsMensuralDur() || this->IsTabGrpNote()) {
         return FUNCTOR_SIBLINGS;
     }
@@ -1040,7 +1040,7 @@ int Note::CalcStem(FunctorParams *functorParams)
         return FUNCTOR_CONTINUE;
     }
 
-    // This now need should be NULL and the chord stem length will be 0
+    // This now should be NULL and the chord stem length will be 0
     params->m_interface = NULL;
     params->m_chordStemLength = 0;
 

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -227,7 +227,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
     assert(params->m_staff);
     assert(params->m_layer);
     assert(params->m_interface);
-    
+
     const int staffSize = params->m_staff->m_drawingStaffSize;
     const int stemShift = params->m_doc->GetDrawingStemWidth(staffSize) / 2;
     const bool drawingCueSize = this->GetDrawingCueSize();

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -227,10 +227,10 @@ int Stem::CalcStem(FunctorParams *functorParams)
     assert(params->m_staff);
     assert(params->m_layer);
     assert(params->m_interface);
-
-    int staffSize = params->m_staff->m_drawingStaffSize;
-    int stemShift = params->m_doc->GetDrawingStemWidth(staffSize) / 2;
-    bool drawingCueSize = this->GetDrawingCueSize();
+    
+    const int staffSize = params->m_staff->m_drawingStaffSize;
+    const int stemShift = params->m_doc->GetDrawingStemWidth(staffSize) / 2;
+    const bool drawingCueSize = this->GetDrawingCueSize();
 
     // For notes longer than half notes the stem is always 0
     if (params->m_dur < DUR_2) {
@@ -252,7 +252,7 @@ int Stem::CalcStem(FunctorParams *functorParams)
     }
     // Do not adjust the baseStem for stem sameas notes (its length is in m_chordStemLength)
     else if (!params->m_isStemSameasSecondary) {
-        int thirdUnit = unit / 3;
+        const int thirdUnit = unit / 3;
         const data_STEMDIRECTION stemDir = params->m_interface->GetDrawingStemDir();
         baseStem = -(params->m_interface->CalcStemLenInThirdUnits(params->m_staff, stemDir) * thirdUnit);
         if (drawingCueSize) baseStem = params->m_doc->GetCueSize(baseStem);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1506,10 +1506,10 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         if (((parent->GetDrawingDur() > DUR_1) || ((parent->GetStemDir() != STEMDIRECTION_NONE)))
             && stem->GetVisible() != BOOLEAN_false) {
             /************** Stem/notehead direction: **************/
-            const int staffY = staff->GetDrawingY();
-            const int verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
+            const int staffCenter
+                = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
             const data_STEMDIRECTION stemDir
-                = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDir(layer, parent, verticalCenter);
+                = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDir(layer, parent, staffCenter);
             /************** Draw stem: **************/
             dc->StartGraphic(element, "", element->GetID());
             this->DrawMensuralStem(dc, parent, staff, stemDir, parent->GetDrawingX(), parent->GetDrawingY());

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1512,7 +1512,7 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
                 = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDir(layer, parent, verticalCenter);
             /************** Draw stem: **************/
             dc->StartGraphic(element, "", element->GetID());
-            this->DrawMensuralStem(dc, parent, staff, stemDir, parent->GetDrawingRadius(m_doc), parent->GetDrawingX(), parent->GetDrawingY());
+            this->DrawMensuralStem(dc, parent, staff, stemDir, parent->GetDrawingX(), parent->GetDrawingY());
             dc->EndGraphic(element, this);
         }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -266,7 +266,7 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             if (note->IsMensuralDur()) {
                 if (accid->GetFunc() != accidLog_FUNC_edit) onStaff = (accid->GetOnstaff() != BOOLEAN_false);
                 const int verticalCenter = staffTop - (staff->m_drawingLines - 1) * unit;
-                const data_STEMDIRECTION stemDir = this->GetMensuralStemDirection(layer, note, verticalCenter);
+                const data_STEMDIRECTION stemDir = this->GetMensuralStemDir(layer, note, verticalCenter);
                 if ((drawingDur > DUR_1) || (drawingDur < DUR_BR)) {
                     if (stemDir == STEMDIRECTION_up) {
                         noteTop = note->GetDrawingY() + unit * STANDARD_STEMLENGTH;
@@ -1508,7 +1508,8 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
             /************** Stem/notehead direction: **************/
             const int staffY = staff->GetDrawingY();
             const int verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
-            const data_STEMDIRECTION stemDir = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDirection(layer, parent, verticalCenter);
+            const data_STEMDIRECTION stemDir
+                = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDir(layer, parent, verticalCenter);
             /************** Draw stem: **************/
             dc->StartGraphic(element, "", element->GetID());
             this->DrawMensuralStem(dc, parent, staff, stemDir, parent->GetDrawingRadius(m_doc), parent->GetDrawingX(), parent->GetDrawingY());

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1500,6 +1500,24 @@ void View::DrawStem(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     Stem *stem = vrv_cast<Stem *>(element);
     assert(stem);
 
+    // We check if this belongs to a mensural note
+    Note *parent = vrv_cast<Note *>(stem->GetFirstAncestor(NOTE));
+    if (parent && parent->IsMensuralDur()) {
+        if (((parent->GetDrawingDur() > DUR_1) || ((parent->GetStemDir() != STEMDIRECTION_NONE)))
+            && stem->GetVisible() != BOOLEAN_false) {
+            /************** Stem/notehead direction: **************/
+            const int staffY = staff->GetDrawingY();
+            const int verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
+            const data_STEMDIRECTION stemDir = (stem->HasDir()) ? stem->GetDir() : this->GetMensuralStemDirection(layer, parent, verticalCenter);
+            /************** Draw stem: **************/
+            dc->StartGraphic(element, "", element->GetID());
+            this->DrawMensuralStem(dc, parent, staff, stemDir, parent->GetDrawingRadius(m_doc), parent->GetDrawingX(), parent->GetDrawingY());
+            dc->EndGraphic(element, this);
+        }
+
+        return;
+    }
+
     // Do not draw virtual (e.g., whole note) stems
     if (stem->IsVirtual()) return;
 

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -174,18 +174,15 @@ void View::DrawMensuralStem(
         In both cases, as in CWMN, each shorter duration gets one additional flag. */
     const int nbFlags = (mensural_black ? drawingDur - DUR_2 : drawingDur - DUR_4);
 
+    // SMuFL'S mensural stems are not centered
     const int halfStemWidth
         = m_doc->GetGlyphWidth(SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize) / 2;
     const int yOffset = m_doc->GetDrawingUnit(staffSize) - halfStemWidth;
+    originY = (dir == STEMDIRECTION_up) ? originY + yOffset : originY - yOffset;
 
     // draw the stems and the flags
-
-    dc->StartCustomGraphic("stem");
-
     wchar_t code;
     if (dir == STEMDIRECTION_up) {
-        originY += yOffset;
-
         switch (nbFlags) {
             case 1: code = SMUFL_E949_mensuralCombStemUpFlagSemiminima; break;
             case 2: code = SMUFL_E94B_mensuralCombStemUpFlagFusa; break;
@@ -193,7 +190,6 @@ void View::DrawMensuralStem(
         }
     }
     else {
-        originY -= yOffset;
         switch (nbFlags) {
             case 1: code = SMUFL_E94A_mensuralCombStemDownFlagSemiminima; break;
             case 2: code = SMUFL_E94C_mensuralCombStemDownFlagFusa; break;
@@ -202,7 +198,6 @@ void View::DrawMensuralStem(
     }
 
     this->DrawSmuflCode(dc, xn + radius - halfStemWidth, originY, code, staff->m_drawingStaffSize, drawingCueSize);
-    dc->EndCustomGraphic();
 
     // Store the stem direction ?
     note->SetDrawingStemDir(dir);

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -145,16 +145,15 @@ void View::DrawMensur(DeviceContext *dc, LayerElement *element, Layer *layer, St
     dc->EndGraphic(element, this);
 } // namespace vrv
 
-
 /* This function draws any flags as well as the stem. */
 
-void View::DrawMensuralStem(
-    DeviceContext *dc, Note *note, Staff *staff, data_STEMDIRECTION dir, int radius, int xn, int originY, int heightY)
+void View::DrawMensuralStem(DeviceContext *dc, Note *note, Staff *staff, data_STEMDIRECTION dir, int xn, int originY)
 {
     assert(note);
 
     const int staffSize = staff->m_drawingStaffSize;
     const int drawingDur = note->GetDrawingDur();
+    const int radius = note->GetDrawingRadius(m_doc);
     // Cue size is currently disabled
     const bool drawingCueSize = false;
     const bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -691,7 +691,7 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
     }
 }
 
-data_STEMDIRECTION View::GetMensuralStemDirection(Layer *layer, Note *note, int verticalCenter)
+data_STEMDIRECTION View::GetMensuralStemDir(Layer *layer, Note *note, int verticalCenter)
 {
     // constants
     const int drawingDur = note->GetDrawingDur();

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -163,7 +163,7 @@ void View::DrawMensuralStem(
         In both cases, as in CWMN, each shorter duration gets one additional flag. */
     const int nbFlags = (mensural_black ? drawingDur - DUR_2 : drawingDur - DUR_4);
 
-    // SMuFL'S mensural stems are not centered
+    // SMuFL's mensural stems are not centered
     const int halfStemWidth
         = m_doc->GetGlyphWidth(SMUFL_E93E_mensuralCombStemUp, staff->m_drawingStaffSize, drawingCueSize) / 2;
     const int yOffset = m_doc->GetDrawingUnit(staffSize) - halfStemWidth;

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -51,7 +51,6 @@ void View::DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *lay
     const int yNote = element->GetDrawingY();
     const int xNote = element->GetDrawingX();
     const int drawingDur = note->GetDrawingDur();
-    const bool mensural_black = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
 
     /************** Noteheads: **************/
 
@@ -68,17 +67,6 @@ void View::DrawMensuralNote(DeviceContext *dc, LayerElement *element, Layer *lay
         dc->StartCustomGraphic("notehead");
         this->DrawSmuflCode(dc, xNote, yNote, code, staff->m_drawingStaffSize, false);
         dc->EndCustomGraphic();
-        // For semibrevis with stem in black notation, encoded with an explicit stem direction
-        if (((drawingDur > DUR_1) || ((note->GetStemDir() != STEMDIRECTION_NONE) && mensural_black))
-            && note->GetStemVisible() != BOOLEAN_false) {
-            /************** Stem/notehead direction: **************/
-            const int radius = note->GetDrawingRadius(m_doc);
-            const int staffY = staff->GetDrawingY();
-            const int verticalCenter = staffY - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * 2;
-            const data_STEMDIRECTION stemDir = this->GetMensuralStemDirection(layer, note, verticalCenter);
-            /************** Draw stem: **************/
-            this->DrawMensuralStem(dc, note, staff, stemDir, radius, xNote, yNote);
-        }
     }
 
     /************ Draw children (verse / syl) ************/
@@ -156,6 +144,7 @@ void View::DrawMensur(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     dc->EndGraphic(element, this);
 } // namespace vrv
+
 
 /* This function draws any flags as well as the stem. */
 


### PR DESCRIPTION
This PR changes drawing method for mensural stems to allow more than one stem.

 ![image](https://user-images.githubusercontent.com/7693447/186938522-6f6f38c8-e628-450c-b459-c7675c8d8918.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Multiple stems on notes</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2022-08-24">2022-08-24</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot></annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.12.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" notationtype="mensural" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <note dur="minima" oct="5" pname="c">
                           <stem dir="up" xml:id="stem-01a" />
                           <stem dir="down" xml:id="stem-01b" />
                        </note>
                        <note dur="semiminima" oct="5" pname="c">
                           <stem dir="up" xml:id="stem-02a" />
                           <stem dir="down" xml:id="stem-02b" />
                        </note>
                        <note dur="fusa" oct="5" pname="c">
                           <stem dir="up" xml:id="stem-03" />
                        </note>
                        <note dur="semifusa" oct="5" pname="c">
                        </note>
                        <note dur="maxima" oct="5" pname="c">
                           <stem dir="up" xml:id="stem-maxima_a" />
                           <stem dir="down" xml:id="stem-maxima_b" />
                        </note>
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```