### PR TITLE
Develop js logging

### DIFF
--- a/emscripten/npm/src/index.js
+++ b/emscripten/npm/src/index.js
@@ -1,5 +1,8 @@
 import { VerovioToolkit } from "./verovio-toolkit.js";
+import { logLevel, enableLog } from "./verovio-logger.js";
 
 export {
     VerovioToolkit,
+    logLevel,
+    enableLog,
 };

--- a/emscripten/npm/src/prebundle-module.js
+++ b/emscripten/npm/src/prebundle-module.js
@@ -1,10 +1,15 @@
 import DefaultVerovioModule from "../../build/verovio.js";
 import { VerovioToolkit } from "./verovio-toolkit.js";
+import { logLevel, enableLog } from "./verovio-logger.js";
 
 class VerovioToolkitDefaultModule extends VerovioToolkit {
     constructor(VerovioModule = DefaultVerovioModule) {
         super(VerovioModule);
     }
+}
+
+function enableLogDefaultModule(level, VerovioModule = DefaultVerovioModule) {
+    enableLog(level, VerovioModule);
 }
 
 // Assign Module to window to prevent breaking changes.
@@ -16,4 +21,6 @@ if (typeof window !== "undefined") {
 export default {
     module: DefaultVerovioModule,
     toolkit: VerovioToolkitDefaultModule,
+    logLevel,
+    enableLog: enableLogDefaultModule,
 };

--- a/emscripten/npm/src/prebundle-module.js
+++ b/emscripten/npm/src/prebundle-module.js
@@ -8,7 +8,7 @@ class VerovioToolkitDefaultModule extends VerovioToolkit {
     }
 }
 
-function enableLogDefaultModule(level, VerovioModule = DefaultVerovioModule) {
+function enableLogDefaultModule(level = logLevel.debug, VerovioModule = DefaultVerovioModule) {
     enableLog(level, VerovioModule);
 }
 

--- a/emscripten/npm/src/verovio-logger.js
+++ b/emscripten/npm/src/verovio-logger.js
@@ -8,7 +8,7 @@ export const logLevel = {
     error: 4,
 };
 
-export function enableLog(level, VerovioModule) {
+export function enableLog(level = logLevel.debug, VerovioModule) {
     const proxy = createEmscriptenProxy(VerovioModule);
     const ptr = proxy.constructor();
     proxy.enableLog(ptr, level);

--- a/emscripten/npm/src/verovio-logger.js
+++ b/emscripten/npm/src/verovio-logger.js
@@ -1,0 +1,15 @@
+import { createEmscriptenProxy } from "./emscripten-proxy.js";
+
+export const logLevel = {
+    off: 0,
+    debug: 1,
+    info: 2,
+    warning: 3,
+    error: 4,
+};
+
+export function enableLog(level, VerovioModule) {
+    const proxy = createEmscriptenProxy(VerovioModule);
+    const ptr = proxy.constructor();
+    proxy.enableLog(ptr, level);
+}


### PR DESCRIPTION
Implements https://github.com/rism-digital/verovio/issues/3122.

Setting `VerovioModule` as second parameter and a wrapper function with the default value of `DefaultVerovioModule` in `prebundle-module.js` allows us to use `verovio.enableLog(verovio.logLevel.error)` without the need of passing the module as an argument. But at the same time we can use this method in ESM:

verovio-toolkit-wasm.js:

```html
<script src="verovio-toolkit-wasm.js"></script>
<script>
verovio.module.onRuntimeInitialized = () => {
    verovio.enableLog(verovio.logLevel.error);
}
</script>
```

ESM:

```js
import createVerovioModule from 'verovio/wasm';
import { logLevel, enableLog } from 'verovio/esm';

createVerovioModule().then(VerovioModule => {
    enableLog(logLevel.error, VerovioModule);
});
```

I'm not exposing `enableLog` in the VerovioToolkit because this should enabled per module one not per toolkit instance, is this correct? The downside of this is that we have to create a second EmscriptenProxy and call the constructor to get the pointer:

```js
export function enableLog(level = logLevel.debug, VerovioModule) {
    const proxy = createEmscriptenProxy(VerovioModule);
    const ptr = proxy.constructor();
    proxy.enableLog(ptr, level);
}
```

Could this be prevented by adding it to the toolkit and then calling is per toolkit instance and not per module?

Currently there is no difference when I test this. It does not matter what log level I pass or if I call `enableLog` at all. Is this because it is not yet implemented on the C++ side or is there something wrong on my side?

I set `logLevel.debug` as default value for the parameter so you can use `enableLog()` to print all logs.