### PR TITLE
Fix unnecessary xRel for notes after grace chords

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -1149,10 +1149,12 @@ public:
     {
         m_doc = doc;
         m_diameter = 0;
+        m_alignmentType = 0;
     }
 
     Doc *m_doc;
     int m_diameter;
+    int m_alignmentType;
 };
 
 //----------------------------------------------------------------------------

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -779,6 +779,7 @@ int Chord::CalcChordNoteHeads(FunctorParams *functorParams)
             params->m_diameter = params->m_doc->GetGlyphWidth(
                 code, staff->m_drawingStaffSize, this->GetDrawingCueSize() ? bottomNote->GetDrawingCueSize() : false);
         }
+        params->m_alignmentType = this->GetAlignment()->GetType();
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1116,7 +1116,8 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
     }
 
     // Nothing to do for notes that are not in a cluster and without base diameter for the chord
-    if (!params->m_diameter && !m_cluster) return FUNCTOR_SIBLINGS;
+    if ((!params->m_diameter || params->m_alignmentType != this->GetAlignment()->GetType()) && !m_cluster)
+        return FUNCTOR_SIBLINGS;
 
     /************** notehead direction **************/
 


### PR DESCRIPTION
- changed code to make sure that notes consider diameter of the chords only in cases they are from the same alignment

