### PR TITLE
Load selected mdiv only

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -753,6 +753,7 @@ public:
 
     OptionArray m_appXPathQuery;
     OptionArray m_choiceXPathQuery;
+    OptionBool m_loadSelectedMdivOnly;
     OptionBool m_mdivAll;
     OptionString m_mdivXPathQuery;
     OptionArray m_substXPathQuery;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4217,6 +4217,9 @@ bool MEIInput::ReadMdivChildren(Object *parent, pugi::xml_node parentNode, bool 
             success = this->ReadMdiv(parent, current, makeVisible);
         }
         else if (std::string(current.name()) == "score") {
+            // Possibly skip content on load
+            if (!isVisible && m_doc->GetOptions()->m_loadSelectedMdivOnly.GetValue()) continue;
+            // Read only the first score
             success = this->ReadScore(parent, current);
             if (parentNode.last_child() != current) {
                 LogWarning("Skipping nodes after <score> element");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1535,6 +1535,11 @@ Options::Options()
     m_choiceXPathQuery.Init();
     this->Register(&m_choiceXPathQuery, "choiceXPathQuery", &m_selectors);
 
+    m_loadSelectedMdivOnly.SetInfo(
+        "Load selected Mdiv only", "Load only the selected mdiv; the content of the other is skipped");
+    m_loadSelectedMdivOnly.Init(false);
+    this->Register(&m_loadSelectedMdivOnly, "loadSelectedMdivOnly", &m_selectors);
+
     m_mdivAll.SetInfo("Mdiv all", "Load and render all <mdiv> elements in the MEI files");
     m_mdivAll.Init(false);
     this->Register(&m_mdivAll, "mdivAll", &m_selectors);


### PR DESCRIPTION
This PR adds an option `--load-selected-mdiv-only`. If switched on, only visible Mdivs are loaded. This reduces the memory peak when dealing with very large files (e.g. symphonies) consisting of several movements.