### PR TITLE
Fix infinite loop

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1200,17 +1200,17 @@ void View::DrawMultiRest(DeviceContext *dc, LayerElement *element, Layer *layer,
     }
 
     // We do not support more than three chars
-    const int num = std::min(multiRest->GetNum(), 999);
+    const int num = multiRest->HasNum() ? std::min(multiRest->GetNum(), 999) : 1;
 
-    const int mutliRestThickness
+    const int multiRestThickness
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_doc->GetOptions()->m_multiRestThickness.GetValue();
     // Position centered in staff
     int y2 = staff->GetDrawingY() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1)
-        - mutliRestThickness / 2;
+        - multiRestThickness / 2;
     if (multiRest->HasLoc()) {
         y2 -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1 - multiRest->GetLoc());
     }
-    int y1 = y2 + mutliRestThickness;
+    int y1 = y2 + multiRestThickness;
 
     if (multiRest->UseBlockStyle(m_doc)) {
         // This is 1/2 the length of the black rectangle


### PR DESCRIPTION
This PR fixes an infinite loop when using `multirest` without `@num`.

<details>
<summary> Show MEI example </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2017-05-29">29 May 2017</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>When the block attribute is used, Verovio renders combinations of the 1, 2, and 4 measure rest forms.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="1.1.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="C" clef.line="1" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure right="dbl">
                     <staff n="1">
                        <layer n="1">
                           <multiRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure right="dbl">
                     <staff n="1">
                        <layer n="1">
                           <multiRest num="5" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>