### PR TITLE
Remove SkipLayoutOnLoad and use --breaks instead

### DIFF
--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -626,13 +626,6 @@ public:
     ///@{
 
     /**
-     * Skip the layout on load to speed up MIDI or timemap output.
-     *
-     * @ingroup nodoc
-     */
-    void SkipLayoutOnLoad(bool value);
-
-    /**
      * Render the page to the deviceContext.
      *
      * Page number is 1-based.
@@ -764,8 +757,6 @@ private:
     FileFormat m_outputTo;
 
     Options *m_options;
-
-    bool m_skipLayoutOnLoad;
 
     /**
      * The C buffer string.

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -79,8 +79,6 @@ Toolkit::Toolkit(bool initFont)
 
     m_options = m_doc.GetOptions();
 
-    m_skipLayoutOnLoad = false;
-
     m_editorToolkit = NULL;
 
 #ifndef NO_RUNTIME
@@ -746,7 +744,7 @@ bool Toolkit::LoadData(const std::string &data)
     // to be converted
     if (m_doc.GetType() == Transcription || m_doc.GetType() == Facs) breaks = BREAKS_none;
 
-    if (!m_skipLayoutOnLoad && (breaks != BREAKS_none)) {
+    if (breaks != BREAKS_none) {
         if (input->GetLayoutInformation() == LAYOUT_ENCODED
             && (breaks == BREAKS_encoded || breaks == BREAKS_line || breaks == BREAKS_smart)) {
             if (breaks == BREAKS_encoded) {
@@ -796,11 +794,6 @@ bool Toolkit::LoadData(const std::string &data)
 #endif
 
     return true;
-}
-
-void Toolkit::SkipLayoutOnLoad(bool value)
-{
-    m_skipLayoutOnLoad = value;
 }
 
 std::string Toolkit::GetMEI(const std::string &jsonOptions)

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -468,9 +468,9 @@ int main(int argc, char **argv)
         outfile = removeExtension(outfile);
     }
 
-    // Skip the layout for MIDI and timemap output
+    // Skip the layout for MIDI and timemap output by setting --breaks to none
     if ((outformat == "midi") || (outformat == "timemap")) {
-        toolkit.SkipLayoutOnLoad(true);
+        toolkit.SetOptions("{'breaks': 'none'}");
     }
 
     // Load the std input or load the file


### PR DESCRIPTION
* Since the method / option was used only in the command-line, we can replace it with `--breaks none`