### PR TITLE
Refine collision handling between slurs and tuplets

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1121,6 +1121,11 @@ public:
     virtual int AdjustTupletNumOverlap(FunctorParams *) const { return FUNCTOR_CONTINUE; }
 
     /**
+     * Adjust the Y position of tuplets by inner slurs
+     */
+    virtual int AdjustTupletWithSlurs(FunctorParams *) { return FUNCTOR_CONTINUE; }
+
+    /**
      * Adjust the position of the StaffAlignment.
      */
     virtual int AdjustYPos(FunctorParams *) { return FUNCTOR_CONTINUE; }

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -241,6 +241,8 @@ private:
     // Determine whether a layer element should lie above or below the slur
     bool IsElementBelow(const LayerElement *element, const Staff *startStaff, const Staff *endStaff) const;
     bool IsElementBelow(const FloatingPositioner *positioner, const Staff *startStaff, const Staff *endStaff) const;
+    // Discard tuplets that don't have to be considered for slur adjustment
+    void DiscardTupletElements(FloatingCurvePositioner *curve, int xMin, int xMax);
     ///@}
 
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -117,6 +117,11 @@ public:
     int AdjustTupletsY(FunctorParams *functorParams) override;
 
     /**
+     * See Object::AdjustTupletWithSlurs
+     */
+    int AdjustTupletWithSlurs(FunctorParams *functorParams) override;
+
+    /**
      * See Object::ResetHorizontalAlignment
      */
     int ResetHorizontalAlignment(FunctorParams *functorParams) override;

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -16,6 +16,7 @@
 namespace vrv {
 
 class Note;
+class Slur;
 class TupletBracket;
 
 //----------------------------------------------------------------------------
@@ -77,6 +78,15 @@ public:
     ///@}
 
     /**
+     * @name Getter and setter for the inner slurs.
+     */
+    ///@{
+    const std::set<const Slur *> &GetInnerSlurs() const { return m_innerSlurs; }
+    void AddInnerSlur(const Slur *slur) { m_innerSlurs.insert(slur); }
+    void ResetInnerSlurs() { m_innerSlurs.clear(); }
+    ///@}
+
+    /**
      * Calculate the position of the bracket and the num looking at the stem direction or at the encoded values (if
      * any). Called in View::DrawTuplet the first time it is called (and not trough a dedicated CalcTuplet functor)
      */
@@ -111,6 +121,11 @@ public:
      * See Object::ResetHorizontalAlignment
      */
     int ResetHorizontalAlignment(FunctorParams *functorParams) override;
+
+    /**
+     * See Object::ResetVerticalAlignment
+     */
+    int ResetVerticalAlignment(FunctorParams *functorParams) override;
 
     /**
      * See Object::ResetData
@@ -163,14 +178,16 @@ private:
      * Set in Tuplet::GetDrawingLeftRightXRel from Tuplet::AdjustTupletsX.
      */
     LayerElement *m_drawingRight;
-    /** The calcultated drawing position of the bracket set in Tuplet::CalcDrawingBracketAndNumPos  */
+    /** The calculated drawing position of the bracket set in Tuplet::CalcDrawingBracketAndNumPos  */
     data_STAFFREL_basic m_drawingBracketPos;
-    /** The calcultated drawing position of the num set in Tuplet::CalcDrawingBracketAndNumPos  */
+    /** The calculated drawing position of the num set in Tuplet::CalcDrawingBracketAndNumPos  */
     data_STAFFREL_basic m_drawingNumPos;
     /** The beam with which the bracket aligns (in any) set in Tuplet::AdjustTupletsX */
     Beam *m_bracketAlignedBeam;
     /** The beam with which the num aligns (in any) set in Tuplet::AdjustTupletsX */
     Beam *m_numAlignedBeam;
+    /** The slurs avoided by the tuplet, set during drawing */
+    std::set<const Slur *> m_innerSlurs;
 };
 
 } // namespace vrv

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -16,7 +16,6 @@
 namespace vrv {
 
 class Note;
-class Slur;
 class TupletBracket;
 
 //----------------------------------------------------------------------------
@@ -81,8 +80,8 @@ public:
      * @name Getter and setter for the inner slurs.
      */
     ///@{
-    const std::set<const Slur *> &GetInnerSlurs() const { return m_innerSlurs; }
-    void AddInnerSlur(const Slur *slur) { m_innerSlurs.insert(slur); }
+    const std::set<const FloatingCurvePositioner *> &GetInnerSlurs() const { return m_innerSlurs; }
+    void AddInnerSlur(const FloatingCurvePositioner *slur) { m_innerSlurs.insert(slur); }
     void ResetInnerSlurs() { m_innerSlurs.clear(); }
     ///@}
 
@@ -187,7 +186,7 @@ private:
     /** The beam with which the num aligns (in any) set in Tuplet::AdjustTupletsX */
     Beam *m_numAlignedBeam;
     /** The slurs avoided by the tuplet, set during drawing */
-    std::set<const Slur *> m_innerSlurs;
+    std::set<const FloatingCurvePositioner *> m_innerSlurs;
 };
 
 } // namespace vrv

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -542,6 +542,11 @@ void Page::LayOutVertically()
     view.SetPage(this->GetIdx(), false);
     view.DrawCurrentPage(&bBoxDC, false);
 
