### PR TITLE
Enable use of old PAE parser

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -20,6 +20,7 @@ option(NO_HUMDRUM_SUPPORT       "Disable Humdrum support"                      O
 option(MUSICXML_DEFAULT_HUMDRUM "Enable MusicXML to Humdrum by default"        OFF)
 option(NO_RUNTIME               "Disable runtime clock support"                ON)
 option(BUILD_AS_LIBRARY         "Build Verovio as library"                     OFF)
+option(USE_PAE_OLD_PARSER       "Use old PAE parser"                           OFF)
 
 if (NO_HUMDRUM_SUPPORT AND MUSICXML_DEFAULT_HUMDRUM)
     message(SEND_ERROR "Default MusicXML to Humdrum cannot be enabled by default without Humdrum support")
@@ -41,6 +42,7 @@ if(MSVC)
     add_definitions(/W2)
     add_definitions(/wd4244)          # suppress warning of possible loss of precision
     add_definitions(-DNO_PAE_SUPPORT) # regex is working differently under Windows so PAE is not supported (yet)
+    add_definitions(-DUSE_PAE_OLD_PARSER)
     add_definitions(/std:c++17)
     include_directories(../include/win32)
 else()
@@ -115,6 +117,10 @@ endif()
 
 if(NO_PAE_SUPPORT)
     add_definitions(-DNO_PAE_SUPPORT)
+endif()
+
+if(USE_PAE_OLD_PARSER)
+    add_definitions(-DUSE_PAE_OLD_PARSER)
 endif()
 
 if(NO_MUSICXML_SUPPORT)

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -15,7 +15,7 @@
  */
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
-//#define USE_PAE_OLD_PARSER
+#define USE_PAE_OLD_PARSER
 //----------------------------------------------------------------------------
 //----------------------------------------------------------------------------
 
@@ -403,6 +403,13 @@ public:
     // constructors and destructors
     PAEInput(Doc *doc);
     virtual ~PAEInput();
+
+    /**
+     * Return a JSON object with the validation log
+     * It is a single object when an input error is encountered.
+     * Otherwise, validation log errors/warnings are listed in their respective JSON input keys
+     */
+    jsonxx::Object GetValidationLog();
 
 #ifndef NO_PAE_SUPPORT
     bool Import(const std::string &pae) override;

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -640,6 +640,24 @@ PAEInput::PAEInput(Doc *doc)
 
 PAEInput::~PAEInput() {}
 
+jsonxx::Object PAEInput::GetValidationLog()
+{
+    jsonxx::Object log;
+
+    log << "Using old PAE parser";
+    /*// If we have an input error, that is the only one to log
+    if (!m_inputLog.empty()) {
+        log = m_inputLog;
+        return log;
+    }
+    if (!m_keysigLog.empty()) log << "keysig" << m_keysigLog;
+    if (!m_clefLog.empty()) log << "clef" << m_clefLog;
+    if (!m_timesigLog.empty()) log << "timesig" << m_timesigLog;
+    if (!m_dataLog.empty()) log << "data" << m_dataLog;
+    // LogDebug("%s", log.json().c_str());*/
+    return log;
+}
+
 #ifndef NO_PAE_SUPPORT
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Goals:
Enable use of old PAE parser defining `USE_PAE_OLD_PARSER` in [iopae.h](https://github.com/carlolic/verovio/blob/develop-pae-old-parser/include/vrv/iopae.h)
Older code inside the definition must be adapted to what is outside the definition (see `GetValidationLog()`).
Change the cmake file to enable the option `USE_PAE_OLD_PARSER` in the command line.

This PR is just to help comments and review. **Please, do not merge yet!**