### PR TITLE
Develop unit

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -655,7 +655,7 @@ public:
     OptionBool m_svgFormatRaw;
     OptionBool m_svgRemoveXlink;
     OptionArray m_svgAdditionalAttribute;
-    OptionInt m_unit;
+    OptionDbl m_unit;
     OptionBool m_useFacsimile;
     OptionBool m_usePgFooterForAll;
     OptionBool m_usePgHeaderForAll;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -209,10 +209,11 @@ public:
         m_defaultValue = 0.0;
         m_minValue = 0.0;
         m_maxValue = 0.0;
+        m_definitionFactor = false;
     }
     virtual ~OptionDbl() {}
     void CopyTo(Option *option) override;
-    void Init(double defaultValue, double minValue, double maxValue);
+    void Init(double defaultValue, double minValue, double maxValue, bool definitionFactor = false);
 
     bool SetValueDbl(double value) override;
     bool SetValue(const std::string &value) override;
@@ -222,7 +223,8 @@ public:
     void Reset() override;
     bool IsSet() const override;
 
-    double GetValue() const { return m_value; }
+    double GetValue() const;
+    double GetUnfactoredValue() const;
     double GetDefault() const { return m_defaultValue; }
     double GetMin() const { return m_minValue; }
     double GetMax() const { return m_maxValue; }
@@ -237,6 +239,7 @@ private:
     double m_defaultValue;
     double m_minValue;
     double m_maxValue;
+    bool m_definitionFactor;
 };
 
 //----------------------------------------------------------------------------
@@ -254,6 +257,7 @@ public:
         m_defaultValue = 0;
         m_minValue = 0;
         m_maxValue = 0;
+        m_definitionFactor = false;
     }
     virtual ~OptionInt() {}
     void CopyTo(Option *option) override;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -239,12 +239,13 @@ void OptionDbl::CopyTo(Option *option)
     *child = *this;
 }
 
-void OptionDbl::Init(double defaultValue, double minValue, double maxValue)
+void OptionDbl::Init(double defaultValue, double minValue, double maxValue, bool definitionFactor)
 {
     m_value = defaultValue;
     m_defaultValue = defaultValue;
     m_minValue = minValue;
     m_maxValue = maxValue;
+    m_definitionFactor = definitionFactor;
 }
 
 bool OptionDbl::SetValue(const std::string &value)
@@ -265,6 +266,16 @@ std::string OptionDbl::GetDefaultStrValue() const
 bool OptionDbl::SetValueDbl(double value)
 {
     return this->SetValue(value);
+}
+
+double OptionDbl::GetValue() const
+{
+    return (m_definitionFactor) ? m_value * DEFINITION_FACTOR : m_value;
+}
+
+double OptionDbl::GetUnfactoredValue() const
+{
+    return m_value;
 }
 
 bool OptionDbl::SetValue(double value)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1164,7 +1164,7 @@ Options::Options()
     this->Register(&m_svgAdditionalAttribute, "svgAdditionalAttribute", &m_general);
 
     m_unit.SetInfo("Unit", "The MEI unit (1⁄2 of the distance between the staff lines)");
-    m_unit.Init(9, 6, 20, true);
+    m_unit.Init(9.0, 4.5, 12.0, true);
     this->Register(&m_unit, "unit", &m_general);
 
     m_useBraceGlyph.SetInfo("Use Brace Glyph", "Use brace glyph from current font");

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -936,7 +936,7 @@ std::string Toolkit::GetOptions(bool defaultValues) const
         const OptionJson *optJson = dynamic_cast<const OptionJson *>(iter->second);
 
         if (optDbl) {
-            double dblValue = (defaultValues) ? optDbl->GetDefault() : optDbl->GetValue();
+            double dblValue = (defaultValues) ? optDbl->GetDefault() : optDbl->GetUnfactoredValue();
             jsonxx::Value value(dblValue);
             value.precision_ = 2;
             o << iter->first << value;


### PR DESCRIPTION
Change MEI unit option to double and adjust possible values
* Default value remains 9.0
* Minimum is now 4.5
* Maximum is now 12.0

These values follow the standard practice described in Behind Bars and will be documented better in the Reference book.