### PR TITLE
Humdrum import: Handle clef changes in the middle of a rest

### DIFF
--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -806,6 +806,8 @@ protected:
     template <class ELEMENT> void addArticulations(ELEMENT element, hum::HTp token);
     template <class ELEMENT> hum::HumNum convertRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> void setRhythmFromDuration(ELEMENT element, hum::HumNum dur);
+    template <class ELEMENT> void setGesturalRhythmFromDuration(ELEMENT element, hum::HumNum dur);
+    template <class ELEMENT> void setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::HumNum visdur, hum::HumNum gesdur);
     template <class ELEMENT> hum::HumNum convertMensuralRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> hum::HumNum setDuration(ELEMENT element, hum::HumNum duration);
     template <class ELEMENT> void setStaff(ELEMENT element, int staffnum);


### PR DESCRIPTION
Clef change in the middle of a space was already handled.  In the case of a (visible) rest, we need to keep the visual duration of the original rest, set it's gestural duration to the pre-clef duration, and add a space after the clef containing the remainder of the duration (i.e. the post-clef duration).