### PR TITLE
Reduce memory and executable size

### DIFF
--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -23,10 +23,6 @@ namespace vrv {
 // Att
 //----------------------------------------------------------------------------
 
-Att::Att() : AttConverter() {}
-
-Att::~Att() {}
-
 std::string Att::StrToStr(std::string str) const
 {
     return str;

--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -23,24 +23,24 @@ namespace vrv {
 
 /**
  * This is the base class for all MEI att classes.
- * It is not an abstract class but it should not be instanciated directly.
+ * It cannot be instanciated outside the Att class hierarchy.
  * The att classes are generated with the libmei parser for Verovio.
  */
-class Att : public AttConverter {
-public:
+class Att : public AttConverterBase {
+protected:
     /** @name Constructors and destructor */
     ///@{
-    Att();
-    virtual ~Att();
+    Att() = default;
+    ~Att() = default;
     ///@}
 
+public:
     static data_ACCIDENTAL_WRITTEN AccidentalGesturalToWritten(data_ACCIDENTAL_GESTURAL accid);
     static data_ACCIDENTAL_GESTURAL AccidentalWrittenToGestural(data_ACCIDENTAL_WRITTEN accid);
 
     static data_STAFFREL StaffrelBasicToStaffrel(data_STAFFREL_basic staffrelBasic);
     static data_STAFFREL_basic StaffrelToStaffrelBasic(data_STAFFREL staffrel);
 
-public:
     /** Dummy string converter */
     std::string StrToStr(std::string str) const;
 

--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -23,7 +23,7 @@ namespace vrv {
 
 /**
  * This is the base class for all MEI att classes.
- * It cannot be instanciated outside the Att class hierarchy.
+ * It cannot be instantiated outside the Att class hierarchy.
  * The att classes are generated with the libmei parser for Verovio.
  */
 class Att : public AttConverterBase {

--- a/libmei/dist/attconverter.cpp
+++ b/libmei/dist/attconverter.cpp
@@ -25,10 +25,10 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
-// AttConverter
+// AttConverterBase
 //----------------------------------------------------------------------------
 
-std::string AttConverter::AccidentalGesturalToStr(data_ACCIDENTAL_GESTURAL data) const
+std::string AttConverterBase::AccidentalGesturalToStr(data_ACCIDENTAL_GESTURAL data) const
 {
     std::string value;
     switch (data) {
@@ -61,7 +61,7 @@ std::string AttConverter::AccidentalGesturalToStr(data_ACCIDENTAL_GESTURAL data)
     return value;
 }
 
-data_ACCIDENTAL_GESTURAL AttConverter::StrToAccidentalGestural(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_GESTURAL AttConverterBase::StrToAccidentalGestural(const std::string &value, bool logWarning) const
 {
     if (value == "s") return ACCIDENTAL_GESTURAL_s;
     if (value == "f") return ACCIDENTAL_GESTURAL_f;
@@ -89,7 +89,7 @@ data_ACCIDENTAL_GESTURAL AttConverter::StrToAccidentalGestural(const std::string
     return ACCIDENTAL_GESTURAL_NONE;
 }
 
-std::string AttConverter::AccidentalGesturalBasicToStr(data_ACCIDENTAL_GESTURAL_basic data) const
+std::string AttConverterBase::AccidentalGesturalBasicToStr(data_ACCIDENTAL_GESTURAL_basic data) const
 {
     std::string value;
     switch (data) {
@@ -108,7 +108,7 @@ std::string AttConverter::AccidentalGesturalBasicToStr(data_ACCIDENTAL_GESTURAL_
     return value;
 }
 
-data_ACCIDENTAL_GESTURAL_basic AttConverter::StrToAccidentalGesturalBasic(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_GESTURAL_basic AttConverterBase::StrToAccidentalGesturalBasic(const std::string &value, bool logWarning) const
 {
     if (value == "s") return ACCIDENTAL_GESTURAL_basic_s;
     if (value == "f") return ACCIDENTAL_GESTURAL_basic_f;
@@ -122,7 +122,7 @@ data_ACCIDENTAL_GESTURAL_basic AttConverter::StrToAccidentalGesturalBasic(const 
     return ACCIDENTAL_GESTURAL_basic_NONE;
 }
 
-std::string AttConverter::AccidentalGesturalExtendedToStr(data_ACCIDENTAL_GESTURAL_extended data) const
+std::string AttConverterBase::AccidentalGesturalExtendedToStr(data_ACCIDENTAL_GESTURAL_extended data) const
 {
     std::string value;
     switch (data) {
@@ -138,7 +138,7 @@ std::string AttConverter::AccidentalGesturalExtendedToStr(data_ACCIDENTAL_GESTUR
     return value;
 }
 
-data_ACCIDENTAL_GESTURAL_extended AttConverter::StrToAccidentalGesturalExtended(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_GESTURAL_extended AttConverterBase::StrToAccidentalGesturalExtended(const std::string &value, bool logWarning) const
 {
     if (value == "su") return ACCIDENTAL_GESTURAL_extended_su;
     if (value == "sd") return ACCIDENTAL_GESTURAL_extended_sd;
@@ -149,7 +149,7 @@ data_ACCIDENTAL_GESTURAL_extended AttConverter::StrToAccidentalGesturalExtended(
     return ACCIDENTAL_GESTURAL_extended_NONE;
 }
 
-std::string AttConverter::AccidentalWrittenToStr(data_ACCIDENTAL_WRITTEN data) const
+std::string AttConverterBase::AccidentalWrittenToStr(data_ACCIDENTAL_WRITTEN data) const
 {
     std::string value;
     switch (data) {
@@ -193,7 +193,7 @@ std::string AttConverter::AccidentalWrittenToStr(data_ACCIDENTAL_WRITTEN data) c
     return value;
 }
 
-data_ACCIDENTAL_WRITTEN AttConverter::StrToAccidentalWritten(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_WRITTEN AttConverterBase::StrToAccidentalWritten(const std::string &value, bool logWarning) const
 {
     if (value == "s") return ACCIDENTAL_WRITTEN_s;
     if (value == "f") return ACCIDENTAL_WRITTEN_f;
@@ -232,7 +232,7 @@ data_ACCIDENTAL_WRITTEN AttConverter::StrToAccidentalWritten(const std::string &
     return ACCIDENTAL_WRITTEN_NONE;
 }
 
-std::string AttConverter::AccidentalWrittenBasicToStr(data_ACCIDENTAL_WRITTEN_basic data) const
+std::string AttConverterBase::AccidentalWrittenBasicToStr(data_ACCIDENTAL_WRITTEN_basic data) const
 {
     std::string value;
     switch (data) {
@@ -256,7 +256,7 @@ std::string AttConverter::AccidentalWrittenBasicToStr(data_ACCIDENTAL_WRITTEN_ba
     return value;
 }
 
-data_ACCIDENTAL_WRITTEN_basic AttConverter::StrToAccidentalWrittenBasic(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_WRITTEN_basic AttConverterBase::StrToAccidentalWrittenBasic(const std::string &value, bool logWarning) const
 {
     if (value == "s") return ACCIDENTAL_WRITTEN_basic_s;
     if (value == "f") return ACCIDENTAL_WRITTEN_basic_f;
@@ -275,7 +275,7 @@ data_ACCIDENTAL_WRITTEN_basic AttConverter::StrToAccidentalWrittenBasic(const st
     return ACCIDENTAL_WRITTEN_basic_NONE;
 }
 
-std::string AttConverter::AccidentalWrittenExtendedToStr(data_ACCIDENTAL_WRITTEN_extended data) const
+std::string AttConverterBase::AccidentalWrittenExtendedToStr(data_ACCIDENTAL_WRITTEN_extended data) const
 {
     std::string value;
     switch (data) {
@@ -297,7 +297,7 @@ std::string AttConverter::AccidentalWrittenExtendedToStr(data_ACCIDENTAL_WRITTEN
     return value;
 }
 
-data_ACCIDENTAL_WRITTEN_extended AttConverter::StrToAccidentalWrittenExtended(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_WRITTEN_extended AttConverterBase::StrToAccidentalWrittenExtended(const std::string &value, bool logWarning) const
 {
     if (value == "su") return ACCIDENTAL_WRITTEN_extended_su;
     if (value == "sd") return ACCIDENTAL_WRITTEN_extended_sd;
@@ -314,7 +314,7 @@ data_ACCIDENTAL_WRITTEN_extended AttConverter::StrToAccidentalWrittenExtended(co
     return ACCIDENTAL_WRITTEN_extended_NONE;
 }
 
-std::string AttConverter::AccidentalAeuToStr(data_ACCIDENTAL_aeu data) const
+std::string AttConverterBase::AccidentalAeuToStr(data_ACCIDENTAL_aeu data) const
 {
     std::string value;
     switch (data) {
@@ -334,7 +334,7 @@ std::string AttConverter::AccidentalAeuToStr(data_ACCIDENTAL_aeu data) const
     return value;
 }
 
-data_ACCIDENTAL_aeu AttConverter::StrToAccidentalAeu(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_aeu AttConverterBase::StrToAccidentalAeu(const std::string &value, bool logWarning) const
 {
     if (value == "bms") return ACCIDENTAL_aeu_bms;
     if (value == "kms") return ACCIDENTAL_aeu_kms;
@@ -349,7 +349,7 @@ data_ACCIDENTAL_aeu AttConverter::StrToAccidentalAeu(const std::string &value, b
     return ACCIDENTAL_aeu_NONE;
 }
 
-std::string AttConverter::AccidentalPersianToStr(data_ACCIDENTAL_persian data) const
+std::string AttConverterBase::AccidentalPersianToStr(data_ACCIDENTAL_persian data) const
 {
     std::string value;
     switch (data) {
@@ -363,7 +363,7 @@ std::string AttConverter::AccidentalPersianToStr(data_ACCIDENTAL_persian data) c
     return value;
 }
 
-data_ACCIDENTAL_persian AttConverter::StrToAccidentalPersian(const std::string &value, bool logWarning) const
+data_ACCIDENTAL_persian AttConverterBase::StrToAccidentalPersian(const std::string &value, bool logWarning) const
 {
     if (value == "koron") return ACCIDENTAL_persian_koron;
     if (value == "sori") return ACCIDENTAL_persian_sori;
@@ -372,7 +372,7 @@ data_ACCIDENTAL_persian AttConverter::StrToAccidentalPersian(const std::string &
     return ACCIDENTAL_persian_NONE;
 }
 
-std::string AttConverter::ArticulationToStr(data_ARTICULATION data) const
+std::string AttConverterBase::ArticulationToStr(data_ARTICULATION data) const
 {
     std::string value;
     switch (data) {
@@ -420,7 +420,7 @@ std::string AttConverter::ArticulationToStr(data_ARTICULATION data) const
     return value;
 }
 
-data_ARTICULATION AttConverter::StrToArticulation(const std::string &value, bool logWarning) const
+data_ARTICULATION AttConverterBase::StrToArticulation(const std::string &value, bool logWarning) const
 {
     if (value == "acc") return ARTICULATION_acc;
     if (value == "acc-inv") return ARTICULATION_acc_inv;
@@ -463,7 +463,7 @@ data_ARTICULATION AttConverter::StrToArticulation(const std::string &value, bool
     return ARTICULATION_NONE;
 }
 
-std::string AttConverter::BarmethodToStr(data_BARMETHOD data) const
+std::string AttConverterBase::BarmethodToStr(data_BARMETHOD data) const
 {
     std::string value;
     switch (data) {
@@ -478,7 +478,7 @@ std::string AttConverter::BarmethodToStr(data_BARMETHOD data) const
     return value;
 }
 
-data_BARMETHOD AttConverter::StrToBarmethod(const std::string &value, bool logWarning) const
+data_BARMETHOD AttConverterBase::StrToBarmethod(const std::string &value, bool logWarning) const
 {
     if (value == "mensur") return BARMETHOD_mensur;
     if (value == "staff") return BARMETHOD_staff;
@@ -488,7 +488,7 @@ data_BARMETHOD AttConverter::StrToBarmethod(const std::string &value, bool logWa
     return BARMETHOD_NONE;
 }
 
-std::string AttConverter::BarrenditionToStr(data_BARRENDITION data) const
+std::string AttConverterBase::BarrenditionToStr(data_BARRENDITION data) const
 {
     std::string value;
     switch (data) {
@@ -515,7 +515,7 @@ std::string AttConverter::BarrenditionToStr(data_BARRENDITION data) const
     return value;
 }
 
-data_BARRENDITION AttConverter::StrToBarrendition(const std::string &value, bool logWarning) const
+data_BARRENDITION AttConverterBase::StrToBarrendition(const std::string &value, bool logWarning) const
 {
     if (value == "dashed") return BARRENDITION_dashed;
     if (value == "dotted") return BARRENDITION_dotted;
@@ -537,7 +537,7 @@ data_BARRENDITION AttConverter::StrToBarrendition(const std::string &value, bool
     return BARRENDITION_NONE;
 }
 
-std::string AttConverter::BeamplaceToStr(data_BEAMPLACE data) const
+std::string AttConverterBase::BeamplaceToStr(data_BEAMPLACE data) const
 {
     std::string value;
     switch (data) {
@@ -552,7 +552,7 @@ std::string AttConverter::BeamplaceToStr(data_BEAMPLACE data) const
     return value;
 }
 
-data_BEAMPLACE AttConverter::StrToBeamplace(const std::string &value, bool logWarning) const
+data_BEAMPLACE AttConverterBase::StrToBeamplace(const std::string &value, bool logWarning) const
 {
     if (value == "above") return BEAMPLACE_above;
     if (value == "below") return BEAMPLACE_below;
@@ -562,7 +562,7 @@ data_BEAMPLACE AttConverter::StrToBeamplace(const std::string &value, bool logWa
     return BEAMPLACE_NONE;
 }
 
-std::string AttConverter::BetypeToStr(data_BETYPE data) const
+std::string AttConverterBase::BetypeToStr(data_BETYPE data) const
 {
     std::string value;
     switch (data) {
@@ -587,7 +587,7 @@ std::string AttConverter::BetypeToStr(data_BETYPE data) const
     return value;
 }
 
-data_BETYPE AttConverter::StrToBetype(const std::string &value, bool logWarning) const
+data_BETYPE AttConverterBase::StrToBetype(const std::string &value, bool logWarning) const
 {
     if (value == "byte") return BETYPE_byte;
     if (value == "smil") return BETYPE_smil;
@@ -607,7 +607,7 @@ data_BETYPE AttConverter::StrToBetype(const std::string &value, bool logWarning)
     return BETYPE_NONE;
 }
 
-std::string AttConverter::BooleanToStr(data_BOOLEAN data) const
+std::string AttConverterBase::BooleanToStr(data_BOOLEAN data) const
 {
     std::string value;
     switch (data) {
@@ -621,7 +621,7 @@ std::string AttConverter::BooleanToStr(data_BOOLEAN data) const
     return value;
 }
 
-data_BOOLEAN AttConverter::StrToBoolean(const std::string &value, bool logWarning) const
+data_BOOLEAN AttConverterBase::StrToBoolean(const std::string &value, bool logWarning) const
 {
     if (value == "true") return BOOLEAN_true;
     if (value == "false") return BOOLEAN_false;
@@ -630,7 +630,7 @@ data_BOOLEAN AttConverter::StrToBoolean(const std::string &value, bool logWarnin
     return BOOLEAN_NONE;
 }
 
-std::string AttConverter::CertaintyToStr(data_CERTAINTY data) const
+std::string AttConverterBase::CertaintyToStr(data_CERTAINTY data) const
 {
     std::string value;
     switch (data) {
@@ -646,7 +646,7 @@ std::string AttConverter::CertaintyToStr(data_CERTAINTY data) const
     return value;
 }
 
-data_CERTAINTY AttConverter::StrToCertainty(const std::string &value, bool logWarning) const
+data_CERTAINTY AttConverterBase::StrToCertainty(const std::string &value, bool logWarning) const
 {
     if (value == "high") return CERTAINTY_high;
     if (value == "medium") return CERTAINTY_medium;
@@ -657,7 +657,7 @@ data_CERTAINTY AttConverter::StrToCertainty(const std::string &value, bool logWa
     return CERTAINTY_NONE;
 }
 
-std::string AttConverter::ClefshapeToStr(data_CLEFSHAPE data) const
+std::string AttConverterBase::ClefshapeToStr(data_CLEFSHAPE data) const
 {
     std::string value;
     switch (data) {
@@ -675,7 +675,7 @@ std::string AttConverter::ClefshapeToStr(data_CLEFSHAPE data) const
     return value;
 }
 
-data_CLEFSHAPE AttConverter::StrToClefshape(const std::string &value, bool logWarning) const
+data_CLEFSHAPE AttConverterBase::StrToClefshape(const std::string &value, bool logWarning) const
 {
     if (value == "G") return CLEFSHAPE_G;
     if (value == "GG") return CLEFSHAPE_GG;
@@ -688,7 +688,7 @@ data_CLEFSHAPE AttConverter::StrToClefshape(const std::string &value, bool logWa
     return CLEFSHAPE_NONE;
 }
 
-std::string AttConverter::ClusterToStr(data_CLUSTER data) const
+std::string AttConverterBase::ClusterToStr(data_CLUSTER data) const
 {
     std::string value;
     switch (data) {
@@ -703,7 +703,7 @@ std::string AttConverter::ClusterToStr(data_CLUSTER data) const
     return value;
 }
 
-data_CLUSTER AttConverter::StrToCluster(const std::string &value, bool logWarning) const
+data_CLUSTER AttConverterBase::StrToCluster(const std::string &value, bool logWarning) const
 {
     if (value == "white") return CLUSTER_white;
     if (value == "black") return CLUSTER_black;
@@ -713,7 +713,7 @@ data_CLUSTER AttConverter::StrToCluster(const std::string &value, bool logWarnin
     return CLUSTER_NONE;
 }
 
-std::string AttConverter::ColornamesToStr(data_COLORNAMES data) const
+std::string AttConverterBase::ColornamesToStr(data_COLORNAMES data) const
 {
     std::string value;
     switch (data) {
@@ -873,7 +873,7 @@ std::string AttConverter::ColornamesToStr(data_COLORNAMES data) const
     return value;
 }
 
-data_COLORNAMES AttConverter::StrToColornames(const std::string &value, bool logWarning) const
+data_COLORNAMES AttConverterBase::StrToColornames(const std::string &value, bool logWarning) const
 {
     if (value == "aliceblue") return COLORNAMES_aliceblue;
     if (value == "antiquewhite") return COLORNAMES_antiquewhite;
@@ -1028,7 +1028,7 @@ data_COLORNAMES AttConverter::StrToColornames(const std::string &value, bool log
     return COLORNAMES_NONE;
 }
 
-std::string AttConverter::CompassdirectionToStr(data_COMPASSDIRECTION data) const
+std::string AttConverterBase::CompassdirectionToStr(data_COMPASSDIRECTION data) const
 {
     std::string value;
     switch (data) {
@@ -1048,7 +1048,7 @@ std::string AttConverter::CompassdirectionToStr(data_COMPASSDIRECTION data) cons
     return value;
 }
 
-data_COMPASSDIRECTION AttConverter::StrToCompassdirection(const std::string &value, bool logWarning) const
+data_COMPASSDIRECTION AttConverterBase::StrToCompassdirection(const std::string &value, bool logWarning) const
 {
     if (value == "n") return COMPASSDIRECTION_n;
     if (value == "e") return COMPASSDIRECTION_e;
@@ -1063,7 +1063,7 @@ data_COMPASSDIRECTION AttConverter::StrToCompassdirection(const std::string &val
     return COMPASSDIRECTION_NONE;
 }
 
-std::string AttConverter::CompassdirectionBasicToStr(data_COMPASSDIRECTION_basic data) const
+std::string AttConverterBase::CompassdirectionBasicToStr(data_COMPASSDIRECTION_basic data) const
 {
     std::string value;
     switch (data) {
@@ -1079,7 +1079,7 @@ std::string AttConverter::CompassdirectionBasicToStr(data_COMPASSDIRECTION_basic
     return value;
 }
 
-data_COMPASSDIRECTION_basic AttConverter::StrToCompassdirectionBasic(const std::string &value, bool logWarning) const
+data_COMPASSDIRECTION_basic AttConverterBase::StrToCompassdirectionBasic(const std::string &value, bool logWarning) const
 {
     if (value == "n") return COMPASSDIRECTION_basic_n;
     if (value == "e") return COMPASSDIRECTION_basic_e;
@@ -1090,7 +1090,7 @@ data_COMPASSDIRECTION_basic AttConverter::StrToCompassdirectionBasic(const std::
     return COMPASSDIRECTION_basic_NONE;
 }
 
-std::string AttConverter::CompassdirectionExtendedToStr(data_COMPASSDIRECTION_extended data) const
+std::string AttConverterBase::CompassdirectionExtendedToStr(data_COMPASSDIRECTION_extended data) const
 {
     std::string value;
     switch (data) {
@@ -1106,7 +1106,7 @@ std::string AttConverter::CompassdirectionExtendedToStr(data_COMPASSDIRECTION_ex
     return value;
 }
 
-data_COMPASSDIRECTION_extended AttConverter::StrToCompassdirectionExtended(const std::string &value, bool logWarning) const
+data_COMPASSDIRECTION_extended AttConverterBase::StrToCompassdirectionExtended(const std::string &value, bool logWarning) const
 {
     if (value == "ne") return COMPASSDIRECTION_extended_ne;
     if (value == "nw") return COMPASSDIRECTION_extended_nw;
@@ -1117,7 +1117,7 @@ data_COMPASSDIRECTION_extended AttConverter::StrToCompassdirectionExtended(const
     return COMPASSDIRECTION_extended_NONE;
 }
 
-std::string AttConverter::CoursetuningToStr(data_COURSETUNING data) const
+std::string AttConverterBase::CoursetuningToStr(data_COURSETUNING data) const
 {
     std::string value;
     switch (data) {
@@ -1137,7 +1137,7 @@ std::string AttConverter::CoursetuningToStr(data_COURSETUNING data) const
     return value;
 }
 
-data_COURSETUNING AttConverter::StrToCoursetuning(const std::string &value, bool logWarning) const
+data_COURSETUNING AttConverterBase::StrToCoursetuning(const std::string &value, bool logWarning) const
 {
     if (value == "guitar.standard") return COURSETUNING_guitar_standard;
     if (value == "guitar.drop.D") return COURSETUNING_guitar_drop_D;
@@ -1152,7 +1152,7 @@ data_COURSETUNING AttConverter::StrToCoursetuning(const std::string &value, bool
     return COURSETUNING_NONE;
 }
 
-std::string AttConverter::DivisioToStr(data_DIVISIO data) const
+std::string AttConverterBase::DivisioToStr(data_DIVISIO data) const
 {
     std::string value;
     switch (data) {
@@ -1171,7 +1171,7 @@ std::string AttConverter::DivisioToStr(data_DIVISIO data) const
     return value;
 }
 
-data_DIVISIO AttConverter::StrToDivisio(const std::string &value, bool logWarning) const
+data_DIVISIO AttConverterBase::StrToDivisio(const std::string &value, bool logWarning) const
 {
     if (value == "ternaria") return DIVISIO_ternaria;
     if (value == "quaternaria") return DIVISIO_quaternaria;
@@ -1185,7 +1185,7 @@ data_DIVISIO AttConverter::StrToDivisio(const std::string &value, bool logWarnin
     return DIVISIO_NONE;
 }
 
-std::string AttConverter::DurationrestsMensuralToStr(data_DURATIONRESTS_mensural data) const
+std::string AttConverterBase::DurationrestsMensuralToStr(data_DURATIONRESTS_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -1207,7 +1207,7 @@ std::string AttConverter::DurationrestsMensuralToStr(data_DURATIONRESTS_mensural
     return value;
 }
 
-data_DURATIONRESTS_mensural AttConverter::StrToDurationrestsMensural(const std::string &value, bool logWarning) const
+data_DURATIONRESTS_mensural AttConverterBase::StrToDurationrestsMensural(const std::string &value, bool logWarning) const
 {
     if (value == "2B") return DURATIONRESTS_mensural_2B;
     if (value == "3B") return DURATIONRESTS_mensural_3B;
@@ -1224,7 +1224,7 @@ data_DURATIONRESTS_mensural AttConverter::StrToDurationrestsMensural(const std::
     return DURATIONRESTS_mensural_NONE;
 }
 
-std::string AttConverter::DurqualityMensuralToStr(data_DURQUALITY_mensural data) const
+std::string AttConverterBase::DurqualityMensuralToStr(data_DURQUALITY_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -1242,7 +1242,7 @@ std::string AttConverter::DurqualityMensuralToStr(data_DURQUALITY_mensural data)
     return value;
 }
 
-data_DURQUALITY_mensural AttConverter::StrToDurqualityMensural(const std::string &value, bool logWarning) const
+data_DURQUALITY_mensural AttConverterBase::StrToDurqualityMensural(const std::string &value, bool logWarning) const
 {
     if (value == "perfecta") return DURQUALITY_mensural_perfecta;
     if (value == "imperfecta") return DURQUALITY_mensural_imperfecta;
@@ -1255,7 +1255,7 @@ data_DURQUALITY_mensural AttConverter::StrToDurqualityMensural(const std::string
     return DURQUALITY_mensural_NONE;
 }
 
-std::string AttConverter::EnclosureToStr(data_ENCLOSURE data) const
+std::string AttConverterBase::EnclosureToStr(data_ENCLOSURE data) const
 {
     std::string value;
     switch (data) {
@@ -1271,7 +1271,7 @@ std::string AttConverter::EnclosureToStr(data_ENCLOSURE data) const
     return value;
 }
 
-data_ENCLOSURE AttConverter::StrToEnclosure(const std::string &value, bool logWarning) const
+data_ENCLOSURE AttConverterBase::StrToEnclosure(const std::string &value, bool logWarning) const
 {
     if (value == "paren") return ENCLOSURE_paren;
     if (value == "brack") return ENCLOSURE_brack;
@@ -1282,7 +1282,7 @@ data_ENCLOSURE AttConverter::StrToEnclosure(const std::string &value, bool logWa
     return ENCLOSURE_NONE;
 }
 
-std::string AttConverter::EventrelToStr(data_EVENTREL data) const
+std::string AttConverterBase::EventrelToStr(data_EVENTREL data) const
 {
     std::string value;
     switch (data) {
@@ -1302,7 +1302,7 @@ std::string AttConverter::EventrelToStr(data_EVENTREL data) const
     return value;
 }
 
-data_EVENTREL AttConverter::StrToEventrel(const std::string &value, bool logWarning) const
+data_EVENTREL AttConverterBase::StrToEventrel(const std::string &value, bool logWarning) const
 {
     if (value == "above") return EVENTREL_above;
     if (value == "below") return EVENTREL_below;
@@ -1317,7 +1317,7 @@ data_EVENTREL AttConverter::StrToEventrel(const std::string &value, bool logWarn
     return EVENTREL_NONE;
 }
 
-std::string AttConverter::EventrelBasicToStr(data_EVENTREL_basic data) const
+std::string AttConverterBase::EventrelBasicToStr(data_EVENTREL_basic data) const
 {
     std::string value;
     switch (data) {
@@ -1333,7 +1333,7 @@ std::string AttConverter::EventrelBasicToStr(data_EVENTREL_basic data) const
     return value;
 }
 
-data_EVENTREL_basic AttConverter::StrToEventrelBasic(const std::string &value, bool logWarning) const
+data_EVENTREL_basic AttConverterBase::StrToEventrelBasic(const std::string &value, bool logWarning) const
 {
     if (value == "above") return EVENTREL_basic_above;
     if (value == "below") return EVENTREL_basic_below;
@@ -1344,7 +1344,7 @@ data_EVENTREL_basic AttConverter::StrToEventrelBasic(const std::string &value, b
     return EVENTREL_basic_NONE;
 }
 
-std::string AttConverter::EventrelExtendedToStr(data_EVENTREL_extended data) const
+std::string AttConverterBase::EventrelExtendedToStr(data_EVENTREL_extended data) const
 {
     std::string value;
     switch (data) {
@@ -1360,7 +1360,7 @@ std::string AttConverter::EventrelExtendedToStr(data_EVENTREL_extended data) con
     return value;
 }
 
-data_EVENTREL_extended AttConverter::StrToEventrelExtended(const std::string &value, bool logWarning) const
+data_EVENTREL_extended AttConverterBase::StrToEventrelExtended(const std::string &value, bool logWarning) const
 {
     if (value == "above-left") return EVENTREL_extended_above_left;
     if (value == "above-right") return EVENTREL_extended_above_right;
@@ -1371,7 +1371,7 @@ data_EVENTREL_extended AttConverter::StrToEventrelExtended(const std::string &va
     return EVENTREL_extended_NONE;
 }
 
-std::string AttConverter::FillToStr(data_FILL data) const
+std::string AttConverterBase::FillToStr(data_FILL data) const
 {
     std::string value;
     switch (data) {
@@ -1389,7 +1389,7 @@ std::string AttConverter::FillToStr(data_FILL data) const
     return value;
 }
 
-data_FILL AttConverter::StrToFill(const std::string &value, bool logWarning) const
+data_FILL AttConverterBase::StrToFill(const std::string &value, bool logWarning) const
 {
     if (value == "void") return FILL_void;
     if (value == "solid") return FILL_solid;
@@ -1402,7 +1402,7 @@ data_FILL AttConverter::StrToFill(const std::string &value, bool logWarning) con
     return FILL_NONE;
 }
 
-std::string AttConverter::FlagformMensuralToStr(data_FLAGFORM_mensural data) const
+std::string AttConverterBase::FlagformMensuralToStr(data_FLAGFORM_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -1420,7 +1420,7 @@ std::string AttConverter::FlagformMensuralToStr(data_FLAGFORM_mensural data) con
     return value;
 }
 
-data_FLAGFORM_mensural AttConverter::StrToFlagformMensural(const std::string &value, bool logWarning) const
+data_FLAGFORM_mensural AttConverterBase::StrToFlagformMensural(const std::string &value, bool logWarning) const
 {
     if (value == "straight") return FLAGFORM_mensural_straight;
     if (value == "angled") return FLAGFORM_mensural_angled;
@@ -1433,7 +1433,7 @@ data_FLAGFORM_mensural AttConverter::StrToFlagformMensural(const std::string &va
     return FLAGFORM_mensural_NONE;
 }
 
-std::string AttConverter::FlagposMensuralToStr(data_FLAGPOS_mensural data) const
+std::string AttConverterBase::FlagposMensuralToStr(data_FLAGPOS_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -1448,7 +1448,7 @@ std::string AttConverter::FlagposMensuralToStr(data_FLAGPOS_mensural data) const
     return value;
 }
 
-data_FLAGPOS_mensural AttConverter::StrToFlagposMensural(const std::string &value, bool logWarning) const
+data_FLAGPOS_mensural AttConverterBase::StrToFlagposMensural(const std::string &value, bool logWarning) const
 {
     if (value == "left") return FLAGPOS_mensural_left;
     if (value == "right") return FLAGPOS_mensural_right;
@@ -1458,7 +1458,7 @@ data_FLAGPOS_mensural AttConverter::StrToFlagposMensural(const std::string &valu
     return FLAGPOS_mensural_NONE;
 }
 
-std::string AttConverter::FontsizetermToStr(data_FONTSIZETERM data) const
+std::string AttConverterBase::FontsizetermToStr(data_FONTSIZETERM data) const
 {
     std::string value;
     switch (data) {
@@ -1479,7 +1479,7 @@ std::string AttConverter::FontsizetermToStr(data_FONTSIZETERM data) const
     return value;
 }
 
-data_FONTSIZETERM AttConverter::StrToFontsizeterm(const std::string &value, bool logWarning) const
+data_FONTSIZETERM AttConverterBase::StrToFontsizeterm(const std::string &value, bool logWarning) const
 {
     if (value == "xx-small") return FONTSIZETERM_xx_small;
     if (value == "x-small") return FONTSIZETERM_x_small;
@@ -1495,7 +1495,7 @@ data_FONTSIZETERM AttConverter::StrToFontsizeterm(const std::string &value, bool
     return FONTSIZETERM_NONE;
 }
 
-std::string AttConverter::FontstyleToStr(data_FONTSTYLE data) const
+std::string AttConverterBase::FontstyleToStr(data_FONTSTYLE data) const
 {
     std::string value;
     switch (data) {
@@ -1510,7 +1510,7 @@ std::string AttConverter::FontstyleToStr(data_FONTSTYLE data) const
     return value;
 }
 
-data_FONTSTYLE AttConverter::StrToFontstyle(const std::string &value, bool logWarning) const
+data_FONTSTYLE AttConverterBase::StrToFontstyle(const std::string &value, bool logWarning) const
 {
     if (value == "italic") return FONTSTYLE_italic;
     if (value == "normal") return FONTSTYLE_normal;
@@ -1520,7 +1520,7 @@ data_FONTSTYLE AttConverter::StrToFontstyle(const std::string &value, bool logWa
     return FONTSTYLE_NONE;
 }
 
-std::string AttConverter::FontweightToStr(data_FONTWEIGHT data) const
+std::string AttConverterBase::FontweightToStr(data_FONTWEIGHT data) const
 {
     std::string value;
     switch (data) {
@@ -1534,7 +1534,7 @@ std::string AttConverter::FontweightToStr(data_FONTWEIGHT data) const
     return value;
 }
 
-data_FONTWEIGHT AttConverter::StrToFontweight(const std::string &value, bool logWarning) const
+data_FONTWEIGHT AttConverterBase::StrToFontweight(const std::string &value, bool logWarning) const
 {
     if (value == "bold") return FONTWEIGHT_bold;
     if (value == "normal") return FONTWEIGHT_normal;
@@ -1543,7 +1543,7 @@ data_FONTWEIGHT AttConverter::StrToFontweight(const std::string &value, bool log
     return FONTWEIGHT_NONE;
 }
 
-std::string AttConverter::FrbrrelationshipToStr(data_FRBRRELATIONSHIP data) const
+std::string AttConverterBase::FrbrrelationshipToStr(data_FRBRRELATIONSHIP data) const
 {
     std::string value;
     switch (data) {
@@ -1591,7 +1591,7 @@ std::string AttConverter::FrbrrelationshipToStr(data_FRBRRELATIONSHIP data) cons
     return value;
 }
 
-data_FRBRRELATIONSHIP AttConverter::StrToFrbrrelationship(const std::string &value, bool logWarning) const
+data_FRBRRELATIONSHIP AttConverterBase::StrToFrbrrelationship(const std::string &value, bool logWarning) const
 {
     if (value == "hasAbridgement") return FRBRRELATIONSHIP_hasAbridgement;
     if (value == "isAbridgementOf") return FRBRRELATIONSHIP_isAbridgementOf;
@@ -1634,7 +1634,7 @@ data_FRBRRELATIONSHIP AttConverter::StrToFrbrrelationship(const std::string &val
     return FRBRRELATIONSHIP_NONE;
 }
 
-std::string AttConverter::GlissandoToStr(data_GLISSANDO data) const
+std::string AttConverterBase::GlissandoToStr(data_GLISSANDO data) const
 {
     std::string value;
     switch (data) {
@@ -1649,7 +1649,7 @@ std::string AttConverter::GlissandoToStr(data_GLISSANDO data) const
     return value;
 }
 
-data_GLISSANDO AttConverter::StrToGlissando(const std::string &value, bool logWarning) const
+data_GLISSANDO AttConverterBase::StrToGlissando(const std::string &value, bool logWarning) const
 {
     if (value == "i") return GLISSANDO_i;
     if (value == "m") return GLISSANDO_m;
@@ -1659,7 +1659,7 @@ data_GLISSANDO AttConverter::StrToGlissando(const std::string &value, bool logWa
     return GLISSANDO_NONE;
 }
 
-std::string AttConverter::GraceToStr(data_GRACE data) const
+std::string AttConverterBase::GraceToStr(data_GRACE data) const
 {
     std::string value;
     switch (data) {
@@ -1674,7 +1674,7 @@ std::string AttConverter::GraceToStr(data_GRACE data) const
     return value;
 }
 
-data_GRACE AttConverter::StrToGrace(const std::string &value, bool logWarning) const
+data_GRACE AttConverterBase::StrToGrace(const std::string &value, bool logWarning) const
 {
     if (value == "acc") return GRACE_acc;
     if (value == "unacc") return GRACE_unacc;
@@ -1684,7 +1684,7 @@ data_GRACE AttConverter::StrToGrace(const std::string &value, bool logWarning) c
     return GRACE_NONE;
 }
 
-std::string AttConverter::HeadshapeToStr(data_HEADSHAPE data) const
+std::string AttConverterBase::HeadshapeToStr(data_HEADSHAPE data) const
 {
     std::string value;
     switch (data) {
@@ -1712,7 +1712,7 @@ std::string AttConverter::HeadshapeToStr(data_HEADSHAPE data) const
     return value;
 }
 
-data_HEADSHAPE AttConverter::StrToHeadshape(const std::string &value, bool logWarning) const
+data_HEADSHAPE AttConverterBase::StrToHeadshape(const std::string &value, bool logWarning) const
 {
     if (value == "quarter") return HEADSHAPE_quarter;
     if (value == "half") return HEADSHAPE_half;
@@ -1735,7 +1735,7 @@ data_HEADSHAPE AttConverter::StrToHeadshape(const std::string &value, bool logWa
     return HEADSHAPE_NONE;
 }
 
-std::string AttConverter::HeadshapeListToStr(data_HEADSHAPE_list data) const
+std::string AttConverterBase::HeadshapeListToStr(data_HEADSHAPE_list data) const
 {
     std::string value;
     switch (data) {
@@ -1763,7 +1763,7 @@ std::string AttConverter::HeadshapeListToStr(data_HEADSHAPE_list data) const
     return value;
 }
 
-data_HEADSHAPE_list AttConverter::StrToHeadshapeList(const std::string &value, bool logWarning) const
+data_HEADSHAPE_list AttConverterBase::StrToHeadshapeList(const std::string &value, bool logWarning) const
 {
     if (value == "quarter") return HEADSHAPE_list_quarter;
     if (value == "half") return HEADSHAPE_list_half;
@@ -1786,7 +1786,7 @@ data_HEADSHAPE_list AttConverter::StrToHeadshapeList(const std::string &value, b
     return HEADSHAPE_list_NONE;
 }
 
-std::string AttConverter::HorizontalalignmentToStr(data_HORIZONTALALIGNMENT data) const
+std::string AttConverterBase::HorizontalalignmentToStr(data_HORIZONTALALIGNMENT data) const
 {
     std::string value;
     switch (data) {
@@ -1802,7 +1802,7 @@ std::string AttConverter::HorizontalalignmentToStr(data_HORIZONTALALIGNMENT data
     return value;
 }
 
-data_HORIZONTALALIGNMENT AttConverter::StrToHorizontalalignment(const std::string &value, bool logWarning) const
+data_HORIZONTALALIGNMENT AttConverterBase::StrToHorizontalalignment(const std::string &value, bool logWarning) const
 {
     if (value == "left") return HORIZONTALALIGNMENT_left;
     if (value == "right") return HORIZONTALALIGNMENT_right;
@@ -1813,7 +1813,7 @@ data_HORIZONTALALIGNMENT AttConverter::StrToHorizontalalignment(const std::strin
     return HORIZONTALALIGNMENT_NONE;
 }
 
-std::string AttConverter::LayerschemeToStr(data_LAYERSCHEME data) const
+std::string AttConverterBase::LayerschemeToStr(data_LAYERSCHEME data) const
 {
     std::string value;
     switch (data) {
@@ -1830,7 +1830,7 @@ std::string AttConverter::LayerschemeToStr(data_LAYERSCHEME data) const
     return value;
 }
 
-data_LAYERSCHEME AttConverter::StrToLayerscheme(const std::string &value, bool logWarning) const
+data_LAYERSCHEME AttConverterBase::StrToLayerscheme(const std::string &value, bool logWarning) const
 {
     if (value == "1") return LAYERSCHEME_1;
     if (value == "2o") return LAYERSCHEME_2o;
@@ -1842,7 +1842,7 @@ data_LAYERSCHEME AttConverter::StrToLayerscheme(const std::string &value, bool l
     return LAYERSCHEME_NONE;
 }
 
-std::string AttConverter::LigatureformToStr(data_LIGATUREFORM data) const
+std::string AttConverterBase::LigatureformToStr(data_LIGATUREFORM data) const
 {
     std::string value;
     switch (data) {
@@ -1856,7 +1856,7 @@ std::string AttConverter::LigatureformToStr(data_LIGATUREFORM data) const
     return value;
 }
 
-data_LIGATUREFORM AttConverter::StrToLigatureform(const std::string &value, bool logWarning) const
+data_LIGATUREFORM AttConverterBase::StrToLigatureform(const std::string &value, bool logWarning) const
 {
     if (value == "recta") return LIGATUREFORM_recta;
     if (value == "obliqua") return LIGATUREFORM_obliqua;
@@ -1865,7 +1865,7 @@ data_LIGATUREFORM AttConverter::StrToLigatureform(const std::string &value, bool
     return LIGATUREFORM_NONE;
 }
 
-std::string AttConverter::LineformToStr(data_LINEFORM data) const
+std::string AttConverterBase::LineformToStr(data_LINEFORM data) const
 {
     std::string value;
     switch (data) {
@@ -1881,7 +1881,7 @@ std::string AttConverter::LineformToStr(data_LINEFORM data) const
     return value;
 }
 
-data_LINEFORM AttConverter::StrToLineform(const std::string &value, bool logWarning) const
+data_LINEFORM AttConverterBase::StrToLineform(const std::string &value, bool logWarning) const
 {
     if (value == "dashed") return LINEFORM_dashed;
     if (value == "dotted") return LINEFORM_dotted;
@@ -1892,7 +1892,7 @@ data_LINEFORM AttConverter::StrToLineform(const std::string &value, bool logWarn
     return LINEFORM_NONE;
 }
 
-std::string AttConverter::LinestartendsymbolToStr(data_LINESTARTENDSYMBOL data) const
+std::string AttConverterBase::LinestartendsymbolToStr(data_LINESTARTENDSYMBOL data) const
 {
     std::string value;
     switch (data) {
@@ -1924,7 +1924,7 @@ std::string AttConverter::LinestartendsymbolToStr(data_LINESTARTENDSYMBOL data) 
     return value;
 }
 
-data_LINESTARTENDSYMBOL AttConverter::StrToLinestartendsymbol(const std::string &value, bool logWarning) const
+data_LINESTARTENDSYMBOL AttConverterBase::StrToLinestartendsymbol(const std::string &value, bool logWarning) const
 {
     if (value == "angledown") return LINESTARTENDSYMBOL_angledown;
     if (value == "angleup") return LINESTARTENDSYMBOL_angleup;
@@ -1951,7 +1951,7 @@ data_LINESTARTENDSYMBOL AttConverter::StrToLinestartendsymbol(const std::string 
     return LINESTARTENDSYMBOL_NONE;
 }
 
-std::string AttConverter::LinewidthtermToStr(data_LINEWIDTHTERM data) const
+std::string AttConverterBase::LinewidthtermToStr(data_LINEWIDTHTERM data) const
 {
     std::string value;
     switch (data) {
@@ -1966,7 +1966,7 @@ std::string AttConverter::LinewidthtermToStr(data_LINEWIDTHTERM data) const
     return value;
 }
 
-data_LINEWIDTHTERM AttConverter::StrToLinewidthterm(const std::string &value, bool logWarning) const
+data_LINEWIDTHTERM AttConverterBase::StrToLinewidthterm(const std::string &value, bool logWarning) const
 {
     if (value == "narrow") return LINEWIDTHTERM_narrow;
     if (value == "medium") return LINEWIDTHTERM_medium;
@@ -1976,7 +1976,7 @@ data_LINEWIDTHTERM AttConverter::StrToLinewidthterm(const std::string &value, bo
     return LINEWIDTHTERM_NONE;
 }
 
-std::string AttConverter::MelodicfunctionToStr(data_MELODICFUNCTION data) const
+std::string AttConverterBase::MelodicfunctionToStr(data_MELODICFUNCTION data) const
 {
     std::string value;
     switch (data) {
@@ -2016,7 +2016,7 @@ std::string AttConverter::MelodicfunctionToStr(data_MELODICFUNCTION data) const
     return value;
 }
 
-data_MELODICFUNCTION AttConverter::StrToMelodicfunction(const std::string &value, bool logWarning) const
+data_MELODICFUNCTION AttConverterBase::StrToMelodicfunction(const std::string &value, bool logWarning) const
 {
     if (value == "aln") return MELODICFUNCTION_aln;
     if (value == "ant") return MELODICFUNCTION_ant;
@@ -2051,7 +2051,7 @@ data_MELODICFUNCTION AttConverter::StrToMelodicfunction(const std::string &value
     return MELODICFUNCTION_NONE;
 }
 
-std::string AttConverter::MensurationsignToStr(data_MENSURATIONSIGN data) const
+std::string AttConverterBase::MensurationsignToStr(data_MENSURATIONSIGN data) const
 {
     std::string value;
     switch (data) {
@@ -2078,7 +2078,7 @@ std::string AttConverter::MensurationsignToStr(data_MENSURATIONSIGN data) const
     return value;
 }
 
-data_MENSURATIONSIGN AttConverter::StrToMensurationsign(const std::string &value, bool logWarning) const
+data_MENSURATIONSIGN AttConverterBase::StrToMensurationsign(const std::string &value, bool logWarning) const
 {
     if (value == "C") return MENSURATIONSIGN_C;
     if (value == "O") return MENSURATIONSIGN_O;
@@ -2100,7 +2100,7 @@ data_MENSURATIONSIGN AttConverter::StrToMensurationsign(const std::string &value
     return MENSURATIONSIGN_NONE;
 }
 
-std::string AttConverter::MeterformToStr(data_METERFORM data) const
+std::string AttConverterBase::MeterformToStr(data_METERFORM data) const
 {
     std::string value;
     switch (data) {
@@ -2117,7 +2117,7 @@ std::string AttConverter::MeterformToStr(data_METERFORM data) const
     return value;
 }
 
-data_METERFORM AttConverter::StrToMeterform(const std::string &value, bool logWarning) const
+data_METERFORM AttConverterBase::StrToMeterform(const std::string &value, bool logWarning) const
 {
     if (value == "num") return METERFORM_num;
     if (value == "denomsym") return METERFORM_denomsym;
@@ -2129,7 +2129,7 @@ data_METERFORM AttConverter::StrToMeterform(const std::string &value, bool logWa
     return METERFORM_NONE;
 }
 
-std::string AttConverter::MetersignToStr(data_METERSIGN data) const
+std::string AttConverterBase::MetersignToStr(data_METERSIGN data) const
 {
     std::string value;
     switch (data) {
@@ -2144,7 +2144,7 @@ std::string AttConverter::MetersignToStr(data_METERSIGN data) const
     return value;
 }
 
-data_METERSIGN AttConverter::StrToMetersign(const std::string &value, bool logWarning) const
+data_METERSIGN AttConverterBase::StrToMetersign(const std::string &value, bool logWarning) const
 {
     if (value == "common") return METERSIGN_common;
     if (value == "cut") return METERSIGN_cut;
@@ -2154,7 +2154,7 @@ data_METERSIGN AttConverter::StrToMetersign(const std::string &value, bool logWa
     return METERSIGN_NONE;
 }
 
-std::string AttConverter::MidinamesToStr(data_MIDINAMES data) const
+std::string AttConverterBase::MidinamesToStr(data_MIDINAMES data) const
 {
     std::string value;
     switch (data) {
@@ -2341,7 +2341,7 @@ std::string AttConverter::MidinamesToStr(data_MIDINAMES data) const
     return value;
 }
 
-data_MIDINAMES AttConverter::StrToMidinames(const std::string &value, bool logWarning) const
+data_MIDINAMES AttConverterBase::StrToMidinames(const std::string &value, bool logWarning) const
 {
     if (value == "Acoustic_Grand_Piano") return MIDINAMES_Acoustic_Grand_Piano;
     if (value == "Bright_Acoustic_Piano") return MIDINAMES_Bright_Acoustic_Piano;
@@ -2523,7 +2523,7 @@ data_MIDINAMES AttConverter::StrToMidinames(const std::string &value, bool logWa
     return MIDINAMES_NONE;
 }
 
-std::string AttConverter::ModeToStr(data_MODE data) const
+std::string AttConverterBase::ModeToStr(data_MODE data) const
 {
     std::string value;
     switch (data) {
@@ -2552,7 +2552,7 @@ std::string AttConverter::ModeToStr(data_MODE data) const
     return value;
 }
 
-data_MODE AttConverter::StrToMode(const std::string &value, bool logWarning) const
+data_MODE AttConverterBase::StrToMode(const std::string &value, bool logWarning) const
 {
     if (value == "major") return MODE_major;
     if (value == "minor") return MODE_minor;
@@ -2576,7 +2576,7 @@ data_MODE AttConverter::StrToMode(const std::string &value, bool logWarning) con
     return MODE_NONE;
 }
 
-std::string AttConverter::ModeCmnToStr(data_MODE_cmn data) const
+std::string AttConverterBase::ModeCmnToStr(data_MODE_cmn data) const
 {
     std::string value;
     switch (data) {
@@ -2590,7 +2590,7 @@ std::string AttConverter::ModeCmnToStr(data_MODE_cmn data) const
     return value;
 }
 
-data_MODE_cmn AttConverter::StrToModeCmn(const std::string &value, bool logWarning) const
+data_MODE_cmn AttConverterBase::StrToModeCmn(const std::string &value, bool logWarning) const
 {
     if (value == "major") return MODE_cmn_major;
     if (value == "minor") return MODE_cmn_minor;
@@ -2599,7 +2599,7 @@ data_MODE_cmn AttConverter::StrToModeCmn(const std::string &value, bool logWarni
     return MODE_cmn_NONE;
 }
 
-std::string AttConverter::ModeExtendedToStr(data_MODE_extended data) const
+std::string AttConverterBase::ModeExtendedToStr(data_MODE_extended data) const
 {
     std::string value;
     switch (data) {
@@ -2617,7 +2617,7 @@ std::string AttConverter::ModeExtendedToStr(data_MODE_extended data) const
     return value;
 }
 
-data_MODE_extended AttConverter::StrToModeExtended(const std::string &value, bool logWarning) const
+data_MODE_extended AttConverterBase::StrToModeExtended(const std::string &value, bool logWarning) const
 {
     if (value == "ionian") return MODE_extended_ionian;
     if (value == "hypoionian") return MODE_extended_hypoionian;
@@ -2630,7 +2630,7 @@ data_MODE_extended AttConverter::StrToModeExtended(const std::string &value, boo
     return MODE_extended_NONE;
 }
 
-std::string AttConverter::ModeGregorianToStr(data_MODE_gregorian data) const
+std::string AttConverterBase::ModeGregorianToStr(data_MODE_gregorian data) const
 {
     std::string value;
     switch (data) {
@@ -2651,7 +2651,7 @@ std::string AttConverter::ModeGregorianToStr(data_MODE_gregorian data) const
     return value;
 }
 
-data_MODE_gregorian AttConverter::StrToModeGregorian(const std::string &value, bool logWarning) const
+data_MODE_gregorian AttConverterBase::StrToModeGregorian(const std::string &value, bool logWarning) const
 {
     if (value == "dorian") return MODE_gregorian_dorian;
     if (value == "hypodorian") return MODE_gregorian_hypodorian;
@@ -2667,7 +2667,7 @@ data_MODE_gregorian AttConverter::StrToModeGregorian(const std::string &value, b
     return MODE_gregorian_NONE;
 }
 
-std::string AttConverter::ModsrelationshipToStr(data_MODSRELATIONSHIP data) const
+std::string AttConverterBase::ModsrelationshipToStr(data_MODSRELATIONSHIP data) const
 {
     std::string value;
     switch (data) {
@@ -2688,7 +2688,7 @@ std::string AttConverter::ModsrelationshipToStr(data_MODSRELATIONSHIP data) cons
     return value;
 }
 
-data_MODSRELATIONSHIP AttConverter::StrToModsrelationship(const std::string &value, bool logWarning) const
+data_MODSRELATIONSHIP AttConverterBase::StrToModsrelationship(const std::string &value, bool logWarning) const
 {
     if (value == "preceding") return MODSRELATIONSHIP_preceding;
     if (value == "succeeding") return MODSRELATIONSHIP_succeeding;
@@ -2704,7 +2704,7 @@ data_MODSRELATIONSHIP AttConverter::StrToModsrelationship(const std::string &val
     return MODSRELATIONSHIP_NONE;
 }
 
-std::string AttConverter::MultibreverestsMensuralToStr(data_MULTIBREVERESTS_mensural data) const
+std::string AttConverterBase::MultibreverestsMensuralToStr(data_MULTIBREVERESTS_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -2718,7 +2718,7 @@ std::string AttConverter::MultibreverestsMensuralToStr(data_MULTIBREVERESTS_mens
     return value;
 }
 
-data_MULTIBREVERESTS_mensural AttConverter::StrToMultibreverestsMensural(const std::string &value, bool logWarning) const
+data_MULTIBREVERESTS_mensural AttConverterBase::StrToMultibreverestsMensural(const std::string &value, bool logWarning) const
 {
     if (value == "2B") return MULTIBREVERESTS_mensural_2B;
     if (value == "3B") return MULTIBREVERESTS_mensural_3B;
@@ -2727,7 +2727,7 @@ data_MULTIBREVERESTS_mensural AttConverter::StrToMultibreverestsMensural(const s
     return MULTIBREVERESTS_mensural_NONE;
 }
 
-std::string AttConverter::NeighboringlayerToStr(data_NEIGHBORINGLAYER data) const
+std::string AttConverterBase::NeighboringlayerToStr(data_NEIGHBORINGLAYER data) const
 {
     std::string value;
     switch (data) {
@@ -2741,7 +2741,7 @@ std::string AttConverter::NeighboringlayerToStr(data_NEIGHBORINGLAYER data) cons
     return value;
 }
 
-data_NEIGHBORINGLAYER AttConverter::StrToNeighboringlayer(const std::string &value, bool logWarning) const
+data_NEIGHBORINGLAYER AttConverterBase::StrToNeighboringlayer(const std::string &value, bool logWarning) const
 {
     if (value == "above") return NEIGHBORINGLAYER_above;
     if (value == "below") return NEIGHBORINGLAYER_below;
@@ -2750,7 +2750,7 @@ data_NEIGHBORINGLAYER AttConverter::StrToNeighboringlayer(const std::string &val
     return NEIGHBORINGLAYER_NONE;
 }
 
-std::string AttConverter::NonstaffplaceToStr(data_NONSTAFFPLACE data) const
+std::string AttConverterBase::NonstaffplaceToStr(data_NONSTAFFPLACE data) const
 {
     std::string value;
     switch (data) {
@@ -2775,7 +2775,7 @@ std::string AttConverter::NonstaffplaceToStr(data_NONSTAFFPLACE data) const
     return value;
 }
 
-data_NONSTAFFPLACE AttConverter::StrToNonstaffplace(const std::string &value, bool logWarning) const
+data_NONSTAFFPLACE AttConverterBase::StrToNonstaffplace(const std::string &value, bool logWarning) const
 {
     if (value == "botmar") return NONSTAFFPLACE_botmar;
     if (value == "topmar") return NONSTAFFPLACE_topmar;
@@ -2795,7 +2795,7 @@ data_NONSTAFFPLACE AttConverter::StrToNonstaffplace(const std::string &value, bo
     return NONSTAFFPLACE_NONE;
 }
 
-std::string AttConverter::NotationtypeToStr(data_NOTATIONTYPE data) const
+std::string AttConverterBase::NotationtypeToStr(data_NOTATIONTYPE data) const
 {
     std::string value;
     switch (data) {
@@ -2817,7 +2817,7 @@ std::string AttConverter::NotationtypeToStr(data_NOTATIONTYPE data) const
     return value;
 }
 
-data_NOTATIONTYPE AttConverter::StrToNotationtype(const std::string &value, bool logWarning) const
+data_NOTATIONTYPE AttConverterBase::StrToNotationtype(const std::string &value, bool logWarning) const
 {
     if (value == "cmn") return NOTATIONTYPE_cmn;
     if (value == "mensural") return NOTATIONTYPE_mensural;
@@ -2834,7 +2834,7 @@ data_NOTATIONTYPE AttConverter::StrToNotationtype(const std::string &value, bool
     return NOTATIONTYPE_NONE;
 }
 
-std::string AttConverter::NoteheadmodifierToStr(data_NOTEHEADMODIFIER data) const
+std::string AttConverterBase::NoteheadmodifierToStr(data_NOTEHEADMODIFIER data) const
 {
     std::string value;
     switch (data) {
@@ -2856,7 +2856,7 @@ std::string AttConverter::NoteheadmodifierToStr(data_NOTEHEADMODIFIER data) cons
     return value;
 }
 
-data_NOTEHEADMODIFIER AttConverter::StrToNoteheadmodifier(const std::string &value, bool logWarning) const
+data_NOTEHEADMODIFIER AttConverterBase::StrToNoteheadmodifier(const std::string &value, bool logWarning) const
 {
     if (value == "slash") return NOTEHEADMODIFIER_slash;
     if (value == "backslash") return NOTEHEADMODIFIER_backslash;
@@ -2873,7 +2873,7 @@ data_NOTEHEADMODIFIER AttConverter::StrToNoteheadmodifier(const std::string &val
     return NOTEHEADMODIFIER_NONE;
 }
 
-std::string AttConverter::NoteheadmodifierListToStr(data_NOTEHEADMODIFIER_list data) const
+std::string AttConverterBase::NoteheadmodifierListToStr(data_NOTEHEADMODIFIER_list data) const
 {
     std::string value;
     switch (data) {
@@ -2895,7 +2895,7 @@ std::string AttConverter::NoteheadmodifierListToStr(data_NOTEHEADMODIFIER_list d
     return value;
 }
 
-data_NOTEHEADMODIFIER_list AttConverter::StrToNoteheadmodifierList(const std::string &value, bool logWarning) const
+data_NOTEHEADMODIFIER_list AttConverterBase::StrToNoteheadmodifierList(const std::string &value, bool logWarning) const
 {
     if (value == "slash") return NOTEHEADMODIFIER_list_slash;
     if (value == "backslash") return NOTEHEADMODIFIER_list_backslash;
@@ -2912,7 +2912,7 @@ data_NOTEHEADMODIFIER_list AttConverter::StrToNoteheadmodifierList(const std::st
     return NOTEHEADMODIFIER_list_NONE;
 }
 
-std::string AttConverter::PedalstyleToStr(data_PEDALSTYLE data) const
+std::string AttConverterBase::PedalstyleToStr(data_PEDALSTYLE data) const
 {
     std::string value;
     switch (data) {
@@ -2928,7 +2928,7 @@ std::string AttConverter::PedalstyleToStr(data_PEDALSTYLE data) const
     return value;
 }
 
-data_PEDALSTYLE AttConverter::StrToPedalstyle(const std::string &value, bool logWarning) const
+data_PEDALSTYLE AttConverterBase::StrToPedalstyle(const std::string &value, bool logWarning) const
 {
     if (value == "line") return PEDALSTYLE_line;
     if (value == "pedline") return PEDALSTYLE_pedline;
@@ -2939,7 +2939,7 @@ data_PEDALSTYLE AttConverter::StrToPedalstyle(const std::string &value, bool log
     return PEDALSTYLE_NONE;
 }
 
-std::string AttConverter::PgfuncToStr(data_PGFUNC data) const
+std::string AttConverterBase::PgfuncToStr(data_PGFUNC data) const
 {
     std::string value;
     switch (data) {
@@ -2956,7 +2956,7 @@ std::string AttConverter::PgfuncToStr(data_PGFUNC data) const
     return value;
 }
 
-data_PGFUNC AttConverter::StrToPgfunc(const std::string &value, bool logWarning) const
+data_PGFUNC AttConverterBase::StrToPgfunc(const std::string &value, bool logWarning) const
 {
     if (value == "all") return PGFUNC_all;
     if (value == "first") return PGFUNC_first;
@@ -2968,7 +2968,7 @@ data_PGFUNC AttConverter::StrToPgfunc(const std::string &value, bool logWarning)
     return PGFUNC_NONE;
 }
 
-std::string AttConverter::RelationshipToStr(data_RELATIONSHIP data) const
+std::string AttConverterBase::RelationshipToStr(data_RELATIONSHIP data) const
 {
     std::string value;
     switch (data) {
@@ -3025,7 +3025,7 @@ std::string AttConverter::RelationshipToStr(data_RELATIONSHIP data) const
     return value;
 }
 
-data_RELATIONSHIP AttConverter::StrToRelationship(const std::string &value, bool logWarning) const
+data_RELATIONSHIP AttConverterBase::StrToRelationship(const std::string &value, bool logWarning) const
 {
     if (value == "hasAbridgement") return RELATIONSHIP_hasAbridgement;
     if (value == "isAbridgementOf") return RELATIONSHIP_isAbridgementOf;
@@ -3077,7 +3077,7 @@ data_RELATIONSHIP AttConverter::StrToRelationship(const std::string &value, bool
     return RELATIONSHIP_NONE;
 }
 
-std::string AttConverter::RotationToStr(data_ROTATION data) const
+std::string AttConverterBase::RotationToStr(data_ROTATION data) const
 {
     std::string value;
     switch (data) {
@@ -3096,7 +3096,7 @@ std::string AttConverter::RotationToStr(data_ROTATION data) const
     return value;
 }
 
-data_ROTATION AttConverter::StrToRotation(const std::string &value, bool logWarning) const
+data_ROTATION AttConverterBase::StrToRotation(const std::string &value, bool logWarning) const
 {
     if (value == "none") return ROTATION_none;
     if (value == "down") return ROTATION_down;
@@ -3110,7 +3110,7 @@ data_ROTATION AttConverter::StrToRotation(const std::string &value, bool logWarn
     return ROTATION_NONE;
 }
 
-std::string AttConverter::RotationdirectionToStr(data_ROTATIONDIRECTION data) const
+std::string AttConverterBase::RotationdirectionToStr(data_ROTATIONDIRECTION data) const
 {
     std::string value;
     switch (data) {
@@ -3129,7 +3129,7 @@ std::string AttConverter::RotationdirectionToStr(data_ROTATIONDIRECTION data) co
     return value;
 }
 
-data_ROTATIONDIRECTION AttConverter::StrToRotationdirection(const std::string &value, bool logWarning) const
+data_ROTATIONDIRECTION AttConverterBase::StrToRotationdirection(const std::string &value, bool logWarning) const
 {
     if (value == "none") return ROTATIONDIRECTION_none;
     if (value == "down") return ROTATIONDIRECTION_down;
@@ -3143,7 +3143,7 @@ data_ROTATIONDIRECTION AttConverter::StrToRotationdirection(const std::string &v
     return ROTATIONDIRECTION_NONE;
 }
 
-std::string AttConverter::StaffitemToStr(data_STAFFITEM data) const
+std::string AttConverterBase::StaffitemToStr(data_STAFFITEM data) const
 {
     std::string value;
     switch (data) {
@@ -3184,7 +3184,7 @@ std::string AttConverter::StaffitemToStr(data_STAFFITEM data) const
     return value;
 }
 
-data_STAFFITEM AttConverter::StrToStaffitem(const std::string &value, bool logWarning) const
+data_STAFFITEM AttConverterBase::StrToStaffitem(const std::string &value, bool logWarning) const
 {
     if (value == "accid") return STAFFITEM_accid;
     if (value == "annot") return STAFFITEM_annot;
@@ -3220,7 +3220,7 @@ data_STAFFITEM AttConverter::StrToStaffitem(const std::string &value, bool logWa
     return STAFFITEM_NONE;
 }
 
-std::string AttConverter::StaffitemBasicToStr(data_STAFFITEM_basic data) const
+std::string AttConverterBase::StaffitemBasicToStr(data_STAFFITEM_basic data) const
 {
     std::string value;
     switch (data) {
@@ -3242,7 +3242,7 @@ std::string AttConverter::StaffitemBasicToStr(data_STAFFITEM_basic data) const
     return value;
 }
 
-data_STAFFITEM_basic AttConverter::StrToStaffitemBasic(const std::string &value, bool logWarning) const
+data_STAFFITEM_basic AttConverterBase::StrToStaffitemBasic(const std::string &value, bool logWarning) const
 {
     if (value == "accid") return STAFFITEM_basic_accid;
     if (value == "annot") return STAFFITEM_basic_annot;
@@ -3259,7 +3259,7 @@ data_STAFFITEM_basic AttConverter::StrToStaffitemBasic(const std::string &value,
     return STAFFITEM_basic_NONE;
 }
 
-std::string AttConverter::StaffitemCmnToStr(data_STAFFITEM_cmn data) const
+std::string AttConverterBase::StaffitemCmnToStr(data_STAFFITEM_cmn data) const
 {
     std::string value;
     switch (data) {
@@ -3289,7 +3289,7 @@ std::string AttConverter::StaffitemCmnToStr(data_STAFFITEM_cmn data) const
     return value;
 }
 
-data_STAFFITEM_cmn AttConverter::StrToStaffitemCmn(const std::string &value, bool logWarning) const
+data_STAFFITEM_cmn AttConverterBase::StrToStaffitemCmn(const std::string &value, bool logWarning) const
 {
     if (value == "beam") return STAFFITEM_cmn_beam;
     if (value == "bend") return STAFFITEM_cmn_bend;
@@ -3314,7 +3314,7 @@ data_STAFFITEM_cmn AttConverter::StrToStaffitemCmn(const std::string &value, boo
     return STAFFITEM_cmn_NONE;
 }
 
-std::string AttConverter::StaffitemMensuralToStr(data_STAFFITEM_mensural data) const
+std::string AttConverterBase::StaffitemMensuralToStr(data_STAFFITEM_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -3327,7 +3327,7 @@ std::string AttConverter::StaffitemMensuralToStr(data_STAFFITEM_mensural data) c
     return value;
 }
 
-data_STAFFITEM_mensural AttConverter::StrToStaffitemMensural(const std::string &value, bool logWarning) const
+data_STAFFITEM_mensural AttConverterBase::StrToStaffitemMensural(const std::string &value, bool logWarning) const
 {
     if (value == "ligature") return STAFFITEM_mensural_ligature;
     if (logWarning && !value.empty())
@@ -3335,7 +3335,7 @@ data_STAFFITEM_mensural AttConverter::StrToStaffitemMensural(const std::string &
     return STAFFITEM_mensural_NONE;
 }
 
-std::string AttConverter::StaffrelToStr(data_STAFFREL data) const
+std::string AttConverterBase::StaffrelToStr(data_STAFFREL data) const
 {
     std::string value;
     switch (data) {
@@ -3351,7 +3351,7 @@ std::string AttConverter::StaffrelToStr(data_STAFFREL data) const
     return value;
 }
 
-data_STAFFREL AttConverter::StrToStaffrel(const std::string &value, bool logWarning) const
+data_STAFFREL AttConverterBase::StrToStaffrel(const std::string &value, bool logWarning) const
 {
     if (value == "above") return STAFFREL_above;
     if (value == "below") return STAFFREL_below;
@@ -3362,7 +3362,7 @@ data_STAFFREL AttConverter::StrToStaffrel(const std::string &value, bool logWarn
     return STAFFREL_NONE;
 }
 
-std::string AttConverter::StaffrelBasicToStr(data_STAFFREL_basic data) const
+std::string AttConverterBase::StaffrelBasicToStr(data_STAFFREL_basic data) const
 {
     std::string value;
     switch (data) {
@@ -3376,7 +3376,7 @@ std::string AttConverter::StaffrelBasicToStr(data_STAFFREL_basic data) const
     return value;
 }
 
-data_STAFFREL_basic AttConverter::StrToStaffrelBasic(const std::string &value, bool logWarning) const
+data_STAFFREL_basic AttConverterBase::StrToStaffrelBasic(const std::string &value, bool logWarning) const
 {
     if (value == "above") return STAFFREL_basic_above;
     if (value == "below") return STAFFREL_basic_below;
@@ -3385,7 +3385,7 @@ data_STAFFREL_basic AttConverter::StrToStaffrelBasic(const std::string &value, b
     return STAFFREL_basic_NONE;
 }
 
-std::string AttConverter::StaffrelExtendedToStr(data_STAFFREL_extended data) const
+std::string AttConverterBase::StaffrelExtendedToStr(data_STAFFREL_extended data) const
 {
     std::string value;
     switch (data) {
@@ -3399,7 +3399,7 @@ std::string AttConverter::StaffrelExtendedToStr(data_STAFFREL_extended data) con
     return value;
 }
 
-data_STAFFREL_extended AttConverter::StrToStaffrelExtended(const std::string &value, bool logWarning) const
+data_STAFFREL_extended AttConverterBase::StrToStaffrelExtended(const std::string &value, bool logWarning) const
 {
     if (value == "between") return STAFFREL_extended_between;
     if (value == "within") return STAFFREL_extended_within;
@@ -3408,7 +3408,7 @@ data_STAFFREL_extended AttConverter::StrToStaffrelExtended(const std::string &va
     return STAFFREL_extended_NONE;
 }
 
-std::string AttConverter::StemdirectionToStr(data_STEMDIRECTION data) const
+std::string AttConverterBase::StemdirectionToStr(data_STEMDIRECTION data) const
 {
     std::string value;
     switch (data) {
@@ -3428,7 +3428,7 @@ std::string AttConverter::StemdirectionToStr(data_STEMDIRECTION data) const
     return value;
 }
 
-data_STEMDIRECTION AttConverter::StrToStemdirection(const std::string &value, bool logWarning) const
+data_STEMDIRECTION AttConverterBase::StrToStemdirection(const std::string &value, bool logWarning) const
 {
     if (value == "up") return STEMDIRECTION_up;
     if (value == "down") return STEMDIRECTION_down;
@@ -3443,7 +3443,7 @@ data_STEMDIRECTION AttConverter::StrToStemdirection(const std::string &value, bo
     return STEMDIRECTION_NONE;
 }
 
-std::string AttConverter::StemdirectionBasicToStr(data_STEMDIRECTION_basic data) const
+std::string AttConverterBase::StemdirectionBasicToStr(data_STEMDIRECTION_basic data) const
 {
     std::string value;
     switch (data) {
@@ -3457,7 +3457,7 @@ std::string AttConverter::StemdirectionBasicToStr(data_STEMDIRECTION_basic data)
     return value;
 }
 
-data_STEMDIRECTION_basic AttConverter::StrToStemdirectionBasic(const std::string &value, bool logWarning) const
+data_STEMDIRECTION_basic AttConverterBase::StrToStemdirectionBasic(const std::string &value, bool logWarning) const
 {
     if (value == "up") return STEMDIRECTION_basic_up;
     if (value == "down") return STEMDIRECTION_basic_down;
@@ -3466,7 +3466,7 @@ data_STEMDIRECTION_basic AttConverter::StrToStemdirectionBasic(const std::string
     return STEMDIRECTION_basic_NONE;
 }
 
-std::string AttConverter::StemdirectionExtendedToStr(data_STEMDIRECTION_extended data) const
+std::string AttConverterBase::StemdirectionExtendedToStr(data_STEMDIRECTION_extended data) const
 {
     std::string value;
     switch (data) {
@@ -3484,7 +3484,7 @@ std::string AttConverter::StemdirectionExtendedToStr(data_STEMDIRECTION_extended
     return value;
 }
 
-data_STEMDIRECTION_extended AttConverter::StrToStemdirectionExtended(const std::string &value, bool logWarning) const
+data_STEMDIRECTION_extended AttConverterBase::StrToStemdirectionExtended(const std::string &value, bool logWarning) const
 {
     if (value == "left") return STEMDIRECTION_extended_left;
     if (value == "right") return STEMDIRECTION_extended_right;
@@ -3497,7 +3497,7 @@ data_STEMDIRECTION_extended AttConverter::StrToStemdirectionExtended(const std::
     return STEMDIRECTION_extended_NONE;
 }
 
-std::string AttConverter::StemformMensuralToStr(data_STEMFORM_mensural data) const
+std::string AttConverterBase::StemformMensuralToStr(data_STEMFORM_mensural data) const
 {
     std::string value;
     switch (data) {
@@ -3513,7 +3513,7 @@ std::string AttConverter::StemformMensuralToStr(data_STEMFORM_mensural data) con
     return value;
 }
 
-data_STEMFORM_mensural AttConverter::StrToStemformMensural(const std::string &value, bool logWarning) const
+data_STEMFORM_mensural AttConverterBase::StrToStemformMensural(const std::string &value, bool logWarning) const
 {
     if (value == "circle") return STEMFORM_mensural_circle;
     if (value == "oblique") return STEMFORM_mensural_oblique;
@@ -3524,7 +3524,7 @@ data_STEMFORM_mensural AttConverter::StrToStemformMensural(const std::string &va
     return STEMFORM_mensural_NONE;
 }
 
-std::string AttConverter::StemmodifierToStr(data_STEMMODIFIER data) const
+std::string AttConverterBase::StemmodifierToStr(data_STEMMODIFIER data) const
 {
     std::string value;
     switch (data) {
@@ -3545,7 +3545,7 @@ std::string AttConverter::StemmodifierToStr(data_STEMMODIFIER data) const
     return value;
 }
 
-data_STEMMODIFIER AttConverter::StrToStemmodifier(const std::string &value, bool logWarning) const
+data_STEMMODIFIER AttConverterBase::StrToStemmodifier(const std::string &value, bool logWarning) const
 {
     if (value == "none") return STEMMODIFIER_none;
     if (value == "1slash") return STEMMODIFIER_1slash;
@@ -3561,7 +3561,7 @@ data_STEMMODIFIER AttConverter::StrToStemmodifier(const std::string &value, bool
     return STEMMODIFIER_NONE;
 }
 
-std::string AttConverter::StempositionToStr(data_STEMPOSITION data) const
+std::string AttConverterBase::StempositionToStr(data_STEMPOSITION data) const
 {
     std::string value;
     switch (data) {
@@ -3576,7 +3576,7 @@ std::string AttConverter::StempositionToStr(data_STEMPOSITION data) const
     return value;
 }
 
-data_STEMPOSITION AttConverter::StrToStemposition(const std::string &value, bool logWarning) const
+data_STEMPOSITION AttConverterBase::StrToStemposition(const std::string &value, bool logWarning) const
 {
     if (value == "left") return STEMPOSITION_left;
     if (value == "right") return STEMPOSITION_right;
@@ -3586,7 +3586,7 @@ data_STEMPOSITION AttConverter::StrToStemposition(const std::string &value, bool
     return STEMPOSITION_NONE;
 }
 
-std::string AttConverter::TemperamentToStr(data_TEMPERAMENT data) const
+std::string AttConverterBase::TemperamentToStr(data_TEMPERAMENT data) const
 {
     std::string value;
     switch (data) {
@@ -3602,7 +3602,7 @@ std::string AttConverter::TemperamentToStr(data_TEMPERAMENT data) const
     return value;
 }
 
-data_TEMPERAMENT AttConverter::StrToTemperament(const std::string &value, bool logWarning) const
+data_TEMPERAMENT AttConverterBase::StrToTemperament(const std::string &value, bool logWarning) const
 {
     if (value == "equal") return TEMPERAMENT_equal;
     if (value == "just") return TEMPERAMENT_just;
@@ -3613,7 +3613,7 @@ data_TEMPERAMENT AttConverter::StrToTemperament(const std::string &value, bool l
     return TEMPERAMENT_NONE;
 }
 
-std::string AttConverter::TextrenditionToStr(data_TEXTRENDITION data) const
+std::string AttConverterBase::TextrenditionToStr(data_TEXTRENDITION data) const
 {
     std::string value;
     switch (data) {
@@ -3653,7 +3653,7 @@ std::string AttConverter::TextrenditionToStr(data_TEXTRENDITION data) const
     return value;
 }
 
-data_TEXTRENDITION AttConverter::StrToTextrendition(const std::string &value, bool logWarning) const
+data_TEXTRENDITION AttConverterBase::StrToTextrendition(const std::string &value, bool logWarning) const
 {
     if (value == "quote") return TEXTRENDITION_quote;
     if (value == "quotedbl") return TEXTRENDITION_quotedbl;
@@ -3688,7 +3688,7 @@ data_TEXTRENDITION AttConverter::StrToTextrendition(const std::string &value, bo
     return TEXTRENDITION_NONE;
 }
 
-std::string AttConverter::TextrenditionlistToStr(data_TEXTRENDITIONLIST data) const
+std::string AttConverterBase::TextrenditionlistToStr(data_TEXTRENDITIONLIST data) const
 {
     std::string value;
     switch (data) {
@@ -3728,7 +3728,7 @@ std::string AttConverter::TextrenditionlistToStr(data_TEXTRENDITIONLIST data) co
     return value;
 }
 
-data_TEXTRENDITIONLIST AttConverter::StrToTextrenditionlist(const std::string &value, bool logWarning) const
+data_TEXTRENDITIONLIST AttConverterBase::StrToTextrenditionlist(const std::string &value, bool logWarning) const
 {
     if (value == "quote") return TEXTRENDITIONLIST_quote;
     if (value == "quotedbl") return TEXTRENDITIONLIST_quotedbl;
@@ -3763,7 +3763,7 @@ data_TEXTRENDITIONLIST AttConverter::StrToTextrenditionlist(const std::string &v
     return TEXTRENDITIONLIST_NONE;
 }
 
-std::string AttConverter::VerticalalignmentToStr(data_VERTICALALIGNMENT data) const
+std::string AttConverterBase::VerticalalignmentToStr(data_VERTICALALIGNMENT data) const
 {
     std::string value;
     switch (data) {
@@ -3779,7 +3779,7 @@ std::string AttConverter::VerticalalignmentToStr(data_VERTICALALIGNMENT data) co
     return value;
 }
 
-data_VERTICALALIGNMENT AttConverter::StrToVerticalalignment(const std::string &value, bool logWarning) const
+data_VERTICALALIGNMENT AttConverterBase::StrToVerticalalignment(const std::string &value, bool logWarning) const
 {
     if (value == "top") return VERTICALALIGNMENT_top;
     if (value == "middle") return VERTICALALIGNMENT_middle;
@@ -3790,7 +3790,7 @@ data_VERTICALALIGNMENT AttConverter::StrToVerticalalignment(const std::string &v
     return VERTICALALIGNMENT_NONE;
 }
 
-std::string AttConverter::AccidLogFuncToStr(accidLog_FUNC data) const
+std::string AttConverterBase::AccidLogFuncToStr(accidLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -3804,7 +3804,7 @@ std::string AttConverter::AccidLogFuncToStr(accidLog_FUNC data) const
     return value;
 }
 
-accidLog_FUNC AttConverter::StrToAccidLogFunc(const std::string &value, bool logWarning) const
+accidLog_FUNC AttConverterBase::StrToAccidLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "caution") return accidLog_FUNC_caution;
     if (value == "edit") return accidLog_FUNC_edit;
@@ -3813,7 +3813,7 @@ accidLog_FUNC AttConverter::StrToAccidLogFunc(const std::string &value, bool log
     return accidLog_FUNC_NONE;
 }
 
-std::string AttConverter::AnchoredTextLogFuncToStr(anchoredTextLog_FUNC data) const
+std::string AttConverterBase::AnchoredTextLogFuncToStr(anchoredTextLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -3826,7 +3826,7 @@ std::string AttConverter::AnchoredTextLogFuncToStr(anchoredTextLog_FUNC data) co
     return value;
 }
 
-anchoredTextLog_FUNC AttConverter::StrToAnchoredTextLogFunc(const std::string &value, bool logWarning) const
+anchoredTextLog_FUNC AttConverterBase::StrToAnchoredTextLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "unknown") return anchoredTextLog_FUNC_unknown;
     if (logWarning && !value.empty())
@@ -3834,7 +3834,7 @@ anchoredTextLog_FUNC AttConverter::StrToAnchoredTextLogFunc(const std::string &v
     return anchoredTextLog_FUNC_NONE;
 }
 
-std::string AttConverter::ArpegLogOrderToStr(arpegLog_ORDER data) const
+std::string AttConverterBase::ArpegLogOrderToStr(arpegLog_ORDER data) const
 {
     std::string value;
     switch (data) {
@@ -3849,7 +3849,7 @@ std::string AttConverter::ArpegLogOrderToStr(arpegLog_ORDER data) const
     return value;
 }
 
-arpegLog_ORDER AttConverter::StrToArpegLogOrder(const std::string &value, bool logWarning) const
+arpegLog_ORDER AttConverterBase::StrToArpegLogOrder(const std::string &value, bool logWarning) const
 {
     if (value == "up") return arpegLog_ORDER_up;
     if (value == "down") return arpegLog_ORDER_down;
@@ -3859,7 +3859,7 @@ arpegLog_ORDER AttConverter::StrToArpegLogOrder(const std::string &value, bool l
     return arpegLog_ORDER_NONE;
 }
 
-std::string AttConverter::AudienceAudienceToStr(audience_AUDIENCE data) const
+std::string AttConverterBase::AudienceAudienceToStr(audience_AUDIENCE data) const
 {
     std::string value;
     switch (data) {
@@ -3873,7 +3873,7 @@ std::string AttConverter::AudienceAudienceToStr(audience_AUDIENCE data) const
     return value;
 }
 
-audience_AUDIENCE AttConverter::StrToAudienceAudience(const std::string &value, bool logWarning) const
+audience_AUDIENCE AttConverterBase::StrToAudienceAudience(const std::string &value, bool logWarning) const
 {
     if (value == "private") return audience_AUDIENCE_private;
     if (value == "public") return audience_AUDIENCE_public;
@@ -3882,7 +3882,7 @@ audience_AUDIENCE AttConverter::StrToAudienceAudience(const std::string &value, 
     return audience_AUDIENCE_NONE;
 }
 
-std::string AttConverter::BTremLogFormToStr(bTremLog_FORM data) const
+std::string AttConverterBase::BTremLogFormToStr(bTremLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -3896,7 +3896,7 @@ std::string AttConverter::BTremLogFormToStr(bTremLog_FORM data) const
     return value;
 }
 
-bTremLog_FORM AttConverter::StrToBTremLogForm(const std::string &value, bool logWarning) const
+bTremLog_FORM AttConverterBase::StrToBTremLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "meas") return bTremLog_FORM_meas;
     if (value == "unmeas") return bTremLog_FORM_unmeas;
@@ -3905,7 +3905,7 @@ bTremLog_FORM AttConverter::StrToBTremLogForm(const std::string &value, bool log
     return bTremLog_FORM_NONE;
 }
 
-std::string AttConverter::BeamRendFormToStr(beamRend_FORM data) const
+std::string AttConverterBase::BeamRendFormToStr(beamRend_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -3921,7 +3921,7 @@ std::string AttConverter::BeamRendFormToStr(beamRend_FORM data) const
     return value;
 }
 
-beamRend_FORM AttConverter::StrToBeamRendForm(const std::string &value, bool logWarning) const
+beamRend_FORM AttConverterBase::StrToBeamRendForm(const std::string &value, bool logWarning) const
 {
     if (value == "acc") return beamRend_FORM_acc;
     if (value == "mixed") return beamRend_FORM_mixed;
@@ -3932,7 +3932,7 @@ beamRend_FORM AttConverter::StrToBeamRendForm(const std::string &value, bool log
     return beamRend_FORM_NONE;
 }
 
-std::string AttConverter::BeamingVisBeamrendToStr(beamingVis_BEAMREND data) const
+std::string AttConverterBase::BeamingVisBeamrendToStr(beamingVis_BEAMREND data) const
 {
     std::string value;
     switch (data) {
@@ -3947,7 +3947,7 @@ std::string AttConverter::BeamingVisBeamrendToStr(beamingVis_BEAMREND data) cons
     return value;
 }
 
-beamingVis_BEAMREND AttConverter::StrToBeamingVisBeamrend(const std::string &value, bool logWarning) const
+beamingVis_BEAMREND AttConverterBase::StrToBeamingVisBeamrend(const std::string &value, bool logWarning) const
 {
     if (value == "acc") return beamingVis_BEAMREND_acc;
     if (value == "rit") return beamingVis_BEAMREND_rit;
@@ -3957,7 +3957,7 @@ beamingVis_BEAMREND AttConverter::StrToBeamingVisBeamrend(const std::string &val
     return beamingVis_BEAMREND_NONE;
 }
 
-std::string AttConverter::BracketSpanLogFuncToStr(bracketSpanLog_FUNC data) const
+std::string AttConverterBase::BracketSpanLogFuncToStr(bracketSpanLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -3972,7 +3972,7 @@ std::string AttConverter::BracketSpanLogFuncToStr(bracketSpanLog_FUNC data) cons
     return value;
 }
 
-bracketSpanLog_FUNC AttConverter::StrToBracketSpanLogFunc(const std::string &value, bool logWarning) const
+bracketSpanLog_FUNC AttConverterBase::StrToBracketSpanLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "coloration") return bracketSpanLog_FUNC_coloration;
     if (value == "cross-rhythm") return bracketSpanLog_FUNC_cross_rhythm;
@@ -3982,7 +3982,7 @@ bracketSpanLog_FUNC AttConverter::StrToBracketSpanLogFunc(const std::string &val
     return bracketSpanLog_FUNC_NONE;
 }
 
-std::string AttConverter::CurvatureCurvedirToStr(curvature_CURVEDIR data) const
+std::string AttConverterBase::CurvatureCurvedirToStr(curvature_CURVEDIR data) const
 {
     std::string value;
     switch (data) {
@@ -3997,7 +3997,7 @@ std::string AttConverter::CurvatureCurvedirToStr(curvature_CURVEDIR data) const
     return value;
 }
 
-curvature_CURVEDIR AttConverter::StrToCurvatureCurvedir(const std::string &value, bool logWarning) const
+curvature_CURVEDIR AttConverterBase::StrToCurvatureCurvedir(const std::string &value, bool logWarning) const
 {
     if (value == "above") return curvature_CURVEDIR_above;
     if (value == "below") return curvature_CURVEDIR_below;
@@ -4007,7 +4007,7 @@ curvature_CURVEDIR AttConverter::StrToCurvatureCurvedir(const std::string &value
     return curvature_CURVEDIR_NONE;
 }
 
-std::string AttConverter::CurveLogFuncToStr(curveLog_FUNC data) const
+std::string AttConverterBase::CurveLogFuncToStr(curveLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -4020,7 +4020,7 @@ std::string AttConverter::CurveLogFuncToStr(curveLog_FUNC data) const
     return value;
 }
 
-curveLog_FUNC AttConverter::StrToCurveLogFunc(const std::string &value, bool logWarning) const
+curveLog_FUNC AttConverterBase::StrToCurveLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "unknown") return curveLog_FUNC_unknown;
     if (logWarning && !value.empty())
@@ -4028,7 +4028,7 @@ curveLog_FUNC AttConverter::StrToCurveLogFunc(const std::string &value, bool log
     return curveLog_FUNC_NONE;
 }
 
-std::string AttConverter::CutoutCutoutToStr(cutout_CUTOUT data) const
+std::string AttConverterBase::CutoutCutoutToStr(cutout_CUTOUT data) const
 {
     std::string value;
     switch (data) {
@@ -4041,7 +4041,7 @@ std::string AttConverter::CutoutCutoutToStr(cutout_CUTOUT data) const
     return value;
 }
 
-cutout_CUTOUT AttConverter::StrToCutoutCutout(const std::string &value, bool logWarning) const
+cutout_CUTOUT AttConverterBase::StrToCutoutCutout(const std::string &value, bool logWarning) const
 {
     if (value == "cutout") return cutout_CUTOUT_cutout;
     if (logWarning && !value.empty())
@@ -4049,7 +4049,7 @@ cutout_CUTOUT AttConverter::StrToCutoutCutout(const std::string &value, bool log
     return cutout_CUTOUT_NONE;
 }
 
-std::string AttConverter::DotLogFormToStr(dotLog_FORM data) const
+std::string AttConverterBase::DotLogFormToStr(dotLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4063,7 +4063,7 @@ std::string AttConverter::DotLogFormToStr(dotLog_FORM data) const
     return value;
 }
 
-dotLog_FORM AttConverter::StrToDotLogForm(const std::string &value, bool logWarning) const
+dotLog_FORM AttConverterBase::StrToDotLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "aug") return dotLog_FORM_aug;
     if (value == "div") return dotLog_FORM_div;
@@ -4072,7 +4072,7 @@ dotLog_FORM AttConverter::StrToDotLogForm(const std::string &value, bool logWarn
     return dotLog_FORM_NONE;
 }
 
-std::string AttConverter::EndingsEndingrendToStr(endings_ENDINGREND data) const
+std::string AttConverterBase::EndingsEndingrendToStr(endings_ENDINGREND data) const
 {
     std::string value;
     switch (data) {
@@ -4087,7 +4087,7 @@ std::string AttConverter::EndingsEndingrendToStr(endings_ENDINGREND data) const
     return value;
 }
 
-endings_ENDINGREND AttConverter::StrToEndingsEndingrend(const std::string &value, bool logWarning) const
+endings_ENDINGREND AttConverterBase::StrToEndingsEndingrend(const std::string &value, bool logWarning) const
 {
     if (value == "top") return endings_ENDINGREND_top;
     if (value == "barred") return endings_ENDINGREND_barred;
@@ -4097,7 +4097,7 @@ endings_ENDINGREND AttConverter::StrToEndingsEndingrend(const std::string &value
     return endings_ENDINGREND_NONE;
 }
 
-std::string AttConverter::EpisemaVisFormToStr(episemaVis_FORM data) const
+std::string AttConverterBase::EpisemaVisFormToStr(episemaVis_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4111,7 +4111,7 @@ std::string AttConverter::EpisemaVisFormToStr(episemaVis_FORM data) const
     return value;
 }
 
-episemaVis_FORM AttConverter::StrToEpisemaVisForm(const std::string &value, bool logWarning) const
+episemaVis_FORM AttConverterBase::StrToEpisemaVisForm(const std::string &value, bool logWarning) const
 {
     if (value == "h") return episemaVis_FORM_h;
     if (value == "v") return episemaVis_FORM_v;
@@ -4120,7 +4120,7 @@ episemaVis_FORM AttConverter::StrToEpisemaVisForm(const std::string &value, bool
     return episemaVis_FORM_NONE;
 }
 
-std::string AttConverter::EvidenceEvidenceToStr(evidence_EVIDENCE data) const
+std::string AttConverterBase::EvidenceEvidenceToStr(evidence_EVIDENCE data) const
 {
     std::string value;
     switch (data) {
@@ -4135,7 +4135,7 @@ std::string AttConverter::EvidenceEvidenceToStr(evidence_EVIDENCE data) const
     return value;
 }
 
-evidence_EVIDENCE AttConverter::StrToEvidenceEvidence(const std::string &value, bool logWarning) const
+evidence_EVIDENCE AttConverterBase::StrToEvidenceEvidence(const std::string &value, bool logWarning) const
 {
     if (value == "internal") return evidence_EVIDENCE_internal;
     if (value == "external") return evidence_EVIDENCE_external;
@@ -4145,7 +4145,7 @@ evidence_EVIDENCE AttConverter::StrToEvidenceEvidence(const std::string &value, 
     return evidence_EVIDENCE_NONE;
 }
 
-std::string AttConverter::ExtSymGlyphauthToStr(extSym_GLYPHAUTH data) const
+std::string AttConverterBase::ExtSymGlyphauthToStr(extSym_GLYPHAUTH data) const
 {
     std::string value;
     switch (data) {
@@ -4158,7 +4158,7 @@ std::string AttConverter::ExtSymGlyphauthToStr(extSym_GLYPHAUTH data) const
     return value;
 }
 
-extSym_GLYPHAUTH AttConverter::StrToExtSymGlyphauth(const std::string &value, bool logWarning) const
+extSym_GLYPHAUTH AttConverterBase::StrToExtSymGlyphauth(const std::string &value, bool logWarning) const
 {
     if (value == "smufl") return extSym_GLYPHAUTH_smufl;
     if (logWarning && !value.empty())
@@ -4166,7 +4166,7 @@ extSym_GLYPHAUTH AttConverter::StrToExtSymGlyphauth(const std::string &value, bo
     return extSym_GLYPHAUTH_NONE;
 }
 
-std::string AttConverter::FTremLogFormToStr(fTremLog_FORM data) const
+std::string AttConverterBase::FTremLogFormToStr(fTremLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4180,7 +4180,7 @@ std::string AttConverter::FTremLogFormToStr(fTremLog_FORM data) const
     return value;
 }
 
-fTremLog_FORM AttConverter::StrToFTremLogForm(const std::string &value, bool logWarning) const
+fTremLog_FORM AttConverterBase::StrToFTremLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "meas") return fTremLog_FORM_meas;
     if (value == "unmeas") return fTremLog_FORM_unmeas;
@@ -4189,7 +4189,7 @@ fTremLog_FORM AttConverter::StrToFTremLogForm(const std::string &value, bool log
     return fTremLog_FORM_NONE;
 }
 
-std::string AttConverter::FermataVisFormToStr(fermataVis_FORM data) const
+std::string AttConverterBase::FermataVisFormToStr(fermataVis_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4203,7 +4203,7 @@ std::string AttConverter::FermataVisFormToStr(fermataVis_FORM data) const
     return value;
 }
 
-fermataVis_FORM AttConverter::StrToFermataVisForm(const std::string &value, bool logWarning) const
+fermataVis_FORM AttConverterBase::StrToFermataVisForm(const std::string &value, bool logWarning) const
 {
     if (value == "inv") return fermataVis_FORM_inv;
     if (value == "norm") return fermataVis_FORM_norm;
@@ -4212,7 +4212,7 @@ fermataVis_FORM AttConverter::StrToFermataVisForm(const std::string &value, bool
     return fermataVis_FORM_NONE;
 }
 
-std::string AttConverter::FermataVisShapeToStr(fermataVis_SHAPE data) const
+std::string AttConverterBase::FermataVisShapeToStr(fermataVis_SHAPE data) const
 {
     std::string value;
     switch (data) {
@@ -4227,7 +4227,7 @@ std::string AttConverter::FermataVisShapeToStr(fermataVis_SHAPE data) const
     return value;
 }
 
-fermataVis_SHAPE AttConverter::StrToFermataVisShape(const std::string &value, bool logWarning) const
+fermataVis_SHAPE AttConverterBase::StrToFermataVisShape(const std::string &value, bool logWarning) const
 {
     if (value == "curved") return fermataVis_SHAPE_curved;
     if (value == "square") return fermataVis_SHAPE_square;
@@ -4237,7 +4237,7 @@ fermataVis_SHAPE AttConverter::StrToFermataVisShape(const std::string &value, bo
     return fermataVis_SHAPE_NONE;
 }
 
-std::string AttConverter::FingGrpLogFormToStr(fingGrpLog_FORM data) const
+std::string AttConverterBase::FingGrpLogFormToStr(fingGrpLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4252,7 +4252,7 @@ std::string AttConverter::FingGrpLogFormToStr(fingGrpLog_FORM data) const
     return value;
 }
 
-fingGrpLog_FORM AttConverter::StrToFingGrpLogForm(const std::string &value, bool logWarning) const
+fingGrpLog_FORM AttConverterBase::StrToFingGrpLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "alter") return fingGrpLog_FORM_alter;
     if (value == "combi") return fingGrpLog_FORM_combi;
@@ -4262,7 +4262,7 @@ fingGrpLog_FORM AttConverter::StrToFingGrpLogForm(const std::string &value, bool
     return fingGrpLog_FORM_NONE;
 }
 
-std::string AttConverter::FingGrpVisOrientToStr(fingGrpVis_ORIENT data) const
+std::string AttConverterBase::FingGrpVisOrientToStr(fingGrpVis_ORIENT data) const
 {
     std::string value;
     switch (data) {
@@ -4276,7 +4276,7 @@ std::string AttConverter::FingGrpVisOrientToStr(fingGrpVis_ORIENT data) const
     return value;
 }
 
-fingGrpVis_ORIENT AttConverter::StrToFingGrpVisOrient(const std::string &value, bool logWarning) const
+fingGrpVis_ORIENT AttConverterBase::StrToFingGrpVisOrient(const std::string &value, bool logWarning) const
 {
     if (value == "horiz") return fingGrpVis_ORIENT_horiz;
     if (value == "vert") return fingGrpVis_ORIENT_vert;
@@ -4285,7 +4285,7 @@ fingGrpVis_ORIENT AttConverter::StrToFingGrpVisOrient(const std::string &value, 
     return fingGrpVis_ORIENT_NONE;
 }
 
-std::string AttConverter::GraceGrpLogAttachToStr(graceGrpLog_ATTACH data) const
+std::string AttConverterBase::GraceGrpLogAttachToStr(graceGrpLog_ATTACH data) const
 {
     std::string value;
     switch (data) {
@@ -4300,7 +4300,7 @@ std::string AttConverter::GraceGrpLogAttachToStr(graceGrpLog_ATTACH data) const
     return value;
 }
 
-graceGrpLog_ATTACH AttConverter::StrToGraceGrpLogAttach(const std::string &value, bool logWarning) const
+graceGrpLog_ATTACH AttConverterBase::StrToGraceGrpLogAttach(const std::string &value, bool logWarning) const
 {
     if (value == "pre") return graceGrpLog_ATTACH_pre;
     if (value == "post") return graceGrpLog_ATTACH_post;
@@ -4310,7 +4310,7 @@ graceGrpLog_ATTACH AttConverter::StrToGraceGrpLogAttach(const std::string &value
     return graceGrpLog_ATTACH_NONE;
 }
 
-std::string AttConverter::HairpinLogFormToStr(hairpinLog_FORM data) const
+std::string AttConverterBase::HairpinLogFormToStr(hairpinLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4324,7 +4324,7 @@ std::string AttConverter::HairpinLogFormToStr(hairpinLog_FORM data) const
     return value;
 }
 
-hairpinLog_FORM AttConverter::StrToHairpinLogForm(const std::string &value, bool logWarning) const
+hairpinLog_FORM AttConverterBase::StrToHairpinLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "cres") return hairpinLog_FORM_cres;
     if (value == "dim") return hairpinLog_FORM_dim;
@@ -4333,7 +4333,7 @@ hairpinLog_FORM AttConverter::StrToHairpinLogForm(const std::string &value, bool
     return hairpinLog_FORM_NONE;
 }
 
-std::string AttConverter::HarmAnlFormToStr(harmAnl_FORM data) const
+std::string AttConverterBase::HarmAnlFormToStr(harmAnl_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4347,7 +4347,7 @@ std::string AttConverter::HarmAnlFormToStr(harmAnl_FORM data) const
     return value;
 }
 
-harmAnl_FORM AttConverter::StrToHarmAnlForm(const std::string &value, bool logWarning) const
+harmAnl_FORM AttConverterBase::StrToHarmAnlForm(const std::string &value, bool logWarning) const
 {
     if (value == "explicit") return harmAnl_FORM_explicit;
     if (value == "implied") return harmAnl_FORM_implied;
@@ -4356,7 +4356,7 @@ harmAnl_FORM AttConverter::StrToHarmAnlForm(const std::string &value, bool logWa
     return harmAnl_FORM_NONE;
 }
 
-std::string AttConverter::HarmVisRendgridToStr(harmVis_RENDGRID data) const
+std::string AttConverterBase::HarmVisRendgridToStr(harmVis_RENDGRID data) const
 {
     std::string value;
     switch (data) {
@@ -4371,7 +4371,7 @@ std::string AttConverter::HarmVisRendgridToStr(harmVis_RENDGRID data) const
     return value;
 }
 
-harmVis_RENDGRID AttConverter::StrToHarmVisRendgrid(const std::string &value, bool logWarning) const
+harmVis_RENDGRID AttConverterBase::StrToHarmVisRendgrid(const std::string &value, bool logWarning) const
 {
     if (value == "grid") return harmVis_RENDGRID_grid;
     if (value == "gridtext") return harmVis_RENDGRID_gridtext;
@@ -4381,7 +4381,7 @@ harmVis_RENDGRID AttConverter::StrToHarmVisRendgrid(const std::string &value, bo
     return harmVis_RENDGRID_NONE;
 }
 
-std::string AttConverter::HarpPedalLogAToStr(harpPedalLog_A data) const
+std::string AttConverterBase::HarpPedalLogAToStr(harpPedalLog_A data) const
 {
     std::string value;
     switch (data) {
@@ -4396,7 +4396,7 @@ std::string AttConverter::HarpPedalLogAToStr(harpPedalLog_A data) const
     return value;
 }
 
-harpPedalLog_A AttConverter::StrToHarpPedalLogA(const std::string &value, bool logWarning) const
+harpPedalLog_A AttConverterBase::StrToHarpPedalLogA(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_A_f;
     if (value == "n") return harpPedalLog_A_n;
@@ -4406,7 +4406,7 @@ harpPedalLog_A AttConverter::StrToHarpPedalLogA(const std::string &value, bool l
     return harpPedalLog_A_NONE;
 }
 
-std::string AttConverter::HarpPedalLogBToStr(harpPedalLog_B data) const
+std::string AttConverterBase::HarpPedalLogBToStr(harpPedalLog_B data) const
 {
     std::string value;
     switch (data) {
@@ -4421,7 +4421,7 @@ std::string AttConverter::HarpPedalLogBToStr(harpPedalLog_B data) const
     return value;
 }
 
-harpPedalLog_B AttConverter::StrToHarpPedalLogB(const std::string &value, bool logWarning) const
+harpPedalLog_B AttConverterBase::StrToHarpPedalLogB(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_B_f;
     if (value == "n") return harpPedalLog_B_n;
@@ -4431,7 +4431,7 @@ harpPedalLog_B AttConverter::StrToHarpPedalLogB(const std::string &value, bool l
     return harpPedalLog_B_NONE;
 }
 
-std::string AttConverter::HarpPedalLogCToStr(harpPedalLog_C data) const
+std::string AttConverterBase::HarpPedalLogCToStr(harpPedalLog_C data) const
 {
     std::string value;
     switch (data) {
@@ -4446,7 +4446,7 @@ std::string AttConverter::HarpPedalLogCToStr(harpPedalLog_C data) const
     return value;
 }
 
-harpPedalLog_C AttConverter::StrToHarpPedalLogC(const std::string &value, bool logWarning) const
+harpPedalLog_C AttConverterBase::StrToHarpPedalLogC(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_C_f;
     if (value == "n") return harpPedalLog_C_n;
@@ -4456,7 +4456,7 @@ harpPedalLog_C AttConverter::StrToHarpPedalLogC(const std::string &value, bool l
     return harpPedalLog_C_NONE;
 }
 
-std::string AttConverter::HarpPedalLogDToStr(harpPedalLog_D data) const
+std::string AttConverterBase::HarpPedalLogDToStr(harpPedalLog_D data) const
 {
     std::string value;
     switch (data) {
@@ -4471,7 +4471,7 @@ std::string AttConverter::HarpPedalLogDToStr(harpPedalLog_D data) const
     return value;
 }
 
-harpPedalLog_D AttConverter::StrToHarpPedalLogD(const std::string &value, bool logWarning) const
+harpPedalLog_D AttConverterBase::StrToHarpPedalLogD(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_D_f;
     if (value == "n") return harpPedalLog_D_n;
@@ -4481,7 +4481,7 @@ harpPedalLog_D AttConverter::StrToHarpPedalLogD(const std::string &value, bool l
     return harpPedalLog_D_NONE;
 }
 
-std::string AttConverter::HarpPedalLogEToStr(harpPedalLog_E data) const
+std::string AttConverterBase::HarpPedalLogEToStr(harpPedalLog_E data) const
 {
     std::string value;
     switch (data) {
@@ -4496,7 +4496,7 @@ std::string AttConverter::HarpPedalLogEToStr(harpPedalLog_E data) const
     return value;
 }
 
-harpPedalLog_E AttConverter::StrToHarpPedalLogE(const std::string &value, bool logWarning) const
+harpPedalLog_E AttConverterBase::StrToHarpPedalLogE(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_E_f;
     if (value == "n") return harpPedalLog_E_n;
@@ -4506,7 +4506,7 @@ harpPedalLog_E AttConverter::StrToHarpPedalLogE(const std::string &value, bool l
     return harpPedalLog_E_NONE;
 }
 
-std::string AttConverter::HarpPedalLogFToStr(harpPedalLog_F data) const
+std::string AttConverterBase::HarpPedalLogFToStr(harpPedalLog_F data) const
 {
     std::string value;
     switch (data) {
@@ -4521,7 +4521,7 @@ std::string AttConverter::HarpPedalLogFToStr(harpPedalLog_F data) const
     return value;
 }
 
-harpPedalLog_F AttConverter::StrToHarpPedalLogF(const std::string &value, bool logWarning) const
+harpPedalLog_F AttConverterBase::StrToHarpPedalLogF(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_F_f;
     if (value == "n") return harpPedalLog_F_n;
@@ -4531,7 +4531,7 @@ harpPedalLog_F AttConverter::StrToHarpPedalLogF(const std::string &value, bool l
     return harpPedalLog_F_NONE;
 }
 
-std::string AttConverter::HarpPedalLogGToStr(harpPedalLog_G data) const
+std::string AttConverterBase::HarpPedalLogGToStr(harpPedalLog_G data) const
 {
     std::string value;
     switch (data) {
@@ -4546,7 +4546,7 @@ std::string AttConverter::HarpPedalLogGToStr(harpPedalLog_G data) const
     return value;
 }
 
-harpPedalLog_G AttConverter::StrToHarpPedalLogG(const std::string &value, bool logWarning) const
+harpPedalLog_G AttConverterBase::StrToHarpPedalLogG(const std::string &value, bool logWarning) const
 {
     if (value == "f") return harpPedalLog_G_f;
     if (value == "n") return harpPedalLog_G_n;
@@ -4556,7 +4556,7 @@ harpPedalLog_G AttConverter::StrToHarpPedalLogG(const std::string &value, bool l
     return harpPedalLog_G_NONE;
 }
 
-std::string AttConverter::LineLogFuncToStr(lineLog_FUNC data) const
+std::string AttConverterBase::LineLogFuncToStr(lineLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -4571,7 +4571,7 @@ std::string AttConverter::LineLogFuncToStr(lineLog_FUNC data) const
     return value;
 }
 
-lineLog_FUNC AttConverter::StrToLineLogFunc(const std::string &value, bool logWarning) const
+lineLog_FUNC AttConverterBase::StrToLineLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "coloration") return lineLog_FUNC_coloration;
     if (value == "ligature") return lineLog_FUNC_ligature;
@@ -4581,7 +4581,7 @@ lineLog_FUNC AttConverter::StrToLineLogFunc(const std::string &value, bool logWa
     return lineLog_FUNC_NONE;
 }
 
-std::string AttConverter::LiquescentVisCurveToStr(liquescentVis_CURVE data) const
+std::string AttConverterBase::LiquescentVisCurveToStr(liquescentVis_CURVE data) const
 {
     std::string value;
     switch (data) {
@@ -4595,7 +4595,7 @@ std::string AttConverter::LiquescentVisCurveToStr(liquescentVis_CURVE data) cons
     return value;
 }
 
-liquescentVis_CURVE AttConverter::StrToLiquescentVisCurve(const std::string &value, bool logWarning) const
+liquescentVis_CURVE AttConverterBase::StrToLiquescentVisCurve(const std::string &value, bool logWarning) const
 {
     if (value == "a") return liquescentVis_CURVE_a;
     if (value == "c") return liquescentVis_CURVE_c;
@@ -4604,7 +4604,7 @@ liquescentVis_CURVE AttConverter::StrToLiquescentVisCurve(const std::string &val
     return liquescentVis_CURVE_NONE;
 }
 
-std::string AttConverter::MeasurementUnitToStr(measurement_UNIT data) const
+std::string AttConverterBase::MeasurementUnitToStr(measurement_UNIT data) const
 {
     std::string value;
     switch (data) {
@@ -4633,7 +4633,7 @@ std::string AttConverter::MeasurementUnitToStr(measurement_UNIT data) const
     return value;
 }
 
-measurement_UNIT AttConverter::StrToMeasurementUnit(const std::string &value, bool logWarning) const
+measurement_UNIT AttConverterBase::StrToMeasurementUnit(const std::string &value, bool logWarning) const
 {
     if (value == "byte") return measurement_UNIT_byte;
     if (value == "char") return measurement_UNIT_char;
@@ -4657,7 +4657,7 @@ measurement_UNIT AttConverter::StrToMeasurementUnit(const std::string &value, bo
     return measurement_UNIT_NONE;
 }
 
-std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) const
+std::string AttConverterBase::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) const
 {
     std::string value;
     switch (data) {
@@ -4675,7 +4675,7 @@ std::string AttConverter::MeiVersionMeiversionToStr(meiVersion_MEIVERSION data) 
     return value;
 }
 
-meiVersion_MEIVERSION AttConverter::StrToMeiVersionMeiversion(const std::string &value, bool logWarning) const
+meiVersion_MEIVERSION AttConverterBase::StrToMeiVersionMeiversion(const std::string &value, bool logWarning) const
 {
     if (value == "2013") return meiVersion_MEIVERSION_2013;
     if (value == "3.0.0") return meiVersion_MEIVERSION_3_0_0;
@@ -4688,7 +4688,7 @@ meiVersion_MEIVERSION AttConverter::StrToMeiVersionMeiversion(const std::string 
     return meiVersion_MEIVERSION_NONE;
 }
 
-std::string AttConverter::MensurVisFormToStr(mensurVis_FORM data) const
+std::string AttConverterBase::MensurVisFormToStr(mensurVis_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4702,7 +4702,7 @@ std::string AttConverter::MensurVisFormToStr(mensurVis_FORM data) const
     return value;
 }
 
-mensurVis_FORM AttConverter::StrToMensurVisForm(const std::string &value, bool logWarning) const
+mensurVis_FORM AttConverterBase::StrToMensurVisForm(const std::string &value, bool logWarning) const
 {
     if (value == "horizontal") return mensurVis_FORM_horizontal;
     if (value == "vertical") return mensurVis_FORM_vertical;
@@ -4711,7 +4711,7 @@ mensurVis_FORM AttConverter::StrToMensurVisForm(const std::string &value, bool l
     return mensurVis_FORM_NONE;
 }
 
-std::string AttConverter::MensuralVisMensurformToStr(mensuralVis_MENSURFORM data) const
+std::string AttConverterBase::MensuralVisMensurformToStr(mensuralVis_MENSURFORM data) const
 {
     std::string value;
     switch (data) {
@@ -4725,7 +4725,7 @@ std::string AttConverter::MensuralVisMensurformToStr(mensuralVis_MENSURFORM data
     return value;
 }
 
-mensuralVis_MENSURFORM AttConverter::StrToMensuralVisMensurform(const std::string &value, bool logWarning) const
+mensuralVis_MENSURFORM AttConverterBase::StrToMensuralVisMensurform(const std::string &value, bool logWarning) const
 {
     if (value == "horizontal") return mensuralVis_MENSURFORM_horizontal;
     if (value == "vertical") return mensuralVis_MENSURFORM_vertical;
@@ -4734,7 +4734,7 @@ mensuralVis_MENSURFORM AttConverter::StrToMensuralVisMensurform(const std::strin
     return mensuralVis_MENSURFORM_NONE;
 }
 
-std::string AttConverter::MeterConformanceMetconToStr(meterConformance_METCON data) const
+std::string AttConverterBase::MeterConformanceMetconToStr(meterConformance_METCON data) const
 {
     std::string value;
     switch (data) {
@@ -4749,7 +4749,7 @@ std::string AttConverter::MeterConformanceMetconToStr(meterConformance_METCON da
     return value;
 }
 
-meterConformance_METCON AttConverter::StrToMeterConformanceMetcon(const std::string &value, bool logWarning) const
+meterConformance_METCON AttConverterBase::StrToMeterConformanceMetcon(const std::string &value, bool logWarning) const
 {
     if (value == "c") return meterConformance_METCON_c;
     if (value == "i") return meterConformance_METCON_i;
@@ -4759,7 +4759,7 @@ meterConformance_METCON AttConverter::StrToMeterConformanceMetcon(const std::str
     return meterConformance_METCON_NONE;
 }
 
-std::string AttConverter::MeterSigGrpLogFuncToStr(meterSigGrpLog_FUNC data) const
+std::string AttConverterBase::MeterSigGrpLogFuncToStr(meterSigGrpLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -4775,7 +4775,7 @@ std::string AttConverter::MeterSigGrpLogFuncToStr(meterSigGrpLog_FUNC data) cons
     return value;
 }
 
-meterSigGrpLog_FUNC AttConverter::StrToMeterSigGrpLogFunc(const std::string &value, bool logWarning) const
+meterSigGrpLog_FUNC AttConverterBase::StrToMeterSigGrpLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "alternating") return meterSigGrpLog_FUNC_alternating;
     if (value == "interchanging") return meterSigGrpLog_FUNC_interchanging;
@@ -4786,7 +4786,7 @@ meterSigGrpLog_FUNC AttConverter::StrToMeterSigGrpLogFunc(const std::string &val
     return meterSigGrpLog_FUNC_NONE;
 }
 
-std::string AttConverter::MordentLogFormToStr(mordentLog_FORM data) const
+std::string AttConverterBase::MordentLogFormToStr(mordentLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -4800,7 +4800,7 @@ std::string AttConverter::MordentLogFormToStr(mordentLog_FORM data) const
     return value;
 }
 
-mordentLog_FORM AttConverter::StrToMordentLogForm(const std::string &value, bool logWarning) const
+mordentLog_FORM AttConverterBase::StrToMordentLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "lower") return mordentLog_FORM_lower;
     if (value == "upper") return mordentLog_FORM_upper;
@@ -4809,7 +4809,7 @@ mordentLog_FORM AttConverter::StrToMordentLogForm(const std::string &value, bool
     return mordentLog_FORM_NONE;
 }
 
-std::string AttConverter::NcFormConToStr(ncForm_CON data) const
+std::string AttConverterBase::NcFormConToStr(ncForm_CON data) const
 {
     std::string value;
     switch (data) {
@@ -4824,7 +4824,7 @@ std::string AttConverter::NcFormConToStr(ncForm_CON data) const
     return value;
 }
 
-ncForm_CON AttConverter::StrToNcFormCon(const std::string &value, bool logWarning) const
+ncForm_CON AttConverterBase::StrToNcFormCon(const std::string &value, bool logWarning) const
 {
     if (value == "g") return ncForm_CON_g;
     if (value == "l") return ncForm_CON_l;
@@ -4834,7 +4834,7 @@ ncForm_CON AttConverter::StrToNcFormCon(const std::string &value, bool logWarnin
     return ncForm_CON_NONE;
 }
 
-std::string AttConverter::NcFormCurveToStr(ncForm_CURVE data) const
+std::string AttConverterBase::NcFormCurveToStr(ncForm_CURVE data) const
 {
     std::string value;
     switch (data) {
@@ -4848,7 +4848,7 @@ std::string AttConverter::NcFormCurveToStr(ncForm_CURVE data) const
     return value;
 }
 
-ncForm_CURVE AttConverter::StrToNcFormCurve(const std::string &value, bool logWarning) const
+ncForm_CURVE AttConverterBase::StrToNcFormCurve(const std::string &value, bool logWarning) const
 {
     if (value == "a") return ncForm_CURVE_a;
     if (value == "c") return ncForm_CURVE_c;
@@ -4857,7 +4857,7 @@ ncForm_CURVE AttConverter::StrToNcFormCurve(const std::string &value, bool logWa
     return ncForm_CURVE_NONE;
 }
 
-std::string AttConverter::NcFormRellenToStr(ncForm_RELLEN data) const
+std::string AttConverterBase::NcFormRellenToStr(ncForm_RELLEN data) const
 {
     std::string value;
     switch (data) {
@@ -4871,7 +4871,7 @@ std::string AttConverter::NcFormRellenToStr(ncForm_RELLEN data) const
     return value;
 }
 
-ncForm_RELLEN AttConverter::StrToNcFormRellen(const std::string &value, bool logWarning) const
+ncForm_RELLEN AttConverterBase::StrToNcFormRellen(const std::string &value, bool logWarning) const
 {
     if (value == "l") return ncForm_RELLEN_l;
     if (value == "s") return ncForm_RELLEN_s;
@@ -4880,7 +4880,7 @@ ncForm_RELLEN AttConverter::StrToNcFormRellen(const std::string &value, bool log
     return ncForm_RELLEN_NONE;
 }
 
-std::string AttConverter::NoteGesExtremisToStr(noteGes_EXTREMIS data) const
+std::string AttConverterBase::NoteGesExtremisToStr(noteGes_EXTREMIS data) const
 {
     std::string value;
     switch (data) {
@@ -4894,7 +4894,7 @@ std::string AttConverter::NoteGesExtremisToStr(noteGes_EXTREMIS data) const
     return value;
 }
 
-noteGes_EXTREMIS AttConverter::StrToNoteGesExtremis(const std::string &value, bool logWarning) const
+noteGes_EXTREMIS AttConverterBase::StrToNoteGesExtremis(const std::string &value, bool logWarning) const
 {
     if (value == "highest") return noteGes_EXTREMIS_highest;
     if (value == "lowest") return noteGes_EXTREMIS_lowest;
@@ -4903,7 +4903,7 @@ noteGes_EXTREMIS AttConverter::StrToNoteGesExtremis(const std::string &value, bo
     return noteGes_EXTREMIS_NONE;
 }
 
-std::string AttConverter::NoteHeadsHeadauthToStr(noteHeads_HEADAUTH data) const
+std::string AttConverterBase::NoteHeadsHeadauthToStr(noteHeads_HEADAUTH data) const
 {
     std::string value;
     switch (data) {
@@ -4916,7 +4916,7 @@ std::string AttConverter::NoteHeadsHeadauthToStr(noteHeads_HEADAUTH data) const
     return value;
 }
 
-noteHeads_HEADAUTH AttConverter::StrToNoteHeadsHeadauth(const std::string &value, bool logWarning) const
+noteHeads_HEADAUTH AttConverterBase::StrToNoteHeadsHeadauth(const std::string &value, bool logWarning) const
 {
     if (value == "smufl") return noteHeads_HEADAUTH_smufl;
     if (logWarning && !value.empty())
@@ -4924,7 +4924,7 @@ noteHeads_HEADAUTH AttConverter::StrToNoteHeadsHeadauth(const std::string &value
     return noteHeads_HEADAUTH_NONE;
 }
 
-std::string AttConverter::OctaveLogCollToStr(octaveLog_COLL data) const
+std::string AttConverterBase::OctaveLogCollToStr(octaveLog_COLL data) const
 {
     std::string value;
     switch (data) {
@@ -4937,7 +4937,7 @@ std::string AttConverter::OctaveLogCollToStr(octaveLog_COLL data) const
     return value;
 }
 
-octaveLog_COLL AttConverter::StrToOctaveLogColl(const std::string &value, bool logWarning) const
+octaveLog_COLL AttConverterBase::StrToOctaveLogColl(const std::string &value, bool logWarning) const
 {
     if (value == "coll") return octaveLog_COLL_coll;
     if (logWarning && !value.empty())
@@ -4945,7 +4945,7 @@ octaveLog_COLL AttConverter::StrToOctaveLogColl(const std::string &value, bool l
     return octaveLog_COLL_NONE;
 }
 
-std::string AttConverter::PbVisFoliumToStr(pbVis_FOLIUM data) const
+std::string AttConverterBase::PbVisFoliumToStr(pbVis_FOLIUM data) const
 {
     std::string value;
     switch (data) {
@@ -4959,7 +4959,7 @@ std::string AttConverter::PbVisFoliumToStr(pbVis_FOLIUM data) const
     return value;
 }
 
-pbVis_FOLIUM AttConverter::StrToPbVisFolium(const std::string &value, bool logWarning) const
+pbVis_FOLIUM AttConverterBase::StrToPbVisFolium(const std::string &value, bool logWarning) const
 {
     if (value == "verso") return pbVis_FOLIUM_verso;
     if (value == "recto") return pbVis_FOLIUM_recto;
@@ -4968,7 +4968,7 @@ pbVis_FOLIUM AttConverter::StrToPbVisFolium(const std::string &value, bool logWa
     return pbVis_FOLIUM_NONE;
 }
 
-std::string AttConverter::PedalLogDirToStr(pedalLog_DIR data) const
+std::string AttConverterBase::PedalLogDirToStr(pedalLog_DIR data) const
 {
     std::string value;
     switch (data) {
@@ -4984,7 +4984,7 @@ std::string AttConverter::PedalLogDirToStr(pedalLog_DIR data) const
     return value;
 }
 
-pedalLog_DIR AttConverter::StrToPedalLogDir(const std::string &value, bool logWarning) const
+pedalLog_DIR AttConverterBase::StrToPedalLogDir(const std::string &value, bool logWarning) const
 {
     if (value == "down") return pedalLog_DIR_down;
     if (value == "up") return pedalLog_DIR_up;
@@ -4995,7 +4995,7 @@ pedalLog_DIR AttConverter::StrToPedalLogDir(const std::string &value, bool logWa
     return pedalLog_DIR_NONE;
 }
 
-std::string AttConverter::PedalLogFuncToStr(pedalLog_FUNC data) const
+std::string AttConverterBase::PedalLogFuncToStr(pedalLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -5011,7 +5011,7 @@ std::string AttConverter::PedalLogFuncToStr(pedalLog_FUNC data) const
     return value;
 }
 
-pedalLog_FUNC AttConverter::StrToPedalLogFunc(const std::string &value, bool logWarning) const
+pedalLog_FUNC AttConverterBase::StrToPedalLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "sustain") return pedalLog_FUNC_sustain;
     if (value == "soft") return pedalLog_FUNC_soft;
@@ -5022,7 +5022,7 @@ pedalLog_FUNC AttConverter::StrToPedalLogFunc(const std::string &value, bool log
     return pedalLog_FUNC_NONE;
 }
 
-std::string AttConverter::PointingXlinkactuateToStr(pointing_XLINKACTUATE data) const
+std::string AttConverterBase::PointingXlinkactuateToStr(pointing_XLINKACTUATE data) const
 {
     std::string value;
     switch (data) {
@@ -5038,7 +5038,7 @@ std::string AttConverter::PointingXlinkactuateToStr(pointing_XLINKACTUATE data) 
     return value;
 }
 
-pointing_XLINKACTUATE AttConverter::StrToPointingXlinkactuate(const std::string &value, bool logWarning) const
+pointing_XLINKACTUATE AttConverterBase::StrToPointingXlinkactuate(const std::string &value, bool logWarning) const
 {
     if (value == "onLoad") return pointing_XLINKACTUATE_onLoad;
     if (value == "onRequest") return pointing_XLINKACTUATE_onRequest;
@@ -5049,7 +5049,7 @@ pointing_XLINKACTUATE AttConverter::StrToPointingXlinkactuate(const std::string 
     return pointing_XLINKACTUATE_NONE;
 }
 
-std::string AttConverter::PointingXlinkshowToStr(pointing_XLINKSHOW data) const
+std::string AttConverterBase::PointingXlinkshowToStr(pointing_XLINKSHOW data) const
 {
     std::string value;
     switch (data) {
@@ -5066,7 +5066,7 @@ std::string AttConverter::PointingXlinkshowToStr(pointing_XLINKSHOW data) const
     return value;
 }
 
-pointing_XLINKSHOW AttConverter::StrToPointingXlinkshow(const std::string &value, bool logWarning) const
+pointing_XLINKSHOW AttConverterBase::StrToPointingXlinkshow(const std::string &value, bool logWarning) const
 {
     if (value == "new") return pointing_XLINKSHOW_new;
     if (value == "replace") return pointing_XLINKSHOW_replace;
@@ -5078,7 +5078,7 @@ pointing_XLINKSHOW AttConverter::StrToPointingXlinkshow(const std::string &value
     return pointing_XLINKSHOW_NONE;
 }
 
-std::string AttConverter::RecordTypeRecordtypeToStr(recordType_RECORDTYPE data) const
+std::string AttConverterBase::RecordTypeRecordtypeToStr(recordType_RECORDTYPE data) const
 {
     std::string value;
     switch (data) {
@@ -5104,7 +5104,7 @@ std::string AttConverter::RecordTypeRecordtypeToStr(recordType_RECORDTYPE data) 
     return value;
 }
 
-recordType_RECORDTYPE AttConverter::StrToRecordTypeRecordtype(const std::string &value, bool logWarning) const
+recordType_RECORDTYPE AttConverterBase::StrToRecordTypeRecordtype(const std::string &value, bool logWarning) const
 {
     if (value == "a") return recordType_RECORDTYPE_a;
     if (value == "c") return recordType_RECORDTYPE_c;
@@ -5125,7 +5125,7 @@ recordType_RECORDTYPE AttConverter::StrToRecordTypeRecordtype(const std::string 
     return recordType_RECORDTYPE_NONE;
 }
 
-std::string AttConverter::RegularMethodMethodToStr(regularMethod_METHOD data) const
+std::string AttConverterBase::RegularMethodMethodToStr(regularMethod_METHOD data) const
 {
     std::string value;
     switch (data) {
@@ -5139,7 +5139,7 @@ std::string AttConverter::RegularMethodMethodToStr(regularMethod_METHOD data) co
     return value;
 }
 
-regularMethod_METHOD AttConverter::StrToRegularMethodMethod(const std::string &value, bool logWarning) const
+regularMethod_METHOD AttConverterBase::StrToRegularMethodMethod(const std::string &value, bool logWarning) const
 {
     if (value == "silent") return regularMethod_METHOD_silent;
     if (value == "tags") return regularMethod_METHOD_tags;
@@ -5148,7 +5148,7 @@ regularMethod_METHOD AttConverter::StrToRegularMethodMethod(const std::string &v
     return regularMethod_METHOD_NONE;
 }
 
-std::string AttConverter::RehearsalRehencloseToStr(rehearsal_REHENCLOSE data) const
+std::string AttConverterBase::RehearsalRehencloseToStr(rehearsal_REHENCLOSE data) const
 {
     std::string value;
     switch (data) {
@@ -5163,7 +5163,7 @@ std::string AttConverter::RehearsalRehencloseToStr(rehearsal_REHENCLOSE data) co
     return value;
 }
 
-rehearsal_REHENCLOSE AttConverter::StrToRehearsalRehenclose(const std::string &value, bool logWarning) const
+rehearsal_REHENCLOSE AttConverterBase::StrToRehearsalRehenclose(const std::string &value, bool logWarning) const
 {
     if (value == "box") return rehearsal_REHENCLOSE_box;
     if (value == "circle") return rehearsal_REHENCLOSE_circle;
@@ -5173,7 +5173,7 @@ rehearsal_REHENCLOSE AttConverter::StrToRehearsalRehenclose(const std::string &v
     return rehearsal_REHENCLOSE_NONE;
 }
 
-std::string AttConverter::SbVisFormToStr(sbVis_FORM data) const
+std::string AttConverterBase::SbVisFormToStr(sbVis_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -5186,7 +5186,7 @@ std::string AttConverter::SbVisFormToStr(sbVis_FORM data) const
     return value;
 }
 
-sbVis_FORM AttConverter::StrToSbVisForm(const std::string &value, bool logWarning) const
+sbVis_FORM AttConverterBase::StrToSbVisForm(const std::string &value, bool logWarning) const
 {
     if (value == "hash") return sbVis_FORM_hash;
     if (logWarning && !value.empty())
@@ -5194,7 +5194,7 @@ sbVis_FORM AttConverter::StrToSbVisForm(const std::string &value, bool logWarnin
     return sbVis_FORM_NONE;
 }
 
-std::string AttConverter::StaffGroupingSymSymbolToStr(staffGroupingSym_SYMBOL data) const
+std::string AttConverterBase::StaffGroupingSymSymbolToStr(staffGroupingSym_SYMBOL data) const
 {
     std::string value;
     switch (data) {
@@ -5211,7 +5211,7 @@ std::string AttConverter::StaffGroupingSymSymbolToStr(staffGroupingSym_SYMBOL da
     return value;
 }
 
-staffGroupingSym_SYMBOL AttConverter::StrToStaffGroupingSymSymbol(const std::string &value, bool logWarning) const
+staffGroupingSym_SYMBOL AttConverterBase::StrToStaffGroupingSymSymbol(const std::string &value, bool logWarning) const
 {
     if (value == "brace") return staffGroupingSym_SYMBOL_brace;
     if (value == "bracket") return staffGroupingSym_SYMBOL_bracket;
@@ -5223,7 +5223,7 @@ staffGroupingSym_SYMBOL AttConverter::StrToStaffGroupingSymSymbol(const std::str
     return staffGroupingSym_SYMBOL_NONE;
 }
 
-std::string AttConverter::SylLogConToStr(sylLog_CON data) const
+std::string AttConverterBase::SylLogConToStr(sylLog_CON data) const
 {
     std::string value;
     switch (data) {
@@ -5243,7 +5243,7 @@ std::string AttConverter::SylLogConToStr(sylLog_CON data) const
     return value;
 }
 
-sylLog_CON AttConverter::StrToSylLogCon(const std::string &value, bool logWarning) const
+sylLog_CON AttConverterBase::StrToSylLogCon(const std::string &value, bool logWarning) const
 {
     if (value == "s") return sylLog_CON_s;
     if (value == "d") return sylLog_CON_d;
@@ -5258,7 +5258,7 @@ sylLog_CON AttConverter::StrToSylLogCon(const std::string &value, bool logWarnin
     return sylLog_CON_NONE;
 }
 
-std::string AttConverter::SylLogWordposToStr(sylLog_WORDPOS data) const
+std::string AttConverterBase::SylLogWordposToStr(sylLog_WORDPOS data) const
 {
     std::string value;
     switch (data) {
@@ -5274,7 +5274,7 @@ std::string AttConverter::SylLogWordposToStr(sylLog_WORDPOS data) const
     return value;
 }
 
-sylLog_WORDPOS AttConverter::StrToSylLogWordpos(const std::string &value, bool logWarning) const
+sylLog_WORDPOS AttConverterBase::StrToSylLogWordpos(const std::string &value, bool logWarning) const
 {
     if (value == "i") return sylLog_WORDPOS_i;
     if (value == "m") return sylLog_WORDPOS_m;
@@ -5285,7 +5285,7 @@ sylLog_WORDPOS AttConverter::StrToSylLogWordpos(const std::string &value, bool l
     return sylLog_WORDPOS_NONE;
 }
 
-std::string AttConverter::TargetEvalEvaluateToStr(targetEval_EVALUATE data) const
+std::string AttConverterBase::TargetEvalEvaluateToStr(targetEval_EVALUATE data) const
 {
     std::string value;
     switch (data) {
@@ -5300,7 +5300,7 @@ std::string AttConverter::TargetEvalEvaluateToStr(targetEval_EVALUATE data) cons
     return value;
 }
 
-targetEval_EVALUATE AttConverter::StrToTargetEvalEvaluate(const std::string &value, bool logWarning) const
+targetEval_EVALUATE AttConverterBase::StrToTargetEvalEvaluate(const std::string &value, bool logWarning) const
 {
     if (value == "all") return targetEval_EVALUATE_all;
     if (value == "one") return targetEval_EVALUATE_one;
@@ -5310,7 +5310,7 @@ targetEval_EVALUATE AttConverter::StrToTargetEvalEvaluate(const std::string &val
     return targetEval_EVALUATE_NONE;
 }
 
-std::string AttConverter::TempoLogFuncToStr(tempoLog_FUNC data) const
+std::string AttConverterBase::TempoLogFuncToStr(tempoLog_FUNC data) const
 {
     std::string value;
     switch (data) {
@@ -5326,7 +5326,7 @@ std::string AttConverter::TempoLogFuncToStr(tempoLog_FUNC data) const
     return value;
 }
 
-tempoLog_FUNC AttConverter::StrToTempoLogFunc(const std::string &value, bool logWarning) const
+tempoLog_FUNC AttConverterBase::StrToTempoLogFunc(const std::string &value, bool logWarning) const
 {
     if (value == "continuous") return tempoLog_FUNC_continuous;
     if (value == "instantaneous") return tempoLog_FUNC_instantaneous;
@@ -5337,7 +5337,7 @@ tempoLog_FUNC AttConverter::StrToTempoLogFunc(const std::string &value, bool log
     return tempoLog_FUNC_NONE;
 }
 
-std::string AttConverter::TupletVisNumformatToStr(tupletVis_NUMFORMAT data) const
+std::string AttConverterBase::TupletVisNumformatToStr(tupletVis_NUMFORMAT data) const
 {
     std::string value;
     switch (data) {
@@ -5351,7 +5351,7 @@ std::string AttConverter::TupletVisNumformatToStr(tupletVis_NUMFORMAT data) cons
     return value;
 }
 
-tupletVis_NUMFORMAT AttConverter::StrToTupletVisNumformat(const std::string &value, bool logWarning) const
+tupletVis_NUMFORMAT AttConverterBase::StrToTupletVisNumformat(const std::string &value, bool logWarning) const
 {
     if (value == "count") return tupletVis_NUMFORMAT_count;
     if (value == "ratio") return tupletVis_NUMFORMAT_ratio;
@@ -5360,7 +5360,7 @@ tupletVis_NUMFORMAT AttConverter::StrToTupletVisNumformat(const std::string &val
     return tupletVis_NUMFORMAT_NONE;
 }
 
-std::string AttConverter::TurnLogFormToStr(turnLog_FORM data) const
+std::string AttConverterBase::TurnLogFormToStr(turnLog_FORM data) const
 {
     std::string value;
     switch (data) {
@@ -5374,7 +5374,7 @@ std::string AttConverter::TurnLogFormToStr(turnLog_FORM data) const
     return value;
 }
 
-turnLog_FORM AttConverter::StrToTurnLogForm(const std::string &value, bool logWarning) const
+turnLog_FORM AttConverterBase::StrToTurnLogForm(const std::string &value, bool logWarning) const
 {
     if (value == "lower") return turnLog_FORM_lower;
     if (value == "upper") return turnLog_FORM_upper;
@@ -5383,7 +5383,7 @@ turnLog_FORM AttConverter::StrToTurnLogForm(const std::string &value, bool logWa
     return turnLog_FORM_NONE;
 }
 
-std::string AttConverter::VoltaGroupingSymVoltasymToStr(voltaGroupingSym_VOLTASYM data) const
+std::string AttConverterBase::VoltaGroupingSymVoltasymToStr(voltaGroupingSym_VOLTASYM data) const
 {
     std::string value;
     switch (data) {
@@ -5400,7 +5400,7 @@ std::string AttConverter::VoltaGroupingSymVoltasymToStr(voltaGroupingSym_VOLTASY
     return value;
 }
 
-voltaGroupingSym_VOLTASYM AttConverter::StrToVoltaGroupingSymVoltasym(const std::string &value, bool logWarning) const
+voltaGroupingSym_VOLTASYM AttConverterBase::StrToVoltaGroupingSymVoltasym(const std::string &value, bool logWarning) const
 {
     if (value == "brace") return voltaGroupingSym_VOLTASYM_brace;
     if (value == "bracket") return voltaGroupingSym_VOLTASYM_bracket;
@@ -5412,7 +5412,7 @@ voltaGroupingSym_VOLTASYM AttConverter::StrToVoltaGroupingSymVoltasym(const std:
     return voltaGroupingSym_VOLTASYM_NONE;
 }
 
-std::string AttConverter::WhitespaceXmlspaceToStr(whitespace_XMLSPACE data) const
+std::string AttConverterBase::WhitespaceXmlspaceToStr(whitespace_XMLSPACE data) const
 {
     std::string value;
     switch (data) {
@@ -5426,7 +5426,7 @@ std::string AttConverter::WhitespaceXmlspaceToStr(whitespace_XMLSPACE data) cons
     return value;
 }
 
-whitespace_XMLSPACE AttConverter::StrToWhitespaceXmlspace(const std::string &value, bool logWarning) const
+whitespace_XMLSPACE AttConverterBase::StrToWhitespaceXmlspace(const std::string &value, bool logWarning) const
 {
     if (value == "default") return whitespace_XMLSPACE_default;
     if (value == "preserve") return whitespace_XMLSPACE_preserve;

--- a/libmei/dist/attconverter.h
+++ b/libmei/dist/attconverter.h
@@ -24,10 +24,13 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
-// AttConverter
+// AttConverterBase
 //----------------------------------------------------------------------------
 
-class AttConverter {
+class AttConverterBase {
+protected:
+    AttConverterBase() = default;
+    ~AttConverterBase() = default;
 public:
     std::string AccidentalGesturalToStr(data_ACCIDENTAL_GESTURAL data) const;
     data_ACCIDENTAL_GESTURAL StrToAccidentalGestural(const std::string &value, bool logWarning = true) const;
@@ -475,6 +478,20 @@ public:
 
     std::string WhitespaceXmlspaceToStr(whitespace_XMLSPACE data) const;
     whitespace_XMLSPACE StrToWhitespaceXmlspace(const std::string &value, bool logWarning = true) const;
+};
+
+//----------------------------------------------------------------------------
+// AttConverter
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttConverterBase
+ */
+
+class AttConverter: public AttConverterBase {
+public:
+    AttConverter() = default;
+    virtual ~AttConverter() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_analytical.cpp
+++ b/libmei/dist/atts_analytical.cpp
@@ -31,8 +31,6 @@ AttHarmAnl::AttHarmAnl() : Att()
     ResetHarmAnl();
 }
 
-AttHarmAnl::~AttHarmAnl() {}
-
 void AttHarmAnl::ResetHarmAnl()
 {
     m_form = harmAnl_FORM_NONE;
@@ -72,8 +70,6 @@ AttHarmonicFunction::AttHarmonicFunction() : Att()
 {
     ResetHarmonicFunction();
 }
-
-AttHarmonicFunction::~AttHarmonicFunction() {}
 
 void AttHarmonicFunction::ResetHarmonicFunction()
 {
@@ -115,8 +111,6 @@ AttIntervalHarmonic::AttIntervalHarmonic() : Att()
     ResetIntervalHarmonic();
 }
 
-AttIntervalHarmonic::~AttIntervalHarmonic() {}
-
 void AttIntervalHarmonic::ResetIntervalHarmonic()
 {
     m_inth = "";
@@ -156,8 +150,6 @@ AttIntervalMelodic::AttIntervalMelodic() : Att()
 {
     ResetIntervalMelodic();
 }
-
-AttIntervalMelodic::~AttIntervalMelodic() {}
 
 void AttIntervalMelodic::ResetIntervalMelodic()
 {
@@ -199,8 +191,6 @@ AttKeySigAnl::AttKeySigAnl() : Att()
     ResetKeySigAnl();
 }
 
-AttKeySigAnl::~AttKeySigAnl() {}
-
 void AttKeySigAnl::ResetKeySigAnl()
 {
     m_mode = MODE_NONE;
@@ -240,8 +230,6 @@ AttKeySigDefaultAnl::AttKeySigDefaultAnl() : Att()
 {
     ResetKeySigDefaultAnl();
 }
-
-AttKeySigDefaultAnl::~AttKeySigDefaultAnl() {}
 
 void AttKeySigDefaultAnl::ResetKeySigDefaultAnl()
 {
@@ -313,8 +301,6 @@ AttMelodicFunction::AttMelodicFunction() : Att()
     ResetMelodicFunction();
 }
 
-AttMelodicFunction::~AttMelodicFunction() {}
-
 void AttMelodicFunction::ResetMelodicFunction()
 {
     m_mfunc = MELODICFUNCTION_NONE;
@@ -355,8 +341,6 @@ AttPitchClass::AttPitchClass() : Att()
     ResetPitchClass();
 }
 
-AttPitchClass::~AttPitchClass() {}
-
 void AttPitchClass::ResetPitchClass()
 {
     m_pclass = MEI_UNSET;
@@ -396,8 +380,6 @@ AttSolfa::AttSolfa() : Att()
 {
     ResetSolfa();
 }
-
-AttSolfa::~AttSolfa() {}
 
 void AttSolfa::ResetSolfa()
 {

--- a/libmei/dist/atts_analytical.h
+++ b/libmei/dist/atts_analytical.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttHarmAnl : public Att {
-public:
+protected:
     AttHarmAnl();
-    virtual ~AttHarmAnl();
+    ~AttHarmAnl() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHarmAnl();
 
@@ -60,14 +61,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHarmAnl
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHarmAnl
+ */
+
+class ExtAttHarmAnl : public AttHarmAnl {
+public:
+    ExtAttHarmAnl() = default;
+    virtual ~ExtAttHarmAnl() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHarmonicFunction
 //----------------------------------------------------------------------------
 
 class AttHarmonicFunction : public Att {
-public:
+protected:
     AttHarmonicFunction();
-    virtual ~AttHarmonicFunction();
+    ~AttHarmonicFunction() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHarmonicFunction();
 
@@ -100,14 +116,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHarmonicFunction
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHarmonicFunction
+ */
+
+class ExtAttHarmonicFunction : public AttHarmonicFunction {
+public:
+    ExtAttHarmonicFunction() = default;
+    virtual ~ExtAttHarmonicFunction() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttIntervalHarmonic
 //----------------------------------------------------------------------------
 
 class AttIntervalHarmonic : public Att {
-public:
+protected:
     AttIntervalHarmonic();
-    virtual ~AttIntervalHarmonic();
+    ~AttIntervalHarmonic() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetIntervalHarmonic();
 
@@ -134,14 +165,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttIntervalHarmonic
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttIntervalHarmonic
+ */
+
+class ExtAttIntervalHarmonic : public AttIntervalHarmonic {
+public:
+    ExtAttIntervalHarmonic() = default;
+    virtual ~ExtAttIntervalHarmonic() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttIntervalMelodic
 //----------------------------------------------------------------------------
 
 class AttIntervalMelodic : public Att {
-public:
+protected:
     AttIntervalMelodic();
-    virtual ~AttIntervalMelodic();
+    ~AttIntervalMelodic() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetIntervalMelodic();
 
@@ -173,14 +219,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttIntervalMelodic
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttIntervalMelodic
+ */
+
+class ExtAttIntervalMelodic : public AttIntervalMelodic {
+public:
+    ExtAttIntervalMelodic() = default;
+    virtual ~ExtAttIntervalMelodic() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigAnl
 //----------------------------------------------------------------------------
 
 class AttKeySigAnl : public Att {
-public:
+protected:
     AttKeySigAnl();
-    virtual ~AttKeySigAnl();
+    ~AttKeySigAnl() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigAnl();
 
@@ -207,14 +268,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigAnl
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigAnl
+ */
+
+class ExtAttKeySigAnl : public AttKeySigAnl {
+public:
+    ExtAttKeySigAnl() = default;
+    virtual ~ExtAttKeySigAnl() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigDefaultAnl
 //----------------------------------------------------------------------------
 
 class AttKeySigDefaultAnl : public Att {
-public:
+protected:
     AttKeySigDefaultAnl();
-    virtual ~AttKeySigDefaultAnl();
+    ~AttKeySigDefaultAnl() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigDefaultAnl();
 
@@ -256,14 +332,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigDefaultAnl
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigDefaultAnl
+ */
+
+class ExtAttKeySigDefaultAnl : public AttKeySigDefaultAnl {
+public:
+    ExtAttKeySigDefaultAnl() = default;
+    virtual ~ExtAttKeySigDefaultAnl() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMelodicFunction
 //----------------------------------------------------------------------------
 
 class AttMelodicFunction : public Att {
-public:
+protected:
     AttMelodicFunction();
-    virtual ~AttMelodicFunction();
+    ~AttMelodicFunction() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMelodicFunction();
 
@@ -290,14 +381,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMelodicFunction
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMelodicFunction
+ */
+
+class ExtAttMelodicFunction : public AttMelodicFunction {
+public:
+    ExtAttMelodicFunction() = default;
+    virtual ~ExtAttMelodicFunction() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPitchClass
 //----------------------------------------------------------------------------
 
 class AttPitchClass : public Att {
-public:
+protected:
     AttPitchClass();
-    virtual ~AttPitchClass();
+    ~AttPitchClass() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPitchClass();
 
@@ -324,14 +430,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPitchClass
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPitchClass
+ */
+
+class ExtAttPitchClass : public AttPitchClass {
+public:
+    ExtAttPitchClass() = default;
+    virtual ~ExtAttPitchClass() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSolfa
 //----------------------------------------------------------------------------
 
 class AttSolfa : public Att {
-public:
+protected:
     AttSolfa();
-    virtual ~AttSolfa();
+    ~AttSolfa() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSolfa();
 
@@ -358,6 +479,20 @@ private:
      * movable Do system.
      **/
     std::string m_psolfa;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttSolfa
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSolfa
+ */
+
+class ExtAttSolfa : public AttSolfa {
+public:
+    ExtAttSolfa() = default;
+    virtual ~ExtAttSolfa() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_cmn.cpp
+++ b/libmei/dist/atts_cmn.cpp
@@ -31,8 +31,6 @@ AttArpegLog::AttArpegLog() : Att()
     ResetArpegLog();
 }
 
-AttArpegLog::~AttArpegLog() {}
-
 void AttArpegLog::ResetArpegLog()
 {
     m_order = arpegLog_ORDER_NONE;
@@ -72,8 +70,6 @@ AttBTremLog::AttBTremLog() : Att()
 {
     ResetBTremLog();
 }
-
-AttBTremLog::~AttBTremLog() {}
 
 void AttBTremLog::ResetBTremLog()
 {
@@ -115,8 +111,6 @@ AttBeamPresent::AttBeamPresent() : Att()
     ResetBeamPresent();
 }
 
-AttBeamPresent::~AttBeamPresent() {}
-
 void AttBeamPresent::ResetBeamPresent()
 {
     m_beam = "";
@@ -156,8 +150,6 @@ AttBeamRend::AttBeamRend() : Att()
 {
     ResetBeamRend();
 }
-
-AttBeamRend::~AttBeamRend() {}
 
 void AttBeamRend::ResetBeamRend()
 {
@@ -244,8 +236,6 @@ AttBeamSecondary::AttBeamSecondary() : Att()
     ResetBeamSecondary();
 }
 
-AttBeamSecondary::~AttBeamSecondary() {}
-
 void AttBeamSecondary::ResetBeamSecondary()
 {
     m_breaksec = MEI_UNSET;
@@ -286,8 +276,6 @@ AttBeamedWith::AttBeamedWith() : Att()
     ResetBeamedWith();
 }
 
-AttBeamedWith::~AttBeamedWith() {}
-
 void AttBeamedWith::ResetBeamedWith()
 {
     m_beamWith = NEIGHBORINGLAYER_NONE;
@@ -327,8 +315,6 @@ AttBeamingLog::AttBeamingLog() : Att()
 {
     ResetBeamingLog();
 }
-
-AttBeamingLog::~AttBeamingLog() {}
 
 void AttBeamingLog::ResetBeamingLog()
 {
@@ -385,8 +371,6 @@ AttBeatRptLog::AttBeatRptLog() : Att()
     ResetBeatRptLog();
 }
 
-AttBeatRptLog::~AttBeatRptLog() {}
-
 void AttBeatRptLog::ResetBeatRptLog()
 {
     m_beatdef = 0.0;
@@ -426,8 +410,6 @@ AttBracketSpanLog::AttBracketSpanLog() : Att()
 {
     ResetBracketSpanLog();
 }
-
-AttBracketSpanLog::~AttBracketSpanLog() {}
 
 void AttBracketSpanLog::ResetBracketSpanLog()
 {
@@ -469,8 +451,6 @@ AttCutout::AttCutout() : Att()
     ResetCutout();
 }
 
-AttCutout::~AttCutout() {}
-
 void AttCutout::ResetCutout()
 {
     m_cutout = cutout_CUTOUT_NONE;
@@ -510,8 +490,6 @@ AttExpandable::AttExpandable() : Att()
 {
     ResetExpandable();
 }
-
-AttExpandable::~AttExpandable() {}
 
 void AttExpandable::ResetExpandable()
 {
@@ -553,8 +531,6 @@ AttFTremLog::AttFTremLog() : Att()
     ResetFTremLog();
 }
 
-AttFTremLog::~AttFTremLog() {}
-
 void AttFTremLog::ResetFTremLog()
 {
     m_form = fTremLog_FORM_NONE;
@@ -594,8 +570,6 @@ AttGlissPresent::AttGlissPresent() : Att()
 {
     ResetGlissPresent();
 }
-
-AttGlissPresent::~AttGlissPresent() {}
 
 void AttGlissPresent::ResetGlissPresent()
 {
@@ -637,8 +611,6 @@ AttGraceGrpLog::AttGraceGrpLog() : Att()
     ResetGraceGrpLog();
 }
 
-AttGraceGrpLog::~AttGraceGrpLog() {}
-
 void AttGraceGrpLog::ResetGraceGrpLog()
 {
     m_attach = graceGrpLog_ATTACH_NONE;
@@ -678,8 +650,6 @@ AttGraced::AttGraced() : Att()
 {
     ResetGraced();
 }
-
-AttGraced::~AttGraced() {}
 
 void AttGraced::ResetGraced()
 {
@@ -736,8 +706,6 @@ AttHairpinLog::AttHairpinLog() : Att()
     ResetHairpinLog();
 }
 
-AttHairpinLog::~AttHairpinLog() {}
-
 void AttHairpinLog::ResetHairpinLog()
 {
     m_form = hairpinLog_FORM_NONE;
@@ -792,8 +760,6 @@ AttHarpPedalLog::AttHarpPedalLog() : Att()
 {
     ResetHarpPedalLog();
 }
-
-AttHarpPedalLog::~AttHarpPedalLog() {}
 
 void AttHarpPedalLog::ResetHarpPedalLog()
 {
@@ -925,8 +891,6 @@ AttLvPresent::AttLvPresent() : Att()
     ResetLvPresent();
 }
 
-AttLvPresent::~AttLvPresent() {}
-
 void AttLvPresent::ResetLvPresent()
 {
     m_lv = BOOLEAN_NONE;
@@ -966,8 +930,6 @@ AttMeasureLog::AttMeasureLog() : Att()
 {
     ResetMeasureLog();
 }
-
-AttMeasureLog::~AttMeasureLog() {}
 
 void AttMeasureLog::ResetMeasureLog()
 {
@@ -1024,8 +986,6 @@ AttMeterSigGrpLog::AttMeterSigGrpLog() : Att()
     ResetMeterSigGrpLog();
 }
 
-AttMeterSigGrpLog::~AttMeterSigGrpLog() {}
-
 void AttMeterSigGrpLog::ResetMeterSigGrpLog()
 {
     m_func = meterSigGrpLog_FUNC_NONE;
@@ -1065,8 +1025,6 @@ AttNumberPlacement::AttNumberPlacement() : Att()
 {
     ResetNumberPlacement();
 }
-
-AttNumberPlacement::~AttNumberPlacement() {}
 
 void AttNumberPlacement::ResetNumberPlacement()
 {
@@ -1123,8 +1081,6 @@ AttNumbered::AttNumbered() : Att()
     ResetNumbered();
 }
 
-AttNumbered::~AttNumbered() {}
-
 void AttNumbered::ResetNumbered()
 {
     m_num = MEI_UNSET;
@@ -1165,8 +1121,6 @@ AttOctaveLog::AttOctaveLog() : Att()
     ResetOctaveLog();
 }
 
-AttOctaveLog::~AttOctaveLog() {}
-
 void AttOctaveLog::ResetOctaveLog()
 {
     m_coll = octaveLog_COLL_NONE;
@@ -1206,8 +1160,6 @@ AttPedalLog::AttPedalLog() : Att()
 {
     ResetPedalLog();
 }
-
-AttPedalLog::~AttPedalLog() {}
 
 void AttPedalLog::ResetPedalLog()
 {
@@ -1264,8 +1216,6 @@ AttPianoPedals::AttPianoPedals() : Att()
     ResetPianoPedals();
 }
 
-AttPianoPedals::~AttPianoPedals() {}
-
 void AttPianoPedals::ResetPianoPedals()
 {
     m_pedalStyle = PEDALSTYLE_NONE;
@@ -1305,8 +1255,6 @@ AttRehearsal::AttRehearsal() : Att()
 {
     ResetRehearsal();
 }
-
-AttRehearsal::~AttRehearsal() {}
 
 void AttRehearsal::ResetRehearsal()
 {
@@ -1348,8 +1296,6 @@ AttScoreDefVisCmn::AttScoreDefVisCmn() : Att()
     ResetScoreDefVisCmn();
 }
 
-AttScoreDefVisCmn::~AttScoreDefVisCmn() {}
-
 void AttScoreDefVisCmn::ResetScoreDefVisCmn()
 {
     m_gridShow = BOOLEAN_NONE;
@@ -1389,8 +1335,6 @@ AttSlurRend::AttSlurRend() : Att()
 {
     ResetSlurRend();
 }
-
-AttSlurRend::~AttSlurRend() {}
 
 void AttSlurRend::ResetSlurRend()
 {
@@ -1447,8 +1391,6 @@ AttStemsCmn::AttStemsCmn() : Att()
     ResetStemsCmn();
 }
 
-AttStemsCmn::~AttStemsCmn() {}
-
 void AttStemsCmn::ResetStemsCmn()
 {
     m_stemWith = NEIGHBORINGLAYER_NONE;
@@ -1488,8 +1430,6 @@ AttTieRend::AttTieRend() : Att()
 {
     ResetTieRend();
 }
-
-AttTieRend::~AttTieRend() {}
 
 void AttTieRend::ResetTieRend()
 {
@@ -1545,8 +1485,6 @@ AttTremMeasured::AttTremMeasured() : Att()
 {
     ResetTremMeasured();
 }
-
-AttTremMeasured::~AttTremMeasured() {}
 
 void AttTremMeasured::ResetTremMeasured()
 {

--- a/libmei/dist/atts_cmn.h
+++ b/libmei/dist/atts_cmn.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttArpegLog : public Att {
-public:
+protected:
     AttArpegLog();
-    virtual ~AttArpegLog();
+    ~AttArpegLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetArpegLog();
 
@@ -60,14 +61,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttArpegLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttArpegLog
+ */
+
+class ExtAttArpegLog : public AttArpegLog {
+public:
+    ExtAttArpegLog() = default;
+    virtual ~ExtAttArpegLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBTremLog
 //----------------------------------------------------------------------------
 
 class AttBTremLog : public Att {
-public:
+protected:
     AttBTremLog();
-    virtual ~AttBTremLog();
+    ~AttBTremLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBTremLog();
 
@@ -94,14 +110,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBTremLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBTremLog
+ */
+
+class ExtAttBTremLog : public AttBTremLog {
+public:
+    ExtAttBTremLog() = default;
+    virtual ~ExtAttBTremLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamPresent
 //----------------------------------------------------------------------------
 
 class AttBeamPresent : public Att {
-public:
+protected:
     AttBeamPresent();
-    virtual ~AttBeamPresent();
+    ~AttBeamPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamPresent();
 
@@ -128,14 +159,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamPresent
+ */
+
+class ExtAttBeamPresent : public AttBeamPresent {
+public:
+    ExtAttBeamPresent() = default;
+    virtual ~ExtAttBeamPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamRend
 //----------------------------------------------------------------------------
 
 class AttBeamRend : public Att {
-public:
+protected:
     AttBeamRend();
-    virtual ~AttBeamRend();
+    ~AttBeamRend() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamRend();
 
@@ -180,14 +226,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamRend
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamRend
+ */
+
+class ExtAttBeamRend : public AttBeamRend {
+public:
+    ExtAttBeamRend() = default;
+    virtual ~ExtAttBeamRend() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamSecondary
 //----------------------------------------------------------------------------
 
 class AttBeamSecondary : public Att {
-public:
+protected:
     AttBeamSecondary();
-    virtual ~AttBeamSecondary();
+    ~AttBeamSecondary() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamSecondary();
 
@@ -219,14 +280,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamSecondary
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamSecondary
+ */
+
+class ExtAttBeamSecondary : public AttBeamSecondary {
+public:
+    ExtAttBeamSecondary() = default;
+    virtual ~ExtAttBeamSecondary() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamedWith
 //----------------------------------------------------------------------------
 
 class AttBeamedWith : public Att {
-public:
+protected:
     AttBeamedWith();
-    virtual ~AttBeamedWith();
+    ~AttBeamedWith() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamedWith();
 
@@ -257,14 +333,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamedWith
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamedWith
+ */
+
+class ExtAttBeamedWith : public AttBeamedWith {
+public:
+    ExtAttBeamedWith() = default;
+    virtual ~ExtAttBeamedWith() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamingLog
 //----------------------------------------------------------------------------
 
 class AttBeamingLog : public Att {
-public:
+protected:
     AttBeamingLog();
-    virtual ~AttBeamingLog();
+    ~AttBeamingLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamingLog();
 
@@ -303,14 +394,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamingLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamingLog
+ */
+
+class ExtAttBeamingLog : public AttBeamingLog {
+public:
+    ExtAttBeamingLog() = default;
+    virtual ~ExtAttBeamingLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeatRptLog
 //----------------------------------------------------------------------------
 
 class AttBeatRptLog : public Att {
-public:
+protected:
     AttBeatRptLog();
-    virtual ~AttBeatRptLog();
+    ~AttBeatRptLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeatRptLog();
 
@@ -340,14 +446,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeatRptLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeatRptLog
+ */
+
+class ExtAttBeatRptLog : public AttBeatRptLog {
+public:
+    ExtAttBeatRptLog() = default;
+    virtual ~ExtAttBeatRptLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBracketSpanLog
 //----------------------------------------------------------------------------
 
 class AttBracketSpanLog : public Att {
-public:
+protected:
     AttBracketSpanLog();
-    virtual ~AttBracketSpanLog();
+    ~AttBracketSpanLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBracketSpanLog();
 
@@ -374,14 +495,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBracketSpanLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBracketSpanLog
+ */
+
+class ExtAttBracketSpanLog : public AttBracketSpanLog {
+public:
+    ExtAttBracketSpanLog() = default;
+    virtual ~ExtAttBracketSpanLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCutout
 //----------------------------------------------------------------------------
 
 class AttCutout : public Att {
-public:
+protected:
     AttCutout();
-    virtual ~AttCutout();
+    ~AttCutout() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCutout();
 
@@ -408,14 +544,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCutout
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCutout
+ */
+
+class ExtAttCutout : public AttCutout {
+public:
+    ExtAttCutout() = default;
+    virtual ~ExtAttCutout() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttExpandable
 //----------------------------------------------------------------------------
 
 class AttExpandable : public Att {
-public:
+protected:
     AttExpandable();
-    virtual ~AttExpandable();
+    ~AttExpandable() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetExpandable();
 
@@ -447,14 +598,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttExpandable
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttExpandable
+ */
+
+class ExtAttExpandable : public AttExpandable {
+public:
+    ExtAttExpandable() = default;
+    virtual ~ExtAttExpandable() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFTremLog
 //----------------------------------------------------------------------------
 
 class AttFTremLog : public Att {
-public:
+protected:
     AttFTremLog();
-    virtual ~AttFTremLog();
+    ~AttFTremLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFTremLog();
 
@@ -481,14 +647,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFTremLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFTremLog
+ */
+
+class ExtAttFTremLog : public AttFTremLog {
+public:
+    ExtAttFTremLog() = default;
+    virtual ~ExtAttFTremLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttGlissPresent
 //----------------------------------------------------------------------------
 
 class AttGlissPresent : public Att {
-public:
+protected:
     AttGlissPresent();
-    virtual ~AttGlissPresent();
+    ~AttGlissPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetGlissPresent();
 
@@ -519,14 +700,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttGlissPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttGlissPresent
+ */
+
+class ExtAttGlissPresent : public AttGlissPresent {
+public:
+    ExtAttGlissPresent() = default;
+    virtual ~ExtAttGlissPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttGraceGrpLog
 //----------------------------------------------------------------------------
 
 class AttGraceGrpLog : public Att {
-public:
+protected:
     AttGraceGrpLog();
-    virtual ~AttGraceGrpLog();
+    ~AttGraceGrpLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetGraceGrpLog();
 
@@ -557,14 +753,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttGraceGrpLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttGraceGrpLog
+ */
+
+class ExtAttGraceGrpLog : public AttGraceGrpLog {
+public:
+    ExtAttGraceGrpLog() = default;
+    virtual ~ExtAttGraceGrpLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttGraced
 //----------------------------------------------------------------------------
 
 class AttGraced : public Att {
-public:
+protected:
     AttGraced();
-    virtual ~AttGraced();
+    ~AttGraced() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetGraced();
 
@@ -600,14 +811,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttGraced
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttGraced
+ */
+
+class ExtAttGraced : public AttGraced {
+public:
+    ExtAttGraced() = default;
+    virtual ~ExtAttGraced() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHairpinLog
 //----------------------------------------------------------------------------
 
 class AttHairpinLog : public Att {
-public:
+protected:
     AttHairpinLog();
-    virtual ~AttHairpinLog();
+    ~AttHairpinLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHairpinLog();
 
@@ -644,14 +870,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHairpinLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHairpinLog
+ */
+
+class ExtAttHairpinLog : public AttHairpinLog {
+public:
+    ExtAttHairpinLog() = default;
+    virtual ~ExtAttHairpinLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHarpPedalLog
 //----------------------------------------------------------------------------
 
 class AttHarpPedalLog : public Att {
-public:
+protected:
     AttHarpPedalLog();
-    virtual ~AttHarpPedalLog();
+    ~AttHarpPedalLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHarpPedalLog();
 
@@ -714,14 +955,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHarpPedalLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHarpPedalLog
+ */
+
+class ExtAttHarpPedalLog : public AttHarpPedalLog {
+public:
+    ExtAttHarpPedalLog() = default;
+    virtual ~ExtAttHarpPedalLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLvPresent
 //----------------------------------------------------------------------------
 
 class AttLvPresent : public Att {
-public:
+protected:
     AttLvPresent();
-    virtual ~AttLvPresent();
+    ~AttLvPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLvPresent();
 
@@ -751,14 +1007,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLvPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLvPresent
+ */
+
+class ExtAttLvPresent : public AttLvPresent {
+public:
+    ExtAttLvPresent() = default;
+    virtual ~ExtAttLvPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeasureLog
 //----------------------------------------------------------------------------
 
 class AttMeasureLog : public Att {
-public:
+protected:
     AttMeasureLog();
-    virtual ~AttMeasureLog();
+    ~AttMeasureLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeasureLog();
 
@@ -795,14 +1066,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeasureLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeasureLog
+ */
+
+class ExtAttMeasureLog : public AttMeasureLog {
+public:
+    ExtAttMeasureLog() = default;
+    virtual ~ExtAttMeasureLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterSigGrpLog
 //----------------------------------------------------------------------------
 
 class AttMeterSigGrpLog : public Att {
-public:
+protected:
     AttMeterSigGrpLog();
-    virtual ~AttMeterSigGrpLog();
+    ~AttMeterSigGrpLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterSigGrpLog();
 
@@ -829,14 +1115,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterSigGrpLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterSigGrpLog
+ */
+
+class ExtAttMeterSigGrpLog : public AttMeterSigGrpLog {
+public:
+    ExtAttMeterSigGrpLog() = default;
+    virtual ~ExtAttMeterSigGrpLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNumberPlacement
 //----------------------------------------------------------------------------
 
 class AttNumberPlacement : public Att {
-public:
+protected:
     AttNumberPlacement();
-    virtual ~AttNumberPlacement();
+    ~AttNumberPlacement() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNumberPlacement();
 
@@ -869,14 +1170,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNumberPlacement
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNumberPlacement
+ */
+
+class ExtAttNumberPlacement : public AttNumberPlacement {
+public:
+    ExtAttNumberPlacement() = default;
+    virtual ~ExtAttNumberPlacement() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNumbered
 //----------------------------------------------------------------------------
 
 class AttNumbered : public Att {
-public:
+protected:
     AttNumbered();
-    virtual ~AttNumbered();
+    ~AttNumbered() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNumbered();
 
@@ -903,14 +1219,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNumbered
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNumbered
+ */
+
+class ExtAttNumbered : public AttNumbered {
+public:
+    ExtAttNumbered() = default;
+    virtual ~ExtAttNumbered() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOctaveLog
 //----------------------------------------------------------------------------
 
 class AttOctaveLog : public Att {
-public:
+protected:
     AttOctaveLog();
-    virtual ~AttOctaveLog();
+    ~AttOctaveLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOctaveLog();
 
@@ -943,14 +1274,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOctaveLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOctaveLog
+ */
+
+class ExtAttOctaveLog : public AttOctaveLog {
+public:
+    ExtAttOctaveLog() = default;
+    virtual ~ExtAttOctaveLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPedalLog
 //----------------------------------------------------------------------------
 
 class AttPedalLog : public Att {
-public:
+protected:
     AttPedalLog();
-    virtual ~AttPedalLog();
+    ~AttPedalLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPedalLog();
 
@@ -983,14 +1329,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPedalLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPedalLog
+ */
+
+class ExtAttPedalLog : public AttPedalLog {
+public:
+    ExtAttPedalLog() = default;
+    virtual ~ExtAttPedalLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPianoPedals
 //----------------------------------------------------------------------------
 
 class AttPianoPedals : public Att {
-public:
+protected:
     AttPianoPedals();
-    virtual ~AttPianoPedals();
+    ~AttPianoPedals() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPianoPedals();
 
@@ -1017,14 +1378,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPianoPedals
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPianoPedals
+ */
+
+class ExtAttPianoPedals : public AttPianoPedals {
+public:
+    ExtAttPianoPedals() = default;
+    virtual ~ExtAttPianoPedals() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRehearsal
 //----------------------------------------------------------------------------
 
 class AttRehearsal : public Att {
-public:
+protected:
     AttRehearsal();
-    virtual ~AttRehearsal();
+    ~AttRehearsal() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRehearsal();
 
@@ -1051,14 +1427,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttRehearsal
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRehearsal
+ */
+
+class ExtAttRehearsal : public AttRehearsal {
+public:
+    ExtAttRehearsal() = default;
+    virtual ~ExtAttRehearsal() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttScoreDefVisCmn
 //----------------------------------------------------------------------------
 
 class AttScoreDefVisCmn : public Att {
-public:
+protected:
     AttScoreDefVisCmn();
-    virtual ~AttScoreDefVisCmn();
+    ~AttScoreDefVisCmn() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetScoreDefVisCmn();
 
@@ -1085,14 +1476,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttScoreDefVisCmn
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttScoreDefVisCmn
+ */
+
+class ExtAttScoreDefVisCmn : public AttScoreDefVisCmn {
+public:
+    ExtAttScoreDefVisCmn() = default;
+    virtual ~ExtAttScoreDefVisCmn() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSlurRend
 //----------------------------------------------------------------------------
 
 class AttSlurRend : public Att {
-public:
+protected:
     AttSlurRend();
-    virtual ~AttSlurRend();
+    ~AttSlurRend() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSlurRend();
 
@@ -1127,14 +1533,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSlurRend
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSlurRend
+ */
+
+class ExtAttSlurRend : public AttSlurRend {
+public:
+    ExtAttSlurRend() = default;
+    virtual ~ExtAttSlurRend() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStemsCmn
 //----------------------------------------------------------------------------
 
 class AttStemsCmn : public Att {
-public:
+protected:
     AttStemsCmn();
-    virtual ~AttStemsCmn();
+    ~AttStemsCmn() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStemsCmn();
 
@@ -1165,14 +1586,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStemsCmn
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStemsCmn
+ */
+
+class ExtAttStemsCmn : public AttStemsCmn {
+public:
+    ExtAttStemsCmn() = default;
+    virtual ~ExtAttStemsCmn() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTieRend
 //----------------------------------------------------------------------------
 
 class AttTieRend : public Att {
-public:
+protected:
     AttTieRend();
-    virtual ~AttTieRend();
+    ~AttTieRend() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTieRend();
 
@@ -1207,14 +1643,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTieRend
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTieRend
+ */
+
+class ExtAttTieRend : public AttTieRend {
+public:
+    ExtAttTieRend() = default;
+    virtual ~ExtAttTieRend() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTremMeasured
 //----------------------------------------------------------------------------
 
 class AttTremMeasured : public Att {
-public:
+protected:
     AttTremMeasured();
-    virtual ~AttTremMeasured();
+    ~AttTremMeasured() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTremMeasured();
 
@@ -1238,6 +1689,20 @@ public:
 private:
     /** The performed duration of an individual note in a measured tremolo. **/
     data_DURATION m_unitdur;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTremMeasured
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTremMeasured
+ */
+
+class ExtAttTremMeasured : public AttTremMeasured {
+public:
+    ExtAttTremMeasured() = default;
+    virtual ~ExtAttTremMeasured() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_cmnornaments.cpp
+++ b/libmei/dist/atts_cmnornaments.cpp
@@ -31,8 +31,6 @@ AttMordentLog::AttMordentLog() : Att()
     ResetMordentLog();
 }
 
-AttMordentLog::~AttMordentLog() {}
-
 void AttMordentLog::ResetMordentLog()
 {
     m_form = mordentLog_FORM_NONE;
@@ -88,8 +86,6 @@ AttOrnamPresent::AttOrnamPresent() : Att()
     ResetOrnamPresent();
 }
 
-AttOrnamPresent::~AttOrnamPresent() {}
-
 void AttOrnamPresent::ResetOrnamPresent()
 {
     m_ornam = "";
@@ -129,8 +125,6 @@ AttOrnamentAccid::AttOrnamentAccid() : Att()
 {
     ResetOrnamentAccid();
 }
-
-AttOrnamentAccid::~AttOrnamentAccid() {}
 
 void AttOrnamentAccid::ResetOrnamentAccid()
 {
@@ -186,8 +180,6 @@ AttTurnLog::AttTurnLog() : Att()
 {
     ResetTurnLog();
 }
-
-AttTurnLog::~AttTurnLog() {}
 
 void AttTurnLog::ResetTurnLog()
 {

--- a/libmei/dist/atts_cmnornaments.h
+++ b/libmei/dist/atts_cmnornaments.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttMordentLog : public Att {
-public:
+protected:
     AttMordentLog();
-    virtual ~AttMordentLog();
+    ~AttMordentLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMordentLog();
 
@@ -69,14 +70,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMordentLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMordentLog
+ */
+
+class ExtAttMordentLog : public AttMordentLog {
+public:
+    ExtAttMordentLog() = default;
+    virtual ~ExtAttMordentLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOrnamPresent
 //----------------------------------------------------------------------------
 
 class AttOrnamPresent : public Att {
-public:
+protected:
     AttOrnamPresent();
-    virtual ~AttOrnamPresent();
+    ~AttOrnamPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOrnamPresent();
 
@@ -107,14 +123,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOrnamPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOrnamPresent
+ */
+
+class ExtAttOrnamPresent : public AttOrnamPresent {
+public:
+    ExtAttOrnamPresent() = default;
+    virtual ~ExtAttOrnamPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOrnamentAccid
 //----------------------------------------------------------------------------
 
 class AttOrnamentAccid : public Att {
-public:
+protected:
     AttOrnamentAccid();
-    virtual ~AttOrnamentAccid();
+    ~AttOrnamentAccid() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOrnamentAccid();
 
@@ -147,14 +178,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOrnamentAccid
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOrnamentAccid
+ */
+
+class ExtAttOrnamentAccid : public AttOrnamentAccid {
+public:
+    ExtAttOrnamentAccid() = default;
+    virtual ~ExtAttOrnamentAccid() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTurnLog
 //----------------------------------------------------------------------------
 
 class AttTurnLog : public Att {
-public:
+protected:
     AttTurnLog();
-    virtual ~AttTurnLog();
+    ~AttTurnLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTurnLog();
 
@@ -184,6 +230,20 @@ private:
     data_BOOLEAN m_delayed;
     /** Indicates to what degree the harmonic label is supported by the notation. **/
     turnLog_FORM m_form;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTurnLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTurnLog
+ */
+
+class ExtAttTurnLog : public AttTurnLog {
+public:
+    ExtAttTurnLog() = default;
+    virtual ~ExtAttTurnLog() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_critapp.cpp
+++ b/libmei/dist/atts_critapp.cpp
@@ -31,8 +31,6 @@ AttCrit::AttCrit() : Att()
     ResetCrit();
 }
 
-AttCrit::~AttCrit() {}
-
 void AttCrit::ResetCrit()
 {
     m_cause = "";

--- a/libmei/dist/atts_critapp.h
+++ b/libmei/dist/atts_critapp.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttCrit : public Att {
-public:
+protected:
     AttCrit();
-    virtual ~AttCrit();
+    ~AttCrit() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCrit();
 
@@ -60,6 +61,20 @@ private:
      * typology of possible origins.
      **/
     std::string m_cause;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttCrit
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCrit
+ */
+
+class ExtAttCrit : public AttCrit {
+public:
+    ExtAttCrit() = default;
+    virtual ~ExtAttCrit() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_edittrans.cpp
+++ b/libmei/dist/atts_edittrans.cpp
@@ -31,8 +31,6 @@ AttAgentIdent::AttAgentIdent() : Att()
     ResetAgentIdent();
 }
 
-AttAgentIdent::~AttAgentIdent() {}
-
 void AttAgentIdent::ResetAgentIdent()
 {
     m_agent = "";
@@ -72,8 +70,6 @@ AttReasonIdent::AttReasonIdent() : Att()
 {
     ResetReasonIdent();
 }
-
-AttReasonIdent::~AttReasonIdent() {}
 
 void AttReasonIdent::ResetReasonIdent()
 {

--- a/libmei/dist/atts_edittrans.h
+++ b/libmei/dist/atts_edittrans.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAgentIdent : public Att {
-public:
+protected:
     AttAgentIdent();
-    virtual ~AttAgentIdent();
+    ~AttAgentIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAgentIdent();
 
@@ -63,14 +64,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAgentIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAgentIdent
+ */
+
+class ExtAttAgentIdent : public AttAgentIdent {
+public:
+    ExtAttAgentIdent() = default;
+    virtual ~ExtAttAgentIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttReasonIdent
 //----------------------------------------------------------------------------
 
 class AttReasonIdent : public Att {
-public:
+protected:
     AttReasonIdent();
-    virtual ~AttReasonIdent();
+    ~AttReasonIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetReasonIdent();
 
@@ -98,6 +114,20 @@ private:
      * (unclear).
      **/
     std::string m_reason;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttReasonIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttReasonIdent
+ */
+
+class ExtAttReasonIdent : public AttReasonIdent {
+public:
+    ExtAttReasonIdent() = default;
+    virtual ~ExtAttReasonIdent() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_externalsymbols.cpp
+++ b/libmei/dist/atts_externalsymbols.cpp
@@ -31,8 +31,6 @@ AttExtSym::AttExtSym() : Att()
     ResetExtSym();
 }
 
-AttExtSym::~AttExtSym() {}
-
 void AttExtSym::ResetExtSym()
 {
     m_glyphAuth = "";

--- a/libmei/dist/atts_externalsymbols.h
+++ b/libmei/dist/atts_externalsymbols.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttExtSym : public Att {
-public:
+protected:
     AttExtSym();
-    virtual ~AttExtSym();
+    ~AttExtSym() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetExtSym();
 
@@ -84,6 +85,20 @@ private:
      * glyph.name or glyph.num is taken.
      **/
     std::string m_glyphUri;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttExtSym
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttExtSym
+ */
+
+class ExtAttExtSym : public AttExtSym {
+public:
+    ExtAttExtSym() = default;
+    virtual ~ExtAttExtSym() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_facsimile.cpp
+++ b/libmei/dist/atts_facsimile.cpp
@@ -31,8 +31,6 @@ AttFacsimile::AttFacsimile() : Att()
     ResetFacsimile();
 }
 
-AttFacsimile::~AttFacsimile() {}
-
 void AttFacsimile::ResetFacsimile()
 {
     m_facs = "";

--- a/libmei/dist/atts_facsimile.h
+++ b/libmei/dist/atts_facsimile.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttFacsimile : public Att {
-public:
+protected:
     AttFacsimile();
-    virtual ~AttFacsimile();
+    ~AttFacsimile() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFacsimile();
 
@@ -60,6 +61,20 @@ private:
      * corresponds to it.
      **/
     std::string m_facs;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttFacsimile
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFacsimile
+ */
+
+class ExtAttFacsimile : public AttFacsimile {
+public:
+    ExtAttFacsimile() = default;
+    virtual ~ExtAttFacsimile() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_figtable.cpp
+++ b/libmei/dist/atts_figtable.cpp
@@ -31,8 +31,6 @@ AttTabular::AttTabular() : Att()
     ResetTabular();
 }
 
-AttTabular::~AttTabular() {}
-
 void AttTabular::ResetTabular()
 {
     m_colspan = MEI_UNSET;

--- a/libmei/dist/atts_figtable.h
+++ b/libmei/dist/atts_figtable.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttTabular : public Att {
-public:
+protected:
     AttTabular();
-    virtual ~AttTabular();
+    ~AttTabular() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTabular();
 
@@ -63,6 +64,20 @@ private:
     int m_colspan;
     /** The number of rows spanned by this cell. **/
     int m_rowspan;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTabular
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTabular
+ */
+
+class ExtAttTabular : public AttTabular {
+public:
+    ExtAttTabular() = default;
+    virtual ~ExtAttTabular() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_fingering.cpp
+++ b/libmei/dist/atts_fingering.cpp
@@ -31,8 +31,6 @@ AttFingGrpLog::AttFingGrpLog() : Att()
     ResetFingGrpLog();
 }
 
-AttFingGrpLog::~AttFingGrpLog() {}
-
 void AttFingGrpLog::ResetFingGrpLog()
 {
     m_form = fingGrpLog_FORM_NONE;

--- a/libmei/dist/atts_fingering.h
+++ b/libmei/dist/atts_fingering.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttFingGrpLog : public Att {
-public:
+protected:
     AttFingGrpLog();
-    virtual ~AttFingGrpLog();
+    ~AttFingGrpLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFingGrpLog();
 
@@ -57,6 +58,20 @@ public:
 private:
     /** Indicates to what degree the harmonic label is supported by the notation. **/
     fingGrpLog_FORM m_form;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttFingGrpLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFingGrpLog
+ */
+
+class ExtAttFingGrpLog : public AttFingGrpLog {
+public:
+    ExtAttFingGrpLog() = default;
+    virtual ~ExtAttFingGrpLog() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_frettab.cpp
+++ b/libmei/dist/atts_frettab.cpp
@@ -31,8 +31,6 @@ AttCourseLog::AttCourseLog() : Att()
     ResetCourseLog();
 }
 
-AttCourseLog::~AttCourseLog() {}
-
 void AttCourseLog::ResetCourseLog()
 {
     m_tuningStandard = COURSETUNING_NONE;
@@ -72,8 +70,6 @@ AttNoteGesTab::AttNoteGesTab() : Att()
 {
     ResetNoteGesTab();
 }
-
-AttNoteGesTab::~AttNoteGesTab() {}
 
 void AttNoteGesTab::ResetNoteGesTab()
 {

--- a/libmei/dist/atts_frettab.h
+++ b/libmei/dist/atts_frettab.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttCourseLog : public Att {
-public:
+protected:
     AttCourseLog();
-    virtual ~AttCourseLog();
+    ~AttCourseLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCourseLog();
 
@@ -60,14 +61,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCourseLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCourseLog
+ */
+
+class ExtAttCourseLog : public AttCourseLog {
+public:
+    ExtAttCourseLog() = default;
+    virtual ~ExtAttCourseLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNoteGesTab
 //----------------------------------------------------------------------------
 
 class AttNoteGesTab : public Att {
-public:
+protected:
     AttNoteGesTab();
-    virtual ~AttNoteGesTab();
+    ~AttNoteGesTab() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNoteGesTab();
 
@@ -97,6 +113,20 @@ private:
     int m_tabCourse;
     /** Records which course is to be played. **/
     int m_tabFret;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttNoteGesTab
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNoteGesTab
+ */
+
+class ExtAttNoteGesTab : public AttNoteGesTab {
+public:
+    ExtAttNoteGesTab() = default;
+    virtual ~ExtAttNoteGesTab() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_gestural.cpp
+++ b/libmei/dist/atts_gestural.cpp
@@ -31,8 +31,6 @@ AttAccidentalGes::AttAccidentalGes() : Att()
     ResetAccidentalGes();
 }
 
-AttAccidentalGes::~AttAccidentalGes() {}
-
 void AttAccidentalGes::ResetAccidentalGes()
 {
     m_accidGes = ACCIDENTAL_GESTURAL_NONE;
@@ -72,8 +70,6 @@ AttArticulationGes::AttArticulationGes() : Att()
 {
     ResetArticulationGes();
 }
-
-AttArticulationGes::~AttArticulationGes() {}
 
 void AttArticulationGes::ResetArticulationGes()
 {
@@ -115,8 +111,6 @@ AttBendGes::AttBendGes() : Att()
     ResetBendGes();
 }
 
-AttBendGes::~AttBendGes() {}
-
 void AttBendGes::ResetBendGes()
 {
     m_amount = 0.0;
@@ -156,8 +150,6 @@ AttDurationGes::AttDurationGes() : Att()
 {
     ResetDurationGes();
 }
-
-AttDurationGes::~AttDurationGes() {}
 
 void AttDurationGes::ResetDurationGes()
 {
@@ -274,8 +266,6 @@ AttMdivGes::AttMdivGes() : Att()
     ResetMdivGes();
 }
 
-AttMdivGes::~AttMdivGes() {}
-
 void AttMdivGes::ResetMdivGes()
 {
     m_attacca = BOOLEAN_NONE;
@@ -315,8 +305,6 @@ AttNcGes::AttNcGes() : Att()
 {
     ResetNcGes();
 }
-
-AttNcGes::~AttNcGes() {}
 
 void AttNcGes::ResetNcGes()
 {
@@ -387,8 +375,6 @@ AttNoteGes::AttNoteGes() : Att()
 {
     ResetNoteGes();
 }
-
-AttNoteGes::~AttNoteGes() {}
 
 void AttNoteGes::ResetNoteGes()
 {
@@ -475,8 +461,6 @@ AttOrnamentAccidGes::AttOrnamentAccidGes() : Att()
     ResetOrnamentAccidGes();
 }
 
-AttOrnamentAccidGes::~AttOrnamentAccidGes() {}
-
 void AttOrnamentAccidGes::ResetOrnamentAccidGes()
 {
     m_accidupperGes = ACCIDENTAL_GESTURAL_NONE;
@@ -532,8 +516,6 @@ AttSectionGes::AttSectionGes() : Att()
     ResetSectionGes();
 }
 
-AttSectionGes::~AttSectionGes() {}
-
 void AttSectionGes::ResetSectionGes()
 {
     m_attacca = BOOLEAN_NONE;
@@ -573,8 +555,6 @@ AttSoundLocation::AttSoundLocation() : Att()
 {
     ResetSoundLocation();
 }
-
-AttSoundLocation::~AttSoundLocation() {}
 
 void AttSoundLocation::ResetSoundLocation()
 {
@@ -631,8 +611,6 @@ AttTimestampGes::AttTimestampGes() : Att()
     ResetTimestampGes();
 }
 
-AttTimestampGes::~AttTimestampGes() {}
-
 void AttTimestampGes::ResetTimestampGes()
 {
     m_tstampGes = 0.0;
@@ -687,8 +665,6 @@ AttTimestamp2Ges::AttTimestamp2Ges() : Att()
 {
     ResetTimestamp2Ges();
 }
-
-AttTimestamp2Ges::~AttTimestamp2Ges() {}
 
 void AttTimestamp2Ges::ResetTimestamp2Ges()
 {

--- a/libmei/dist/atts_gestural.h
+++ b/libmei/dist/atts_gestural.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAccidentalGes : public Att {
-public:
+protected:
     AttAccidentalGes();
-    virtual ~AttAccidentalGes();
+    ~AttAccidentalGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAccidentalGes();
 
@@ -60,14 +61,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAccidentalGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAccidentalGes
+ */
+
+class ExtAttAccidentalGes : public AttAccidentalGes {
+public:
+    ExtAttAccidentalGes() = default;
+    virtual ~ExtAttAccidentalGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttArticulationGes
 //----------------------------------------------------------------------------
 
 class AttArticulationGes : public Att {
-public:
+protected:
     AttArticulationGes();
-    virtual ~AttArticulationGes();
+    ~AttArticulationGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetArticulationGes();
 
@@ -94,14 +110,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttArticulationGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttArticulationGes
+ */
+
+class ExtAttArticulationGes : public AttArticulationGes {
+public:
+    ExtAttArticulationGes() = default;
+    virtual ~ExtAttArticulationGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBendGes
 //----------------------------------------------------------------------------
 
 class AttBendGes : public Att {
-public:
+protected:
     AttBendGes();
-    virtual ~AttBendGes();
+    ~AttBendGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBendGes();
 
@@ -132,14 +163,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBendGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBendGes
+ */
+
+class ExtAttBendGes : public AttBendGes {
+public:
+    ExtAttBendGes() = default;
+    virtual ~ExtAttBendGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDurationGes
 //----------------------------------------------------------------------------
 
 class AttDurationGes : public Att {
-public:
+protected:
     AttDurationGes();
-    virtual ~AttDurationGes();
+    ~AttDurationGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationGes();
 
@@ -202,14 +248,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationGes
+ */
+
+class ExtAttDurationGes : public AttDurationGes {
+public:
+    ExtAttDurationGes() = default;
+    virtual ~ExtAttDurationGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMdivGes
 //----------------------------------------------------------------------------
 
 class AttMdivGes : public Att {
-public:
+protected:
     AttMdivGes();
-    virtual ~AttMdivGes();
+    ~AttMdivGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMdivGes();
 
@@ -239,14 +300,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMdivGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMdivGes
+ */
+
+class ExtAttMdivGes : public AttMdivGes {
+public:
+    ExtAttMdivGes() = default;
+    virtual ~ExtAttMdivGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNcGes
 //----------------------------------------------------------------------------
 
 class AttNcGes : public Att {
-public:
+protected:
     AttNcGes();
-    virtual ~AttNcGes();
+    ~AttNcGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNcGes();
 
@@ -285,14 +361,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNcGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNcGes
+ */
+
+class ExtAttNcGes : public AttNcGes {
+public:
+    ExtAttNcGes() = default;
+    virtual ~ExtAttNcGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNoteGes
 //----------------------------------------------------------------------------
 
 class AttNoteGes : public Att {
-public:
+protected:
     AttNoteGes();
-    virtual ~AttNoteGes();
+    ~AttNoteGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNoteGes();
 
@@ -337,14 +428,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNoteGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNoteGes
+ */
+
+class ExtAttNoteGes : public AttNoteGes {
+public:
+    ExtAttNoteGes() = default;
+    virtual ~ExtAttNoteGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOrnamentAccidGes
 //----------------------------------------------------------------------------
 
 class AttOrnamentAccidGes : public Att {
-public:
+protected:
     AttOrnamentAccidGes();
-    virtual ~AttOrnamentAccidGes();
+    ~AttOrnamentAccidGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOrnamentAccidGes();
 
@@ -377,14 +483,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOrnamentAccidGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOrnamentAccidGes
+ */
+
+class ExtAttOrnamentAccidGes : public AttOrnamentAccidGes {
+public:
+    ExtAttOrnamentAccidGes() = default;
+    virtual ~ExtAttOrnamentAccidGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSectionGes
 //----------------------------------------------------------------------------
 
 class AttSectionGes : public Att {
-public:
+protected:
     AttSectionGes();
-    virtual ~AttSectionGes();
+    ~AttSectionGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSectionGes();
 
@@ -414,14 +535,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSectionGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSectionGes
+ */
+
+class ExtAttSectionGes : public AttSectionGes {
+public:
+    ExtAttSectionGes() = default;
+    virtual ~ExtAttSectionGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSoundLocation
 //----------------------------------------------------------------------------
 
 class AttSoundLocation : public Att {
-public:
+protected:
     AttSoundLocation();
-    virtual ~AttSoundLocation();
+    ~AttSoundLocation() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSoundLocation();
 
@@ -454,14 +590,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSoundLocation
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSoundLocation
+ */
+
+class ExtAttSoundLocation : public AttSoundLocation {
+public:
+    ExtAttSoundLocation() = default;
+    virtual ~ExtAttSoundLocation() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTimestampGes
 //----------------------------------------------------------------------------
 
 class AttTimestampGes : public Att {
-public:
+protected:
     AttTimestampGes();
-    virtual ~AttTimestampGes();
+    ~AttTimestampGes() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTimestampGes();
 
@@ -497,14 +648,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTimestampGes
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTimestampGes
+ */
+
+class ExtAttTimestampGes : public AttTimestampGes {
+public:
+    ExtAttTimestampGes() = default;
+    virtual ~ExtAttTimestampGes() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTimestamp2Ges
 //----------------------------------------------------------------------------
 
 class AttTimestamp2Ges : public Att {
-public:
+protected:
     AttTimestamp2Ges();
-    virtual ~AttTimestamp2Ges();
+    ~AttTimestamp2Ges() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTimestamp2Ges();
 
@@ -537,6 +703,20 @@ private:
     data_MEASUREBEAT m_tstamp2Ges;
     /** Records the ending point of an event in terms of ISO time. **/
     std::string m_tstamp2Real;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTimestamp2Ges
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTimestamp2Ges
+ */
+
+class ExtAttTimestamp2Ges : public AttTimestamp2Ges {
+public:
+    ExtAttTimestamp2Ges() = default;
+    virtual ~ExtAttTimestamp2Ges() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_harmony.cpp
+++ b/libmei/dist/atts_harmony.cpp
@@ -31,8 +31,6 @@ AttHarmLog::AttHarmLog() : Att()
     ResetHarmLog();
 }
 
-AttHarmLog::~AttHarmLog() {}
-
 void AttHarmLog::ResetHarmLog()
 {
     m_chordref = "";

--- a/libmei/dist/atts_harmony.h
+++ b/libmei/dist/atts_harmony.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttHarmLog : public Att {
-public:
+protected:
     AttHarmLog();
-    virtual ~AttHarmLog();
+    ~AttHarmLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHarmLog();
 
@@ -57,6 +58,20 @@ public:
 private:
     /** Contains a reference to a chordDef element elsewhere in the document. **/
     std::string m_chordref;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttHarmLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHarmLog
+ */
+
+class ExtAttHarmLog : public AttHarmLog {
+public:
+    ExtAttHarmLog() = default;
+    virtual ~ExtAttHarmLog() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_header.cpp
+++ b/libmei/dist/atts_header.cpp
@@ -31,8 +31,6 @@ AttBifoliumSurfaces::AttBifoliumSurfaces() : Att()
     ResetBifoliumSurfaces();
 }
 
-AttBifoliumSurfaces::~AttBifoliumSurfaces() {}
-
 void AttBifoliumSurfaces::ResetBifoliumSurfaces()
 {
     m_outerRecto = "";
@@ -118,8 +116,6 @@ AttFoliumSurfaces::AttFoliumSurfaces() : Att()
     ResetFoliumSurfaces();
 }
 
-AttFoliumSurfaces::~AttFoliumSurfaces() {}
-
 void AttFoliumSurfaces::ResetFoliumSurfaces()
 {
     m_recto = "";
@@ -175,8 +171,6 @@ AttRecordType::AttRecordType() : Att()
     ResetRecordType();
 }
 
-AttRecordType::~AttRecordType() {}
-
 void AttRecordType::ResetRecordType()
 {
     m_recordtype = recordType_RECORDTYPE_NONE;
@@ -216,8 +210,6 @@ AttRegularMethod::AttRegularMethod() : Att()
 {
     ResetRegularMethod();
 }
-
-AttRegularMethod::~AttRegularMethod() {}
 
 void AttRegularMethod::ResetRegularMethod()
 {

--- a/libmei/dist/atts_header.h
+++ b/libmei/dist/atts_header.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttBifoliumSurfaces : public Att {
-public:
+protected:
     AttBifoliumSurfaces();
-    virtual ~AttBifoliumSurfaces();
+    ~AttBifoliumSurfaces() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBifoliumSurfaces();
 
@@ -90,14 +91,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBifoliumSurfaces
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBifoliumSurfaces
+ */
+
+class ExtAttBifoliumSurfaces : public AttBifoliumSurfaces {
+public:
+    ExtAttBifoliumSurfaces() = default;
+    virtual ~ExtAttBifoliumSurfaces() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFoliumSurfaces
 //----------------------------------------------------------------------------
 
 class AttFoliumSurfaces : public Att {
-public:
+protected:
     AttFoliumSurfaces();
-    virtual ~AttFoliumSurfaces();
+    ~AttFoliumSurfaces() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFoliumSurfaces();
 
@@ -130,14 +146,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFoliumSurfaces
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFoliumSurfaces
+ */
+
+class ExtAttFoliumSurfaces : public AttFoliumSurfaces {
+public:
+    ExtAttFoliumSurfaces() = default;
+    virtual ~ExtAttFoliumSurfaces() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRecordType
 //----------------------------------------------------------------------------
 
 class AttRecordType : public Att {
-public:
+protected:
     AttRecordType();
-    virtual ~AttRecordType();
+    ~AttRecordType() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRecordType();
 
@@ -164,14 +195,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttRecordType
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRecordType
+ */
+
+class ExtAttRecordType : public AttRecordType {
+public:
+    ExtAttRecordType() = default;
+    virtual ~ExtAttRecordType() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRegularMethod
 //----------------------------------------------------------------------------
 
 class AttRegularMethod : public Att {
-public:
+protected:
     AttRegularMethod();
-    virtual ~AttRegularMethod();
+    ~AttRegularMethod() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRegularMethod();
 
@@ -195,6 +241,20 @@ public:
 private:
     /** Indicates the method employed to mark corrections and normalizations. **/
     regularMethod_METHOD m_method;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttRegularMethod
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRegularMethod
+ */
+
+class ExtAttRegularMethod : public AttRegularMethod {
+public:
+    ExtAttRegularMethod() = default;
+    virtual ~ExtAttRegularMethod() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_mei.cpp
+++ b/libmei/dist/atts_mei.cpp
@@ -31,8 +31,6 @@ AttNotationType::AttNotationType() : Att()
     ResetNotationType();
 }
 
-AttNotationType::~AttNotationType() {}
-
 void AttNotationType::ResetNotationType()
 {
     m_notationtype = NOTATIONTYPE_NONE;

--- a/libmei/dist/atts_mei.h
+++ b/libmei/dist/atts_mei.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttNotationType : public Att {
-public:
+protected:
     AttNotationType();
-    virtual ~AttNotationType();
+    ~AttNotationType() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNotationType();
 
@@ -69,6 +70,20 @@ private:
      * element, additional to that given by its notationtype attribute.
      **/
     std::string m_notationsubtype;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttNotationType
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNotationType
+ */
+
+class ExtAttNotationType : public AttNotationType {
+public:
+    ExtAttNotationType() = default;
+    virtual ~ExtAttNotationType() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_mensural.cpp
+++ b/libmei/dist/atts_mensural.cpp
@@ -31,8 +31,6 @@ AttDurationQuality::AttDurationQuality() : Att()
     ResetDurationQuality();
 }
 
-AttDurationQuality::~AttDurationQuality() {}
-
 void AttDurationQuality::ResetDurationQuality()
 {
     m_durQuality = DURQUALITY_mensural_NONE;
@@ -72,8 +70,6 @@ AttMensuralLog::AttMensuralLog() : Att()
 {
     ResetMensuralLog();
 }
-
-AttMensuralLog::~AttMensuralLog() {}
 
 void AttMensuralLog::ResetMensuralLog()
 {
@@ -129,8 +125,6 @@ AttMensuralShared::AttMensuralShared() : Att()
 {
     ResetMensuralShared();
 }
-
-AttMensuralShared::~AttMensuralShared() {}
 
 void AttMensuralShared::ResetMensuralShared()
 {
@@ -232,8 +226,6 @@ AttNoteVisMensural::AttNoteVisMensural() : Att()
     ResetNoteVisMensural();
 }
 
-AttNoteVisMensural::~AttNoteVisMensural() {}
-
 void AttNoteVisMensural::ResetNoteVisMensural()
 {
     m_lig = LIGATUREFORM_NONE;
@@ -274,8 +266,6 @@ AttRestVisMensural::AttRestVisMensural() : Att()
     ResetRestVisMensural();
 }
 
-AttRestVisMensural::~AttRestVisMensural() {}
-
 void AttRestVisMensural::ResetRestVisMensural()
 {
     m_spaces = MEI_UNSET;
@@ -315,8 +305,6 @@ AttStemsMensural::AttStemsMensural() : Att()
 {
     ResetStemsMensural();
 }
-
-AttStemsMensural::~AttStemsMensural() {}
 
 void AttStemsMensural::ResetStemsMensural()
 {

--- a/libmei/dist/atts_mensural.h
+++ b/libmei/dist/atts_mensural.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttDurationQuality : public Att {
-public:
+protected:
     AttDurationQuality();
-    virtual ~AttDurationQuality();
+    ~AttDurationQuality() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationQuality();
 
@@ -64,14 +65,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationQuality
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationQuality
+ */
+
+class ExtAttDurationQuality : public AttDurationQuality {
+public:
+    ExtAttDurationQuality() = default;
+    virtual ~ExtAttDurationQuality() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMensuralLog
 //----------------------------------------------------------------------------
 
 class AttMensuralLog : public Att {
-public:
+protected:
     AttMensuralLog();
-    virtual ~AttMensuralLog();
+    ~AttMensuralLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMensuralLog();
 
@@ -112,14 +128,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMensuralLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMensuralLog
+ */
+
+class ExtAttMensuralLog : public AttMensuralLog {
+public:
+    ExtAttMensuralLog() = default;
+    virtual ~ExtAttMensuralLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMensuralShared
 //----------------------------------------------------------------------------
 
 class AttMensuralShared : public Att {
-public:
+protected:
     AttMensuralShared();
-    virtual ~AttMensuralShared();
+    ~AttMensuralShared() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMensuralShared();
 
@@ -170,14 +201,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMensuralShared
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMensuralShared
+ */
+
+class ExtAttMensuralShared : public AttMensuralShared {
+public:
+    ExtAttMensuralShared() = default;
+    virtual ~ExtAttMensuralShared() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNoteVisMensural
 //----------------------------------------------------------------------------
 
 class AttNoteVisMensural : public Att {
-public:
+protected:
     AttNoteVisMensural();
-    virtual ~AttNoteVisMensural();
+    ~AttNoteVisMensural() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNoteVisMensural();
 
@@ -204,14 +250,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNoteVisMensural
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNoteVisMensural
+ */
+
+class ExtAttNoteVisMensural : public AttNoteVisMensural {
+public:
+    ExtAttNoteVisMensural() = default;
+    virtual ~ExtAttNoteVisMensural() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRestVisMensural
 //----------------------------------------------------------------------------
 
 class AttRestVisMensural : public Att {
-public:
+protected:
     AttRestVisMensural();
-    virtual ~AttRestVisMensural();
+    ~AttRestVisMensural() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRestVisMensural();
 
@@ -238,14 +299,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttRestVisMensural
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRestVisMensural
+ */
+
+class ExtAttRestVisMensural : public AttRestVisMensural {
+public:
+    ExtAttRestVisMensural() = default;
+    virtual ~ExtAttRestVisMensural() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStemsMensural
 //----------------------------------------------------------------------------
 
 class AttStemsMensural : public Att {
-public:
+protected:
     AttStemsMensural();
-    virtual ~AttStemsMensural();
+    ~AttStemsMensural() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStemsMensural();
 
@@ -269,6 +345,20 @@ public:
 private:
     /** Records the form of the stem. **/
     data_STEMFORM_mensural m_stemForm;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttStemsMensural
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStemsMensural
+ */
+
+class ExtAttStemsMensural : public AttStemsMensural {
+public:
+    ExtAttStemsMensural() = default;
+    virtual ~ExtAttStemsMensural() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_midi.cpp
+++ b/libmei/dist/atts_midi.cpp
@@ -31,8 +31,6 @@ AttChannelized::AttChannelized() : Att()
     ResetChannelized();
 }
 
-AttChannelized::~AttChannelized() {}
-
 void AttChannelized::ResetChannelized()
 {
     m_midiChannel = -1;
@@ -118,8 +116,6 @@ AttInstrumentIdent::AttInstrumentIdent() : Att()
     ResetInstrumentIdent();
 }
 
-AttInstrumentIdent::~AttInstrumentIdent() {}
-
 void AttInstrumentIdent::ResetInstrumentIdent()
 {
     m_instr = "";
@@ -159,8 +155,6 @@ AttMidiInstrument::AttMidiInstrument() : Att()
 {
     ResetMidiInstrument();
 }
-
-AttMidiInstrument::~AttMidiInstrument() {}
 
 void AttMidiInstrument::ResetMidiInstrument()
 {
@@ -277,8 +271,6 @@ AttMidiNumber::AttMidiNumber() : Att()
     ResetMidiNumber();
 }
 
-AttMidiNumber::~AttMidiNumber() {}
-
 void AttMidiNumber::ResetMidiNumber()
 {
     m_num = -1;
@@ -318,8 +310,6 @@ AttMidiTempo::AttMidiTempo() : Att()
 {
     ResetMidiTempo();
 }
-
-AttMidiTempo::~AttMidiTempo() {}
 
 void AttMidiTempo::ResetMidiTempo()
 {
@@ -376,8 +366,6 @@ AttMidiValue::AttMidiValue() : Att()
     ResetMidiValue();
 }
 
-AttMidiValue::~AttMidiValue() {}
-
 void AttMidiValue::ResetMidiValue()
 {
     m_val = -1;
@@ -417,8 +405,6 @@ AttMidiValue2::AttMidiValue2() : Att()
 {
     ResetMidiValue2();
 }
-
-AttMidiValue2::~AttMidiValue2() {}
 
 void AttMidiValue2::ResetMidiValue2()
 {
@@ -460,8 +446,6 @@ AttMidiVelocity::AttMidiVelocity() : Att()
     ResetMidiVelocity();
 }
 
-AttMidiVelocity::~AttMidiVelocity() {}
-
 void AttMidiVelocity::ResetMidiVelocity()
 {
     m_vel = -1;
@@ -501,8 +485,6 @@ AttTimeBase::AttTimeBase() : Att()
 {
     ResetTimeBase();
 }
-
-AttTimeBase::~AttTimeBase() {}
 
 void AttTimeBase::ResetTimeBase()
 {

--- a/libmei/dist/atts_midi.h
+++ b/libmei/dist/atts_midi.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttChannelized : public Att {
-public:
+protected:
     AttChannelized();
-    virtual ~AttChannelized();
+    ~AttChannelized() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetChannelized();
 
@@ -78,14 +79,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttChannelized
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttChannelized
+ */
+
+class ExtAttChannelized : public AttChannelized {
+public:
+    ExtAttChannelized() = default;
+    virtual ~ExtAttChannelized() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttInstrumentIdent
 //----------------------------------------------------------------------------
 
 class AttInstrumentIdent : public Att {
-public:
+protected:
     AttInstrumentIdent();
-    virtual ~AttInstrumentIdent();
+    ~AttInstrumentIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetInstrumentIdent();
 
@@ -115,14 +131,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttInstrumentIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttInstrumentIdent
+ */
+
+class ExtAttInstrumentIdent : public AttInstrumentIdent {
+public:
+    ExtAttInstrumentIdent() = default;
+    virtual ~ExtAttInstrumentIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiInstrument
 //----------------------------------------------------------------------------
 
 class AttMidiInstrument : public Att {
-public:
+protected:
     AttMidiInstrument();
-    virtual ~AttMidiInstrument();
+    ~AttMidiInstrument() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiInstrument();
 
@@ -188,14 +219,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiInstrument
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiInstrument
+ */
+
+class ExtAttMidiInstrument : public AttMidiInstrument {
+public:
+    ExtAttMidiInstrument() = default;
+    virtual ~ExtAttMidiInstrument() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiNumber
 //----------------------------------------------------------------------------
 
 class AttMidiNumber : public Att {
-public:
+protected:
     AttMidiNumber();
-    virtual ~AttMidiNumber();
+    ~AttMidiNumber() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiNumber();
 
@@ -222,14 +268,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiNumber
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiNumber
+ */
+
+class ExtAttMidiNumber : public AttMidiNumber {
+public:
+    ExtAttMidiNumber() = default;
+    virtual ~ExtAttMidiNumber() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiTempo
 //----------------------------------------------------------------------------
 
 class AttMidiTempo : public Att {
-public:
+protected:
     AttMidiTempo();
-    virtual ~AttMidiTempo();
+    ~AttMidiTempo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiTempo();
 
@@ -271,14 +332,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiTempo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiTempo
+ */
+
+class ExtAttMidiTempo : public AttMidiTempo {
+public:
+    ExtAttMidiTempo() = default;
+    virtual ~ExtAttMidiTempo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiValue
 //----------------------------------------------------------------------------
 
 class AttMidiValue : public Att {
-public:
+protected:
     AttMidiValue();
-    virtual ~AttMidiValue();
+    ~AttMidiValue() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiValue();
 
@@ -305,14 +381,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiValue
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiValue
+ */
+
+class ExtAttMidiValue : public AttMidiValue {
+public:
+    ExtAttMidiValue() = default;
+    virtual ~ExtAttMidiValue() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiValue2
 //----------------------------------------------------------------------------
 
 class AttMidiValue2 : public Att {
-public:
+protected:
     AttMidiValue2();
-    virtual ~AttMidiValue2();
+    ~AttMidiValue2() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiValue2();
 
@@ -339,14 +430,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiValue2
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiValue2
+ */
+
+class ExtAttMidiValue2 : public AttMidiValue2 {
+public:
+    ExtAttMidiValue2() = default;
+    virtual ~ExtAttMidiValue2() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMidiVelocity
 //----------------------------------------------------------------------------
 
 class AttMidiVelocity : public Att {
-public:
+protected:
     AttMidiVelocity();
-    virtual ~AttMidiVelocity();
+    ~AttMidiVelocity() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMidiVelocity();
 
@@ -373,14 +479,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMidiVelocity
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMidiVelocity
+ */
+
+class ExtAttMidiVelocity : public AttMidiVelocity {
+public:
+    ExtAttMidiVelocity() = default;
+    virtual ~ExtAttMidiVelocity() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTimeBase
 //----------------------------------------------------------------------------
 
 class AttTimeBase : public Att {
-public:
+protected:
     AttTimeBase();
-    virtual ~AttTimeBase();
+    ~AttTimeBase() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTimeBase();
 
@@ -408,6 +529,20 @@ private:
      * Unlike MIDI, MEI permits different values for a score and individual staves.
      **/
     int m_ppq;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTimeBase
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTimeBase
+ */
+
+class ExtAttTimeBase : public AttTimeBase {
+public:
+    ExtAttTimeBase() = default;
+    virtual ~ExtAttTimeBase() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_neumes.cpp
+++ b/libmei/dist/atts_neumes.cpp
@@ -31,8 +31,6 @@ AttNcLog::AttNcLog() : Att()
     ResetNcLog();
 }
 
-AttNcLog::~AttNcLog() {}
-
 void AttNcLog::ResetNcLog()
 {
     m_oct = "";
@@ -87,8 +85,6 @@ AttNcForm::AttNcForm() : Att()
 {
     ResetNcForm();
 }
-
-AttNcForm::~AttNcForm() {}
 
 void AttNcForm::ResetNcForm()
 {

--- a/libmei/dist/atts_neumes.h
+++ b/libmei/dist/atts_neumes.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttNcLog : public Att {
-public:
+protected:
     AttNcLog();
-    virtual ~AttNcLog();
+    ~AttNcLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNcLog();
 
@@ -66,14 +67,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNcLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNcLog
+ */
+
+class ExtAttNcLog : public AttNcLog {
+public:
+    ExtAttNcLog() = default;
+    virtual ~ExtAttNcLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNcForm
 //----------------------------------------------------------------------------
 
 class AttNcForm : public Att {
-public:
+protected:
     AttNcForm();
-    virtual ~AttNcForm();
+    ~AttNcForm() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNcForm();
 
@@ -145,6 +161,20 @@ private:
     std::string m_sShape;
     /** Direction of the pen stroke. **/
     data_COMPASSDIRECTION m_tilt;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttNcForm
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNcForm
+ */
+
+class ExtAttNcForm : public AttNcForm {
+public:
+    ExtAttNcForm() = default;
+    virtual ~ExtAttNcForm() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_pagebased.cpp
+++ b/libmei/dist/atts_pagebased.cpp
@@ -31,8 +31,6 @@ AttMargins::AttMargins() : Att()
     ResetMargins();
 }
 
-AttMargins::~AttMargins() {}
-
 void AttMargins::ResetMargins()
 {
     m_topmar = data_MEASUREMENTUNSIGNED();

--- a/libmei/dist/atts_pagebased.h
+++ b/libmei/dist/atts_pagebased.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttMargins : public Att {
-public:
+protected:
     AttMargins();
-    virtual ~AttMargins();
+    ~AttMargins() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMargins();
 
@@ -75,6 +76,20 @@ private:
     data_MEASUREMENTUNSIGNED m_leftmar;
     /** Indicates the amount of whitespace at the right side of a page. **/
     data_MEASUREMENTUNSIGNED m_rightmar;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttMargins
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMargins
+ */
+
+class ExtAttMargins : public AttMargins {
+public:
+    ExtAttMargins() = default;
+    virtual ~ExtAttMargins() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_performance.cpp
+++ b/libmei/dist/atts_performance.cpp
@@ -31,8 +31,6 @@ AttAlignment::AttAlignment() : Att()
     ResetAlignment();
 }
 
-AttAlignment::~AttAlignment() {}
-
 void AttAlignment::ResetAlignment()
 {
     m_when = "";

--- a/libmei/dist/atts_performance.h
+++ b/libmei/dist/atts_performance.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAlignment : public Att {
-public:
+protected:
     AttAlignment();
-    virtual ~AttAlignment();
+    ~AttAlignment() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAlignment();
 
@@ -60,6 +61,20 @@ private:
      * Its value must be the ID of a when element elsewhere in the document.
      **/
     std::string m_when;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttAlignment
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAlignment
+ */
+
+class ExtAttAlignment : public AttAlignment {
+public:
+    ExtAttAlignment() = default;
+    virtual ~ExtAttAlignment() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_shared.cpp
+++ b/libmei/dist/atts_shared.cpp
@@ -31,8 +31,6 @@ AttAccidLog::AttAccidLog() : Att()
     ResetAccidLog();
 }
 
-AttAccidLog::~AttAccidLog() {}
-
 void AttAccidLog::ResetAccidLog()
 {
     m_func = accidLog_FUNC_NONE;
@@ -72,8 +70,6 @@ AttAccidental::AttAccidental() : Att()
 {
     ResetAccidental();
 }
-
-AttAccidental::~AttAccidental() {}
 
 void AttAccidental::ResetAccidental()
 {
@@ -115,8 +111,6 @@ AttArticulation::AttArticulation() : Att()
     ResetArticulation();
 }
 
-AttArticulation::~AttArticulation() {}
-
 void AttArticulation::ResetArticulation()
 {
     m_artic = std::vector<data_ARTICULATION>();
@@ -156,8 +150,6 @@ AttAttaccaLog::AttAttaccaLog() : Att()
 {
     ResetAttaccaLog();
 }
-
-AttAttaccaLog::~AttAttaccaLog() {}
 
 void AttAttaccaLog::ResetAttaccaLog()
 {
@@ -199,8 +191,6 @@ AttAudience::AttAudience() : Att()
     ResetAudience();
 }
 
-AttAudience::~AttAudience() {}
-
 void AttAudience::ResetAudience()
 {
     m_audience = audience_AUDIENCE_NONE;
@@ -241,8 +231,6 @@ AttAugmentDots::AttAugmentDots() : Att()
     ResetAugmentDots();
 }
 
-AttAugmentDots::~AttAugmentDots() {}
-
 void AttAugmentDots::ResetAugmentDots()
 {
     m_dots = MEI_UNSET;
@@ -282,8 +270,6 @@ AttAuthorized::AttAuthorized() : Att()
 {
     ResetAuthorized();
 }
-
-AttAuthorized::~AttAuthorized() {}
 
 void AttAuthorized::ResetAuthorized()
 {
@@ -340,8 +326,6 @@ AttBarLineLog::AttBarLineLog() : Att()
     ResetBarLineLog();
 }
 
-AttBarLineLog::~AttBarLineLog() {}
-
 void AttBarLineLog::ResetBarLineLog()
 {
     m_form = BARRENDITION_NONE;
@@ -381,8 +365,6 @@ AttBarring::AttBarring() : Att()
 {
     ResetBarring();
 }
-
-AttBarring::~AttBarring() {}
 
 void AttBarring::ResetBarring()
 {
@@ -454,8 +436,6 @@ AttBasic::AttBasic() : Att()
     ResetBasic();
 }
 
-AttBasic::~AttBasic() {}
-
 void AttBasic::ResetBasic()
 {
     m_base = "";
@@ -495,8 +475,6 @@ AttBibl::AttBibl() : Att()
 {
     ResetBibl();
 }
-
-AttBibl::~AttBibl() {}
 
 void AttBibl::ResetBibl()
 {
@@ -538,8 +516,6 @@ AttCalendared::AttCalendared() : Att()
     ResetCalendared();
 }
 
-AttCalendared::~AttCalendared() {}
-
 void AttCalendared::ResetCalendared()
 {
     m_calendar = "";
@@ -579,8 +555,6 @@ AttCanonical::AttCanonical() : Att()
 {
     ResetCanonical();
 }
-
-AttCanonical::~AttCanonical() {}
 
 void AttCanonical::ResetCanonical()
 {
@@ -622,8 +596,6 @@ AttClassed::AttClassed() : Att()
     ResetClassed();
 }
 
-AttClassed::~AttClassed() {}
-
 void AttClassed::ResetClassed()
 {
     m_class = "";
@@ -663,8 +635,6 @@ AttClefLog::AttClefLog() : Att()
 {
     ResetClefLog();
 }
-
-AttClefLog::~AttClefLog() {}
 
 void AttClefLog::ResetClefLog()
 {
@@ -706,8 +676,6 @@ AttClefShape::AttClefShape() : Att()
     ResetClefShape();
 }
 
-AttClefShape::~AttClefShape() {}
-
 void AttClefShape::ResetClefShape()
 {
     m_shape = CLEFSHAPE_NONE;
@@ -747,8 +715,6 @@ AttCleffingLog::AttCleffingLog() : Att()
 {
     ResetCleffingLog();
 }
-
-AttCleffingLog::~AttCleffingLog() {}
 
 void AttCleffingLog::ResetCleffingLog()
 {
@@ -835,8 +801,6 @@ AttColor::AttColor() : Att()
     ResetColor();
 }
 
-AttColor::~AttColor() {}
-
 void AttColor::ResetColor()
 {
     m_color = "";
@@ -876,8 +840,6 @@ AttColoration::AttColoration() : Att()
 {
     ResetColoration();
 }
-
-AttColoration::~AttColoration() {}
 
 void AttColoration::ResetColoration()
 {
@@ -919,8 +881,6 @@ AttCoordX1::AttCoordX1() : Att()
     ResetCoordX1();
 }
 
-AttCoordX1::~AttCoordX1() {}
-
 void AttCoordX1::ResetCoordX1()
 {
     m_coordX1 = 0.0;
@@ -960,8 +920,6 @@ AttCoordX2::AttCoordX2() : Att()
 {
     ResetCoordX2();
 }
-
-AttCoordX2::~AttCoordX2() {}
 
 void AttCoordX2::ResetCoordX2()
 {
@@ -1003,8 +961,6 @@ AttCoordY1::AttCoordY1() : Att()
     ResetCoordY1();
 }
 
-AttCoordY1::~AttCoordY1() {}
-
 void AttCoordY1::ResetCoordY1()
 {
     m_coordY1 = 0.0;
@@ -1044,8 +1000,6 @@ AttCoordinated::AttCoordinated() : Att()
 {
     ResetCoordinated();
 }
-
-AttCoordinated::~AttCoordinated() {}
 
 void AttCoordinated::ResetCoordinated()
 {
@@ -1147,8 +1101,6 @@ AttCue::AttCue() : Att()
     ResetCue();
 }
 
-AttCue::~AttCue() {}
-
 void AttCue::ResetCue()
 {
     m_cue = BOOLEAN_NONE;
@@ -1188,8 +1140,6 @@ AttCurvature::AttCurvature() : Att()
 {
     ResetCurvature();
 }
-
-AttCurvature::~AttCurvature() {}
 
 void AttCurvature::ResetCurvature()
 {
@@ -1261,8 +1211,6 @@ AttCurveRend::AttCurveRend() : Att()
     ResetCurveRend();
 }
 
-AttCurveRend::~AttCurveRend() {}
-
 void AttCurveRend::ResetCurveRend()
 {
     m_lform = LINEFORM_NONE;
@@ -1318,8 +1266,6 @@ AttCustosLog::AttCustosLog() : Att()
     ResetCustosLog();
 }
 
-AttCustosLog::~AttCustosLog() {}
-
 void AttCustosLog::ResetCustosLog()
 {
     m_target = "";
@@ -1360,8 +1306,6 @@ AttDataPointing::AttDataPointing() : Att()
     ResetDataPointing();
 }
 
-AttDataPointing::~AttDataPointing() {}
-
 void AttDataPointing::ResetDataPointing()
 {
     m_data = "";
@@ -1401,8 +1345,6 @@ AttDatable::AttDatable() : Att()
 {
     ResetDatable();
 }
-
-AttDatable::~AttDatable() {}
 
 void AttDatable::ResetDatable()
 {
@@ -1504,8 +1446,6 @@ AttDistances::AttDistances() : Att()
     ResetDistances();
 }
 
-AttDistances::~AttDistances() {}
-
 void AttDistances::ResetDistances()
 {
     m_dirDist = data_MEASUREMENTSIGNED();
@@ -1606,8 +1546,6 @@ AttDotLog::AttDotLog() : Att()
     ResetDotLog();
 }
 
-AttDotLog::~AttDotLog() {}
-
 void AttDotLog::ResetDotLog()
 {
     m_form = dotLog_FORM_NONE;
@@ -1648,8 +1586,6 @@ AttDurationAdditive::AttDurationAdditive() : Att()
     ResetDurationAdditive();
 }
 
-AttDurationAdditive::~AttDurationAdditive() {}
-
 void AttDurationAdditive::ResetDurationAdditive()
 {
     m_dur = DURATION_NONE;
@@ -1689,8 +1625,6 @@ AttDurationDefault::AttDurationDefault() : Att()
 {
     ResetDurationDefault();
 }
-
-AttDurationDefault::~AttDurationDefault() {}
 
 void AttDurationDefault::ResetDurationDefault()
 {
@@ -1762,8 +1696,6 @@ AttDurationLog::AttDurationLog() : Att()
     ResetDurationLog();
 }
 
-AttDurationLog::~AttDurationLog() {}
-
 void AttDurationLog::ResetDurationLog()
 {
     m_dur = DURATION_NONE;
@@ -1803,8 +1735,6 @@ AttDurationRatio::AttDurationRatio() : Att()
 {
     ResetDurationRatio();
 }
-
-AttDurationRatio::~AttDurationRatio() {}
 
 void AttDurationRatio::ResetDurationRatio()
 {
@@ -1861,8 +1791,6 @@ AttEnclosingChars::AttEnclosingChars() : Att()
     ResetEnclosingChars();
 }
 
-AttEnclosingChars::~AttEnclosingChars() {}
-
 void AttEnclosingChars::ResetEnclosingChars()
 {
     m_enclose = ENCLOSURE_NONE;
@@ -1903,8 +1831,6 @@ AttEndings::AttEndings() : Att()
     ResetEndings();
 }
 
-AttEndings::~AttEndings() {}
-
 void AttEndings::ResetEndings()
 {
     m_endingRend = endings_ENDINGREND_NONE;
@@ -1944,8 +1870,6 @@ AttEvidence::AttEvidence() : Att()
 {
     ResetEvidence();
 }
-
-AttEvidence::~AttEvidence() {}
 
 void AttEvidence::ResetEvidence()
 {
@@ -2002,8 +1926,6 @@ AttExtender::AttExtender() : Att()
     ResetExtender();
 }
 
-AttExtender::~AttExtender() {}
-
 void AttExtender::ResetExtender()
 {
     m_extender = BOOLEAN_NONE;
@@ -2043,8 +1965,6 @@ AttExtent::AttExtent() : Att()
 {
     ResetExtent();
 }
-
-AttExtent::~AttExtent() {}
 
 void AttExtent::ResetExtent()
 {
@@ -2086,8 +2006,6 @@ AttFermataPresent::AttFermataPresent() : Att()
     ResetFermataPresent();
 }
 
-AttFermataPresent::~AttFermataPresent() {}
-
 void AttFermataPresent::ResetFermataPresent()
 {
     m_fermata = STAFFREL_basic_NONE;
@@ -2127,8 +2045,6 @@ AttFiling::AttFiling() : Att()
 {
     ResetFiling();
 }
-
-AttFiling::~AttFiling() {}
 
 void AttFiling::ResetFiling()
 {
@@ -2170,8 +2086,6 @@ AttGrpSymLog::AttGrpSymLog() : Att()
     ResetGrpSymLog();
 }
 
-AttGrpSymLog::~AttGrpSymLog() {}
-
 void AttGrpSymLog::ResetGrpSymLog()
 {
     m_level = MEI_UNSET;
@@ -2211,8 +2125,6 @@ AttHandIdent::AttHandIdent() : Att()
 {
     ResetHandIdent();
 }
-
-AttHandIdent::~AttHandIdent() {}
 
 void AttHandIdent::ResetHandIdent()
 {
@@ -2254,8 +2166,6 @@ AttHeight::AttHeight() : Att()
     ResetHeight();
 }
 
-AttHeight::~AttHeight() {}
-
 void AttHeight::ResetHeight()
 {
     m_height = data_MEASUREMENTUNSIGNED();
@@ -2295,8 +2205,6 @@ AttHorizontalAlign::AttHorizontalAlign() : Att()
 {
     ResetHorizontalAlign();
 }
-
-AttHorizontalAlign::~AttHorizontalAlign() {}
 
 void AttHorizontalAlign::ResetHorizontalAlign()
 {
@@ -2338,8 +2246,6 @@ AttInternetMedia::AttInternetMedia() : Att()
     ResetInternetMedia();
 }
 
-AttInternetMedia::~AttInternetMedia() {}
-
 void AttInternetMedia::ResetInternetMedia()
 {
     m_mimetype = "";
@@ -2379,8 +2285,6 @@ AttJoined::AttJoined() : Att()
 {
     ResetJoined();
 }
-
-AttJoined::~AttJoined() {}
 
 void AttJoined::ResetJoined()
 {
@@ -2422,8 +2326,6 @@ AttKeySigLog::AttKeySigLog() : Att()
     ResetKeySigLog();
 }
 
-AttKeySigLog::~AttKeySigLog() {}
-
 void AttKeySigLog::ResetKeySigLog()
 {
     m_sig = std::make_pair(-1, ACCIDENTAL_WRITTEN_NONE);
@@ -2463,8 +2365,6 @@ AttKeySigDefaultLog::AttKeySigDefaultLog() : Att()
 {
     ResetKeySigDefaultLog();
 }
-
-AttKeySigDefaultLog::~AttKeySigDefaultLog() {}
 
 void AttKeySigDefaultLog::ResetKeySigDefaultLog()
 {
@@ -2506,8 +2406,6 @@ AttLabelled::AttLabelled() : Att()
     ResetLabelled();
 }
 
-AttLabelled::~AttLabelled() {}
-
 void AttLabelled::ResetLabelled()
 {
     m_label = "";
@@ -2547,8 +2445,6 @@ AttLang::AttLang() : Att()
 {
     ResetLang();
 }
-
-AttLang::~AttLang() {}
 
 void AttLang::ResetLang()
 {
@@ -2605,8 +2501,6 @@ AttLayerLog::AttLayerLog() : Att()
     ResetLayerLog();
 }
 
-AttLayerLog::~AttLayerLog() {}
-
 void AttLayerLog::ResetLayerLog()
 {
     m_def = "";
@@ -2646,8 +2540,6 @@ AttLayerIdent::AttLayerIdent() : Att()
 {
     ResetLayerIdent();
 }
-
-AttLayerIdent::~AttLayerIdent() {}
 
 void AttLayerIdent::ResetLayerIdent()
 {
@@ -2689,8 +2581,6 @@ AttLineLoc::AttLineLoc() : Att()
     ResetLineLoc();
 }
 
-AttLineLoc::~AttLineLoc() {}
-
 void AttLineLoc::ResetLineLoc()
 {
     m_line = 0;
@@ -2730,8 +2620,6 @@ AttLineRend::AttLineRend() : Att()
 {
     ResetLineRend();
 }
-
-AttLineRend::~AttLineRend() {}
 
 void AttLineRend::ResetLineRend()
 {
@@ -2818,8 +2706,6 @@ AttLineRendBase::AttLineRendBase() : Att()
     ResetLineRendBase();
 }
 
-AttLineRendBase::~AttLineRendBase() {}
-
 void AttLineRendBase::ResetLineRendBase()
 {
     m_lform = LINEFORM_NONE;
@@ -2889,8 +2775,6 @@ AttLinking::AttLinking() : Att()
 {
     ResetLinking();
 }
-
-AttLinking::~AttLinking() {}
 
 void AttLinking::ResetLinking()
 {
@@ -3037,8 +2921,6 @@ AttLyricStyle::AttLyricStyle() : Att()
     ResetLyricStyle();
 }
 
-AttLyricStyle::~AttLyricStyle() {}
-
 void AttLyricStyle::ResetLyricStyle()
 {
     m_lyricAlign = data_MEASUREMENTSIGNED();
@@ -3154,8 +3036,6 @@ AttMeasureNumbers::AttMeasureNumbers() : Att()
     ResetMeasureNumbers();
 }
 
-AttMeasureNumbers::~AttMeasureNumbers() {}
-
 void AttMeasureNumbers::ResetMeasureNumbers()
 {
     m_mnumVisible = BOOLEAN_NONE;
@@ -3196,8 +3076,6 @@ AttMeasurement::AttMeasurement() : Att()
     ResetMeasurement();
 }
 
-AttMeasurement::~AttMeasurement() {}
-
 void AttMeasurement::ResetMeasurement()
 {
     m_unit = "";
@@ -3237,8 +3115,6 @@ AttMediaBounds::AttMediaBounds() : Att()
 {
     ResetMediaBounds();
 }
-
-AttMediaBounds::~AttMediaBounds() {}
 
 void AttMediaBounds::ResetMediaBounds()
 {
@@ -3310,8 +3186,6 @@ AttMedium::AttMedium() : Att()
     ResetMedium();
 }
 
-AttMedium::~AttMedium() {}
-
 void AttMedium::ResetMedium()
 {
     m_medium = "";
@@ -3351,8 +3225,6 @@ AttMeiVersion::AttMeiVersion() : Att()
 {
     ResetMeiVersion();
 }
-
-AttMeiVersion::~AttMeiVersion() {}
 
 void AttMeiVersion::ResetMeiVersion()
 {
@@ -3394,8 +3266,6 @@ AttMetadataPointing::AttMetadataPointing() : Att()
     ResetMetadataPointing();
 }
 
-AttMetadataPointing::~AttMetadataPointing() {}
-
 void AttMetadataPointing::ResetMetadataPointing()
 {
     m_decls = "";
@@ -3436,8 +3306,6 @@ AttMeterConformance::AttMeterConformance() : Att()
     ResetMeterConformance();
 }
 
-AttMeterConformance::~AttMeterConformance() {}
-
 void AttMeterConformance::ResetMeterConformance()
 {
     m_metcon = meterConformance_METCON_NONE;
@@ -3477,8 +3345,6 @@ AttMeterConformanceBar::AttMeterConformanceBar() : Att()
 {
     ResetMeterConformanceBar();
 }
-
-AttMeterConformanceBar::~AttMeterConformanceBar() {}
 
 void AttMeterConformanceBar::ResetMeterConformanceBar()
 {
@@ -3534,8 +3400,6 @@ AttMeterSigLog::AttMeterSigLog() : Att()
 {
     ResetMeterSigLog();
 }
-
-AttMeterSigLog::~AttMeterSigLog() {}
 
 void AttMeterSigLog::ResetMeterSigLog()
 {
@@ -3607,8 +3471,6 @@ AttMeterSigDefaultLog::AttMeterSigDefaultLog() : Att()
     ResetMeterSigDefaultLog();
 }
 
-AttMeterSigDefaultLog::~AttMeterSigDefaultLog() {}
-
 void AttMeterSigDefaultLog::ResetMeterSigDefaultLog()
 {
     m_meterCount = std::pair<std::vector<int>, MeterCountSign>();
@@ -3678,8 +3540,6 @@ AttMmTempo::AttMmTempo() : Att()
 {
     ResetMmTempo();
 }
-
-AttMmTempo::~AttMmTempo() {}
 
 void AttMmTempo::ResetMmTempo()
 {
@@ -3751,8 +3611,6 @@ AttMultinumMeasures::AttMultinumMeasures() : Att()
     ResetMultinumMeasures();
 }
 
-AttMultinumMeasures::~AttMultinumMeasures() {}
-
 void AttMultinumMeasures::ResetMultinumMeasures()
 {
     m_multiNumber = BOOLEAN_NONE;
@@ -3792,8 +3650,6 @@ AttNInteger::AttNInteger() : Att()
 {
     ResetNInteger();
 }
-
-AttNInteger::~AttNInteger() {}
 
 void AttNInteger::ResetNInteger()
 {
@@ -3835,8 +3691,6 @@ AttNNumberLike::AttNNumberLike() : Att()
     ResetNNumberLike();
 }
 
-AttNNumberLike::~AttNNumberLike() {}
-
 void AttNNumberLike::ResetNNumberLike()
 {
     m_n = "";
@@ -3876,8 +3730,6 @@ AttName::AttName() : Att()
 {
     ResetName();
 }
-
-AttName::~AttName() {}
 
 void AttName::ResetName()
 {
@@ -3934,8 +3786,6 @@ AttNotationStyle::AttNotationStyle() : Att()
     ResetNotationStyle();
 }
 
-AttNotationStyle::~AttNotationStyle() {}
-
 void AttNotationStyle::ResetNotationStyle()
 {
     m_musicName = "";
@@ -3990,8 +3840,6 @@ AttNoteHeads::AttNoteHeads() : Att()
 {
     ResetNoteHeads();
 }
-
-AttNoteHeads::~AttNoteHeads() {}
 
 void AttNoteHeads::ResetNoteHeads()
 {
@@ -4153,8 +4001,6 @@ AttOctave::AttOctave() : Att()
     ResetOctave();
 }
 
-AttOctave::~AttOctave() {}
-
 void AttOctave::ResetOctave()
 {
     m_oct = -127;
@@ -4195,8 +4041,6 @@ AttOctaveDefault::AttOctaveDefault() : Att()
     ResetOctaveDefault();
 }
 
-AttOctaveDefault::~AttOctaveDefault() {}
-
 void AttOctaveDefault::ResetOctaveDefault()
 {
     m_octDefault = -127;
@@ -4236,8 +4080,6 @@ AttOctaveDisplacement::AttOctaveDisplacement() : Att()
 {
     ResetOctaveDisplacement();
 }
-
-AttOctaveDisplacement::~AttOctaveDisplacement() {}
 
 void AttOctaveDisplacement::ResetOctaveDisplacement()
 {
@@ -4294,8 +4136,6 @@ AttOneLineStaff::AttOneLineStaff() : Att()
     ResetOneLineStaff();
 }
 
-AttOneLineStaff::~AttOneLineStaff() {}
-
 void AttOneLineStaff::ResetOneLineStaff()
 {
     m_ontheline = BOOLEAN_NONE;
@@ -4335,8 +4175,6 @@ AttOptimization::AttOptimization() : Att()
 {
     ResetOptimization();
 }
-
-AttOptimization::~AttOptimization() {}
 
 void AttOptimization::ResetOptimization()
 {
@@ -4378,8 +4216,6 @@ AttOriginLayerIdent::AttOriginLayerIdent() : Att()
     ResetOriginLayerIdent();
 }
 
-AttOriginLayerIdent::~AttOriginLayerIdent() {}
-
 void AttOriginLayerIdent::ResetOriginLayerIdent()
 {
     m_originLayer = "";
@@ -4420,8 +4256,6 @@ AttOriginStaffIdent::AttOriginStaffIdent() : Att()
     ResetOriginStaffIdent();
 }
 
-AttOriginStaffIdent::~AttOriginStaffIdent() {}
-
 void AttOriginStaffIdent::ResetOriginStaffIdent()
 {
     m_originStaff = "";
@@ -4461,8 +4295,6 @@ AttOriginStartEndId::AttOriginStartEndId() : Att()
 {
     ResetOriginStartEndId();
 }
-
-AttOriginStartEndId::~AttOriginStartEndId() {}
 
 void AttOriginStartEndId::ResetOriginStartEndId()
 {
@@ -4519,8 +4351,6 @@ AttOriginTimestampLog::AttOriginTimestampLog() : Att()
     ResetOriginTimestampLog();
 }
 
-AttOriginTimestampLog::~AttOriginTimestampLog() {}
-
 void AttOriginTimestampLog::ResetOriginTimestampLog()
 {
     m_originTstamp = std::make_pair(-1, -1.0);
@@ -4575,8 +4405,6 @@ AttPages::AttPages() : Att()
 {
     ResetPages();
 }
-
-AttPages::~AttPages() {}
 
 void AttPages::ResetPages()
 {
@@ -4723,8 +4551,6 @@ AttPartIdent::AttPartIdent() : Att()
     ResetPartIdent();
 }
 
-AttPartIdent::~AttPartIdent() {}
-
 void AttPartIdent::ResetPartIdent()
 {
     m_part = "";
@@ -4780,8 +4606,6 @@ AttPitch::AttPitch() : Att()
     ResetPitch();
 }
 
-AttPitch::~AttPitch() {}
-
 void AttPitch::ResetPitch()
 {
     m_pname = PITCHNAME_NONE;
@@ -4821,8 +4645,6 @@ AttPlacementOnStaff::AttPlacementOnStaff() : Att()
 {
     ResetPlacementOnStaff();
 }
-
-AttPlacementOnStaff::~AttPlacementOnStaff() {}
 
 void AttPlacementOnStaff::ResetPlacementOnStaff()
 {
@@ -4864,8 +4686,6 @@ AttPlacementRelEvent::AttPlacementRelEvent() : Att()
     ResetPlacementRelEvent();
 }
 
-AttPlacementRelEvent::~AttPlacementRelEvent() {}
-
 void AttPlacementRelEvent::ResetPlacementRelEvent()
 {
     m_place = data_STAFFREL();
@@ -4905,8 +4725,6 @@ AttPlacementRelStaff::AttPlacementRelStaff() : Att()
 {
     ResetPlacementRelStaff();
 }
-
-AttPlacementRelStaff::~AttPlacementRelStaff() {}
 
 void AttPlacementRelStaff::ResetPlacementRelStaff()
 {
@@ -4948,8 +4766,6 @@ AttPlist::AttPlist() : Att()
     ResetPlist();
 }
 
-AttPlist::~AttPlist() {}
-
 void AttPlist::ResetPlist()
 {
     m_plist = std::vector<std::string>();
@@ -4989,8 +4805,6 @@ AttPointing::AttPointing() : Att()
 {
     ResetPointing();
 }
-
-AttPointing::~AttPointing() {}
 
 void AttPointing::ResetPointing()
 {
@@ -5092,8 +4906,6 @@ AttQuantity::AttQuantity() : Att()
     ResetQuantity();
 }
 
-AttQuantity::~AttQuantity() {}
-
 void AttQuantity::ResetQuantity()
 {
     m_quantity = 0.0;
@@ -5133,8 +4945,6 @@ AttRanging::AttRanging() : Att()
 {
     ResetRanging();
 }
-
-AttRanging::~AttRanging() {}
 
 void AttRanging::ResetRanging()
 {
@@ -5236,8 +5046,6 @@ AttResponsibility::AttResponsibility() : Att()
     ResetResponsibility();
 }
 
-AttResponsibility::~AttResponsibility() {}
-
 void AttResponsibility::ResetResponsibility()
 {
     m_resp = "";
@@ -5277,8 +5085,6 @@ AttRestdurationLog::AttRestdurationLog() : Att()
 {
     ResetRestdurationLog();
 }
-
-AttRestdurationLog::~AttRestdurationLog() {}
 
 void AttRestdurationLog::ResetRestdurationLog()
 {
@@ -5320,8 +5126,6 @@ AttScalable::AttScalable() : Att()
     ResetScalable();
 }
 
-AttScalable::~AttScalable() {}
-
 void AttScalable::ResetScalable()
 {
     m_scale = -1.0;
@@ -5361,8 +5165,6 @@ AttSequence::AttSequence() : Att()
 {
     ResetSequence();
 }
-
-AttSequence::~AttSequence() {}
 
 void AttSequence::ResetSequence()
 {
@@ -5404,8 +5206,6 @@ AttSlashCount::AttSlashCount() : Att()
     ResetSlashCount();
 }
 
-AttSlashCount::~AttSlashCount() {}
-
 void AttSlashCount::ResetSlashCount()
 {
     m_slash = 0;
@@ -5445,8 +5245,6 @@ AttSlurPresent::AttSlurPresent() : Att()
 {
     ResetSlurPresent();
 }
-
-AttSlurPresent::~AttSlurPresent() {}
 
 void AttSlurPresent::ResetSlurPresent()
 {
@@ -5488,8 +5286,6 @@ AttSource::AttSource() : Att()
     ResetSource();
 }
 
-AttSource::~AttSource() {}
-
 void AttSource::ResetSource()
 {
     m_source = "";
@@ -5529,8 +5325,6 @@ AttSpacing::AttSpacing() : Att()
 {
     ResetSpacing();
 }
-
-AttSpacing::~AttSpacing() {}
 
 void AttSpacing::ResetSpacing()
 {
@@ -5617,8 +5411,6 @@ AttStaffLog::AttStaffLog() : Att()
     ResetStaffLog();
 }
 
-AttStaffLog::~AttStaffLog() {}
-
 void AttStaffLog::ResetStaffLog()
 {
     m_def = "";
@@ -5658,8 +5450,6 @@ AttStaffDefLog::AttStaffDefLog() : Att()
 {
     ResetStaffDefLog();
 }
-
-AttStaffDefLog::~AttStaffDefLog() {}
 
 void AttStaffDefLog::ResetStaffDefLog()
 {
@@ -5701,8 +5491,6 @@ AttStaffGroupingSym::AttStaffGroupingSym() : Att()
     ResetStaffGroupingSym();
 }
 
-AttStaffGroupingSym::~AttStaffGroupingSym() {}
-
 void AttStaffGroupingSym::ResetStaffGroupingSym()
 {
     m_symbol = staffGroupingSym_SYMBOL_NONE;
@@ -5743,8 +5531,6 @@ AttStaffIdent::AttStaffIdent() : Att()
     ResetStaffIdent();
 }
 
-AttStaffIdent::~AttStaffIdent() {}
-
 void AttStaffIdent::ResetStaffIdent()
 {
     m_staff = std::vector<int>();
@@ -5784,8 +5570,6 @@ AttStaffItems::AttStaffItems() : Att()
 {
     ResetStaffItems();
 }
-
-AttStaffItems::~AttStaffItems() {}
 
 void AttStaffItems::ResetStaffItems()
 {
@@ -5857,8 +5641,6 @@ AttStaffLoc::AttStaffLoc() : Att()
     ResetStaffLoc();
 }
 
-AttStaffLoc::~AttStaffLoc() {}
-
 void AttStaffLoc::ResetStaffLoc()
 {
     m_loc = MEI_UNSET;
@@ -5898,8 +5680,6 @@ AttStaffLocPitched::AttStaffLocPitched() : Att()
 {
     ResetStaffLocPitched();
 }
-
-AttStaffLocPitched::~AttStaffLocPitched() {}
 
 void AttStaffLocPitched::ResetStaffLocPitched()
 {
@@ -5956,8 +5736,6 @@ AttStartEndId::AttStartEndId() : Att()
     ResetStartEndId();
 }
 
-AttStartEndId::~AttStartEndId() {}
-
 void AttStartEndId::ResetStartEndId()
 {
     m_endid = "";
@@ -5998,8 +5776,6 @@ AttStartId::AttStartId() : Att()
     ResetStartId();
 }
 
-AttStartId::~AttStartId() {}
-
 void AttStartId::ResetStartId()
 {
     m_startid = "";
@@ -6039,8 +5815,6 @@ AttStems::AttStems() : Att()
 {
     ResetStems();
 }
-
-AttStems::~AttStems() {}
 
 void AttStems::ResetStems()
 {
@@ -6187,8 +5961,6 @@ AttSylLog::AttSylLog() : Att()
     ResetSylLog();
 }
 
-AttSylLog::~AttSylLog() {}
-
 void AttSylLog::ResetSylLog()
 {
     m_con = sylLog_CON_NONE;
@@ -6244,8 +6016,6 @@ AttSylText::AttSylText() : Att()
     ResetSylText();
 }
 
-AttSylText::~AttSylText() {}
-
 void AttSylText::ResetSylText()
 {
     m_syl = "";
@@ -6285,8 +6055,6 @@ AttSystems::AttSystems() : Att()
 {
     ResetSystems();
 }
-
-AttSystems::~AttSystems() {}
 
 void AttSystems::ResetSystems()
 {
@@ -6373,8 +6141,6 @@ AttTargetEval::AttTargetEval() : Att()
     ResetTargetEval();
 }
 
-AttTargetEval::~AttTargetEval() {}
-
 void AttTargetEval::ResetTargetEval()
 {
     m_evaluate = targetEval_EVALUATE_NONE;
@@ -6415,8 +6181,6 @@ AttTempoLog::AttTempoLog() : Att()
     ResetTempoLog();
 }
 
-AttTempoLog::~AttTempoLog() {}
-
 void AttTempoLog::ResetTempoLog()
 {
     m_func = tempoLog_FUNC_NONE;
@@ -6456,8 +6220,6 @@ AttTextRendition::AttTextRendition() : Att()
 {
     ResetTextRendition();
 }
-
-AttTextRendition::~AttTextRendition() {}
 
 void AttTextRendition::ResetTextRendition()
 {
@@ -6513,8 +6275,6 @@ AttTextStyle::AttTextStyle() : Att()
 {
     ResetTextStyle();
 }
-
-AttTextStyle::~AttTextStyle() {}
 
 void AttTextStyle::ResetTextStyle()
 {
@@ -6616,8 +6376,6 @@ AttTiePresent::AttTiePresent() : Att()
     ResetTiePresent();
 }
 
-AttTiePresent::~AttTiePresent() {}
-
 void AttTiePresent::ResetTiePresent()
 {
     m_tie = TIE_NONE;
@@ -6657,8 +6415,6 @@ AttTimestampLog::AttTimestampLog() : Att()
 {
     ResetTimestampLog();
 }
-
-AttTimestampLog::~AttTimestampLog() {}
 
 void AttTimestampLog::ResetTimestampLog()
 {
@@ -6700,8 +6456,6 @@ AttTimestamp2Log::AttTimestamp2Log() : Att()
     ResetTimestamp2Log();
 }
 
-AttTimestamp2Log::~AttTimestamp2Log() {}
-
 void AttTimestamp2Log::ResetTimestamp2Log()
 {
     m_tstamp2 = std::make_pair(-1, -1.0);
@@ -6741,8 +6495,6 @@ AttTransposition::AttTransposition() : Att()
 {
     ResetTransposition();
 }
-
-AttTransposition::~AttTransposition() {}
 
 void AttTransposition::ResetTransposition()
 {
@@ -6798,8 +6550,6 @@ AttTuning::AttTuning() : Att()
 {
     ResetTuning();
 }
-
-AttTuning::~AttTuning() {}
 
 void AttTuning::ResetTuning()
 {
@@ -6871,8 +6621,6 @@ AttTupletPresent::AttTupletPresent() : Att()
     ResetTupletPresent();
 }
 
-AttTupletPresent::~AttTupletPresent() {}
-
 void AttTupletPresent::ResetTupletPresent()
 {
     m_tuplet = "";
@@ -6913,8 +6661,6 @@ AttTyped::AttTyped() : Att()
     ResetTyped();
 }
 
-AttTyped::~AttTyped() {}
-
 void AttTyped::ResetTyped()
 {
     m_type = "";
@@ -6954,8 +6700,6 @@ AttTypography::AttTypography() : Att()
 {
     ResetTypography();
 }
-
-AttTypography::~AttTypography() {}
 
 void AttTypography::ResetTypography()
 {
@@ -7087,8 +6831,6 @@ AttVerticalAlign::AttVerticalAlign() : Att()
     ResetVerticalAlign();
 }
 
-AttVerticalAlign::~AttVerticalAlign() {}
-
 void AttVerticalAlign::ResetVerticalAlign()
 {
     m_valign = VERTICALALIGNMENT_NONE;
@@ -7128,8 +6870,6 @@ AttVerticalGroup::AttVerticalGroup() : Att()
 {
     ResetVerticalGroup();
 }
-
-AttVerticalGroup::~AttVerticalGroup() {}
 
 void AttVerticalGroup::ResetVerticalGroup()
 {
@@ -7171,8 +6911,6 @@ AttVisibility::AttVisibility() : Att()
     ResetVisibility();
 }
 
-AttVisibility::~AttVisibility() {}
-
 void AttVisibility::ResetVisibility()
 {
     m_visible = BOOLEAN_NONE;
@@ -7212,8 +6950,6 @@ AttVisualOffsetHo::AttVisualOffsetHo() : Att()
 {
     ResetVisualOffsetHo();
 }
-
-AttVisualOffsetHo::~AttVisualOffsetHo() {}
 
 void AttVisualOffsetHo::ResetVisualOffsetHo()
 {
@@ -7255,8 +6991,6 @@ AttVisualOffsetTo::AttVisualOffsetTo() : Att()
     ResetVisualOffsetTo();
 }
 
-AttVisualOffsetTo::~AttVisualOffsetTo() {}
-
 void AttVisualOffsetTo::ResetVisualOffsetTo()
 {
     m_to = 0.0;
@@ -7297,8 +7031,6 @@ AttVisualOffsetVo::AttVisualOffsetVo() : Att()
     ResetVisualOffsetVo();
 }
 
-AttVisualOffsetVo::~AttVisualOffsetVo() {}
-
 void AttVisualOffsetVo::ResetVisualOffsetVo()
 {
     m_vo = data_MEASUREMENTSIGNED();
@@ -7338,8 +7070,6 @@ AttVisualOffset2Ho::AttVisualOffset2Ho() : Att()
 {
     ResetVisualOffset2Ho();
 }
-
-AttVisualOffset2Ho::~AttVisualOffset2Ho() {}
 
 void AttVisualOffset2Ho::ResetVisualOffset2Ho()
 {
@@ -7396,8 +7126,6 @@ AttVisualOffset2To::AttVisualOffset2To() : Att()
     ResetVisualOffset2To();
 }
 
-AttVisualOffset2To::~AttVisualOffset2To() {}
-
 void AttVisualOffset2To::ResetVisualOffset2To()
 {
     m_startto = 0.0;
@@ -7452,8 +7180,6 @@ AttVisualOffset2Vo::AttVisualOffset2Vo() : Att()
 {
     ResetVisualOffset2Vo();
 }
-
-AttVisualOffset2Vo::~AttVisualOffset2Vo() {}
 
 void AttVisualOffset2Vo::ResetVisualOffset2Vo()
 {
@@ -7510,8 +7236,6 @@ AttVoltaGroupingSym::AttVoltaGroupingSym() : Att()
     ResetVoltaGroupingSym();
 }
 
-AttVoltaGroupingSym::~AttVoltaGroupingSym() {}
-
 void AttVoltaGroupingSym::ResetVoltaGroupingSym()
 {
     m_voltasym = voltaGroupingSym_VOLTASYM_NONE;
@@ -7551,8 +7275,6 @@ AttWhitespace::AttWhitespace() : Att()
 {
     ResetWhitespace();
 }
-
-AttWhitespace::~AttWhitespace() {}
 
 void AttWhitespace::ResetWhitespace()
 {
@@ -7594,8 +7316,6 @@ AttWidth::AttWidth() : Att()
     ResetWidth();
 }
 
-AttWidth::~AttWidth() {}
-
 void AttWidth::ResetWidth()
 {
     m_width = data_MEASUREMENTUNSIGNED();
@@ -7635,8 +7355,6 @@ AttXy::AttXy() : Att()
 {
     ResetXy();
 }
-
-AttXy::~AttXy() {}
 
 void AttXy::ResetXy()
 {
@@ -7692,8 +7410,6 @@ AttXy2::AttXy2() : Att()
 {
     ResetXy2();
 }
-
-AttXy2::~AttXy2() {}
 
 void AttXy2::ResetXy2()
 {

--- a/libmei/dist/atts_shared.h
+++ b/libmei/dist/atts_shared.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAccidLog : public Att {
-public:
+protected:
     AttAccidLog();
-    virtual ~AttAccidLog();
+    ~AttAccidLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAccidLog();
 
@@ -60,14 +61,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAccidLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAccidLog
+ */
+
+class ExtAttAccidLog : public AttAccidLog {
+public:
+    ExtAttAccidLog() = default;
+    virtual ~ExtAttAccidLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAccidental
 //----------------------------------------------------------------------------
 
 class AttAccidental : public Att {
-public:
+protected:
     AttAccidental();
-    virtual ~AttAccidental();
+    ~AttAccidental() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAccidental();
 
@@ -94,14 +110,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAccidental
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAccidental
+ */
+
+class ExtAttAccidental : public AttAccidental {
+public:
+    ExtAttAccidental() = default;
+    virtual ~ExtAttAccidental() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttArticulation
 //----------------------------------------------------------------------------
 
 class AttArticulation : public Att {
-public:
+protected:
     AttArticulation();
-    virtual ~AttArticulation();
+    ~AttArticulation() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetArticulation();
 
@@ -134,14 +165,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttArticulation
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttArticulation
+ */
+
+class ExtAttArticulation : public AttArticulation {
+public:
+    ExtAttArticulation() = default;
+    virtual ~ExtAttArticulation() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAttaccaLog
 //----------------------------------------------------------------------------
 
 class AttAttaccaLog : public Att {
-public:
+protected:
     AttAttaccaLog();
-    virtual ~AttAttaccaLog();
+    ~AttAttaccaLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAttaccaLog();
 
@@ -168,14 +214,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAttaccaLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAttaccaLog
+ */
+
+class ExtAttAttaccaLog : public AttAttaccaLog {
+public:
+    ExtAttAttaccaLog() = default;
+    virtual ~ExtAttAttaccaLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAudience
 //----------------------------------------------------------------------------
 
 class AttAudience : public Att {
-public:
+protected:
     AttAudience();
-    virtual ~AttAudience();
+    ~AttAudience() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAudience();
 
@@ -202,14 +263,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAudience
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAudience
+ */
+
+class ExtAttAudience : public AttAudience {
+public:
+    ExtAttAudience() = default;
+    virtual ~ExtAttAudience() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAugmentDots
 //----------------------------------------------------------------------------
 
 class AttAugmentDots : public Att {
-public:
+protected:
     AttAugmentDots();
-    virtual ~AttAugmentDots();
+    ~AttAugmentDots() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAugmentDots();
 
@@ -236,14 +312,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAugmentDots
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAugmentDots
+ */
+
+class ExtAttAugmentDots : public AttAugmentDots {
+public:
+    ExtAttAugmentDots() = default;
+    virtual ~ExtAttAugmentDots() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAuthorized
 //----------------------------------------------------------------------------
 
 class AttAuthorized : public Att {
-public:
+protected:
     AttAuthorized();
-    virtual ~AttAuthorized();
+    ~AttAuthorized() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAuthorized();
 
@@ -284,14 +375,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAuthorized
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAuthorized
+ */
+
+class ExtAttAuthorized : public AttAuthorized {
+public:
+    ExtAttAuthorized() = default;
+    virtual ~ExtAttAuthorized() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBarLineLog
 //----------------------------------------------------------------------------
 
 class AttBarLineLog : public Att {
-public:
+protected:
     AttBarLineLog();
-    virtual ~AttBarLineLog();
+    ~AttBarLineLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBarLineLog();
 
@@ -318,14 +424,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBarLineLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBarLineLog
+ */
+
+class ExtAttBarLineLog : public AttBarLineLog {
+public:
+    ExtAttBarLineLog() = default;
+    virtual ~ExtAttBarLineLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBarring
 //----------------------------------------------------------------------------
 
 class AttBarring : public Att {
-public:
+protected:
     AttBarring();
-    virtual ~AttBarring();
+    ~AttBarring() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBarring();
 
@@ -371,14 +492,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBarring
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBarring
+ */
+
+class ExtAttBarring : public AttBarring {
+public:
+    ExtAttBarring() = default;
+    virtual ~ExtAttBarring() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBasic
 //----------------------------------------------------------------------------
 
 class AttBasic : public Att {
-public:
+protected:
     AttBasic();
-    virtual ~AttBasic();
+    ~AttBasic() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBasic();
 
@@ -405,14 +541,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBasic
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBasic
+ */
+
+class ExtAttBasic : public AttBasic {
+public:
+    ExtAttBasic() = default;
+    virtual ~ExtAttBasic() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBibl
 //----------------------------------------------------------------------------
 
 class AttBibl : public Att {
-public:
+protected:
     AttBibl();
-    virtual ~AttBibl();
+    ~AttBibl() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBibl();
 
@@ -442,14 +593,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBibl
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBibl
+ */
+
+class ExtAttBibl : public AttBibl {
+public:
+    ExtAttBibl() = default;
+    virtual ~ExtAttBibl() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCalendared
 //----------------------------------------------------------------------------
 
 class AttCalendared : public Att {
-public:
+protected:
     AttCalendared();
-    virtual ~AttCalendared();
+    ~AttCalendared() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCalendared();
 
@@ -479,14 +645,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCalendared
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCalendared
+ */
+
+class ExtAttCalendared : public AttCalendared {
+public:
+    ExtAttCalendared() = default;
+    virtual ~ExtAttCalendared() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCanonical
 //----------------------------------------------------------------------------
 
 class AttCanonical : public Att {
-public:
+protected:
     AttCanonical();
-    virtual ~AttCanonical();
+    ~AttCanonical() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCanonical();
 
@@ -517,14 +698,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCanonical
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCanonical
+ */
+
+class ExtAttCanonical : public AttCanonical {
+public:
+    ExtAttCanonical() = default;
+    virtual ~ExtAttCanonical() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttClassed
 //----------------------------------------------------------------------------
 
 class AttClassed : public Att {
-public:
+protected:
     AttClassed();
-    virtual ~AttClassed();
+    ~AttClassed() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetClassed();
 
@@ -554,14 +750,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttClassed
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttClassed
+ */
+
+class ExtAttClassed : public AttClassed {
+public:
+    ExtAttClassed() = default;
+    virtual ~ExtAttClassed() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttClefLog
 //----------------------------------------------------------------------------
 
 class AttClefLog : public Att {
-public:
+protected:
     AttClefLog();
-    virtual ~AttClefLog();
+    ~AttClefLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetClefLog();
 
@@ -591,14 +802,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttClefLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttClefLog
+ */
+
+class ExtAttClefLog : public AttClefLog {
+public:
+    ExtAttClefLog() = default;
+    virtual ~ExtAttClefLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttClefShape
 //----------------------------------------------------------------------------
 
 class AttClefShape : public Att {
-public:
+protected:
     AttClefShape();
-    virtual ~AttClefShape();
+    ~AttClefShape() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetClefShape();
 
@@ -625,14 +851,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttClefShape
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttClefShape
+ */
+
+class ExtAttClefShape : public AttClefShape {
+public:
+    ExtAttClefShape() = default;
+    virtual ~ExtAttClefShape() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCleffingLog
 //----------------------------------------------------------------------------
 
 class AttCleffingLog : public Att {
-public:
+protected:
     AttCleffingLog();
-    virtual ~AttCleffingLog();
+    ~AttCleffingLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCleffingLog();
 
@@ -681,14 +922,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCleffingLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCleffingLog
+ */
+
+class ExtAttCleffingLog : public AttCleffingLog {
+public:
+    ExtAttCleffingLog() = default;
+    virtual ~ExtAttCleffingLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttColor
 //----------------------------------------------------------------------------
 
 class AttColor : public Att {
-public:
+protected:
     AttColor();
-    virtual ~AttColor();
+    ~AttColor() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetColor();
 
@@ -718,14 +974,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttColor
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttColor
+ */
+
+class ExtAttColor : public AttColor {
+public:
+    ExtAttColor() = default;
+    virtual ~ExtAttColor() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttColoration
 //----------------------------------------------------------------------------
 
 class AttColoration : public Att {
-public:
+protected:
     AttColoration();
-    virtual ~AttColoration();
+    ~AttColoration() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetColoration();
 
@@ -759,14 +1030,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttColoration
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttColoration
+ */
+
+class ExtAttColoration : public AttColoration {
+public:
+    ExtAttColoration() = default;
+    virtual ~ExtAttColoration() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCoordX1
 //----------------------------------------------------------------------------
 
 class AttCoordX1 : public Att {
-public:
+protected:
     AttCoordX1();
-    virtual ~AttCoordX1();
+    ~AttCoordX1() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCoordX1();
 
@@ -793,14 +1079,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCoordX1
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCoordX1
+ */
+
+class ExtAttCoordX1 : public AttCoordX1 {
+public:
+    ExtAttCoordX1() = default;
+    virtual ~ExtAttCoordX1() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCoordX2
 //----------------------------------------------------------------------------
 
 class AttCoordX2 : public Att {
-public:
+protected:
     AttCoordX2();
-    virtual ~AttCoordX2();
+    ~AttCoordX2() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCoordX2();
 
@@ -827,14 +1128,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCoordX2
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCoordX2
+ */
+
+class ExtAttCoordX2 : public AttCoordX2 {
+public:
+    ExtAttCoordX2() = default;
+    virtual ~ExtAttCoordX2() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCoordY1
 //----------------------------------------------------------------------------
 
 class AttCoordY1 : public Att {
-public:
+protected:
     AttCoordY1();
-    virtual ~AttCoordY1();
+    ~AttCoordY1() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCoordY1();
 
@@ -861,14 +1177,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCoordY1
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCoordY1
+ */
+
+class ExtAttCoordY1 : public AttCoordY1 {
+public:
+    ExtAttCoordY1() = default;
+    virtual ~ExtAttCoordY1() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCoordinated
 //----------------------------------------------------------------------------
 
 class AttCoordinated : public Att {
-public:
+protected:
     AttCoordinated();
-    virtual ~AttCoordinated();
+    ~AttCoordinated() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCoordinated();
 
@@ -924,14 +1255,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCoordinated
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCoordinated
+ */
+
+class ExtAttCoordinated : public AttCoordinated {
+public:
+    ExtAttCoordinated() = default;
+    virtual ~ExtAttCoordinated() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCue
 //----------------------------------------------------------------------------
 
 class AttCue : public Att {
-public:
+protected:
     AttCue();
-    virtual ~AttCue();
+    ~AttCue() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCue();
 
@@ -958,14 +1304,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCue
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCue
+ */
+
+class ExtAttCue : public AttCue {
+public:
+    ExtAttCue() = default;
+    virtual ~ExtAttCue() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCurvature
 //----------------------------------------------------------------------------
 
 class AttCurvature : public Att {
-public:
+protected:
     AttCurvature();
-    virtual ~AttCurvature();
+    ~AttCurvature() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCurvature();
 
@@ -1016,14 +1377,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCurvature
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCurvature
+ */
+
+class ExtAttCurvature : public AttCurvature {
+public:
+    ExtAttCurvature() = default;
+    virtual ~ExtAttCurvature() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCurveRend
 //----------------------------------------------------------------------------
 
 class AttCurveRend : public Att {
-public:
+protected:
     AttCurveRend();
-    virtual ~AttCurveRend();
+    ~AttCurveRend() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCurveRend();
 
@@ -1058,14 +1434,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCurveRend
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCurveRend
+ */
+
+class ExtAttCurveRend : public AttCurveRend {
+public:
+    ExtAttCurveRend() = default;
+    virtual ~ExtAttCurveRend() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCustosLog
 //----------------------------------------------------------------------------
 
 class AttCustosLog : public Att {
-public:
+protected:
     AttCustosLog();
-    virtual ~AttCustosLog();
+    ~AttCustosLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCustosLog();
 
@@ -1092,14 +1483,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCustosLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCustosLog
+ */
+
+class ExtAttCustosLog : public AttCustosLog {
+public:
+    ExtAttCustosLog() = default;
+    virtual ~ExtAttCustosLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDataPointing
 //----------------------------------------------------------------------------
 
 class AttDataPointing : public Att {
-public:
+protected:
     AttDataPointing();
-    virtual ~AttDataPointing();
+    ~AttDataPointing() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDataPointing();
 
@@ -1126,14 +1532,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDataPointing
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDataPointing
+ */
+
+class ExtAttDataPointing : public AttDataPointing {
+public:
+    ExtAttDataPointing() = default;
+    virtual ~ExtAttDataPointing() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDatable
 //----------------------------------------------------------------------------
 
 class AttDatable : public Att {
-public:
+protected:
     AttDatable();
-    virtual ~AttDatable();
+    ~AttDatable() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDatable();
 
@@ -1184,14 +1605,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDatable
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDatable
+ */
+
+class ExtAttDatable : public AttDatable {
+public:
+    ExtAttDatable() = default;
+    virtual ~ExtAttDatable() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDistances
 //----------------------------------------------------------------------------
 
 class AttDistances : public Att {
-public:
+protected:
     AttDistances();
-    virtual ~AttDistances();
+    ~AttDistances() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDistances();
 
@@ -1245,14 +1681,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDistances
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDistances
+ */
+
+class ExtAttDistances : public AttDistances {
+public:
+    ExtAttDistances() = default;
+    virtual ~ExtAttDistances() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDotLog
 //----------------------------------------------------------------------------
 
 class AttDotLog : public Att {
-public:
+protected:
     AttDotLog();
-    virtual ~AttDotLog();
+    ~AttDotLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDotLog();
 
@@ -1279,14 +1730,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDotLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDotLog
+ */
+
+class ExtAttDotLog : public AttDotLog {
+public:
+    ExtAttDotLog() = default;
+    virtual ~ExtAttDotLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDurationAdditive
 //----------------------------------------------------------------------------
 
 class AttDurationAdditive : public Att {
-public:
+protected:
     AttDurationAdditive();
-    virtual ~AttDurationAdditive();
+    ~AttDurationAdditive() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationAdditive();
 
@@ -1316,14 +1782,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationAdditive
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationAdditive
+ */
+
+class ExtAttDurationAdditive : public AttDurationAdditive {
+public:
+    ExtAttDurationAdditive() = default;
+    virtual ~ExtAttDurationAdditive() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDurationDefault
 //----------------------------------------------------------------------------
 
 class AttDurationDefault : public Att {
-public:
+protected:
     AttDurationDefault();
-    virtual ~AttDurationDefault();
+    ~AttDurationDefault() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationDefault();
 
@@ -1372,14 +1853,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationDefault
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationDefault
+ */
+
+class ExtAttDurationDefault : public AttDurationDefault {
+public:
+    ExtAttDurationDefault() = default;
+    virtual ~ExtAttDurationDefault() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDurationLog
 //----------------------------------------------------------------------------
 
 class AttDurationLog : public Att {
-public:
+protected:
     AttDurationLog();
-    virtual ~AttDurationLog();
+    ~AttDurationLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationLog();
 
@@ -1409,14 +1905,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationLog
+ */
+
+class ExtAttDurationLog : public AttDurationLog {
+public:
+    ExtAttDurationLog() = default;
+    virtual ~ExtAttDurationLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttDurationRatio
 //----------------------------------------------------------------------------
 
 class AttDurationRatio : public Att {
-public:
+protected:
     AttDurationRatio();
-    virtual ~AttDurationRatio();
+    ~AttDurationRatio() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetDurationRatio();
 
@@ -1452,14 +1963,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttDurationRatio
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttDurationRatio
+ */
+
+class ExtAttDurationRatio : public AttDurationRatio {
+public:
+    ExtAttDurationRatio() = default;
+    virtual ~ExtAttDurationRatio() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttEnclosingChars
 //----------------------------------------------------------------------------
 
 class AttEnclosingChars : public Att {
-public:
+protected:
     AttEnclosingChars();
-    virtual ~AttEnclosingChars();
+    ~AttEnclosingChars() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetEnclosingChars();
 
@@ -1491,14 +2017,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttEnclosingChars
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttEnclosingChars
+ */
+
+class ExtAttEnclosingChars : public AttEnclosingChars {
+public:
+    ExtAttEnclosingChars() = default;
+    virtual ~ExtAttEnclosingChars() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttEndings
 //----------------------------------------------------------------------------
 
 class AttEndings : public Att {
-public:
+protected:
     AttEndings();
-    virtual ~AttEndings();
+    ~AttEndings() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetEndings();
 
@@ -1525,14 +2066,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttEndings
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttEndings
+ */
+
+class ExtAttEndings : public AttEndings {
+public:
+    ExtAttEndings() = default;
+    virtual ~ExtAttEndings() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttEvidence
 //----------------------------------------------------------------------------
 
 class AttEvidence : public Att {
-public:
+protected:
     AttEvidence();
-    virtual ~AttEvidence();
+    ~AttEvidence() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetEvidence();
 
@@ -1568,14 +2124,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttEvidence
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttEvidence
+ */
+
+class ExtAttEvidence : public AttEvidence {
+public:
+    ExtAttEvidence() = default;
+    virtual ~ExtAttEvidence() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttExtender
 //----------------------------------------------------------------------------
 
 class AttExtender : public Att {
-public:
+protected:
     AttExtender();
-    virtual ~AttExtender();
+    ~AttExtender() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetExtender();
 
@@ -1602,14 +2173,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttExtender
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttExtender
+ */
+
+class ExtAttExtender : public AttExtender {
+public:
+    ExtAttExtender() = default;
+    virtual ~ExtAttExtender() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttExtent
 //----------------------------------------------------------------------------
 
 class AttExtent : public Att {
-public:
+protected:
     AttExtent();
-    virtual ~AttExtent();
+    ~AttExtent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetExtent();
 
@@ -1640,14 +2226,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttExtent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttExtent
+ */
+
+class ExtAttExtent : public AttExtent {
+public:
+    ExtAttExtent() = default;
+    virtual ~ExtAttExtent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFermataPresent
 //----------------------------------------------------------------------------
 
 class AttFermataPresent : public Att {
-public:
+protected:
     AttFermataPresent();
-    virtual ~AttFermataPresent();
+    ~AttFermataPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFermataPresent();
 
@@ -1678,14 +2279,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFermataPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFermataPresent
+ */
+
+class ExtAttFermataPresent : public AttFermataPresent {
+public:
+    ExtAttFermataPresent() = default;
+    virtual ~ExtAttFermataPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFiling
 //----------------------------------------------------------------------------
 
 class AttFiling : public Att {
-public:
+protected:
     AttFiling();
-    virtual ~AttFiling();
+    ~AttFiling() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFiling();
 
@@ -1715,14 +2331,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFiling
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFiling
+ */
+
+class ExtAttFiling : public AttFiling {
+public:
+    ExtAttFiling() = default;
+    virtual ~ExtAttFiling() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttGrpSymLog
 //----------------------------------------------------------------------------
 
 class AttGrpSymLog : public Att {
-public:
+protected:
     AttGrpSymLog();
-    virtual ~AttGrpSymLog();
+    ~AttGrpSymLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetGrpSymLog();
 
@@ -1749,14 +2380,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttGrpSymLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttGrpSymLog
+ */
+
+class ExtAttGrpSymLog : public AttGrpSymLog {
+public:
+    ExtAttGrpSymLog() = default;
+    virtual ~ExtAttGrpSymLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHandIdent
 //----------------------------------------------------------------------------
 
 class AttHandIdent : public Att {
-public:
+protected:
     AttHandIdent();
-    virtual ~AttHandIdent();
+    ~AttHandIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHandIdent();
 
@@ -1786,14 +2432,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHandIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHandIdent
+ */
+
+class ExtAttHandIdent : public AttHandIdent {
+public:
+    ExtAttHandIdent() = default;
+    virtual ~ExtAttHandIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHeight
 //----------------------------------------------------------------------------
 
 class AttHeight : public Att {
-public:
+protected:
     AttHeight();
-    virtual ~AttHeight();
+    ~AttHeight() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHeight();
 
@@ -1820,14 +2481,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHeight
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHeight
+ */
+
+class ExtAttHeight : public AttHeight {
+public:
+    ExtAttHeight() = default;
+    virtual ~ExtAttHeight() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHorizontalAlign
 //----------------------------------------------------------------------------
 
 class AttHorizontalAlign : public Att {
-public:
+protected:
     AttHorizontalAlign();
-    virtual ~AttHorizontalAlign();
+    ~AttHorizontalAlign() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHorizontalAlign();
 
@@ -1854,14 +2530,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHorizontalAlign
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHorizontalAlign
+ */
+
+class ExtAttHorizontalAlign : public AttHorizontalAlign {
+public:
+    ExtAttHorizontalAlign() = default;
+    virtual ~ExtAttHorizontalAlign() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttInternetMedia
 //----------------------------------------------------------------------------
 
 class AttInternetMedia : public Att {
-public:
+protected:
     AttInternetMedia();
-    virtual ~AttInternetMedia();
+    ~AttInternetMedia() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetInternetMedia();
 
@@ -1892,14 +2583,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttInternetMedia
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttInternetMedia
+ */
+
+class ExtAttInternetMedia : public AttInternetMedia {
+public:
+    ExtAttInternetMedia() = default;
+    virtual ~ExtAttInternetMedia() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttJoined
 //----------------------------------------------------------------------------
 
 class AttJoined : public Att {
-public:
+protected:
     AttJoined();
-    virtual ~AttJoined();
+    ~AttJoined() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetJoined();
 
@@ -1933,14 +2639,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttJoined
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttJoined
+ */
+
+class ExtAttJoined : public AttJoined {
+public:
+    ExtAttJoined() = default;
+    virtual ~ExtAttJoined() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigLog
 //----------------------------------------------------------------------------
 
 class AttKeySigLog : public Att {
-public:
+protected:
     AttKeySigLog();
-    virtual ~AttKeySigLog();
+    ~AttKeySigLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigLog();
 
@@ -1967,14 +2688,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigLog
+ */
+
+class ExtAttKeySigLog : public AttKeySigLog {
+public:
+    ExtAttKeySigLog() = default;
+    virtual ~ExtAttKeySigLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigDefaultLog
 //----------------------------------------------------------------------------
 
 class AttKeySigDefaultLog : public Att {
-public:
+protected:
     AttKeySigDefaultLog();
-    virtual ~AttKeySigDefaultLog();
+    ~AttKeySigDefaultLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigDefaultLog();
 
@@ -2001,14 +2737,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigDefaultLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigDefaultLog
+ */
+
+class ExtAttKeySigDefaultLog : public AttKeySigDefaultLog {
+public:
+    ExtAttKeySigDefaultLog() = default;
+    virtual ~ExtAttKeySigDefaultLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLabelled
 //----------------------------------------------------------------------------
 
 class AttLabelled : public Att {
-public:
+protected:
     AttLabelled();
-    virtual ~AttLabelled();
+    ~AttLabelled() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLabelled();
 
@@ -2039,14 +2790,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLabelled
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLabelled
+ */
+
+class ExtAttLabelled : public AttLabelled {
+public:
+    ExtAttLabelled() = default;
+    virtual ~ExtAttLabelled() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLang
 //----------------------------------------------------------------------------
 
 class AttLang : public Att {
-public:
+protected:
     AttLang();
-    virtual ~AttLang();
+    ~AttLang() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLang();
 
@@ -2079,14 +2845,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLang
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLang
+ */
+
+class ExtAttLang : public AttLang {
+public:
+    ExtAttLang() = default;
+    virtual ~ExtAttLang() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLayerLog
 //----------------------------------------------------------------------------
 
 class AttLayerLog : public Att {
-public:
+protected:
     AttLayerLog();
-    virtual ~AttLayerLog();
+    ~AttLayerLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLayerLog();
 
@@ -2113,14 +2894,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLayerLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLayerLog
+ */
+
+class ExtAttLayerLog : public AttLayerLog {
+public:
+    ExtAttLayerLog() = default;
+    virtual ~ExtAttLayerLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLayerIdent
 //----------------------------------------------------------------------------
 
 class AttLayerIdent : public Att {
-public:
+protected:
     AttLayerIdent();
-    virtual ~AttLayerIdent();
+    ~AttLayerIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLayerIdent();
 
@@ -2147,14 +2943,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLayerIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLayerIdent
+ */
+
+class ExtAttLayerIdent : public AttLayerIdent {
+public:
+    ExtAttLayerIdent() = default;
+    virtual ~ExtAttLayerIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLineLoc
 //----------------------------------------------------------------------------
 
 class AttLineLoc : public Att {
-public:
+protected:
     AttLineLoc();
-    virtual ~AttLineLoc();
+    ~AttLineLoc() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLineLoc();
 
@@ -2185,14 +2996,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLineLoc
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLineLoc
+ */
+
+class ExtAttLineLoc : public AttLineLoc {
+public:
+    ExtAttLineLoc() = default;
+    virtual ~ExtAttLineLoc() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLineRend
 //----------------------------------------------------------------------------
 
 class AttLineRend : public Att {
-public:
+protected:
     AttLineRend();
-    virtual ~AttLineRend();
+    ~AttLineRend() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLineRend();
 
@@ -2237,14 +3063,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLineRend
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLineRend
+ */
+
+class ExtAttLineRend : public AttLineRend {
+public:
+    ExtAttLineRend() = default;
+    virtual ~ExtAttLineRend() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLineRendBase
 //----------------------------------------------------------------------------
 
 class AttLineRendBase : public Att {
-public:
+protected:
     AttLineRendBase();
-    virtual ~AttLineRendBase();
+    ~AttLineRendBase() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLineRendBase();
 
@@ -2291,14 +3132,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLineRendBase
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLineRendBase
+ */
+
+class ExtAttLineRendBase : public AttLineRendBase {
+public:
+    ExtAttLineRendBase() = default;
+    virtual ~ExtAttLineRendBase() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLinking
 //----------------------------------------------------------------------------
 
 class AttLinking : public Att {
-public:
+protected:
     AttLinking();
-    virtual ~AttLinking();
+    ~AttLinking() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLinking();
 
@@ -2379,14 +3235,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLinking
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLinking
+ */
+
+class ExtAttLinking : public AttLinking {
+public:
+    ExtAttLinking() = default;
+    virtual ~ExtAttLinking() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLyricStyle
 //----------------------------------------------------------------------------
 
 class AttLyricStyle : public Att {
-public:
+protected:
     AttLyricStyle();
-    virtual ~AttLyricStyle();
+    ~AttLyricStyle() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLyricStyle();
 
@@ -2445,14 +3316,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLyricStyle
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLyricStyle
+ */
+
+class ExtAttLyricStyle : public AttLyricStyle {
+public:
+    ExtAttLyricStyle() = default;
+    virtual ~ExtAttLyricStyle() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeasureNumbers
 //----------------------------------------------------------------------------
 
 class AttMeasureNumbers : public Att {
-public:
+protected:
     AttMeasureNumbers();
-    virtual ~AttMeasureNumbers();
+    ~AttMeasureNumbers() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeasureNumbers();
 
@@ -2479,14 +3365,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeasureNumbers
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeasureNumbers
+ */
+
+class ExtAttMeasureNumbers : public AttMeasureNumbers {
+public:
+    ExtAttMeasureNumbers() = default;
+    virtual ~ExtAttMeasureNumbers() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeasurement
 //----------------------------------------------------------------------------
 
 class AttMeasurement : public Att {
-public:
+protected:
     AttMeasurement();
-    virtual ~AttMeasurement();
+    ~AttMeasurement() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeasurement();
 
@@ -2513,14 +3414,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeasurement
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeasurement
+ */
+
+class ExtAttMeasurement : public AttMeasurement {
+public:
+    ExtAttMeasurement() = default;
+    virtual ~ExtAttMeasurement() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMediaBounds
 //----------------------------------------------------------------------------
 
 class AttMediaBounds : public Att {
-public:
+protected:
     AttMediaBounds();
-    virtual ~AttMediaBounds();
+    ~AttMediaBounds() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMediaBounds();
 
@@ -2572,14 +3488,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMediaBounds
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMediaBounds
+ */
+
+class ExtAttMediaBounds : public AttMediaBounds {
+public:
+    ExtAttMediaBounds() = default;
+    virtual ~ExtAttMediaBounds() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMedium
 //----------------------------------------------------------------------------
 
 class AttMedium : public Att {
-public:
+protected:
     AttMedium();
-    virtual ~AttMedium();
+    ~AttMedium() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMedium();
 
@@ -2606,14 +3537,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMedium
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMedium
+ */
+
+class ExtAttMedium : public AttMedium {
+public:
+    ExtAttMedium() = default;
+    virtual ~ExtAttMedium() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeiVersion
 //----------------------------------------------------------------------------
 
 class AttMeiVersion : public Att {
-public:
+protected:
     AttMeiVersion();
-    virtual ~AttMeiVersion();
+    ~AttMeiVersion() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeiVersion();
 
@@ -2640,14 +3586,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeiVersion
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeiVersion
+ */
+
+class ExtAttMeiVersion : public AttMeiVersion {
+public:
+    ExtAttMeiVersion() = default;
+    virtual ~ExtAttMeiVersion() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMetadataPointing
 //----------------------------------------------------------------------------
 
 class AttMetadataPointing : public Att {
-public:
+protected:
     AttMetadataPointing();
-    virtual ~AttMetadataPointing();
+    ~AttMetadataPointing() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMetadataPointing();
 
@@ -2678,14 +3639,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMetadataPointing
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMetadataPointing
+ */
+
+class ExtAttMetadataPointing : public AttMetadataPointing {
+public:
+    ExtAttMetadataPointing() = default;
+    virtual ~ExtAttMetadataPointing() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterConformance
 //----------------------------------------------------------------------------
 
 class AttMeterConformance : public Att {
-public:
+protected:
     AttMeterConformance();
-    virtual ~AttMeterConformance();
+    ~AttMeterConformance() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterConformance();
 
@@ -2715,14 +3691,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterConformance
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterConformance
+ */
+
+class ExtAttMeterConformance : public AttMeterConformance {
+public:
+    ExtAttMeterConformance() = default;
+    virtual ~ExtAttMeterConformance() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterConformanceBar
 //----------------------------------------------------------------------------
 
 class AttMeterConformanceBar : public Att {
-public:
+protected:
     AttMeterConformanceBar();
-    virtual ~AttMeterConformanceBar();
+    ~AttMeterConformanceBar() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterConformanceBar();
 
@@ -2764,14 +3755,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterConformanceBar
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterConformanceBar
+ */
+
+class ExtAttMeterConformanceBar : public AttMeterConformanceBar {
+public:
+    ExtAttMeterConformanceBar() = default;
+    virtual ~ExtAttMeterConformanceBar() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterSigLog
 //----------------------------------------------------------------------------
 
 class AttMeterSigLog : public Att {
-public:
+protected:
     AttMeterSigLog();
-    virtual ~AttMeterSigLog();
+    ~AttMeterSigLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterSigLog();
 
@@ -2813,14 +3819,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterSigLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterSigLog
+ */
+
+class ExtAttMeterSigLog : public AttMeterSigLog {
+public:
+    ExtAttMeterSigLog() = default;
+    virtual ~ExtAttMeterSigLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterSigDefaultLog
 //----------------------------------------------------------------------------
 
 class AttMeterSigDefaultLog : public Att {
-public:
+protected:
     AttMeterSigDefaultLog();
-    virtual ~AttMeterSigDefaultLog();
+    ~AttMeterSigDefaultLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterSigDefaultLog();
 
@@ -2870,14 +3891,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterSigDefaultLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterSigDefaultLog
+ */
+
+class ExtAttMeterSigDefaultLog : public AttMeterSigDefaultLog {
+public:
+    ExtAttMeterSigDefaultLog() = default;
+    virtual ~ExtAttMeterSigDefaultLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMmTempo
 //----------------------------------------------------------------------------
 
 class AttMmTempo : public Att {
-public:
+protected:
     AttMmTempo();
-    virtual ~AttMmTempo();
+    ~AttMmTempo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMmTempo();
 
@@ -2922,14 +3958,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMmTempo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMmTempo
+ */
+
+class ExtAttMmTempo : public AttMmTempo {
+public:
+    ExtAttMmTempo() = default;
+    virtual ~ExtAttMmTempo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMultinumMeasures
 //----------------------------------------------------------------------------
 
 class AttMultinumMeasures : public Att {
-public:
+protected:
     AttMultinumMeasures();
-    virtual ~AttMultinumMeasures();
+    ~AttMultinumMeasures() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMultinumMeasures();
 
@@ -2959,14 +4010,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMultinumMeasures
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMultinumMeasures
+ */
+
+class ExtAttMultinumMeasures : public AttMultinumMeasures {
+public:
+    ExtAttMultinumMeasures() = default;
+    virtual ~ExtAttMultinumMeasures() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNInteger
 //----------------------------------------------------------------------------
 
 class AttNInteger : public Att {
-public:
+protected:
     AttNInteger();
-    virtual ~AttNInteger();
+    ~AttNInteger() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNInteger();
 
@@ -2997,14 +4063,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNInteger
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNInteger
+ */
+
+class ExtAttNInteger : public AttNInteger {
+public:
+    ExtAttNInteger() = default;
+    virtual ~ExtAttNInteger() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNNumberLike
 //----------------------------------------------------------------------------
 
 class AttNNumberLike : public Att {
-public:
+protected:
     AttNNumberLike();
-    virtual ~AttNNumberLike();
+    ~AttNNumberLike() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNNumberLike();
 
@@ -3035,14 +4116,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNNumberLike
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNNumberLike
+ */
+
+class ExtAttNNumberLike : public AttNNumberLike {
+public:
+    ExtAttNNumberLike() = default;
+    virtual ~ExtAttNNumberLike() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttName
 //----------------------------------------------------------------------------
 
 class AttName : public Att {
-public:
+protected:
     AttName();
-    virtual ~AttName();
+    ~AttName() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetName();
 
@@ -3081,14 +4177,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttName
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttName
+ */
+
+class ExtAttName : public AttName {
+public:
+    ExtAttName() = default;
+    virtual ~ExtAttName() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNotationStyle
 //----------------------------------------------------------------------------
 
 class AttNotationStyle : public Att {
-public:
+protected:
     AttNotationStyle();
-    virtual ~AttNotationStyle();
+    ~AttNotationStyle() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNotationStyle();
 
@@ -3123,14 +4234,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNotationStyle
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNotationStyle
+ */
+
+class ExtAttNotationStyle : public AttNotationStyle {
+public:
+    ExtAttNotationStyle() = default;
+    virtual ~ExtAttNotationStyle() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttNoteHeads
 //----------------------------------------------------------------------------
 
 class AttNoteHeads : public Att {
-public:
+protected:
     AttNoteHeads();
-    virtual ~AttNoteHeads();
+    ~AttNoteHeads() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetNoteHeads();
 
@@ -3219,14 +4345,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttNoteHeads
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttNoteHeads
+ */
+
+class ExtAttNoteHeads : public AttNoteHeads {
+public:
+    ExtAttNoteHeads() = default;
+    virtual ~ExtAttNoteHeads() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOctave
 //----------------------------------------------------------------------------
 
 class AttOctave : public Att {
-public:
+protected:
     AttOctave();
-    virtual ~AttOctave();
+    ~AttOctave() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOctave();
 
@@ -3253,14 +4394,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOctave
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOctave
+ */
+
+class ExtAttOctave : public AttOctave {
+public:
+    ExtAttOctave() = default;
+    virtual ~ExtAttOctave() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOctaveDefault
 //----------------------------------------------------------------------------
 
 class AttOctaveDefault : public Att {
-public:
+protected:
     AttOctaveDefault();
-    virtual ~AttOctaveDefault();
+    ~AttOctaveDefault() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOctaveDefault();
 
@@ -3291,14 +4447,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOctaveDefault
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOctaveDefault
+ */
+
+class ExtAttOctaveDefault : public AttOctaveDefault {
+public:
+    ExtAttOctaveDefault() = default;
+    virtual ~ExtAttOctaveDefault() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOctaveDisplacement
 //----------------------------------------------------------------------------
 
 class AttOctaveDisplacement : public Att {
-public:
+protected:
     AttOctaveDisplacement();
-    virtual ~AttOctaveDisplacement();
+    ~AttOctaveDisplacement() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOctaveDisplacement();
 
@@ -3331,14 +4502,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOctaveDisplacement
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOctaveDisplacement
+ */
+
+class ExtAttOctaveDisplacement : public AttOctaveDisplacement {
+public:
+    ExtAttOctaveDisplacement() = default;
+    virtual ~ExtAttOctaveDisplacement() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOneLineStaff
 //----------------------------------------------------------------------------
 
 class AttOneLineStaff : public Att {
-public:
+protected:
     AttOneLineStaff();
-    virtual ~AttOneLineStaff();
+    ~AttOneLineStaff() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOneLineStaff();
 
@@ -3369,14 +4555,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOneLineStaff
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOneLineStaff
+ */
+
+class ExtAttOneLineStaff : public AttOneLineStaff {
+public:
+    ExtAttOneLineStaff() = default;
+    virtual ~ExtAttOneLineStaff() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOptimization
 //----------------------------------------------------------------------------
 
 class AttOptimization : public Att {
-public:
+protected:
     AttOptimization();
-    virtual ~AttOptimization();
+    ~AttOptimization() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOptimization();
 
@@ -3406,14 +4607,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOptimization
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOptimization
+ */
+
+class ExtAttOptimization : public AttOptimization {
+public:
+    ExtAttOptimization() = default;
+    virtual ~ExtAttOptimization() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOriginLayerIdent
 //----------------------------------------------------------------------------
 
 class AttOriginLayerIdent : public Att {
-public:
+protected:
     AttOriginLayerIdent();
-    virtual ~AttOriginLayerIdent();
+    ~AttOriginLayerIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOriginLayerIdent();
 
@@ -3440,14 +4656,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOriginLayerIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOriginLayerIdent
+ */
+
+class ExtAttOriginLayerIdent : public AttOriginLayerIdent {
+public:
+    ExtAttOriginLayerIdent() = default;
+    virtual ~ExtAttOriginLayerIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOriginStaffIdent
 //----------------------------------------------------------------------------
 
 class AttOriginStaffIdent : public Att {
-public:
+protected:
     AttOriginStaffIdent();
-    virtual ~AttOriginStaffIdent();
+    ~AttOriginStaffIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOriginStaffIdent();
 
@@ -3477,14 +4708,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOriginStaffIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOriginStaffIdent
+ */
+
+class ExtAttOriginStaffIdent : public AttOriginStaffIdent {
+public:
+    ExtAttOriginStaffIdent() = default;
+    virtual ~ExtAttOriginStaffIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOriginStartEndId
 //----------------------------------------------------------------------------
 
 class AttOriginStartEndId : public Att {
-public:
+protected:
     AttOriginStartEndId();
-    virtual ~AttOriginStartEndId();
+    ~AttOriginStartEndId() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOriginStartEndId();
 
@@ -3517,14 +4763,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOriginStartEndId
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOriginStartEndId
+ */
+
+class ExtAttOriginStartEndId : public AttOriginStartEndId {
+public:
+    ExtAttOriginStartEndId() = default;
+    virtual ~ExtAttOriginStartEndId() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttOriginTimestampLog
 //----------------------------------------------------------------------------
 
 class AttOriginTimestampLog : public Att {
-public:
+protected:
     AttOriginTimestampLog();
-    virtual ~AttOriginTimestampLog();
+    ~AttOriginTimestampLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetOriginTimestampLog();
 
@@ -3564,14 +4825,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttOriginTimestampLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttOriginTimestampLog
+ */
+
+class ExtAttOriginTimestampLog : public AttOriginTimestampLog {
+public:
+    ExtAttOriginTimestampLog() = default;
+    virtual ~ExtAttOriginTimestampLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPages
 //----------------------------------------------------------------------------
 
 class AttPages : public Att {
-public:
+protected:
     AttPages();
-    virtual ~AttPages();
+    ~AttPages() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPages();
 
@@ -3646,14 +4922,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPages
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPages
+ */
+
+class ExtAttPages : public AttPages {
+public:
+    ExtAttPages() = default;
+    virtual ~ExtAttPages() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPartIdent
 //----------------------------------------------------------------------------
 
 class AttPartIdent : public Att {
-public:
+protected:
     AttPartIdent();
-    virtual ~AttPartIdent();
+    ~AttPartIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPartIdent();
 
@@ -3692,14 +4983,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPartIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPartIdent
+ */
+
+class ExtAttPartIdent : public AttPartIdent {
+public:
+    ExtAttPartIdent() = default;
+    virtual ~ExtAttPartIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPitch
 //----------------------------------------------------------------------------
 
 class AttPitch : public Att {
-public:
+protected:
     AttPitch();
-    virtual ~AttPitch();
+    ~AttPitch() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPitch();
 
@@ -3726,14 +5032,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPitch
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPitch
+ */
+
+class ExtAttPitch : public AttPitch {
+public:
+    ExtAttPitch() = default;
+    virtual ~ExtAttPitch() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPlacementOnStaff
 //----------------------------------------------------------------------------
 
 class AttPlacementOnStaff : public Att {
-public:
+protected:
     AttPlacementOnStaff();
-    virtual ~AttPlacementOnStaff();
+    ~AttPlacementOnStaff() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPlacementOnStaff();
 
@@ -3763,14 +5084,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPlacementOnStaff
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPlacementOnStaff
+ */
+
+class ExtAttPlacementOnStaff : public AttPlacementOnStaff {
+public:
+    ExtAttPlacementOnStaff() = default;
+    virtual ~ExtAttPlacementOnStaff() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPlacementRelEvent
 //----------------------------------------------------------------------------
 
 class AttPlacementRelEvent : public Att {
-public:
+protected:
     AttPlacementRelEvent();
-    virtual ~AttPlacementRelEvent();
+    ~AttPlacementRelEvent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPlacementRelEvent();
 
@@ -3797,14 +5133,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPlacementRelEvent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPlacementRelEvent
+ */
+
+class ExtAttPlacementRelEvent : public AttPlacementRelEvent {
+public:
+    ExtAttPlacementRelEvent() = default;
+    virtual ~ExtAttPlacementRelEvent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPlacementRelStaff
 //----------------------------------------------------------------------------
 
 class AttPlacementRelStaff : public Att {
-public:
+protected:
     AttPlacementRelStaff();
-    virtual ~AttPlacementRelStaff();
+    ~AttPlacementRelStaff() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPlacementRelStaff();
 
@@ -3831,14 +5182,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPlacementRelStaff
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPlacementRelStaff
+ */
+
+class ExtAttPlacementRelStaff : public AttPlacementRelStaff {
+public:
+    ExtAttPlacementRelStaff() = default;
+    virtual ~ExtAttPlacementRelStaff() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPlist
 //----------------------------------------------------------------------------
 
 class AttPlist : public Att {
-public:
+protected:
     AttPlist();
-    virtual ~AttPlist();
+    ~AttPlist() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPlist();
 
@@ -3871,14 +5237,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPlist
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPlist
+ */
+
+class ExtAttPlist : public AttPlist {
+public:
+    ExtAttPlist() = default;
+    virtual ~ExtAttPlist() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPointing
 //----------------------------------------------------------------------------
 
 class AttPointing : public Att {
-public:
+protected:
     AttPointing();
-    virtual ~AttPointing();
+    ~AttPointing() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPointing();
 
@@ -3935,14 +5316,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPointing
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPointing
+ */
+
+class ExtAttPointing : public AttPointing {
+public:
+    ExtAttPointing() = default;
+    virtual ~ExtAttPointing() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttQuantity
 //----------------------------------------------------------------------------
 
 class AttQuantity : public Att {
-public:
+protected:
     AttQuantity();
-    virtual ~AttQuantity();
+    ~AttQuantity() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetQuantity();
 
@@ -3972,14 +5368,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttQuantity
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttQuantity
+ */
+
+class ExtAttQuantity : public AttQuantity {
+public:
+    ExtAttQuantity() = default;
+    virtual ~ExtAttQuantity() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRanging
 //----------------------------------------------------------------------------
 
 class AttRanging : public Att {
-public:
+protected:
     AttRanging();
-    virtual ~AttRanging();
+    ~AttRanging() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRanging();
 
@@ -4040,14 +5451,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttRanging
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRanging
+ */
+
+class ExtAttRanging : public AttRanging {
+public:
+    ExtAttRanging() = default;
+    virtual ~ExtAttRanging() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttResponsibility
 //----------------------------------------------------------------------------
 
 class AttResponsibility : public Att {
-public:
+protected:
     AttResponsibility();
-    virtual ~AttResponsibility();
+    ~AttResponsibility() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetResponsibility();
 
@@ -4078,14 +5504,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttResponsibility
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttResponsibility
+ */
+
+class ExtAttResponsibility : public AttResponsibility {
+public:
+    ExtAttResponsibility() = default;
+    virtual ~ExtAttResponsibility() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttRestdurationLog
 //----------------------------------------------------------------------------
 
 class AttRestdurationLog : public Att {
-public:
+protected:
     AttRestdurationLog();
-    virtual ~AttRestdurationLog();
+    ~AttRestdurationLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetRestdurationLog();
 
@@ -4115,14 +5556,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttRestdurationLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttRestdurationLog
+ */
+
+class ExtAttRestdurationLog : public AttRestdurationLog {
+public:
+    ExtAttRestdurationLog() = default;
+    virtual ~ExtAttRestdurationLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttScalable
 //----------------------------------------------------------------------------
 
 class AttScalable : public Att {
-public:
+protected:
     AttScalable();
-    virtual ~AttScalable();
+    ~AttScalable() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetScalable();
 
@@ -4149,14 +5605,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttScalable
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttScalable
+ */
+
+class ExtAttScalable : public AttScalable {
+public:
+    ExtAttScalable() = default;
+    virtual ~ExtAttScalable() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSequence
 //----------------------------------------------------------------------------
 
 class AttSequence : public Att {
-public:
+protected:
     AttSequence();
-    virtual ~AttSequence();
+    ~AttSequence() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSequence();
 
@@ -4186,14 +5657,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSequence
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSequence
+ */
+
+class ExtAttSequence : public AttSequence {
+public:
+    ExtAttSequence() = default;
+    virtual ~ExtAttSequence() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSlashCount
 //----------------------------------------------------------------------------
 
 class AttSlashCount : public Att {
-public:
+protected:
     AttSlashCount();
-    virtual ~AttSlashCount();
+    ~AttSlashCount() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSlashCount();
 
@@ -4220,14 +5706,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSlashCount
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSlashCount
+ */
+
+class ExtAttSlashCount : public AttSlashCount {
+public:
+    ExtAttSlashCount() = default;
+    virtual ~ExtAttSlashCount() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSlurPresent
 //----------------------------------------------------------------------------
 
 class AttSlurPresent : public Att {
-public:
+protected:
     AttSlurPresent();
-    virtual ~AttSlurPresent();
+    ~AttSlurPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSlurPresent();
 
@@ -4258,14 +5759,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSlurPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSlurPresent
+ */
+
+class ExtAttSlurPresent : public AttSlurPresent {
+public:
+    ExtAttSlurPresent() = default;
+    virtual ~ExtAttSlurPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSource
 //----------------------------------------------------------------------------
 
 class AttSource : public Att {
-public:
+protected:
     AttSource();
-    virtual ~AttSource();
+    ~AttSource() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSource();
 
@@ -4297,14 +5813,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSource
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSource
+ */
+
+class ExtAttSource : public AttSource {
+public:
+    ExtAttSource() = default;
+    virtual ~ExtAttSource() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSpacing
 //----------------------------------------------------------------------------
 
 class AttSpacing : public Att {
-public:
+protected:
     AttSpacing();
-    virtual ~AttSpacing();
+    ~AttSpacing() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSpacing();
 
@@ -4358,14 +5889,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSpacing
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSpacing
+ */
+
+class ExtAttSpacing : public AttSpacing {
+public:
+    ExtAttSpacing() = default;
+    virtual ~ExtAttSpacing() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffLog
 //----------------------------------------------------------------------------
 
 class AttStaffLog : public Att {
-public:
+protected:
     AttStaffLog();
-    virtual ~AttStaffLog();
+    ~AttStaffLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffLog();
 
@@ -4392,14 +5938,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffLog
+ */
+
+class ExtAttStaffLog : public AttStaffLog {
+public:
+    ExtAttStaffLog() = default;
+    virtual ~ExtAttStaffLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffDefLog
 //----------------------------------------------------------------------------
 
 class AttStaffDefLog : public Att {
-public:
+protected:
     AttStaffDefLog();
-    virtual ~AttStaffDefLog();
+    ~AttStaffDefLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffDefLog();
 
@@ -4426,14 +5987,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffDefLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffDefLog
+ */
+
+class ExtAttStaffDefLog : public AttStaffDefLog {
+public:
+    ExtAttStaffDefLog() = default;
+    virtual ~ExtAttStaffDefLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffGroupingSym
 //----------------------------------------------------------------------------
 
 class AttStaffGroupingSym : public Att {
-public:
+protected:
     AttStaffGroupingSym();
-    virtual ~AttStaffGroupingSym();
+    ~AttStaffGroupingSym() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffGroupingSym();
 
@@ -4460,14 +6036,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffGroupingSym
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffGroupingSym
+ */
+
+class ExtAttStaffGroupingSym : public AttStaffGroupingSym {
+public:
+    ExtAttStaffGroupingSym() = default;
+    virtual ~ExtAttStaffGroupingSym() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffIdent
 //----------------------------------------------------------------------------
 
 class AttStaffIdent : public Att {
-public:
+protected:
     AttStaffIdent();
-    virtual ~AttStaffIdent();
+    ~AttStaffIdent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffIdent();
 
@@ -4498,14 +6089,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffIdent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffIdent
+ */
+
+class ExtAttStaffIdent : public AttStaffIdent {
+public:
+    ExtAttStaffIdent() = default;
+    virtual ~ExtAttStaffIdent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffItems
 //----------------------------------------------------------------------------
 
 class AttStaffItems : public Att {
-public:
+protected:
     AttStaffItems();
-    virtual ~AttStaffItems();
+    ~AttStaffItems() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffItems();
 
@@ -4550,14 +6156,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffItems
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffItems
+ */
+
+class ExtAttStaffItems : public AttStaffItems {
+public:
+    ExtAttStaffItems() = default;
+    virtual ~ExtAttStaffItems() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffLoc
 //----------------------------------------------------------------------------
 
 class AttStaffLoc : public Att {
-public:
+protected:
     AttStaffLoc();
-    virtual ~AttStaffLoc();
+    ~AttStaffLoc() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffLoc();
 
@@ -4584,14 +6205,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffLoc
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffLoc
+ */
+
+class ExtAttStaffLoc : public AttStaffLoc {
+public:
+    ExtAttStaffLoc() = default;
+    virtual ~ExtAttStaffLoc() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffLocPitched
 //----------------------------------------------------------------------------
 
 class AttStaffLocPitched : public Att {
-public:
+protected:
     AttStaffLocPitched();
-    virtual ~AttStaffLocPitched();
+    ~AttStaffLocPitched() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffLocPitched();
 
@@ -4624,14 +6260,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffLocPitched
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffLocPitched
+ */
+
+class ExtAttStaffLocPitched : public AttStaffLocPitched {
+public:
+    ExtAttStaffLocPitched() = default;
+    virtual ~ExtAttStaffLocPitched() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStartEndId
 //----------------------------------------------------------------------------
 
 class AttStartEndId : public Att {
-public:
+protected:
     AttStartEndId();
-    virtual ~AttStartEndId();
+    ~AttStartEndId() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStartEndId();
 
@@ -4661,14 +6312,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStartEndId
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStartEndId
+ */
+
+class ExtAttStartEndId : public AttStartEndId {
+public:
+    ExtAttStartEndId() = default;
+    virtual ~ExtAttStartEndId() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStartId
 //----------------------------------------------------------------------------
 
 class AttStartId : public Att {
-public:
+protected:
     AttStartId();
-    virtual ~AttStartId();
+    ~AttStartId() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStartId();
 
@@ -4698,14 +6364,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStartId
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStartId
+ */
+
+class ExtAttStartId : public AttStartId {
+public:
+    ExtAttStartId() = default;
+    virtual ~ExtAttStartId() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStems
 //----------------------------------------------------------------------------
 
 class AttStems : public Att {
-public:
+protected:
     AttStems();
-    virtual ~AttStems();
+    ~AttStems() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStems();
 
@@ -4781,14 +6462,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStems
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStems
+ */
+
+class ExtAttStems : public AttStems {
+public:
+    ExtAttStems() = default;
+    virtual ~ExtAttStems() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSylLog
 //----------------------------------------------------------------------------
 
 class AttSylLog : public Att {
-public:
+protected:
     AttSylLog();
-    virtual ~AttSylLog();
+    ~AttSylLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSylLog();
 
@@ -4824,14 +6520,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSylLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSylLog
+ */
+
+class ExtAttSylLog : public AttSylLog {
+public:
+    ExtAttSylLog() = default;
+    virtual ~ExtAttSylLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSylText
 //----------------------------------------------------------------------------
 
 class AttSylText : public Att {
-public:
+protected:
     AttSylText();
-    virtual ~AttSylText();
+    ~AttSylText() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSylText();
 
@@ -4858,14 +6569,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSylText
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSylText
+ */
+
+class ExtAttSylText : public AttSylText {
+public:
+    ExtAttSylText() = default;
+    virtual ~ExtAttSylText() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSystems
 //----------------------------------------------------------------------------
 
 class AttSystems : public Att {
-public:
+protected:
     AttSystems();
-    virtual ~AttSystems();
+    ~AttSystems() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSystems();
 
@@ -4923,14 +6649,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSystems
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSystems
+ */
+
+class ExtAttSystems : public AttSystems {
+public:
+    ExtAttSystems() = default;
+    virtual ~ExtAttSystems() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTargetEval
 //----------------------------------------------------------------------------
 
 class AttTargetEval : public Att {
-public:
+protected:
     AttTargetEval();
-    virtual ~AttTargetEval();
+    ~AttTargetEval() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTargetEval();
 
@@ -4960,14 +6701,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTargetEval
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTargetEval
+ */
+
+class ExtAttTargetEval : public AttTargetEval {
+public:
+    ExtAttTargetEval() = default;
+    virtual ~ExtAttTargetEval() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTempoLog
 //----------------------------------------------------------------------------
 
 class AttTempoLog : public Att {
-public:
+protected:
     AttTempoLog();
-    virtual ~AttTempoLog();
+    ~AttTempoLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTempoLog();
 
@@ -4994,14 +6750,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTempoLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTempoLog
+ */
+
+class ExtAttTempoLog : public AttTempoLog {
+public:
+    ExtAttTempoLog() = default;
+    virtual ~ExtAttTempoLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTextRendition
 //----------------------------------------------------------------------------
 
 class AttTextRendition : public Att {
-public:
+protected:
     AttTextRendition();
-    virtual ~AttTextRendition();
+    ~AttTextRendition() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTextRendition();
 
@@ -5034,14 +6805,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTextRendition
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTextRendition
+ */
+
+class ExtAttTextRendition : public AttTextRendition {
+public:
+    ExtAttTextRendition() = default;
+    virtual ~ExtAttTextRendition() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTextStyle
 //----------------------------------------------------------------------------
 
 class AttTextStyle : public Att {
-public:
+protected:
     AttTextStyle();
-    virtual ~AttTextStyle();
+    ~AttTextStyle() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTextStyle();
 
@@ -5109,14 +6895,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTextStyle
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTextStyle
+ */
+
+class ExtAttTextStyle : public AttTextStyle {
+public:
+    ExtAttTextStyle() = default;
+    virtual ~ExtAttTextStyle() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTiePresent
 //----------------------------------------------------------------------------
 
 class AttTiePresent : public Att {
-public:
+protected:
     AttTiePresent();
-    virtual ~AttTiePresent();
+    ~AttTiePresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTiePresent();
 
@@ -5147,14 +6948,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTiePresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTiePresent
+ */
+
+class ExtAttTiePresent : public AttTiePresent {
+public:
+    ExtAttTiePresent() = default;
+    virtual ~ExtAttTiePresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTimestampLog
 //----------------------------------------------------------------------------
 
 class AttTimestampLog : public Att {
-public:
+protected:
     AttTimestampLog();
-    virtual ~AttTimestampLog();
+    ~AttTimestampLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTimestampLog();
 
@@ -5184,14 +7000,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTimestampLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTimestampLog
+ */
+
+class ExtAttTimestampLog : public AttTimestampLog {
+public:
+    ExtAttTimestampLog() = default;
+    virtual ~ExtAttTimestampLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTimestamp2Log
 //----------------------------------------------------------------------------
 
 class AttTimestamp2Log : public Att {
-public:
+protected:
     AttTimestamp2Log();
-    virtual ~AttTimestamp2Log();
+    ~AttTimestamp2Log() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTimestamp2Log();
 
@@ -5221,14 +7052,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTimestamp2Log
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTimestamp2Log
+ */
+
+class ExtAttTimestamp2Log : public AttTimestamp2Log {
+public:
+    ExtAttTimestamp2Log() = default;
+    virtual ~ExtAttTimestamp2Log() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTransposition
 //----------------------------------------------------------------------------
 
 class AttTransposition : public Att {
-public:
+protected:
     AttTransposition();
-    virtual ~AttTransposition();
+    ~AttTransposition() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTransposition();
 
@@ -5267,14 +7113,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTransposition
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTransposition
+ */
+
+class ExtAttTransposition : public AttTransposition {
+public:
+    ExtAttTransposition() = default;
+    virtual ~ExtAttTransposition() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTuning
 //----------------------------------------------------------------------------
 
 class AttTuning : public Att {
-public:
+protected:
     AttTuning();
-    virtual ~AttTuning();
+    ~AttTuning() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTuning();
 
@@ -5316,14 +7177,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTuning
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTuning
+ */
+
+class ExtAttTuning : public AttTuning {
+public:
+    ExtAttTuning() = default;
+    virtual ~ExtAttTuning() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTupletPresent
 //----------------------------------------------------------------------------
 
 class AttTupletPresent : public Att {
-public:
+protected:
     AttTupletPresent();
-    virtual ~AttTupletPresent();
+    ~AttTupletPresent() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTupletPresent();
 
@@ -5354,14 +7230,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTupletPresent
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTupletPresent
+ */
+
+class ExtAttTupletPresent : public AttTupletPresent {
+public:
+    ExtAttTupletPresent() = default;
+    virtual ~ExtAttTupletPresent() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTyped
 //----------------------------------------------------------------------------
 
 class AttTyped : public Att {
-public:
+protected:
     AttTyped();
-    virtual ~AttTyped();
+    ~AttTyped() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTyped();
 
@@ -5391,14 +7282,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTyped
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTyped
+ */
+
+class ExtAttTyped : public AttTyped {
+public:
+    ExtAttTyped() = default;
+    virtual ~ExtAttTyped() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTypography
 //----------------------------------------------------------------------------
 
 class AttTypography : public Att {
-public:
+protected:
     AttTypography();
-    virtual ~AttTypography();
+    ~AttTypography() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTypography();
 
@@ -5470,14 +7376,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttTypography
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTypography
+ */
+
+class ExtAttTypography : public AttTypography {
+public:
+    ExtAttTypography() = default;
+    virtual ~ExtAttTypography() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVerticalAlign
 //----------------------------------------------------------------------------
 
 class AttVerticalAlign : public Att {
-public:
+protected:
     AttVerticalAlign();
-    virtual ~AttVerticalAlign();
+    ~AttVerticalAlign() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVerticalAlign();
 
@@ -5504,14 +7425,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVerticalAlign
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVerticalAlign
+ */
+
+class ExtAttVerticalAlign : public AttVerticalAlign {
+public:
+    ExtAttVerticalAlign() = default;
+    virtual ~ExtAttVerticalAlign() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVerticalGroup
 //----------------------------------------------------------------------------
 
 class AttVerticalGroup : public Att {
-public:
+protected:
     AttVerticalGroup();
-    virtual ~AttVerticalGroup();
+    ~AttVerticalGroup() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVerticalGroup();
 
@@ -5538,14 +7474,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVerticalGroup
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVerticalGroup
+ */
+
+class ExtAttVerticalGroup : public AttVerticalGroup {
+public:
+    ExtAttVerticalGroup() = default;
+    virtual ~ExtAttVerticalGroup() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisibility
 //----------------------------------------------------------------------------
 
 class AttVisibility : public Att {
-public:
+protected:
     AttVisibility();
-    virtual ~AttVisibility();
+    ~AttVisibility() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisibility();
 
@@ -5575,14 +7526,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisibility
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisibility
+ */
+
+class ExtAttVisibility : public AttVisibility {
+public:
+    ExtAttVisibility() = default;
+    virtual ~ExtAttVisibility() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffsetHo
 //----------------------------------------------------------------------------
 
 class AttVisualOffsetHo : public Att {
-public:
+protected:
     AttVisualOffsetHo();
-    virtual ~AttVisualOffsetHo();
+    ~AttVisualOffsetHo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffsetHo();
 
@@ -5613,14 +7579,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffsetHo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffsetHo
+ */
+
+class ExtAttVisualOffsetHo : public AttVisualOffsetHo {
+public:
+    ExtAttVisualOffsetHo() = default;
+    virtual ~ExtAttVisualOffsetHo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffsetTo
 //----------------------------------------------------------------------------
 
 class AttVisualOffsetTo : public Att {
-public:
+protected:
     AttVisualOffsetTo();
-    virtual ~AttVisualOffsetTo();
+    ~AttVisualOffsetTo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffsetTo();
 
@@ -5650,14 +7631,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffsetTo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffsetTo
+ */
+
+class ExtAttVisualOffsetTo : public AttVisualOffsetTo {
+public:
+    ExtAttVisualOffsetTo() = default;
+    virtual ~ExtAttVisualOffsetTo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffsetVo
 //----------------------------------------------------------------------------
 
 class AttVisualOffsetVo : public Att {
-public:
+protected:
     AttVisualOffsetVo();
-    virtual ~AttVisualOffsetVo();
+    ~AttVisualOffsetVo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffsetVo();
 
@@ -5688,14 +7684,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffsetVo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffsetVo
+ */
+
+class ExtAttVisualOffsetVo : public AttVisualOffsetVo {
+public:
+    ExtAttVisualOffsetVo() = default;
+    virtual ~ExtAttVisualOffsetVo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffset2Ho
 //----------------------------------------------------------------------------
 
 class AttVisualOffset2Ho : public Att {
-public:
+protected:
     AttVisualOffset2Ho();
-    virtual ~AttVisualOffset2Ho();
+    ~AttVisualOffset2Ho() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffset2Ho();
 
@@ -5734,14 +7745,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffset2Ho
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffset2Ho
+ */
+
+class ExtAttVisualOffset2Ho : public AttVisualOffset2Ho {
+public:
+    ExtAttVisualOffset2Ho() = default;
+    virtual ~ExtAttVisualOffset2Ho() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffset2To
 //----------------------------------------------------------------------------
 
 class AttVisualOffset2To : public Att {
-public:
+protected:
     AttVisualOffset2To();
-    virtual ~AttVisualOffset2To();
+    ~AttVisualOffset2To() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffset2To();
 
@@ -5780,14 +7806,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffset2To
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffset2To
+ */
+
+class ExtAttVisualOffset2To : public AttVisualOffset2To {
+public:
+    ExtAttVisualOffset2To() = default;
+    virtual ~ExtAttVisualOffset2To() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVisualOffset2Vo
 //----------------------------------------------------------------------------
 
 class AttVisualOffset2Vo : public Att {
-public:
+protected:
     AttVisualOffset2Vo();
-    virtual ~AttVisualOffset2Vo();
+    ~AttVisualOffset2Vo() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVisualOffset2Vo();
 
@@ -5826,14 +7867,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVisualOffset2Vo
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVisualOffset2Vo
+ */
+
+class ExtAttVisualOffset2Vo : public AttVisualOffset2Vo {
+public:
+    ExtAttVisualOffset2Vo() = default;
+    virtual ~ExtAttVisualOffset2Vo() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttVoltaGroupingSym
 //----------------------------------------------------------------------------
 
 class AttVoltaGroupingSym : public Att {
-public:
+protected:
     AttVoltaGroupingSym();
-    virtual ~AttVoltaGroupingSym();
+    ~AttVoltaGroupingSym() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetVoltaGroupingSym();
 
@@ -5860,14 +7916,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttVoltaGroupingSym
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttVoltaGroupingSym
+ */
+
+class ExtAttVoltaGroupingSym : public AttVoltaGroupingSym {
+public:
+    ExtAttVoltaGroupingSym() = default;
+    virtual ~ExtAttVoltaGroupingSym() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttWhitespace
 //----------------------------------------------------------------------------
 
 class AttWhitespace : public Att {
-public:
+protected:
     AttWhitespace();
-    virtual ~AttWhitespace();
+    ~AttWhitespace() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetWhitespace();
 
@@ -5894,14 +7965,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttWhitespace
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttWhitespace
+ */
+
+class ExtAttWhitespace : public AttWhitespace {
+public:
+    ExtAttWhitespace() = default;
+    virtual ~ExtAttWhitespace() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttWidth
 //----------------------------------------------------------------------------
 
 class AttWidth : public Att {
-public:
+protected:
     AttWidth();
-    virtual ~AttWidth();
+    ~AttWidth() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetWidth();
 
@@ -5928,14 +8014,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttWidth
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttWidth
+ */
+
+class ExtAttWidth : public AttWidth {
+public:
+    ExtAttWidth() = default;
+    virtual ~ExtAttWidth() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttXy
 //----------------------------------------------------------------------------
 
 class AttXy : public Att {
-public:
+protected:
     AttXy();
-    virtual ~AttXy();
+    ~AttXy() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetXy();
 
@@ -5976,14 +8077,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttXy
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttXy
+ */
+
+class ExtAttXy : public AttXy {
+public:
+    ExtAttXy() = default;
+    virtual ~ExtAttXy() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttXy2
 //----------------------------------------------------------------------------
 
 class AttXy2 : public Att {
-public:
+protected:
     AttXy2();
-    virtual ~AttXy2();
+    ~AttXy2() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetXy2();
 
@@ -6013,6 +8129,20 @@ private:
     double m_x2;
     /** Encodes the optional 2nd y coordinate. **/
     double m_y2;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttXy2
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttXy2
+ */
+
+class ExtAttXy2 : public AttXy2 {
+public:
+    ExtAttXy2() = default;
+    virtual ~ExtAttXy2() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_usersymbols.cpp
+++ b/libmei/dist/atts_usersymbols.cpp
@@ -31,8 +31,6 @@ AttAltSym::AttAltSym() : Att()
     ResetAltSym();
 }
 
-AttAltSym::~AttAltSym() {}
-
 void AttAltSym::ResetAltSym()
 {
     m_altsym = "";
@@ -72,8 +70,6 @@ AttAnchoredTextLog::AttAnchoredTextLog() : Att()
 {
     ResetAnchoredTextLog();
 }
-
-AttAnchoredTextLog::~AttAnchoredTextLog() {}
 
 void AttAnchoredTextLog::ResetAnchoredTextLog()
 {
@@ -115,8 +111,6 @@ AttCurveLog::AttCurveLog() : Att()
     ResetCurveLog();
 }
 
-AttCurveLog::~AttCurveLog() {}
-
 void AttCurveLog::ResetCurveLog()
 {
     m_func = "";
@@ -156,8 +150,6 @@ AttLineLog::AttLineLog() : Att()
 {
     ResetLineLog();
 }
-
-AttLineLog::~AttLineLog() {}
 
 void AttLineLog::ResetLineLog()
 {

--- a/libmei/dist/atts_usersymbols.h
+++ b/libmei/dist/atts_usersymbols.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAltSym : public Att {
-public:
+protected:
     AttAltSym();
-    virtual ~AttAltSym();
+    ~AttAltSym() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAltSym();
 
@@ -64,14 +65,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAltSym
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAltSym
+ */
+
+class ExtAttAltSym : public AttAltSym {
+public:
+    ExtAttAltSym() = default;
+    virtual ~ExtAttAltSym() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttAnchoredTextLog
 //----------------------------------------------------------------------------
 
 class AttAnchoredTextLog : public Att {
-public:
+protected:
     AttAnchoredTextLog();
-    virtual ~AttAnchoredTextLog();
+    ~AttAnchoredTextLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAnchoredTextLog();
 
@@ -98,14 +114,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAnchoredTextLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAnchoredTextLog
+ */
+
+class ExtAttAnchoredTextLog : public AttAnchoredTextLog {
+public:
+    ExtAttAnchoredTextLog() = default;
+    virtual ~ExtAttAnchoredTextLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCurveLog
 //----------------------------------------------------------------------------
 
 class AttCurveLog : public Att {
-public:
+protected:
     AttCurveLog();
-    virtual ~AttCurveLog();
+    ~AttCurveLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCurveLog();
 
@@ -132,14 +163,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCurveLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCurveLog
+ */
+
+class ExtAttCurveLog : public AttCurveLog {
+public:
+    ExtAttCurveLog() = default;
+    virtual ~ExtAttCurveLog() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLineLog
 //----------------------------------------------------------------------------
 
 class AttLineLog : public Att {
-public:
+protected:
     AttLineLog();
-    virtual ~AttLineLog();
+    ~AttLineLog() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLineLog();
 
@@ -163,6 +209,20 @@ public:
 private:
     /** Describes the function of the bracketed event sequence. **/
     std::string m_func;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttLineLog
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLineLog
+ */
+
+class ExtAttLineLog : public AttLineLog {
+public:
+    ExtAttLineLog() = default;
+    virtual ~ExtAttLineLog() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atts_visual.cpp
+++ b/libmei/dist/atts_visual.cpp
@@ -31,8 +31,6 @@ AttAnnotVis::AttAnnotVis() : Att()
     ResetAnnotVis();
 }
 
-AttAnnotVis::~AttAnnotVis() {}
-
 void AttAnnotVis::ResetAnnotVis()
 {
     m_place = data_PLACEMENT();
@@ -72,8 +70,6 @@ AttArpegVis::AttArpegVis() : Att()
 {
     ResetArpegVis();
 }
-
-AttArpegVis::~AttArpegVis() {}
 
 void AttArpegVis::ResetArpegVis()
 {
@@ -205,8 +201,6 @@ AttBarLineVis::AttBarLineVis() : Att()
     ResetBarLineVis();
 }
 
-AttBarLineVis::~AttBarLineVis() {}
-
 void AttBarLineVis::ResetBarLineVis()
 {
     m_len = 0.0;
@@ -276,8 +270,6 @@ AttBeamingVis::AttBeamingVis() : Att()
 {
     ResetBeamingVis();
 }
-
-AttBeamingVis::~AttBeamingVis() {}
 
 void AttBeamingVis::ResetBeamingVis()
 {
@@ -349,8 +341,6 @@ AttBeatRptVis::AttBeatRptVis() : Att()
     ResetBeatRptVis();
 }
 
-AttBeatRptVis::~AttBeatRptVis() {}
-
 void AttBeatRptVis::ResetBeatRptVis()
 {
     m_slash = BEATRPT_REND_NONE;
@@ -391,8 +381,6 @@ AttChordVis::AttChordVis() : Att()
     ResetChordVis();
 }
 
-AttChordVis::~AttChordVis() {}
-
 void AttChordVis::ResetChordVis()
 {
     m_cluster = CLUSTER_NONE;
@@ -432,8 +420,6 @@ AttCleffingVis::AttCleffingVis() : Att()
 {
     ResetCleffingVis();
 }
-
-AttCleffingVis::~AttCleffingVis() {}
 
 void AttCleffingVis::ResetCleffingVis()
 {
@@ -490,8 +476,6 @@ AttEpisemaVis::AttEpisemaVis() : Att()
     ResetEpisemaVis();
 }
 
-AttEpisemaVis::~AttEpisemaVis() {}
-
 void AttEpisemaVis::ResetEpisemaVis()
 {
     m_form = episemaVis_FORM_NONE;
@@ -546,8 +530,6 @@ AttFTremVis::AttFTremVis() : Att()
 {
     ResetFTremVis();
 }
-
-AttFTremVis::~AttFTremVis() {}
 
 void AttFTremVis::ResetFTremVis()
 {
@@ -619,8 +601,6 @@ AttFermataVis::AttFermataVis() : Att()
     ResetFermataVis();
 }
 
-AttFermataVis::~AttFermataVis() {}
-
 void AttFermataVis::ResetFermataVis()
 {
     m_form = fermataVis_FORM_NONE;
@@ -676,8 +656,6 @@ AttFingGrpVis::AttFingGrpVis() : Att()
     ResetFingGrpVis();
 }
 
-AttFingGrpVis::~AttFingGrpVis() {}
-
 void AttFingGrpVis::ResetFingGrpVis()
 {
     m_orient = fingGrpVis_ORIENT_NONE;
@@ -717,8 +695,6 @@ AttHairpinVis::AttHairpinVis() : Att()
 {
     ResetHairpinVis();
 }
-
-AttHairpinVis::~AttHairpinVis() {}
 
 void AttHairpinVis::ResetHairpinVis()
 {
@@ -805,8 +781,6 @@ AttHarmVis::AttHarmVis() : Att()
     ResetHarmVis();
 }
 
-AttHarmVis::~AttHarmVis() {}
-
 void AttHarmVis::ResetHarmVis()
 {
     m_rendgrid = harmVis_RENDGRID_NONE;
@@ -846,8 +820,6 @@ AttHispanTickVis::AttHispanTickVis() : Att()
 {
     ResetHispanTickVis();
 }
-
-AttHispanTickVis::~AttHispanTickVis() {}
 
 void AttHispanTickVis::ResetHispanTickVis()
 {
@@ -904,8 +876,6 @@ AttKeySigVis::AttKeySigVis() : Att()
     ResetKeySigVis();
 }
 
-AttKeySigVis::~AttKeySigVis() {}
-
 void AttKeySigVis::ResetKeySigVis()
 {
     m_sigShowchange = BOOLEAN_NONE;
@@ -945,8 +915,6 @@ AttKeySigDefaultVis::AttKeySigDefaultVis() : Att()
 {
     ResetKeySigDefaultVis();
 }
-
-AttKeySigDefaultVis::~AttKeySigDefaultVis() {}
 
 void AttKeySigDefaultVis::ResetKeySigDefaultVis()
 {
@@ -1003,8 +971,6 @@ AttLigatureVis::AttLigatureVis() : Att()
     ResetLigatureVis();
 }
 
-AttLigatureVis::~AttLigatureVis() {}
-
 void AttLigatureVis::ResetLigatureVis()
 {
     m_form = LIGATUREFORM_NONE;
@@ -1044,8 +1010,6 @@ AttLineVis::AttLineVis() : Att()
 {
     ResetLineVis();
 }
-
-AttLineVis::~AttLineVis() {}
 
 void AttLineVis::ResetLineVis()
 {
@@ -1162,8 +1126,6 @@ AttLiquescentVis::AttLiquescentVis() : Att()
     ResetLiquescentVis();
 }
 
-AttLiquescentVis::~AttLiquescentVis() {}
-
 void AttLiquescentVis::ResetLiquescentVis()
 {
     m_curve = liquescentVis_CURVE_NONE;
@@ -1218,8 +1180,6 @@ AttMensurVis::AttMensurVis() : Att()
 {
     ResetMensurVis();
 }
-
-AttMensurVis::~AttMensurVis() {}
 
 void AttMensurVis::ResetMensurVis()
 {
@@ -1305,8 +1265,6 @@ AttMensuralVis::AttMensuralVis() : Att()
 {
     ResetMensuralVis();
 }
-
-AttMensuralVis::~AttMensuralVis() {}
 
 void AttMensuralVis::ResetMensuralVis()
 {
@@ -1453,8 +1411,6 @@ AttMeterSigVis::AttMeterSigVis() : Att()
     ResetMeterSigVis();
 }
 
-AttMeterSigVis::~AttMeterSigVis() {}
-
 void AttMeterSigVis::ResetMeterSigVis()
 {
     m_form = METERFORM_NONE;
@@ -1494,8 +1450,6 @@ AttMeterSigDefaultVis::AttMeterSigDefaultVis() : Att()
 {
     ResetMeterSigDefaultVis();
 }
-
-AttMeterSigDefaultVis::~AttMeterSigDefaultVis() {}
 
 void AttMeterSigDefaultVis::ResetMeterSigDefaultVis()
 {
@@ -1552,8 +1506,6 @@ AttMultiRestVis::AttMultiRestVis() : Att()
     ResetMultiRestVis();
 }
 
-AttMultiRestVis::~AttMultiRestVis() {}
-
 void AttMultiRestVis::ResetMultiRestVis()
 {
     m_block = BOOLEAN_NONE;
@@ -1593,8 +1545,6 @@ AttPbVis::AttPbVis() : Att()
 {
     ResetPbVis();
 }
-
-AttPbVis::~AttPbVis() {}
 
 void AttPbVis::ResetPbVis()
 {
@@ -1636,8 +1586,6 @@ AttPedalVis::AttPedalVis() : Att()
     ResetPedalVis();
 }
 
-AttPedalVis::~AttPedalVis() {}
-
 void AttPedalVis::ResetPedalVis()
 {
     m_form = PEDALSTYLE_NONE;
@@ -1677,8 +1625,6 @@ AttPlicaVis::AttPlicaVis() : Att()
 {
     ResetPlicaVis();
 }
-
-AttPlicaVis::~AttPlicaVis() {}
 
 void AttPlicaVis::ResetPlicaVis()
 {
@@ -1735,8 +1681,6 @@ AttQuilismaVis::AttQuilismaVis() : Att()
     ResetQuilismaVis();
 }
 
-AttQuilismaVis::~AttQuilismaVis() {}
-
 void AttQuilismaVis::ResetQuilismaVis()
 {
     m_waves = MEI_UNSET;
@@ -1776,8 +1720,6 @@ AttSbVis::AttSbVis() : Att()
 {
     ResetSbVis();
 }
-
-AttSbVis::~AttSbVis() {}
 
 void AttSbVis::ResetSbVis()
 {
@@ -1819,8 +1761,6 @@ AttScoreDefVis::AttScoreDefVis() : Att()
     ResetScoreDefVis();
 }
 
-AttScoreDefVis::~AttScoreDefVis() {}
-
 void AttScoreDefVis::ResetScoreDefVis()
 {
     m_vuHeight = "";
@@ -1860,8 +1800,6 @@ AttSectionVis::AttSectionVis() : Att()
 {
     ResetSectionVis();
 }
-
-AttSectionVis::~AttSectionVis() {}
 
 void AttSectionVis::ResetSectionVis()
 {
@@ -1903,8 +1841,6 @@ AttSignifLetVis::AttSignifLetVis() : Att()
     ResetSignifLetVis();
 }
 
-AttSignifLetVis::~AttSignifLetVis() {}
-
 void AttSignifLetVis::ResetSignifLetVis()
 {
     m_place = data_EVENTREL();
@@ -1945,8 +1881,6 @@ AttSpaceVis::AttSpaceVis() : Att()
     ResetSpaceVis();
 }
 
-AttSpaceVis::~AttSpaceVis() {}
-
 void AttSpaceVis::ResetSpaceVis()
 {
     m_compressable = BOOLEAN_NONE;
@@ -1986,8 +1920,6 @@ AttStaffDefVis::AttStaffDefVis() : Att()
 {
     ResetStaffDefVis();
 }
-
-AttStaffDefVis::~AttStaffDefVis() {}
 
 void AttStaffDefVis::ResetStaffDefVis()
 {
@@ -2089,8 +2021,6 @@ AttStaffGrpVis::AttStaffGrpVis() : Att()
     ResetStaffGrpVis();
 }
 
-AttStaffGrpVis::~AttStaffGrpVis() {}
-
 void AttStaffGrpVis::ResetStaffGrpVis()
 {
     m_barThru = BOOLEAN_NONE;
@@ -2130,8 +2060,6 @@ AttStemVis::AttStemVis() : Att()
 {
     ResetStemVis();
 }
-
-AttStemVis::~AttStemVis() {}
 
 void AttStemVis::ResetStemVis()
 {
@@ -2247,8 +2175,6 @@ AttTupletVis::AttTupletVis() : Att()
 {
     ResetTupletVis();
 }
-
-AttTupletVis::~AttTupletVis() {}
 
 void AttTupletVis::ResetTupletVis()
 {

--- a/libmei/dist/atts_visual.h
+++ b/libmei/dist/atts_visual.h
@@ -30,10 +30,11 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 class AttAnnotVis : public Att {
-public:
+protected:
     AttAnnotVis();
-    virtual ~AttAnnotVis();
+    ~AttAnnotVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetAnnotVis();
 
@@ -62,14 +63,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttAnnotVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttAnnotVis
+ */
+
+class ExtAttAnnotVis : public AttAnnotVis {
+public:
+    ExtAttAnnotVis() = default;
+    virtual ~ExtAttAnnotVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttArpegVis
 //----------------------------------------------------------------------------
 
 class AttArpegVis : public Att {
-public:
+protected:
     AttArpegVis();
-    virtual ~AttArpegVis();
+    ~AttArpegVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetArpegVis();
 
@@ -134,14 +150,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttArpegVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttArpegVis
+ */
+
+class ExtAttArpegVis : public AttArpegVis {
+public:
+    ExtAttArpegVis() = default;
+    virtual ~ExtAttArpegVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBarLineVis
 //----------------------------------------------------------------------------
 
 class AttBarLineVis : public Att {
-public:
+protected:
     AttBarLineVis();
-    virtual ~AttBarLineVis();
+    ~AttBarLineVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBarLineVis();
 
@@ -184,14 +215,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBarLineVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBarLineVis
+ */
+
+class ExtAttBarLineVis : public AttBarLineVis {
+public:
+    ExtAttBarLineVis() = default;
+    virtual ~ExtAttBarLineVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeamingVis
 //----------------------------------------------------------------------------
 
 class AttBeamingVis : public Att {
-public:
+protected:
     AttBeamingVis();
-    virtual ~AttBeamingVis();
+    ~AttBeamingVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeamingVis();
 
@@ -230,14 +276,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeamingVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeamingVis
+ */
+
+class ExtAttBeamingVis : public AttBeamingVis {
+public:
+    ExtAttBeamingVis() = default;
+    virtual ~ExtAttBeamingVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttBeatRptVis
 //----------------------------------------------------------------------------
 
 class AttBeatRptVis : public Att {
-public:
+protected:
     AttBeatRptVis();
-    virtual ~AttBeatRptVis();
+    ~AttBeatRptVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetBeatRptVis();
 
@@ -264,14 +325,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttBeatRptVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttBeatRptVis
+ */
+
+class ExtAttBeatRptVis : public AttBeatRptVis {
+public:
+    ExtAttBeatRptVis() = default;
+    virtual ~ExtAttBeatRptVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttChordVis
 //----------------------------------------------------------------------------
 
 class AttChordVis : public Att {
-public:
+protected:
     AttChordVis();
-    virtual ~AttChordVis();
+    ~AttChordVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetChordVis();
 
@@ -303,14 +379,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttChordVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttChordVis
+ */
+
+class ExtAttChordVis : public AttChordVis {
+public:
+    ExtAttChordVis() = default;
+    virtual ~ExtAttChordVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttCleffingVis
 //----------------------------------------------------------------------------
 
 class AttCleffingVis : public Att {
-public:
+protected:
     AttCleffingVis();
-    virtual ~AttCleffingVis();
+    ~AttCleffingVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetCleffingVis();
 
@@ -343,14 +434,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttCleffingVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttCleffingVis
+ */
+
+class ExtAttCleffingVis : public AttCleffingVis {
+public:
+    ExtAttCleffingVis() = default;
+    virtual ~ExtAttCleffingVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttEpisemaVis
 //----------------------------------------------------------------------------
 
 class AttEpisemaVis : public Att {
-public:
+protected:
     AttEpisemaVis();
-    virtual ~AttEpisemaVis();
+    ~AttEpisemaVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetEpisemaVis();
 
@@ -383,14 +489,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttEpisemaVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttEpisemaVis
+ */
+
+class ExtAttEpisemaVis : public AttEpisemaVis {
+public:
+    ExtAttEpisemaVis() = default;
+    virtual ~ExtAttEpisemaVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFTremVis
 //----------------------------------------------------------------------------
 
 class AttFTremVis : public Att {
-public:
+protected:
     AttFTremVis();
-    virtual ~AttFTremVis();
+    ~AttFTremVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFTremVis();
 
@@ -429,14 +550,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFTremVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFTremVis
+ */
+
+class ExtAttFTremVis : public AttFTremVis {
+public:
+    ExtAttFTremVis() = default;
+    virtual ~ExtAttFTremVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFermataVis
 //----------------------------------------------------------------------------
 
 class AttFermataVis : public Att {
-public:
+protected:
     AttFermataVis();
-    virtual ~AttFermataVis();
+    ~AttFermataVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFermataVis();
 
@@ -469,14 +605,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFermataVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFermataVis
+ */
+
+class ExtAttFermataVis : public AttFermataVis {
+public:
+    ExtAttFermataVis() = default;
+    virtual ~ExtAttFermataVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttFingGrpVis
 //----------------------------------------------------------------------------
 
 class AttFingGrpVis : public Att {
-public:
+protected:
     AttFingGrpVis();
-    virtual ~AttFingGrpVis();
+    ~AttFingGrpVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetFingGrpVis();
 
@@ -503,14 +654,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttFingGrpVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttFingGrpVis
+ */
+
+class ExtAttFingGrpVis : public AttFingGrpVis {
+public:
+    ExtAttFingGrpVis() = default;
+    virtual ~ExtAttFingGrpVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHairpinVis
 //----------------------------------------------------------------------------
 
 class AttHairpinVis : public Att {
-public:
+protected:
     AttHairpinVis();
-    virtual ~AttHairpinVis();
+    ~AttHairpinVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHairpinVis();
 
@@ -569,14 +735,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHairpinVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHairpinVis
+ */
+
+class ExtAttHairpinVis : public AttHairpinVis {
+public:
+    ExtAttHairpinVis() = default;
+    virtual ~ExtAttHairpinVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHarmVis
 //----------------------------------------------------------------------------
 
 class AttHarmVis : public Att {
-public:
+protected:
     AttHarmVis();
-    virtual ~AttHarmVis();
+    ~AttHarmVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHarmVis();
 
@@ -603,14 +784,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHarmVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHarmVis
+ */
+
+class ExtAttHarmVis : public AttHarmVis {
+public:
+    ExtAttHarmVis() = default;
+    virtual ~ExtAttHarmVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttHispanTickVis
 //----------------------------------------------------------------------------
 
 class AttHispanTickVis : public Att {
-public:
+protected:
     AttHispanTickVis();
-    virtual ~AttHispanTickVis();
+    ~AttHispanTickVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetHispanTickVis();
 
@@ -643,14 +839,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttHispanTickVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttHispanTickVis
+ */
+
+class ExtAttHispanTickVis : public AttHispanTickVis {
+public:
+    ExtAttHispanTickVis() = default;
+    virtual ~ExtAttHispanTickVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigVis
 //----------------------------------------------------------------------------
 
 class AttKeySigVis : public Att {
-public:
+protected:
     AttKeySigVis();
-    virtual ~AttKeySigVis();
+    ~AttKeySigVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigVis();
 
@@ -677,14 +888,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigVis
+ */
+
+class ExtAttKeySigVis : public AttKeySigVis {
+public:
+    ExtAttKeySigVis() = default;
+    virtual ~ExtAttKeySigVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttKeySigDefaultVis
 //----------------------------------------------------------------------------
 
 class AttKeySigDefaultVis : public Att {
-public:
+protected:
     AttKeySigDefaultVis();
-    virtual ~AttKeySigDefaultVis();
+    ~AttKeySigDefaultVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetKeySigDefaultVis();
 
@@ -717,14 +943,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttKeySigDefaultVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttKeySigDefaultVis
+ */
+
+class ExtAttKeySigDefaultVis : public AttKeySigDefaultVis {
+public:
+    ExtAttKeySigDefaultVis() = default;
+    virtual ~ExtAttKeySigDefaultVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLigatureVis
 //----------------------------------------------------------------------------
 
 class AttLigatureVis : public Att {
-public:
+protected:
     AttLigatureVis();
-    virtual ~AttLigatureVis();
+    ~AttLigatureVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLigatureVis();
 
@@ -751,14 +992,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLigatureVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLigatureVis
+ */
+
+class ExtAttLigatureVis : public AttLigatureVis {
+public:
+    ExtAttLigatureVis() = default;
+    virtual ~ExtAttLigatureVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLineVis
 //----------------------------------------------------------------------------
 
 class AttLineVis : public Att {
-public:
+protected:
     AttLineVis();
-    virtual ~AttLineVis();
+    ~AttLineVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLineVis();
 
@@ -817,14 +1073,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLineVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLineVis
+ */
+
+class ExtAttLineVis : public AttLineVis {
+public:
+    ExtAttLineVis() = default;
+    virtual ~ExtAttLineVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttLiquescentVis
 //----------------------------------------------------------------------------
 
 class AttLiquescentVis : public Att {
-public:
+protected:
     AttLiquescentVis();
-    virtual ~AttLiquescentVis();
+    ~AttLiquescentVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetLiquescentVis();
 
@@ -857,14 +1128,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttLiquescentVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttLiquescentVis
+ */
+
+class ExtAttLiquescentVis : public AttLiquescentVis {
+public:
+    ExtAttLiquescentVis() = default;
+    virtual ~ExtAttLiquescentVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMensurVis
 //----------------------------------------------------------------------------
 
 class AttMensurVis : public Att {
-public:
+protected:
     AttMensurVis();
-    virtual ~AttMensurVis();
+    ~AttMensurVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMensurVis();
 
@@ -909,14 +1195,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMensurVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMensurVis
+ */
+
+class ExtAttMensurVis : public AttMensurVis {
+public:
+    ExtAttMensurVis() = default;
+    virtual ~ExtAttMensurVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMensuralVis
 //----------------------------------------------------------------------------
 
 class AttMensuralVis : public Att {
-public:
+protected:
     AttMensuralVis();
-    virtual ~AttMensuralVis();
+    ~AttMensuralVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMensuralVis();
 
@@ -993,14 +1294,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMensuralVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMensuralVis
+ */
+
+class ExtAttMensuralVis : public AttMensuralVis {
+public:
+    ExtAttMensuralVis() = default;
+    virtual ~ExtAttMensuralVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterSigVis
 //----------------------------------------------------------------------------
 
 class AttMeterSigVis : public Att {
-public:
+protected:
     AttMeterSigVis();
-    virtual ~AttMeterSigVis();
+    ~AttMeterSigVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterSigVis();
 
@@ -1027,14 +1343,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterSigVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterSigVis
+ */
+
+class ExtAttMeterSigVis : public AttMeterSigVis {
+public:
+    ExtAttMeterSigVis() = default;
+    virtual ~ExtAttMeterSigVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMeterSigDefaultVis
 //----------------------------------------------------------------------------
 
 class AttMeterSigDefaultVis : public Att {
-public:
+protected:
     AttMeterSigDefaultVis();
-    virtual ~AttMeterSigDefaultVis();
+    ~AttMeterSigDefaultVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMeterSigDefaultVis();
 
@@ -1070,14 +1401,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMeterSigDefaultVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMeterSigDefaultVis
+ */
+
+class ExtAttMeterSigDefaultVis : public AttMeterSigDefaultVis {
+public:
+    ExtAttMeterSigDefaultVis() = default;
+    virtual ~ExtAttMeterSigDefaultVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttMultiRestVis
 //----------------------------------------------------------------------------
 
 class AttMultiRestVis : public Att {
-public:
+protected:
     AttMultiRestVis();
-    virtual ~AttMultiRestVis();
+    ~AttMultiRestVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetMultiRestVis();
 
@@ -1108,14 +1454,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttMultiRestVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttMultiRestVis
+ */
+
+class ExtAttMultiRestVis : public AttMultiRestVis {
+public:
+    ExtAttMultiRestVis() = default;
+    virtual ~ExtAttMultiRestVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPbVis
 //----------------------------------------------------------------------------
 
 class AttPbVis : public Att {
-public:
+protected:
     AttPbVis();
-    virtual ~AttPbVis();
+    ~AttPbVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPbVis();
 
@@ -1145,14 +1506,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPbVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPbVis
+ */
+
+class ExtAttPbVis : public AttPbVis {
+public:
+    ExtAttPbVis() = default;
+    virtual ~ExtAttPbVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPedalVis
 //----------------------------------------------------------------------------
 
 class AttPedalVis : public Att {
-public:
+protected:
     AttPedalVis();
-    virtual ~AttPedalVis();
+    ~AttPedalVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPedalVis();
 
@@ -1179,14 +1555,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPedalVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPedalVis
+ */
+
+class ExtAttPedalVis : public AttPedalVis {
+public:
+    ExtAttPedalVis() = default;
+    virtual ~ExtAttPedalVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttPlicaVis
 //----------------------------------------------------------------------------
 
 class AttPlicaVis : public Att {
-public:
+protected:
     AttPlicaVis();
-    virtual ~AttPlicaVis();
+    ~AttPlicaVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetPlicaVis();
 
@@ -1223,14 +1614,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttPlicaVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttPlicaVis
+ */
+
+class ExtAttPlicaVis : public AttPlicaVis {
+public:
+    ExtAttPlicaVis() = default;
+    virtual ~ExtAttPlicaVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttQuilismaVis
 //----------------------------------------------------------------------------
 
 class AttQuilismaVis : public Att {
-public:
+protected:
     AttQuilismaVis();
-    virtual ~AttQuilismaVis();
+    ~AttQuilismaVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetQuilismaVis();
 
@@ -1257,14 +1663,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttQuilismaVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttQuilismaVis
+ */
+
+class ExtAttQuilismaVis : public AttQuilismaVis {
+public:
+    ExtAttQuilismaVis() = default;
+    virtual ~ExtAttQuilismaVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSbVis
 //----------------------------------------------------------------------------
 
 class AttSbVis : public Att {
-public:
+protected:
     AttSbVis();
-    virtual ~AttSbVis();
+    ~AttSbVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSbVis();
 
@@ -1291,14 +1712,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSbVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSbVis
+ */
+
+class ExtAttSbVis : public AttSbVis {
+public:
+    ExtAttSbVis() = default;
+    virtual ~ExtAttSbVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttScoreDefVis
 //----------------------------------------------------------------------------
 
 class AttScoreDefVis : public Att {
-public:
+protected:
     AttScoreDefVis();
-    virtual ~AttScoreDefVis();
+    ~AttScoreDefVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetScoreDefVis();
 
@@ -1329,14 +1765,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttScoreDefVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttScoreDefVis
+ */
+
+class ExtAttScoreDefVis : public AttScoreDefVis {
+public:
+    ExtAttScoreDefVis() = default;
+    virtual ~ExtAttScoreDefVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSectionVis
 //----------------------------------------------------------------------------
 
 class AttSectionVis : public Att {
-public:
+protected:
     AttSectionVis();
-    virtual ~AttSectionVis();
+    ~AttSectionVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSectionVis();
 
@@ -1363,14 +1814,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSectionVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSectionVis
+ */
+
+class ExtAttSectionVis : public AttSectionVis {
+public:
+    ExtAttSectionVis() = default;
+    virtual ~ExtAttSectionVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSignifLetVis
 //----------------------------------------------------------------------------
 
 class AttSignifLetVis : public Att {
-public:
+protected:
     AttSignifLetVis();
-    virtual ~AttSignifLetVis();
+    ~AttSignifLetVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSignifLetVis();
 
@@ -1397,14 +1863,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSignifLetVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSignifLetVis
+ */
+
+class ExtAttSignifLetVis : public AttSignifLetVis {
+public:
+    ExtAttSignifLetVis() = default;
+    virtual ~ExtAttSignifLetVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttSpaceVis
 //----------------------------------------------------------------------------
 
 class AttSpaceVis : public Att {
-public:
+protected:
     AttSpaceVis();
-    virtual ~AttSpaceVis();
+    ~AttSpaceVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetSpaceVis();
 
@@ -1434,14 +1915,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttSpaceVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttSpaceVis
+ */
+
+class ExtAttSpaceVis : public AttSpaceVis {
+public:
+    ExtAttSpaceVis() = default;
+    virtual ~ExtAttSpaceVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffDefVis
 //----------------------------------------------------------------------------
 
 class AttStaffDefVis : public Att {
-public:
+protected:
     AttStaffDefVis();
-    virtual ~AttStaffDefVis();
+    ~AttStaffDefVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffDefVis();
 
@@ -1497,14 +1993,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffDefVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffDefVis
+ */
+
+class ExtAttStaffDefVis : public AttStaffDefVis {
+public:
+    ExtAttStaffDefVis() = default;
+    virtual ~ExtAttStaffDefVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStaffGrpVis
 //----------------------------------------------------------------------------
 
 class AttStaffGrpVis : public Att {
-public:
+protected:
     AttStaffGrpVis();
-    virtual ~AttStaffGrpVis();
+    ~AttStaffGrpVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStaffGrpVis();
 
@@ -1534,14 +2045,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStaffGrpVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStaffGrpVis
+ */
+
+class ExtAttStaffGrpVis : public AttStaffGrpVis {
+public:
+    ExtAttStaffGrpVis() = default;
+    virtual ~ExtAttStaffGrpVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttStemVis
 //----------------------------------------------------------------------------
 
 class AttStemVis : public Att {
-public:
+protected:
     AttStemVis();
-    virtual ~AttStemVis();
+    ~AttStemVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetStemVis();
 
@@ -1608,14 +2134,29 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// ExtAttStemVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttStemVis
+ */
+
+class ExtAttStemVis : public AttStemVis {
+public:
+    ExtAttStemVis() = default;
+    virtual ~ExtAttStemVis() = default;
+};
+
+//----------------------------------------------------------------------------
 // AttTupletVis
 //----------------------------------------------------------------------------
 
 class AttTupletVis : public Att {
-public:
+protected:
     AttTupletVis();
-    virtual ~AttTupletVis();
+    ~AttTupletVis() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void ResetTupletVis();
 
@@ -1660,6 +2201,20 @@ private:
     data_BOOLEAN m_durVisible;
     /** Controls how the num:numbase ratio is to be displayed. **/
     tupletVis_NUMFORMAT m_numFormat;
+};
+
+//----------------------------------------------------------------------------
+// ExtAttTupletVis
+//----------------------------------------------------------------------------
+
+/**
+ * Instantiable version of AttTupletVis
+ */
+
+class ExtAttTupletVis : public AttTupletVis {
+public:
+    ExtAttTupletVis() = default;
+    virtual ~ExtAttTupletVis() = default;
 };
 
 } // namespace vrv

--- a/libmei/dist/atttypes.h
+++ b/libmei/dist/atttypes.h
@@ -22,7 +22,7 @@ namespace vrv {
 /**
  * MEI data.ACCIDENTAL.GESTURAL
  */
-enum data_ACCIDENTAL_GESTURAL {
+enum data_ACCIDENTAL_GESTURAL : int8_t {
     ACCIDENTAL_GESTURAL_NONE = 0,
     ACCIDENTAL_GESTURAL_s,
     ACCIDENTAL_GESTURAL_f,
@@ -51,7 +51,7 @@ enum data_ACCIDENTAL_GESTURAL {
 /**
  * MEI data.ACCIDENTAL.GESTURAL.basic
  */
-enum data_ACCIDENTAL_GESTURAL_basic {
+enum data_ACCIDENTAL_GESTURAL_basic : int8_t {
     ACCIDENTAL_GESTURAL_basic_NONE = 0,
     ACCIDENTAL_GESTURAL_basic_s,
     ACCIDENTAL_GESTURAL_basic_f,
@@ -66,7 +66,7 @@ enum data_ACCIDENTAL_GESTURAL_basic {
 /**
  * MEI data.ACCIDENTAL.GESTURAL.extended
  */
-enum data_ACCIDENTAL_GESTURAL_extended {
+enum data_ACCIDENTAL_GESTURAL_extended : int8_t {
     ACCIDENTAL_GESTURAL_extended_NONE = 0,
     ACCIDENTAL_GESTURAL_extended_su,
     ACCIDENTAL_GESTURAL_extended_sd,
@@ -78,7 +78,7 @@ enum data_ACCIDENTAL_GESTURAL_extended {
 /**
  * MEI data.ACCIDENTAL.WRITTEN
  */
-enum data_ACCIDENTAL_WRITTEN {
+enum data_ACCIDENTAL_WRITTEN : int8_t {
     ACCIDENTAL_WRITTEN_NONE = 0,
     ACCIDENTAL_WRITTEN_s,
     ACCIDENTAL_WRITTEN_f,
@@ -118,7 +118,7 @@ enum data_ACCIDENTAL_WRITTEN {
 /**
  * MEI data.ACCIDENTAL.WRITTEN.basic
  */
-enum data_ACCIDENTAL_WRITTEN_basic {
+enum data_ACCIDENTAL_WRITTEN_basic : int8_t {
     ACCIDENTAL_WRITTEN_basic_NONE = 0,
     ACCIDENTAL_WRITTEN_basic_s,
     ACCIDENTAL_WRITTEN_basic_f,
@@ -138,7 +138,7 @@ enum data_ACCIDENTAL_WRITTEN_basic {
 /**
  * MEI data.ACCIDENTAL.WRITTEN.extended
  */
-enum data_ACCIDENTAL_WRITTEN_extended {
+enum data_ACCIDENTAL_WRITTEN_extended : int8_t {
     ACCIDENTAL_WRITTEN_extended_NONE = 0,
     ACCIDENTAL_WRITTEN_extended_su,
     ACCIDENTAL_WRITTEN_extended_sd,
@@ -156,7 +156,7 @@ enum data_ACCIDENTAL_WRITTEN_extended {
 /**
  * MEI data.ACCIDENTAL.aeu
  */
-enum data_ACCIDENTAL_aeu {
+enum data_ACCIDENTAL_aeu : int8_t {
     ACCIDENTAL_aeu_NONE = 0,
     ACCIDENTAL_aeu_bms,
     ACCIDENTAL_aeu_kms,
@@ -172,7 +172,7 @@ enum data_ACCIDENTAL_aeu {
 /**
  * MEI data.ACCIDENTAL.persian
  */
-enum data_ACCIDENTAL_persian {
+enum data_ACCIDENTAL_persian : int8_t {
     ACCIDENTAL_persian_NONE = 0,
     ACCIDENTAL_persian_koron,
     ACCIDENTAL_persian_sori,
@@ -182,7 +182,7 @@ enum data_ACCIDENTAL_persian {
 /**
  * MEI data.ARTICULATION
  */
-enum data_ARTICULATION {
+enum data_ARTICULATION : int8_t {
     ARTICULATION_NONE = 0,
     ARTICULATION_acc,
     ARTICULATION_acc_inv,
@@ -226,7 +226,7 @@ enum data_ARTICULATION {
 /**
  * MEI data.BARMETHOD
  */
-enum data_BARMETHOD {
+enum data_BARMETHOD : int8_t {
     BARMETHOD_NONE = 0,
     BARMETHOD_mensur,
     BARMETHOD_staff,
@@ -237,7 +237,7 @@ enum data_BARMETHOD {
 /**
  * MEI data.BARRENDITION
  */
-enum data_BARRENDITION {
+enum data_BARRENDITION : int8_t {
     BARRENDITION_NONE = 0,
     BARRENDITION_dashed,
     BARRENDITION_dotted,
@@ -260,7 +260,7 @@ enum data_BARRENDITION {
 /**
  * MEI data.BEAMPLACE
  */
-enum data_BEAMPLACE {
+enum data_BEAMPLACE : int8_t {
     BEAMPLACE_NONE = 0,
     BEAMPLACE_above,
     BEAMPLACE_below,
@@ -271,7 +271,7 @@ enum data_BEAMPLACE {
 /**
  * MEI data.BETYPE
  */
-enum data_BETYPE {
+enum data_BETYPE : int8_t {
     BETYPE_NONE = 0,
     BETYPE_byte,
     BETYPE_smil,
@@ -292,7 +292,7 @@ enum data_BETYPE {
 /**
  * MEI data.BOOLEAN
  */
-enum data_BOOLEAN {
+enum data_BOOLEAN : int8_t {
     BOOLEAN_NONE = 0,
     BOOLEAN_true,
     BOOLEAN_false,
@@ -302,7 +302,7 @@ enum data_BOOLEAN {
 /**
  * MEI data.CERTAINTY
  */
-enum data_CERTAINTY {
+enum data_CERTAINTY : int8_t {
     CERTAINTY_NONE = 0,
     CERTAINTY_high,
     CERTAINTY_medium,
@@ -314,7 +314,7 @@ enum data_CERTAINTY {
 /**
  * MEI data.CLEFSHAPE
  */
-enum data_CLEFSHAPE {
+enum data_CLEFSHAPE : int8_t {
     CLEFSHAPE_NONE = 0,
     CLEFSHAPE_G,
     CLEFSHAPE_GG,
@@ -328,7 +328,7 @@ enum data_CLEFSHAPE {
 /**
  * MEI data.CLUSTER
  */
-enum data_CLUSTER {
+enum data_CLUSTER : int8_t {
     CLUSTER_NONE = 0,
     CLUSTER_white,
     CLUSTER_black,
@@ -495,7 +495,7 @@ enum data_COLORNAMES {
 /**
  * MEI data.COMPASSDIRECTION
  */
-enum data_COMPASSDIRECTION {
+enum data_COMPASSDIRECTION : int8_t {
     COMPASSDIRECTION_NONE = 0,
     COMPASSDIRECTION_n,
     COMPASSDIRECTION_e,
@@ -511,7 +511,7 @@ enum data_COMPASSDIRECTION {
 /**
  * MEI data.COMPASSDIRECTION.basic
  */
-enum data_COMPASSDIRECTION_basic {
+enum data_COMPASSDIRECTION_basic : int8_t {
     COMPASSDIRECTION_basic_NONE = 0,
     COMPASSDIRECTION_basic_n,
     COMPASSDIRECTION_basic_e,
@@ -523,7 +523,7 @@ enum data_COMPASSDIRECTION_basic {
 /**
  * MEI data.COMPASSDIRECTION.extended
  */
-enum data_COMPASSDIRECTION_extended {
+enum data_COMPASSDIRECTION_extended : int8_t {
     COMPASSDIRECTION_extended_NONE = 0,
     COMPASSDIRECTION_extended_ne,
     COMPASSDIRECTION_extended_nw,
@@ -535,7 +535,7 @@ enum data_COMPASSDIRECTION_extended {
 /**
  * MEI data.COURSETUNING
  */
-enum data_COURSETUNING {
+enum data_COURSETUNING : int8_t {
     COURSETUNING_NONE = 0,
     COURSETUNING_guitar_standard,
     COURSETUNING_guitar_drop_D,
@@ -551,7 +551,7 @@ enum data_COURSETUNING {
 /**
  * MEI data.DIVISIO
  */
-enum data_DIVISIO {
+enum data_DIVISIO : int8_t {
     DIVISIO_NONE = 0,
     DIVISIO_ternaria,
     DIVISIO_quaternaria,
@@ -566,7 +566,7 @@ enum data_DIVISIO {
 /**
  * MEI data.DURATIONRESTS.mensural
  */
-enum data_DURATIONRESTS_mensural {
+enum data_DURATIONRESTS_mensural : int8_t {
     DURATIONRESTS_mensural_NONE = 0,
     DURATIONRESTS_mensural_2B,
     DURATIONRESTS_mensural_3B,
@@ -584,7 +584,7 @@ enum data_DURATIONRESTS_mensural {
 /**
  * MEI data.DURQUALITY.mensural
  */
-enum data_DURQUALITY_mensural {
+enum data_DURQUALITY_mensural : int8_t {
     DURQUALITY_mensural_NONE = 0,
     DURQUALITY_mensural_perfecta,
     DURQUALITY_mensural_imperfecta,
@@ -598,7 +598,7 @@ enum data_DURQUALITY_mensural {
 /**
  * MEI data.ENCLOSURE
  */
-enum data_ENCLOSURE {
+enum data_ENCLOSURE : int8_t {
     ENCLOSURE_NONE = 0,
     ENCLOSURE_paren,
     ENCLOSURE_brack,
@@ -610,7 +610,7 @@ enum data_ENCLOSURE {
 /**
  * MEI data.EVENTREL
  */
-enum data_EVENTREL {
+enum data_EVENTREL : int8_t {
     EVENTREL_NONE = 0,
     EVENTREL_above,
     EVENTREL_below,
@@ -626,7 +626,7 @@ enum data_EVENTREL {
 /**
  * MEI data.EVENTREL.basic
  */
-enum data_EVENTREL_basic {
+enum data_EVENTREL_basic : int8_t {
     EVENTREL_basic_NONE = 0,
     EVENTREL_basic_above,
     EVENTREL_basic_below,
@@ -638,7 +638,7 @@ enum data_EVENTREL_basic {
 /**
  * MEI data.EVENTREL.extended
  */
-enum data_EVENTREL_extended {
+enum data_EVENTREL_extended : int8_t {
     EVENTREL_extended_NONE = 0,
     EVENTREL_extended_above_left,
     EVENTREL_extended_above_right,
@@ -650,7 +650,7 @@ enum data_EVENTREL_extended {
 /**
  * MEI data.FILL
  */
-enum data_FILL {
+enum data_FILL : int8_t {
     FILL_NONE = 0,
     FILL_void,
     FILL_solid,
@@ -664,7 +664,7 @@ enum data_FILL {
 /**
  * MEI data.FLAGFORM.mensural
  */
-enum data_FLAGFORM_mensural {
+enum data_FLAGFORM_mensural : int8_t {
     FLAGFORM_mensural_NONE = 0,
     FLAGFORM_mensural_straight,
     FLAGFORM_mensural_angled,
@@ -678,7 +678,7 @@ enum data_FLAGFORM_mensural {
 /**
  * MEI data.FLAGPOS.mensural
  */
-enum data_FLAGPOS_mensural {
+enum data_FLAGPOS_mensural : int8_t {
     FLAGPOS_mensural_NONE = 0,
     FLAGPOS_mensural_left,
     FLAGPOS_mensural_right,
@@ -689,7 +689,7 @@ enum data_FLAGPOS_mensural {
 /**
  * MEI data.FONTSIZETERM
  */
-enum data_FONTSIZETERM {
+enum data_FONTSIZETERM : int8_t {
     FONTSIZETERM_NONE = 0,
     FONTSIZETERM_xx_small,
     FONTSIZETERM_x_small,
@@ -706,7 +706,7 @@ enum data_FONTSIZETERM {
 /**
  * MEI data.FONTSTYLE
  */
-enum data_FONTSTYLE {
+enum data_FONTSTYLE : int8_t {
     FONTSTYLE_NONE = 0,
     FONTSTYLE_italic,
     FONTSTYLE_normal,
@@ -717,7 +717,7 @@ enum data_FONTSTYLE {
 /**
  * MEI data.FONTWEIGHT
  */
-enum data_FONTWEIGHT {
+enum data_FONTWEIGHT : int8_t {
     FONTWEIGHT_NONE = 0,
     FONTWEIGHT_bold,
     FONTWEIGHT_normal,
@@ -727,7 +727,7 @@ enum data_FONTWEIGHT {
 /**
  * MEI data.FRBRRELATIONSHIP
  */
-enum data_FRBRRELATIONSHIP {
+enum data_FRBRRELATIONSHIP : int8_t {
     FRBRRELATIONSHIP_NONE = 0,
     FRBRRELATIONSHIP_hasAbridgement,
     FRBRRELATIONSHIP_isAbridgementOf,
@@ -771,7 +771,7 @@ enum data_FRBRRELATIONSHIP {
 /**
  * MEI data.GLISSANDO
  */
-enum data_GLISSANDO {
+enum data_GLISSANDO : int8_t {
     GLISSANDO_NONE = 0,
     GLISSANDO_i,
     GLISSANDO_m,
@@ -782,7 +782,7 @@ enum data_GLISSANDO {
 /**
  * MEI data.GRACE
  */
-enum data_GRACE {
+enum data_GRACE : int8_t {
     GRACE_NONE = 0,
     GRACE_acc,
     GRACE_unacc,
@@ -793,7 +793,7 @@ enum data_GRACE {
 /**
  * MEI data.HEADSHAPE
  */
-enum data_HEADSHAPE {
+enum data_HEADSHAPE : int8_t {
     HEADSHAPE_NONE = 0,
     HEADSHAPE_quarter,
     HEADSHAPE_half,
@@ -817,7 +817,7 @@ enum data_HEADSHAPE {
 /**
  * MEI data.HEADSHAPE.list
  */
-enum data_HEADSHAPE_list {
+enum data_HEADSHAPE_list : int8_t {
     HEADSHAPE_list_NONE = 0,
     HEADSHAPE_list_quarter,
     HEADSHAPE_list_half,
@@ -841,7 +841,7 @@ enum data_HEADSHAPE_list {
 /**
  * MEI data.HORIZONTALALIGNMENT
  */
-enum data_HORIZONTALALIGNMENT {
+enum data_HORIZONTALALIGNMENT : int8_t {
     HORIZONTALALIGNMENT_NONE = 0,
     HORIZONTALALIGNMENT_left,
     HORIZONTALALIGNMENT_right,
@@ -853,7 +853,7 @@ enum data_HORIZONTALALIGNMENT {
 /**
  * MEI data.LAYERSCHEME
  */
-enum data_LAYERSCHEME {
+enum data_LAYERSCHEME : int8_t {
     LAYERSCHEME_NONE = 0,
     LAYERSCHEME_1,
     LAYERSCHEME_2o,
@@ -866,7 +866,7 @@ enum data_LAYERSCHEME {
 /**
  * MEI data.LIGATUREFORM
  */
-enum data_LIGATUREFORM {
+enum data_LIGATUREFORM : int8_t {
     LIGATUREFORM_NONE = 0,
     LIGATUREFORM_recta,
     LIGATUREFORM_obliqua,
@@ -876,7 +876,7 @@ enum data_LIGATUREFORM {
 /**
  * MEI data.LINEFORM
  */
-enum data_LINEFORM {
+enum data_LINEFORM : int8_t {
     LINEFORM_NONE = 0,
     LINEFORM_dashed,
     LINEFORM_dotted,
@@ -888,7 +888,7 @@ enum data_LINEFORM {
 /**
  * MEI data.LINESTARTENDSYMBOL
  */
-enum data_LINESTARTENDSYMBOL {
+enum data_LINESTARTENDSYMBOL : int8_t {
     LINESTARTENDSYMBOL_NONE = 0,
     LINESTARTENDSYMBOL_angledown,
     LINESTARTENDSYMBOL_angleup,
@@ -916,7 +916,7 @@ enum data_LINESTARTENDSYMBOL {
 /**
  * MEI data.LINEWIDTHTERM
  */
-enum data_LINEWIDTHTERM {
+enum data_LINEWIDTHTERM : int8_t {
     LINEWIDTHTERM_NONE = 0,
     LINEWIDTHTERM_narrow,
     LINEWIDTHTERM_medium,
@@ -927,7 +927,7 @@ enum data_LINEWIDTHTERM {
 /**
  * MEI data.MELODICFUNCTION
  */
-enum data_MELODICFUNCTION {
+enum data_MELODICFUNCTION : int8_t {
     MELODICFUNCTION_NONE = 0,
     MELODICFUNCTION_aln,
     MELODICFUNCTION_ant,
@@ -963,7 +963,7 @@ enum data_MELODICFUNCTION {
 /**
  * MEI data.MENSURATIONSIGN
  */
-enum data_MENSURATIONSIGN {
+enum data_MENSURATIONSIGN : int8_t {
     MENSURATIONSIGN_NONE = 0,
     MENSURATIONSIGN_C,
     MENSURATIONSIGN_O,
@@ -986,7 +986,7 @@ enum data_MENSURATIONSIGN {
 /**
  * MEI data.METERFORM
  */
-enum data_METERFORM {
+enum data_METERFORM : int8_t {
     METERFORM_NONE = 0,
     METERFORM_num,
     METERFORM_denomsym,
@@ -999,7 +999,7 @@ enum data_METERFORM {
 /**
  * MEI data.METERSIGN
  */
-enum data_METERSIGN {
+enum data_METERSIGN : int8_t {
     METERSIGN_NONE = 0,
     METERSIGN_common,
     METERSIGN_cut,
@@ -1193,7 +1193,7 @@ enum data_MIDINAMES {
 /**
  * MEI data.MODE
  */
-enum data_MODE {
+enum data_MODE : int8_t {
     MODE_NONE = 0,
     MODE_major,
     MODE_minor,
@@ -1218,7 +1218,7 @@ enum data_MODE {
 /**
  * MEI data.MODE.cmn
  */
-enum data_MODE_cmn {
+enum data_MODE_cmn : int8_t {
     MODE_cmn_NONE = 0,
     MODE_cmn_major,
     MODE_cmn_minor,
@@ -1228,7 +1228,7 @@ enum data_MODE_cmn {
 /**
  * MEI data.MODE.extended
  */
-enum data_MODE_extended {
+enum data_MODE_extended : int8_t {
     MODE_extended_NONE = 0,
     MODE_extended_ionian,
     MODE_extended_hypoionian,
@@ -1242,7 +1242,7 @@ enum data_MODE_extended {
 /**
  * MEI data.MODE.gregorian
  */
-enum data_MODE_gregorian {
+enum data_MODE_gregorian : int8_t {
     MODE_gregorian_NONE = 0,
     MODE_gregorian_dorian,
     MODE_gregorian_hypodorian,
@@ -1259,7 +1259,7 @@ enum data_MODE_gregorian {
 /**
  * MEI data.MODSRELATIONSHIP
  */
-enum data_MODSRELATIONSHIP {
+enum data_MODSRELATIONSHIP : int8_t {
     MODSRELATIONSHIP_NONE = 0,
     MODSRELATIONSHIP_preceding,
     MODSRELATIONSHIP_succeeding,
@@ -1276,7 +1276,7 @@ enum data_MODSRELATIONSHIP {
 /**
  * MEI data.MULTIBREVERESTS.mensural
  */
-enum data_MULTIBREVERESTS_mensural {
+enum data_MULTIBREVERESTS_mensural : int8_t {
     MULTIBREVERESTS_mensural_NONE = 0,
     MULTIBREVERESTS_mensural_2B,
     MULTIBREVERESTS_mensural_3B,
@@ -1286,7 +1286,7 @@ enum data_MULTIBREVERESTS_mensural {
 /**
  * MEI data.NEIGHBORINGLAYER
  */
-enum data_NEIGHBORINGLAYER {
+enum data_NEIGHBORINGLAYER : int8_t {
     NEIGHBORINGLAYER_NONE = 0,
     NEIGHBORINGLAYER_above,
     NEIGHBORINGLAYER_below,
@@ -1296,7 +1296,7 @@ enum data_NEIGHBORINGLAYER {
 /**
  * MEI data.NONSTAFFPLACE
  */
-enum data_NONSTAFFPLACE {
+enum data_NONSTAFFPLACE : int8_t {
     NONSTAFFPLACE_NONE = 0,
     NONSTAFFPLACE_botmar,
     NONSTAFFPLACE_topmar,
@@ -1317,7 +1317,7 @@ enum data_NONSTAFFPLACE {
 /**
  * MEI data.NOTATIONTYPE
  */
-enum data_NOTATIONTYPE {
+enum data_NOTATIONTYPE : int8_t {
     NOTATIONTYPE_NONE = 0,
     NOTATIONTYPE_cmn,
     NOTATIONTYPE_mensural,
@@ -1335,7 +1335,7 @@ enum data_NOTATIONTYPE {
 /**
  * MEI data.NOTEHEADMODIFIER
  */
-enum data_NOTEHEADMODIFIER {
+enum data_NOTEHEADMODIFIER : int8_t {
     NOTEHEADMODIFIER_NONE = 0,
     NOTEHEADMODIFIER_slash,
     NOTEHEADMODIFIER_backslash,
@@ -1353,7 +1353,7 @@ enum data_NOTEHEADMODIFIER {
 /**
  * MEI data.NOTEHEADMODIFIER.list
  */
-enum data_NOTEHEADMODIFIER_list {
+enum data_NOTEHEADMODIFIER_list : int8_t {
     NOTEHEADMODIFIER_list_NONE = 0,
     NOTEHEADMODIFIER_list_slash,
     NOTEHEADMODIFIER_list_backslash,
@@ -1371,7 +1371,7 @@ enum data_NOTEHEADMODIFIER_list {
 /**
  * MEI data.PEDALSTYLE
  */
-enum data_PEDALSTYLE {
+enum data_PEDALSTYLE : int8_t {
     PEDALSTYLE_NONE = 0,
     PEDALSTYLE_line,
     PEDALSTYLE_pedline,
@@ -1383,7 +1383,7 @@ enum data_PEDALSTYLE {
 /**
  * MEI data.PGFUNC
  */
-enum data_PGFUNC {
+enum data_PGFUNC : int8_t {
     PGFUNC_NONE = 0,
     PGFUNC_all,
     PGFUNC_first,
@@ -1396,7 +1396,7 @@ enum data_PGFUNC {
 /**
  * MEI data.RELATIONSHIP
  */
-enum data_RELATIONSHIP {
+enum data_RELATIONSHIP : int8_t {
     RELATIONSHIP_NONE = 0,
     RELATIONSHIP_hasAbridgement,
     RELATIONSHIP_isAbridgementOf,
@@ -1449,7 +1449,7 @@ enum data_RELATIONSHIP {
 /**
  * MEI data.ROTATION
  */
-enum data_ROTATION {
+enum data_ROTATION : int8_t {
     ROTATION_NONE = 0,
     ROTATION_none,
     ROTATION_down,
@@ -1464,7 +1464,7 @@ enum data_ROTATION {
 /**
  * MEI data.ROTATIONDIRECTION
  */
-enum data_ROTATIONDIRECTION {
+enum data_ROTATIONDIRECTION : int8_t {
     ROTATIONDIRECTION_NONE = 0,
     ROTATIONDIRECTION_none,
     ROTATIONDIRECTION_down,
@@ -1479,7 +1479,7 @@ enum data_ROTATIONDIRECTION {
 /**
  * MEI data.STAFFITEM
  */
-enum data_STAFFITEM {
+enum data_STAFFITEM : int8_t {
     STAFFITEM_NONE = 0,
     STAFFITEM_accid,
     STAFFITEM_annot,
@@ -1516,7 +1516,7 @@ enum data_STAFFITEM {
 /**
  * MEI data.STAFFITEM.basic
  */
-enum data_STAFFITEM_basic {
+enum data_STAFFITEM_basic : int8_t {
     STAFFITEM_basic_NONE = 0,
     STAFFITEM_basic_accid,
     STAFFITEM_basic_annot,
@@ -1534,7 +1534,7 @@ enum data_STAFFITEM_basic {
 /**
  * MEI data.STAFFITEM.cmn
  */
-enum data_STAFFITEM_cmn {
+enum data_STAFFITEM_cmn : int8_t {
     STAFFITEM_cmn_NONE = 0,
     STAFFITEM_cmn_beam,
     STAFFITEM_cmn_bend,
@@ -1560,7 +1560,7 @@ enum data_STAFFITEM_cmn {
 /**
  * MEI data.STAFFITEM.mensural
  */
-enum data_STAFFITEM_mensural {
+enum data_STAFFITEM_mensural : int8_t {
     STAFFITEM_mensural_NONE = 0,
     STAFFITEM_mensural_ligature,
     STAFFITEM_mensural_MAX
@@ -1569,7 +1569,7 @@ enum data_STAFFITEM_mensural {
 /**
  * MEI data.STAFFREL
  */
-enum data_STAFFREL {
+enum data_STAFFREL : int8_t {
     STAFFREL_NONE = 0,
     STAFFREL_above,
     STAFFREL_below,
@@ -1581,7 +1581,7 @@ enum data_STAFFREL {
 /**
  * MEI data.STAFFREL.basic
  */
-enum data_STAFFREL_basic {
+enum data_STAFFREL_basic : int8_t {
     STAFFREL_basic_NONE = 0,
     STAFFREL_basic_above,
     STAFFREL_basic_below,
@@ -1591,7 +1591,7 @@ enum data_STAFFREL_basic {
 /**
  * MEI data.STAFFREL.extended
  */
-enum data_STAFFREL_extended {
+enum data_STAFFREL_extended : int8_t {
     STAFFREL_extended_NONE = 0,
     STAFFREL_extended_between,
     STAFFREL_extended_within,
@@ -1601,7 +1601,7 @@ enum data_STAFFREL_extended {
 /**
  * MEI data.STEMDIRECTION
  */
-enum data_STEMDIRECTION {
+enum data_STEMDIRECTION : int8_t {
     STEMDIRECTION_NONE = 0,
     STEMDIRECTION_up,
     STEMDIRECTION_down,
@@ -1617,7 +1617,7 @@ enum data_STEMDIRECTION {
 /**
  * MEI data.STEMDIRECTION.basic
  */
-enum data_STEMDIRECTION_basic {
+enum data_STEMDIRECTION_basic : int8_t {
     STEMDIRECTION_basic_NONE = 0,
     STEMDIRECTION_basic_up,
     STEMDIRECTION_basic_down,
@@ -1627,7 +1627,7 @@ enum data_STEMDIRECTION_basic {
 /**
  * MEI data.STEMDIRECTION.extended
  */
-enum data_STEMDIRECTION_extended {
+enum data_STEMDIRECTION_extended : int8_t {
     STEMDIRECTION_extended_NONE = 0,
     STEMDIRECTION_extended_left,
     STEMDIRECTION_extended_right,
@@ -1641,7 +1641,7 @@ enum data_STEMDIRECTION_extended {
 /**
  * MEI data.STEMFORM.mensural
  */
-enum data_STEMFORM_mensural {
+enum data_STEMFORM_mensural : int8_t {
     STEMFORM_mensural_NONE = 0,
     STEMFORM_mensural_circle,
     STEMFORM_mensural_oblique,
@@ -1653,7 +1653,7 @@ enum data_STEMFORM_mensural {
 /**
  * MEI data.STEMMODIFIER
  */
-enum data_STEMMODIFIER {
+enum data_STEMMODIFIER : int8_t {
     STEMMODIFIER_NONE = 0,
     STEMMODIFIER_none,
     STEMMODIFIER_1slash,
@@ -1670,7 +1670,7 @@ enum data_STEMMODIFIER {
 /**
  * MEI data.STEMPOSITION
  */
-enum data_STEMPOSITION {
+enum data_STEMPOSITION : int8_t {
     STEMPOSITION_NONE = 0,
     STEMPOSITION_left,
     STEMPOSITION_right,
@@ -1681,7 +1681,7 @@ enum data_STEMPOSITION {
 /**
  * MEI data.TEMPERAMENT
  */
-enum data_TEMPERAMENT {
+enum data_TEMPERAMENT : int8_t {
     TEMPERAMENT_NONE = 0,
     TEMPERAMENT_equal,
     TEMPERAMENT_just,
@@ -1693,7 +1693,7 @@ enum data_TEMPERAMENT {
 /**
  * MEI data.TEXTRENDITION
  */
-enum data_TEXTRENDITION {
+enum data_TEXTRENDITION : int8_t {
     TEXTRENDITION_NONE = 0,
     TEXTRENDITION_quote,
     TEXTRENDITION_quotedbl,
@@ -1729,7 +1729,7 @@ enum data_TEXTRENDITION {
 /**
  * MEI data.TEXTRENDITIONLIST
  */
-enum data_TEXTRENDITIONLIST {
+enum data_TEXTRENDITIONLIST : int8_t {
     TEXTRENDITIONLIST_NONE = 0,
     TEXTRENDITIONLIST_quote,
     TEXTRENDITIONLIST_quotedbl,
@@ -1765,7 +1765,7 @@ enum data_TEXTRENDITIONLIST {
 /**
  * MEI data.VERTICALALIGNMENT
  */
-enum data_VERTICALALIGNMENT {
+enum data_VERTICALALIGNMENT : int8_t {
     VERTICALALIGNMENT_NONE = 0,
     VERTICALALIGNMENT_top,
     VERTICALALIGNMENT_middle,
@@ -1777,7 +1777,7 @@ enum data_VERTICALALIGNMENT {
 /**
  * MEI att.accid.log@func
  */
-enum accidLog_FUNC {
+enum accidLog_FUNC : int8_t {
     accidLog_FUNC_NONE = 0,
     accidLog_FUNC_caution,
     accidLog_FUNC_edit,
@@ -1787,7 +1787,7 @@ enum accidLog_FUNC {
 /**
  * MEI att.anchoredText.log@func
  */
-enum anchoredTextLog_FUNC {
+enum anchoredTextLog_FUNC : int8_t {
     anchoredTextLog_FUNC_NONE = 0,
     anchoredTextLog_FUNC_unknown,
     anchoredTextLog_FUNC_MAX
@@ -1796,7 +1796,7 @@ enum anchoredTextLog_FUNC {
 /**
  * MEI att.arpeg.log@order
  */
-enum arpegLog_ORDER {
+enum arpegLog_ORDER : int8_t {
     arpegLog_ORDER_NONE = 0,
     arpegLog_ORDER_up,
     arpegLog_ORDER_down,
@@ -1807,7 +1807,7 @@ enum arpegLog_ORDER {
 /**
  * MEI att.audience@audience
  */
-enum audience_AUDIENCE {
+enum audience_AUDIENCE : int8_t {
     audience_AUDIENCE_NONE = 0,
     audience_AUDIENCE_private,
     audience_AUDIENCE_public,
@@ -1817,7 +1817,7 @@ enum audience_AUDIENCE {
 /**
  * MEI att.bTrem.log@form
  */
-enum bTremLog_FORM {
+enum bTremLog_FORM : int8_t {
     bTremLog_FORM_NONE = 0,
     bTremLog_FORM_meas,
     bTremLog_FORM_unmeas,
@@ -1827,7 +1827,7 @@ enum bTremLog_FORM {
 /**
  * MEI att.beamRend@form
  */
-enum beamRend_FORM {
+enum beamRend_FORM : int8_t {
     beamRend_FORM_NONE = 0,
     beamRend_FORM_acc,
     beamRend_FORM_mixed,
@@ -1839,7 +1839,7 @@ enum beamRend_FORM {
 /**
  * MEI att.beaming.vis@beam.rend
  */
-enum beamingVis_BEAMREND {
+enum beamingVis_BEAMREND : int8_t {
     beamingVis_BEAMREND_NONE = 0,
     beamingVis_BEAMREND_acc,
     beamingVis_BEAMREND_rit,
@@ -1850,7 +1850,7 @@ enum beamingVis_BEAMREND {
 /**
  * MEI att.bracketSpan.log@func
  */
-enum bracketSpanLog_FUNC {
+enum bracketSpanLog_FUNC : int8_t {
     bracketSpanLog_FUNC_NONE = 0,
     bracketSpanLog_FUNC_coloration,
     bracketSpanLog_FUNC_cross_rhythm,
@@ -1861,7 +1861,7 @@ enum bracketSpanLog_FUNC {
 /**
  * MEI att.curvature@curvedir
  */
-enum curvature_CURVEDIR {
+enum curvature_CURVEDIR : int8_t {
     curvature_CURVEDIR_NONE = 0,
     curvature_CURVEDIR_above,
     curvature_CURVEDIR_below,
@@ -1872,7 +1872,7 @@ enum curvature_CURVEDIR {
 /**
  * MEI att.curve.log@func
  */
-enum curveLog_FUNC {
+enum curveLog_FUNC : int8_t {
     curveLog_FUNC_NONE = 0,
     curveLog_FUNC_unknown,
     curveLog_FUNC_MAX
@@ -1881,7 +1881,7 @@ enum curveLog_FUNC {
 /**
  * MEI att.cutout@cutout
  */
-enum cutout_CUTOUT {
+enum cutout_CUTOUT : int8_t {
     cutout_CUTOUT_NONE = 0,
     cutout_CUTOUT_cutout,
     cutout_CUTOUT_MAX
@@ -1890,7 +1890,7 @@ enum cutout_CUTOUT {
 /**
  * MEI att.dot.log@form
  */
-enum dotLog_FORM {
+enum dotLog_FORM : int8_t {
     dotLog_FORM_NONE = 0,
     dotLog_FORM_aug,
     dotLog_FORM_div,
@@ -1900,7 +1900,7 @@ enum dotLog_FORM {
 /**
  * MEI att.endings@ending.rend
  */
-enum endings_ENDINGREND {
+enum endings_ENDINGREND : int8_t {
     endings_ENDINGREND_NONE = 0,
     endings_ENDINGREND_top,
     endings_ENDINGREND_barred,
@@ -1911,7 +1911,7 @@ enum endings_ENDINGREND {
 /**
  * MEI att.episema.vis@form
  */
-enum episemaVis_FORM {
+enum episemaVis_FORM : int8_t {
     episemaVis_FORM_NONE = 0,
     episemaVis_FORM_h,
     episemaVis_FORM_v,
@@ -1921,7 +1921,7 @@ enum episemaVis_FORM {
 /**
  * MEI att.evidence@evidence
  */
-enum evidence_EVIDENCE {
+enum evidence_EVIDENCE : int8_t {
     evidence_EVIDENCE_NONE = 0,
     evidence_EVIDENCE_internal,
     evidence_EVIDENCE_external,
@@ -1932,7 +1932,7 @@ enum evidence_EVIDENCE {
 /**
  * MEI att.extSym@glyph.auth
  */
-enum extSym_GLYPHAUTH {
+enum extSym_GLYPHAUTH : int8_t {
     extSym_GLYPHAUTH_NONE = 0,
     extSym_GLYPHAUTH_smufl,
     extSym_GLYPHAUTH_MAX
@@ -1941,7 +1941,7 @@ enum extSym_GLYPHAUTH {
 /**
  * MEI att.fTrem.log@form
  */
-enum fTremLog_FORM {
+enum fTremLog_FORM : int8_t {
     fTremLog_FORM_NONE = 0,
     fTremLog_FORM_meas,
     fTremLog_FORM_unmeas,
@@ -1951,7 +1951,7 @@ enum fTremLog_FORM {
 /**
  * MEI att.fermata.vis@form
  */
-enum fermataVis_FORM {
+enum fermataVis_FORM : int8_t {
     fermataVis_FORM_NONE = 0,
     fermataVis_FORM_inv,
     fermataVis_FORM_norm,
@@ -1961,7 +1961,7 @@ enum fermataVis_FORM {
 /**
  * MEI att.fermata.vis@shape
  */
-enum fermataVis_SHAPE {
+enum fermataVis_SHAPE : int8_t {
     fermataVis_SHAPE_NONE = 0,
     fermataVis_SHAPE_curved,
     fermataVis_SHAPE_square,
@@ -1972,7 +1972,7 @@ enum fermataVis_SHAPE {
 /**
  * MEI att.fingGrp.log@form
  */
-enum fingGrpLog_FORM {
+enum fingGrpLog_FORM : int8_t {
     fingGrpLog_FORM_NONE = 0,
     fingGrpLog_FORM_alter,
     fingGrpLog_FORM_combi,
@@ -1983,7 +1983,7 @@ enum fingGrpLog_FORM {
 /**
  * MEI att.fingGrp.vis@orient
  */
-enum fingGrpVis_ORIENT {
+enum fingGrpVis_ORIENT : int8_t {
     fingGrpVis_ORIENT_NONE = 0,
     fingGrpVis_ORIENT_horiz,
     fingGrpVis_ORIENT_vert,
@@ -1993,7 +1993,7 @@ enum fingGrpVis_ORIENT {
 /**
  * MEI att.graceGrp.log@attach
  */
-enum graceGrpLog_ATTACH {
+enum graceGrpLog_ATTACH : int8_t {
     graceGrpLog_ATTACH_NONE = 0,
     graceGrpLog_ATTACH_pre,
     graceGrpLog_ATTACH_post,
@@ -2004,7 +2004,7 @@ enum graceGrpLog_ATTACH {
 /**
  * MEI att.hairpin.log@form
  */
-enum hairpinLog_FORM {
+enum hairpinLog_FORM : int8_t {
     hairpinLog_FORM_NONE = 0,
     hairpinLog_FORM_cres,
     hairpinLog_FORM_dim,
@@ -2014,7 +2014,7 @@ enum hairpinLog_FORM {
 /**
  * MEI att.harm.anl@form
  */
-enum harmAnl_FORM {
+enum harmAnl_FORM : int8_t {
     harmAnl_FORM_NONE = 0,
     harmAnl_FORM_explicit,
     harmAnl_FORM_implied,
@@ -2024,7 +2024,7 @@ enum harmAnl_FORM {
 /**
  * MEI att.harm.vis@rendgrid
  */
-enum harmVis_RENDGRID {
+enum harmVis_RENDGRID : int8_t {
     harmVis_RENDGRID_NONE = 0,
     harmVis_RENDGRID_grid,
     harmVis_RENDGRID_gridtext,
@@ -2035,7 +2035,7 @@ enum harmVis_RENDGRID {
 /**
  * MEI att.harpPedal.log@a
  */
-enum harpPedalLog_A {
+enum harpPedalLog_A : int8_t {
     harpPedalLog_A_NONE = 0,
     harpPedalLog_A_f,
     harpPedalLog_A_n,
@@ -2046,7 +2046,7 @@ enum harpPedalLog_A {
 /**
  * MEI att.harpPedal.log@b
  */
-enum harpPedalLog_B {
+enum harpPedalLog_B : int8_t {
     harpPedalLog_B_NONE = 0,
     harpPedalLog_B_f,
     harpPedalLog_B_n,
@@ -2057,7 +2057,7 @@ enum harpPedalLog_B {
 /**
  * MEI att.harpPedal.log@c
  */
-enum harpPedalLog_C {
+enum harpPedalLog_C : int8_t {
     harpPedalLog_C_NONE = 0,
     harpPedalLog_C_f,
     harpPedalLog_C_n,
@@ -2068,7 +2068,7 @@ enum harpPedalLog_C {
 /**
  * MEI att.harpPedal.log@d
  */
-enum harpPedalLog_D {
+enum harpPedalLog_D : int8_t {
     harpPedalLog_D_NONE = 0,
     harpPedalLog_D_f,
     harpPedalLog_D_n,
@@ -2079,7 +2079,7 @@ enum harpPedalLog_D {
 /**
  * MEI att.harpPedal.log@e
  */
-enum harpPedalLog_E {
+enum harpPedalLog_E : int8_t {
     harpPedalLog_E_NONE = 0,
     harpPedalLog_E_f,
     harpPedalLog_E_n,
@@ -2090,7 +2090,7 @@ enum harpPedalLog_E {
 /**
  * MEI att.harpPedal.log@f
  */
-enum harpPedalLog_F {
+enum harpPedalLog_F : int8_t {
     harpPedalLog_F_NONE = 0,
     harpPedalLog_F_f,
     harpPedalLog_F_n,
@@ -2101,7 +2101,7 @@ enum harpPedalLog_F {
 /**
  * MEI att.harpPedal.log@g
  */
-enum harpPedalLog_G {
+enum harpPedalLog_G : int8_t {
     harpPedalLog_G_NONE = 0,
     harpPedalLog_G_f,
     harpPedalLog_G_n,
@@ -2112,7 +2112,7 @@ enum harpPedalLog_G {
 /**
  * MEI att.line.log@func
  */
-enum lineLog_FUNC {
+enum lineLog_FUNC : int8_t {
     lineLog_FUNC_NONE = 0,
     lineLog_FUNC_coloration,
     lineLog_FUNC_ligature,
@@ -2123,7 +2123,7 @@ enum lineLog_FUNC {
 /**
  * MEI att.liquescent.vis@curve
  */
-enum liquescentVis_CURVE {
+enum liquescentVis_CURVE : int8_t {
     liquescentVis_CURVE_NONE = 0,
     liquescentVis_CURVE_a,
     liquescentVis_CURVE_c,
@@ -2133,7 +2133,7 @@ enum liquescentVis_CURVE {
 /**
  * MEI att.measurement@unit
  */
-enum measurement_UNIT {
+enum measurement_UNIT : int8_t {
     measurement_UNIT_NONE = 0,
     measurement_UNIT_byte,
     measurement_UNIT_char,
@@ -2158,7 +2158,7 @@ enum measurement_UNIT {
 /**
  * MEI att.meiVersion@meiversion
  */
-enum meiVersion_MEIVERSION {
+enum meiVersion_MEIVERSION : int8_t {
     meiVersion_MEIVERSION_NONE = 0,
     meiVersion_MEIVERSION_2013,
     meiVersion_MEIVERSION_3_0_0,
@@ -2172,7 +2172,7 @@ enum meiVersion_MEIVERSION {
 /**
  * MEI att.mensur.vis@form
  */
-enum mensurVis_FORM {
+enum mensurVis_FORM : int8_t {
     mensurVis_FORM_NONE = 0,
     mensurVis_FORM_horizontal,
     mensurVis_FORM_vertical,
@@ -2182,7 +2182,7 @@ enum mensurVis_FORM {
 /**
  * MEI att.mensural.vis@mensur.form
  */
-enum mensuralVis_MENSURFORM {
+enum mensuralVis_MENSURFORM : int8_t {
     mensuralVis_MENSURFORM_NONE = 0,
     mensuralVis_MENSURFORM_horizontal,
     mensuralVis_MENSURFORM_vertical,
@@ -2192,7 +2192,7 @@ enum mensuralVis_MENSURFORM {
 /**
  * MEI att.meterConformance@metcon
  */
-enum meterConformance_METCON {
+enum meterConformance_METCON : int8_t {
     meterConformance_METCON_NONE = 0,
     meterConformance_METCON_c,
     meterConformance_METCON_i,
@@ -2203,7 +2203,7 @@ enum meterConformance_METCON {
 /**
  * MEI att.meterSigGrp.log@func
  */
-enum meterSigGrpLog_FUNC {
+enum meterSigGrpLog_FUNC : int8_t {
     meterSigGrpLog_FUNC_NONE = 0,
     meterSigGrpLog_FUNC_alternating,
     meterSigGrpLog_FUNC_interchanging,
@@ -2215,7 +2215,7 @@ enum meterSigGrpLog_FUNC {
 /**
  * MEI att.mordent.log@form
  */
-enum mordentLog_FORM {
+enum mordentLog_FORM : int8_t {
     mordentLog_FORM_NONE = 0,
     mordentLog_FORM_lower,
     mordentLog_FORM_upper,
@@ -2225,7 +2225,7 @@ enum mordentLog_FORM {
 /**
  * MEI att.ncForm@con
  */
-enum ncForm_CON {
+enum ncForm_CON : int8_t {
     ncForm_CON_NONE = 0,
     ncForm_CON_g,
     ncForm_CON_l,
@@ -2236,7 +2236,7 @@ enum ncForm_CON {
 /**
  * MEI att.ncForm@curve
  */
-enum ncForm_CURVE {
+enum ncForm_CURVE : int8_t {
     ncForm_CURVE_NONE = 0,
     ncForm_CURVE_a,
     ncForm_CURVE_c,
@@ -2246,7 +2246,7 @@ enum ncForm_CURVE {
 /**
  * MEI att.ncForm@rellen
  */
-enum ncForm_RELLEN {
+enum ncForm_RELLEN : int8_t {
     ncForm_RELLEN_NONE = 0,
     ncForm_RELLEN_l,
     ncForm_RELLEN_s,
@@ -2256,7 +2256,7 @@ enum ncForm_RELLEN {
 /**
  * MEI att.note.ges@extremis
  */
-enum noteGes_EXTREMIS {
+enum noteGes_EXTREMIS : int8_t {
     noteGes_EXTREMIS_NONE = 0,
     noteGes_EXTREMIS_highest,
     noteGes_EXTREMIS_lowest,
@@ -2266,7 +2266,7 @@ enum noteGes_EXTREMIS {
 /**
  * MEI att.noteHeads@head.auth
  */
-enum noteHeads_HEADAUTH {
+enum noteHeads_HEADAUTH : int8_t {
     noteHeads_HEADAUTH_NONE = 0,
     noteHeads_HEADAUTH_smufl,
     noteHeads_HEADAUTH_MAX
@@ -2275,7 +2275,7 @@ enum noteHeads_HEADAUTH {
 /**
  * MEI att.octave.log@coll
  */
-enum octaveLog_COLL {
+enum octaveLog_COLL : int8_t {
     octaveLog_COLL_NONE = 0,
     octaveLog_COLL_coll,
     octaveLog_COLL_MAX
@@ -2284,7 +2284,7 @@ enum octaveLog_COLL {
 /**
  * MEI att.pb.vis@folium
  */
-enum pbVis_FOLIUM {
+enum pbVis_FOLIUM : int8_t {
     pbVis_FOLIUM_NONE = 0,
     pbVis_FOLIUM_verso,
     pbVis_FOLIUM_recto,
@@ -2294,7 +2294,7 @@ enum pbVis_FOLIUM {
 /**
  * MEI att.pedal.log@dir
  */
-enum pedalLog_DIR {
+enum pedalLog_DIR : int8_t {
     pedalLog_DIR_NONE = 0,
     pedalLog_DIR_down,
     pedalLog_DIR_up,
@@ -2306,7 +2306,7 @@ enum pedalLog_DIR {
 /**
  * MEI att.pedal.log@func
  */
-enum pedalLog_FUNC {
+enum pedalLog_FUNC : int8_t {
     pedalLog_FUNC_NONE = 0,
     pedalLog_FUNC_sustain,
     pedalLog_FUNC_soft,
@@ -2318,7 +2318,7 @@ enum pedalLog_FUNC {
 /**
  * MEI att.pointing@xlink:actuate
  */
-enum pointing_XLINKACTUATE {
+enum pointing_XLINKACTUATE : int8_t {
     pointing_XLINKACTUATE_NONE = 0,
     pointing_XLINKACTUATE_onLoad,
     pointing_XLINKACTUATE_onRequest,
@@ -2330,7 +2330,7 @@ enum pointing_XLINKACTUATE {
 /**
  * MEI att.pointing@xlink:show
  */
-enum pointing_XLINKSHOW {
+enum pointing_XLINKSHOW : int8_t {
     pointing_XLINKSHOW_NONE = 0,
     pointing_XLINKSHOW_new,
     pointing_XLINKSHOW_replace,
@@ -2343,7 +2343,7 @@ enum pointing_XLINKSHOW {
 /**
  * MEI att.recordType@recordtype
  */
-enum recordType_RECORDTYPE {
+enum recordType_RECORDTYPE : int8_t {
     recordType_RECORDTYPE_NONE = 0,
     recordType_RECORDTYPE_a,
     recordType_RECORDTYPE_c,
@@ -2365,7 +2365,7 @@ enum recordType_RECORDTYPE {
 /**
  * MEI att.regularMethod@method
  */
-enum regularMethod_METHOD {
+enum regularMethod_METHOD : int8_t {
     regularMethod_METHOD_NONE = 0,
     regularMethod_METHOD_silent,
     regularMethod_METHOD_tags,
@@ -2375,7 +2375,7 @@ enum regularMethod_METHOD {
 /**
  * MEI att.rehearsal@reh.enclose
  */
-enum rehearsal_REHENCLOSE {
+enum rehearsal_REHENCLOSE : int8_t {
     rehearsal_REHENCLOSE_NONE = 0,
     rehearsal_REHENCLOSE_box,
     rehearsal_REHENCLOSE_circle,
@@ -2386,7 +2386,7 @@ enum rehearsal_REHENCLOSE {
 /**
  * MEI att.sb.vis@form
  */
-enum sbVis_FORM {
+enum sbVis_FORM : int8_t {
     sbVis_FORM_NONE = 0,
     sbVis_FORM_hash,
     sbVis_FORM_MAX
@@ -2395,7 +2395,7 @@ enum sbVis_FORM {
 /**
  * MEI att.staffGroupingSym@symbol
  */
-enum staffGroupingSym_SYMBOL {
+enum staffGroupingSym_SYMBOL : int8_t {
     staffGroupingSym_SYMBOL_NONE = 0,
     staffGroupingSym_SYMBOL_brace,
     staffGroupingSym_SYMBOL_bracket,
@@ -2408,7 +2408,7 @@ enum staffGroupingSym_SYMBOL {
 /**
  * MEI att.syl.log@con
  */
-enum sylLog_CON {
+enum sylLog_CON : int8_t {
     sylLog_CON_NONE = 0,
     sylLog_CON_s,
     sylLog_CON_d,
@@ -2424,7 +2424,7 @@ enum sylLog_CON {
 /**
  * MEI att.syl.log@wordpos
  */
-enum sylLog_WORDPOS {
+enum sylLog_WORDPOS : int8_t {
     sylLog_WORDPOS_NONE = 0,
     sylLog_WORDPOS_i,
     sylLog_WORDPOS_m,
@@ -2436,7 +2436,7 @@ enum sylLog_WORDPOS {
 /**
  * MEI att.targetEval@evaluate
  */
-enum targetEval_EVALUATE {
+enum targetEval_EVALUATE : int8_t {
     targetEval_EVALUATE_NONE = 0,
     targetEval_EVALUATE_all,
     targetEval_EVALUATE_one,
@@ -2447,7 +2447,7 @@ enum targetEval_EVALUATE {
 /**
  * MEI att.tempo.log@func
  */
-enum tempoLog_FUNC {
+enum tempoLog_FUNC : int8_t {
     tempoLog_FUNC_NONE = 0,
     tempoLog_FUNC_continuous,
     tempoLog_FUNC_instantaneous,
@@ -2459,7 +2459,7 @@ enum tempoLog_FUNC {
 /**
  * MEI att.tuplet.vis@num.format
  */
-enum tupletVis_NUMFORMAT {
+enum tupletVis_NUMFORMAT : int8_t {
     tupletVis_NUMFORMAT_NONE = 0,
     tupletVis_NUMFORMAT_count,
     tupletVis_NUMFORMAT_ratio,
@@ -2469,7 +2469,7 @@ enum tupletVis_NUMFORMAT {
 /**
  * MEI att.turn.log@form
  */
-enum turnLog_FORM {
+enum turnLog_FORM : int8_t {
     turnLog_FORM_NONE = 0,
     turnLog_FORM_lower,
     turnLog_FORM_upper,
@@ -2479,7 +2479,7 @@ enum turnLog_FORM {
 /**
  * MEI att.voltaGroupingSym@voltasym
  */
-enum voltaGroupingSym_VOLTASYM {
+enum voltaGroupingSym_VOLTASYM : int8_t {
     voltaGroupingSym_VOLTASYM_NONE = 0,
     voltaGroupingSym_VOLTASYM_brace,
     voltaGroupingSym_VOLTASYM_bracket,
@@ -2492,7 +2492,7 @@ enum voltaGroupingSym_VOLTASYM {
 /**
  * MEI att.whitespace@xml:space
  */
-enum whitespace_XMLSPACE {
+enum whitespace_XMLSPACE : int8_t {
     whitespace_XMLSPACE_NONE = 0,
     whitespace_XMLSPACE_default,
     whitespace_XMLSPACE_preserve,

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -97,6 +97,10 @@ private:
 // ExtAtt{attGroupNameUpper}
 //----------------------------------------------------------------------------
 
+/**
+ * Instantiable version of Att{attGroupNameUpper}
+ */
+
 class ExtAtt{attGroupNameUpper} : public Att{attGroupNameUpper} {{
 public:
     ExtAtt{attGroupNameUpper}() = default;
@@ -348,11 +352,11 @@ CONVERTER_END_H = """}};
 // AttConverter
 //----------------------------------------------------------------------------
 
-class AttConverter: public AttConverterBase {
+class AttConverter: public AttConverterBase {{
 public:
     AttConverter() = default;
     virtual ~AttConverter() = default;
-};
+}};
 
 }} // namespace {ns}
 

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -302,7 +302,7 @@ TYPE_GRP_END = """}} // namespace {ns}
 TYPE_START = """/**
  * MEI {meitype}
  */
-enum {vrvtype} {{
+enum {vrvtype}{enumtype} {{
     {val_prefix}_NONE = 0,"""
 
 TYPE_VALUE = """
@@ -862,6 +862,7 @@ def create_att_datatypes(cpp_ns: str, schema, outdir: Path):
         type_start_fmt = {
             "meitype": data_type,
             "vrvtype": vrv_getformattedtype(data_type),
+            "enumtype": " : int8_t" if len(values) < 64 else "",
             "val_prefix":  val_prefix
         }
         att_type_data_types.append(TYPE_START.format_map(type_start_fmt))
@@ -917,6 +918,7 @@ def create_att_datatypes(cpp_ns: str, schema, outdir: Path):
         type_start_fmt = {
             "meitype": list_type,
             "vrvtype": val_prefix,
+            "enumtype": " : int8_t" if len(values) < 64 else "",
             "val_prefix":  val_prefix
         }
         att_type_data_list.append(TYPE_START.format_map(type_start_fmt))

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -68,10 +68,11 @@ ATTCLASS_H = """
 //----------------------------------------------------------------------------
 
 class Att{attGroupNameUpper} : public Att {{
-public:
+protected:
     Att{attGroupNameUpper}();
-    virtual ~Att{attGroupNameUpper}();
+    ~Att{attGroupNameUpper}() = default;
 
+public:
     /** Reset the default values for the attribute class **/
     void Reset{attGroupNameUpper}();
 
@@ -91,6 +92,16 @@ public:
 
 private:
 {members}}};
+
+//----------------------------------------------------------------------------
+// ExtAtt{attGroupNameUpper}
+//----------------------------------------------------------------------------
+
+class ExtAtt{attGroupNameUpper} : public Att{attGroupNameUpper} {{
+public:
+    ExtAtt{attGroupNameUpper}() = default;
+    virtual ~ExtAtt{attGroupNameUpper}() = default;
+}};
 """
 
 ATTCLASS_METHODS_H = """    void Set{attNameUpper}({attType} {attNameLowerJoined}_) {{ m_{attNameLowerJoined} = {attNameLowerJoined}_; }}
@@ -131,8 +142,6 @@ Att{attGroupNameUpper}::Att{attGroupNameUpper}() : Att()
 {{
     Reset{attGroupNameUpper}();
 }}
-
-Att{attGroupNameUpper}::~Att{attGroupNameUpper}() {{}}
 
 void Att{attGroupNameUpper}::Reset{attGroupNameUpper}()
 {{
@@ -323,9 +332,8 @@ namespace {ns} {{
 //----------------------------------------------------------------------------
 
 class AttConverterBase {{
-public:
-    AttConverterBase() = default;
 protected:
+    AttConverterBase() = default;
     ~AttConverterBase() = default;
 public:"""
 

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -319,10 +319,14 @@ CONVERTER_H = """
 namespace {ns} {{
 
 //----------------------------------------------------------------------------
-// AttConverter
+// AttConverterBase
 //----------------------------------------------------------------------------
 
-class AttConverter {{
+class AttConverterBase {{
+public:
+    AttConverterBase() = default;
+protected:
+    ~AttConverterBase() = default;
 public:"""
 
 CONVERTER_METHODS_H = """
@@ -331,6 +335,16 @@ CONVERTER_METHODS_H = """
 """
 
 CONVERTER_END_H = """}};
+
+//----------------------------------------------------------------------------
+// AttConverter
+//----------------------------------------------------------------------------
+
+class AttConverter: public AttConverterBase {
+public:
+    AttConverter() = default;
+    virtual ~AttConverter() = default;
+};
 
 }} // namespace {ns}
 
@@ -352,18 +366,18 @@ CONVERTER_CPP = """
 namespace {ns} {{
 
 //----------------------------------------------------------------------------
-// AttConverter
+// AttConverterBase
 //----------------------------------------------------------------------------
 """
 
 CONVERTER_METHOD1_START_CPP = """
-std::string AttConverter::{fname}ToStr({type} data) const
+std::string AttConverterBase::{fname}ToStr({type} data) const
 {{
     std::string value;
     switch (data) {{"""
 
 CONVERTER_METHOD2_START_CPP = """
-{type} AttConverter::StrTo{fname}(const std::string &value, bool logWarning) const
+{type} AttConverterBase::StrTo{fname}(const std::string &value, bool logWarning) const
 {{"""
 
 CONVERTER_METHOD1_CPP = """

--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -352,6 +352,10 @@ CONVERTER_END_H = """}};
 // AttConverter
 //----------------------------------------------------------------------------
 
+/**
+ * Instantiable version of AttConverterBase
+ */
+
 class AttConverter: public AttConverterBase {{
 public:
     AttConverter() = default;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2412,13 +2412,13 @@ void MEIOutput::WriteClef(pugi::xml_node currentNode, Clef *clef)
 
     // Only write att values if representing an attribute or in MEI basic
     if (!this->IsTreeObject(clef)) {
-        AttCleffingLog cleffingLog;
+        ExtAttCleffingLog cleffingLog;
         cleffingLog.SetClefShape(clef->GetShape());
         cleffingLog.SetClefLine(clef->GetLine());
         cleffingLog.SetClefDis(clef->GetDis());
         cleffingLog.SetClefDisPlace(clef->GetDisPlace());
         cleffingLog.WriteCleffingLog(currentNode);
-        AttCleffingVis cleffingVis;
+        ExtAttCleffingVis cleffingVis;
         cleffingVis.SetClefColor(clef->GetColor());
         cleffingVis.SetClefVisible(clef->GetVisible());
         cleffingVis.WriteCleffingVis(currentNode);
@@ -2505,18 +2505,18 @@ void MEIOutput::WriteKeySig(pugi::xml_node currentNode, KeySig *keySig)
 
     // Only write att values if representing an attribute or in MEI basic
     if (!this->IsTreeObject(keySig)) {
-        AttKeySigDefaultAnl attKeySigDefaultAnl;
+        ExtAttKeySigDefaultAnl attKeySigDefaultAnl;
         // Broken in MEI 4.0.2 - waiting for a fix
         // attKeySigDefaultAnl.SetKeyAccid(keySig->GetAccid());
         attKeySigDefaultAnl.SetKeyMode(keySig->GetMode());
         attKeySigDefaultAnl.SetKeyPname(keySig->GetPname());
         attKeySigDefaultAnl.WriteKeySigDefaultAnl(currentNode);
-        AttKeySigDefaultLog attKeySigDefaultLog;
+        ExtAttKeySigDefaultLog attKeySigDefaultLog;
         // If there is no @sig, try to build it from the keyAccid children.
         const data_KEYSIGNATURE sig = (keySig->HasSig()) ? keySig->GetSig() : keySig->ConvertToSig();
         attKeySigDefaultLog.SetKeySig(sig);
         attKeySigDefaultLog.WriteKeySigDefaultLog(currentNode);
-        AttKeySigDefaultVis attKeySigDefaultVis;
+        ExtAttKeySigDefaultVis attKeySigDefaultVis;
         attKeySigDefaultVis.SetKeysigShow(keySig->GetVisible());
         attKeySigDefaultVis.SetKeysigShowchange(keySig->GetSigShowchange());
         attKeySigDefaultVis.WriteKeySigDefaultVis(currentNode);
@@ -2545,18 +2545,18 @@ void MEIOutput::WriteMensur(pugi::xml_node currentNode, Mensur *mensur)
     assert(mensur);
 
     if (!this->IsTreeObject(mensur)) {
-        AttMensuralLog mensuralLog;
+        ExtAttMensuralLog mensuralLog;
 
         mensuralLog.SetProportNum(mensur->GetNum());
         mensuralLog.SetProportNumbase(mensur->GetNumbase());
         mensuralLog.WriteMensuralLog(currentNode);
-        AttMensuralShared mensuralShared;
+        ExtAttMensuralShared mensuralShared;
         mensuralShared.SetModusmaior(mensur->GetModusmaior());
         mensuralShared.SetModusminor(mensur->GetModusminor());
         mensuralShared.SetProlatio(mensur->GetProlatio());
         mensuralShared.SetTempus(mensur->GetTempus());
         mensuralShared.WriteMensuralShared(currentNode);
-        AttMensuralVis mensuralVis;
+        ExtAttMensuralVis mensuralVis;
         mensuralVis.SetMensurDot(mensur->GetDot());
         mensuralVis.SetMensurColor(mensur->GetColor());
         mensuralVis.SetMensurOrient(mensur->GetOrient());
@@ -2582,12 +2582,12 @@ void MEIOutput::WriteMeterSig(pugi::xml_node currentNode, MeterSig *meterSig)
 
     // Only write att values if representing an attribute or in MEI basic
     if (!this->IsTreeObject(meterSig)) {
-        AttMeterSigDefaultLog meterSigDefaultLog;
+        ExtAttMeterSigDefaultLog meterSigDefaultLog;
         meterSigDefaultLog.SetMeterCount(meterSig->GetCount());
         meterSigDefaultLog.SetMeterSym(meterSig->GetSym());
         meterSigDefaultLog.SetMeterUnit(meterSig->GetUnit());
         meterSigDefaultLog.WriteMeterSigDefaultLog(currentNode);
-        AttMeterSigDefaultVis meterSigDefaultVis;
+        ExtAttMeterSigDefaultVis meterSigDefaultVis;
         meterSigDefaultVis.SetMeterForm(meterSig->GetForm());
         meterSigDefaultVis.WriteMeterSigDefaultVis(currentNode);
         return;
@@ -4589,9 +4589,9 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
     object->ReadSystems(element);
     object->ReadTyped(element);
 
-    AttCleffingLog cleffingLog;
+    ExtAttCleffingLog cleffingLog;
     cleffingLog.ReadCleffingLog(element);
-    AttCleffingVis cleffingVis;
+    ExtAttCleffingVis cleffingVis;
     cleffingVis.ReadCleffingVis(element);
     if (cleffingLog.HasClefShape()) {
         Clef *vrvClef = new Clef();
@@ -4605,11 +4605,11 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
         object->AddChild(vrvClef);
     }
 
-    AttKeySigDefaultAnl keySigDefaultAnl;
+    ExtAttKeySigDefaultAnl keySigDefaultAnl;
     keySigDefaultAnl.ReadKeySigDefaultAnl(element);
-    AttKeySigDefaultLog keySigDefaultLog;
+    ExtAttKeySigDefaultLog keySigDefaultLog;
     keySigDefaultLog.ReadKeySigDefaultLog(element);
-    AttKeySigDefaultVis keySigDefaultVis;
+    ExtAttKeySigDefaultVis keySigDefaultVis;
     keySigDefaultVis.ReadKeySigDefaultVis(element);
     if (keySigDefaultAnl.HasKeyAccid() || keySigDefaultAnl.HasKeyMode() || keySigDefaultAnl.HasKeyPname()
         || keySigDefaultLog.HasKeySig() || keySigDefaultVis.HasKeysigShow() || keySigDefaultVis.HasKeysigShowchange()) {
@@ -4625,11 +4625,11 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
         object->AddChild(vrvKeySig);
     }
 
-    AttMensuralLog mensuralLog;
+    ExtAttMensuralLog mensuralLog;
     mensuralLog.ReadMensuralLog(element);
-    AttMensuralShared mensuralShared;
+    ExtAttMensuralShared mensuralShared;
     mensuralShared.ReadMensuralShared(element);
-    AttMensuralVis mensuralVis;
+    ExtAttMensuralVis mensuralVis;
     mensuralVis.ReadMensuralVis(element);
     if (mensuralShared.HasProlatio() || mensuralShared.HasTempus() || mensuralLog.HasProportNum()
         || mensuralLog.HasProportNumbase() || mensuralVis.HasMensurSign()) {
@@ -4657,9 +4657,9 @@ bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *obje
         object->AddChild(vrvMensur);
     }
 
-    AttMeterSigDefaultLog meterSigDefaultLog;
+    ExtAttMeterSigDefaultLog meterSigDefaultLog;
     meterSigDefaultLog.ReadMeterSigDefaultLog(element);
-    AttMeterSigDefaultVis meterSigDefaultVis;
+    ExtAttMeterSigDefaultVis meterSigDefaultVis;
     meterSigDefaultVis.ReadMeterSigDefaultVis(element);
     if (meterSigDefaultLog.HasMeterCount() || meterSigDefaultLog.HasMeterSym() || meterSigDefaultLog.HasMeterUnit()) {
         MeterSig *vrvMeterSig = new MeterSig();
@@ -4795,7 +4795,7 @@ bool MEIInput::ReadStaffGrp(Object *parent, pugi::xml_node staffGrp)
     vrvStaffGrp->ReadBasic(staffGrp);
     vrvStaffGrp->ReadLabelled(staffGrp);
     vrvStaffGrp->ReadNNumberLike(staffGrp);
-    AttStaffGroupingSym groupingSym;
+    ExtAttStaffGroupingSym groupingSym;
     groupingSym.ReadStaffGroupingSym(staffGrp);
     if (groupingSym.HasSymbol()) {
         GrpSym *vrvGrpSym = new GrpSym();
@@ -6284,7 +6284,7 @@ bool MEIInput::ReadChord(Object *parent, pugi::xml_node chord)
     vrvChord->ReadTiePresent(chord);
     vrvChord->ReadVisibility(chord);
 
-    AttArticulation artic;
+    ExtAttArticulation artic;
     artic.ReadArticulation(chord);
     if (artic.HasArtic()) {
         Artic *vrvArtic = new Artic();
@@ -6324,9 +6324,9 @@ bool MEIInput::ReadClef(Object *parent, pugi::xml_node clef)
 
 void MEIInput::ReadAccidAttr(pugi::xml_node node, Object *object)
 {
-    AttAccidental accidental;
+    ExtAttAccidental accidental;
     accidental.ReadAccidental(node);
-    AttAccidentalGes accidentalGestural;
+    ExtAttAccidentalGes accidentalGestural;
     accidentalGestural.ReadAccidentalGes(node);
     if (accidental.HasAccid() || accidentalGestural.HasAccidGes()) {
         Accid *vrvAccid = new Accid();
@@ -6656,7 +6656,7 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
     vrvNote->ReadTiePresent(note);
     vrvNote->ReadVisibility(note);
 
-    AttArticulation artic;
+    ExtAttArticulation artic;
     artic.ReadArticulation(note);
     if (artic.HasArtic()) {
         Artic *vrvArtic = new Artic();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -17,7 +17,7 @@
 
 //----------------------------------------------------------------------------
 
-#include "att.h"
+#include "attconverter.h"
 #include "vrv.h"
 #include "vrvdef.h"
 
@@ -605,7 +605,7 @@ void OptionStaffrel::Init(data_STAFFREL defaultValue)
 
 bool OptionStaffrel::SetValue(const std::string &value)
 {
-    Att converter;
+    AttConverter converter;
     data_STAFFREL staffrel = converter.StrToStaffrel(value);
     if (staffrel == STAFFREL_NONE) {
         LogError("Parameter '%s' not valid", value.c_str());
@@ -617,13 +617,13 @@ bool OptionStaffrel::SetValue(const std::string &value)
 
 std::string OptionStaffrel::GetStrValue() const
 {
-    Att converter;
+    AttConverter converter;
     return converter.StaffrelToStr(m_value);
 }
 
 std::string OptionStaffrel::GetDefaultStrValue() const
 {
-    Att converter;
+    AttConverter converter;
     return converter.StaffrelToStr(m_defaultValue);
 }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -289,11 +289,9 @@ void SvgDeviceContext::StartGraphic(
         assert(att);
         if (att->HasFontname()) m_currentNode.append_attribute("font-family") = att->GetFontname().c_str();
         if (att->HasFontstyle())
-            m_currentNode.append_attribute("font-style")
-                = att->AttConverter::FontstyleToStr(att->GetFontstyle()).c_str();
+            m_currentNode.append_attribute("font-style") = att->FontstyleToStr(att->GetFontstyle()).c_str();
         if (att->HasFontweight())
-            m_currentNode.append_attribute("font-weight")
-                = att->AttConverter::FontweightToStr(att->GetFontweight()).c_str();
+            m_currentNode.append_attribute("font-weight") = att->FontweightToStr(att->GetFontweight()).c_str();
     }
 
     if (object->HasAttClass(ATT_VISIBILITY)) {
@@ -369,11 +367,9 @@ void SvgDeviceContext::StartTextGraphic(Object *object, std::string gClass, std:
         assert(att);
         if (att->HasFontname()) m_currentNode.append_attribute("font-family") = att->GetFontname().c_str();
         if (att->HasFontstyle())
-            m_currentNode.append_attribute("font-style")
-                = att->AttConverter::FontstyleToStr(att->GetFontstyle()).c_str();
+            m_currentNode.append_attribute("font-style") = att->FontstyleToStr(att->GetFontstyle()).c_str();
         if (att->HasFontweight())
-            m_currentNode.append_attribute("font-weight")
-                = att->AttConverter::FontweightToStr(att->GetFontweight()).c_str();
+            m_currentNode.append_attribute("font-weight") = att->FontweightToStr(att->GetFontweight()).c_str();
     }
 
     if (object->HasAttClass(ATT_WHITESPACE)) {


### PR DESCRIPTION
This PR reduces memory consumption of Verovio by 10-15% through optimisations in the generated LibMEI code. 
Here are the sizes of selected types in bytes:

| Class | Before | After | Reduction |
| ----- | ------ | ----- | --------- |
| Accid | 1136 | 984 | 13.4% |
| Measure | 3216 | 2984 | 7.2% |
| Note | 1792 | 1480 | 17.4% |

The reduction is mainly achieved by generating the attributes non-polymorphic with protected constructor and destructor. To still be able to use them outside the class hierarchy (as required i.e. in `iomei.cpp`), we also generate instantiable versions named `ExtAtt*`.

An interesting side effect of this is that the size of the executable is also reduced:

| Before | After | Reduction |
| ------ | ----- | ------- |
| 15.924 MB | 14.930 MB | 6.2% |

Runtime is not effected (neither positive nor negative). This PR addresses ideas discussed before in https://github.com/rism-digital/verovio/discussions/3065 .