### PR TITLE
Humdrum: Support for negative figured bass numbers

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8660,17 +8660,10 @@ std::u32string HumdrumInput::convertFBNumber(const std::string &input, hum::HTp 
         accidental = 0;
     }
 
-    if (input.find("v") != std::string::npos) {
-        // display minus sign for negative numbers if "v" signifier is present
+    if (input.find("~") != std::string::npos) {
+        // display minus sign for negative numbers if "~" signifier is present
         output += '-';
     }
-
-    /*
-    if (input.find("^") != std::string::npos) {
-        // display plus sign for positive numbers if "^" signifier is present
-        output += '+';
-    }
-    */
 
     // accidental in front of number unless an "r" is present:
     if ((!slash) && (input.find("r") == std::string::npos) && (!reverse)) {

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8660,8 +8660,8 @@ std::u32string HumdrumInput::convertFBNumber(const std::string &input, hum::HTp 
         accidental = 0;
     }
 
-    if (input.find("m") != std::string::npos) {
-        // display minus for negative numbers if "m" signifier is present
+    if (input.find("v") != std::string::npos) {
+        // display minus sign for negative numbers if "v" signifier is present
         output += '-';
     }
 

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8660,6 +8660,11 @@ std::u32string HumdrumInput::convertFBNumber(const std::string &input, hum::HTp 
         accidental = 0;
     }
 
+    if (input.find("m") != std::string::npos) {
+        // display minus for negative numbers if "m" signifier is present
+        output += '-';
+    }
+
     // accidental in front of number unless an "r" is present:
     if ((!slash) && (input.find("r") == std::string::npos) && (!reverse)) {
         std::u32string accid = getVisualFBAccidental(accidental);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8665,6 +8665,13 @@ std::u32string HumdrumInput::convertFBNumber(const std::string &input, hum::HTp 
         output += '-';
     }
 
+    /*
+    if (input.find("^") != std::string::npos) {
+        // display plus sign for positive numbers if "^" signifier is present
+        output += '+';
+    }
+    */
+
     // accidental in front of number unless an "r" is present:
     if ((!slash) && (input.find("r") == std::string::npos) && (!reverse)) {
         std::u32string accid = getVisualFBAccidental(accidental);


### PR DESCRIPTION
In preparation for the upcoming feature for automatically generated figured bass numbers in https://github.com/craigsapp/humlib/pull/53 I am adding functionality for negative numbers to iohumdrum.cpp.

For figured bass this is probably not important as I have never seen negative figured bass numbers. But since this can also create an *Intervallsatz* I think it's a good idea a enable support for negative numbers.

@craigsapp and I have been discussing about the signifier. I chose `m` for `minus` since it probably won't be necessary to add a plus sign for positive numbers in future.

Negative numbers can be encoded by adding the `m` signifier:

```tsv
**kern	**kern	**fb
*clefG2	*clefG2	*
4cc	4f	m5
4cc	4a#	#m3
*-	*-	*-
```

Examples:

<img width="905" alt="Bildschirm­foto 2023-01-12 um 20 27 52" src="https://user-images.githubusercontent.com/865594/212164114-528f170f-0822-47e9-84da-62f082979e19.png">

<img width="1176" alt="Bildschirm­foto 2023-01-12 um 20 32 55" src="https://user-images.githubusercontent.com/865594/212164142-e1b63b27-c475-41db-bb2a-a4c4fbceadc9.png">

