### PR TITLE
Improve page rescaling

### DIFF
--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -113,11 +113,17 @@ public:
         m_userScaleX = scaleX;
         m_userScaleY = scaleY;
     }
+    void SetBaseSize(int width, int height)
+    {
+        m_baseWidth = width;
+        m_baseHeight = height;
+    }
     int GetWidth() const { return m_width; }
     int GetHeight() const { return m_height; }
     int GetContentHeight() const { return m_contentHeight; }
     double GetUserScaleX() { return m_userScaleX; }
     double GetUserScaleY() { return m_userScaleY; }
+    std::pair<int, int> GetBaseSize() const { return std::make_pair(m_baseWidth, m_baseHeight); }
     ///@}
 
     /**
@@ -330,6 +336,10 @@ private:
     /** stores the width and height of the device context */
     int m_width;
     int m_height;
+
+    /** stores base width and height of the device context before application of scale */
+    int m_baseWidth = 0;
+    int m_baseHeight = 0;
 
     /** stores the height of graphic content */
     int m_contentHeight;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -71,6 +71,8 @@ public:
         m_contentHeight = 0;
         m_userScaleX = 1.0;
         m_userScaleY = 1.0;
+        m_baseWidth = 0;
+        m_baseHeight = 0;
     }
     DeviceContext(ClassId classId)
     {
@@ -83,6 +85,8 @@ public:
         m_contentHeight = 0;
         m_userScaleX = 1.0;
         m_userScaleY = 1.0;
+        m_baseWidth = 0;
+        m_baseHeight = 0;
     }
     virtual ~DeviceContext(){};
     ClassId GetClassId() const { return m_classId; }
@@ -338,8 +342,8 @@ private:
     int m_height;
 
     /** stores base width and height of the device context before application of scale */
-    int m_baseWidth = 0;
-    int m_baseHeight = 0;
+    int m_baseWidth;
+    int m_baseHeight;
 
     /** stores the height of graphic content */
     int m_contentHeight;

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -131,6 +131,10 @@ void SvgDeviceContext::Commit(bool xml_declaration)
         width /= 10;
         format = "%gmm";
     }
+    else {
+        height = std::ceil(height);
+        width = std::ceil(width);
+    }
 
     if (m_svgViewBox) {
         m_svgNode.prepend_attribute("viewBox") = StringFormat("0 0 %g %g", width, height).c_str();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -132,8 +132,15 @@ void SvgDeviceContext::Commit(bool xml_declaration)
         format = "%gmm";
     }
     else {
-        height = std::ceil(height);
-        width = std::ceil(width);
+        const auto [baseWidth, baseHeight] = this->GetBaseSize();
+        if (baseWidth && baseHeight) {
+            height = baseHeight;
+            width = baseWidth;
+        }
+        else {
+            height = std::ceil(height);
+            width = std::ceil(width);
+        }
     }
 
     if (m_svgViewBox) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1363,6 +1363,7 @@ bool Toolkit::RenderToDeviceContext(int pageNo, DeviceContext *deviceContext)
     assert(userScale != 0.0);
 
     if (m_options->m_scaleToPageSize.GetValue()) {
+        deviceContext->SetBaseSize(width, height);
         height *= (1.0 / userScale);
         width *= (1.0 / userScale);
     }


### PR DESCRIPTION
When `--scale` and `--scale-to-page-size` are used together, sometimes resulting width/height are not equal to the original values.
This PR addresses that problem. Additionally, when `px` are used for size, it's rounded up to make sure that we have size in exact number of pixels.