### PR TITLE
Humdrum import: Handle clef changes in the middle of a rest

### DIFF
--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -785,6 +785,9 @@ protected:
     void insertGlissandos(std::vector<hum::HTp> &tokens);
     void createGlissando(hum::HTp glissStart, hum::HTp glissEnd);
     void setSmuflContent(Symbol *symbol, const std::string &name);
+    data_DURATION oneOverDenominatorToDur(int denominator);
+    bool isExpressibleDuration(hum::HumNum duration);
+    pair<data_DURATION, int> getDurAndDots(hum::HumNum duration);
 
     // header related functions: ///////////////////////////////////////////
     void createHeader();
@@ -806,7 +809,6 @@ protected:
     template <class ELEMENT> void addArticulations(ELEMENT element, hum::HTp token);
     template <class ELEMENT> hum::HumNum convertRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> void setRhythmFromDuration(ELEMENT element, hum::HumNum dur);
-    template <class ELEMENT> void setGesturalRhythmFromDuration(ELEMENT element, hum::HumNum dur);
     template <class ELEMENT> void setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::HumNum visdur, hum::HumNum gesdur);
     template <class ELEMENT> hum::HumNum convertMensuralRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> hum::HumNum setDuration(ELEMENT element, hum::HumNum duration);

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -806,6 +806,8 @@ protected:
     template <class ELEMENT> void addArticulations(ELEMENT element, hum::HTp token);
     template <class ELEMENT> hum::HumNum convertRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> void setRhythmFromDuration(ELEMENT element, hum::HumNum dur);
