### PR TITLE
Fix beam clef collision

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -190,10 +190,11 @@ public:
  * member 1: y coordinate of the beam left side
  * member 2: y coordinate of the beam right side
  * member 3: x coordinate of the beam left side (starting point)
- * member 4: slope of the beam
- * member 5: overlap margin that beam needs to be displaced by
- * member 6: the Doc
- * member 7: the flag indicating whether element from different layer is being processed
+ * member 4: x coordinate of the beam right side (end point)
+ * member 5: slope of the beam
+ * member 6: overlap margin that beam needs to be displaced by
+ * member 7: the Doc
+ * member 8: the flag indicating whether element from different layer is being processed
  **/
 
 class AdjustBeamParams : public FunctorParams {
@@ -204,6 +205,7 @@ public:
         m_y1 = 0;
         m_y2 = 0;
         m_x1 = 0;
+        m_x2 = 0;
         m_beamSlope = 0.0;
         m_directionBias = 0;
         m_overlapMargin = 0;
@@ -215,6 +217,7 @@ public:
     int m_y1;
     int m_y2;
     int m_x1;
+    int m_x2;
     double m_beamSlope;
     int m_directionBias;
     int m_overlapMargin;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -2105,9 +2105,10 @@ int Beam::AdjustBeams(FunctorParams *functorParams)
         }
         else {
             params->m_beam = this;
-            params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
+            params->m_y1 = m_beamSegment.m_beamElementCoordRefs.front()->m_yBeam;
             params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
             params->m_x1 = m_beamSegment.m_beamElementCoordRefs.front()->m_x;
+            params->m_x2 = m_beamSegment.m_beamElementCoordRefs.back()->m_x;
             params->m_beamSlope = m_beamSegment.m_beamSlope;
             params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
             params->m_overlapMargin

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -206,8 +206,7 @@ int Clef::AdjustBeams(FunctorParams *functorParams)
     if (!params->m_beam) return FUNCTOR_SIBLINGS;
     // ignore elements that start before/after the beam
     if (this->GetDrawingX() < params->m_x1) return FUNCTOR_CONTINUE;
-    const int beamRight = params->m_x1 + (params->m_y2 - params->m_y1) / params->m_beamSlope;
-    if (this->GetDrawingX() > beamRight) return FUNCTOR_CONTINUE;
+    if (this->GetDrawingX() > params->m_x2) return FUNCTOR_CONTINUE;
 
     Staff *staff = this->GetAncestorStaff();
     // find number of beams at current position

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -137,9 +137,10 @@ int FTrem::AdjustBeams(FunctorParams *functorParams)
         }
         else {
             params->m_beam = this;
-            params->m_y1 = (*m_beamSegment.m_beamElementCoordRefs.begin())->m_yBeam;
+            params->m_y1 = m_beamSegment.m_beamElementCoordRefs.front()->m_yBeam;
             params->m_y2 = m_beamSegment.m_beamElementCoordRefs.back()->m_yBeam;
             params->m_x1 = m_beamSegment.m_beamElementCoordRefs.front()->m_x;
+            params->m_x2 = m_beamSegment.m_beamElementCoordRefs.back()->m_x;
             params->m_beamSlope = m_beamSegment.m_beamSlope;
             params->m_directionBias = (m_drawingPlace == BEAMPLACE_above) ? 1 : -1;
             params->m_overlapMargin


### PR DESCRIPTION
This PR fixes collisions between clefs and horizontal beams.

| Before | After |
| ----- | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/201086788-fafe7678-d428-46c8-89a5-e7357b406006.png) | ![After](https://user-images.githubusercontent.com/63608463/201086824-32e2cbf4-a421-4033-b616-0dbb81211eb5.png) |

<details>
<summary> Show MEI example </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
  <meiHead>
    <fileDesc>
      <titleStmt>
      </titleStmt>
      <pubStmt>
      </pubStmt>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application xml:id="sibelius" version="8300">
          <name type="operating-system">macOS</name>
        </application>
        <application xml:id="sibmei" type="plugin" version="2.1.0">
          <name>Sibelius to MEI Exporter (2.1.0)</name>
        </application>
      </appInfo>
    </encodingDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef key.pname="c" key.mode="minor" midi.bpm="100">
            <staffGrp>
              <staffDef type="embeddedAnnotation" clef.line="2" clef.shape="G" n="1" scale="75%" lines="5">
                <keySig sig="2f" />
                <meterSig count="4" unit="4" sym="common" />
              </staffDef>
              <staffDef clef.line="4" clef.shape="C" n="2" lines="5">
                <keySig sig="2f" />
                <meterSig count="4" unit="4" sym="common" />
              </staffDef>
            </staffGrp>
          </scoreDef>
          <section>
            <measure xml:id="m-1487" n="44">
              <staff xml:id="m-1488" n="1">
                <layer n="1">
                  <beam xml:id="b-1">
                    <note xml:id="m-1493" dur="16" oct="4" pname="b">
                      <accid accid="f" />
                    </note>
                    <note xml:id="m-1496" dur="16" oct="4" pname="a" />
                    <note xml:id="m-1497" dur="16" oct="4" pname="b" accid.ges="f" />
                    <note xml:id="m-1498" dur="16" oct="4" pname="a" />
                  </beam>
                </layer>
              </staff>
              <staff xml:id="m-1499" n="2" facs="#facsZone-m-1499">
                <layer n="1">
                  <beam xml:id="b-2">
                    <note xml:id="m-1510" dur="16" oct="2" pname="g" />
                    <clef xml:id="c-1" line="2" shape="G" />
                    <note xml:id="m-1513" dur="16" oct="4" pname="g" />
                    <note xml:id="m-1514" dur="16" oct="4" pname="f" />
                    <note xml:id="m-1515" dur="16" oct="4" pname="g" />
                  </beam>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

