### PR TITLE
Fix repeated duration with dot in PAE output

### DIFF
--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -539,34 +539,32 @@ void PAEOutput::WriteDur(DurationInterface *interface)
 {
     assert(interface);
 
-    if ((interface->GetDur() != m_currentDur) || (interface->GetDots() != m_currentDots)) {
-        m_currentDur = interface->GetDur();
-        m_currentDots = (interface->HasDots()) ? interface->GetDots() : 0;
-        std::string dur;
-        switch (m_currentDur) {
-            case (DURATION_long): dur = "0"; break;
-            case (DURATION_breve): dur = "9"; break;
-            case (DURATION_1): dur = "1"; break;
-            case (DURATION_2): dur = "2"; break;
-            case (DURATION_4): dur = "4"; break;
-            case (DURATION_8): dur = "8"; break;
-            case (DURATION_16): dur = "6"; break;
-            case (DURATION_32): dur = "3"; break;
-            case (DURATION_64): dur = "5"; break;
-            case (DURATION_128): dur = "7"; break;
-            case (DURATION_maxima): dur = "0"; break;
-            case (DURATION_longa): dur = "0"; break;
-            case (DURATION_brevis): dur = "9"; break;
-            case (DURATION_semibrevis): dur = "1"; break;
-            case (DURATION_minima): dur = "2"; break;
-            case (DURATION_semiminima): dur = "4"; break;
-            case (DURATION_fusa): dur = "8"; break;
-            case (DURATION_semifusa): dur = "6"; break;
-            default: LogWarning("Unsupported duration"); dur = "4";
-        }
-        m_streamStringOutput << dur;
-        m_streamStringOutput << std::string(m_currentDots, '.');
+    m_currentDur = interface->GetDur();
+    m_currentDots = (interface->HasDots()) ? interface->GetDots() : 0;
+    std::string dur;
+    switch (m_currentDur) {
+        case (DURATION_long): dur = "0"; break;
+        case (DURATION_breve): dur = "9"; break;
+        case (DURATION_1): dur = "1"; break;
+        case (DURATION_2): dur = "2"; break;
+        case (DURATION_4): dur = "4"; break;
+        case (DURATION_8): dur = "8"; break;
+        case (DURATION_16): dur = "6"; break;
+        case (DURATION_32): dur = "3"; break;
+        case (DURATION_64): dur = "5"; break;
+        case (DURATION_128): dur = "7"; break;
+        case (DURATION_maxima): dur = "0"; break;
+        case (DURATION_longa): dur = "0"; break;
+        case (DURATION_brevis): dur = "9"; break;
+        case (DURATION_semibrevis): dur = "1"; break;
+        case (DURATION_minima): dur = "2"; break;
+        case (DURATION_semiminima): dur = "4"; break;
+        case (DURATION_fusa): dur = "8"; break;
+        case (DURATION_semifusa): dur = "6"; break;
+        default: LogWarning("Unsupported duration"); dur = "4";
     }
+    m_streamStringOutput << dur;
+    m_streamStringOutput << std::string(m_currentDots, '.');
 }
 
 void PAEOutput::WriteGrace(AttGraced *attGraced)


### PR DESCRIPTION
The generated PAE was not as expected in case of notes with dotted duration. In particular, the dotted duration was output only for the first note and not for all notes before duration change. Example: `4.AAA` -> `4.AAA` instead of `4.A4.A4.A` (in case of no dots, the output was as expected: `4AAA` -> `4A4A4A`).
I removed the if-statement checking whether duration or number of dots has changed since, as far as I understand, we want to output duration after each note. The code worked for non-dotted duration only because in this case `interface->GetDots()` is not assigned, whereas `m_currentDots` is 0 or -1.

