### PR TITLE
Refactor brackets

### DIFF
--- a/include/vrv/bracketspan.h
+++ b/include/vrv/bracketspan.h
@@ -56,6 +56,11 @@ public:
     }
     ///@}
 
+    /**
+     * Calculate the bracket line width.
+     */
+    int GetLineWidth(const Doc *doc, int unit) const;
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -505,7 +505,7 @@ enum FunctorCode { FUNCTOR_CONTINUE = 0, FUNCTOR_SIBLINGS, FUNCTOR_STOP };
 // data.LINEWIDTHTERM factors
 //----------------------------------------------------------------------------
 
-#define LINEWIDTHTERM_factor_narrow 0.5
+#define LINEWIDTHTERM_factor_narrow 1.0
 #define LINEWIDTHTERM_factor_medium 2.0
 #define LINEWIDTHTERM_factor_wide 4.0
 

--- a/src/bracketspan.cpp
+++ b/src/bracketspan.cpp
@@ -56,6 +56,30 @@ void BracketSpan::Reset()
     this->ResetLineRendBase();
 }
 
+int BracketSpan::GetLineWidth(const Doc *doc, int unit) const
+{
+    int lineWidth = doc->GetOptions()->m_octaveLineThickness.GetValue() * unit;
+    if (this->HasLwidth()) {
+        if (this->GetLwidth().GetType() == LINEWIDTHTYPE_lineWidthTerm) {
+            switch (this->GetLwidth().GetLineWithTerm()) {
+                case LINEWIDTHTERM_narrow: lineWidth *= LINEWIDTHTERM_factor_narrow; break;
+                case LINEWIDTHTERM_medium: lineWidth *= LINEWIDTHTERM_factor_medium; break;
+                case LINEWIDTHTERM_wide: lineWidth *= LINEWIDTHTERM_factor_wide; break;
+                default: break;
+            }
+        }
+        else if (this->GetLwidth().GetType() == LINEWIDTHTYPE_measurementunsigned) {
+            if (this->GetLwidth().GetMeasurementunsigned().GetType() == MEASUREMENTTYPE_px) {
+                lineWidth = this->GetLwidth().GetMeasurementunsigned().GetPx();
+            }
+            else {
+                lineWidth = this->GetLwidth().GetMeasurementunsigned().GetVu() * unit;
+            }
+        }
+    }
+    return lineWidth;
+}
+
 //----------------------------------------------------------------------------
 // BracketSpan functor methods
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -479,11 +479,13 @@ void View::DrawBracketSpan(
                 lineWidth = bracketSpan->GetLwidth().GetMeasurementunsigned().GetPx();
             }
             else {
-                lineWidth = bracketSpan->GetLwidth().GetMeasurementunsigned().GetVu()
-                    * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+                lineWidth = bracketSpan->GetLwidth().GetMeasurementunsigned().GetVu() * unit;
             }
         }
     }
+
+    x1 += lineWidth / 2;
+    x2 -= lineWidth / 2;
 
     dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
     dc->SetBrush(m_currentColour, AxSOLID);
@@ -495,9 +497,9 @@ void View::DrawBracketSpan(
         if (bracketSpan->GetLstartsym() != LINESTARTENDSYMBOL_none) {
             // Left hook
             Point hookLeft[3];
-            hookLeft[0] = { ToDeviceContextX(x1 + lineWidth / 2), ToDeviceContextY(y - unit * 2) };
-            hookLeft[1] = { ToDeviceContextX(x1 + lineWidth / 2), ToDeviceContextY(y) };
-            hookLeft[2] = { ToDeviceContextX(x1 + lineWidth + unit), ToDeviceContextY(y) };
+            hookLeft[0] = { ToDeviceContextX(x1), ToDeviceContextY(y - unit * 2) };
+            hookLeft[1] = { ToDeviceContextX(x1), ToDeviceContextY(y) };
+            hookLeft[2] = { ToDeviceContextX(x1 + lineWidth / 2 + unit), ToDeviceContextY(y) };
             dc->DrawPolyline(3, hookLeft);
         }
     }
