### PR TITLE
Improve layout of line objects

### DIFF
--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -82,10 +82,10 @@ public:
 
     /**
      * @name Get and set maximum drawing yRel that is persistent for the floating object across all its floating
-     * positioners, which allows for persisten vertical positioning for some elements
+     * positioners, which allows for persistent vertical positioning for some elements
      */
     ///@{
-    void SetMaxDrawingYRel(int maxDrawingYRel);
+    void SetMaxDrawingYRel(int maxDrawingYRel, data_STAFFREL place);
     int GetMaxDrawingYRel() const { return m_maxDrawingYRel; };
     ///@}
 
@@ -279,6 +279,14 @@ public:
      */
     void CalcDrawingYRel(Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlappingBBox);
 
+    /**
+     * Align extender elements across systems
+     */
+    void AlignExtenders();
+
+    /**
+     * Calculate the vertical space below the element and above the bounding box
+     */
     int GetSpaceBelow(
         const Doc *doc, const StaffAlignment *staffAlignment, const BoundingBox *horizOverlappingBBox) const;
 

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -282,7 +282,7 @@ public:
     /**
      * Align extender elements across systems
      */
-    void AlignExtenders();
+    void AdjustExtenders();
 
     /**
      * Calculate the vertical space below the element and above the bounding box

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -255,6 +255,15 @@ public:
     ///@}
 
     /**
+     * @name Get and set the drawing extender width.
+     * Should be nonzero only if the extender line is not included in the bounding box.
+     */
+    ///@{
+    int GetDrawingExtenderWidth() const { return m_drawingExtenderWidth; }
+    void SetDrawingExtenderWidth(int extenderWidth) { m_drawingExtenderWidth = extenderWidth; }
+    ///@}
+
+    /**
      * Return the horizontal margin for overlap with another element
      * This can be negative, if elements are allowed to slightly overlap
      */
@@ -299,6 +308,11 @@ protected:
      * It is re-computed everytime the object is drawn and it is not stored in the file.
      */
     int m_drawingYRel;
+
+    /**
+     * The horizontal width of the extender line whenever it is not included in the bounding box.
+     */
+    int m_drawingExtenderWidth;
 
     /**
      * A pointer to the FloatingObject it represents.

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -264,6 +264,11 @@ public:
     ///@}
 
     /**
+     * Check for horizontal overlap with special consideration for extender lines
+     */
+    bool HasHorizontalOverlapWith(const BoundingBox *bbox, int unit) const;
+
+    /**
      * Return the horizontal margin for overlap with another element
      * This can be negative, if elements are allowed to slightly overlap
      */

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -378,10 +378,28 @@ void FloatingPositioner::SetDrawingYRel(int drawingYRel, bool force)
     }
 }
 
+bool FloatingPositioner::HasHorizontalOverlapWith(const BoundingBox *bbox, int unit) const
+{
+    int bboxExtenderWidth = 0;
+    const FloatingPositioner *bboxPositioner = dynamic_cast<const FloatingPositioner *>(bbox);
+    if (bboxPositioner) {
+        bboxExtenderWidth = bboxPositioner->GetDrawingExtenderWidth();
+    }
+
+    const int margin = this->GetAdmissibleHorizOverlapMargin(bbox, unit);
+
+    if (!this->HasContentBB() || !bbox->HasContentBB()) return false;
+    if (this->GetContentRight() + m_drawingExtenderWidth <= bbox->GetContentLeft() - margin) return false;
+    if (this->GetContentLeft() >= bbox->GetContentRight() + bboxExtenderWidth + margin) return false;
+
+    return true;
+}
+
 int FloatingPositioner::GetAdmissibleHorizOverlapMargin(const BoundingBox *bbox, int unit) const
 {
     const LayerElement *element = dynamic_cast<const LayerElement *>(bbox);
     if (element) {
+        if (this->GetObject()->IsExtenderElement()) return 8 * unit;
         if ((this->GetObject()->Is(DYNAM)) && element->GetFirstAncestor(BEAM)) {
             return 2 * unit;
         }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -321,6 +321,8 @@ void FloatingPositioner::ResetPositioner()
 
     m_drawingYRel = 0;
     m_drawingXRel = 0;
+
+    m_drawingExtenderWidth = 0;
 }
 
 int FloatingPositioner::GetDrawingX() const

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -519,7 +519,7 @@ void FloatingPositioner::CalcDrawingYRel(
     }
 }
 
-void FloatingPositioner::AlignExtenders()
+void FloatingPositioner::AdjustExtenders()
 {
     const bool isExtender = m_object->Is({ DIR, DYNAM, TEMPO }) && m_object->IsExtenderElement();
     if (!isExtender) return;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -2386,8 +2386,8 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
             }
             else {
                 above->SetOverflowAbove(overflowAbove);
-                above->AddBBoxAbove(current);
             }
