### PR TITLE
Handle conversion errors in options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -258,6 +258,8 @@ bool OptionDbl::SetValue(const std::string &value)
         number = std::stod(value);
     }
     catch (const std::exception &e) {
+        LogError("Unable to set parameter value %s for '%s'; conversion to double failed", value.c_str(),
+            this->GetKey().c_str());
         return false;
     }
 
@@ -344,6 +346,8 @@ bool OptionInt::SetValue(const std::string &value)
         number = std::stoi(value);
     }
     catch (const std::exception &e) {
+        LogError("Unable to set parameter value %s for '%s'; conversion to integer failed", value.c_str(),
+            this->GetKey().c_str());
         return false;
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -252,7 +252,17 @@ void OptionDbl::Init(double defaultValue, double minValue, double maxValue, bool
 
 bool OptionDbl::SetValue(const std::string &value)
 {
-    return this->SetValue(std::stod(value));
+    // Convert string to double
+    double number = 0.0;
+    try {
+        number = std::stod(value);
+    }
+    catch (const std::exception &e) {
+        return false;
+    }
+
+    // Check bounds and set the value
+    return this->SetValue(number);
 }
 
 std::string OptionDbl::GetStrValue() const
@@ -328,7 +338,17 @@ bool OptionInt::SetValueDbl(double value)
 
 bool OptionInt::SetValue(const std::string &value)
 {
-    return this->SetValue(std::stoi(value));
+    // Convert string to int
+    int number = 0;
+    try {
+        number = std::stoi(value);
+    }
+    catch (const std::exception &e) {
+        return false;
+    }
+
+    // Check bounds and set the value
+    return this->SetValue(number);
 }
 
 std::string OptionInt::GetStrValue() const

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -313,7 +313,6 @@ int main(int argc, char **argv)
     }
 
     int c;
-    int seed = 0;
     std::string key;
     int option_index = 0;
     vrv::Option *opt = NULL;
@@ -367,17 +366,18 @@ int main(int argc, char **argv)
                 break;
 
             case 's':
-                if (!toolkit.SetScale(atoi(optarg))) {
-                    exit(1);
+                if (!options->m_scale.SetValue(optarg)) {
+                    vrv::LogWarning("Setting scale with %s failed, default value used", optarg);
                 }
                 break;
 
             case 'v': show_version = 1; break;
 
             case 'x':
-                seed = atoi(optarg);
-                options->m_xmlIdSeed.SetValue(seed);
-                vrv::Object::SeedID(seed);
+                if (!options->m_xmlIdSeed.SetValue(optarg)) {
+                    vrv::LogWarning("Setting xml seed with %s failed, default value used", optarg);
+                }
+                vrv::Object::SeedID(options->m_xmlIdSeed.GetValue());
                 break;
 
             case 'z':

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -375,7 +375,7 @@ int main(int argc, char **argv)
 
             case 'x':
                 if (!options->m_xmlIdSeed.SetValue(optarg)) {
-                    vrv::LogWarning("Setting xml seed with %s failed, default value used", optarg);
+                    vrv::LogWarning("Setting xml id seed with %s failed, default value used", optarg);
                 }
                 vrv::Object::SeedID(options->m_xmlIdSeed.GetValue());
                 break;


### PR DESCRIPTION
Verovio crashes when passing a non-numeric string to an integer or double option, i.e. `--page-margin-left thirty-three`. This PR improves the error handling and adds error messages for failed numeric conversions.