### PR TITLE
Fixed: Add a command for checking a font

### DIFF
--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -350,7 +350,7 @@ def __combine_alternates_and_supported(opts) -> dict:
         metadata: dict = json.load(jsonfile)
 
     if not os.access(metadata_pth, os.R_OK):
-        log.warning("The metadata file could be read at %s", metadata_pth)
+        log.warning("The metadata file could not be read at %s", metadata_pth)
         return supported_glyphs
 
     alternate_glyphs: dict = __get_alternate_glyphs(supported_glyphs, metadata)

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -172,7 +172,6 @@ def extract_fonts(opts: Namespace) -> bool:
     )
 
     supported_glyphs: dict = __combine_alternates_and_supported(opts)
-    metadata_pth: Path = Path(font_data_pth, f"{fontname.lower()}_metadata.json")
 
     with open(metadata_pth, "r") as jfile:
         metadata: dict = json.load(jfile)

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -630,9 +630,7 @@ if __name__ == "__main__":
     Extracts the supported glyphs from an SVG font file and creates the SMuFL header file for Verovio. 
     """
     parser_smufl = subparsers.add_parser("smufl", description=smufl_description)
-    parser_smufl.add_argument(
-        "--supported", help=supported_xml_help, default="./supported.xml"
-    )
+    parser_smufl.add_argument("--supported", help=supported_xml_help, default="./supported.xml")
     parser_smufl.add_argument("--header-out", default="../include/vrv/")
     parser_smufl.set_defaults(func=generate_smufl)
 
@@ -642,9 +640,7 @@ if __name__ == "__main__":
     """
     parser_extract = subparsers.add_parser("extract", description=extract_description)
     parser_extract.add_argument("fontname")
-    parser_extract.add_argument(
-        "--supported", help=supported_xml_help, default="./supported.xml"
-    )
+    parser_extract.add_argument("--supported", help=supported_xml_help, default="./supported.xml")
     parser_extract.add_argument(
         "--data", help="Path to the Verovio data directory", default="../data"
     )
@@ -719,14 +715,14 @@ if __name__ == "__main__":
     Optionally, with the use of the `--show-unsupported` flag, will also show the list of glyphs that are in
     the font that are not supported by Verovio.
     """
-    unsupported_help: str = "Also show a list of glyphs in the font that are not supported by Verovio."
+    unsupported_help: str = (
+        "Also show a list of glyphs in the font that are not supported by Verovio."
+    )
     parser_check = subparsers.add_parser(
         "check", description=check_description, formatter_class=RawTextHelpFormatter
     )
     parser_check.add_argument("fontname", help=fontname_help)
-    parser_check.add_argument(
-        "--supported", help=supported_xml_help, default="./supported.xml"
-    )
+    parser_check.add_argument("--supported", help=supported_xml_help, default="./supported.xml")
     parser_check.add_argument("--source", help="The font source parent directory", default="./")
     parser_check.add_argument("--show-unsupported", help=unsupported_help, action="store_true")
 

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -350,7 +350,7 @@ def __combine_alternates_and_supported(opts) -> dict:
         metadata: dict = json.load(jsonfile)
 
     if not os.access(metadata_pth, os.R_OK):
-        log.warning("No alternate glyphs file could be read at %s", metadata_pth)
+        log.warning("The metadata file could be read at %s", metadata_pth)
         return supported_glyphs
 
     alternate_glyphs: dict = __get_alternate_glyphs(supported_glyphs, metadata)


### PR DESCRIPTION
The `check [fontname]` command will check a font's full SVG file against the list of supported glyphs, and will report the code of any glyph that is supported by Verovio, but that is not in that font.

Optionally, it can also show the list of glyphs in the font that are not supported by Verovio by passing the `--show-unsupported` flag.

Fixes #3035