### PR TITLE
Generator script improvements

### DIFF
--- a/libmei/tools/cpp.py
+++ b/libmei/tools/cpp.py
@@ -1214,7 +1214,7 @@ public:
 
 
 def create_basic_validator(configure: dict, outdir: Path):
-    basic_path = Path(configure["basic_odd"])
+    basic_path = Path(configure["config_dir"]) / Path(configure["basic_odd"])
     with basic_path.open("r") as basic_schema:
         bschema = MeiSchema(basic_schema, resolve_elements=True)
 
@@ -1268,7 +1268,8 @@ def create(schema, configure: dict) -> bool:
     global DATATYPES
     lg.debug("Begin Verovio C++ Output ...")
 
-    datatypes: Path = Path(configure["datatypes"])
+    config_dir: Path = Path(configure["config_dir"])
+    datatypes: Path = config_dir / Path(configure["datatypes"])
     if not datatypes.exists():
         lg.error("Datatypes file could not be found")
         return False
@@ -1276,13 +1277,13 @@ def create(schema, configure: dict) -> bool:
     DATATYPES = yaml.safe_load(datatypes.open("r"))
 
     ns: str = configure["namespace"]
-    outdir: Path = Path(configure["output_dir"])
+    outdir: Path = config_dir / Path(configure["output_dir"])
 
     # if we output element classes, then we do not output the attmodule class
     if configure["elements"]:
         create_element_classes(ns, schema, outdir)
         if addons := configure.get("addons_dir"):
-            copy_addons(ns, Path(addons), outdir)
+            copy_addons(ns, config_dir / Path(addons), outdir)
         else:
             lg.warning("Element output was configured, but no addons directory was provided.")
     else:

--- a/libmei/tools/parseschema2.py
+++ b/libmei/tools/parseschema2.py
@@ -66,6 +66,7 @@ if __name__ == "__main__":
 
     config: dict = yaml.safe_load(open(args.config, "r"))
     config["compiled"] = args.compiled
+    config["config_dir"] = args.config.parent
 
     if config["debug"]:
         log.setLevel(logging.DEBUG)

--- a/libmei/tools/parseschema2.py
+++ b/libmei/tools/parseschema2.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     p = ArgumentParser(usage='%(prog)s [-c config path] [compiled odd path]')
 
     p.add_argument("compiled", help="A compiled ODD file", type=Path)
-    p.add_argument("-c", "--config", help="Path to a config file", type=Path)
+    p.add_argument("-c", "--config", help="Path to a config file", required=True, type=Path)
 
     args = p.parse_args()
 


### PR DESCRIPTION
This PR improves the usage of the LibMEI generator script a bit.
- The configuration is now a required argument. Before the script was crashing when leaving it out.
- Running the script from another directory now works, i.e.
`python3 tools/parseschema2.py -c tools/config.yml mei/develop/mei-verovio_compiled.odd` 