### PR TITLE
Add check for empty bounding boxes

### DIFF
--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -445,6 +445,7 @@ double StaffAlignment::GetJustificationFactor(const Doc *doc) const
 
 int StaffAlignment::CalcOverflowAbove(const BoundingBox *box) const
 {
+    if (!box->HasContentVerticalBB()) return 0;
     if (box->Is(FLOATING_POSITIONER)) {
         const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(box);
         assert(positioner);
@@ -455,6 +456,7 @@ int StaffAlignment::CalcOverflowAbove(const BoundingBox *box) const
 
 int StaffAlignment::CalcOverflowBelow(const BoundingBox *box) const
 {
+    if (!box->HasContentVerticalBB()) return 0;
     if (box->Is(FLOATING_POSITIONER)) {
         const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(box);
         assert(positioner);


### PR DESCRIPTION
This PR fixes a case where an empty direction blew up the entire system layout.

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/202734567-387b23a6-01e3-4d69-b982-9ee203cf2ed8.png) | ![After](https://user-images.githubusercontent.com/63608463/202734592-3cd6ae4a-e527-469d-9f86-572422163cb6.png) |
