### PR TITLE
Add contours to the feature extraction

### DIFF
--- a/include/vrv/featureextractor.h
+++ b/include/vrv/featureextractor.h
@@ -61,6 +61,8 @@ public:
 
     jsonxx::Array m_intervalsChromatic;
     jsonxx::Array m_intervalsDiatonic;
+    jsonxx::Array m_intervalGrossContour;
+    jsonxx::Array m_intervalRefinedContour;
     jsonxx::Array m_intervalsIds;
 
 private:

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -112,12 +112,23 @@ void FeatureExtractor::Extract(Object *object, GenerateFeaturesParams *params)
 
         // We have a previous note (or more with tied notes), so we can calculate an interval
         if (!m_previousNotes.empty()) {
-            std::string intervalChromatic
-                = StringFormat("%d", note->GetMIDIPitch() - m_previousNotes.front()->GetMIDIPitch());
-            m_intervalsChromatic << intervalChromatic;
-            std::string intervalDiatonic
+            const int intervalChromatic = note->GetMIDIPitch() - m_previousNotes.front()->GetMIDIPitch();
+            if (intervalChromatic == 0) {
+                m_intervalGrossContour << "s";
+                m_intervalRefinedContour << "s";
+            }
+            else if (intervalChromatic < 0) {
+                m_intervalGrossContour << "D";
+                m_intervalRefinedContour << ((intervalChromatic < -2) ? "D" : "d");
+            }
+            else {
+                m_intervalGrossContour << "U";
+                m_intervalRefinedContour << ((intervalChromatic > 2) ? "U" : "u");
+            }
+            m_intervalsChromatic << StringFormat("%d", intervalChromatic);
+            std::string intervalDiatonicStr
                 = StringFormat("%d", note->GetDiatonicPitch() - m_previousNotes.front()->GetDiatonicPitch());
-            m_intervalsDiatonic << intervalDiatonic;
+            m_intervalsDiatonic << intervalDiatonicStr;
             jsonxx::Array intervalsIds;
             for (auto previousNote : m_previousNotes) intervalsIds << previousNote->GetID();
             intervalsIds << note->GetID();
@@ -138,6 +149,8 @@ void FeatureExtractor::ToJson(std::string &output)
 
     o << "intervalsChromatic" << m_intervalsChromatic;
     o << "intervalsDiatonic" << m_intervalsDiatonic;
+    o << "intervalGrossContour" << m_intervalGrossContour;
+    o << "intervalRefinedContour" << m_intervalRefinedContour;
     o << "intervalsIds" << m_intervalsIds;
 
     output = o.json();


### PR DESCRIPTION
Tokens are
* `s` for unison
* `U` for up
* `D` for down
* `u` or `d` for refined contour if the interval is one or two semitones (up or down respectively)

```
@clef:G-2
@keysig:
@timesig:4/4
@data:'2C4DCb/ECGG/GFGE
```
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/689412/200899425-586d5b04-a2bd-4c3b-9be0-449b0eac3e7c.png">

```json
{
	"intervalGrossContour": [
		"U",
		"D",
		"U",
		"D",
		"U",
		"s",
		"s",
		"D",
		"U",
		"D" 
	],
	"intervalRefinedContour": [
		"u",
		"d",
		"U",
		"D",
		"U",
		"s",
		"s",
		"d",
		"u",
		"D" 
	]
}
```