### PR TITLE
beamSpan stem fix

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -204,7 +204,6 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
             const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
             if (coord->m_partialFlagPlace == coord->m_beamRelativePlace) {
                 stemOffset = (coord->m_dur - DUR_8) * beamInterface->m_beamWidth;
-                if (stemOffset && m_firstNoteOrChord && (m_firstNoteOrChord->m_yBeam % unit)) stemOffset -= unit / 2;
             }
             else if (el->GetIsInBeamSpan() && (coord->m_partialFlagPlace != BEAMPLACE_above)
                 && (coord->m_stem->GetDrawingStemDir() == STEMDIRECTION_up)) {

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -201,10 +201,14 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
         }
         else if (beamInterface->m_drawingPlace == BEAMPLACE_mixed) {
             int stemOffset = 0;
+            const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
             if (coord->m_partialFlagPlace == coord->m_beamRelativePlace) {
                 stemOffset = (coord->m_dur - DUR_8) * beamInterface->m_beamWidth;
-                const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
                 if (stemOffset && m_firstNoteOrChord && (m_firstNoteOrChord->m_yBeam % unit)) stemOffset -= unit / 2;
+            }
+            else if (el->GetIsInBeamSpan() && (coord->m_partialFlagPlace != BEAMPLACE_above)
+                && (coord->m_stem->GetDrawingStemDir() == STEMDIRECTION_up)) {
+                stemOffset = -unit / 2;
             }
             // handle cross-staff fTrem cases
             const auto [beams, beamsFloat] = beamInterface->GetFloatingBeamCount();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -17,6 +17,7 @@
 #include "annot.h"
 #include "app.h"
 #include "beam.h"
+#include "beamspan.h"
 #include "choice.h"
 #include "clef.h"
 #include "comparison.h"
@@ -1647,6 +1648,15 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
     assert(parent);
     assert(measure);
     assert(system);
+
+    ListOfObjects objects = parent->FindAllDescendantsByType(BEAMSPAN, false);
+    for (auto element : objects) {
+        BeamSpan *beamSpan = vrv_cast<BeamSpan *>(element);
+        BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
+        if (segment) {
+            segment->CalcBeam(segment->GetLayer(), segment->GetStaff(), m_doc, beamSpan, beamSpan->m_drawingPlace);
+        }
+    }
 
     for (auto current : parent->GetChildren()) {
         if (current->Is(STAFF)) {


### PR DESCRIPTION
This fixes an issue with incorrect stem lengths for `beamSpan` in cross-staff situations.

![image](https://user-images.githubusercontent.com/7693447/210424045-d943fc5d-283e-4b9d-910c-be89287d11a2.png)
