### PR TITLE
Position reh above staff start

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2422,6 +2422,10 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         }
         const int staffSize = (*staffIter)->m_drawingStaffSize;
 
+        if ((system->GetFirst(MEASURE) != measure) && adjustPosition) {
+            params.m_x = (*staffIter)->GetDrawingX();
+        }
+
         params.m_enclosedRend.clear();
         params.m_y = reh->GetDrawingY() + yMargin * m_doc->GetDrawingUnit(staffSize);
         params.m_pointSize = m_doc->GetDrawingLyricFont(staffSize)->GetPointSize();


### PR DESCRIPTION
Small fix to make sure that `reh` is positioned above the barline when tstamp is 0 and there is metersig present in the measure.
![image](https://user-images.githubusercontent.com/1819669/212666635-7d54a0e7-8bad-4e0e-98d4-f21ab411de55.png)

After:
![image](https://user-images.githubusercontent.com/1819669/212666703-80fcfada-932b-43dc-af67-2508a98cea95.png)