### PR TITLE
Ensure unique xml IDs

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -651,6 +651,8 @@ public:
 
     static std::string GenerateRandID();
 
+    static uint32_t Hash(uint32_t number, bool reverse = false);
+
     static bool sortByUlx(Object *a, Object *b);
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -12,7 +12,6 @@
 #include <functional>
 #include <iterator>
 #include <map>
-#include <random>
 #include <string>
 
 //----------------------------------------------------------------------------
@@ -647,9 +646,9 @@ public:
     // Static methods //
     //----------------//
 
-    static void SeedID(unsigned int seed = 0);
+    static void SeedID(uint32_t seed = 0);
 
-    static std::string GenerateRandID();
+    static std::string GenerateHashID();
 
     static uint32_t Hash(uint32_t number, bool reverse = false);
 
@@ -1672,9 +1671,9 @@ private:
     static thread_local unsigned long s_objectCounter;
 
     /**
-     * Pseudo random number engine for ID generation
+     * XML id counter
      */
-    static thread_local std::mt19937 s_randomGenerator;
+    static thread_local uint32_t s_xmlIDCounter;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -99,7 +99,7 @@ std::string GetVersion();
  * Encode the integer value using the specified base (max is 62)
  * Base 36 uses 0-9 and a-z, base 62 also A-Z.
  */
-std::string BaseEncodeInt(unsigned int value, unsigned int base);
+std::string BaseEncodeInt(uint32_t value, uint8_t base);
 
 /**
  *

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -547,7 +547,7 @@ void MusicXmlInput::FillSpace(Layer *layer, int dur)
 
 void MusicXmlInput::GenerateID(pugi::xml_node node)
 {
-    std::string id = StringFormat("%s-%s", node.name(), Object::GenerateRandID().c_str()).c_str();
+    std::string id = StringFormat("%s-%s", node.name(), Object::GenerateHashID().c_str()).c_str();
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     node.append_attribute("xml:id").set_value(id.c_str());
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1213,6 +1213,15 @@ std::string Object::GenerateRandID()
     return BaseEncodeInt(nr, 36);
 }
 
+uint32_t Object::Hash(uint32_t number, bool reverse)
+{
+    const uint32_t magicNumber = reverse ? 0x119de1f3 : 0x45d9f3b;
+    number = ((number >> 16) ^ number) * magicNumber;
+    number = ((number >> 16) ^ number) * magicNumber;
+    number = (number >> 16) ^ number;
+    return number;
+}
+
 bool Object::sortByUlx(Object *a, Object *b)
 {
     FacsimileInterface *fa = NULL, *fb = NULL;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -13,6 +13,7 @@
 #include <climits>
 #include <iostream>
 #include <math.h>
+#include <random>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -62,7 +63,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 thread_local unsigned long Object::s_objectCounter = 0;
-thread_local std::mt19937 Object::s_randomGenerator;
+thread_local uint32_t Object::s_xmlIDCounter = 0;
 
 Object::Object() : BoundingBox()
 {
@@ -768,7 +769,7 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
 
 void Object::GenerateID()
 {
-    m_id = m_classIdStr.at(0) + Object::GenerateRandID();
+    m_id = m_classIdStr.at(0) + Object::GenerateHashID();
 }
 
 void Object::ResetID()
@@ -1190,25 +1191,23 @@ Object *Object::FindPreviousChild(Comparison *comp, Object *start)
 // Static methods for Object
 //----------------------------------------------------------------------------
 
-void Object::SeedID(unsigned int seed)
+void Object::SeedID(uint32_t seed)
 {
-    // Init random number generator for ids
     if (seed == 0) {
+        // Random start ID
         std::random_device rd;
-        s_randomGenerator.seed(rd());
+        std::mt19937 randomGenerator(rd());
+        s_xmlIDCounter = randomGenerator();
     }
     else {
-        s_randomGenerator.seed(seed);
+        // Deterministic start ID
+        s_xmlIDCounter = Hash(seed);
     }
 }
 
-std::string Object::GenerateRandID()
+std::string Object::GenerateHashID()
 {
-    unsigned int nr = s_randomGenerator();
-
-    // char str[17];
-    // snprintf(str, 17, "%016d", nr);
-    // return std::string(str);
+    uint32_t nr = Hash(++s_xmlIDCounter);
 
     return BaseEncodeInt(nr, 36);
 }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -71,7 +71,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
 
     m_outdata.clear();
 
-    m_glyphPostfixId = Object::GenerateRandID();
+    m_glyphPostfixId = Object::GenerateHashID();
 }
 
 SvgDeviceContext::~SvgDeviceContext() {}

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -282,7 +282,7 @@ std::string GetVersion()
 
 static const std::string base62Chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-std::string BaseEncodeInt(unsigned int value, unsigned int base)
+std::string BaseEncodeInt(uint32_t value, uint8_t base)
 {
     assert(base > 10);
     assert(base < 63);


### PR DESCRIPTION
So far Verovio generated xml IDs from random 32 bit numbers. Interestingly, even with good pseudo random generators, there is a fair chance to obtain duplicates pretty soon. The probability of having at least one duplicate already hits 1% after 9300 generated IDs:
<img width="1002" alt="birthday-prob" src="https://user-images.githubusercontent.com/63608463/220861006-6b90fd36-bfc9-4e3f-9e86-ac0e4eb80a1c.png">
This is known as [birthday problem](https://en.wikipedia.org/wiki/Birthday_problem). It is not just theory, duplicated IDs were found by Klaus in larger MEI files.

This PR drops the randomness in the ID generation and uses a hash function to calculate deterministic IDs. This ensures uniqueness, since the [hash function used is bijective](https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key). Thus we can have short and unique xml IDs without the need to switch to longer 128 bit UUIDs.