### PR TITLE
Improve slurs over articulations

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -623,13 +623,20 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
             = (spannedElement->m_boundingBox->GetSelfLeft() + spannedElement->m_boundingBox->GetSelfRight()) / 2.0;
         const float distanceRatio = float(xMiddle - bezierCurve.p1.x) / float(dist);
 
-        // In case of cross-staff, ignore obstacles which completely lie on the other side of the slur near the
-        // endpoints
+        // Ignore obstacles in a different layer which completely lie on the other side of the slur near the endpoints
         const int elementHeight
             = std::abs(spannedElement->m_boundingBox->GetSelfTop() - spannedElement->m_boundingBox->GetSelfBottom());
-        if (curve->IsCrossStaff() && (intersection > elementHeight + 4 * margin)
-            && (std::abs(distanceRatio - 0.5) > 0.45)) {
-            spannedElement->m_discarded = true;
+        if (intersection > elementHeight + 4 * margin) {
+            const LayerElement *layerElement = dynamic_cast<const LayerElement *>(spannedElement->m_boundingBox);
+            if (distanceRatio < 0.05) {
+                spannedElement->m_discarded = layerElement
+                    ? (layerElement->GetOriginalLayerN() != this->GetStart()->GetOriginalLayerN())
+                    : true;
+            }
+            else if (distanceRatio > 0.95) {
+                spannedElement->m_discarded
+                    = layerElement ? (layerElement->GetOriginalLayerN() != this->GetEnd()->GetOriginalLayerN()) : true;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR improves an example with slurs intersecting articulations. The criteria for ignoring spanned elements now consider layers instead of the slur being cross staff.

| Before | After |
| ------ | ----- |
| <img width="438" alt="Before" src="https://user-images.githubusercontent.com/63608463/191021532-4fc3b157-e2c7-488a-85be-b023e6e37e0a.png"> | <img width="426" alt="After" src="https://user-images.githubusercontent.com/63608463/191021569-e2e19c71-b5c4-4101-b4e2-ae9570cad702.png"> |

<details>
<summary>Show MEI example</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt><date isodate="2020-03-07" type="encoding-date">2020-03-07</date>
            <availability>
               <distributor>OpenScore (CC0)</distributor>
            </availability>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-1m9nccn">
         <appInfo xml:id="appinfo-11kfap0">
            <application xml:id="application-n8m299" isodate="2022-09-16T14:01:41" version="3.12.0-dev-9af6a41">
               <name xml:id="name-mtb0t8">Verovio</name>
               <p xml:id="p-w9jsdh">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m11wa2do">
            <score xml:id="s1nnsa81">
               <scoreDef xml:id="s1wn5wvh">
                  <staffGrp xml:id="s1tc6brj">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="6">
                        <label xml:id="l1o78fxq">Chant<lb xml:id="lbfs2qj" />Voice</label>
                        <instrDef xml:id="i6x0avq" midi.channel="0" midi.instrnum="68" midi.volume="78.00%" />
                        <clef xml:id="cu5eeir" shape="G" line="2" />
                        <keySig xml:id="kt2an05" sig="0" />
                        <meterSig xml:id="m11r8d8n" count="2" sym="cut" unit="2" />
                     </staffDef>
                     <staffGrp xml:id="P2" bar.thru="true">
                        <label xml:id="l1qnr9y">Piano</label>
                        <instrDef xml:id="i1iuyly3" midi.channel="1" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef xml:id="s1pcj0e5" n="2" lines="5" ppq="6">
                           <clef xml:id="c3getkp" shape="G" line="2" />
                           <keySig xml:id="k1s1pgpl" sig="0" />
                           <meterSig xml:id="m1qpat2j" count="2" sym="cut" unit="2" />
                        </staffDef>
                        <staffDef xml:id="s1wgjysx" n="3" lines="5" ppq="6">
                           <clef xml:id="co0ng5i" shape="F" line="4" />
                           <keySig xml:id="k13iopif" sig="0" />
                           <meterSig xml:id="mc0a23g" count="2" sym="cut" unit="2" />
                        </staffDef>
                        <grpSym xml:id="g1lbnpqh" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="sgcaz4e">
                  <pb xml:id="p7i2rm" />
                  <measure xml:id="m1iea86g" n="1">
                     <staff xml:id="stbdh0e" n="1">
                        <layer xml:id="lq8mobv" n="1">
                           <mRest xml:id="ma3bgyi" />
                        </layer>
                     </staff>
                     <staff xml:id="s73z8m1" n="2">
                        <layer xml:id="l4dtmwf" n="1">
                           <beam xml:id="b1jb1a0v">
                              <tuplet xml:id="t1f1htl0" num="3" numbase="2" bracket.visible="false">
                                 <chord xml:id="cy0rxcy" dur.ppq="2" dur="8" staff="3" stem.dir="up">
                                    <artic xml:id="a1qnrqil" artic="stacc" />
                                    <artic xml:id="a10jxagf" artic="ten" />
                                    <note xml:id="npmw7m1" oct="4" pname="f" />
                                    <note xml:id="nqz2471" oct="4" pname="b" />
                                 </chord>
                                 <chord xml:id="c38wp7l" dur.ppq="2" dur="8" stem.dir="down">
                                    <note xml:id="n9x17w3" oct="5" pname="g" />
                                    <note xml:id="n1rl7vlx" oct="6" pname="e" />
                                 </chord>
                                 <chord xml:id="c13qdnp7" dur.ppq="2" dur="8" stem.dir="down">
                                    <artic xml:id="aggj6gu" artic="stacc" />
                                    <note xml:id="n1wqv930" oct="5" pname="e" />
                                    <note xml:id="n1t9shiv" oct="5" pname="b" />
                                 </chord>
                              </tuplet>
                           </beam>
                           <beam xml:id="b4b7zl8">
                              <tuplet xml:id="t1601zpx" num="3" numbase="2" bracket.visible="false">
                                 <chord xml:id="cpe9g15" dur.ppq="2" dur="8" staff="3" stem.dir="up">
                                    <artic xml:id="agttt2a" artic="stacc" />
                                    <artic xml:id="as3ycj0" artic="ten" />
                                    <note xml:id="n11it1x5" oct="5" pname="e" />
                                    <note xml:id="n1gt1bms" oct="5" pname="g" />
                                 </chord>
                                 <chord xml:id="c1xgnokb" dur.ppq="2" dur="8" stem.dir="down">
                                    <note xml:id="n3bwyts" oct="4" pname="g" />
                                    <note xml:id="n13nm164" oct="5" pname="e" />
                                 </chord>
                                 <chord xml:id="ceb9ys0" dur.ppq="2" dur="8" stem.dir="down">
                                    <artic xml:id="aswpt14" artic="stacc" />
                                    <note xml:id="n197e3hg" oct="4" pname="e" />
                                    <note xml:id="ngcpial" oct="4" pname="b" />
                                 </chord>
                              </tuplet>
                           </beam>
                           <beam xml:id="b1g57z0m">
                              <tuplet xml:id="tnerpaz" num="3" numbase="2" bracket.visible="false">
                                 <chord xml:id="czs3h79" dur.ppq="2" dur="8" staff="3" stem.dir="up">
                                    <artic xml:id="a11wigci" artic="stacc" />
                                    <artic xml:id="a157vix3" artic="ten" />
                                    <note xml:id="n1p7qblj" oct="4" pname="f" />
                                    <note xml:id="nrd6cy8" oct="4" pname="b" accid="f" />
                                 </chord>
                                 <chord xml:id="ceat1tb" dur.ppq="2" dur="8" stem.dir="down">
                                    <note xml:id="nvv5xd6" oct="4" pname="g" />
                                    <note xml:id="nij4c3v" oct="5" pname="d" />
                                 </chord>
                                 <chord xml:id="ceg46lq" dur.ppq="2" dur="8" stem.dir="down">
                                    <artic xml:id="axj5vle" artic="stacc" />
                                    <note xml:id="n1a6swnr" oct="4" pname="d" />
                                    <note xml:id="n1covzxq" oct="4" pname="b" accid="f" />
                                 </chord>
                              </tuplet>
                           </beam>
                           <beam xml:id="bepd2tr">
                              <tuplet xml:id="t8pf9z4" num="3" numbase="2" bracket.visible="false">
                                 <chord xml:id="cmijfhu" dur.ppq="2" dur="8" staff="3" stem.dir="up">
                                    <artic xml:id="a1r94pyj" artic="stacc" />
                                    <artic xml:id="a149kft6" artic="ten" />
                                    <note xml:id="nu89qcu" oct="5" pname="d" />
                                    <note xml:id="ndzp8vq" oct="5" pname="f" />
                                 </chord>
                                 <chord xml:id="cf1e9gi" dur.ppq="2" dur="8" stem.dir="down">
                                    <note xml:id="nk1l640" oct="5" pname="g" />
                                    <note xml:id="n1rhovit" oct="6" pname="d" />
                                 </chord>
                                 <chord xml:id="cgnuhvc" dur.ppq="2" dur="8" stem.dir="down">
                                    <artic xml:id="ao8vya6" artic="stacc" />
                                    <note xml:id="n11u81ow" oct="5" pname="d" />
                                    <note xml:id="n1ct74u" oct="5" pname="b" accid="f" />
                                 </chord>
                              </tuplet>
                           </beam>
                        </layer>
                        <layer xml:id="l1n420oc" n="2">
                           <mSpace xml:id="m1d77slo" />
                        </layer>
                     </staff>
                     <staff xml:id="sx3u7or" n="3">
                        <layer xml:id="l1rkqcc7" n="5">
                           <space xml:id="scer4gx" dur.ppq="12" dur="2" />
                           <space xml:id="s1nxr1d8" dur.ppq="12" dur="2" />
                        </layer>
                     </staff>
                     <tempo xml:id="t1xmbf5d" place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="110.000000">
                        <rend xml:id="r1a9s1qr" fontweight="bold">Assez vite, souplement</rend>
                     </tempo>
                     <dir xml:id="d1aemxgf" place="above" staff="2" tstamp="1.166667" vgrp="211">
                        <rend xml:id="ro7ermf" fontstyle="italic">bien égal et léger</rend>
                     </dir>
                     <slur xml:id="s1kd468m" startid="#n9x17w3" endid="#n1wqv930" curvedir="above" />
                     <slur xml:id="sph2y48" startid="#n3bwyts" endid="#n197e3hg" curvedir="above" />
                     <slur xml:id="s12hoqfy" startid="#nvv5xd6" endid="#n1a6swnr" curvedir="above" />
                     <slur xml:id="s17lgx9e" startid="#nk1l640" endid="#n11u81ow" curvedir="above" />
                     <dynam xml:id="d1isuyjf" place="above" staff="3" tstamp="1.000000" val="33" vgrp="200">pp</dynam>
                     <pedal xml:id="pa6yww4" staff="3" tstamp="1.000000" dir="down" form="line" place="below" vgrp="80" />
                     <pedal xml:id="p1k5ajth" staff="3" tstamp="1.900000" dir="up" form="line" place="below" vgrp="200" />
                     <pedal xml:id="p17ln9p4" staff="3" tstamp="2.000000" dir="down" form="line" place="below" vgrp="80" />
                     <pedal xml:id="pc8y9mx" staff="3" tstamp="2.900000" dir="up" form="line" place="below" vgrp="200" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
