### PR TITLE
Enhance Gliss line styles

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -544,7 +544,6 @@ protected:
     void DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width, int dashLength = 0, int gapLength = 0);
     void DrawHorizontalLine(
         DeviceContext *dc, int x1, int x2, int y1, int width, int dashLength = 0, int gapLength = 0);
-    void DrawRoundedLine(DeviceContext *dc, int x1, int y1, int x2, int y2, int width);
     void DrawVerticalSegmentedLine(
         DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength = 0, int gapLength = 0);
     void DrawHorizontalSegmentedLine(

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2098,13 +2098,26 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
             const int height = m_doc->GetGlyphHeight(glissGlyph, staff->m_drawingStaffSize, false);
             const Point orig(x1, y1 - height / 2);
             this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, glissGlyph);
-
             break;
         }
-        case LINEFORM_solid:
+        case LINEFORM_dashed:
+            dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
+            dc->ResetPen();
+            break;
+        case LINEFORM_dotted:
+            dc->SetPen(m_currentColour, lineWidth * 3 / 2, AxDOT, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
+            dc->ResetPen();
+            break;
+        case LINEFORM_solid: [[fallthrough]];
         default: {
-            // only solid lines for now
-            this->DrawRoundedLine(dc, x1, y1, x2, y2, lineWidth);
+            dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
+            dc->ResetPen();
             break;
         }
     }

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -52,20 +52,6 @@ void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int wid
     return;
 }
 
-void View::DrawRoundedLine(DeviceContext *dc, int x1, int y1, int x2, int y2, int width)
-{
-    assert(dc);
-
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, 0, 0, AxCAP_ROUND);
-    dc->SetBrush(m_currentColour, AxSOLID);
-
-    dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
-
-    dc->ResetPen();
-    dc->ResetBrush();
-    return;
-}
-
 void View::DrawVerticalSegmentedLine(
     DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength, int gapLength)
 {


### PR DESCRIPTION
This adds additional line styles to `gliss`.

![gliss-new](https://user-images.githubusercontent.com/7693447/210266871-9a8cf8bd-f0f3-4c4e-9ccb-c9a018f7872f.png)

`dotted` lines are a bit thicker to better match the other styles. 
`DrawRoundedLine` was removed for this in favor of using `SetPen` directly.