### PR TITLE
Add option to scale the output to the page size

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -625,6 +625,7 @@ public:
     OptionIntMap m_pedalStyle;
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
+    OptionBool m_scaleToPageSize;
     OptionBool m_showRuntime;
     OptionBool m_shrinkToFit;
     OptionBool m_staccatoCenter;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1957,6 +1957,12 @@ Page *Doc::SetDrawingPage(int pageIdx)
         m_drawingPageMarginLeft = m_options->m_pageMarginLeft.GetValue();
         m_drawingPageMarginRight = m_options->m_pageMarginRight.GetValue();
         m_drawingPageMarginTop = m_options->m_pageMarginTop.GetValue();
+
+        if (m_options->m_scaleToPageSize.GetValue()) {
+            m_drawingPageHeight = m_drawingPageHeight * 100 / m_options->m_scale.GetValue();
+            m_drawingPageWidth = m_drawingPageWidth * 100 / m_options->m_scale.GetValue();
+            // Margins do remain the same
+        }
     }
 
     if (m_options->m_landscape.GetValue()) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1085,6 +1085,11 @@ Options::Options()
     m_removeIds.Init(false);
     this->Register(&m_removeIds, "removeIds", &m_general);
 
+    m_scaleToPageSize.SetInfo(
+        "Scale to fit the page size", "Scale the content within the page instead of scaling the page itself");
+    m_scaleToPageSize.Init(false);
+    this->Register(&m_scaleToPageSize, "scaleToPageSize", &m_general);
+
     m_showRuntime.SetInfo("Show runtime on CLI", "Display the total runtime on command-line");
     m_showRuntime.Init(false);
     this->Register(&m_showRuntime, "showRuntime", &m_general);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -427,6 +427,12 @@ void SvgDeviceContext::StartPage()
                                                         .c_str();
     }
 
+    // page rectangle - for debugging
+    // pugi::xml_node pageRect = m_currentNode.append_child("rect");
+    // pageRect.append_attribute("fill") = "pink";
+    // pageRect.append_attribute("height") = StringFormat("%d", this->GetHeight()* DEFINITION_FACTOR).c_str();
+    // pageRect.append_attribute("width") = StringFormat("%d", this->GetWidth() * DEFINITION_FACTOR).c_str();
+
     // a graphic for the origin
     m_currentNode = m_currentNode.append_child("g");
     m_svgNodeStack.push_back(m_currentNode);
@@ -434,12 +440,13 @@ void SvgDeviceContext::StartPage()
     m_currentNode.append_attribute("transform")
         = StringFormat("translate(%d, %d)", (int)((double)m_originX), (int)((double)m_originY)).c_str();
 
-    // margin rectangle for debugging
-    // pugi::xml_node rect = m_currentNode.append_child("rect");
-    // rect.append_attribute("fill") = "pink";
-    // rect.append_attribute("height") = StringFormat("%d", this->GetHeight() * DEFINITION_FACTOR - 2 *
-    // m_originY).c_str(); rect.append_attribute("width") = StringFormat("%d", this->GetWidth() * DEFINITION_FACTOR - 2
-    // * m_originX).c_str();
+    // margin rectangle - for debugging
+    // pugi::xml_node marginRect = m_currentNode.append_child("rect");
+    // marginRect.append_attribute("fill") = "yellow";
+    // marginRect.append_attribute("height") = StringFormat("%d", this->GetHeight() * DEFINITION_FACTOR - 2 *
+    // m_originY).c_str();
+    // marginRect.append_attribute("width") = StringFormat("%d", this->GetWidth() * DEFINITION_FACTOR - 2
+    //* m_originX).c_str();
 
     m_pageNode = m_currentNode;
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1355,16 +1355,21 @@ bool Toolkit::RenderToDeviceContext(int pageNo, DeviceContext *deviceContext)
 
     // set dimensions
     if (m_options->m_landscape.GetValue()) {
-        deviceContext->SetWidth(height);
-        deviceContext->SetHeight(width);
-    }
-    else {
-        deviceContext->SetWidth(width);
-        deviceContext->SetHeight(height);
+        std::swap(height, width);
     }
 
-    double userScale = m_view.GetPPUFactor() * m_options->m_scale.GetValue() / 100;
+    double userScale = m_view.GetPPUFactor() * 100 / m_options->m_scale.GetValue();
+    assert(userScale != 0.0);
+
+    if (m_options->m_scaleToPageSize.GetValue()) {
+        height *= userScale;
+        width *= userScale;
+        userScale = 1.0 / userScale;
+    }
+
     deviceContext->SetUserScale(userScale, userScale);
+    deviceContext->SetWidth(width);
+    deviceContext->SetHeight(height);
 
     if (m_doc.GetType() == Facs) {
         deviceContext->SetWidth(m_doc.GetFacsimile()->GetMaxX());

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1358,13 +1358,12 @@ bool Toolkit::RenderToDeviceContext(int pageNo, DeviceContext *deviceContext)
         std::swap(height, width);
     }
 
-    double userScale = m_view.GetPPUFactor() * 100 / m_options->m_scale.GetValue();
+    double userScale = m_view.GetPPUFactor() * m_options->m_scale.GetValue() / 100;
     assert(userScale != 0.0);
 
     if (m_options->m_scaleToPageSize.GetValue()) {
-        height *= userScale;
-        width *= userScale;
-        userScale = 1.0 / userScale;
+        height *= (1.0 / userScale);
+        width *= (1.0 / userScale);
     }
 
     deviceContext->SetUserScale(userScale, userScale);


### PR DESCRIPTION
When the `scale` parameter is set, Verovio scales the output page accordingly. This means that, when targetting a certain output size, one needs to calculate the page size according to the scale parameter. 

The `--scale-to-page-size` option makes it possible to have Verovio behaving the other way around. That is, always producing an output with the same size independently from the scale factor and instead scaling the content. `RedoLayout()` needs to be called once the scale value is changed.

For example, with the option `--scale-to-page-size` on and `--page-height 800` and `--page-width 1000`, we have the following output with a scale of `100`, `50` and `10` respectively:

![image](https://user-images.githubusercontent.com/689412/188276312-0159576e-842e-4e5d-a43c-90f339a0aa9b.png)

---

![image](https://user-images.githubusercontent.com/689412/188276297-dbb8ffec-a2ac-4863-bfba-77961897375d.png)

---

![image](https://user-images.githubusercontent.com/689412/188276281-2c34e07d-aa9d-4eab-8ecd-dd435750da08.png)

---

This addresses requests raised before in #1533 and and #1055