### PR TITLE
keep C major keySig in SVG

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -902,7 +902,9 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     // C major (0) key sig and no cancellation
     else if ((keySig->GetAccidCount() == 0) && (keySig->m_drawingCancelAccidCount == 0)) {
+        dc->StartGraphic(element, "", element->GetID());
         keySig->SetEmptyBB();
+        dc->EndGraphic(element, this);
         return;
     }
 


### PR DESCRIPTION
When there _is_ a keySig it is expected to show up in the SVG, even if it's "only" C major. 😉 