### PR TITLE
Fix for barline/note overlap

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2150,6 +2150,9 @@ int LayerElement::AdjustXPos(FunctorParams *functorParams)
             params->m_cumulatedXShift += adjust;
             params->m_upcomingMinPos += adjust;
         }
+        else {
+            params->m_upcomingMinPos = std::max(selfRight, params->m_upcomingMinPos);
+        }
     }
     else {
         params->m_upcomingMinPos = std::max(selfRight, params->m_upcomingMinPos);


### PR DESCRIPTION
Fixes a regression caused by #3274

Before:
![image](https://user-images.githubusercontent.com/1819669/220323647-d1344df0-c562-45c8-a072-f296b19fa7ed.png)
After:
![image](https://user-images.githubusercontent.com/1819669/220323793-14ac816a-413f-4392-ba72-cc56eb0150aa.png)
