### PR TITLE
setOption with boolean in toolkit

### DIFF
--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -280,6 +280,7 @@ public:
      * @return True if the option was successfully set
      */
     bool SetOption(const std::string &option, const std::string &value);
+    bool SetOption(const std::string &option, const bool value);
 
     /**
      * Reset all options to default values

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1129,6 +1129,22 @@ bool Toolkit::SetOption(const std::string &option, const std::string &value)
     return result;
 }
 
+bool Toolkit::SetOption(const std::string &option, const bool value)
+{
+    // Set option value
+    if (m_options->GetItems()->count(option) == 0) {
+        LogError("Unsupported option '%s'", option.c_str());
+        return false;
+    }
+    OptionBool *optBool = dynamic_cast<OptionBool *>(m_options->GetItems()->at(option));
+    if (!optBool) {
+        LogError("Option '%s' is non-boolean", option.c_str());
+        return false;
+    }
+
+    return optBool->SetValueBool(value);
+}
+
 void Toolkit::ResetOptions()
 {
     std::for_each(m_options->GetItems()->begin(), m_options->GetItems()->end(),


### PR DESCRIPTION
This PR adds the possibility to pass a boolean to set an option in the toolkit (see #3072). 

So in addition to this

```Python
setOption(optionName, "true")
```

you can also use

```Python
setOption(optionName, True)
```

It's probably not the most elegant solution but does the job. 