+            above->AddBBoxAbove(current);
         }
     }
 
@@ -2401,8 +2401,8 @@ int Object::CalcBBoxOverflows(FunctorParams *functorParams)
             }
             else {
                 below->SetOverflowBelow(overflowBelow);
-                below->AddBBoxBelow(current);
             }
+            below->AddBBoxBelow(current);
         }
     }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -959,9 +959,6 @@ int System::AdjustFloatingPositioners(FunctorParams *functorParams)
     AdjustFloatingPositionerGrpsParams adjustFloatingPositionerGrpsParams(params->m_doc);
     Functor adjustFloatingPositionerGrps(&Object::AdjustFloatingPositionerGrps);
 
-    params->m_classId = GLISS;
-    m_systemAligner.Process(params->m_functor, params);
-
     params->m_classId = LV;
     m_systemAligner.Process(params->m_functor, params);
 

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -850,12 +850,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
             // elements - vertically)
             i = std::find_if(i, end, [iter, drawingUnit](BoundingBox *elem) {
-                if ((*iter)->GetObject()->IsExtenderElement() && !elem->Is(FLOATING_POSITIONER)) {
-                    return (*iter)->HorizontalContentOverlap(elem, drawingUnit * 8)
-                        || (*iter)->VerticalContentOverlap(elem);
-                }
-                const int margin = (*iter)->GetAdmissibleHorizOverlapMargin(elem, drawingUnit);
-                return (*iter)->HorizontalContentOverlap(elem, margin);
+                return (*iter)->HasHorizontalOverlapWith(elem, drawingUnit);
             });
             if (i != end) {
                 // update the yRel accordingly

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -853,7 +853,7 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
         }
 
         // Vertically align extender elements across systems
-        (*iter)->AlignExtenders();
+        (*iter)->AdjustExtenders();
 
         //  Now update the staffAlignment max overflow (above or below) and add the positioner to the list of
         //  overflowing elements

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -844,20 +844,14 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             if (params->m_classId == HAIRPIN) continue;
         }
 
-        auto i = overflowBoxes->begin();
-        auto end = overflowBoxes->end();
-        while (i != end) {
-            // find all the overflowing elements from the staff that overlap horizontally (and, in case of extender
-            // elements - vertically)
-            i = std::find_if(i, end, [iter, drawingUnit](BoundingBox *elem) {
-                return (*iter)->HasHorizontalOverlapWith(elem, drawingUnit);
-            });
-            if (i != end) {
+        // Find all the overflowing elements from the staff that overlap horizontally
+        for (auto i = overflowBoxes->begin(); i != overflowBoxes->end(); ++i) {
+            if ((*iter)->HasHorizontalOverlapWith(*i, drawingUnit)) {
                 // update the yRel accordingly
                 (*iter)->CalcDrawingYRel(params->m_doc, this, *i);
-                ++i;
             }
         }
+
         //  Now update the staffAlignment max overflow (above or below) and add the positioner to the list of
         //  overflowing elements
         if (place == STAFFREL_above) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -852,6 +852,9 @@ int StaffAlignment::AdjustFloatingPositioners(FunctorParams *functorParams)
             }
         }
 
