### PR TITLE
Fixed: Also copy the CSS files to the data dir

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -247,5 +247,5 @@ install(
 install(
     DIRECTORY ../data/
     DESTINATION share/verovio
-    FILES_MATCHING PATTERN "*.xml" PATTERN "*.svg"
+    FILES_MATCHING PATTERN "*.xml" PATTERN "*.svg" PATTERN "*.css"
 )


### PR DESCRIPTION
Fixes an issue where the CSS could not be loaded by Verovio if it was installed with 'make install'.