### PR TITLE
Fix tie note collisions

### DIFF
--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -220,13 +220,13 @@ bool Tie::CalculatePosition(const Doc *doc, const Staff *staff, int x1, int x2, 
 
     // shortTie correction cannot be applied for chords
     const bool isShortTie = !startParentChord && !endParentChord && (endPoint.x - startPoint.x < 4 * drawingUnit);
-    const bool isSameDirection = !(note1 && note2) || (note1->GetStemDir() == note2->GetStemDir());
+    const bool isGraceToNoteTie = (note1 && note2) && note1->IsGraceNote() && !note2->IsGraceNote();
 
     const int ySign = (drawingCurveDir == curvature_CURVEDIR_above) ? 1 : -1;
 
     startPoint.y += ySign * drawingUnit / 2;
     endPoint.y += ySign * drawingUnit / 2;
-    if (isShortTie && isSameDirection) {
+    if (isShortTie && !isGraceToNoteTie) {
         startPoint.y += ySign * drawingUnit;
         endPoint.y += ySign * drawingUnit;
     }


### PR DESCRIPTION
This PR fixes collisions between ties and noteheads that appeared occasionally (regression from #2797 ).

Example (Tie-008 from the test library):

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/211808941-f0fd40cf-1a41-48d3-b634-22eeae1932e1.png) | ![After](https://user-images.githubusercontent.com/63608463/211808982-ee00a1b6-e93c-48b0-b69f-29bd81450c3f.png) |
