### PR TITLE
Add text font fallback

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -14,6 +14,7 @@
 
 #include "attdef.h"
 #include "vrv.h"
+#include "vrvdef.h"
 
 namespace vrv {
 
@@ -141,7 +142,7 @@ public:
         m_faceName.clear();
         m_encoding = 0; // was wxFONTENCODING_DEFAULT;
         m_widthToHeightRatio = 1.0;
-        m_smuflFont = false;
+        m_smuflFont = SMUFL_NONE;
     }
     virtual ~FontInfo(){};
 
@@ -155,7 +156,7 @@ public:
     int GetFamily() const { return m_family; }
     int GetEncoding() const { return m_encoding; }
     float GetWidthToHeightRatio() const { return m_widthToHeightRatio; }
-    bool GetSmuflFont() const { return m_smuflFont; }
+    SmuflTextFont GetSmuflFont() const { return m_smuflFont; }
 
     void SetPointSize(int pointSize) { m_pointSize = pointSize; }
     void SetStyle(data_FONTSTYLE style) { m_style = style; }
@@ -166,7 +167,8 @@ public:
     void SetFamily(int family) { m_family = family; }
     void SetEncoding(int encoding) { m_encoding = encoding; }
     void SetWidthToHeightRatio(float ratio) { m_widthToHeightRatio = ratio; }
-    void SetSmuflFont(bool smuflFont) { m_smuflFont = smuflFont; }
+    void SetSmuflFont(SmuflTextFont smuflFont) { m_smuflFont = smuflFont; }
+    void SetSmuflWithFallback(bool fallback) { m_smuflFont = (fallback) ? SMUFL_FONT_FALLBACK : SMUFL_FONT_SELECTED; }
 
 private:
     int m_pointSize;
@@ -178,7 +180,7 @@ private:
     std::string m_faceName;
     int m_encoding;
     float m_widthToHeightRatio;
-    bool m_smuflFont;
+    SmuflTextFont m_smuflFont;
 };
 
 // ---------------------------------------------------------------------------

--- a/include/vrv/glyph.h
+++ b/include/vrv/glyph.h
@@ -83,6 +83,14 @@ public:
     ///@}
 
     /**
+     * @name Setter and getter for the fallback falg
+     */
+    ///@{
+    bool GetFallback() const { return m_isFallback; }
+    void SetFallback(bool isFallback) { m_isFallback = isFallback; }
+    ///@}
+
+    /**
      * Add an anchor for the glyph.
      * The string is turn into a SMuFLGlyphAnchor ("cutOutNE" => SMUFL_cutOutNE)
      */
@@ -118,6 +126,8 @@ private:
     std::string m_path;
     /** A map of the available anchors */
     std::map<SMuFLGlyphAnchor, Point> m_anchors;
+    /** A flag indicating it is a fallback */
+    bool m_isFallback;
 };
 
 } // namespace vrv

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -73,6 +73,11 @@ public:
     ///@}
 
     /**
+     * Check if the text has any charachter that needs the smufl fallback font
+     */
+    bool IsSmuflFallbackNeeded(const std::u32string &text) const;
+
+    /**
      * Text fonts
      */
     ///@{

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -89,7 +89,7 @@ public:
     static char32_t GetSmuflGlyphForUnicodeChar(const char32_t unicodeChar);
 
 private:
-    bool LoadFont(const std::string &fontName);
+    bool LoadFont(const std::string &fontName, bool withFallback = true);
 
 private:
     /** The font name of the font that is currently loaded */

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -260,6 +260,11 @@ private:
     void VrvTextFont() { m_vrvTextFont = true; }
 
     /**
+     * Change the flag for indicating the use of the fallback music font as text font
+     */
+    void VrvTextFontFallback() { m_vrvTextFontFallback = true; }
+
+    /**
      * Flush the data to the internal buffer.
      * Adds the xml tag if necessary and the <defs> from m_smuflGlyphs
      */
@@ -289,6 +294,11 @@ private:
      * DeviceContext::VrvTextFont. The font is included as woff2 in Commit()
      */
     bool m_vrvTextFont;
+
+    /**
+     * Flag indicating we need a fallback font for the music Glyphs
+     */
+    bool m_vrvTextFontFallback;
 
     // we use a std::stringstream because we want to prepend the <defs> which will know only when we reach the end of
     // the page

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -638,6 +638,12 @@ enum { KEY_LEFT = 37, KEY_UP = 38, KEY_RIGHT = 39, KEY_DOWN = 40 };
 enum StemSameasDrawingRole { SAMEAS_NONE = 0, SAMEAS_UNSET, SAMEAS_PRIMARY, SAMEAS_SECONDARY };
 
 //----------------------------------------------------------------------------