@@ -508,22 +510,22 @@ void View::DrawBracketSpan(
         if (bracketSpan->GetLendsym() != LINESTARTENDSYMBOL_none) {
             // Right hook
             Point hookRight[3];
-            hookRight[0] = { ToDeviceContextX(x2 - lineWidth / 2), ToDeviceContextY(y - unit * 2) };
-            hookRight[1] = { ToDeviceContextX(x2 - lineWidth / 2), ToDeviceContextY(y) };
-            hookRight[2] = { ToDeviceContextX(x2 - lineWidth - unit), ToDeviceContextY(y) };
+            hookRight[0] = { ToDeviceContextX(x2), ToDeviceContextY(y - unit * 2) };
+            hookRight[1] = { ToDeviceContextX(x2), ToDeviceContextY(y) };
+            hookRight[2] = { ToDeviceContextX(x2 - lineWidth / 2 - unit), ToDeviceContextY(y) };
             dc->DrawPolyline(3, hookRight);
         }
     }
     // We have a @lform - draw a full line
     if (bracketSpan->HasLform()) {
         if (bracketSpan->GetLform() == LINEFORM_dashed) {
-            dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_BUTT, AxJOIN_ARCS);
+            dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE, AxJOIN_ARCS);
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
             dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
             // Adjust start and end
             x1 += unit * 2;
-            x2 -= unit;
+            x2 -= unit + lineWidth;
         }
         dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
     }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -460,29 +460,7 @@ void View::DrawBracketSpan(
     }
 
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    int lineWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-
-    if (bracketSpan->HasLwidth()) {
-        if (bracketSpan->GetLwidth().GetType() == LINEWIDTHTYPE_lineWidthTerm) {
-            if (bracketSpan->GetLwidth().GetLineWithTerm() == LINEWIDTHTERM_narrow) {
-                lineWidth *= LINEWIDTHTERM_factor_narrow;
-            }
-            else if (bracketSpan->GetLwidth().GetLineWithTerm() == LINEWIDTHTERM_medium) {
-                lineWidth *= LINEWIDTHTERM_factor_medium;
-            }
-            else if (bracketSpan->GetLwidth().GetLineWithTerm() == LINEWIDTHTERM_wide) {
-                lineWidth *= LINEWIDTHTERM_factor_wide;
-            }
-        }
-        else if (bracketSpan->GetLwidth().GetType() == LINEWIDTHTYPE_measurementunsigned) {
-            if (bracketSpan->GetLwidth().GetMeasurementunsigned().GetType() == MEASUREMENTTYPE_px) {
-                lineWidth = bracketSpan->GetLwidth().GetMeasurementunsigned().GetPx();
-            }
-            else {
-                lineWidth = bracketSpan->GetLwidth().GetMeasurementunsigned().GetVu() * unit;
-            }
-        }
-    }
+    const int lineWidth = bracketSpan->GetLineWidth(m_doc, unit);
 
     x1 += lineWidth / 2;
     x2 -= lineWidth / 2;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -477,7 +477,7 @@ void View::DrawBracketSpan(
             Point hookLeft[3];
             hookLeft[0] = { ToDeviceContextX(x1), ToDeviceContextY(y - unit * 2) };
             hookLeft[1] = { ToDeviceContextX(x1), ToDeviceContextY(y) };
-            hookLeft[2] = { ToDeviceContextX(x1 + lineWidth / 2 + unit), ToDeviceContextY(y) };
+            hookLeft[2] = { ToDeviceContextX(x1 + unit), ToDeviceContextY(y) };
             dc->DrawPolyline(3, hookLeft);
         }
     }
