### PR TITLE
Draw mensural dots as diamonds

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1063,7 +1063,7 @@ int Note::CalcStem(FunctorParams *functorParams)
     params->m_isGraceNote = this->IsGraceNote();
     params->m_isStemSameasSecondary = false;
 
-    int staffSize = staff->m_drawingStaffSize;
+    const int staffSize = staff->m_drawingStaffSize;
 
     params->m_verticalCenter
         = staff->GetDrawingY() - params->m_doc->GetDrawingUnit(staffSize) * (staff->m_drawingLines - 1);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -753,9 +753,9 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffs
     if (currentBrush.GetOpacity() != 1.0)
         polygonChild.append_attribute("fill-opacity") = StringFormat("%f", currentBrush.GetOpacity()).c_str();
 
-    std::string pointsString;
-    for (int i = 0; i < n; ++i) {
-        pointsString += StringFormat("%d,%d ", points[i].x + xOffset, points[i].y + yOffset);
+    std::string pointsString = StringFormat("%d,%d", points[0].x + xOffset, points[0].y + yOffset);
+    for (int i = 1; i < n; ++i) {
+        pointsString += " " + StringFormat("%d,%d", points[i].x + xOffset, points[i].y + yOffset);
     }
     polygonChild.append_attribute("points") = pointsString.c_str();
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1810,14 +1810,18 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
 
 void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, const Staff *staff, bool dimin)
 {
-    int i;
-
+    const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     if (staff->IsOnStaffLine(y, m_doc)) {
-        y += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        y += unit;
     }
     const double distance = dimin ? m_doc->GetOptions()->m_graceFactor.GetValue() : 1.0;
-    for (i = 0; i < dots; ++i) {
-        this->DrawDot(dc, x, y, staff->m_drawingStaffSize, dimin);
+    for (int i = 0; i < dots; ++i) {
+        if (staff->IsMensural()) {
+            this->DrawDiamond(dc, x - unit / 2, y, unit, unit, true, 0);
+        }
+        else {
+            this->DrawDot(dc, x, y, staff->m_drawingStaffSize, dimin);
+        }
         // HARDCODED
         x += m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 1.5 * distance;
     }


### PR DESCRIPTION
This PR reactivates the old DrawDiamond method for drawing mensural dots.

![image](https://user-images.githubusercontent.com/7693447/190368129-082e2c6b-e74d-4bda-82f6-b4c1f166e6c5.png)

Also it improves SVG output slightly by writing polygon points without space at the end.