### PR TITLE
Improve comments

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -92,7 +92,7 @@ public:
 
     /**
      * Special method for forcing bounding boxes to be updated
-     * Used for invisible elements (e.g. <space>) that needs to be take into account in spacing
+     * Used for invisible elements (e.g., <space>) that needs to be take into account in spacing
      */
     void DrawPlaceholder(int x, int y) override;
 

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -201,7 +201,7 @@ public:
 
     /**
      * Special method for forcing bounding boxes to be updated
-     * Used for invisible elements (e.g. <space>) that needs to be take into account in spacing
+     * Used for invisible elements (e.g., <space>) that needs to be take into account in spacing
      */
     virtual void DrawPlaceholder(int x, int y){};
 

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -256,7 +256,7 @@ public:
     BezierCurve() {}
     BezierCurve(const Point &p1, const Point &c1, const Point &c2, const Point &p2) : p1(p1), c1(c1), c2(c2), p2(p2) {}
 
-    // Helper to rotate all points within bezier curve around @rotationPoint by @angle
+    // Helper to rotate all points within bezier curve around \@rotationPoint by \@angle
     void Rotate(float angle, const Point &rotationPoint);
 
     /**

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -96,7 +96,7 @@ public:
     /**
      * Return information about the position in the beam.
      * (no const since the cached list is updated)
-     * Object * is a pointer to the object implementing the interface (e.g, Beam, fTrem)
+     * Object * is a pointer to the object implementing the interface (e.g., Beam, fTrem)
      */
     ///@{
     bool IsFirstIn(const Object *object, const LayerElement *element) const;

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -318,7 +318,7 @@ private:
     void WriteRevisionDesc(pugi::xml_node meiHead);
 
     /**
-     * Write the @xml:id to the currentNode
+     * Write the \@xml:id to the currentNode
      */
     void WriteXmlId(pugi::xml_node currentNode, Object *object);
 

--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -278,7 +278,7 @@ private:
     Layer *SelectLayer(short int staffNb, Measure *measure);
 
     /*
-     * Returns the layer with @n=layerNb on the staff.
+     * Returns the layer with \@n=layerNb on the staff.
      * Creates the layer if not found.
      */
     Layer *SelectLayer(short int layerNb, Staff *staff);
@@ -404,7 +404,7 @@ private:
     ///@}
 
     /*
-     * @name Helper method for setting @staff attribute for chords
+     * @name Helper method for setting \@staff attribute for chords
      */
     ///@{
     void SetChordStaff(Layer *layer);

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -177,8 +177,8 @@ private:
     bool m_docScoreDef; // Indicates that we are writing the document scoreDef
     bool m_mensural; // Indicates that the incipit is mensural (initial staffDef)
     bool m_skip; // Processing a staff or a layer to skip
-    int m_layerN; // The @n of the first layer within the first staff
-    int m_staffN; // The @n of the first staff (initial staffDef)
+    int m_layerN; // The \@n of the first layer within the first staff
+    int m_staffN; // The \@n of the first staff (initial staffDef)
     int m_currentOct; // The current octave
     int m_currentDur; // The current duration
     int m_currentDots;
@@ -533,7 +533,7 @@ public:
 
 private:
     /**
-     * Convert the old-style @clef:... @keysig:... @data:... to a JSON input
+     * Convert the old-style \@clef:... \@keysig:... \@data:... to a JSON input
      */
     jsonxx::Object InputKeysToJson(const std::string &inputKeys);
 
@@ -690,7 +690,7 @@ private:
 
     /**
      * A flag indicating the incipit is mensural.
-     * Based on the @clef of the input.
+     * Based on the \@clef of the input.
      */
     bool m_isMensural;
 

--- a/include/vrv/linkinginterface.h
+++ b/include/vrv/linkinginterface.h
@@ -100,7 +100,7 @@ public:
 
 protected:
     /**
-     * Extract the fragment of the start or end @xml:id if given
+     * Extract the fragment of the start or end \@xml:id if given
      */
     void SetIDStr();
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -237,7 +237,7 @@ public:
     /**
      * Reset pointers after a copy and assignment constructor call.
      * This methods has to be called expicitly when overriden because it is not called from the constructors.
-     * Do not forget to call base-class equivalent whenever applicable (e.g, with more than one hierarchy level).
+     * Do not forget to call base-class equivalent whenever applicable (e.g., with more than one hierarchy level).
      */
     virtual void CloneReset();
 
@@ -789,7 +789,7 @@ public:
     virtual int ConvertToUnCastOffMensural(FunctorParams *) { return FUNCTOR_CONTINUE; }
 
     /**
-     * Convert analytical markup (@fermata, @tie) to elements.
+     * Convert analytical markup (\@fermata, \@tie) to elements.
      * See Doc::ConvertMarkupAnalyticalDoc
      */
     virtual int ConvertMarkupAnalytical(FunctorParams *) { return FUNCTOR_CONTINUE; }
@@ -1268,17 +1268,17 @@ public:
     virtual int PrepareFacsimile(FunctorParams *functorParams);
 
     /**
-     * Match linking element (e.g, @next).
+     * Match linking element (e.g., \@next).
      */
     virtual int PrepareLinking(FunctorParams *functorParams);
 
     /**
-     * Prepare list of elements in the @plist.
+     * Prepare list of elements in the \@plist.
      */
     virtual int PreparePlist(FunctorParams *functorParams);
 
     /**
-     * Match elements of @plist
+     * Match elements of \@plist
      */
     virtual int PrepareProcessPlist(FunctorParams *functorParams);
 
