### PR TITLE
Fix access to global Module variable in loadZipDataBuffer

### DIFF
--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -14,6 +14,10 @@ export class VerovioToolkit {
         VerovioToolkit.instances.push(this);
     }
 
+    get module() {
+        return this.VerovioModule;
+    }
+
     destroy() {
         VerovioToolkit.instances.splice(VerovioToolkit.instances.findIndex(i => i.ptr === this.ptr), 1);
         console.debug("Deleting toolkit instance");
@@ -119,10 +123,10 @@ export class VerovioToolkit {
         }
         var dataArray = new Uint8Array(data);
         var dataSize = dataArray.length * dataArray.BYTES_PER_ELEMENT;
-        var dataPtr = Module._malloc(dataSize);
-        Module.HEAPU8.set(dataArray, dataPtr);
+        var dataPtr = this.module._malloc(dataSize);
+        this.module.HEAPU8.set(dataArray, dataPtr);
         var res = this.proxy.loadZipDataBuffer(this.ptr, dataPtr, dataSize);
-        Module._free(dataPtr);
+        this.module._free(dataPtr);
         return res;
     }
 


### PR DESCRIPTION
Fixes https://github.com/rism-digital/verovio/issues/3037.

Introduces access to the VerovioModule with a new `module`getter in VerovioToolkit:

```js
export class VerovioToolkit {
    // ...
    get module() {
        return this.VerovioModule;
    }
}

const tk = new VerovioToolkit();
console.log(tk.module);
```

I still get an error when running `loadZipDataBuffer` as described in https://github.com/rism-digital/verovio/issues/3037#issuecomment-1260655896. But this seems to be unrelated to the issue and @wergo confirmed that this fixes the problem.

<img width="276" alt="Bildschirmfoto 2022-09-28 um 11 39 22" src="https://user-images.githubusercontent.com/865594/192745861-b5cf6404-8c3f-4dd3-972b-3212d60faa62.png">