@@ -490,7 +490,7 @@ void View::DrawBracketSpan(
             Point hookRight[3];
             hookRight[0] = { ToDeviceContextX(x2), ToDeviceContextY(y - unit * 2) };
             hookRight[1] = { ToDeviceContextX(x2), ToDeviceContextY(y) };
-            hookRight[2] = { ToDeviceContextX(x2 - lineWidth / 2 - unit), ToDeviceContextY(y) };
+            hookRight[2] = { ToDeviceContextX(x2 - unit), ToDeviceContextY(y) };
             dc->DrawPolyline(3, hookRight);
         }
     }
@@ -706,13 +706,13 @@ void View::DrawOctave(
     dc->ResetFont();
 
     if (octave->GetExtender() != BOOLEAN_false) {
-        const int lineWidth = octave->GetLineWidth(m_doc, m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
+        const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        const int lineWidth = octave->GetLineWidth(m_doc, unit);
+        const int gap = lineWidth * 4;
 
         // adjust is to avoid the figure to touch the line
         x1 += m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) + lineWidth;
         if (altSymbols) x1 += extend.m_width / 2;
-
-        const int gap = lineWidth * 4;
 
         dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, gap, AxCAP_SQUARE);
         dc->SetBrush(m_currentColour, AxSOLID);
@@ -733,8 +733,8 @@ void View::DrawOctave(
         }
 
         // adjust vertical ends
-        y1 -= lineWidth / 2;
-        y2 += (disPlace == STAFFREL_basic_above) ? -extend.m_height : extend.m_height;
+        y1 += (disPlace == STAFFREL_basic_above) ? -lineWidth / 2 : lineWidth / 2;
+        y2 = (disPlace == STAFFREL_basic_above) ? y1 - unit * 2 : y1 + unit * 2;
 
         if (x1 > x2) {
             // make sure we have a minimal extender line
@@ -747,8 +747,8 @@ void View::DrawOctave(
             if (spanningType == SPANNING_END || spanningType == SPANNING_START_END) {
                 if (octave->GetLform() == LINEFORM_dotted) {
                     // make sure we have at least two dots for the dotted hook
-                    dc->SetPen(m_currentColour, lineWidth * 3 / 2, AxDOT, 0, std::min(gap, extend.m_height - lineWidth),
-                        AxCAP_ROUND);
+                    dc->SetPen(
+                        m_currentColour, lineWidth * 3 / 2, AxDOT, 0, std::min(gap, unit * 2 - lineWidth), AxCAP_ROUND);
                     dc->DrawLine(
                         ToDeviceContextX(x2), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
                 }
@@ -758,8 +758,7 @@ void View::DrawOctave(
                     Point hookRight[3];
                     hookRight[0] = { ToDeviceContextX(x2), ToDeviceContextY(y2) };
                     hookRight[1] = { ToDeviceContextX(x2), ToDeviceContextY(y1) };
-                    hookRight[2] = { ToDeviceContextX(x2 - m_doc->GetDrawingUnit(staff->m_drawingStaffSize)),
-                        ToDeviceContextY(y1) };
+                    hookRight[2] = { ToDeviceContextX(x2 - unit), ToDeviceContextY(y1) };
                     dc->DrawPolyline(3, hookRight);
                 }
             }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1135,7 +1135,6 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
     if (!f->GetStart() || !f->GetEnd()) return;
 
     const int y = this->GetFYRel(f, staff);
-    TextExtend extend;
 
     // The both correspond to the current system, which means no system break in-between (simple case)
     if (spanningType == SPANNING_START_END) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -519,10 +519,10 @@ void View::DrawBracketSpan(
     // We have a @lform - draw a full line
     if (bracketSpan->HasLform()) {
         if (bracketSpan->GetLform() == LINEFORM_dashed) {
-            dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE, AxJOIN_ARCS);
+            dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE);
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
-            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
             // Adjust start and end
             x1 += unit * 2;
             x2 -= unit + lineWidth;
@@ -2878,7 +2878,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
             endX -= std::max(lineWidth + unit / 2 - rightBarLineWidth, 0);
         }
 
-        dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_ARCS);
+        dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_MITER);
         Point p[4];
         p[0] = { ToDeviceContextX(startX), ToDeviceContextY(y1) };
         p[1] = { ToDeviceContextX(startX), ToDeviceContextY(y2) };

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -500,10 +500,12 @@ void View::DrawBracketSpan(
             dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE);
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
-            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
             // Adjust start and end
-            x1 += unit * 2;
-            x2 -= unit + lineWidth;
+            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
+            x1 += unit + lineWidth * 2;
+            x2 -= unit + lineWidth * 2;
+            const int diff = (x2 - x1) % (lineWidth * 3 + 1);
+            x1 += diff / 2;
         }
         dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
     }

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -125,9 +125,9 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
         bracketLeft[1] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft) };
         bracketLeft[2] = { ToDeviceContextX(xNumLeft), ToDeviceContextY(yNumLeft) };
         Point bracketRight[3];