+        // Vertically align extender elements across systems
+        (*iter)->AlignExtenders();
+
         //  Now update the staffAlignment max overflow (above or below) and add the positioner to the list of
         //  overflowing elements
         if (place == STAFFREL_above) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1103,6 +1103,8 @@ void View::DrawControlElementConnector(
 
     if (deactivate) {
         dc->DeactivateGraphic();
+        // If the extender line is not included in the bounding box, then store its width
+        element->GetCurrentFloatingPositioner()->SetDrawingExtenderWidth(dist);
     }
 
     for (int i = 0; i < nbDashes; ++i) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1952,10 +1952,10 @@ int View::GetFYRel(F *f, Staff *staff)
     y -= (alignment->GetStaffHeight() + alignment->GetOverflowBelow());
 
     FloatingPositioner *positioner = alignment->FindFirstFloatingPositioner(HARM);
-    // There is no other harm, we use the bottom line.
-    if (!positioner) return y;
-
-    y = positioner->GetDrawingY();
+    // If there is no other harm, we use the bottom line.
+    if (positioner) {
+        y = positioner->GetDrawingY();
+    }
 
     Object *fb = f->GetFirstAncestor(FB);
     assert(fb);


### PR DESCRIPTION
This PR improves the layout of line like objects.

**Simple example**

| Before | After |
| ------ | ----- |
| <img width="772" alt="Before1" src="https://user-images.githubusercontent.com/63608463/215029288-10241e86-b4cc-4afe-98fe-e2f584e42c5e.png"> | <img width="759" alt="After1" src="https://user-images.githubusercontent.com/63608463/215029315-5dbcee46-59ed-42c3-9181-628e7f692bff.png"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Multiple text extenders</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2023-01-23">2023-01-23</date>
         </pubStmt>
         <notesStmt>
            <annot>Different types of lines.</annot>
         </notesStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n01" dur="4" oct="4" pname="e" />
                           <note xml:id="n02" dur="4" oct="5" pname="e" />
                           <note xml:id="n03" dur="4" oct="4" pname="e" />
                           <note xml:id="n04" dur="4" oct="5" pname="e" />
                        </layer>
                     </staff>
                     <dynam extender="true" startid="#n01" endid="#n08">cresc.</dynam>
                     <dir extender="true" startid="#n03" endid="#n06">stringendo</dir>
                  </measure>
                  <sb />
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n05" dur="4" oct="4" pname="e" />
                           <note xml:id="n06" dur="4" oct="5" pname="e" />
                           <note xml:id="n07" dur="4" oct="4" pname="e" />
                           <note xml:id="n08" dur="4" oct="5" pname="e" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

Here the underlying issue was that extender lines are sometimes included in the bounding box and sometimes they are not. This was not considered in the layout before.

**Complex example**

| Before | After |
| ------ | ----- |
| <img width="866" alt="Before2" src="https://user-images.githubusercontent.com/63608463/215029809-48b5d733-2a6d-44f9-baae-1d200e2064d6.png"> | <img width="827" alt="After2" src="https://user-images.githubusercontent.com/63608463/215029839-40eb92bb-e3e4-42c4-8769-089ca19ebc62.png"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0" ?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron" ?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Line-like objects</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2022-01-10">2022-01-10</date>
         </pubStmt>
         <notesStmt>
            <annot>Different types of lines.</annot>
         </notesStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n01" dur="1" oct="4" pname="f" />
                           <note xml:id="n02" dur="1" oct="5" pname="e" />
                           <note xml:id="n03" dur="1" oct="4" pname="f" />
                           <note xml:id="n04" dur="1" oct="5" pname="c" tie="i" />
                        </layer>
                     </staff>
                     <gliss staff="1" startid="#n01" endid="#n02" lform="dashed" />
                     <gliss staff="1" startid="#n02" endid="#n03" lform="wavy" />
                     <gliss staff="1" startid="#n03" endid="#n04" lform="solid" />
                     <trill staff="1" startid="#n04" endid="#n10" extender="true" />
                     <octave staff="1" startid="#n01" endid="#n10" dis="8" dis.place="above" />
                     <bracketSpan staff="1" tstamp="1.000000" tstamp2="0m+41.0000" func="ligature" lform="dashed" />
                     <dynam extender="true" startid="#n01" tstamp2="1m+16">cresc.</dynam>
                     <harm place="below" staff="1" tstamp="1">
                        <fb>
                           <f extender="true" startid="#n01" tstamp2="0m+10">6</f>
                           <f extender="true" startid="#n01" tstamp2="1m+14">2</f>
                           <f extender="true" startid="#n01" tstamp2="1m+8">4</f>
                        </fb>
                     </harm>
                     <tempo staff="1" startid="#n01" endid="#n04" extender="true">acc.</tempo>
                  </measure>
                  <sb />
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n05" dur="1" oct="5" pname="c" tie="m" />
                           <note xml:id="n06" dur="1" oct="5" pname="c" tie="m" />
                           <note xml:id="n07" dur="1" oct="5" pname="c" tie="m" />
                           <note xml:id="n08" dur="1" oct="5" pname="c" tie="m" />
                           <note xml:id="n09" dur="1" oct="5" pname="c" tie="m" />
                           <note xml:id="n10" dur="1" oct="5" pname="c" tie="t" />
                        </layer>
                     </staff>
                     <bracketSpan staff="1" startid="#n05" endid="#n06" func="ligature" lwidth="0.750000vu" />
                     <bracketSpan staff="1" startid="#n07" endid="#n08" func="ligature" lform="dotted" />
                     <bracketSpan staff="1" startid="#n09" endid="#n10" func="cross-rhythm" lform="solid" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

Here there were several issues:
- (RED) The Dynam extender line is further away from the staff than it should be. The problem is that the Glissando was moved below the staff during floating positioning. It then pushes away the Dynam. However, the glissando itself looks innocent since its position is recalculated during drawing.
- (ORANGE) The continuation of the Fb extender lines collide with each other and with the continuation of the Dynam extender line.
- (YELLOW) The continuation of the Dynam extender line should have the same staff distance as in the first system.

