### PR TITLE
Note offset fix

### DIFF
--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1107,7 +1107,7 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
     assert(params);
 
     // Nothing to calculate if note is not part of the chord
-    if (!this->GetParent()->Is(CHORD)) return FUNCTOR_SIBLINGS;
+    if (!this->IsChordTone()) return FUNCTOR_SIBLINGS;
 
     Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     const int staffSize = staff->m_drawingStaffSize;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -1106,6 +1106,9 @@ int Note::CalcChordNoteHeads(FunctorParams *functorParams)
     CalcChordNoteHeadsParams *params = vrv_params_cast<CalcChordNoteHeadsParams *>(functorParams);
     assert(params);
 
+    // Nothing to calculate if note is not part of the chord
+    if (!this->GetParent()->Is(CHORD)) return FUNCTOR_SIBLINGS;
+
     Staff *staff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
     const int staffSize = staff->m_drawingStaffSize;
 


### PR DESCRIPTION
A small fix to make sure that CalcChordNoteHeads method processes only notes that are part of the chord.
Before:
![image](https://user-images.githubusercontent.com/1819669/220937385-ef507192-372c-4461-9cff-6b0a46c98836.png)
After:
![image](https://user-images.githubusercontent.com/1819669/220937445-2c1cad47-99fa-4c7b-b24b-1dd8987254cd.png)
