### PR TITLE
Change gliss to default to wavy

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2048,18 +2048,6 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
     }
 
     switch (gliss->GetLform()) {
-        case LINEFORM_wavy: {
-            const int length = static_cast<int>(hypot(x2 - x1, y2 - y1));
-            const double angle = RadToDeg(atan2(y1 - y2, x2 - x1));
-            // Smufl glyphs are horizontal - Rotate them counter clockwise
-            dc->RotateGraphic(Point(ToDeviceContextX(x1), ToDeviceContextY(y1)), angle);
-
-            const char32_t glissGlyph = SMUFL_EAAF_wiggleGlissando;
-            const int height = m_doc->GetGlyphHeight(glissGlyph, staff->m_drawingStaffSize, false);
-            const Point orig(x1, y1 - height / 2);
-            this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, glissGlyph);
-            break;
-        }
         case LINEFORM_dashed:
             dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
             dc->SetBrush(m_currentColour, AxSOLID);
@@ -2072,12 +2060,23 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
-        case LINEFORM_solid: [[fallthrough]];
-        default: {
+        case LINEFORM_solid:
             dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
             dc->SetBrush(m_currentColour, AxSOLID);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
+            break;
+        case LINEFORM_wavy: [[fallthrough]];
+        default: {
+            const int length = static_cast<int>(hypot(x2 - x1, y2 - y1));
+            const double angle = RadToDeg(atan2(y1 - y2, x2 - x1));
+            // Smufl glyphs are horizontal - Rotate them counter clockwise
+            dc->RotateGraphic(Point(ToDeviceContextX(x1), ToDeviceContextY(y1)), angle);
+
+            const char32_t glissGlyph = SMUFL_EAAF_wiggleGlissando;
+            const int height = m_doc->GetGlyphHeight(glissGlyph, staff->m_drawingStaffSize, false);
+            const Point orig(x1, y1 - height / 2);
+            this->DrawSmuflLine(dc, orig, length, staff->m_drawingStaffSize, false, glissGlyph);
             break;
         }
     }


### PR DESCRIPTION
This PR is a small change for glissandos to default to wavy lines if no `@lform` is specified. 
