### PR TITLE
Implement pedline support

### DIFF
--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -152,7 +152,7 @@ int Pedal::PrepareFloatingGrps(FunctorParams *functorParams)
     System *system = vrv_cast<System *>(this->GetFirstAncestor(SYSTEM));
     assert(system);
     data_PEDALSTYLE form = this->GetPedalForm(params->m_doc, system);
-    if (form == PEDALSTYLE_line) {
+    if (form == PEDALSTYLE_line || form == PEDALSTYLE_pedline) {
         params->m_pedalLines.push_back(this);
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -995,21 +995,17 @@ void View::DrawPedalLine(
         endRadius = pedal->GetEnd()->GetDrawingRadius(m_doc);
     }
 
-    // The both correspond to the current system, which means no system break in-between (simple case)
-    if (spanningType == SPANNING_START_END) {
+    // Adjust the start if necessary
+    if (spanningType == SPANNING_START_END || spanningType == SPANNING_START) {
         x1 -= startRadius;
+        // With pedline we need to take into account the initial symbol
+        if (pedal->GetForm() == PEDALSTYLE_pedline) {
+            x1 += m_doc->GetGlyphWidth(SMUFL_E650_keyboardPedalPed, staff->m_drawingStaffSize, false);
+        }
+    }
+    // Adjust the end if necessary
+    if (spanningType == SPANNING_START_END || spanningType == SPANNING_END) {
         x2 -= endRadius - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-    }
-    // Only the first parent is the same, this means that the syl is "open" at the end of the system
-    else if (spanningType == SPANNING_START) {
-        x1 -= startRadius;
-    }
-    // We are in the system of the last note - draw the connector from the beginning of the system
-    else if (spanningType == SPANNING_END) {
-        x2 -= endRadius - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-    }
-    else {
-        // nothing to adjust
     }
 
     if (graphic) {
@@ -1022,10 +1018,12 @@ void View::DrawPedalLine(
     const int bracketSize = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
     const int lineWidth = m_options->m_pedalLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
-    // Opening bracket
+    // Opening bracket - but only if not a pedline value
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
-        this->DrawFilledRectangle(dc, x1, y, x1 + bracketSize / 2, y + lineWidth);
-        this->DrawFilledRectangle(dc, x1, y, x1 + lineWidth, y + bracketSize);
+        if (pedal->GetForm() != PEDALSTYLE_pedline) {
+            this->DrawFilledRectangle(dc, x1, y, x1 + bracketSize / 2, y + lineWidth);
+            this->DrawFilledRectangle(dc, x1, y, x1 + lineWidth, y + bracketSize);
+        }
     }
     // Closing bracket
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
@@ -2231,8 +2229,11 @@ void View::DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *
 
     data_PEDALSTYLE form = pedal->GetPedalForm(m_doc, system);
 
+    bool drawSymbol = (form != PEDALSTYLE_line);
+    if (pedal->GetDir() == pedalLog_DIR_up && form == PEDALSTYLE_pedline) drawSymbol = false;
+
     // Draw a symbol, if it's not a line
-    if (form != PEDALSTYLE_line) {
+    if (drawSymbol) {
 
         bool bounceStar = true;
         if (form == PEDALSTYLE_altpedstar) bounceStar = false;


### PR DESCRIPTION
This PR adds support for `@form="pedline"` recently added to MEI.

Rendering from the [ test suite](https://github.com/rism-digital/verovio.org/blob/414621f4084c58dd475a1d48c64febdb50deb7d9/_tests/pedal/pedal-006.mei):

<img width="412" alt="image" src="https://user-images.githubusercontent.com/689412/194712711-4f56bd70-7974-44e3-bef1-cdd7cbe617a1.png">

For now, the adjustment of the line assumes a default "Ped." symbol `SMUFL_E650_keyboardPedalPed`. Taking into account other glyphs can be done separately.