-        bracketRight[0] = { ToDeviceContextX(xNumRight + lineWidth), ToDeviceContextY(yNumRight) };
+        bracketRight[0] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight + bracketHeight) };
         bracketRight[1] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight) };
-        bracketRight[2] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight + bracketHeight) };
+        bracketRight[2] = { ToDeviceContextX(xNumRight), ToDeviceContextY(yNumRight) };
 
         dc->DrawPolyline(3, bracketLeft);
         dc->DrawPolyline(3, bracketRight);

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -96,46 +96,55 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
         return;
     }
 
-    data_STAFFREL_basic position = tuplet->GetDrawingBracketPos();
-    const int lineWidth
-        = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
-
     dc->ResumeGraphic(tupletBracket, tupletBracket->GetID());
 
-    const int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
-    const int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
-    const int yLeft = tupletBracket->GetDrawingYLeft() - lineWidth / 2;
-    const int yRight = tupletBracket->GetDrawingYRight() - lineWidth / 2;
-    int bracketHeight;
+    const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+    const int lineWidth
+        = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
+    const int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft() + lineWidth / 2;
+    const int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight() - lineWidth / 2;
+    const int yLeft = tupletBracket->GetDrawingYLeft();
+    const int yRight = tupletBracket->GetDrawingYRight();
+    int bracketHeight = (tuplet->GetDrawingBracketPos() == STAFFREL_basic_above) ? -1 : 1;
+
+    dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_MITER);
 
     // Draw a bracket with a gap
     if (tupletBracket->GetAlignedNum() && tupletBracket->GetAlignedNum()->HasSelfBB()) {
-        const int xNumLeft
-            = tupletBracket->GetAlignedNum()->GetSelfLeft() - m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-        const int xNumRight
-            = tupletBracket->GetAlignedNum()->GetSelfRight() + m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+        const int xNumLeft = tupletBracket->GetAlignedNum()->GetSelfLeft() - unit / 2;
+        const int xNumRight = tupletBracket->GetAlignedNum()->GetSelfRight() + unit / 2;
         const double slope = (double)(yRight - yLeft) / (double)(xRight - xLeft);
         const int yNumLeft = yLeft + slope * (xNumLeft - xLeft);
-        this->DrawObliquePolygon(dc, xLeft, yLeft, xNumLeft, yNumLeft, lineWidth);
         const int yNumRight = yRight - slope * (xRight - xNumRight);
-        this->DrawObliquePolygon(dc, xNumRight, yNumRight, xRight, yRight, lineWidth);
         bracketHeight
-            = abs(tupletBracket->GetAlignedNum()->GetSelfTop() - tupletBracket->GetAlignedNum()->GetSelfBottom()) / 2;
+            *= abs(tupletBracket->GetAlignedNum()->GetSelfTop() - tupletBracket->GetAlignedNum()->GetSelfBottom()) / 2
+            - lineWidth / 2;
+
+        Point bracketLeft[3];
+        bracketLeft[0] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft + bracketHeight) };
+        bracketLeft[1] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft) };
+        bracketLeft[2] = { ToDeviceContextX(xNumLeft), ToDeviceContextY(yNumLeft) };
+        Point bracketRight[3];
+        bracketRight[0] = { ToDeviceContextX(xNumRight + lineWidth), ToDeviceContextY(yNumRight) };
+        bracketRight[1] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight) };
+        bracketRight[2] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight + bracketHeight) };
+
+        dc->DrawPolyline(3, bracketLeft);
+        dc->DrawPolyline(3, bracketRight);
     }
     else {
-        this->DrawObliquePolygon(dc, xLeft, yLeft, xRight, yRight, lineWidth);
-        // HARDCODED
-        bracketHeight = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * 6 / 5;
+        bracketHeight *= unit + lineWidth;
+
+        Point bracket[4];
+        bracket[0] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft + bracketHeight) };
+        bracket[1] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft) };
+        bracket[2] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight) };
+        bracket[3] = { ToDeviceContextX(xRight), ToDeviceContextY(yRight + bracketHeight) };
+
+        dc->DrawPolyline(4, bracket);
     }
 
