### PR TITLE
Bug fix: repeated duration in PAE output

### DIFF
--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -538,7 +538,7 @@ void PAEOutput::WriteTupletEnd(Tuplet *tuplet)
 void PAEOutput::WriteDur(DurationInterface *interface)
 {
     assert(interface);
- 
+
     const int ndots = (interface->HasDots()) ? interface->GetDots() : 0;
     if ((interface->GetDur() != m_currentDur) || (ndots != m_currentDots)) {
         m_currentDur = interface->GetDur();

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -539,9 +539,10 @@ void PAEOutput::WriteDur(DurationInterface *interface)
 {
     assert(interface);
 
-    if ((interface->GetDur() != m_currentDur) || (interface->GetDots() != m_currentDots)) {
+    int m_dots = (interface->HasDots()) ? interface->GetDots() : 0;
+    if ((interface->GetDur() != m_currentDur) || (m_dots != m_currentDots)) {
         m_currentDur = interface->GetDur();
-        m_currentDots = (interface->HasDots()) ? interface->GetDots() : 0;
+        m_currentDots = m_dots;
         std::string dur;
         switch (m_currentDur) {
             case (DURATION_long): dur = "0"; break;

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -538,11 +538,11 @@ void PAEOutput::WriteTupletEnd(Tuplet *tuplet)
 void PAEOutput::WriteDur(DurationInterface *interface)
 {
     assert(interface);
-
-    int m_dots = (interface->HasDots()) ? interface->GetDots() : 0;
-    if ((interface->GetDur() != m_currentDur) || (m_dots != m_currentDots)) {
+ 
+    const int ndots = (interface->HasDots()) ? interface->GetDots() : 0;
+    if ((interface->GetDur() != m_currentDur) || (ndots != m_currentDots)) {
         m_currentDur = interface->GetDur();
-        m_currentDots = m_dots;
+        m_currentDots = ndots;
         std::string dur;
         switch (m_currentDur) {
             case (DURATION_long): dur = "0"; break;


### PR DESCRIPTION
Note duration should be shown in the PAE output only if the duration has changed.
Bug description: in case of duration without dots, duration is repeated for each note, even if it has not changed. 
Example: `4A4CE` -> `4A4C4E` but it should be `4ACE`