### PR TITLE
Fix problem with hairpin/dynam vgrp ordering

### DIFF
--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -276,12 +276,6 @@ int Dynam::PrepareFloatingGrps(FunctorParams *functorParams)
 
     params->m_dynams.push_back(this);
 
-    for (auto &hairpin : params->m_hairpins) {
-        if ((hairpin->GetEnd() == this->GetStart()) && (hairpin->GetStaff() == this->GetStaff())) {
-            if (!hairpin->GetRightLink()) hairpin->SetRightLink(this);
-        }
-    }
-
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -229,26 +229,6 @@ int Hairpin::PrepareFloatingGrps(FunctorParams *functorParams)
     // Only try to link them if start and end are resolved
     if (!this->GetStart() || !this->GetEnd()) return FUNCTOR_CONTINUE;
 
-    for (auto &dynam : params->m_dynams) {
-        if ((dynam->GetStart() == this->GetStart()) && (dynam->GetStaff() == this->GetStaff())) {
-            if (!m_leftLink) this->SetLeftLink(dynam);
-        }
-        else if ((dynam->GetStart() == this->GetEnd()) && (dynam->GetStaff() == this->GetStaff())) {
-            if (!m_rightLink) this->SetRightLink(dynam);
-        }
-    }
-
-    for (auto &hairpin : params->m_hairpins) {
-        if ((hairpin->GetEnd() == this->GetStart()) && (hairpin->GetStaff() == this->GetStaff())) {
-            if (!m_leftLink) this->SetLeftLink(hairpin);
-            if (!hairpin->GetRightLink()) hairpin->SetRightLink(this);
-        }
-        if ((hairpin->GetStart() == this->GetEnd()) && (hairpin->GetStaff() == this->GetStaff())) {
-            if (!hairpin->GetLeftLink()) hairpin->SetLeftLink(this);
-            if (!m_rightLink) this->SetRightLink(hairpin);
-        }
-    }
-
     params->m_hairpins.push_back(this);
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
- changed code to make sure that order of hairpins/dynams in the MEI file didn't influence positioning of elements during the rendering

This PR fixes the problem where the order of elements in the MEI decided how they would be rendered:
![image](https://user-images.githubusercontent.com/1819669/215557730-ba984fd5-7f88-49a2-9de7-4e0e03055927.png)
In both cases hairpin have the same start timestamp as dynamic, but in second measure dynamic was first in order and in fourth - second.
After the fix:
![image](https://user-images.githubusercontent.com/1819669/215557816-7175c946-a8ea-4886-be56-f1394508dce1.png)

<details><summary>MEI</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Haipin/dynam order</title>
         </titleStmt>
         <pubStmt>
            <date>2023-01-30</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="unknown">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef key.mode="major" key.sig="1s" meter.count="4" meter.unit="4">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="9">
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="4" pname="c" />
                           <note dur="2" oct="4" pname="g" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="dim" vgrp="200"/>
                  </measure>
                  <measure n="10">
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="4" pname="c" />
                           <note dur="2" oct="4" pname="g" />
                        </layer>
                     </staff>
                     <dynam place="below" staff="1" tstamp="1.000000"  vgrp="200">pp</dynam>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+0.0000" form="dim" vgrp="200"/>
                  </measure>
                  <measure n="11">
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="4" pname="c" />
                           <note dur="2" oct="4" pname="g" />
                        </layer>
                     </staff>
                     <hairpin staff="1" tstamp="1.000000" tstamp2="1m+1.0000" form="dim" vgrp="200"/>
                  </measure>
                  <measure n="12">
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="4" pname="c" />
                           <note dur="2" oct="4" pname="g" />
                        </layer>
                     </staff>
                     <hairpin xml:id="next-02" staff="1" tstamp="1.000000" tstamp2="4.0000" form="dim" vgrp="200"/>
                     <dynam xml:id="next-01" place="below" staff="1" tstamp="1.000000"  vgrp="200">pp</dynam>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>