### PR TITLE
add deg attribute to note

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -13,6 +13,7 @@
 //----------------------------------------------------------------------------
 
 #include "accid.h"
+#include "atts_analytical.h"
 #include "atts_externalsymbols.h"
 #include "atts_frettab.h"
 #include "atts_mensural.h"
@@ -54,6 +55,7 @@ class Note : public LayerElement,
              public AttCue,
              public AttExtSym,
              public AttGraced,
+             public AttHarmonicFunction,
              public AttMidiVelocity,
              public AttNoteGesTab,
              public AttNoteHeads,

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2668,6 +2668,7 @@ void MEIOutput::WriteNote(pugi::xml_node currentNode, Note *note)
     note->WriteCue(currentNode);
     note->WriteExtSym(currentNode);
     note->WriteGraced(currentNode);
+    note->WriteHarmonicFunction(currentNode);
     note->WriteMidiVelocity(currentNode);
     note->WriteNoteGesTab(currentNode);
     note->WriteNoteHeads(currentNode);
@@ -6620,6 +6621,7 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
     vrvNote->ReadCue(note);
     vrvNote->ReadExtSym(note);
     vrvNote->ReadGraced(note);
+    vrvNote->ReadHarmonicFunction(note);
     vrvNote->ReadMidiVelocity(note);
     vrvNote->ReadNoteGesTab(note);
     vrvNote->ReadNoteHeads(note);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -61,6 +61,7 @@ Note::Note()
     , AttCue()
     , AttExtSym()
     , AttGraced()
+    , AttHarmonicFunction()
     , AttMidiVelocity()
     , AttNoteGesTab()
     , AttNoteHeads()
@@ -78,6 +79,7 @@ Note::Note()
     this->RegisterAttClass(ATT_CUE);
     this->RegisterAttClass(ATT_EXTSYM);
     this->RegisterAttClass(ATT_GRACED);
+    this->RegisterAttClass(ATT_HARMONICFUNCTION);
     this->RegisterAttClass(ATT_NOTEGESTAB);
     this->RegisterAttClass(ATT_NOTEHEADS);
     this->RegisterAttClass(ATT_NOTEVISMENSURAL);
@@ -104,6 +106,7 @@ void Note::Reset()
     this->ResetCue();
     this->ResetExtSym();
     this->ResetGraced();
+    this->ResetHarmonicFunction();
     this->ResetNoteGesTab();
     this->ResetNoteHeads();
     this->ResetNoteVisMensural();


### PR DESCRIPTION
This adds the ability to store data from a `**deg` spine in the `@deg` attribute of a note. 

See https://music-encoding.org/guidelines/dev/data-types/data.SCALEDEGREE.html

However, when there are multiple `**deg` spines I'm not sure what should be done. 
