### PR TITLE
Fix font generation

### DIFF
--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -148,13 +148,9 @@ def extract_fonts(opts: Namespace) -> bool:
         log.error("Could not read %s. Does it exist?", font_pth)
         return False
 
-    if not os.access(output_pth, os.W_OK):
-        log.error("Could not write to %s. Check permissions.", output_pth)
-        return False
-
     if not glyph_file_pth.is_dir():
         log.debug("Creating %s", glyph_file_pth)
-        glyph_file_pth.mkdir(exist_ok=True)
+        glyph_file_pth.mkdir(parents=True)
 
     svg_data = __read_svg_font_file(str(font_pth))
     if not svg_data:

--- a/fonts/generate.py
+++ b/fonts/generate.py
@@ -148,6 +148,10 @@ def extract_fonts(opts: Namespace) -> bool:
         log.error("Could not read %s. Does it exist?", font_pth)
         return False
 
+    if not os.access(data_pth, os.W_OK):
+        log.error("Could not write to %s. Check permissions.", data_pth)
+        return False
+
     if not glyph_file_pth.is_dir():
         log.debug("Creating %s", glyph_file_pth)
         glyph_file_pth.mkdir(parents=True)


### PR DESCRIPTION
This PR improves the font generation script to enable starting with a clean output. 

Checking if it is possible to write to the bounding box file before creating the directory doesn't make sense. With that it is not possible to remove this file and start the generation new. (Also there is no check in place for the css file.)

Also `exist_ok` doesn't make much sense because we should never get to the line if it exists. Instead, using `parents=True` makes sure you can delete the whole `data` folder.