### PR TITLE
Remove limitation for the use of `<symbol>` within `<dir>`

### DIFF
--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -538,26 +538,6 @@ protected:
 };
 
 //----------------------------------------------------------------------------
-// VisibleSymbol
-//----------------------------------------------------------------------------
-/**
- * This class evaluates if the object is a visible Symbol.
- */
-class VisibleSymbol : public ClassIdComparison {
-
-public:
-    VisibleSymbol() : ClassIdComparison(SYMBOL) {}
-
-    bool operator()(const Object *object) override
-    {
-        if (!MatchesType(object)) return false;
-        const Symbol *symbol = vrv_cast<const Symbol *>(object);
-        assert(symbol);
-        return (symbol->m_visibility == Visible);
-    }
-};
-
-//----------------------------------------------------------------------------
 // Filters class
 //----------------------------------------------------------------------------
 

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -69,11 +69,6 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
-     * Overwritten method for dir
-     */
-    void AddChild(Object *object) override;
-
-    /**
      * See FloatingObject::IsExtenderElement
      */
     bool IsExtenderElement() const override { return GetExtender() == BOOLEAN_true; }

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -22,7 +22,7 @@ namespace vrv {
 /**
  * This class models the MEI <symbol> element.
  */
-class Symbol : public TextElement, public AttColor, public AttExtSym {
+class Symbol : public TextElement, public AttColor, public AttExtSym, public AttTypography {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -11,7 +11,7 @@
 #include "atts_externalsymbols.h"
 #include "atts_shared.h"
 #include "atts_visual.h"
-#include "object.h"
+#include "textelement.h"
 
 namespace vrv {
 
@@ -22,7 +22,7 @@ namespace vrv {
 /**
  * This class models the MEI <symbol> element.
  */
-class Symbol : public Object, public AttColor, public AttExtSym {
+class Symbol : public TextElement, public AttColor, public AttExtSym {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods
@@ -49,14 +49,6 @@ public:
 private:
     //
 public:
-    /**
-     * Holds the visibility (hidden or visible) for an symbol element.
-     * By default, a symbo elements is visible but it is make invisible when with mixed content
-     * The reason is that we cannot render SVG <g> within <text>.
-     * Symbol with text is not supported by Verovio.
-     */
-    VisibilityType m_visibility;
-
 private:
 };
 

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -259,7 +259,6 @@ protected:
     void DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, Staff *staff, Measure *measure);
     void DrawTextChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
     void DrawFbChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
-    void DrawSymbolChildren(DeviceContext *dc, Object *parent, Staff *staff, TextDrawingParams &params);
     void DrawRunningChildren(DeviceContext *dc, Object *parent, TextDrawingParams &params);
     ///@}
 
@@ -386,7 +385,7 @@ protected:
     void DrawNum(DeviceContext *dc, Num *num, TextDrawingParams &params);
     void DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params);
     void DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params);
-    void DrawSymbol(DeviceContext *dc, Staff *staff, Symbol *symbol, TextDrawingParams &params);
+    void DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params);
     void DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params);
     void DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params, int staffSize);
 

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -111,7 +111,6 @@ enum ClassId : uint16_t {
     STAFFGRP,
     SURFACE,
     SVG,
-    SYMBOL,
     SYSTEM,
     SYSTEM_ALIGNER,
     SYSTEM_ALIGNMENT,
@@ -250,6 +249,7 @@ enum ClassId : uint16_t {
     LB,
     NUM,
     REND,
+    SYMBOL,
     TEXT,
     TEXT_ELEMENT_max,
     //

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -64,11 +64,8 @@ void Dir::Reset()
 
 bool Dir::IsSupportedChild(Object *child)
 {
-    if (child->Is({ LB, REND, TEXT })) {
+    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
         assert(dynamic_cast<TextElement *>(child));
-    }
-    else if (child->Is(SYMBOL)) {
-        assert(dynamic_cast<Symbol *>(child));
     }
     else if (child->IsEditorialElement()) {
         assert(dynamic_cast<EditorialElement *>(child));
@@ -77,35 +74,6 @@ bool Dir::IsSupportedChild(Object *child)
         return false;
     }
     return true;
-}
-
-void Dir::AddChild(Object *child)
-{
-    if (!this->IsSupportedChild(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
-        return;
-    }
-
-    child->SetParent(this);
-
-    ArrayOfObjects &children = this->GetChildrenForModification();
-
-    children.push_back(child);
-
-    ClassIdComparison symbol(SYMBOL);
-    symbol.ReverseComparison();
-    if (this->FindDescendantByComparison(&symbol)) {
-        for (const auto child : children) {
-            if (!child->Is(SYMBOL)) continue;
-            Symbol *symbol = vrv_cast<Symbol *>(child);
-            if (symbol->m_visibility != Hidden) {
-                LogWarning("Element <symbol> within <dir> can only be rendered if not mixed with other elements");
-                symbol->m_visibility = Hidden;
-            }
-        }
-    }
-
-    Modify();
 }
 
 bool Dir::AreChildrenAlignedTo(data_HORIZONTALALIGNMENT alignment) const

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2856,6 +2856,7 @@ void MEIOutput::WriteSymbol(pugi::xml_node currentNode, Symbol *symbol)
     this->WriteTextElement(currentNode, symbol);
     symbol->WriteColor(currentNode);
     symbol->WriteExtSym(currentNode);
+    symbol->WriteTypography(currentNode);
 }
 
 void MEIOutput::WriteText(pugi::xml_node element, Text *text)
@@ -6777,6 +6778,7 @@ bool MEIInput::ReadSymbol(Object *parent, pugi::xml_node symbol)
 
     vrvSymbol->ReadColor(symbol);
     vrvSymbol->ReadExtSym(symbol);
+    vrvSymbol->ReadTypography(symbol);
 
     parent->AddChild(vrvSymbol);
     this->ReadUnsupportedAttr(symbol, vrvSymbol);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2853,10 +2853,9 @@ void MEIOutput::WriteSymbol(pugi::xml_node currentNode, Symbol *symbol)
 {
     assert(symbol);
 
+    this->WriteTextElement(currentNode, symbol);
     symbol->WriteColor(currentNode);
     symbol->WriteExtSym(currentNode);
-
-    this->WriteXmlId(currentNode, symbol);
 }
 
 void MEIOutput::WriteText(pugi::xml_node element, Text *text)
@@ -6774,15 +6773,7 @@ bool MEIInput::ReadSvg(Object *parent, pugi::xml_node svg)
 bool MEIInput::ReadSymbol(Object *parent, pugi::xml_node symbol)
 {
     Symbol *vrvSymbol = new Symbol();
-    this->SetMeiID(symbol, vrvSymbol);
-
-    if (parent->IsEditorialElement()) {
-        std::string meiElementName = parent->GetClassName();
-        std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
-        LogWarning("Element <%s> within <%s> is not supported and will not be rendered", symbol.name(),
-            meiElementName.c_str());
-        vrvSymbol->m_visibility = Hidden;
-    }
+    this->ReadTextElement(symbol, vrvSymbol);
 
     vrvSymbol->ReadColor(symbol);
     vrvSymbol->ReadExtSym(symbol);

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Symbol> s_factory("symbol", SYMBOL);
 
-Symbol::Symbol() : Object(SYMBOL, "symbol-"), AttColor(), AttExtSym()
+Symbol::Symbol() : TextElement(SYMBOL, "symbol-"), AttColor(), AttExtSym()
 {
     this->Reset();
 
@@ -37,12 +37,10 @@ Symbol::~Symbol() {}
 
 void Symbol::Reset()
 {
-    Object::Reset();
+    TextElement::Reset();
 
     this->ResetColor();
     this->ResetExtSym();
-
-    m_visibility = Visible;
 }
 
 bool Symbol::IsSupportedChild(Object *child)

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -25,12 +25,13 @@ namespace vrv {
 
 static const ClassRegistrar<Symbol> s_factory("symbol", SYMBOL);
 
-Symbol::Symbol() : TextElement(SYMBOL, "symbol-"), AttColor(), AttExtSym()
+Symbol::Symbol() : TextElement(SYMBOL, "symbol-"), AttColor(), AttExtSym(), AttTypography()
 {
     this->Reset();
 
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_EXTSYM);
+    this->RegisterAttClass(ATT_TYPOGRAPHY);
 }
 
 Symbol::~Symbol() {}
@@ -41,6 +42,7 @@ void Symbol::Reset()
 
     this->ResetColor();
     this->ResetExtSym();
+    this->ResetTypography();
 }
 
 bool Symbol::IsSupportedChild(Object *child)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1608,21 +1608,16 @@ void View::DrawDir(DeviceContext *dc, Dir *dir, Measure *measure, System *system
             params.m_y -= m_doc->GetTextXHeight(&dirTxt, false) / 2;
         }
 
-        VisibleSymbol visibleSymbol;
-        if (dir->FindDescendantByComparison(&visibleSymbol)) {
-            this->DrawSymbolChildren(dc, dir, *staffIter, params);
-        }
-        else {
-            dc->SetBrush(m_currentColour, AxSOLID);
-            dc->SetFont(&dirTxt);
+        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetFont(&dirTxt);
 
-            dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
-            DrawTextChildren(dc, dir, params);
-            dc->EndText();
+        dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
+        DrawTextChildren(dc, dir, params);
+        dc->EndText();
 
-            dc->ResetFont();
-            dc->ResetBrush();
-        }
+        dc->ResetFont();
+        dc->ResetBrush();
+
         this->DrawTextEnclosure(dc, params, (*staffIter)->m_drawingStaffSize);
     }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1702,9 +1702,6 @@ void View::DrawTextChildren(DeviceContext *dc, Object *parent, TextDrawingParams
             // cast to EditorialElement check in DrawTextEditorialElement
             this->DrawTextEditorialElement(dc, dynamic_cast<EditorialElement *>(current), params);
         }
-        else if (current->Is(SYMBOL)) {
-            // assert(symbol->m_visibility == Hidden);
-        }
         else {
             assert(false);
         }
@@ -1723,21 +1720,6 @@ void View::DrawFbChildren(DeviceContext *dc, Object *parent, TextDrawingParams &
         else if (current->IsEditorialElement()) {
             // cast to EditorialElement check in DrawLayerEditorialElement
             this->DrawFbEditorialElement(dc, dynamic_cast<EditorialElement *>(current), params);
-        }
-        else {
-            assert(false);
-        }
-    }
-}
-
-void View::DrawSymbolChildren(DeviceContext *dc, Object *parent, Staff *staff, TextDrawingParams &params)
-{
-    assert(dc);
-    assert(parent);
-
-    for (auto current : parent->GetChildren()) {
-        if (current->Is(SYMBOL)) {
-            this->DrawSymbol(dc, staff, dynamic_cast<Symbol *>(current), params);
         }
         else {
             assert(false);

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -220,6 +220,11 @@ void View::DrawTextElement(DeviceContext *dc, TextElement *element, TextDrawingP
         assert(rend);
         this->DrawRend(dc, rend, params);
     }
+    else if (element->Is(SYMBOL)) {
+        Symbol *symbol = vrv_cast<Symbol *>(element);
+        assert(symbol);
+        this->DrawSymbol(dc, symbol, params);
+    }
     else if (element->Is(TEXT)) {
         Text *text = vrv_cast<Text *>(element);
         assert(text);
@@ -472,22 +477,35 @@ void View::DrawSvg(DeviceContext *dc, Svg *svg, TextDrawingParams &params)
     dc->EndGraphic(svg, this);
 }
 
-void View::DrawSymbol(DeviceContext *dc, Staff *staff, Symbol *symbol, TextDrawingParams &params)
+void View::DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &params)
 {
     assert(dc);
     assert(symbol);
 
-    dc->StartGraphic(symbol, "", symbol->GetID());
+    dc->StartTextGraphic(symbol, "", symbol->GetID());
 
     const wchar_t code = symbol->GetSymbolGlyph();
+    std::wstring str;
+    str.push_back(code);
 
-    this->DrawSmuflCode(dc, params.m_x, params.m_y, code, staff->m_drawingStaffSize, false);
+    FontInfo symbolFont;
 
-    if (code) {
-        params.m_x += m_doc->GetGlyphAdvX(code, staff->m_drawingStaffSize, false);
+    if (symbol->HasGlyphAuth() && symbol->GetGlyphAuth() == "smufl") {
+        symbolFont.SetSmuflFont(true);
+        symbolFont.SetFaceName("Leipzig");
+        // By default explicitly render it as normal
+        symbolFont.SetStyle(FONTSTYLE_normal);
+        int pointSize = (symbolFont.GetPointSize() != 0) ? symbolFont.GetPointSize() : params.m_pointSize;
+        symbolFont.SetPointSize(pointSize * m_doc->GetMusicToLyricFontSizeRatio());
     }
 
-    dc->EndGraphic(symbol, this);
+    dc->SetFont(&symbolFont);
+
+    this->DrawTextString(dc, str, params);
+
+    dc->ResetFont();
+
+    dc->EndTextGraphic(symbol, this);
 }
 
 } // namespace vrv


### PR DESCRIPTION
This PR remove the limitation for `<symbol>` which could not be mixed with text or editorial markup within `<dir>`. This is not possible.

![image](https://user-images.githubusercontent.com/689412/190400209-cd3758b6-adeb-4482-9d01-09956f5d911f.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Symbol mixed with text</title>
            </titleStmt>
            <pubStmt>
                <date>2022-02-15</date>
            </pubStmt>
            <notesStmt>
                <annot>Sybmol can be mixed with text.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.9.0" label="2">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef>
                        <staffGrp>
                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <note dur="4" oct="4" pname="c" />
                                    <note dur="4" oct="4" pname="c" />
                                    <note dur="4" oct="4" pname="c" />
                                    <note dur="4" oct="4" pname="c" />
                                </layer>
                            </staff>
                            <dir place="above" staff="1" tstamp="1">Symbols such as <symbol glyph.auth="smufl" glyph.name="coda"></symbol> can be mixed with text</dir>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>

```

By default the font style is rendered as normal because it is not very likely to have music symbols in italic - italic is the default for `<dir>`. However, the font style can still be set to italic on the symbol itself if desired.