### PR TITLE
Build modularized JS toolkit with support for `-s EXPORT_ES6`

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -193,6 +193,9 @@ if (BUILD_AS_LIBRARY)
 ###########
 
 elseif (BUILD_AS_WASM)
+    if (EMSCRIPTEN_VERSION VERSION_LESS "3.1.27")
+        message(FATAL_ERROR "You need em++ 3.1.27 or greater")
+    endif()
     message(STATUS "***** Building Verovio as WASM BC *****")
     add_library(verovio STATIC ../tools/c_wrapper.cpp ${all_SRC})
 

--- a/emscripten/buildNpmPackage
+++ b/emscripten/buildNpmPackage
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e -o pipefail
 
 # clean dist folder and reinstall node modules
 rm -rf ./npm/dist

--- a/emscripten/buildNpmPackage
+++ b/emscripten/buildNpmPackage
@@ -12,11 +12,11 @@ npm --prefix npm run prebundle
 
 # build modularized emscripten module with humdrum
 ./buildToolkit -c -w -M -m
-cp ./build/verovio.js ./npm/dist/verovio-module-hum.js
+cp ./build/verovio.js ./npm/dist/verovio-module-hum.mjs
 
 # build modularized emscripten module without humdrum
 ./buildToolkit -c -w -M -H -m
-cp ./build/verovio.js ./npm/dist/verovio-module.js
+cp ./build/verovio.js ./npm/dist/verovio-module.mjs
 
 # build CommonJS and ESM code for verovio toolkit
 npm --prefix npm run build

--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -239,7 +239,7 @@ if ($makeQ) {
 
 print "*************\nBuilding makefile...\n";
 my $cmakeCmd = "$EMCMAKE cmake ../cmake $cmake -DCMAKE_CXX_FLAGS=\"$FLAGS\"";
-system($cmakeCmd);
+system($cmakeCmd) == 0 or die "system $cmakeCmd failed: $?";
 
 print "*************\nCompiling...\n";
 my $makeCmd = "$EMMAKE make -j 8";

--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -230,7 +230,7 @@ $exports .= "]\"";
 
 my $extra_exports = "-s EXPORTED_RUNTIME_METHODS='[\"cwrap\"]'";
 
-my $modularize = $modularizeQ ? "-s MODULARIZE=1 -s EXPORT_NAME=\"'createVerovioModule'\"" : "";
+my $modularize = $modularizeQ ? "-s MODULARIZE=1 -s EXPORT_ES6=1 -s EXPORT_NAME=\"'createVerovioModule'\"" : "";
 
 if ($makeQ) {
 	system("rm -rf CMakeFiles/");

--- a/emscripten/npm/package.json
+++ b/emscripten/npm/package.json
@@ -9,8 +9,8 @@
       "import": "./dist/verovio.mjs",
       "require": "./dist/verovio.cjs"
     },
-    "./wasm": "./dist/verovio-module.js",
-    "./wasm-hum": "./dist/verovio-module-hum.js"
+    "./wasm": "./dist/verovio-module.mjs",
+    "./wasm-hum": "./dist/verovio-module-hum.mjs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Related to https://github.com/rism-digital/verovio/issues/3168.

Recently there was some progress in emscripten to support ECMAScript modules and https://github.com/emscripten-core/emscripten/issues/11792 was implemented in https://github.com/emscripten-core/emscripten/pull/17915. This means that since `em++` v3.1.27 we can use the `EXPORT_ES6` flag to generate an ESM build of the emscripten module instead of a CommonJS module (that can be imported with ESM).

Is there anything I can add to force usage of em++ v3.1.27?

I did some tests an even without 3bca155 everything did work just fine in my project. But adding `mjs` as file extension will probably be the safer method to ensure the verovio-module will be used with ESM. For other usage you can still use `verovio-toolkit-wasm.js` with CommonJS due to the UMD format.

Probably this won't fix all cases when using verovio with bundlers (see this comment https://github.com/emscripten-core/emscripten/issues/11792#issuecomment-1319507031) but it should still improve ESM support.