+    // Adjust the position of tuplets by slurs
+    FunctorDocParams adjustTupletWithSlursParams(doc);
+    Functor adjustTupletWithSlurs(&Object::AdjustTupletWithSlurs);
+    this->Process(&adjustTupletWithSlurs, &adjustTupletWithSlursParams);
+
     // Fill the arrays of bounding boxes (above and below) for each staff alignment for which the box overflows.
     CalcBBoxOverflowsParams calcBBoxOverflowsParams(doc);
     Functor calcBBoxOverflows(&Object::CalcBBoxOverflows);

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -683,7 +683,7 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
                     = layerElement ? (layerElement->GetOriginalLayerN() != this->GetEnd()->GetOriginalLayerN()) : true;
             }
             // Ignore tuplet elements
-            if (layerElement->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
+            if (layerElement && layerElement->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
                 spannedElement->m_discarded = true;
             }
         }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -342,7 +342,7 @@ void Slur::AddSpannedElements(
         const bool isContained = (xLeft > xMin) && (xRight < xMax);
         const bool isOverlapping = ((xLeft > xMin) && (xLeft < xMax)) || ((xRight > xMin) && (xRight < xMax));
 
-        const Tuplet *tuplet = vrv_cast<const Tuplet *>(element->GetFirstAncestor(TUPLET));
+        const Tuplet *tuplet = vrv_cast<const Tuplet *>(element->GetFirstAncestor(TUPLET, 1));
         const bool isHorizontalTupletBracket = tuplet && !tuplet->GetBracketAlignedBeam();
 
         if (isContained || (isOverlapping && !isHorizontalTupletBracket)) {
@@ -351,9 +351,11 @@ void Slur::AddSpannedElements(
             spannedElement->m_isBelow = this->IsElementBelow(element, startStaff, endStaff);
             curve->AddSpannedElement(spannedElement);
         }
-        else if (!isOverlapping || (isOverlapping && isHorizontalTupletBracket)) {
-            // Exceptional case where the slur actually modifies a spanned element
-            const_cast<Tuplet *>(tuplet)->AddInnerSlur(curve);
+        else if (tuplet) {
+            if (!isOverlapping || (isOverlapping && isHorizontalTupletBracket)) {
+                // Exceptional case where the slur actually modifies a spanned element
+                const_cast<Tuplet *>(tuplet)->AddInnerSlur(curve);
+            }
         }
 
         if (!curve->IsCrossStaff() && element->m_crossStaff) {

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -667,10 +667,11 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
             = (spannedElement->m_boundingBox->GetSelfLeft() + spannedElement->m_boundingBox->GetSelfRight()) / 2.0;
         const float distanceRatio = float(xMiddle - bezierCurve.p1.x) / float(dist);
 
-        // Ignore obstacles in a different layer which completely lie on the other side of the slur near the endpoints
+        // Check if obstacles completely lie on the other side of the slur
         const int elementHeight
             = std::abs(spannedElement->m_boundingBox->GetSelfTop() - spannedElement->m_boundingBox->GetSelfBottom());
         if (intersection > elementHeight + 4 * margin) {
+            // Ignore elements in a different layer near the endpoints
             const LayerElement *layerElement = dynamic_cast<const LayerElement *>(spannedElement->m_boundingBox);
             if (distanceRatio < 0.05) {
                 spannedElement->m_discarded = layerElement
@@ -680,6 +681,10 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
             else if (distanceRatio > 0.95) {
                 spannedElement->m_discarded
                     = layerElement ? (layerElement->GetOriginalLayerN() != this->GetEnd()->GetOriginalLayerN()) : true;
+            }
+            // Ignore tuplet elements
+            if (layerElement->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
+                spannedElement->m_discarded = true;
             }
         }
     }

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -412,9 +412,14 @@ void Slur::DiscardTupletElements(FloatingCurvePositioner *curve, int xMin, int x
             const bool isContained = (xLeft > xMin) && (xRight < xMax);
             const bool isOverlapping = ((xLeft > xMin) && (xLeft < xMax)) || ((xRight > xMin) && (xRight < xMax));
 
-            // Slurs avoid inner tuplets and overlapping tuplets which are beam aligned
+            // Slurs avoid inner tuplets
             if (isContained) continue;
-            if (isOverlapping && tuplet->GetBracketAlignedBeam()) continue;
+
+            // Slurs avoid overlapping tuplets which are beam aligned or not significantly longer
+            if (isOverlapping) {
+                if (tuplet->GetBracketAlignedBeam()) continue;
+                if (xRight - xLeft < 2 * (xMax - xMin)) continue;
+            }
 
             // Discard the tuplet bracket and register the slur for tuplet adjustment
             spannedElement->m_discarded = true;
@@ -682,8 +687,8 @@ void Slur::FilterSpannedElements(FloatingCurvePositioner *curve, const BezierCur
                 spannedElement->m_discarded
                     = layerElement ? (layerElement->GetOriginalLayerN() != this->GetEnd()->GetOriginalLayerN()) : true;
             }
-            // Ignore tuplet elements
-            if (layerElement && layerElement->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
+            // Ignore tuplet numbers
+            if (layerElement && layerElement->Is(TUPLET_NUM)) {
                 spannedElement->m_discarded = true;
             }
         }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -698,6 +698,10 @@ int Tuplet::AdjustTupletWithSlurs(FunctorParams *functorParams)
     }
     TupletNum *tupletNum = vrv_cast<TupletNum *>(this->GetFirst(TUPLET_NUM));
 
+    const Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+    const int margin = params->m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2;
+    const int sign = (m_drawingBracketPos == STAFFREL_basic_above) ? 1 : -1;
+
     const int xLeft = this->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
     const int xRight = this->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
     const int yLeft = tupletBracket->GetDrawingYLeft();
@@ -706,8 +710,8 @@ int Tuplet::AdjustTupletWithSlurs(FunctorParams *functorParams)
     int tupletShift = 0;
 
     for (auto curve : m_innerSlurs) {
-        const int shift = tupletBracket->Intersects(curve, CONTENT, 0);
-        if (shift != 0) {
+        const int shift = tupletBracket->Intersects(curve, CONTENT, margin) * sign;
+        if (shift > 0) {
             // The shift is calculated from the entire bounding box of the tuplet bracket.
             // If the bracket is angled and the slur is short, then this might be too coarse.
             // We reduce the shift by the height of the subbox that cannot be hit.
@@ -731,7 +735,6 @@ int Tuplet::AdjustTupletWithSlurs(FunctorParams *functorParams)
 
     // Apply the tuplet shift from slurs
     if (tupletShift) {
-        const int sign = (m_drawingBracketPos == STAFFREL_basic_above) ? 1 : -1;
         tupletBracket->SetDrawingYRel(tupletBracket->GetDrawingYRel() + sign * tupletShift);
         if (tupletNum) tupletNum->SetDrawingYRel(tupletNum->GetDrawingYRel() + sign * tupletShift);
     }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -688,6 +688,58 @@ int Tuplet::AdjustTupletsY(FunctorParams *functorParams)
     return FUNCTOR_SIBLINGS;
 }
 
+int Tuplet::AdjustTupletWithSlurs(FunctorParams *functorParams)
+{
+    FunctorDocParams *params = vrv_params_cast<FunctorDocParams *>(functorParams);
+    assert(params);
+
+    TupletBracket *tupletBracket = vrv_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
+    if (!tupletBracket || m_innerSlurs.empty()) {
+        return FUNCTOR_SIBLINGS;
+    }
+    TupletNum *tupletNum = vrv_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM, 1));
+
+    const int xLeft = this->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
+    const int xRight = this->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();
+    const int yLeft = tupletBracket->GetDrawingYLeft();
+    const int yRight = tupletBracket->GetDrawingYRight();
+    const double tupletSlope = double(yRight - yLeft) / double(xRight - xLeft);
+    int tupletShift = 0;
+
+    for (auto curve : m_innerSlurs) {
+        const int shift = tupletBracket->Intersects(curve, CONTENT, 0);
+        if (shift != 0) {
+            // The shift is calculated from the entire bounding box of the tuplet bracket.
+            // If the bracket is angled and the slur is short, then this might be too coarse.
+            // We reduce the shift by the height of the subbox that cannot be hit.
+            Point points[4];
+            curve->GetPoints(points);
+            const int curveXLeft = std::max(points[0].x, xLeft);
+            const int curveXRight = std::min(points[3].x, xRight);
+            const int curveYLeft = tupletSlope * (curveXLeft - xLeft) + yLeft;
+            const int curveYRight = tupletSlope * (curveXRight - xLeft) + yLeft;
+
+            int reduction = 0;
+            if (m_drawingBracketPos == STAFFREL_basic_above) {
+                reduction = std::min(curveYLeft, curveYRight) - std::min(yLeft, yRight);
+            }
+            else {
+                reduction = std::max(yLeft, yRight) - std::max(curveYLeft, curveYRight);
+            }
+            tupletShift = std::max(shift - reduction, tupletShift);
+        }
+    }
+
+    // Apply the tuplet shift from slurs
+    if (tupletShift) {
+        const int sign = (m_drawingBracketPos == STAFFREL_basic_above) ? 1 : -1;
+        tupletBracket->SetDrawingYRel(tupletBracket->GetDrawingYRel() + sign * tupletShift);
+        if (tupletNum) tupletNum->SetDrawingYRel(tupletNum->GetDrawingYRel() + sign * tupletShift);
+    }
+
+    return FUNCTOR_SIBLINGS;
+}
+
 int Tuplet::ResetData(FunctorParams *functorParams)
 {
     // Call parent one too

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -714,4 +714,14 @@ int Tuplet::ResetHorizontalAlignment(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+int Tuplet::ResetVerticalAlignment(FunctorParams *functorParams)
+{
+    // Call parent one too
+    LayerElement::ResetVerticalAlignment(functorParams);
+
+    this->ResetInnerSlurs();
+
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -142,7 +142,7 @@ void Tuplet::AddChild(Object *child)
 
 void Tuplet::AdjustTupletBracketY(const Doc *doc, const Staff *staff)
 {
-    TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
+    TupletBracket *tupletBracket = vrv_cast<TupletBracket *>(this->GetFirst(TUPLET_BRACKET));
     if (!tupletBracket || (this->GetBracketVisible() == BOOLEAN_false)) return;
 
     // if bracket is used for beam elements - process that part separately
@@ -266,7 +266,7 @@ void Tuplet::AdjustTupletBracketBeamY(const Doc *doc, const Staff *staff, Tuplet
 
 void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
 {
-    TupletNum *tupletNum = dynamic_cast<TupletNum *>(FindDescendantByType(TUPLET_NUM));
+    TupletNum *tupletNum = vrv_cast<TupletNum *>(this->GetFirst(TUPLET_NUM));
     if (!tupletNum || (this->GetNumVisible() == BOOLEAN_false)) return;
 
     // The num is within a bracket
@@ -512,14 +512,14 @@ void Tuplet::GetDrawingLeftRightXRel(int &xRelLeft, int &xRelRight, const Doc *d
 
 int Tuplet::PrepareLayerElementParts(FunctorParams *functorParams)
 {
-    TupletBracket *currentBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET, 1));
-    TupletNum *currentNum = dynamic_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM, 1));
+    TupletBracket *currentBracket = vrv_cast<TupletBracket *>(this->GetFirst(TUPLET_BRACKET));
+    TupletNum *currentNum = vrv_cast<TupletNum *>(this->GetFirst(TUPLET_NUM));
 
     bool beamed = false;
     // Are we contained in a beam?
     if (this->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH)) {
         // is only the tuplet beamed? (will not work with nested tuplets)
-        Beam *currentBeam = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
+        Beam *currentBeam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
         if (currentBeam->GetChildCount() == 1) {
             beamed = true;
         }
@@ -566,9 +566,8 @@ int Tuplet::PrepareLayerElementParts(FunctorParams *functorParams)
     /*********** Get the left and right element ***********/
 
     ClassIdsComparison comparison({ CHORD, NOTE, REST });
-    m_drawingLeft = dynamic_cast<LayerElement *>(this->FindDescendantByComparison(&comparison));
-    m_drawingRight
-        = dynamic_cast<LayerElement *>(this->FindDescendantByComparison(&comparison, UNLIMITED_DEPTH, BACKWARD));
+    m_drawingLeft = vrv_cast<LayerElement *>(this->FindDescendantByComparison(&comparison));
+    m_drawingRight = vrv_cast<LayerElement *>(this->FindDescendantByComparison(&comparison, UNLIMITED_DEPTH, BACKWARD));
 
     return FUNCTOR_CONTINUE;
 }
@@ -596,12 +595,12 @@ int Tuplet::AdjustTupletsX(FunctorParams *functorParams)
     assert(m_drawingBracketPos != STAFFREL_basic_NONE);
 
     // Carefull: this will not work if the tuplet has editorial markup (one child) and then notes + one beam
-    Beam *beamParent = dynamic_cast<Beam *>(this->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
+    Beam *beamParent = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM, MAX_BEAM_DEPTH));
     // Are we contained in a beam?
     if (beamParent) {
         m_bracketAlignedBeam = beamParent;
     }
-    Beam *beamChild = dynamic_cast<Beam *>(this->FindDescendantByType(BEAM));
+    Beam *beamChild = vrv_cast<Beam *>(this->FindDescendantByType(BEAM));
     // Do we contain a beam?
     if (beamChild) {
         if ((this->GetChildCount(NOTE) == 0) && (this->GetChildCount(CHORD) == 0) && (this->GetChildCount(BEAM) == 1)) {
@@ -636,13 +635,13 @@ int Tuplet::AdjustTupletsX(FunctorParams *functorParams)
     int xRelRight;
     this->GetDrawingLeftRightXRel(xRelLeft, xRelRight, params->m_doc);
 
-    TupletBracket *tupletBracket = dynamic_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
+    TupletBracket *tupletBracket = vrv_cast<TupletBracket *>(this->GetFirst(TUPLET_BRACKET));
     if (tupletBracket && (this->GetBracketVisible() != BOOLEAN_false)) {
         tupletBracket->SetDrawingXRelLeft(xRelLeft);
         tupletBracket->SetDrawingXRelRight(xRelRight);
     }
 
-    TupletNum *tupletNum = dynamic_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM));
+    TupletNum *tupletNum = vrv_cast<TupletNum *>(this->GetFirst(TUPLET_NUM));
     if (tupletNum && (this->GetNumVisible() != BOOLEAN_false)) {
         // We have a bracket and the num is not on its opposite side
         if (tupletBracket && (m_drawingNumPos == m_drawingBracketPos)) {
@@ -693,11 +692,11 @@ int Tuplet::AdjustTupletWithSlurs(FunctorParams *functorParams)
     FunctorDocParams *params = vrv_params_cast<FunctorDocParams *>(functorParams);
     assert(params);
 
-    TupletBracket *tupletBracket = vrv_cast<TupletBracket *>(this->FindDescendantByType(TUPLET_BRACKET));
+    TupletBracket *tupletBracket = vrv_cast<TupletBracket *>(this->GetFirst(TUPLET_BRACKET));
     if (!tupletBracket || m_innerSlurs.empty()) {
         return FUNCTOR_SIBLINGS;
     }
-    TupletNum *tupletNum = vrv_cast<TupletNum *>(this->FindDescendantByType(TUPLET_NUM, 1));
+    TupletNum *tupletNum = vrv_cast<TupletNum *>(this->GetFirst(TUPLET_NUM));
 
     const int xLeft = this->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft();
     const int xRight = this->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight();


### PR DESCRIPTION
This PR improves the collision handling between slurs and tuplets. It introduces a flexible stacking order.

For short slurs the tuplet bracket is stacked on the slur. Closes #3203 .

<img width="500" alt="SlurTuplet1" src="https://user-images.githubusercontent.com/63608463/214073031-6087954e-8030-417b-b87d-e8b74c8e47ff.png">

Longer slurs are stacked on tuplets (as before).

<img width="605" alt="SlurTuplet2" src="https://user-images.githubusercontent.com/63608463/214073415-0927ffa2-7158-4593-b783-1bf2c61b89dd.png">

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Pickup note spacing</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2017-07-28">2017-07-28</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="2.0.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="400">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="0">
                     <staff n="1">
                        <layer n="1">
                           <note dur="8" oct="4" pname="e" accid.ges="n" />
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end">
                     <staff n="1">
                        <layer n="1">
                          <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="true" num.format="count">
                             <note xml:id="note-1" dur="2" oct="4" pname="g" />
                             <note dur="4" oct="4" pname="a" />
                          </tuplet>
                          <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="true" num.format="count">
                            <note dur="2" oct="5" pname="e" />
                            <note dur="4" oct="4" pname="g" />
                          </tuplet>
                          <note xml:id="note-2" dur="2" oct="5" pname="f" />
                        </layer>
                     </staff>
                     <slur staff="1" startid="#note-1" endid="#note-2" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>


This closes (or at least) improves some other issues. Closes #2417 .

<img width="500" alt="SlurTuplet3" src="https://user-images.githubusercontent.com/63608463/214074092-07b5cc37-003f-45f6-85a1-b58235e58bf5.png">

Closes #2686 .

<img width="600" alt="SlurTuplet4" src="https://user-images.githubusercontent.com/63608463/214074798-ae70d3ab-43c5-43fa-a8b8-e16fe9478c8f.png">

<img width="600" alt="SlurTuplet5" src="https://user-images.githubusercontent.com/63608463/214074865-ef86f06c-6581-46b7-bf4b-7229017f37e3.png">