-    if (position == STAFFREL_basic_above) {
-        bracketHeight *= -1;
-    }
-
-    this->DrawFilledRectangle(
-        dc, xLeft, yLeft + lineWidth / 2, xLeft + lineWidth, yLeft + bracketHeight + lineWidth / 2);
-    this->DrawFilledRectangle(
-        dc, xRight, yRight + lineWidth / 2, xRight - lineWidth, yRight + bracketHeight + lineWidth / 2);
+    dc->ResetPen();
 
     dc->EndResumedGraphic(tupletBracket, this);
 

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -107,7 +107,7 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     const int yRight = tupletBracket->GetDrawingYRight();
     int bracketHeight = (tuplet->GetDrawingBracketPos() == STAFFREL_basic_above) ? -1 : 1;
 
-    dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_MITER);
+    dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
 
     // Draw a bracket with a gap
     if (tupletBracket->GetAlignedNum() && tupletBracket->GetAlignedNum()->HasSelfBB()) {
@@ -117,8 +117,7 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
         const int yNumLeft = yLeft + slope * (xNumLeft - xLeft);
         const int yNumRight = yRight - slope * (xRight - xNumRight);
         bracketHeight
-            *= abs(tupletBracket->GetAlignedNum()->GetSelfTop() - tupletBracket->GetAlignedNum()->GetSelfBottom()) / 2
-            - lineWidth / 2;
+            *= abs(tupletBracket->GetAlignedNum()->GetSelfTop() - tupletBracket->GetAlignedNum()->GetSelfBottom()) / 2;
 
         Point bracketLeft[3];
         bracketLeft[0] = { ToDeviceContextX(xLeft), ToDeviceContextY(yLeft + bracketHeight) };


### PR DESCRIPTION
This PR  brings a major refinement of brackets. 

* `octave` and `bracketSpan` now share the same thickness (i.e. you can control both with `--octaveLineThickness`)
* `octave` and `bracketSpan` now share the same hooks (height of 1 staff space)
* `octave` with dashed line has a solid hook (as seen in Gould)
* `octave` with dotted line will round the length to the nearest integer multiple of calculated end point and makes sure at least two dots are drawn as end hooks 

![Bildschirm­foto 2023-01-18 um 14 13 29](https://user-images.githubusercontent.com/7693447/213182392-2fe81f38-24dc-4eeb-b8fa-2dcd2d5dd075.png)

* `bracketSpan` with dotted line will now center the dotted line between the hooks

![Bildschirm­foto 2023-01-18 um 14 15 42](https://user-images.githubusercontent.com/7693447/213182857-3ec3f15f-6fd9-467a-97df-df501056a4e4.png)

* `tuplet` brackets now use SVG polylines (i.e. a single element for each bracket part) and gives the number a bit more space (as seen in Gould)

<img width="1246" alt="new" src="https://user-images.githubusercontent.com/7693447/213183168-2347f967-84b1-41d5-9e5a-874e17b0a7b5.png">

* basically all distances now are based on unit instead of `stemWidth`