+// Smufl text font (selected font or fallback)
+//----------------------------------------------------------------------------
+
+enum SmuflTextFont { SMUFL_NONE = 0, SMUFL_FONT_SELECTED, SMUFL_FONT_FALLBACK };
+
+//----------------------------------------------------------------------------
 // Legacy Wolfgang defines
 //----------------------------------------------------------------------------
 

--- a/src/glyph.cpp
+++ b/src/glyph.cpp
@@ -36,6 +36,7 @@ Glyph::Glyph()
     m_unitsPerEm = 20480;
     m_codeStr = "[unset]";
     m_path = "[unset]";
+    m_isFallback = false;
 }
 
 Glyph::Glyph(std::string path, std::string codeStr)
@@ -47,6 +48,7 @@ Glyph::Glyph(std::string path, std::string codeStr)
     m_horizAdvX = 0;
     m_unitsPerEm = 20480;
     m_codeStr = codeStr;
+    m_isFallback = false;
 
     pugi::xml_document doc;
     pugi::xml_parse_result result = doc.load_file(path.c_str());

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -96,6 +96,16 @@ char32_t Resources::GetGlyphCode(const std::string &smuflName) const
     return m_glyphNameTable.count(smuflName) ? m_glyphNameTable.at(smuflName) : 0;
 }
 
