### PR TITLE
Unify iterators

### DIFF
--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -216,7 +216,7 @@ void BBoxDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOff
     int y1 = points[0].y + yOffset;
     int y2 = y1;
 
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < n; ++i) {
         x1 = std::min(x1, points[i].x + xOffset);
         x2 = std::max(x2, points[i].x + xOffset);
         y1 = std::min(y1, points[i].y + yOffset);
@@ -362,7 +362,7 @@ void BBoxDeviceContext::DrawMusicText(const std::u32string &text, int x, int y, 
     char32_t smuflGlyph = 0;
     if (setSmuflGlyph && (text.length() == 1)) smuflGlyph = text.at(0);
 
-    for (unsigned int i = 0; i < text.length(); i++) {
+    for (size_t i = 0; i < text.length(); ++i) {
         char32_t c = text.at(i);
         const Glyph *glyph = resources->GetGlyph(c);
         if (!glyph) {
@@ -425,9 +425,8 @@ void BBoxDeviceContext::UpdateBB(int x1, int y1, int x2, int y2, char32_t glyph)
         if (glyph != 0) (m_objects.back())->SetBoundingBoxGlyph(glyph, m_fontStack.top()->GetPointSize());
     }
 
-    int i;
     // Stretch the content BB of the other objects
-    for (i = 0; i < (int)m_objects.size(); i++) {
+    for (size_t i = 0; i < m_objects.size(); ++i) {
         if (!m_isDeactivatedX) (m_objects.at(i))->UpdateContentBBoxX(m_view->ToLogicalX(x1), m_view->ToLogicalX(x2));
         if (!m_isDeactivatedY) (m_objects.at(i))->UpdateContentBBoxY(m_view->ToLogicalY(y1), m_view->ToLogicalY(y2));
     }

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -573,15 +573,13 @@ void BeamSegment::CalcBeamInit(
     assert(doc);
     assert(beamInterface);
 
-    int i;
-
     int elementCount = (int)m_beamElementCoordRefs.size();
     assert(elementCount > 0);
 
     /******************************************************************/
     // initialization
 
-    for (i = 0; i < elementCount; ++i) {
+    for (int i = 0; i < elementCount; ++i) {
         BeamElementCoord *coord = m_beamElementCoordRefs.at(i);
         coord->m_x = coord->m_element->GetDrawingX();
     }
@@ -630,7 +628,7 @@ void BeamSegment::CalcBeamInit(
     };
 
     // elementCount holds the last one
-    for (i = 0; i < elementCount; ++i) {
+    for (int i = 0; i < elementCount; ++i) {
         BeamElementCoord *coord = m_beamElementCoordRefs.at(i);
         coord->m_yBeam = 0;
 

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -88,7 +88,7 @@ int BeatRpt::GenerateMIDI(FunctorParams *functorParams)
     // filter last beat and copy all notes
     smf::MidiEvent event;
     int eventcount = params->m_midiFile->getEventCount(params->m_midiTrack);
-    for (int i = 0; i < eventcount; i++) {
+    for (int i = 0; i < eventcount; ++i) {
         event = params->m_midiFile->getEvent(params->m_midiTrack, i);
         if (event.tick > starttime * tpq)
             break;

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -238,14 +238,13 @@ bool BoundingBox::VerticalSelfOverlap(const BoundingBox *other, int margin) cons
 int BoundingBox::HorizontalLeftOverlap(const BoundingBox *other, const Doc *doc, int margin, int vMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
-    int i, j;
     int anchor1, anchor2;
     int overlap = 0;
 
     anchor1 = this->GetRectangles(SMUFL_cutOutNW, SMUFL_cutOutSW, BB1rect, doc->GetResources());
     anchor2 = other->GetRectangles(SMUFL_cutOutNE, SMUFL_cutOutSE, BB2rect, doc->GetResources());
-    for (i = 0; i < anchor1; ++i) {
-        for (j = 0; j < anchor2; ++j) {
+    for (int i = 0; i < anchor1; ++i) {
+        for (int j = 0; j < anchor2; ++j) {
             overlap = std::max(overlap, RectLeftOverlap(BB1rect[i], BB2rect[j], margin, vMargin));
         }
     }
@@ -256,14 +255,13 @@ int BoundingBox::HorizontalLeftOverlap(const BoundingBox *other, const Doc *doc,
 int BoundingBox::HorizontalRightOverlap(const BoundingBox *other, const Doc *doc, int margin, int vMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
-    int i, j;
     int anchor1, anchor2;
     int overlap = 0;
 
     anchor1 = this->GetRectangles(SMUFL_cutOutNE, SMUFL_cutOutSE, BB1rect, doc->GetResources());
     anchor2 = other->GetRectangles(SMUFL_cutOutNW, SMUFL_cutOutSW, BB2rect, doc->GetResources());
-    for (i = 0; i < anchor1; ++i) {
-        for (j = 0; j < anchor2; ++j) {
+    for (int i = 0; i < anchor1; ++i) {
+        for (int j = 0; j < anchor2; ++j) {
             overlap = std::max(overlap, RectRightOverlap(BB1rect[i], BB2rect[j], margin, vMargin));
         }
     }
@@ -274,14 +272,13 @@ int BoundingBox::HorizontalRightOverlap(const BoundingBox *other, const Doc *doc
 int BoundingBox::VerticalTopOverlap(const BoundingBox *other, const Doc *doc, int margin, int hMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
-    int i, j;
     int anchor1, anchor2;
     int overlap = 0;
 
     anchor1 = this->GetRectangles(SMUFL_cutOutNW, SMUFL_cutOutNE, BB1rect, doc->GetResources());
     anchor2 = other->GetRectangles(SMUFL_cutOutSW, SMUFL_cutOutSE, BB2rect, doc->GetResources());
-    for (i = 0; i < anchor1; ++i) {
-        for (j = 0; j < anchor2; ++j) {
+    for (int i = 0; i < anchor1; ++i) {
+        for (int j = 0; j < anchor2; ++j) {
             overlap = std::max(overlap, RectTopOverlap(BB1rect[i], BB2rect[j], margin, hMargin));
         }
     }
@@ -292,14 +289,13 @@ int BoundingBox::VerticalTopOverlap(const BoundingBox *other, const Doc *doc, in
 int BoundingBox::VerticalBottomOverlap(const BoundingBox *other, const Doc *doc, int margin, int hMargin) const
 {
     Point BB1rect[3][2], BB2rect[3][2];
-    int i, j;
     int anchor1, anchor2;
     int overlap = 0;
 
     anchor1 = this->GetRectangles(SMUFL_cutOutSW, SMUFL_cutOutSE, BB1rect, doc->GetResources());
     anchor2 = other->GetRectangles(SMUFL_cutOutNW, SMUFL_cutOutNE, BB2rect, doc->GetResources());
-    for (i = 0; i < anchor1; ++i) {
-        for (j = 0; j < anchor2; ++j) {
+    for (int i = 0; i < anchor1; ++i) {
+        for (int j = 0; j < anchor2; ++j) {
             overlap = std::max(overlap, RectBottomOverlap(BB1rect[i], BB2rect[j], margin, hMargin));
         }
     }
@@ -1038,8 +1034,7 @@ void BoundingBox::ApproximateBezierBoundingBox(
     todx = dx - cx;
     tody = dy - cy;
     double step = 1.0 / BEZIER_APPROXIMATION;
-    int i;
-    for (i = 0; i < (int)(BEZIER_APPROXIMATION + 1.0); ++i) {
+    for (int i = 0; i < (int)(BEZIER_APPROXIMATION + 1.0); ++i) {
         double d = i * step;
         px = ax + d * tobx;
         py = ay + d * toby;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -252,7 +252,7 @@ void DeviceContext::GetTextExtent(const std::u32string &string, TextExtend *exte
 
     const Glyph *unknown = resources->GetTextGlyph(L'o');
 
-    for (unsigned int i = 0; i < string.length(); ++i) {
+    for (size_t i = 0; i < string.length(); ++i) {
         char32_t c = string[i];
         const Glyph *glyph = resources->GetTextGlyph(c);
         if (!glyph) {
@@ -284,7 +284,7 @@ void DeviceContext::GetSmuflTextExtent(const std::u32string &string, TextExtend 
     extend->m_width = 0;
     extend->m_height = 0;
 
-    for (unsigned int i = 0; i < string.length(); ++i) {
+    for (size_t i = 0; i < string.length(); ++i) {
         char32_t c = string[i];
         const Glyph *glyph = resources->GetGlyph(c);
         if (!glyph) {

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -141,8 +141,7 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
     int lastDur, currentDur;
 
     m_beamElementCoords.reserve(childList.size());
-    int i;
-    for (i = 0; i < (int)childList.size(); ++i) {
+    for (size_t i = 0; i < childList.size(); ++i) {
         m_beamElementCoords.push_back(new BeamElementCoord());
     }
 
@@ -288,14 +287,14 @@ bool BeamDrawingInterface::IsHorizontal() const
     items.reserve(m_beamElementCoords.size());
     directions.reserve(m_beamElementCoords.size());
 
-    for (int i = 0; i < elementCount; ++i) {
+    for (size_t i = 0; i < elementCount; ++i) {
         BeamElementCoord *coord = m_beamElementCoords.at(i);
         if (!coord->m_stem || !coord->m_closestNote) continue;
 
         items.push_back(coord->m_closestNote->GetDrawingY());
         directions.push_back(coord->m_beamRelativePlace);
     }
-    int itemCount = (int)items.size();
+    size_t itemCount = items.size();
 
     if (itemCount < 2) return true;
 
@@ -313,7 +312,7 @@ bool BeamDrawingInterface::IsHorizontal() const
     const bool lastStep = (last != items.at(items.size() - 2));
     if ((items.size() > 2) && (firstStep || lastStep)) {
         // Detect concave shapes
-        for (int i = 1; i < itemCount - 1; ++i) {
+        for (size_t i = 1; i < itemCount - 1; ++i) {
             if (m_drawingPlace == BEAMPLACE_above) {
                 if ((items.at(i) >= first) && (items.at(i) >= last)) return true;
             }
@@ -366,7 +365,7 @@ bool BeamDrawingInterface::IsHorizontalMixedBeam(
     data_STEMDIRECTION outsidePitchDirection = GetNoteDirection(items.front(), items.back());
     std::map<data_STEMDIRECTION, int> beamDirections{ { STEMDIRECTION_NONE, 0 }, { STEMDIRECTION_up, 0 },
         { STEMDIRECTION_down, 0 } };
-    for (int i = 0; i < (int)items.size(); ++i) {
+    for (size_t i = 0; i < items.size(); ++i) {
         if (directions[i] == BEAMPLACE_above) {
             if (previousTop == VRV_UNSET) {
                 previousTop = items[i];
@@ -407,15 +406,14 @@ bool BeamDrawingInterface::IsRepeatedPattern() const
     std::vector<int> items;
     items.reserve(m_beamElementCoords.size());
 
-    int i;
-    for (i = 0; i < elementCount; ++i) {
+    for (size_t i = 0; i < elementCount; ++i) {
         BeamElementCoord *coord = m_beamElementCoords.at(i);
         if (!coord->m_stem || !coord->m_closestNote) continue;
 
         // Could this be an overflow with 32 bits?
         items.push_back(coord->m_closestNote->GetDrawingY() * DUR_MAX + coord->m_dur);
     }
-    int itemCount = (int)items.size();
+    size_t itemCount = items.size();
 
     // No pattern with at least 4 elements or if all elements are the same
     if ((itemCount < 4) || (std::equal(items.begin() + 1, items.end(), items.begin()))) {
@@ -424,18 +422,17 @@ bool BeamDrawingInterface::IsRepeatedPattern() const
 
     // Find all possible dividers for the sequence (without 1 and its size)
     std::vector<int> dividers;
-    for (i = 2; i <= itemCount / 2; ++i) {
+    for (int i = 2; i <= itemCount / 2; ++i) {
         if (itemCount % i == 0) dividers.push_back(i);
     }
 
     // Correlate a sub-array for each divider until a sequence is found (if any)
-    for (i = 0; i < (int)dividers.size(); ++i) {
+    for (size_t i = 0; i < dividers.size(); ++i) {
         int divider = dividers.at(i);
-        int j;
         bool pattern = true;
         std::vector<int>::iterator iter = items.begin();
         std::vector<int> v1 = std::vector<int>(iter, iter + divider);
-        for (j = 1; j < (itemCount / divider); ++j) {
+        for (int j = 1; j < (itemCount / divider); ++j) {
             std::vector<int> v2 = std::vector<int>(iter + j * divider, iter + (j + 1) * divider);
             if (v1 != v2) {
                 pattern = false;

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -248,9 +248,8 @@ std::u32string Dynam::GetSymbolStr(const std::u32string &str, const bool singleG
 
     // Otherwise replace it letter by letter
     dynam = str;
-    int i;
     std::u32string from, to;
-    for (i = 0; i < DYNAM_CHARS; ++i) {
+    for (size_t i = 0; i < DYNAM_CHARS; ++i) {
         from = dynamChars[i];
         to = dynamSmufl[i];
         for (size_t pos = 0; (pos = dynam.find(from, pos)) != std::string::npos; pos += to.size())

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -202,7 +202,7 @@ bool EditorToolkitCMN::Chain(jsonxx::Array actions)
 {
     bool status = true;
     m_chainedId = "";
-    for (int i = 0; i < (int)actions.size(); i++) {
+    for (int i = 0; i < (int)actions.size(); ++i) {
         status = this->ParseEditorAction(actions.get<jsonxx::Object>(i).json(), !status);
         m_editInfo.import("uuid", m_chainedId);
     }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -202,7 +202,7 @@ bool EditorToolkitNeume::Chain(jsonxx::Array actions)
 {
     bool status = true;
     jsonxx::Object results;
-    for (int i = 0; i < (int)actions.size(); i++) {
+    for (int i = 0; i < (int)actions.size(); ++i) {
         if (!actions.has<jsonxx::Object>(i)) {
             LogError("Action %d was not an object", i);
             m_infoObject.reset();
@@ -652,7 +652,7 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
         stavesVector.push_back(newStaff);
         StaffSort staffSort;
         std::stable_sort(stavesVector.begin(), stavesVector.end(), staffSort);
-        for (int i = 0; i < (int)staves.size(); i++) {
+        for (int i = 0; i < (int)staves.size(); ++i) {
             if (stavesVector.at(i) == newStaff) {
                 parent->InsertChild(newStaff, i);
                 parent->Modify();
@@ -2544,7 +2544,7 @@ bool EditorToolkitNeume::ParseInsertAction(jsonxx::Object param, std::string *el
     if (param.has<jsonxx::Object>("attributes")) {
         jsonxx::Object o = param.get<jsonxx::Object>("attributes");
         auto m = o.kv_map();
-        for (auto it = m.begin(); it != m.end(); it++) {
+        for (auto it = m.begin(); it != m.end(); ++it) {
             if (o.has<jsonxx::String>(it->first)) {
                 attributes->emplace(attributes->end(), it->first, o.get<jsonxx::String>(it->first));
             }
@@ -2570,7 +2570,7 @@ bool EditorToolkitNeume::ParseMergeAction(jsonxx::Object param, std::vector<std:
 {
     if (!param.has<jsonxx::Array>("elementIds")) return false;
     jsonxx::Array array = param.get<jsonxx::Array>("elementIds");
-    for (int i = 0; i < (int)array.size(); i++) {
+    for (int i = 0; i < (int)array.size(); ++i) {
         elementIds->push_back(array.get<jsonxx::String>(i));
     }
     return true;
@@ -2692,7 +2692,7 @@ bool EditorToolkitNeume::ParseGroupAction(
     (*groupType) = param.get<jsonxx::String>("groupType");
     if (!param.has<jsonxx::Array>("elementIds")) return false;
     jsonxx::Array array = param.get<jsonxx::Array>("elementIds");
-    for (int i = 0; i < (int)array.size(); i++) {
+    for (int i = 0; i < (int)array.size(); ++i) {
         elementIds->push_back(array.get<jsonxx::String>(i));
     }
 
@@ -2706,7 +2706,7 @@ bool EditorToolkitNeume::ParseUngroupAction(
     (*groupType) = param.get<jsonxx::String>("groupType");
     if (!param.has<jsonxx::Array>("elementIds")) return false;
     jsonxx::Array array = param.get<jsonxx::Array>("elementIds");
-    for (int i = 0; i < (int)array.size(); i++) {
+    for (int i = 0; i < (int)array.size(); ++i) {
         elementIds->push_back(array.get<jsonxx::String>(i));
     }
 
@@ -2727,7 +2727,7 @@ bool EditorToolkitNeume::ParseToggleLigatureAction(
 {
     if (!param.has<jsonxx::Array>("elementIds")) return false;
     jsonxx::Array array = param.get<jsonxx::Array>("elementIds");
-    for (int i = 0; i < (int)array.size(); i++) {
+    for (int i = 0; i < (int)array.size(); ++i) {
         elementIds->push_back(array.get<jsonxx::String>(i));
     }
     if (!param.has<jsonxx::String>("isLigature")) return false;

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -82,7 +82,7 @@ void ExpansionMap::Expand(const xsdAnyURI_List &expansionList, xsdAnyURI_List &e
                 std::vector<std::string> clonedIds;
                 clonedIds.push_back(clonedObject->GetID());
                 this->GetIDList(clonedObject, clonedIds);
-                for (int i = 0; (i < (int)oldIds.size()) && (i < (int)clonedIds.size()); i++) {
+                for (size_t i = 0; (i < oldIds.size()) && (i < clonedIds.size()); ++i) {
                     this->AddExpandedIDToExpansionMap(oldIds.at(i), clonedIds.at(i));
                 }
 

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -55,11 +55,10 @@ Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType t
 
 const Alignment *HorizontalAligner::SearchAlignmentAtTime(double time, AlignmentType type, int &idx) const
 {
-    int i;
     idx = -1; // the index if we reach the end.
     const Alignment *alignment = NULL;
     // First try to see if we already have something at the time position
-    for (i = 0; i < this->GetAlignmentCount(); ++i) {
+    for (int i = 0; i < this->GetAlignmentCount(); ++i) {
         alignment = vrv_cast<const Alignment *>(this->GetChild(i));
         assert(alignment);
 
@@ -164,10 +163,9 @@ void MeasureAligner::SetMaxTime(double time)
     int idx = m_rightBarLineAlignment->GetIdx();
     assert(idx != -1);
 
-    int i;
     Alignment *alignment = NULL;
     // Increase the time position for all alignment from the right barline
-    for (i = idx; i < this->GetAlignmentCount(); ++i) {
+    for (int i = idx; i < this->GetAlignmentCount(); ++i) {
         alignment = vrv_cast<Alignment *>(this->GetChild(i));
         assert(alignment);
         // Change it only if higher than before
@@ -353,9 +351,8 @@ void GraceAligner::StackGraceElement(LayerElement *element)
 
 void GraceAligner::AlignStack()
 {
-    int i;
     double time = 0.0;
-    for (i = (int)m_graceStack.size(); i > 0; i--) {
+    for (size_t i = m_graceStack.size(); i > 0; --i) {
         LayerElement *element = vrv_cast<LayerElement *>(m_graceStack.at(i - 1));
         assert(element);
         // get the duration of the event
@@ -435,7 +432,7 @@ void GraceAligner::SetGraceAlignmentXPos(const Doc *doc)
         // We space with a notehead (non grace size) which seems to be a reasonable default spacing with margin
         // Ideally we should look at the duration in that alignment and also the maximum staff scaling for this aligner
         alignment->SetXRel(-i * doc->GetGlyphWidth(SMUFL_E0A4_noteheadBlack, 100, false));
-        i++;
+        ++i;
     }
 }
 
@@ -883,7 +880,6 @@ bool TimestampAligner::IsSupportedChild(Object *child)
 
 TimestampAttr *TimestampAligner::GetTimestampAtTime(double time)
 {
-    int i;
     int idx = -1; // the index if we reach the end.
     // We need to adjust the position since timestamp 0 to 1.0 are before 0 musical time
     time = time - 1.0;
@@ -892,7 +888,7 @@ TimestampAttr *TimestampAligner::GetTimestampAtTime(double time)
     ArrayOfObjects &children = this->GetChildrenForModification();
 
     // First try to see if we already have something at the time position
-    for (i = 0; i < this->GetChildCount(); ++i) {
+    for (int i = 0; i < this->GetChildCount(); ++i) {
         timestampAttr = vrv_cast<TimestampAttr *>(children.at(i));
         assert(timestampAttr);
 
@@ -1500,11 +1496,10 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
     }
 
     int count = (int)m_accidSpace.size();
-    int i, j;
 
     std::vector<Accid *> adjustedAccids;
     // Align the octaves
-    for (i = 0; i < count - 1; ++i) {
+    for (int i = 0; i < count - 1; ++i) {
         if (m_accidSpace.at(i)->GetDrawingOctaveAccid() != NULL) {
             this->AdjustAccidWithAccidSpace(m_accidSpace.at(i), params->m_doc, staffSize, adjustedAccids);
             this->AdjustAccidWithAccidSpace(
@@ -1526,7 +1521,7 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
 
     int middle = (count % 2) ? (count / 2) + 1 : (count / 2);
     // Zig-zag processing
-    for (i = 0, j = count - 1; i < middle; i++, j--) {
+    for (int i = 0, j = count - 1; i < middle; ++i, --j) {
         // top one - but skip octaves
         if (!m_accidSpace.at(j)->GetDrawingOctaveAccid() && !m_accidSpace.at(j)->GetDrawingOctave())
             this->AdjustAccidWithAccidSpace(m_accidSpace.at(j), params->m_doc, staffSize, adjustedAccids);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -6868,7 +6868,7 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         else {
             LogWarning("Element <%s> is unknown and will be ignored", xmlElement.name());
         }
-        i++;
+        ++i;
     }
     return success;
 }
@@ -7824,8 +7824,7 @@ bool MEIInput::ReadTupletSpanAsTuplet(Measure *measure, pugi::xml_node tupletSpa
     int startIdx = startChild->GetIdx();
     int endIdx = endChild->GetIdx();
     // LogDebug("%d %d %s!", startIdx, endIdx, start->GetID().c_str());
-    int i;
-    for (i = endIdx; i >= startIdx; i--) {
+    for (int i = endIdx; i >= startIdx; --i) {
         LayerElement *element = dynamic_cast<LayerElement *>(parentLayer->DetachChild(i));
         if (element) tuplet->AddChild(element);
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -722,7 +722,7 @@ void MusicXmlInput::PrintMetronome(pugi::xml_node metronome, Tempo *tempo)
                     [](const auto pair) { return pair.first == MetronomeElements::SEPARATOR; });
                 const short int dotCount = (short int)std::count_if(
                     iter, separator, [](const auto pair) { return pair.first == MetronomeElements::BEAT_UNIT_DOT; });
-                for (short int i = 0; i < dotCount; i++) {
+                for (short int i = 0; i < dotCount; ++i) {
                     verovioText += U"\xE1E7"; // SMUFL augmentation dot
                 }
                 // set @mmUnit and @mmDots attributes only based on the first beat-unit in the sequence
@@ -1547,7 +1547,7 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, shor
                 }
             }
         }
-        i++;
+        ++i;
     }
 
     // clean up part specific stacks
@@ -1591,8 +1591,7 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
         measure->AddChild(mNum);
     }
 
-    int i = 0;
-    for (i = 0; i < nbStaves; i++) {
+    for (int i = 0; i < nbStaves; ++i) {
         // the staff @n must take into account the staffOffset
         Staff *staff = new Staff();
         staff->SetN(i + 1 + staffOffset);

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -802,7 +802,7 @@ void PAEInput::parsePlainAndEasy(std::istream &infile)
 
         if (incipit[i] == ' ') {
             // just skip
-            i++;
+            ++i;
         }
 
         // octaves
@@ -966,7 +966,7 @@ void PAEInput::parsePlainAndEasy(std::istream &infile)
             }
         }
 
-        i++;
+        ++i;
     }
 
     // we need to add the last measure if it has no barLine at the end
@@ -1056,7 +1056,7 @@ int PAEInput::getOctave(const char *incipit, char *octave, int index)
         *octave = BASE_OCT;
         while ((i + 1 < length) && (incipit[i + 1] == '\'')) {
             (*octave)++;
-            i++;
+            ++i;
         }
     }
     else if (incipit[i] == ',') {
@@ -1064,7 +1064,7 @@ int PAEInput::getOctave(const char *incipit, char *octave, int index)
         *octave = BASE_OCT - 1;
         while ((i + 1 < length) && (incipit[i + 1] == ',')) {
             (*octave)--;
-            i++;
+            ++i;
         }
     }
 
@@ -1120,7 +1120,7 @@ int PAEInput::getDuration(const char *incipit, data_DURATION *duration, int *dot
     *dot = 0;
     while ((i + 1 < length) && (incipit[i + 1] == '.')) {
         (*dot)++;
-        i++;
+        ++i;
     }
     if ((*dot == 1) && (incipit[i] == 7)) {
         // neumatic notation
@@ -1156,7 +1156,7 @@ int PAEInput::getDurations(const char *incipit, pae::Measure *measure, int index
         measure->dots.push_back(dot);
         // j++;
         if ((i + 1 < length) && isdigit(incipit[i + 1])) {
-            i++;
+            ++i;
         }
         else {
             break;
@@ -1183,14 +1183,14 @@ int PAEInput::getAccidental(const char *incipit, data_ACCIDENTAL_WRITTEN *accide
         *accident = ACCIDENTAL_WRITTEN_s;
         if ((i + 1 < length) && (incipit[i + 1] == 'x')) {
             *accident = ACCIDENTAL_WRITTEN_x;
-            i++;
+            ++i;
         }
     }
     else if (incipit[i] == 'b') {
         *accident = ACCIDENTAL_WRITTEN_f;
         if ((i + 1 < length) && (incipit[i + 1] == 'b')) {
             *accident = ACCIDENTAL_WRITTEN_ff;
-            i++;
+            ++i;
         }
     }
     return i - index;
@@ -1321,7 +1321,7 @@ int PAEInput::getGraceNote(const char *incipit, pae::Note *note, int index)
     else if (incipit[i] == 'q') {
         note->appoggiatura = 1;
         if ((i + 1 < length) && (incipit[i + 1] == 'q')) {
-            i++;
+            ++i;
             int r = i;
             while ((r < length) && (incipit[r] != 'r')) {
                 if ((incipit[r] - 'A' >= 0) && (incipit[r] - 'A' < 7)) {
@@ -1376,12 +1376,12 @@ int PAEInput::getTimeInfo(const char *incipit, MeterSig *meter, Mensur *mensur, 
     }
 
     // find the end of time signature
-    i++; // the time signature length is at least 1
+    ++i; // the time signature length is a least 1
     while (i < length) {
         if (!isdigit(incipit[i]) && (incipit[i] != '/') && (incipit[i] != '.')) {
             break;
         }
-        i++;
+        ++i;
     }
 
     // use a substring for the time signature
@@ -1495,7 +1495,7 @@ int PAEInput::getClefInfo(const char *incipit, Clef *mclef, int index)
         if (incipit[index] == '+') {
             m_is_mensural = true;
         }
-        i++;
+        ++i;
         index++;
     }
 
@@ -1624,7 +1624,7 @@ int PAEInput::getAbbreviation(const char *incipit, pae::Measure *measure, int in
     else { //
         int abbreviation_stop = (int)measure->notes.size();
         while ((i + 1 < length) && (incipit[i + 1] == 'f')) {
-            i++;
+            ++i;
             for (int j = measure->abbreviation_offset; j < abbreviation_stop; ++j) {
                 measure->notes.push_back(measure->notes.at(j));
                 // With abbreviation, repeat clefs but do not copy keySig, meterSig and mensur
@@ -1695,7 +1695,7 @@ int PAEInput::getKeyInfo(const char *incipit, KeySig *key, int index)
             if (alt_nr < 7) {
                 enclosedAccids.at(alt_nr) = enclosed;
             }
-            i++;
+            ++i;
         }
     }
 
@@ -1887,7 +1887,7 @@ void PAEInput::convertMeasure(pae::Measure *measure)
 
     m_nested_objects.clear();
 
-    for (unsigned int i = 0; i < measure->notes.size(); ++i) {
+    for (size_t i = 0; i < measure->notes.size(); ++i) {
         pae::Note *note = &measure->notes.at(i);
         parseNote(note);
     }
@@ -2189,8 +2189,7 @@ void PAEInput::getAtRecordKeyValue(char *key, char *value, const char *input)
     strcpy(value, &input[index]);
 
     // Truncate string to first space
-    size_t i;
-    for (i = strlen(value) - 2; i > 0; i--) {
+    for (size_t i = strlen(value) - 2; i > 0; --i) {
         if (isspace(value[i])) {
             value[i] = EMPTY;
             continue;
@@ -2864,7 +2863,7 @@ bool PAEInput::Import(const std::string &input)
         if (c == pae::CONTAINER_END) continue;
         // Otherwise go ahead
         this->AddToken(c, i);
-        i++;
+        ++i;
     }
 
     // Add a token marking the end - special use of the CONTAINER_END with no object

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -747,8 +747,7 @@ int Layer::AlignHorizontallyEnd(FunctorParams *functorParams)
     assert(staff);
     int graceAlignerId = params->m_doc->GetOptions()->m_graceRhythmAlign.GetValue() ? 0 : staff->GetN();
 
-    int i;
-    for (i = 0; i < params->m_measureAligner->GetChildCount(); ++i) {
+    for (int i = 0; i < params->m_measureAligner->GetChildCount(); ++i) {
         Alignment *alignment = vrv_cast<Alignment *>(params->m_measureAligner->GetChild(i));
         assert(alignment);
         if (alignment->HasGraceAligner(graceAlignerId)) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -120,8 +120,7 @@ Object::Object(const Object &object) : BoundingBox(object)
         return;
     }
 
-    int i;
-    for (i = 0; i < (int)object.m_children.size(); ++i) {
+    for (size_t i = 0; i < (int)object.m_children.size(); ++i) {
         Object *current = object.m_children.at(i);
         Object *clone = current->Clone();
         if (clone) {
@@ -167,8 +166,7 @@ Object &Object::operator=(const Object &object)
         if (link) link->AddBackLink(&object);
 
         if (object.CopyChildren()) {
-            int i;
-            for (i = 0; i < (int)object.m_children.size(); ++i) {
+            for (size_t i = 0; i < object.m_children.size(); ++i) {
                 Object *current = object.m_children.at(i);
                 Object *clone = current->Clone();
                 if (clone) {
@@ -288,8 +286,7 @@ void Object::MoveChildrenFrom(Object *sourceParent, int idx, bool allowTypeChang
         assert("Object must be of the same type");
     }
 
-    int i;
-    for (i = 0; i < (int)sourceParent->m_children.size(); ++i) {
+    for (int i = 0; i < (int)sourceParent->m_children.size(); ++i) {
         Object *child = sourceParent->Relinquish(i);
         if (idx != -1) {
             this->InsertChild(child, idx);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -439,8 +439,7 @@ bool OptionArray::SetValue(const std::string &value)
 std::string OptionArray::GetStrValue() const
 {
     std::stringstream ss;
-    int i;
-    for (i = 0; i < (int)m_values.size(); ++i) {
+    for (size_t i = 0; i < m_values.size(); ++i) {
         if (i != 0) {
             ss << ", ";
         }
@@ -452,8 +451,7 @@ std::string OptionArray::GetStrValue() const
 std::string OptionArray::GetDefaultStrValue() const
 {
     std::stringstream ss;
-    int i;
-    for (i = 0; i < (int)m_defaultValues.size(); ++i) {
+    for (size_t i = 0; i < m_defaultValues.size(); ++i) {
         if (i != 0) {
             ss << ", ";
         }
@@ -568,8 +566,7 @@ std::string OptionIntMap::GetStrValuesAsStr(bool withoutDefault) const
 {
     std::vector<std::string> strValues = this->GetStrValues(withoutDefault);
     std::stringstream ss;
-    int i;
-    for (i = 0; i < (int)strValues.size(); ++i) {
+    for (size_t i = 0; i < strValues.size(); ++i) {
         if (i != 0) {
             ss << ", ";
         }

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -108,7 +108,7 @@ char32_t Resources::GetGlyphCode(const std::string &smuflName) const
 
 bool Resources::IsSmuflFallbackNeeded(const std::u32string &text) const
 {
-    for (int i = 0; i < (int)text.length(); ++i) {
+    for (size_t i = 0; i < text.length(); ++i) {
         char32_t c = text.at(i);
         const Glyph *glyph = this->GetGlyph(c);
         if (glyph && glyph->GetFallback()) return true;

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -71,8 +71,7 @@ void RunningElement::Reset()
     m_drawingPage = NULL;
     m_drawingYRel = 0;
 
-    int i;
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         m_drawingScalingPercent[i] = 100;
     }
 }
@@ -170,8 +169,7 @@ void RunningElement::SetDrawingPage(Page *page)
 int RunningElement::GetContentHeight() const
 {
     int height = 0;
-    int i;
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         height += this->GetRowHeight(i);
     }
     return height;
@@ -181,9 +179,8 @@ int RunningElement::GetRowHeight(int row) const
 {
     assert((row >= 0) && (row < 3));
 
-    int i;
     int height = 0;
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         height = std::max(height, this->GetCellHeight(row * 3 + i));
     }
     return height;
@@ -193,9 +190,8 @@ int RunningElement::GetColHeight(int col) const
 {
     assert((col >= 0) && (col < 3));
 
-    int i;
     int height = 0;
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         height += this->GetCellHeight(i * 3 + col);
     }
     return height;
@@ -218,13 +214,12 @@ int RunningElement::GetCellHeight(int cell) const
 
 bool RunningElement::AdjustDrawingScaling(int width)
 {
-    int i, j;
     bool scale = false;
     // For each row
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         int rowWidth = 0;
         // For each column
-        for (j = 0; j < 3; ++j) {
+        for (int j = 0; j < 3; ++j) {
             ArrayOfTextElements *textElements = &m_cells[i * 3 + j];
             ArrayOfTextElements::iterator iter;
             int columnWidth = 0;
@@ -247,11 +242,10 @@ bool RunningElement::AdjustDrawingScaling(int width)
 
 bool RunningElement::AdjustRunningElementYPos()
 {
-    int i, j;
     ArrayOfTextElements::iterator iter;
 
     // First adjust the content of each cell
-    for (i = 0; i < 9; ++i) {
+    for (int i = 0; i < 9; ++i) {
         int cumulatedYRel = 0;
         ArrayOfTextElements *textElements = &m_cells[i];
         // For each object
@@ -267,10 +261,10 @@ bool RunningElement::AdjustRunningElementYPos()
 
     int rowYRel = 0;
     // For each row
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         int currentRowHeigt = this->GetRowHeight(i);
         // For each column
-        for (j = 0; j < 3; ++j) {
+        for (int j = 0; j < 3; ++j) {
             int cell = i * 3 + j;
             int colYShift = 0;
             // middle row - it needs to be middle-aligned so calculate the colYShift accordingly
@@ -380,11 +374,10 @@ void RunningElement::AddPageNum(data_HORIZONTALALIGNMENT halign, data_VERTICALAL
 
 int RunningElement::PrepareDataInitialization(FunctorParams *)
 {
-    int i;
-    for (i = 0; i < 9; ++i) {
+    for (int i = 0; i < 9; ++i) {
         m_cells[i].clear();
     }
-    for (i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; ++i) {
         m_drawingScalingPercent[i] = 100;
     }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -855,7 +855,7 @@ int ScoreDef::GenerateMIDI(FunctorParams *functorParams)
         const double tuneHz = this->GetTuneHz();
         // Add tuning for all keys from 0 to 127
         std::vector<std::pair<int, double>> tuneFrequencies;
-        for (int i = 0; i < 127; i++) {
+        for (int i = 0; i < 127; ++i) {
             double freq = pow(2.0, (i - 69.0) / 12.0) * tuneHz;
             tuneFrequencies.push_back(std::make_pair(i, freq));
         }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -253,8 +253,7 @@ void Staff::AddLedgerLines(ArrayOfLedgerLines &lines, int count, int left, int r
     assert(left < right);
 
     if ((int)lines.size() < count) lines.resize(count);
-    int i = 0;
-    for (i = 0; i < count; ++i) {
+    for (int i = 0; i < count; ++i) {
         lines.at(i).AddDash(left, right, extension);
     }
 }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1011,7 +1011,7 @@ void SvgDeviceContext::DrawMusicText(const std::u32string &text, int x, int y, b
     }
 
     // print chars one by one
-    for (unsigned int i = 0; i < text.length(); ++i) {
+    for (size_t i = 0; i < text.length(); ++i) {
         char32_t c = text.at(i);
         const Glyph *glyph = resources->GetGlyph(c);
         if (!glyph) {

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1083,8 +1083,7 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
         else if (json.has<jsonxx::Array>(iter->first)) {
             jsonxx::Array values = json.get<jsonxx::Array>(iter->first);
             std::vector<std::string> strValues;
-            int i;
-            for (i = 0; i < (int)values.size(); ++i) {
+            for (int i = 0; i < (int)values.size(); ++i) {
                 if (values.has<jsonxx::String>(i)) strValues.push_back(values.get<jsonxx::String>(i));
                 // LogDebug("String: %s", values.get<jsonxx::String>(i).c_str());
             }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -713,7 +713,7 @@ bool Transposer::GetKeyTonic(const std::string &keyTonic, TransPitch &tonic)
     int pitch = 0;
     int accid = 0;
     int state = 0;
-    for (unsigned int i = 0; i < (unsigned int)keyTonic.size(); ++i) {
+    for (size_t i = 0; i < keyTonic.size(); ++i) {
         switch (state) {
             case 0:
                 switch (keyTonic[i]) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -860,7 +860,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             if (i != end) {
                 // update the yRel accordingly
                 (*iter)->CalcDrawingYRel(params->m_doc, this, *i);
-                i++;
+                ++i;
             }
         }
         //  Now update the staffAlignment max overflow (above or below) and add the positioner to the list of
@@ -928,7 +928,7 @@ int StaffAlignment::AdjustFloatingPositionersBetween(FunctorParams *functorParam
                     diffY = y;
                     adjusted = true;
                 }
-                i++;
+                ++i;
             }
         }
         if (!adjusted) {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -168,8 +168,7 @@ std::u32string View::IntToSmuflFigures(unsigned short number, int offset)
     stream << number;
     std::u32string str = UTF8to32(stream.str());
 
-    int i;
-    for (i = 0; i < (int)str.size(); ++i) {
+    for (size_t i = 0; i < str.size(); ++i) {
         str[i] += offset - 48;
     }
     return str;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1069,7 +1069,7 @@ void View::DrawControlElementConnector(
     const int minDashSpace = m_doc->GetOptions()->m_extenderLineMinSpace.GetValue() * unit;
     const int halfDashLength = unit * 2 / 3;
 
-    int dist = x2 - x1;
+    const int dist = x2 - x1;
     int nbDashes = dist / dashSpace;
 
     int margin = dist / 2;
@@ -1105,8 +1105,7 @@ void View::DrawControlElementConnector(
         dc->DeactivateGraphic();
     }
 
-    int i;
-    for (i = 0; i < nbDashes; ++i) {
+    for (int i = 0; i < nbDashes; ++i) {
         int x = x1 + margin + (i * dashSpace);
         x = std::max(x, x1);
 
@@ -1276,7 +1275,7 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
         const int halfDashLength = dashLength / 2;
 
         const int dashSpace = m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) * 5 / 3;
-        int dist = x2 - x1;
+        const int dist = x2 - x1;
         int nbDashes = dist / dashSpace;
 
         int margin = dist / 2;
@@ -1292,8 +1291,7 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
             margin = (dist - ((nbDashes - 1) * dashSpace)) / 2;
         }
 
-        int i;
-        for (i = 0; i < nbDashes; ++i) {
+        for (int i = 0; i < nbDashes; ++i) {
             int x = x1 + margin + (i * dashSpace);
             x = std::max(x, x1);
 

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -55,8 +55,8 @@ void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int wid
 void View::DrawVerticalSegmentedLine(
     DeviceContext *dc, int x1, SegmentedLine &line, int width, int dashLength, int gapLength)
 {
-    int i, start, end;
-    for (i = 0; i < line.GetSegmentCount(); i++) {
+    int start, end;
+    for (int i = 0; i < line.GetSegmentCount(); ++i) {
         std::tie(start, end) = line.GetStartEnd(i);
         this->DrawVerticalLine(dc, start, end, x1, width, dashLength, gapLength);
     }
@@ -65,8 +65,8 @@ void View::DrawVerticalSegmentedLine(
 void View::DrawHorizontalSegmentedLine(
     DeviceContext *dc, int y1, SegmentedLine &line, int width, int dashLength, int gapLength)
 {
-    int i, start, end;
-    for (i = 0; i < line.GetSegmentCount(); i++) {
+    int start, end;
+    for (int i = 0; i < line.GetSegmentCount(); ++i) {
         std::tie(start, end) = line.GetStartEnd(i);
         this->DrawHorizontalLine(dc, start, end, y1, width, dashLength, gapLength);
     }

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -201,11 +201,11 @@ void View::DrawMaximaToBrevis(DeviceContext *dc, int y, LayerElement *element, L
     Note *note = vrv_cast<Note *>(element);
     assert(note);
 
-    bool isMensuralBlack = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
-    bool fillNotehead = (isMensuralBlack || note->GetColored()) && !(isMensuralBlack && note->GetColored());
+    const bool isMensuralBlack = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
+    const bool fillNotehead = (isMensuralBlack || note->GetColored()) && !(isMensuralBlack && note->GetColored());
 
-    int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
-    int strokeWidth = 2.8 * stemWidth;
+    const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+    const int strokeWidth = 2.8 * stemWidth;
 
     int shape = LIGATURE_DEFAULT;
     if (note->GetActualDur() != DUR_BR) {
@@ -465,11 +465,11 @@ void View::DrawPlica(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     Note *note = vrv_cast<Note *>(plica->GetFirstAncestor(NOTE));
     assert(note);
 
-    bool isMensuralBlack = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
-    int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+    const bool isMensuralBlack = (staff->m_drawingNotationType == NOTATIONTYPE_mensural_black);
+    const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
 
-    bool isLonga = (note->GetActualDur() == DUR_LG);
-    bool up = (plica->GetDir() == STEMDIRECTION_basic_up);
+    const bool isLonga = (note->GetActualDur() == DUR_LG);
+    const bool up = (plica->GetDir() == STEMDIRECTION_basic_up);
 
     int shape = LIGATURE_DEFAULT;
     Point topLeft, bottomRight;

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -182,7 +182,7 @@ void View::DrawNc(DeviceContext *dc, LayerElement *element, Layer *layer, Staff 
 
     yValue = clefYPosition + pitchOffset + octaveOffset - rotateOffset;
 
-    for (auto it = params.begin(); it != params.end(); it++) {
+    for (auto it = params.begin(); it != params.end(); ++it) {
         this->DrawSmuflCode(dc, noteX + it->xOffset * noteWidth, yValue + it->yOffset * noteHeight, it->fontNo,
             staff->m_drawingStaffSize, false, true);
     }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -76,7 +76,7 @@ void View::DrawDirString(DeviceContext *dc, const std::u32string &str, TextDrawi
     std::u32string convertedStr = str;
     // If the current font is a music font, we want to convert Music Unicode glyph to SMuFL
     if (dc->GetFont()->GetSmuflFont()) {
-        for (int i = 0; i < (int)str.size(); i++) {
+        for (size_t i = 0; i < str.size(); ++i) {
             convertedStr[i] = Resources::GetSmuflGlyphForUnicodeChar(str.at(i));
         }
     }

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -360,20 +360,20 @@ std::string Base64Encode(unsigned char const *bytesToEncode, unsigned int inLen)
             charArray4[2] = ((charArray3[1] & 0x0f) << 2) + ((charArray3[2] & 0xc0) >> 6);
             charArray4[3] = charArray3[2] & 0x3f;
 
-            for (i = 0; (i < 4); i++) ret += base64Chars[charArray4[i]];
+            for (i = 0; (i < 4); ++i) ret += base64Chars[charArray4[i]];
             i = 0;
         }
     }
 
     if (i) {
-        for (int j = i; j < 3; j++) charArray3[j] = '\0';
+        for (int j = i; j < 3; ++j) charArray3[j] = '\0';
 
         charArray4[0] = (charArray3[0] & 0xfc) >> 2;
         charArray4[1] = ((charArray3[0] & 0x03) << 4) + ((charArray3[1] & 0xf0) >> 4);
         charArray4[2] = ((charArray3[1] & 0x0f) << 2) + ((charArray3[2] & 0xc0) >> 6);
         charArray4[3] = charArray3[2] & 0x3f;
 
-        for (int j = 0; (j < i + 1); j++) ret += base64Chars[charArray4[j]];
+        for (int j = 0; (j < i + 1); ++j) ret += base64Chars[charArray4[j]];
 
         while ((i++ < 3)) ret += '=';
     }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
         long_options[i].has_arg = (optBool) ? no_argument : required_argument;
         long_options[i].flag = 0;
         long_options[i].val = 0;
-        i++;
+        ++i;
     }
 
     // Concatenate the base options


### PR DESCRIPTION
This PR tries to unify iterators by not declaring counters before and trying to avoid casting when simply iterate by `size()` or `length()`.