### PR TITLE
Beam stem fix

### DIFF
--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -156,7 +156,7 @@ private:
     int CalcMixedBeamCenterY(int step, int unit) const;
 
     // Helper to calculate location and duration of the note that would be setting highest/lowest point for the beam
-    std::pair<int, int> CalcStemDefiningNote(const Staff *staff, data_BEAMPLACE place) const;
+    std::tuple<int, int, int> CalcStemDefiningNote(const Staff *staff, data_BEAMPLACE place) const;
 
     // Calculate positioning for the horizontal beams
     void CalcHorizontalBeam(const Doc *doc, const Staff *staff, const BeamDrawingInterface *beamInterface);
@@ -442,7 +442,7 @@ public:
     void SetClosestNoteOrTabDurSym(data_STEMDIRECTION stemDir, bool outsideStaff);
 
     /** Heleper for calculating the stem length for staff notation and tablature beams within the staff */
-    int CalculateStemLength(const Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal) const;
+    int CalculateStemLength(const Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal, int preferredDur) const;
 
     /** Helper for calculating the stem length for tablature beam placed outside the staff */
     int CalculateStemLengthTab(const Staff *staff, data_STEMDIRECTION stemDir) const;

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -441,7 +441,7 @@ public:
     /** Set the note or closest note for chord or tabdursym for tablature beams placed outside the staff */
     void SetClosestNoteOrTabDurSym(data_STEMDIRECTION stemDir, bool outsideStaff);
 
-    /** Heleper for calculating the stem length for staff notation and tablature beams within the staff */
+    /** Helper for calculating the stem length for staff notation and tablature beams within the staff */
     int CalculateStemLength(const Staff *staff, data_STEMDIRECTION stemDir, bool isHorizontal, int preferredDur) const;
 
     /** Helper for calculating the stem length for tablature beam placed outside the staff */


### PR DESCRIPTION
closes #2921 closes #2865

![image](https://user-images.githubusercontent.com/1819669/217224115-55d13633-ac05-4026-bb07-23320abb3c64.png)
The rendering isn't exactly the same as in 3.7, but this should be the best improvement that we can get while following other rules for beams and stem width while not breaking other existing examples.