+    template <class ELEMENT> void setGesturalRhythmFromDuration(ELEMENT element, hum::HumNum dur);
+    template <class ELEMENT> void setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::HumNum visdur, hum::HumNum gesdur);
     template <class ELEMENT> hum::HumNum convertMensuralRhythm(ELEMENT element, hum::HTp token, int subtoken = -1);
     template <class ELEMENT> hum::HumNum setDuration(ELEMENT element, hum::HumNum duration);
     template <class ELEMENT> void setStaff(ELEMENT element, int staffnum);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -9885,7 +9885,8 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                             clef->SetID(id);
                         }
                         if (restSplitToken != NULL) {
-                            // Add the second part of a split invisible rest:
+                            // Add the second part of a split invisible rest (or
+                            // the invisible second part of a split visible rest):
                             Space *irest = new Space();
                             if (m_doc->GetOptions()->m_humType.GetValue()) {
                                 embedQstampInClass(irest, restSplitToken, *restSplitToken);
@@ -10114,12 +10115,14 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                 if ((i < (int)layerdata.size() - 1) && layerdata[i + 1]->isClef()) {
                     hum::HumNum dur = layerdata[i]->getDuration();
                     hum::HumNum ndur = layerdata[i + 1]->getDurationFromStart() - layerdata[i]->getDurationFromStart();
+                    hum::HumNum remainingDur = dur - ndur;
 
-                    if (ndur < dur) {
+                    if ((ndur < dur)
+                            && isExpressibleDuration(ndur)
+                            && isExpressibleDuration(remainingDur)) {
                         // create a split invisible rest so that an intervening clef
                         // can be positioned properly.
                         // split the space into two pieces, this is the firsthalf.
-                        hum::HumNum splitdur = dur - ndur;
                         Space *irest = new Space();
                         if (m_doc->GetOptions()->m_humType.GetValue()) {
                             embedQstampInClass(irest, layerdata[i], *layerdata[i]);
@@ -10127,14 +10130,14 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         setLocationId(irest, layerdata[i]);
                         appendElement(elements, pointers, irest);
                         // convertRhythm(irest, layerdata[i]);
-                        setRhythmFromDuration(irest, splitdur);
+                        setRhythmFromDuration(irest, ndur);
                         processSlurs(layerdata[i]);
                         processPhrases(layerdata[i]);
                         processDynamics(layerdata[i], staffindex);
                         processDirections(layerdata[i], staffindex);
                         // Store rest here to complete the split after the clef change.
                         restSplitToken = layerdata[i];
-                        remainingSplitDur = ndur;
+                        remainingSplitDur = remainingDur;
                     }
                     else {
                         // normal space
@@ -10172,8 +10175,11 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                 if ((i < (int)layerdata.size() - 1) && layerdata[i + 1]->isClef()) {
                     hum::HumNum dur = layerdata[i]->getDuration();
                     hum::HumNum ndur = layerdata[i + 1]->getDurationFromStart() - layerdata[i]->getDurationFromStart();
+                    hum::HumNum remainingDur = dur - ndur;
 
-                    if (ndur < dur) {
+                    if ((ndur < dur)
+                            && isExpressibleDuration(ndur)
+                            && isExpressibleDuration(remainingDur)) {
                         // Create a split rest so that an intervening clef
                         // can be positioned properly.  There will be two
                         // pieces: first: this original rest, with the visual
@@ -10182,7 +10188,6 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         // rest (space) that has the post-clef duration.
                         // Here we emit the original rest, and save off what
                         // the second rest should be.
-                        hum::HumNum splitdur = dur - ndur;
                         Rest *rest1 = new Rest();
                         if (m_doc->GetOptions()->m_humType.GetValue()) {
                             embedQstampInClass(rest1, layerdata[i], *layerdata[i]);
@@ -10190,14 +10195,14 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         setLocationId(rest1, layerdata[i]);
                         appendElement(elements, pointers, rest1);
                         // convertRhythm(irest, layerdata[i]);
-                        setVisualAndGesturalRhythmFromDuration(rest1, dur, splitdur);
+                        setVisualAndGesturalRhythmFromDuration(rest1, dur, ndur);
                         processSlurs(layerdata[i]);
                         processPhrases(layerdata[i]);
                         processDynamics(layerdata[i], staffindex);
                         processDirections(layerdata[i], staffindex);
                         // Store rest here to complete the split after the clef change.
                         restSplitToken = layerdata[i];
-                        remainingSplitDur = ndur;
+                        remainingSplitDur = remainingDur;
                     }
                     else {
                         hum::HumNum restDur = hum::Convert::recipToDuration(layerdata[i]);
@@ -10447,6 +10452,180 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
     }
 
     return true;
+}
+
+//////////////////////////////
+//
+// HumdrumInput::isExpressibleDuration -- returns whether or not this
+//      duration can be expressed as MEI @dur/@dots attributes. We limit
+//      ourselves to three dots, and take into account the current tuplet
+//      scaling.
+//
+
+bool HumdrumInput::isExpressibleDuration(hum::HumNum duration)
+{
+    // convert to whole note units
+    hum::HumNum dur = duration / 4;
+    // take into account current tuplet scaling
+    dur *= m_tupletscaling;
+
+    if (dur.getDenominator() == 1) {
+        if (dur.getNumerator() == 2) {
+            return true;  // breve
+        } else if (dur.getNumerator() == 3) {
+            return true; // dotted breve
+        } else if (dur.getNumerator() == 4) {
+            return true;  // long
+        } else if (dur.getNumerator() == 6) {
+            return true; // dotted long
+        } else if (dur.getNumerator() == 8) {
+            return true;  // maxima
+        } else if (dur.getNumerator() == 12) {
+            return true; // dotted maxima
+        }
+    }
+
+    // decide if the rhythm can be represented as 1/2**n with no dots.
+    if (dur.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(dur.getDenominator())) {
+            return true;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with one dot.
+    hum::HumNum test1dot = (dur * 2) / 3;
+    if (test1dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test1dot.getDenominator())) {
+            return true;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with two dots.
+    hum::HumNum test2dot = (dur * 4) / 7;
+    if (test2dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test2dot.getDenominator())) {
+            return true;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with three dots.
+    hum::HumNum test3dot = (dur * 8) / 15;
+    if (test3dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test3dot.getDenominator())) {
+            return true;
+        }
+    }
+
+    // duration required more than three dots or is not 1/2**n at all.
+    return false;
+
+}
+
+data_DURATION HumdrumInput::oneOverDenominatorToDur(int denominator) {
+    switch (denominator) {
+        case 1: return DURATION_1;
+        case 2: return DURATION_2;
+        case 4: return DURATION_4;
+        case 8: return DURATION_8;
+        case 16: return DURATION_16;
+        case 32: return DURATION_32;
+        case 64: return DURATION_64;
+        case 128: return DURATION_128;
+        case 256: return DURATION_256;
+        case 512: return DURATION_512;
+        case 1024: return DURATION_1024;
+        case 2048: return DURATION_2048;
+    }
+    return DURATION_NONE;
+}
+
+//////////////////////////////
+//
+// HumdrumInput::isExpressibleDuration -- returns MEI @dur/@dots attributes
+//      for a duration.
+//
+
+pair<data_DURATION, int> HumdrumInput::getDurAndDots(hum::HumNum duration)
+{
+    pair<data_DURATION, int> output;
+
+    // convert to whole note units
+    hum::HumNum dur = duration / 4;
+    // take into account current tuplet scaling
+    dur *= m_tupletscaling;
+
+    if (dur.getDenominator() == 1) {
+        if (dur.getNumerator() == 2) {
+            output.first = DURATION_breve;
+            output.second = 0;
+            return output; // breve
+        } else if (dur.getNumerator() == 3) {
+            output.first = DURATION_breve;
+            output.second = 1;
+            return output; // dotted breve
+        } else if (dur.getNumerator() == 4) {
+            output.first = DURATION_long;
+            output.second = 0;
+            return output;  // long
+        } else if (dur.getNumerator() == 6) {
+            output.first = DURATION_long;
+            output.second = 1;
+            return output; // dotted long
+        } else if (dur.getNumerator() == 8) {
+            output.first = DURATION_maxima;
+            output.second = 0;
+            return output;  // maxima
+        } else if (dur.getNumerator() == 12) {
+            output.first = DURATION_maxima;
+            output.second = 1;
+            return output; // dotted maxima
+        }
+    }
+
+    // decide if the rhythm can be represented as 1/2**n with no dots.
+    if (dur.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(dur.getDenominator())) {
+            output.first = oneOverDenominatorToDur(dur.getDenominator());
+            output.second = 0;
+            return output;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with one dot.
+    hum::HumNum test1dot = (dur * 2) / 3;
+    if (test1dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test1dot.getDenominator())) {
+            output.first = oneOverDenominatorToDur(test1dot.getDenominator());
+            output.second = 1;
+            return output;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with two dots.
+    hum::HumNum test2dot = (dur * 4) / 7;
+    if (test2dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test2dot.getDenominator())) {
+            output.first = oneOverDenominatorToDur(test2dot.getDenominator());
+            output.second = 2;
+            return output;
+        }
+    }
+
+    // now decide if the rhythm can be represented as 1/2**n with three dots.
+    hum::HumNum test3dot = (dur * 8) / 15;
+    if (test3dot.getNumerator() == 1) {
+        if (hum::Convert::isPowerOfTwo(test3dot.getDenominator())) {
+            output.first = oneOverDenominatorToDur(test3dot.getDenominator());
+            output.second = 3;
+            return output;
+        }
+    }
+
+    // duration required more than three dots or is not 1/2**n at all.
+    output.first = DURATION_NONE;
+    output.second = 0;
+    return output;
+
 }
 
 //////////////////////////////
@@ -22485,87 +22664,37 @@ template <class ELEMENT> hum::HumNum HumdrumInput::convertMensuralRhythm(ELEMENT
 
 //////////////////////////////
 //
-// HumdrumInput::setRhythmFromDuration -- Used for splitting invisible rests across
-//    clef changes, so a simple algorithm.  Currently does not allow for tuplets or
-//    dotted rhythms.
+// HumdrumInput::setRhythmFromDuration --
 //
 
-template <class ELEMENT> void HumdrumInput::setRhythmFromDuration(ELEMENT element, hum::HumNum dur)
+template <class ELEMENT> void HumdrumInput::setRhythmFromDuration(ELEMENT element, hum::HumNum duration)
 {
-    dur /= 4; // convert to whole-note units
-
-    if (dur.isInteger()) {
-        switch (dur.getNumerator()) {
-            case 1: element->SetDur(DURATION_1); break;
-            case 2: element->SetDur(DURATION_breve); break;
-            case 4: element->SetDur(DURATION_long); break;
-            case 8: element->SetDur(DURATION_maxima); break;
-        }
-    }
-    else if (dur.getNumerator() == 1) {
-        switch (dur.getDenominator()) {
-            case 2: element->SetDur(DURATION_2); break;
-            case 4: element->SetDur(DURATION_4); break;
-            case 8: element->SetDur(DURATION_8); break;
-            case 16: element->SetDur(DURATION_16); break;
-            case 32: element->SetDur(DURATION_32); break;
-            case 64: element->SetDur(DURATION_64); break;
-            case 128: element->SetDur(DURATION_128); break;
-            case 256: element->SetDur(DURATION_256); break;
-            case 512: element->SetDur(DURATION_512); break;
-            case 1024: element->SetDur(DURATION_1024); break;
-            case 2048: element->SetDur(DURATION_2048); break;
-        }
+    pair<data_DURATION, int> durAndDots = getDurAndDots(duration);
+    element->SetDur(durAndDots.first);
+    if (durAndDots.second != 0) {
+        element->SetDots(durAndDots.second);
     }
 }
 
 //////////////////////////////
 //
-// HumdrumInput::setGesturalRhythmFromDuration -- Used for splitting rests across
-//    clef changes, so a simple algorithm.  Currently does not allow for tuplets or
-//    dotted rhythms.
-//
-
-template <class ELEMENT> void HumdrumInput::setGesturalRhythmFromDuration(ELEMENT element, hum::HumNum dur)
-{
-    dur /= 4; // convert to whole-note units
-
-    if (dur.isInteger()) {
-        switch (dur.getNumerator()) {
-            case 1: element->SetDurGes(DURATION_1); break;
-            case 2: element->SetDurGes(DURATION_breve); break;
-            case 4: element->SetDurGes(DURATION_long); break;
-            case 8: element->SetDurGes(DURATION_maxima); break;
-        }
-    }
-    else if (dur.getNumerator() == 1) {
-        switch (dur.getDenominator()) {
-            case 2: element->SetDurGes(DURATION_2); break;
-            case 4: element->SetDurGes(DURATION_4); break;
-            case 8: element->SetDurGes(DURATION_8); break;
-            case 16: element->SetDurGes(DURATION_16); break;
-            case 32: element->SetDurGes(DURATION_32); break;
-            case 64: element->SetDurGes(DURATION_64); break;
-            case 128: element->SetDurGes(DURATION_128); break;
-            case 256: element->SetDurGes(DURATION_256); break;
-            case 512: element->SetDurGes(DURATION_512); break;
-            case 1024: element->SetDurGes(DURATION_1024); break;
-            case 2048: element->SetDurGes(DURATION_2048); break;
-        }
-    }
-}
-
-//////////////////////////////
-//
-// HumdrumInput::setVisualAndGesturalRhythmFromDuration -- Used for splitting rests across
-//    clef changes, so a simple algorithm.  Currently does not allow for tuplets or
-//    dotted rhythms.
+// HumdrumInput::setVisualAndGesturalRhythmFromDuration --
 //
 
 template <class ELEMENT> void HumdrumInput::setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::HumNum visdur, hum::HumNum gesdur)
 {
-    setRhythmFromDuration(element, visdur);
-    setGesturalRhythmFromDuration(element, gesdur);
+    pair<data_DURATION, int> visDurAndDots = getDurAndDots(visdur);
+    element->SetDur(visDurAndDots.first);
+    if (visDurAndDots.second != 0) {
+        element->SetDots(visDurAndDots.second);
+    }
+    pair<data_DURATION, int> gesDurAndDots = getDurAndDots(gesdur);
+    if (gesDurAndDots.first != visDurAndDots.first) {
+        element->SetDurGes(gesDurAndDots.first);
+    }
+    if (gesDurAndDots.second != visDurAndDots.second) {
+        element->SetDotsGes(gesDurAndDots.second);
+    }
 }
 
 //////////////////////////////

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -10199,6 +10199,30 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                         restSplitToken = layerdata[i];
                         remainingSplitDur = ndur;
                     }
+                    else {
+                        hum::HumNum restDur = hum::Convert::recipToDuration(layerdata[i]);
+                        if ((restDur == duration) && (restDur == timesigdurs[startline])) {
+                            // whole-measure rest with something else also in
+                            // measure (such as grace notes).
+                            MRest *mrest = new MRest();
+                            setLocationId(mrest, layerdata[i]);
+                            appendElement(elements, pointers, mrest);
+                            // colorRest(mrest, *layerdata[i], line, field);
+                            verticalRest(mrest, *layerdata[i]);
+                        }
+                        else {
+                            Rest *rest = new Rest();
+                            setLocationId(rest, layerdata[i]);
+                            appendElement(elements, pointers, rest);
+                            convertRest(rest, layerdata[i], -1, staffindex);
+                            colorRest(rest, *layerdata[i], line, field);
+                            verticalRest(rest, *layerdata[i]);
+                        }
+                        processSlurs(layerdata[i]);
+                        processPhrases(layerdata[i]);
+                        processDynamics(layerdata[i], staffindex);
+                        processDirections(layerdata[i], staffindex);
+                    }
                 }
                 else {
                     hum::HumNum restDur = hum::Convert::recipToDuration(layerdata[i]);


### PR DESCRIPTION
Clef change in the middle of a space was already handled. In the case of a (visible) rest, we need to keep the visual duration of the original rest, set it's gestural duration to the pre-clef duration, and add a space after the clef containing the remainder of the duration (i.e. the post-clef duration).