### PR TITLE
WIP: Recognize CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -26,6 +26,13 @@ if (NO_HUMDRUM_SUPPORT AND MUSICXML_DEFAULT_HUMDRUM)
     message(SEND_ERROR "Default MusicXML to Humdrum cannot be enabled by default without Humdrum support")
 endif()
 
+if (VEROVIO_RESOURCE_DIRECTORY)
+    MESSAGE("Custom resource directory")
+    add_compile_definitions(RESOURCE_DIR="${VEROVIO_RESOURCE_DIRECTORY}")
+else()
+    add_compile_definitions(RESOURCE_DIR="${CMAKE_INSTALL_PREFIX}/share/verovio")
+endif()
+
 include_directories(
     ../include
     ../include/crc
@@ -239,8 +246,7 @@ else()
 endif()
 
 install(
-    TARGETS verovio
-    DESTINATION /usr/local/bin
+    TARGETS verovio DESTINATION bin
 )
 install(
     DIRECTORY ../data/

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -26,12 +26,8 @@ if (NO_HUMDRUM_SUPPORT AND MUSICXML_DEFAULT_HUMDRUM)
     message(SEND_ERROR "Default MusicXML to Humdrum cannot be enabled by default without Humdrum support")
 endif()
 
-if (VEROVIO_RESOURCE_DIRECTORY)
-    MESSAGE("Custom resource directory")
-    add_compile_definitions(RESOURCE_DIR="${VEROVIO_RESOURCE_DIRECTORY}")
-else()
-    add_compile_definitions(RESOURCE_DIR="${CMAKE_INSTALL_PREFIX}/share/verovio")
-endif()
+# Sets the compile-time value for the RESOURCE_DIR macro in the source code.
+add_compile_definitions(RESOURCE_DIR="${CMAKE_INSTALL_PREFIX}/share/verovio")
 
 include_directories(
     ../include

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -43,6 +43,15 @@ namespace vrv {
 #define VERSION_DEV true
 
 //----------------------------------------------------------------------------
+// Resource directory
+//----------------------------------------------------------------------------
+#ifdef RESOURCE_DIR
+#define VRV_RESOURCE_DIR RESOURCE_DIR
+#else
+#define VRV_RESOURCE_DIR "/usr/local/share/verovio"
+#endif
+
+//----------------------------------------------------------------------------
 // Cast redefinition
 //----------------------------------------------------------------------------
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,11 +19,6 @@
 #include "att.h"
 #include "vrv.h"
 
-#ifdef RESOURCE_DIR
-#define VRV_RESOURCE_DIR RESOURCE_DIR
-#else
-#define VRV_RESOURCE_DIR "/usr/local/share/verovio"
-#endif
 
 namespace vrv {
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,7 +19,6 @@
 #include "att.h"
 #include "vrv.h"
 
-
 namespace vrv {
 
 const std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,6 +19,12 @@
 #include "att.h"
 #include "vrv.h"
 
+#ifdef RESOURCE_DIR
+#define VRV_RESOURCE_DIR RESOURCE_DIR
+#else
+#define VRV_RESOURCE_DIR "/usr/local/share/verovio"
+#endif
+
 namespace vrv {
 
 const std::map<int, std::string> Option::s_breaks = { { BREAKS_none, "none" }, { BREAKS_auto, "auto" },
@@ -902,7 +908,7 @@ Options::Options()
     m_baseOptions.AddOption(&m_page);
 
     m_resourcePath.SetInfo("Resource path", "Path to the directory with Verovio resources");
-    m_resourcePath.Init("/usr/local/share/verovio");
+    m_resourcePath.Init(VRV_RESOURCE_DIR);
     m_resourcePath.SetKey("resourcePath");
     m_resourcePath.SetShortOption('r', true);
     m_baseOptions.AddOption(&m_resourcePath);

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -20,13 +20,19 @@
 
 #include "pugixml.hpp"
 
+#ifdef RESOURCE_DIR
+#define VRV_RESOURCE_DIR RESOURCE_DIR
+#else
+#define VRV_RESOURCE_DIR "/usr/local/share/verovio"
+#endif
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
 // Static members with some default values
 //----------------------------------------------------------------------------
 
-thread_local std::string Resources::s_defaultPath = "/usr/local/share/verovio";
+thread_local std::string Resources::s_defaultPath = VRV_RESOURCE_DIR;
 const Resources::StyleAttributes Resources::k_defaultStyle{ data_FONTWEIGHT::FONTWEIGHT_normal,
     data_FONTSTYLE::FONTSTYLE_normal };
 

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -20,12 +20,6 @@
 
 #include "pugixml.hpp"
 
-#ifdef RESOURCE_DIR
-#define VRV_RESOURCE_DIR RESOURCE_DIR
-#else
-#define VRV_RESOURCE_DIR "/usr/local/share/verovio"
-#endif
-
 namespace vrv {
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
By setting an absolute path to the install directory in the CMakeLists.txt file, the cmake build was ignoring the CMAKE_INSTALL_PREFIX.  By changing it to a relative path the CMAKE_INSTALL_PREFIX seems to work as expected.

These changes make it possible to adapt the installation of Verovio to different OS filesystem layouts. (e.g., homebrew on Mac uses /opt/homebrew instead of /usr/local now). 

In addition, the path to the resources directory was changed to work with CMAKE_INSTALL_PREFIX. This necessitated a change in the source code, since the value was previously hard-coded. (Please review this bit -- my C++ `#defines` are pretty bad!)

This was tested and seemed to work, but would benefit from wider testing.

```
$ mkdir -p /tmp/verovio
$ cd /path/to/verovio/tools
$ cmake ../cmake -DCMAKE_INSTALL_PREFIX=/tmp/verovio  (also possible: cmake ../cmake --install-prefix=/tmp/verovio)
$ make -j 8
$ make install
```

The executable should now be in `/tmp/verovio/bin` and the resources in `/tmp/verovio/share`.
