### PR TITLE
Add a custom json key to add header information during the PAE import

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -104,6 +104,11 @@ public:
     bool GenerateMeasureNumbers();
 
     /**
+     * Generate an MEI header
+     */
+    void GenerateMEIHeader(bool meiBasic);
+
+    /**
      * Getter and setter for the DocType.
      * The setter resets the document.
      */

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -92,8 +92,6 @@ public:
     bool WriteObjectEnd(Object *object) override;
 
 private:
-    bool WriteDoc(Doc *doc);
-
     /**
      * @name Methods for writing containers (measures, staff, etc) scoreDef and related.
      */

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -558,6 +558,11 @@ private:
     bool Parse();
 
     /**
+     * Parse the metadata in the \@header json object
+     */
+    void ParseHeader(jsonxx::Object &header);
+
+    /**
      * @name Methods that convert pae::Token::m_char to pae::Token::m_objects
      *
      * The order in which they are called is important.

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -291,11 +291,11 @@ void Doc::GenerateMEIHeader(bool meiBasic)
         application.append_attribute("xml:id") = "verovio";
         application.append_attribute("version") = GetVersion().c_str();
         pugi::xml_node name = application.append_child("name");
-        name.append_child(pugi::node_pcdata).set_value(StringFormat("Verovio (%s)", GetVersion().c_str()).c_str());
+        name.text().set(StringFormat("Verovio (%s)", GetVersion().c_str()).c_str());
         // projectDesc
         pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.append_child(pugi::node_pcdata).set_value(StringFormat("MEI encoded with Verovio").c_str());
+        p1.text().set(StringFormat("MEI encoded with Verovio").c_str());
     }
 }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -265,6 +265,33 @@ bool Doc::GenerateMeasureNumbers()
     return true;
 }
 
+void Doc::GenerateMEIHeader(bool meiBasic)
+{
+    m_header.remove_children();
+    pugi::xml_node meiHead = m_header.append_child("meiHead");
+    pugi::xml_node fileDesc = meiHead.append_child("fileDesc");
+    pugi::xml_node titleStmt = fileDesc.append_child("titleStmt");
+    titleStmt.append_child("title");
+    pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
+    pugi::xml_node date = pubStmt.append_child("date");
+
+    // date
+    time_t t = time(0); // get time now
+    struct tm *now = localtime(&t);
+    std::string dateStr = StringFormat("%d-%02d-%02d %02d:%02d:%02d", now->tm_year + 1900, now->tm_mon + 1,
+        now->tm_mday, now->tm_hour, now->tm_min, now->tm_sec);
+    date.append_child(pugi::node_pcdata).set_value(dateStr.c_str());
+
+    if (!meiBasic) {
+        // encodingDesc
+        pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
+        pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
+        pugi::xml_node p1 = projectDesc.append_child("p");
+        p1.append_child(pugi::node_pcdata)
+            .set_value(StringFormat("Encoded with Verovio version %s", GetVersion().c_str()).c_str());
+    }
+}
+
 bool Doc::HasTimemap() const
 {
     return (m_timemapTempo == m_options->m_midiTempoAdjustment.GetValue());

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -278,17 +278,24 @@ void Doc::GenerateMEIHeader(bool meiBasic)
     // date
     time_t t = time(0); // get time now
     struct tm *now = localtime(&t);
-    std::string dateStr = StringFormat("%d-%02d-%02d %02d:%02d:%02d", now->tm_year + 1900, now->tm_mon + 1,
+    std::string dateStr = StringFormat("%d-%02d-%02d-%02d:%02d:%02d", now->tm_year + 1900, now->tm_mon + 1,
         now->tm_mday, now->tm_hour, now->tm_min, now->tm_sec);
-    date.append_child(pugi::node_pcdata).set_value(dateStr.c_str());
+    date.append_attribute("isodate") = dateStr.c_str();
 
     if (!meiBasic) {
         // encodingDesc
         pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
+        // appInfo/application/name
+        pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
+        pugi::xml_node application = appInfo.append_child("application");
+        application.append_attribute("xml:id") = "verovio";
+        application.append_attribute("version") = GetVersion().c_str();
+        pugi::xml_node name = application.append_child("name");
+        name.append_child(pugi::node_pcdata).set_value(StringFormat("Verovio (%s)", GetVersion().c_str()).c_str());
+        // projectDesc
         pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.append_child(pugi::node_pcdata)
-            .set_value(StringFormat("Encoded with Verovio version %s", GetVersion().c_str()).c_str());
+        p1.append_child(pugi::node_pcdata).set_value(StringFormat("MEI encoded with Verovio").c_str());
     }
 }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1252,10 +1252,10 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     GenerateID(app);
     pugi::xml_node appName = app.append_child("name");
     GenerateID(appName);
-    appName.append_child(pugi::node_pcdata).set_value("Verovio");
+    appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
     GenerateID(appText);
-    appText.append_child(pugi::node_pcdata).set_value("Transcoded from MusicXML");
+    appText.text().set("Transcoded from MusicXML");
 
     // isodate and version
     time_t t = time(0); // get time now

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2775,7 +2775,16 @@ bool PAEInput::Import(const std::string &input)
     m_hasMeterSig = false;
     m_hasMensur = false;
 
+    m_doc->Reset();
+    m_doc->SetType(Raw);
+
     bool success = true;
+
+    jsonxx::Object header;
+    if (jsonInput.has<jsonxx::Object>("header")) {
+        header = jsonInput.get<jsonxx::Object>("header");
+        ParseHeader(header);
+    }
 
     std::string keySigStr;
     if (jsonInput.has<jsonxx::String>("keysig")) keySigStr = jsonInput.get<jsonxx::String>("keysig");
@@ -2932,8 +2941,6 @@ bool PAEInput::Parse()
         return false;
     }
 
-    m_doc->Reset();
-    m_doc->SetType(Raw);
     // Set the notation type
     if (m_isMensural) m_doc->m_notationType = NOTATIONTYPE_mensural;
     // The mdiv
@@ -3155,6 +3162,11 @@ bool PAEInput::ConvertKeySig()
     }
 
     return true;
+}
+
+void PAEInput::ParseHeader(jsonxx::Object &header)
+{
+    m_doc->GenerateMEIHeader(false);
 }
 
 bool PAEInput::ConvertClef()

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2783,7 +2783,7 @@ bool PAEInput::Import(const std::string &input)
     pugi::xml_node projectDesc = m_doc->m_header.first_child().select_node("//projectDesc").node();
     if (projectDesc) {
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.append_child(pugi::node_pcdata).set_value("Converted from Plaine and Easie to MEI");
+        p1.text().set("Converted from Plaine and Easie to MEI");
     }
 
     bool success = true;
@@ -3189,13 +3189,13 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
     if (!title) title = titleStmt.append_child("title");
 
     if (header.has<jsonxx::String>("source_title")) {
-        title.append_child(pugi::node_pcdata).set_value(header.get<jsonxx::String>("source_title").c_str());
+        title.text().set(header.get<jsonxx::String>("source_title").c_str());
     }
 
     if (header.has<jsonxx::String>("title")) {
         pugi::xml_node subTitle = titleStmt.append_child("title");
         subTitle.append_attribute("type") = "subordinate";
-        subTitle.append_child(pugi::node_pcdata).set_value(header.get<jsonxx::String>("title").c_str());
+        subTitle.text().set(header.get<jsonxx::String>("title").c_str());
         if (header.has<jsonxx::String>("movement")) {
             subTitle.append_attribute("label") = header.get<jsonxx::String>("movement").c_str();
         }
@@ -3203,7 +3203,7 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
 
     if (header.has<jsonxx::String>("composer")) {
         pugi::xml_node composer = titleStmt.append_child("composer");
-        composer.append_child(pugi::node_pcdata).set_value(header.get<jsonxx::String>("composer").c_str());
+        composer.text().set(header.get<jsonxx::String>("composer").c_str());
     }
 
     if (header.has<jsonxx::String>("source_url") || header.has<jsonxx::String>("download_url")) {
@@ -3225,7 +3225,7 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
         jsonxx::Array array = header.get<jsonxx::Array>("notes");
         for (int i = 0; i < (int)array.size(); ++i) {
             pugi::xml_node annot = notesStmt.append_child("annot");
-            annot.append_child(pugi::node_pcdata).set_value(array.get<jsonxx::String>(i).c_str());
+            annot.text().set(array.get<jsonxx::String>(i).c_str());
         }
     }
 
@@ -3237,7 +3237,7 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
         pugi::xml_node work = m_doc->m_header.first_child().append_child("workList").append_child("work");
         pugi::xml_node title = work.append_child("title");
         if (header.has<jsonxx::String>("title")) {
-            title.append_child(pugi::node_pcdata).set_value(header.get<jsonxx::String>("title").c_str());
+            title.text().set(header.get<jsonxx::String>("title").c_str());
         }
         pugi::xml_node incip = work.append_child("incip");
         if (header.has<jsonxx::String>("role")) {
@@ -3268,7 +3268,7 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
             jsonxx::Array array = header.get<jsonxx::Array>("text_incipits");
             for (int i = 0; i < (int)array.size(); ++i) {
                 pugi::xml_node p = incipText.append_child("p");
-                p.append_child(pugi::node_pcdata).set_value(array.get<jsonxx::String>(i).c_str());
+                p.text().set(array.get<jsonxx::String>(i).c_str());
             }
         }
     }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -112,7 +112,7 @@ void SvgDeviceContext::IncludeTextFont(const std::string &fontname, const Resour
 
     pugi::xml_node css = m_svgNode.append_child("style");
     css.append_attribute("type") = "text/css";
-    css.append_child(pugi::node_pcdata).set_value(cssContent.c_str());
+    css.text().set(cssContent.c_str());
 }
 
 void SvgDeviceContext::Commit(bool xml_declaration)
@@ -272,7 +272,7 @@ void SvgDeviceContext::StartGraphic(
         if (att->HasLabel()) {
             pugi::xml_node svgTitle = m_currentNode.prepend_child("title");
             svgTitle.append_attribute("class") = "labelAttr";
-            svgTitle.append_child(pugi::node_pcdata).set_value(att->GetLabel().c_str());
+            svgTitle.text().set(att->GetLabel().c_str());
         }
     }
 
@@ -352,7 +352,7 @@ void SvgDeviceContext::StartTextGraphic(Object *object, std::string gClass, std:
         if (att->HasLabel()) {
             pugi::xml_node svgTitle = m_currentNode.prepend_child("title");
             svgTitle.append_attribute("class") = "labelAttr";
-            svgTitle.append_child(pugi::node_pcdata).set_value(att->GetLabel().c_str());
+            svgTitle.text().set(att->GetLabel().c_str());
         }
     }
 
@@ -455,7 +455,7 @@ void SvgDeviceContext::StartPage()
     if (!m_css.empty()) {
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
-        m_currentNode.append_child(pugi::node_pcdata).set_value(m_css.c_str());
+        m_currentNode.text().set(m_css.c_str());
         m_currentNode = m_svgNodeStack.back();
     }
 
@@ -971,7 +971,7 @@ void SvgDeviceContext::DrawText(
         }
     }
     textChild.append_attribute("class") = "text";
-    textChild.append_child(pugi::node_pcdata).set_value(svgText.c_str());
+    textChild.text().set(svgText.c_str());
 
     if ((x != 0) && (y != 0) && (x != VRV_UNSET) && (y != VRV_UNSET) && (width != 0) && (height != 0)
         && (width != VRV_UNSET) && (height != VRV_UNSET)) {
@@ -1075,7 +1075,7 @@ void SvgDeviceContext::DrawBackgroundImage(int x, int y) {}
 void SvgDeviceContext::AddDescription(const std::string &text)
 {
     pugi::xml_node desc = m_currentNode.append_child("desc");
-    desc.append_child(pugi::node_pcdata).set_value(text.c_str());
+    desc.text().set(text.c_str());
 }
 
 void SvgDeviceContext::AppendIdAndClass(


### PR DESCRIPTION
The `x-header` key can have an object with following metadata (example):
```json
{ 
    "clef": "GG2",
    "keysig": "bBEA",
    "data": "4CDC",
    "x-header": {
            "title": "GLORIA. agadio",
            "composer": "Smith, John (1900-2000)",
            "download_url": "https://rism.online/source/123/incipits/1.1.1/mei",
            "source_url": "https://rism.online/source/123/",
            "movement": "1.1.1",
            "scoring": "vl (1), pno",
            "key_mode": "F# mixolydian",
            "voice_instrument": "Tenor",
            "role": "Evangelist",
            "source_title": "Mass in F# mixolydian",
            "notes": ["Corrected by hand", "Corrected again!"],
            "text_incipits": ["Save me O God and that with speed"]
    }
}
```
Producing the following MEI header
```xml
<meiHead>
   <fileDesc>
      <titleStmt>
         <title>Mass in F# mixolydian</title>
         <title type="subordinate" label="1.1.1">GLORIA. agadio</title>
         <composer>Smith, John (1900-2000)</composer>
      </titleStmt>
      <pubStmt>
         <date isodate="2023-02-17-12:36:32" />
         <identifier>
            <ptr type="rism:Source" target="https://rism.online/source/123/" />
            <ptr type="rism:Incipit" target="https://rism.online/source/123/incipits/1.1.1/mei" />
         </identifier>
      </pubStmt>
      <notesStmt>
         <annot>Corrected by hand</annot>
         <annot>Corrected again!</annot>
      </notesStmt>
   </fileDesc>
   <encodingDesc>
      <appInfo>
         <application xml:id="verovio" version="3.15.0-dev-73b5586-dirty">
            <name>Verovio (3.15.0-dev-73b5586-dirty)</name>
         </application>
      </appInfo>
      <projectDesc>
         <p>MEI encoded with Verovio</p>
         <p>Converted from Plaine and Easie to MEI</p>
      </projectDesc>
   </encodingDesc>
   <workList>
      <work>
         <title>GLORIA. agadio</title>
         <incip>
            <role>Evangelist</role>
            <perfResList>
               <perfRes>Tenor</perfRes>
               <perfRes>vl (1), pno</perfRes>
            </perfResList>
            <key>F# mixolydian</key>
            <incipText>
               <p>Save me O God and that with speed</p>
            </incipText>
         </incip>
      </work>
   </workList>
</meiHead>

```
This will be used in RISM Online to make the RISM Incipits available as MEI with some metadata.