### PR TITLE
Use pen width for bounding boxes

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -159,6 +159,11 @@ private:
      */
     void ResetGraphicRotation();
 
+    /**
+     * Get the overlap due to pen width on the left/right
+     */
+    std::pair<int, int> GetPenWidthOverlap() const;
+
 public:
     //
 private:

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -255,6 +255,12 @@ public:
     ///@}
 
     /**
+     * Return the horizontal margin for overlap with another element
+     * This can be negative, if elements are allowed to slightly overlap
+     */
+    int GetAdmissibleHorizOverlapMargin(const BoundingBox *bbox, int unit) const;
+
+    /**
      * Update the Y drawing relative position based on collision detection with the overlapping bounding box
      */
     void CalcDrawingYRel(Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlappingBBox);

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -189,7 +189,7 @@ public:
     /**
      * Return the width of the right barline based on the barline form
      */
-    int CalculateRightBarLineWidth(Doc *doc, int staffSize);
+    int CalculateRightBarLineWidth(const Doc *doc, int staffSize) const;
 
     /**
      * Return the width of the measure, including the barLine width

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -194,28 +194,12 @@ void BBoxDeviceContext::DrawEllipticArc(int x, int y, int width, int height, dou
 
 void BBoxDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
 {
-    if (x1 > x2) {
-        int tmp = x1;
-        x1 = x2;
-        x2 = tmp;
-    }
-    if (y1 > y2) {
-        int tmp = y1;
-        y1 = y2;
-        y2 = tmp;
-    }
+    if (x1 > x2) std::swap(x1, x2);
+    if (y1 > y2) std::swap(y1, y2);
 
-    int penWidth = m_penStack.top().GetWidth();
-    int p1 = penWidth / 2;
-    int p2 = p1;
-    // how odd line width is handled might depend on the implementation of the device context.
-    // however, we expect the actually width to be shifted on the left/top
-    // e.g., with 7, 4 on the left and 3 on the right
-    if (penWidth % 2) {
-        p1++;
-    }
+    const std::pair<int, int> overlap = this->GetPenWidthOverlap();
 
-    this->UpdateBB(x1 - p1, y1 - p1, x2 + p2, y2 + p2);
+    this->UpdateBB(x1 - overlap.first, y1 - overlap.second, x2 + overlap.second, y2 + overlap.first);
 }
 
 void BBoxDeviceContext::DrawPolyline(int n, Point points[], int xOffset, int yOffset)
@@ -456,6 +440,20 @@ void BBoxDeviceContext::ResetGraphicRotation()
     m_rotationAngle = 0.0;
     m_rotationOrigin.x = 0;
     m_rotationOrigin.y = 0;
+}
+
+std::pair<int, int> BBoxDeviceContext::GetPenWidthOverlap() const
+{
+    const int penWidth = m_penStack.top().GetWidth();
+    int p1 = penWidth / 2;
+    int p2 = p1;
+
+    // How odd line width is handled might depend on the implementation of the device context.
+    // However, we expect the actual width to be shifted on the left/top
+    // e.g., with 7, 4 on the left and 3 on the right.
+    if (penWidth % 2) ++p1;
+
+    return { p1, p2 };
 }
 
 } // namespace vrv

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -184,12 +184,10 @@ void BBoxDeviceContext::DrawEllipse(int x, int y, int width, int height)
 
 void BBoxDeviceContext::DrawEllipticArc(int x, int y, int width, int height, double start, double end)
 {
-    int penWidth = m_penStack.top().GetWidth();
-    if (penWidth % 2) {
-        penWidth += 1;
-    }
+    const std::pair<int, int> overlap = this->GetPenWidthOverlap();
+
     // needs to be fixed - for now uses the entire rectangle
-    this->UpdateBB(x - penWidth / 2, y - penWidth / 2, x + width + penWidth / 2, y + height + penWidth / 2);
+    this->UpdateBB(x - overlap.first, y - overlap.second, x + width + overlap.second, y + height + overlap.first);
 }
 
 void BBoxDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
@@ -219,12 +217,15 @@ void BBoxDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOff
     int y2 = y1;
 
     for (int i = 0; i < n; i++) {
-        if (points[i].x + xOffset < x1) x1 = points[i].x + xOffset;
-        if (points[i].x + xOffset > x2) x2 = points[i].x + xOffset;
-        if (points[i].y + yOffset < y1) y1 = points[i].y + yOffset;
-        if (points[i].y + yOffset > y2) y2 = points[i].y + yOffset;
+        x1 = std::min(x1, points[i].x + xOffset);
+        x2 = std::max(x2, points[i].x + xOffset);
+        y1 = std::min(y1, points[i].y + yOffset);
+        y2 = std::max(y2, points[i].y + yOffset);
     }
-    this->UpdateBB(x1, y1, x2, y2);
+
+    const std::pair<int, int> overlap = this->GetPenWidthOverlap();
+
+    this->UpdateBB(x1 - overlap.first, y1 - overlap.second, x2 + overlap.second, y2 + overlap.first);
 }
 
 void BBoxDeviceContext::DrawRectangle(int x, int y, int width, int height)
@@ -243,13 +244,10 @@ void BBoxDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height
         width = -width;
         x -= width;
     }
-    int penWidth = m_penStack.top().GetWidth();
 
-    if (penWidth % 2) {
-        penWidth += 1;
-    }
+    const std::pair<int, int> overlap = this->GetPenWidthOverlap();
 
-    this->UpdateBB(x - penWidth / 2, y - penWidth / 2, x + width + penWidth / 2, y + height + penWidth / 2);
+    this->UpdateBB(x - overlap.first, y - overlap.second, x + width + overlap.second, y + height + overlap.first);
 }
 
 void BBoxDeviceContext::DrawPlaceholder(int x, int y)

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -384,15 +384,6 @@ int FloatingPositioner::GetAdmissibleHorizOverlapMargin(const BoundingBox *bbox,
             return 2 * unit;
         }
     }
-
-    if (bbox->Is(FLOATING_POSITIONER)) {
-        const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(bbox);
-        // Endings are allowed to slightly overlap
-        if (this->GetObject()->Is(ENDING) && positioner->GetObject()->Is(ENDING)) {
-            return -2 * unit;
-        }
-    }
-
     return 0;
 }
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -376,6 +376,26 @@ void FloatingPositioner::SetDrawingYRel(int drawingYRel, bool force)
     }
 }
 
+int FloatingPositioner::GetAdmissibleHorizOverlapMargin(const BoundingBox *bbox, int unit) const
+{
+    const LayerElement *element = dynamic_cast<const LayerElement *>(bbox);
+    if (element) {
+        if ((this->GetObject()->Is(DYNAM)) && element->GetFirstAncestor(BEAM)) {
+            return 2 * unit;
+        }
+    }
+
+    if (bbox->Is(FLOATING_POSITIONER)) {
+        const FloatingPositioner *positioner = vrv_cast<const FloatingPositioner *>(bbox);
+        // Endings are allowed to slightly overlap
+        if (this->GetObject()->Is(ENDING) && positioner->GetObject()->Is(ENDING)) {
+            return -2 * unit;
+        }
+    }
+
+    return 0;
+}
+
 void FloatingPositioner::CalcDrawingYRel(
     Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlappingBBox)
 {

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -285,7 +285,7 @@ int Measure::GetRightBarLineXRel() const
     return 0;
 }
 
-int Measure::CalculateRightBarLineWidth(Doc *doc, int staffSize)
+int Measure::CalculateRightBarLineWidth(const Doc *doc, int staffSize) const
 {
     const BarLine *barline = this->GetRightBarLine();
     if (!barline) return 0;

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -298,7 +298,8 @@ int Measure::CalculateRightBarLineWidth(const Doc *doc, int staffSize) const
     int width = 0;
     switch (barline->GetForm()) {
         case BARRENDITION_dbl:
-        case BARRENDITION_dbldashed: {
+        case BARRENDITION_dbldashed:
+        case BARRENDITION_dbldotted: {
             width = barLineSeparation + barLineWidth;
             break;
         }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -849,15 +849,12 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         while (i != end) {
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
-            LayerElement *element = dynamic_cast<LayerElement *>(*i);
-            const bool additionalMargin
-                = ((*iter)->GetObject()->Is(DYNAM) && element && element->GetFirstAncestor(BEAM));
-            const int margin = additionalMargin ? params->m_doc->GetDrawingDoubleUnit(m_staff->m_drawingStaffSize) : 0;
-            i = std::find_if(i, end, [iter, drawingUnit, margin](BoundingBox *elem) {
+            i = std::find_if(i, end, [iter, drawingUnit](BoundingBox *elem) {
                 if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
                     return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)
                         || (*iter)->VerticalContentOverlap(elem);
                 }
+                const int margin = (*iter)->GetAdmissibleHorizOverlapMargin(elem, drawingUnit);
                 return (*iter)->HorizontalContentOverlap(elem, margin);
             });
             if (i != end) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2869,9 +2869,18 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
 
         const int staffLineWidth = m_options->m_staffLineWidth.GetValue() * unit;
         const int startX = x1 - staffLineWidth;
-        const int endX = (measure == system->FindDescendantByType(MEASURE, 1, BACKWARD))
-            ? x2 + endingMeasure->CalculateRightBarLineWidth(m_doc, staffSize) - lineWidth / 2 - staffLineWidth
-            : x2;
+
+        const int rightBarLineWidth = endingMeasure->CalculateRightBarLineWidth(m_doc, staffSize);
+        int endX = x2;
+        if (measure == system->FindDescendantByType(MEASURE, 1, BACKWARD)) {
+            // Right align the ending in the last measure of the system
+            endX += rightBarLineWidth - lineWidth / 2 - staffLineWidth;
+        }
+        else {
+            // Ensure that successive endings do not overlap horizontally
+            endX -= std::max(lineWidth + unit / 2 - rightBarLineWidth, 0);
+        }
+
         dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_ARCS);
         Point p[4];
         p[0] = { ToDeviceContextX(startX), ToDeviceContextY(y1) };

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2872,11 +2872,12 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
 
         const int rightBarLineWidth = endingMeasure->CalculateRightBarLineWidth(m_doc, staffSize);
         int endX = x2;
-        if (measure == system->FindDescendantByType(MEASURE, 1, BACKWARD)) {
+        if ((spanningType == SPANNING_START) || (spanningType == SPANNING_MIDDLE)
+            || (endingMeasure == system->FindDescendantByType(MEASURE, 1, BACKWARD))) {
             // Right align the ending in the last measure of the system
             endX += rightBarLineWidth - lineWidth / 2 - staffLineWidth;
         }
-        else {
+        else if (endingMeasure->GetDrawingRightBarLine() != BARRENDITION_invis) {
             // Ensure that successive endings do not overlap horizontally
             endX -= std::max(lineWidth + unit / 2 - rightBarLineWidth, 0);
         }
@@ -2887,10 +2888,12 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         p[1] = { ToDeviceContextX(startX), ToDeviceContextY(y2) };
         p[2] = { ToDeviceContextX(endX), ToDeviceContextY(y2) };
         p[3] = { ToDeviceContextX(endX), ToDeviceContextY(y1) };
-        if ((spanningType == SPANNING_END) || (ending->GetLstartsym() == LINESTARTENDSYMBOL_none)) {
+        if ((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE)
+            || (ending->GetLstartsym() == LINESTARTENDSYMBOL_none)) {
             p[0] = p[1];
         }
-        if ((spanningType == SPANNING_START) || (ending->GetLendsym() == LINESTARTENDSYMBOL_none)) {
+        if ((spanningType == SPANNING_START) || (spanningType == SPANNING_MIDDLE)
+            || (ending->GetLendsym() == LINESTARTENDSYMBOL_none)) {
             p[3] = p[2];
         }
         dc->DrawPolyline(4, p);


### PR DESCRIPTION
This PR unifies the handling of pen width for bounding boxes and adds consideration of pen width for polygons and polylines.

As a consequence, in some cases the bounding boxes of endings now slightly horizontally overlap. We instruct the layout that this is OK. See Ending-002 in the test suite.