### PR TITLE
New: Add Python 3.11 wheel

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       # Ensure that a wheel builder finishes even if another fails
       fail-fast: false
-      # Build the wheels for Linux, Windows and macOS for Python 3.10
+      # Build the wheels for Linux, Windows and macOS
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         architecture: [x86, x64]
         include:
           - os: macos-latest


### PR DESCRIPTION
Python 3.11 has been released, so we should build wheels for it.

(All other versions of Python were checked for being in support. 3.7 will go out of support in 4 months.)