### PR TITLE
Take staff line thickness into account

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -462,7 +462,8 @@ void View::DrawGrpSym(DeviceContext *dc, Measure *measure, StaffGrp *staffGrp, i
     switch (groupSymbol->GetSymbol()) {
         case staffGroupingSym_SYMBOL_line: {
             const int lineWidth = m_doc->GetDrawingUnit(staffSize) * m_options->m_bracketThickness.GetValue();
-            this->DrawVerticalLine(dc, yTop, yBottom, x - 1.5 * lineWidth, lineWidth);
+            const int yOffset = m_doc->GetDrawingUnit(staffSize) * m_options->m_staffLineWidth.GetValue() / 2;
+            this->DrawVerticalLine(dc, yTop + yOffset, yBottom - yOffset, x - 1.5 * lineWidth, lineWidth);
             x -= 2 * lineWidth;
             break;
         }


### PR DESCRIPTION
Small fix to make group lines actually have full staff height. 

![after](https://user-images.githubusercontent.com/7693447/203372645-be4d4b6c-6598-4320-b221-fd41130e713a.png)