+bool Resources::IsSmuflFallbackNeeded(const std::u32string &text) const
+{
+    for (int i = 0; i < (int)text.length(); ++i) {
+        char32_t c = text.at(i);
+        const Glyph *glyph = this->GetGlyph(c);
+        if (glyph && glyph->GetFallback()) return true;
+    }
+    return false;
+}
+
 void Resources::SelectTextFont(data_FONTWEIGHT fontWeight, data_FONTSTYLE fontStyle) const
 {
     if (fontWeight == FONTWEIGHT_NONE) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1667,10 +1667,11 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
         FontInfo vrvTxt;
         vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
         vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-        vrvTxt.SetSmuflFont(true);
-        dc->SetFont(&vrvTxt);
         std::u32string str;
         str.push_back(SMUFL_E551_lyricsElision);
+        bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(str);
+        vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
+        dc->SetFont(&vrvTxt);
         dc->DrawText(UTF32to8(str), str);
         dc->ResetFont();
         dc->ReactivateGraphic();

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -391,6 +391,8 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         params.m_pointSize = rendFont.GetPointSize();
     }
     if (rend->HasFontfam() && rend->GetFontfam() == "smufl") {
+        // Because we do not have the string at this stage we rely only on the selected font
+        // This means fallback will not work for missing glyphs within <rend>
         rendFont.SetSmuflWithFallback(SMUFL_FONT_SELECTED);
         rendFont.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
         int pointSize = (rendFont.GetPointSize() != 0) ? rendFont.GetPointSize() : params.m_pointSize;

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -117,7 +117,8 @@ void View::DrawDynamString(DeviceContext *dc, const std::u32string &str, TextDra
                 FontInfo vrvTxt;
                 vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
                 vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-                vrvTxt.SetSmuflFont(true);
+                bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(smuflStr);
+                vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
                 vrvTxt.SetStyle(FONTSTYLE_normal);
                 dc->SetFont(&vrvTxt);
                 this->DrawTextString(dc, smuflStr, params);
@@ -188,7 +189,8 @@ void View::DrawHarmString(DeviceContext *dc, const std::u32string &str, TextDraw
             FontInfo vrvTxt;
             vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
             vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-            vrvTxt.SetSmuflFont(true);
+            bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(smuflAccid);
+            vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
             dc->SetFont(&vrvTxt);
             // Once we have rendered the some text to not pass x / y anymore
             dc->DrawText(UTF32to8(smuflAccid), smuflAccid, toDcX, toDcY);
@@ -275,10 +277,11 @@ void View::DrawLyricString(
         FontInfo vrvTxt;
         vrvTxt.SetPointSize(dc->GetFont()->GetPointSize() * m_doc->GetMusicToLyricFontSizeRatio());
         vrvTxt.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
-        vrvTxt.SetSmuflFont(true);
-        dc->SetFont(&vrvTxt);
         std::u32string elision;
         elision.push_back(SMUFL_E551_lyricsElision);
+        bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(elision);
+        vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
+        dc->SetFont(&vrvTxt);
         if (params) {
             dc->DrawText(UTF32to8(elision), elision, params->m_x, params->m_y, params->m_width, params->m_height);
         }
@@ -388,7 +391,7 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
         params.m_pointSize = rendFont.GetPointSize();
     }
     if (rend->HasFontfam() && rend->GetFontfam() == "smufl") {
-        rendFont.SetSmuflFont(true);
+        rendFont.SetSmuflWithFallback(SMUFL_FONT_SELECTED);
         rendFont.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
         int pointSize = (rendFont.GetPointSize() != 0) ? rendFont.GetPointSize() : params.m_pointSize;
         rendFont.SetPointSize(pointSize * m_doc->GetMusicToLyricFontSizeRatio());
@@ -552,7 +555,8 @@ void View::DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &para
     }
 
     if (symbol->HasGlyphAuth() && symbol->GetGlyphAuth() == "smufl") {
-        symbolFont.SetSmuflFont(true);
+        bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(str);
+        symbolFont.SetSmuflWithFallback(isFallbackNeeded);
         symbolFont.SetFaceName(m_doc->GetOptions()->m_font.GetValue());
         int pointSize = (symbolFont.GetPointSize() != 0) ? symbolFont.GetPointSize() : params.m_pointSize;
         symbolFont.SetPointSize(pointSize * m_doc->GetMusicToLyricFontSizeRatio());


### PR DESCRIPTION
The PR adds a font fallback for smufl glyphs in text that rely on the woff2 font. If a glyph is missing in the selected font, rendering will fallback on Leipzig. If other texts element include smufl glyphs that exist in the selected font, then both woff2 fonts will be included.

Example with Leland and fallback on the Leipzig for the elision glyphs:

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/689412/201356751-3097f468-54d6-4593-8bbf-4950bfbb4715.png">


```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt></pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-0000001524618759">
         <appInfo xml:id="appinfo-0000000492606509">
            <application xml:id="application-0000000688137578" isodate="2020-03-06T10:57:54" version="2.6.0-dev-71070ce">
               <name xml:id="name-0000001328834351">Verovio</name>
               <p xml:id="p-0000002036492104">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mdiv-0000000728426042">
            <score xml:id="score-0000001999699994">
               <scoreDef xml:id="scoredef-0000002076790294" midi.bpm="121">
                  <staffGrp xml:id="staffgrp-0000000557864736">
                     <staffDef xml:id="staffdef-0000001259557467" n="1" lines="5" ppq="2" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" meter.sym="common">
                        <keySig xml:id="keysig-0000000231478358" mode="major" sig="2f" />
                        <instrDef xml:id="instrdef-0000000119015150" midi.channel="0" midi.instrnum="48" midi.volume="80.00%" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-0000000838723608">
                  <pb xml:id="pb-0000000345020748" />
                  <measure xml:id="measure-0000000460274445" n="1">
                     <staff xml:id="staff-0000000401453663" n="1">
                        <layer xml:id="layer-0000001985578814" n="1">
                           <rest xml:id="rest-0000001874736165" dur.ppq="2" dur="4" />
                           <note xml:id="note-0000000810656371" dur.ppq="1" dur="8" oct="4" pname="d" stem.dir="up">
                              <verse xml:id="verse-0000001065370829" n="1">
                                 <syl xml:id="syl-0000002116357964" con="b">De</syl>
                                 <syl xml:id="syl-0000001081761921" con="s">a</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000828590539" dur.ppq="1" dur="8" oct="4" pname="d" stem.dir="up">
                              <verse xml:id="verse-0000001837221825" n="1">
                                 <syl xml:id="syl-0000001667336209" con="s" wordpos="t">quel</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000049117142" dur.ppq="2" dur="4" oct="4" pname="g" stem.dir="up">
                              <verse xml:id="verse-0000000878085146" n="1">
                                 <syl xml:id="syl-0000000469426638" con="d" wordpos="i">mu</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000001413050235" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up">
                              <verse xml:id="verse-0000000113647472" n="1">
                                 <syl xml:id="syl-0000000960099721" con="b">ro</syl>
                                 <syl xml:id="syl-0000001497249258" con="s" wordpos="t">en</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000001495329057" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="up">
                              <verse xml:id="verse-0000002141823805" n="1">
                                 <syl xml:id="syl-0000001511799621" con="s">la</syl>
                              </verse>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-0000000562677263" n="2">
                     <staff xml:id="staff-0000000863035375" n="1">
                        <layer xml:id="layer-0000000930995787" n="1">
                           <note xml:id="note-0000000680340067" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000001284954414" n="1">
                                 <syl xml:id="syl-0000001133281866" con="d" wordpos="i">rui</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000002139752951" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000000745934409" n="1">
                                 <syl xml:id="syl-0000002057564524" con="s" wordpos="t">na</syl>
                              </verse>
                           </note>
                           <rest xml:id="rest-0000000963805034" dur.ppq="1" dur="8" />
                           <note xml:id="note-0000000202057117" dur.ppq="1" dur="8" oct="5" pname="d" stem.dir="down">
                              <verse xml:id="verse-0000000802319512" n="1">
                                 <syl xml:id="syl-0000000534218671" con="d" wordpos="i">re</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000790535605" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000001997416957" n="1">
                                 <syl xml:id="syl-0000001122426395" con="d" wordpos="m">pa</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000755501560" dur.ppq="1" dur="8" oct="4" pname="b" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000000303034852" n="1">
                                 <syl xml:id="syl-0000001423030527" con="s" wordpos="t">ra</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000002108365534" dur.ppq="1" dur="8" oct="4" pname="a" stem.dir="up">
                              <verse xml:id="verse-0000001819354438" n="1">
                                 <syl xml:id="syl-0000002017873480" con="b">mi</syl>
                                 <syl xml:id="syl-0000000669915262" con="s">a</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000001732653601" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up">
                              <verse xml:id="verse-0000000830818687" n="1">
                                 <syl xml:id="syl-0000000630999615" con="d" wordpos="m">ten</syl>
                              </verse>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-0000001452320564" n="3">
                     <staff xml:id="staff-0000000532149639" n="1">
                        <layer xml:id="layer-0000001717076565" n="1">
                           <note xml:id="note-0000001020579569" dur.ppq="2" dur="4" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000000928927594" n="1">
                                 <syl xml:id="syl-0000000279958668" con="s" wordpos="t">ción.</syl>
                              </verse>
                           </note>
                           <rest xml:id="rest-0000002062071811" dur.ppq="2" dur="4" />
                           <note xml:id="note-0000001149832191" dur.ppq="1" dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000000300541758" n="1">
                                 <syl xml:id="syl-0000000323788962" con="d" wordpos="i">Mi</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000001904070037" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000002051287912" n="1">
                                 <syl xml:id="syl-0000000293468046" con="s" wordpos="t">ra,</syl>
                              </verse>
                           </note>
                           <rest xml:id="rest-0000001420639815" dur.ppq="1" dur="8" />
                           <note xml:id="note-0000000970183359" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up">
                              <verse xml:id="verse-0000000028383042" n="1">
                                 <syl xml:id="syl-0000000292417260" con="d" wordpos="i">Ri</syl>
                              </verse>
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-0000001278365147" right="invis" n="4">
                     <staff xml:id="staff-0000001511597378" n="1">
                        <layer xml:id="layer-0000000685588036" n="1">
                           <note xml:id="note-0000001428354897" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000001788547713" n="1">
                                 <syl xml:id="syl-0000001792805332" con="d" wordpos="m">se</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000002024121059" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000001114186486" n="1">
                                 <syl xml:id="syl-0000000074868362" con="s" wordpos="t">lo,</syl>
                              </verse>
                           </note>
                           <rest xml:id="rest-0000001587810492" dur.ppq="1" dur="8" />
                           <note xml:id="note-0000001699141422" dur.ppq="1" dur="8" oct="4" pname="g" stem.dir="up">
                              <verse xml:id="verse-0000000232341748" n="1">
                                 <syl xml:id="syl-0000000842488390" con="b">que</syl>
                                 <syl xml:id="syl-0000000766430937" con="s">es</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000467022703" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000000197839536" n="1">
                                 <syl xml:id="syl-0000000784395996" con="s">más</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000734860046" dur.ppq="1" dur="8" oct="5" pname="c" stem.dir="down">
                              <verse xml:id="verse-0000000614339225" n="1">
                                 <syl xml:id="syl-0000000097979799" con="s">de</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000092711189" dur.ppq="1" dur="8" oct="5" pname="d" stem.dir="down">
                              <verse xml:id="verse-0000001271309448" n="1">
                                 <syl xml:id="syl-0000001583088533" con="s">lo</syl>
                              </verse>
                           </note>
                           <note xml:id="note-0000000140939009" dur.ppq="1" dur="8" oct="5" pname="e" stem.dir="down" accid.ges="f">
                              <verse xml:id="verse-0000001088666406" n="1">
                                 <syl xml:id="syl-0000000655613202" con="s">que</syl>
                              </verse>
                           </note>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
