### PR TITLE
Fix tremolo slashes overlaps

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1125,7 +1125,7 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
                 overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
             }
         }
-        else {         
+        else {
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
         }
         // if there is no overlap between elements, make additinal checks for some of the edge cases

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2144,7 +2144,8 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
     }
     else if (this->Is(NOTE) && (next == ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
         Note *note = vrv_cast<Note *>(this);
-        if (note->HasStemMod() && (note->GetStemMod() < STEMMODIFIER_MAX) && (note->GetDrawingStemDir() == STEMDIRECTION_up)) {
+        if (note->HasStemMod() && (note->GetStemMod() < STEMMODIFIER_MAX)
+            && (note->GetDrawingStemDir() == STEMDIRECTION_up)) {
             const int adjust = drawingUnit;
             params->m_cumulatedXShift += adjust;
             params->m_upcomingMinPos += adjust;

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1124,11 +1124,13 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
             }
         }
         else {
-            Note *note = vrv_cast<Note *>(this);
-            if (note->HasStemMod() && note->GetStemMod() < STEMMODIFIER_MAX) {
-                const int tremWidth = params->m_doc->GetGlyphWidth(SMUFL_E220_tremolo1, params->m_staffSize, false);
-                margin = std::max(margin, tremWidth / 2);
-            }
+            if (this->Is(NOTE)) {
+                Note *note = vrv_cast<Note *>(this);
+                if (note->HasStemMod() && note->GetStemMod() < STEMMODIFIER_MAX) {
+                    const int tremWidth = params->m_doc->GetGlyphWidth(SMUFL_E220_tremolo1, params->m_staffSize, false);
+                    margin = std::max(margin, tremWidth / 2);
+                }
+            }            
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
         }
         // if there is no overlap between elements, make additinal checks for some of the edge cases

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1090,6 +1090,11 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
         // For note to note alignment, make sure there is a standard spacing even if they do not overlap
         // vertically
         if (this->Is(NOTE) && element->Is(NOTE)) {
+            Note *note = vrv_cast<Note *>(this);
+            if (note->HasStemMod() && note->GetStemMod() < STEMMODIFIER_MAX) {
+                const int tremWidth = params->m_doc->GetGlyphWidth(SMUFL_E220_tremolo1, params->m_staffSize, false);
+                margin = std::max(margin, tremWidth / 2);
+            }
             overlap = std::max(overlap, element->GetSelfRight() - this->GetSelfLeft() + margin);
         }
         else if (this->Is(ACCID) && element->Is(NOTE)) {
@@ -1119,6 +1124,11 @@ std::pair<int, int> LayerElement::CalculateXPosOffset(FunctorParams *functorPara
             }
         }
         else {
+            Note *note = vrv_cast<Note *>(this);
+            if (note->HasStemMod() && note->GetStemMod() < STEMMODIFIER_MAX) {
+                const int tremWidth = params->m_doc->GetGlyphWidth(SMUFL_E220_tremolo1, params->m_staffSize, false);
+                margin = std::max(margin, tremWidth / 2);
+            }
             overlap = std::max(overlap, boundingBox->HorizontalRightOverlap(this, params->m_doc, margin));
         }
         // if there is no overlap between elements, make additinal checks for some of the edge cases
@@ -2133,6 +2143,14 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
         if (additionalOffset > params->m_currentAlignment.m_offset) {
             params->m_currentAlignment.m_offset = additionalOffset;
             params->m_currentAlignment.m_overlappingBB = this;
+        }
+    }
+    else if (this->Is(NOTE) && (next == ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
+        Note *note = vrv_cast<Note *>(this);
+        if (note->HasStemMod() && (note->GetStemMod() < STEMMODIFIER_MAX) && note->GetStemDir() == STEMDIRECTION_up) {
+            const int adjust = drawingUnit / 2;
+            params->m_cumulatedXShift += adjust;
+            params->m_upcomingMinPos += adjust;
         }
     }
     else {


### PR DESCRIPTION
Fix for tremolo slashes ovelaping with other elements (notes/accid/barlines).

Before:
![image](https://user-images.githubusercontent.com/1819669/219054428-04330981-5887-4774-84a7-690ddb9ddbd7.png)

After:
![image](https://user-images.githubusercontent.com/1819669/219054451-f688fa8a-06fe-49b6-b2d8-9bb8767244bf.png)


<details><summary>MEI:</summary>

``XML<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title/>
            <respStmt/>
         </titleStmt>
         <pubStmt/>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mu3zhmd">
            <score xml:id="spvr2ed">
               <scoreDef>
                  <staffGrp xml:id="saxcj1g">
                     <staffGrp xml:id="ssookh0">
                        <staffGrp xml:id="s16dt69m">
                           <staffDef xml:id="P15" n="15" lines="5">
                              <label xml:id="l16drxl4">Violino I</label>
                              <clef xml:id="cm1im6b" shape="G" line="2"/>
                              <keySig xml:id="k1d86kac" mode="major" sig="3f"/>
                              <meterSig xml:id="m15x9440" count="2" unit="4"/>
                           </staffDef>
                        </staffGrp>
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="s1h82oca">
                  <pb/>
                  <measure xml:id="ms1h99" n="432" corresp="#ms1h99">
                     <staff n="15">
                        <layer n="1">
                           <beam>
                             <bTrem xml:id="b15yf3ni" form="meas">
                               <note xml:id="n10pkkl1" dur="16" oct="4" pname="g" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="bc62etd" form="meas">
                               <note xml:id="n1wus1qw" dur="16" oct="4" pname="f" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="b1noiwqv" form="meas">
                               <note xml:id="ni8ne75" dur="16" oct="4" pname="e" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="bjqxx3w" form="meas">
                               <note xml:id="n1ju7fn" dur="16" oct="4" pname="d" stem.mod="1slash" accid="f"/>
                             </bTrem>
                            </beam>
                            <beam>
                             <bTrem xml:id="bdah2pm" form="meas">
                               <note xml:id="n744bjk" dur="16" oct="4" pname="e" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="b3u7b1a" form="meas">
                               <note xml:id="n11h5xal" dur="16" oct="4" pname="d" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="b3u0xp6" form="meas">
                               <note xml:id="n18u4nfn" dur="16" oct="4" pname="c" stem.mod="1slash" accid="f"/>
                             </bTrem>
                             <bTrem xml:id="b3w8r8q" form="meas">
                               <note xml:id="nh6vbc6" dur="16" oct="3" pname="b" stem.mod="1slash" accid="f"/>
                             </bTrem>
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>