### PR TITLE
Fix stem mod placement issue

### DIFF
--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -388,7 +388,7 @@ void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
     if (bTrem) {
         stemMod = bTrem->GetDrawingStemMod();
     }
-    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < 8)) {
+    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < STEMMODIFIER_MAX)) {
         stemMod = this->GetDrawingStemMod();
     }
     if ((stemMod == STEMMODIFIER_NONE) || (stemMod == STEMMODIFIER_none)) return;
@@ -416,7 +416,7 @@ void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
         }
         case STEMMODIFIER_sprech:
         case STEMMODIFIER_z: {
-            height += (noteLoc % 2) ? 3 * unit : 2 * unit;
+            height += 2 * unit;
             if (stemMod == STEMMODIFIER_sprech) height -= sign * glyphHalfHeight;
             break;
         }

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -205,11 +205,13 @@ int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) cons
 
     const int glyphHeight = doc->GetGlyphHeight(code, staffSize, false);
     const int actualLength = std::abs(this->GetDrawingStemLen()) - lenAdjust / unit * unit;
-    int val = std::abs(m_stemModRelY);
+    int diff = 0;
     if ((stemMod == STEMMODIFIER_sprech) && (this->GetDrawingStemDir() == STEMDIRECTION_down)) {
-        val -= glyphHeight / 2;
+        diff = std::abs(actualLength - std::abs(m_stemModRelY));
     }
-    const int diff = std::abs(actualLength - val) - 0.5 * glyphHeight;
+    else {
+        diff = actualLength - std::abs(m_stemModRelY) - 0.5 * glyphHeight;
+    }
     const int halfUnit = 0.5 * unit;
 
     int adjust = 0;

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -207,7 +207,7 @@ int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) cons
     const int actualLength = std::abs(this->GetDrawingStemLen()) - lenAdjust / unit * unit;
     int val = std::abs(m_stemModRelY);
     if ((stemMod == STEMMODIFIER_sprech) && (this->GetDrawingStemDir() == STEMDIRECTION_down)) {
-        val -= 0.5 * glyphHeight;
+        val -= glyphHeight / 2;
     }
     const int diff = std::abs(actualLength - val) - 0.5 * glyphHeight;
     const int halfUnit = 0.5 * unit;

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -188,7 +188,7 @@ int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) cons
     if (bTrem) {
         stemMod = bTrem->GetDrawingStemMod();
     }
-    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < 8)) {
+    else if (this->HasDrawingStemMod() && (this->GetDrawingStemMod() < STEMMODIFIER_MAX)) {
         stemMod = this->GetDrawingStemMod();
     }
     if ((stemMod == STEMMODIFIER_NONE) || (stemMod == STEMMODIFIER_none)) return 0;
@@ -205,7 +205,11 @@ int Stem::AdjustSlashes(const Doc *doc, const Staff *staff, int flagOffset) cons
 
     const int glyphHeight = doc->GetGlyphHeight(code, staffSize, false);
     const int actualLength = std::abs(this->GetDrawingStemLen()) - lenAdjust / unit * unit;
-    const int diff = actualLength - std::abs(m_stemModRelY) - 0.5 * glyphHeight;
+    int val = std::abs(m_stemModRelY);
+    if ((stemMod == STEMMODIFIER_sprech) && (this->GetDrawingStemDir() == STEMDIRECTION_down)) {
+        val -= 0.5 * glyphHeight;
+    }
+    const int diff = std::abs(actualLength - val) - 0.5 * glyphHeight;
     const int halfUnit = 0.5 * unit;
 
     int adjust = 0;
@@ -402,11 +406,11 @@ void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
     const int noteLoc = note->GetDrawingLoc();
     int height = 2 * unit;
     switch (stemMod) {
-        case STEMMODIFIER_1slash:
-        case STEMMODIFIER_2slash:
-        case STEMMODIFIER_3slash:
-        case STEMMODIFIER_4slash:
-        case STEMMODIFIER_5slash:
+        case STEMMODIFIER_1slash: [[fallthrough]];
+        case STEMMODIFIER_2slash: [[fallthrough]];
+        case STEMMODIFIER_3slash: [[fallthrough]];
+        case STEMMODIFIER_4slash: [[fallthrough]];
+        case STEMMODIFIER_5slash: [[fallthrough]];
         case STEMMODIFIER_6slash: {
             if (noteLoc % 2 == 0) height += unit;
             height += glyphHalfHeight;
@@ -414,9 +418,9 @@ void Stem::CalculateStemModRelY(const Doc *doc, const Staff *staff)
                 height += doc->GetGlyphHeight(SMUFL_E220_tremolo1, staff->m_drawingStaffSize, false) / 2;
             break;
         }
-        case STEMMODIFIER_sprech:
+        case STEMMODIFIER_sprech: [[fallthrough]];
         case STEMMODIFIER_z: {
-            height += 2 * unit;
+            height += unit;
             if (stemMod == STEMMODIFIER_sprech) height -= sign * glyphHalfHeight;
             break;
         }


### PR DESCRIPTION
This PR fixes an issue with placement of 'sprechstimme' and 'buzz roll' stem mods.
Before:
![image](https://user-images.githubusercontent.com/1819669/213389039-6a02bff5-dd57-4c8c-8c21-d3a7d8ddcd33.png)
After:
![image](https://user-images.githubusercontent.com/1819669/213389190-084d01d8-4736-45fd-91b1-f2a56bb25982.png)

<details><summary>MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Sprechstimme placement bug</title>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2023-01-11" type="encoding-date">2023-01-11</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="F" line="4" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="3" pname="d" stem.mod="sprech" />
                           <note dur="4" oct="3" pname="e" stem.mod="sprech" />
                           <note dur="4" oct="3" pname="f" stem.mod="sprech" />
                           <note dur="4" oct="3" pname="g" stem.mod="sprech" />
                        </layer>
                        <layer n="2">
                           <note dur="4" oct="3" pname="d" stem.mod="sprech" />
                           <note dur="4" oct="3" pname="c" stem.mod="sprech" />
                           <note dur="4" oct="2" pname="b" stem.mod="sprech" />
                           <note dur="4" oct="2" pname="a" stem.mod="sprech" />
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="3" pname="a" stem.mod="sprech" />
                           <note dur="4" oct="3" pname="b" stem.mod="sprech" />
                           <note dur="4" oct="4" pname="c" stem.mod="sprech" />
                           <note dur="4" oct="4" pname="d" stem.mod="sprech" />
                        </layer>
                        <layer n="2">
                           <note dur="4" oct="2" pname="g" stem.mod="sprech" />
                           <note dur="4" oct="2" pname="f" stem.mod="sprech" />
                           <note dur="4" oct="2" pname="e" stem.mod="sprech" />
                           <note dur="4" oct="2" pname="d" stem.mod="sprech" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>