### PR TITLE
Fix wrong namespaces in LibMEI

### DIFF
--- a/libmei/attclasses.h
+++ b/libmei/attclasses.h
@@ -296,6 +296,6 @@ enum AttClassId {
     ATT_CLASS_max
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_CLASSES_H__

--- a/libmei/attconverter.cpp
+++ b/libmei/attconverter.cpp
@@ -5433,4 +5433,4 @@ whitespace_XMLSPACE AttConverter::StrToWhitespaceXmlspace(const std::string &val
     return whitespace_XMLSPACE_NONE;
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/attconverter.h
+++ b/libmei/attconverter.h
@@ -477,6 +477,6 @@ public:
     whitespace_XMLSPACE StrToWhitespaceXmlspace(const std::string &value, bool logWarning = true) const;
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_CONVERTER_H__

--- a/libmei/atts_analytical.cpp
+++ b/libmei/atts_analytical.cpp
@@ -629,4 +629,4 @@ void Att::GetAnalytical(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_analytical.h
+++ b/libmei/atts_analytical.h
@@ -378,6 +378,6 @@ private:
     /* include <attpsolfa> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_ANALYTICAL_H__

--- a/libmei/atts_cmn.cpp
+++ b/libmei/atts_cmn.cpp
@@ -2301,4 +2301,4 @@ void Att::GetCmn(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_cmn.h
+++ b/libmei/atts_cmn.h
@@ -1302,6 +1302,6 @@ private:
     /* include <attunitdur> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_CMN_H__

--- a/libmei/atts_cmnornaments.cpp
+++ b/libmei/atts_cmnornaments.cpp
@@ -346,4 +346,4 @@ void Att::GetCmnornaments(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_cmnornaments.h
+++ b/libmei/atts_cmnornaments.h
@@ -194,6 +194,6 @@ private:
     /* include <attform> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_CMNORNAMENTS_H__

--- a/libmei/atts_critapp.cpp
+++ b/libmei/atts_critapp.cpp
@@ -97,4 +97,4 @@ void Att::GetCritapp(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_critapp.h
+++ b/libmei/atts_critapp.h
@@ -64,6 +64,6 @@ private:
     /* include <attcause> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_CRITAPP_H__

--- a/libmei/atts_edittrans.cpp
+++ b/libmei/atts_edittrans.cpp
@@ -158,4 +158,4 @@ void Att::GetEdittrans(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_edittrans.h
+++ b/libmei/atts_edittrans.h
@@ -104,6 +104,6 @@ private:
     /* include <attreason> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_EDITTRANS_H__

--- a/libmei/atts_externalsymbols.cpp
+++ b/libmei/atts_externalsymbols.cpp
@@ -163,4 +163,4 @@ void Att::GetExternalsymbols(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_externalsymbols.h
+++ b/libmei/atts_externalsymbols.h
@@ -88,6 +88,6 @@ private:
     /* include <attglyph.uri> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_EXTERNALSYMBOLS_H__

--- a/libmei/atts_facsimile.cpp
+++ b/libmei/atts_facsimile.cpp
@@ -97,4 +97,4 @@ void Att::GetFacsimile(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_facsimile.h
+++ b/libmei/atts_facsimile.h
@@ -64,6 +64,6 @@ private:
     /* include <attfacs> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_FACSIMILE_H__

--- a/libmei/atts_figtable.cpp
+++ b/libmei/atts_figtable.cpp
@@ -119,4 +119,4 @@ void Att::GetFigtable(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_figtable.h
+++ b/libmei/atts_figtable.h
@@ -67,6 +67,6 @@ private:
     /* include <attrowspan> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_FIGTABLE_H__

--- a/libmei/atts_fingering.cpp
+++ b/libmei/atts_fingering.cpp
@@ -97,4 +97,4 @@ void Att::GetFingering(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_fingering.h
+++ b/libmei/atts_fingering.h
@@ -61,6 +61,6 @@ private:
     /* include <attform> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_FINGERING_H__

--- a/libmei/atts_frettab.cpp
+++ b/libmei/atts_frettab.cpp
@@ -180,4 +180,4 @@ void Att::GetFrettab(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_frettab.h
+++ b/libmei/atts_frettab.h
@@ -103,6 +103,6 @@ private:
     /* include <atttab.fret> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_FRETTAB_H__

--- a/libmei/atts_gestural.cpp
+++ b/libmei/atts_gestural.cpp
@@ -1098,4 +1098,4 @@ void Att::GetGestural(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_gestural.h
+++ b/libmei/atts_gestural.h
@@ -569,6 +569,6 @@ private:
     /* include <atttstamp2.real> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_GESTURAL_H__

--- a/libmei/atts_harmony.cpp
+++ b/libmei/atts_harmony.cpp
@@ -97,4 +97,4 @@ void Att::GetHarmony(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_harmony.h
+++ b/libmei/atts_harmony.h
@@ -61,6 +61,6 @@ private:
     /* include <attchordref> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_HARMONY_H__

--- a/libmei/atts_header.cpp
+++ b/libmei/atts_header.cpp
@@ -368,4 +368,4 @@ void Att::GetHeader(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_header.h
+++ b/libmei/atts_header.h
@@ -205,6 +205,6 @@ private:
     /* include <attmethod> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_HEADER_H__

--- a/libmei/atts_mei.cpp
+++ b/libmei/atts_mei.cpp
@@ -119,4 +119,4 @@ void Att::GetMei(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_mei.h
+++ b/libmei/atts_mei.h
@@ -73,6 +73,6 @@ private:
     /* include <attnotationsubtype> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_MEI_H__

--- a/libmei/atts_mensural.cpp
+++ b/libmei/atts_mensural.cpp
@@ -766,4 +766,4 @@ void Att::GetMensural(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_mensural.h
+++ b/libmei/atts_mensural.h
@@ -397,6 +397,6 @@ private:
     /* include <attstem.form> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_MENSURAL_H__

--- a/libmei/atts_midi.cpp
+++ b/libmei/atts_midi.cpp
@@ -783,4 +783,4 @@ void Att::GetMidi(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_midi.h
+++ b/libmei/atts_midi.h
@@ -428,6 +428,6 @@ private:
     /* include <attppq> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_MIDI_H__

--- a/libmei/atts_neumes.cpp
+++ b/libmei/atts_neumes.cpp
@@ -334,4 +334,4 @@ void Att::GetNeumes(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_neumes.h
+++ b/libmei/atts_neumes.h
@@ -151,6 +151,6 @@ private:
     /* include <atttilt> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_NEUMES_H__

--- a/libmei/atts_pagebased.cpp
+++ b/libmei/atts_pagebased.cpp
@@ -97,4 +97,4 @@ void Att::GetPagebased(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_pagebased.h
+++ b/libmei/atts_pagebased.h
@@ -61,6 +61,6 @@ private:
     /* include <attsurface> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_PAGEBASED_H__

--- a/libmei/atts_performance.cpp
+++ b/libmei/atts_performance.cpp
@@ -97,4 +97,4 @@ void Att::GetPerformance(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_performance.h
+++ b/libmei/atts_performance.h
@@ -64,6 +64,6 @@ private:
     /* include <attwhen> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_PERFORMANCE_H__

--- a/libmei/atts_shared.cpp
+++ b/libmei/atts_shared.cpp
@@ -2744,9 +2744,9 @@ bool AttLang::ReadLang(pugi::xml_node element)
         element.remove_attribute("xml:lang");
         hasAttribute = true;
     }
-    if (element.attribute("xml:translit")) {
-        this->SetTranslit(StrToStr(element.attribute("xml:translit").value()));
-        element.remove_attribute("xml:translit");
+    if (element.attribute("translit")) {
+        this->SetTranslit(StrToStr(element.attribute("translit").value()));
+        element.remove_attribute("translit");
         hasAttribute = true;
     }
     return hasAttribute;
@@ -2760,7 +2760,7 @@ bool AttLang::WriteLang(pugi::xml_node element)
         wroteAttribute = true;
     }
     if (this->HasTranslit()) {
-        element.append_attribute("xml:translit") = StrToStr(this->GetTranslit()).c_str();
+        element.append_attribute("translit") = StrToStr(this->GetTranslit()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -5363,14 +5363,14 @@ bool AttPointing::ReadPointing(pugi::xml_node element)
         element.remove_attribute("xlink:show");
         hasAttribute = true;
     }
-    if (element.attribute("xlink:target")) {
-        this->SetTarget(StrToStr(element.attribute("xlink:target").value()));
-        element.remove_attribute("xlink:target");
+    if (element.attribute("target")) {
+        this->SetTarget(StrToStr(element.attribute("target").value()));
+        element.remove_attribute("target");
         hasAttribute = true;
     }
-    if (element.attribute("xlink:targettype")) {
-        this->SetTargettype(StrToStr(element.attribute("xlink:targettype").value()));
-        element.remove_attribute("xlink:targettype");
+    if (element.attribute("targettype")) {
+        this->SetTargettype(StrToStr(element.attribute("targettype").value()));
+        element.remove_attribute("targettype");
         hasAttribute = true;
     }
     return hasAttribute;
@@ -5392,11 +5392,11 @@ bool AttPointing::WritePointing(pugi::xml_node element)
         wroteAttribute = true;
     }
     if (this->HasTarget()) {
-        element.append_attribute("xlink:target") = StrToStr(this->GetTarget()).c_str();
+        element.append_attribute("target") = StrToStr(this->GetTarget()).c_str();
         wroteAttribute = true;
     }
     if (this->HasTargettype()) {
-        element.append_attribute("xlink:targettype") = StrToStr(this->GetTargettype()).c_str();
+        element.append_attribute("targettype") = StrToStr(this->GetTargettype()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -8686,7 +8686,7 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
             att->SetLang(att->StrToStr(attrValue));
             return true;
         }
-        if (attrType == "xml:translit") {
+        if (attrType == "translit") {
             att->SetTranslit(att->StrToStr(attrValue));
             return true;
         }
@@ -9214,11 +9214,11 @@ bool Att::SetShared(Object *element, const std::string &attrType, const std::str
             att->SetShow(att->StrToStr(attrValue));
             return true;
         }
-        if (attrType == "xlink:target") {
+        if (attrType == "target") {
             att->SetTarget(att->StrToStr(attrValue));
             return true;
         }
-        if (attrType == "xlink:targettype") {
+        if (attrType == "targettype") {
             att->SetTargettype(att->StrToStr(attrValue));
             return true;
         }
@@ -10190,7 +10190,7 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
             attributes->push_back({ "xml:lang", att->StrToStr(att->GetLang()) });
         }
         if (att->HasTranslit()) {
-            attributes->push_back({ "xml:translit", att->StrToStr(att->GetTranslit()) });
+            attributes->push_back({ "translit", att->StrToStr(att->GetTranslit()) });
         }
     }
     if (element->HasAttClass(ATT_LAYERLOG)) {
@@ -10627,10 +10627,10 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
             attributes->push_back({ "xlink:show", att->StrToStr(att->GetShow()) });
         }
         if (att->HasTarget()) {
-            attributes->push_back({ "xlink:target", att->StrToStr(att->GetTarget()) });
+            attributes->push_back({ "target", att->StrToStr(att->GetTarget()) });
         }
         if (att->HasTargettype()) {
-            attributes->push_back({ "xlink:targettype", att->StrToStr(att->GetTargettype()) });
+            attributes->push_back({ "targettype", att->StrToStr(att->GetTargettype()) });
         }
     }
     if (element->HasAttClass(ATT_QUANTITY)) {
@@ -11079,4 +11079,4 @@ void Att::GetShared(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_shared.h
+++ b/libmei/atts_shared.h
@@ -6221,6 +6221,6 @@ private:
     /* include <atty2> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_SHARED_H__

--- a/libmei/atts_usersymbols.cpp
+++ b/libmei/atts_usersymbols.cpp
@@ -280,4 +280,4 @@ void Att::GetUsersymbols(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_usersymbols.h
+++ b/libmei/atts_usersymbols.h
@@ -173,6 +173,6 @@ private:
     /* include <attfunc> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_USERSYMBOLS_H__

--- a/libmei/atts_visual.cpp
+++ b/libmei/atts_visual.cpp
@@ -3073,4 +3073,4 @@ void Att::GetVisual(const Object *element, ArrayOfStrAttr *attributes)
     }
 }
 
-} // vrv namespace
+} // namespace vrv

--- a/libmei/atts_visual.h
+++ b/libmei/atts_visual.h
@@ -1581,6 +1581,6 @@ private:
     /* include <attnum.format> */
 };
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATTS_VISUAL_H__

--- a/libmei/atttypes.h
+++ b/libmei/atttypes.h
@@ -2499,6 +2499,6 @@ enum whitespace_XMLSPACE {
 };
 
 
-} // vrv namespace
+} // namespace vrv
 
 #endif // __VRV_ATT_TYPES_H__


### PR DESCRIPTION
Another update to LibMEI with [fixed namespace propagation](https://github.com/rism-digital/libmei/pull/21/commits/ed1248f767ced2a02a1ba181972ad8381b4da1c2).