Before:
![image](https://user-images.githubusercontent.com/1819669/217536077-cd7e84d1-b9a8-4efa-af66-096747c0ae8a.png)

After:
![image](https://user-images.githubusercontent.com/1819669/217536115-95cd76d2-7cc2-47ca-9a21-ab993d14c4af.png)

<details><summary>MEI</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <encodingDesc xml:id="encodingdesc-1u5bjla">
         <appInfo xml:id="appinfo-w260jg">
            <application xml:id="application-ogjyvu" isodate="2023-02-07T10:45:51" version="3.15.0-dev[undefined]">
               <name xml:id="name-11sr7kj">Verovio</name>
               <p xml:id="p-c6vgxq">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mb8418g">
            <score xml:id="s1xqgmhi">
               <scoreDef xml:id="s39t934">
                  <staffGrp xml:id="s1r5c60c">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <label xml:id="llnnqjx">Piano</label>
                        <labelAbbr xml:id="l17l4c3w">Pno.</labelAbbr>
                        <instrDef xml:id="i15w7rgd" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef xml:id="sxla1cq" n="1" lines="5" ppq="6">
                           <clef xml:id="c78ujh7" shape="G" line="2" />
                           <keySig xml:id="kqn7nxl" sig="1s" />
                           <meterSig xml:id="m2ea82q" count="4" sym="common" unit="4" />
                        </staffDef>
                        <staffDef xml:id="s163u18n" n="2" lines="5" ppq="6">
                           <clef xml:id="ccmqk4d" shape="F" line="4" />
                           <keySig xml:id="kd8s8o6" sig="1s" />
                           <meterSig xml:id="m179daft" count="4" sym="common" unit="4" />
                        </staffDef>
                        <grpSym xml:id="g1el8vkb" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s1a739k">
                  <pb xml:id="pb39nv7" />
                  <measure xml:id="m1owpvel" n="8">
                     <staff xml:id="su9wuda" n="1">
                        <layer xml:id="lkgvdoh" n="1">
                           <beam>
                              <chord xml:id="c1lj3gbw" dur.ppq="0" dur="32" grace="acc" stem.dir="up">
                                 <note xml:id="np0tz23" oct="3" pname="b" />
                                 <note xml:id="n1uxw410" oct="4" pname="c" />
                              </chord>
                              <note xml:id="n5sgi9g" dur.ppq="0" dur="32" oct="4" pname="e" grace="acc" stem.dir="up" />
                              <note xml:id="n1eb6wdk" dur.ppq="0" dur="32" oct="4" pname="g" grace="acc" stem.dir="up" />
                              <note xml:id="n32we6b" dur.ppq="0" dur="32" oct="4" pname="b" grace="acc" stem.dir="up" />
                              <note xml:id="n12dnc6g" dur.ppq="0" dur="32" oct="5" pname="e" grace="acc" stem.dir="up" />
                           </beam>
                           <note xml:id="n1y6xkj5" dur.ppq="12" dur="2" oct="4" pname="b" stem.dir="up" />
                           <beam xml:id="b16yw71x">
                              <note xml:id="n10iy3t" dur.ppq="3" dur="8" oct="4" pname="b" stem.dir="up" />
                              <note xml:id="nwl1h2f" dur.ppq="3" dur="8" oct="4" pname="a" stem.dir="up" />
                              <note xml:id="n1hmynwc" dur.ppq="3" dur="8" oct="5" pname="d" stem.dir="up" />
                              <note xml:id="nt0r3rv" dur.ppq="3" dur="8" oct="4" pname="b" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer xml:id="l1f3802j" n="2">
                           <rest xml:id="rny1c71" dur.ppq="3" dur="8" />
                           <beam xml:id="b2kde2k">
                              <note xml:id="nuh7o9z" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down">
                                 <artic xml:id="aotrk59" artic="stacc" />
                              </note>
                              <note xml:id="n1mpo3n9" dur.ppq="3" dur="8" oct="4" pname="g" stem.dir="down">
                                 <artic xml:id="a14d2qz" artic="stacc" />
                              </note>
                              <note xml:id="nul9d3i" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down">
                                 <artic xml:id="aomc639" artic="stacc" />
                              </note>
                           </beam>
                           <beam xml:id="bpwixen">
                              <note xml:id="n1l7zc97" dur.ppq="3" dur="8" oct="4" pname="c" stem.dir="down" />
                              <note xml:id="n1k8vc3x" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down" />
                              <note xml:id="n11okf4f" dur.ppq="3" dur="8" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="nn9g8s3" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="s1drx9ze" n="2">
                        <layer xml:id="l18rwyub" n="5">
                           <rest xml:id="r1e094u0" dur.ppq="6" dur="4" />
                           <note xml:id="n1gzwime" dur.ppq="6" dur="4" oct="3" pname="b" stem.dir="up">
                              <artic xml:id="ar4kgqp" artic="acc" />
                           </note>
                           <beam xml:id="b1eycren">
                              <note xml:id="nmyq11m" dur.ppq="3" dur="8" oct="3" pname="b" stem.dir="up" />
                              <note xml:id="n1fxwf2k" dur.ppq="3" dur="8" oct="3" pname="a" stem.dir="up" />
                              <note xml:id="nl6ziuh" dur.ppq="3" dur="8" oct="4" pname="d" stem.dir="up" />
                              <note xml:id="n1okgjwj" dur.ppq="3" dur="8" oct="3" pname="b" stem.dir="up" />
                           </beam>
                        </layer>
                        <layer xml:id="l1jqu52v" n="6">
                           <note xml:id="n16p1gh6" dur.ppq="24" dur="1" oct="1" pname="f" accid.ges="s" />
                        </layer>
                     </staff>
                     <dir xml:id="d1aqjr47" staff="1" tstamp="1.000000" vgrp="200">
                        <rend xml:id="rxvqsfw" fontweight="bold">En mesure</rend>
                     </dir>
                     <tie xml:id="t1b6bnnw" startid="#n32we6b" endid="#n1y6xkj5" />
                     <slur xml:id="smnl16y" startid="#n1y6xkj5" endid="#nav07z4" curvedir="above" />
                     <tie xml:id="t1b7jnhq" startid="#n1y6xkj5" endid="#n10iy3t" />
                     <slur xml:id="smkey67" startid="#n1gzwime" endid="#n10yrs3c" curvedir="above" />
                     <tie xml:id="t86ql4g" startid="#n1gzwime" endid="#nmyq11m" />
                  </measure>
                  <sb xml:id="s1xdi7u1" />
                  <measure xml:id="mxt10e0" n="9">
                     <staff xml:id="s3izz8n" n="1">
                        <layer xml:id="l126rosr" n="1">
                           <note xml:id="nqf3szv" dur.ppq="6" dur="4" oct="4" pname="b" stem.dir="up">
                              <artic xml:id="am6n09" artic="ten" />
                           </note>
                           <note xml:id="ngf3kjq" dur.ppq="6" dur="4" oct="4" pname="a" stem.dir="up">
                              <artic xml:id="a1flbpxx" artic="ten" />
                           </note>
                           <note xml:id="nmas64q" dur.ppq="6" dur="4" oct="4" pname="g" stem.dir="up">
                              <artic xml:id="aoedp1l" artic="ten" />
                           </note>
                           <note xml:id="n6n8j4x" dur.ppq="6" dur="4" oct="4" pname="a" stem.dir="up">
                              <artic xml:id="acd1l93" artic="ten" />
                           </note>
                        </layer>
                        <layer xml:id="l1y8cs6m" n="2">
                           <beam xml:id="b1jigjlc">
                              <note xml:id="nudbxib" dur.ppq="3" dur="8" oct="4" pname="c" stem.dir="down" />
                              <chord xml:id="cksccqh" dur.ppq="3" dur="8" stem.dir="down">
                                 <note xml:id="nd3btnd" oct="3" pname="f" accid.ges="s" />
                                 <note xml:id="nq01ojg" oct="4" pname="e" />
                              </chord>
                              <note xml:id="n1xgucil" dur.ppq="3" dur="8" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="n1pxr9x" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down" />
                           </beam>
                           <beam xml:id="b12v4gqb">
                              <note xml:id="n2hcfg" dur.ppq="3" dur="8" oct="4" pname="c" stem.dir="down" />
                              <note xml:id="n1lquskj" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down" />
                              <note xml:id="ncgedgh" dur.ppq="3" dur="8" oct="4" pname="a" stem.dir="down" />
                              <note xml:id="n1dhdihw" dur.ppq="3" dur="8" oct="4" pname="e" stem.dir="down" />
                           </beam>
                        </layer>
                     </staff>
                     <staff xml:id="s1mket02" n="2">
                        <layer xml:id="l9bw6qq" n="5">
                           <note xml:id="n1vuua6e" dur.ppq="6" dur="4" oct="3" pname="b" stem.dir="up" />
                           <note xml:id="n1lxkkyc" dur.ppq="6" dur="4" oct="3" pname="f" stem.dir="up" accid.ges="s" />
                           <note xml:id="n1ggyy7e" dur.ppq="6" dur="4" oct="3" pname="b" stem.dir="up" />
                           <note xml:id="nraldzl" dur.ppq="6" dur="4" oct="3" pname="a" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1jz8bko" n="6">
                           <rest xml:id="r17u9flq" dur.ppq="3" dur="8" />
                           <chord xml:id="c552e8o" dur.ppq="3" dur="8" stem.dir="down">
                              <note xml:id="n14e1ot3" oct="2" pname="d" />
                              <note xml:id="n1wafii" oct="2" pname="a" />
                           </chord>
                           <chord xml:id="co78w1p" dur.ppq="6" dur="4" stem.dir="down">
                              <note xml:id="ngono8k" oct="2" pname="d" />
                              <note xml:id="n12iz3tk" oct="2" pname="a" />
                           </chord>
                           <chord xml:id="c1c02uqf" dur.ppq="12" dur="2" stem.dir="down">
                              <note xml:id="nuk6o8u" oct="2" pname="d" />
                              <note xml:id="nnlvwzw" oct="2" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="t19l6x25" startid="#n14e1ot3" endid="#ngono8k" />
                     <tie xml:id="t1f6z6xb" startid="#n1wafii" endid="#n12iz3tk" />
                     <tie xml:id="txh05o2" startid="#ngono8k" endid="#nuk6o8u" />
                     <tie xml:id="t17x7t6j" startid="#n12iz3tk" endid="#nnlvwzw" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```

</details>