@@ -1311,7 +1311,7 @@ public:
 
     /**
      * Match start and end for TimeSpanningInterface elements with tstamp(2) attributes.
-     * It is performed only on TimeSpanningInterface elements withouth @startid (or @endid).
+     * It is performed only on TimeSpanningInterface elements withouth \@startid (or \@endid).
      * It adds to the start (and end) measure a TimeStampAttr to the Measure::m_tstamps.
      */
     virtual int PrepareTimestamps(FunctorParams *) { return FUNCTOR_CONTINUE; }
@@ -1645,7 +1645,7 @@ private:
 
     /**
      * A flag indicating if the Object represents an attribute in the original MEI.
-     * For example, a Artic child in Note for an original @artic
+     * For example, a Artic child in Note for an original \@artic
      */
     bool m_isAttribute;
 

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -221,7 +221,7 @@ public:
     /** Page top margin (MEI scoredef@page.topmar). Saved if != 0 */
     int m_pageMarginTop;
     /**
-     * Surface (MEI @surface). Saved as facsimile for transciption layout.
+     * Surface (MEI \@surface). Saved as facsimile for transciption layout.
      * For now, the target of the <graphic> element within surface is loaded here.
      */
     std::string m_surface;

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -77,7 +77,7 @@ public:
      * @name Get a copy of the clef, keysig, mensur and meterSig.
      * These methods create new objects (heap) that will need to be deleted.
      * They also convert attribute value objects to an object. For example,
-     * if a staffDef has a @key.sig, the copy will be a KeySig object.
+     * if a staffDef has a \@key.sig, the copy will be a KeySig object.
      * The conversion from attribute to element is performed in the appropriate
      * constructor of each corresponding class (Clef, KeySig, etc.)
      */
@@ -192,7 +192,7 @@ public:
     ///@}
 
     /**
-     * Return all the @n values of the staffDef in a scoreDef
+     * Return all the \@n values of the staffDef in a scoreDef
      */
     std::vector<int> GetStaffNs() const;
 

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -126,7 +126,7 @@ public:
     int GetStaffIdx() const { return Object::GetIdx(); }
 
     /**
-     * Calculate the yRel for the staff given a @loc value
+     * Calculate the yRel for the staff given a \@loc value
      */
     int CalcPitchPosYRel(const Doc *doc, int loc) const;
 

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -118,7 +118,7 @@ public:
 
 protected:
     /**
-     * Extract the fragment of the start or end @xml:id if given
+     * Extract the fragment of the start or end \@xml:id if given
      */
     void SetIDStr();
 

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -164,7 +164,7 @@ public:
     /**
      * @name Methods for managing verse count with / without the collapse option
      * When setting a value of 0, then 1 is assumed. This occurs
-     * Typically with one single verse and no @n in <verse>
+     * Typically with one single verse and no \@n in <verse>
      * Without the collapse option, the count is the greatest @n
      * With the collapse option, the count is number of verses.
      * The position is calculated from the bottom.
@@ -205,7 +205,7 @@ public:
 
     /**
      * @name Setter and getter of the staff from which the alignment is created alignment.
-     * Used for accessing the staff @n, the size, etc.
+     * Used for accessing the staff \@n, the size, etc.
      */
     ///@{
     Staff *GetStaff() { return m_staff; }
@@ -418,7 +418,7 @@ private:
     ///@}
 
     /**
-     * The list of overflowing bounding boxes (e.g, LayerElement or FloatingPositioner)
+     * The list of overflowing bounding boxes (e.g., LayerElement or FloatingPositioner)
      */
     std::vector<BoundingBox *> m_overflowAboveBBoxes;
     std::vector<BoundingBox *> m_overflowBelowBBoxes;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -392,9 +392,9 @@ typedef bool (*NotePredicate)(const Note *);
  * Generic int map recursive structure for storing hierachy of values
  * For example, we want to process all staves one by one, and within each staff
  * all layer one by one, and so one (lyrics, etc.). In IntTree, we can store
- * @n with all existing values (1 => 1 => 1; 2 => 1 => 1)
+ * \@n with all existing values (1 => 1 => 1; 2 => 1 => 1)
  * The stucture must be filled first and can then be used by instanciating a vector
- * of corresponding Comparison (typically AttNIntegerComparison for @n attribute).
+ * of corresponding Comparison (typically AttNIntegerComparison for \@n attribute).
  * See Doc::PrepareData for an example.
  */
 struct IntTree {

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -207,7 +207,7 @@ int BarLine::ConvertToCastOffMensural(FunctorParams *functorParams)
     }
 
     // Make a segment break
-    // First case: new need to add a new measure segment (e.g, first pass)
+    // First case: new need to add a new measure segment (e.g., first pass)
     if (params->m_targetSubSystem->GetChildCount() <= params->m_segmentIdx) {
         params->m_targetMeasure = new Measure(convertToMeasured);
         if (convertToMeasured) {

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -210,7 +210,7 @@ void BBoxDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
     int p2 = p1;
     // how odd line width is handled might depend on the implementation of the device context.
     // however, we expect the actually width to be shifted on the left/top
-    // e.g. with 7, 4 on the left and 3 on the right
+    // e.g., with 7, 4 on the left and 3 on the right
     if (penWidth % 2) {
         p1++;
     }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -948,7 +948,7 @@ void SvgDeviceContext::DrawText(
     std::string fontFaceName = m_fontStack.top()->GetFaceName();
 
     pugi::xml_node textChild = AppendChild("tspan");
-    // We still add @xml::space (No: this seems to create problems with Safari)
+    // We still add @xml:space (No: this seems to create problems with Safari)
     // textChild.append_attribute("xml:space") = "preserve";
     // Set the @font-family only if it is not the same as in the parent node
     if (!fontFaceName.empty() && (fontFaceName != currentFaceName)) {


### PR DESCRIPTION
This small PR unifies `e.g.` spelling in comments and escapes `@` characters (See https://doxygen.nl/manual/commands.html#cmdat).