### PR TITLE
Develop same direction beam overlap

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -952,40 +952,38 @@ int LayerElement::CalcLayerOverlap(const Doc *doc, int direction, int y1, int y2
 
     Staff *staff = this->GetAncestorStaff();
 
+    const int unit = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     int leftMargin = 0;
     int rightMargin = 0;
     std::vector<int> elementOverlaps;
     for (Object *object : collidingElementsList) {
         LayerElement *layerElement = vrv_cast<LayerElement *>(object);
         if (!this->HorizontalContentOverlap(object)) continue;
+        const int elementBottom = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true);
+        const int elementTop = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true);
         if (direction > 0) {
             // make sure that there's actual overlap first
-            if ((layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) > y1)
-                && (layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) > y2))
-                continue;
-            leftMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y1;
-            rightMargin = layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) - y2;
+            if ((elementBottom > y1) && (elementBottom > y2)) continue;
+            leftMargin = elementTop - y1;
+            rightMargin = elementTop - y2;
         }
         else {
             // make sure that there's actual overlap first
-            if ((layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) < y1)
-                && (layerElement->GetDrawingTop(doc, staff->m_drawingStaffSize, true) < y2))
-                continue;
-            leftMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y1;
-            rightMargin = layerElement->GetDrawingBottom(doc, staff->m_drawingStaffSize, true) - y2;
+            if ((elementTop < y1) && (elementTop < y2)) continue;
+            leftMargin = elementBottom - y1;
+            rightMargin = elementBottom - y2;
         }
         elementOverlaps.emplace_back(std::max(leftMargin * direction, rightMargin * direction));
     }
     if (elementOverlaps.empty()) return 0;
 
-    const int staffOffset = doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const auto maxOverlap = std::max_element(elementOverlaps.begin(), elementOverlaps.end());
     int overlap = 0;
     if (*maxOverlap >= 0) {
-        overlap = ((*maxOverlap == 0) ? staffOffset : *maxOverlap) * direction;
+        overlap = ((*maxOverlap == 0) ? unit : *maxOverlap) * direction;
     }
     else {
-        int maxShorteningInHalfUnits = (std::abs(*maxOverlap) / staffOffset) * 2;
+        int maxShorteningInHalfUnits = (std::abs(*maxOverlap) / unit) * 2;
         if (maxShorteningInHalfUnits > 0) --maxShorteningInHalfUnits;
         this->SetElementShortening(maxShorteningInHalfUnits);
     }


### PR DESCRIPTION
closes #3068 

There is still a problem with overlapping articulation in the last measure, but I don’t think that’s something that can be changed in current context. Making beams any more shorter that they already is would make them look silly.
![image](https://user-images.githubusercontent.com/1819669/221144906-d578dff5-094b-4798-b205-4c021bd83e8f.png)
