### PR TITLE
Allow octave after grace note 'g' or 'q'

### DIFF
--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -3933,6 +3933,10 @@ bool PAEInput::ConvertGrace()
             if (this->Was(token, pae::ACCIDENTAL_INTERNAL)) {
                 continue;
             }
+            // Having an octave is fine
+            if (this->Was(token, pae::OCTAVE)) {
+                continue;
+            }
             // Having a duration is fine for appogiatura
             if (this->Is(token, pae::DURATION)) {
                 // For acciaccature, not in pedantic mode


### PR DESCRIPTION
The PAE parser forbids octaves between grace note ('g' or 'q') and note name. For example: `q'8D4C` is not allowed and produces the error code 31 (_A grace note using 'g' or 'q' must be followed by a note_). The aim of this PR is to allow to enter octaves after the grace note sign, as already possible for accidentals and duration. 

The error code 31 will still be triggered in case something else than accidental, duration (only for appoggiatura) or octave is written between grace note symbol and note name. 