### PR TITLE
Flexible alignment of octave accidentals

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -177,6 +177,27 @@ public:
     }
 };
 
+//----------------------------------------------------------------------------
+// AccidOctaveSort
+//----------------------------------------------------------------------------
+
+/**
+ * Equivalence of accidentals that are an octave apart
+ */
+class AccidOctaveSort {
+
+public:
+    AccidOctaveSort() = default;
+
+    // Encodes parent ID + accid type + pitch
+    std::string GetOctaveID(const Accid *accid) const;
+
+    bool operator()(const Accid *first, const Accid *second) const
+    {
+        return this->GetOctaveID(first) < this->GetOctaveID(second);
+    }
+};
+
 } // namespace vrv
 
 #endif

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -62,17 +62,6 @@ public:
     bool HasToBeAligned() const override { return true; }
 
     /**
-     * @name Set and get drawing octave flag
-     */
-    ///@{
-    void SetDrawingOctave(bool isDrawingOctave) { m_isDrawingOctave = isDrawingOctave; }
-    bool GetDrawingOctave() const { return m_isDrawingOctave; }
-    void SetDrawingOctaveAccid(Accid *drawingOctave) { m_drawingOctave = drawingOctave; }
-    Accid *GetDrawingOctaveAccid() { return m_drawingOctave; }
-    const Accid *GetDrawingOctaveAccid() const { return m_drawingOctave; }
-    ///@}
-
-    /**
      * @name Set and get drawing unison accid
      */
     ///@{
@@ -91,7 +80,7 @@ public:
      * Adjust X position of accid in relation to other element
      */
     void AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
-        std::vector<Accid *> &adjustedAccids);
+        std::set<Accid *> &adjustedAccids);
 
     /**
      * Adjust accid position if it's placed above/below staff so that it does not overlap with ledger lines
@@ -141,9 +130,7 @@ private:
 public:
     //
 private:
-    Accid *m_drawingOctave;
     Accid *m_drawingUnison;
-    bool m_isDrawingOctave;
     bool m_alignedWithSameLayer;
 };
 

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -139,27 +139,21 @@ private:
 //----------------------------------------------------------------------------
 
 /**
- * Sort Object by drawing Y value or by layerN
+ * Sort Object by drawing Y value
  */
 class AccidSpaceSort {
 
 public:
-    AccidSpaceSort() {}
+    AccidSpaceSort() = default;
 
     bool operator()(const Accid *first, const Accid *second) const
     {
-        if (first->GetDrawingY() < second->GetDrawingY()) {
-            return true;
-        }
-        else if (first->GetDrawingY() > second->GetDrawingY()) {
-            return false;
+        if (first->GetDrawingY() == second->GetDrawingY()) {
+            // with unissons, natural should always be the last accidental
+            return ((first->GetAccid() == ACCIDENTAL_WRITTEN_n) && (second->GetAccid() != ACCIDENTAL_WRITTEN_n));
         }
         else {
-            // with unissons, natural should always be the last accidental (assuming there is a natural)
-            if ((first->GetAccid() == ACCIDENTAL_WRITTEN_n) || (second->GetAccid() == ACCIDENTAL_WRITTEN_n)) {
-                return (first->GetAccid() != ACCIDENTAL_WRITTEN_n);
-            }
-            return first->GetDrawingY() < second->GetDrawingY();
+            return (first->GetDrawingY() > second->GetDrawingY());
         }
     }
 };

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -329,9 +329,9 @@ public:
     void AddToAccidSpace(Accid *accid);
 
     /**
-     * See Object::AjustAccidX
+     * See Object::AdjustAccidX
      */
-    void AdjustAccidWithAccidSpace(Accid *accid, const Doc *doc, int staffSize, std::vector<Accid *> &adjustedAccids);
+    void AdjustAccidWithAccidSpace(Accid *accid, const Doc *doc, int staffSize, std::set<Accid *> &adjustedAccids);
 
     /**
      * Return true if one of objects overlaps with accidentals from current reference (i.e. if there are accidentals)

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -112,7 +112,6 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
 
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
-    const int verticalMargin = unit / 4;
 
     // Reduce spacing for successive accidentals
     if (element->Is(ACCID)) {
@@ -128,7 +127,7 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
         }
     }
 
-    if (!this->VerticalSelfOverlap(element, 0)) {
+    if (!this->VerticalSelfOverlap(element)) {
         this->AdjustToLedgerLines(doc, element, staffSize);
         return;
     }
@@ -145,6 +144,7 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
         }
     }
 
+    const int verticalMargin = unit / 4;
     if (element->Is(ACCID)) {
         Accid *accid = vrv_cast<Accid *>(element);
         if (!this->HorizontalLeftOverlap(element, doc, horizontalMargin, verticalMargin)) {

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -302,4 +302,21 @@ int Accid::ResetHorizontalAlignment(FunctorParams *functorParams)
     return FUNCTOR_CONTINUE;
 }
 
+//----------------------------------------------------------------------------
+// AccidOctaveSort
+//----------------------------------------------------------------------------
+
+std::string AccidOctaveSort::GetOctaveID(const Accid *accid) const
+{
+    const Note *note = vrv_cast<const Note *>(accid->GetFirstAncestor(NOTE));
+    assert(note);
+    const Chord *chord = note->IsChordTone();
+
+    std::string octaveID = chord ? chord->GetID() : note->GetID();
+    octaveID += "-" + std::to_string(accid->GetAccid());
+    octaveID += "-" + std::to_string(note->GetPname());
+
+    return octaveID;
+}
+
 } // namespace vrv

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -112,7 +112,6 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
 
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
-
     // Reduce spacing for successive accidentals
     if (element->Is(ACCID)) {
         horizontalMargin *= 0.66;
@@ -126,8 +125,9 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
             horizontalMargin = std::max(horizontalMargin, value);
         }
     }
+    const int verticalMargin = unit / 4;
 
-    if (!this->VerticalSelfOverlap(element)) {
+    if (!this->VerticalSelfOverlap(element, verticalMargin)) {
         this->AdjustToLedgerLines(doc, element, staffSize);
         return;
     }
@@ -144,7 +144,6 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
         }
     }
 
-    const int verticalMargin = unit / 4;
     if (element->Is(ACCID)) {
         Accid *accid = vrv_cast<Accid *>(element);
         if (!this->HorizontalLeftOverlap(element, doc, horizontalMargin, verticalMargin)) {

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -103,7 +103,7 @@ void Accid::AdjustToLedgerLines(const Doc *doc, LayerElement *element, int staff
 }
 
 void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::vector<Accid *> &leftAccids,
-    std::vector<Accid *> &adjustedAccids)
+    std::set<Accid *> &adjustedAccids)
 {
     assert(element);
     assert(doc);
@@ -152,7 +152,7 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
             leftAccids.push_back(accid);
             return;
         }
-        if (std::find(adjustedAccids.begin(), adjustedAccids.end(), accid) == adjustedAccids.end()) return;
+        if (adjustedAccids.count(accid) == 0) return;
     }
 
     int xRelShift = 0;
@@ -166,8 +166,7 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
     // Move only to the left
     if (xRelShift > 0) {
         this->SetDrawingXRel(this->GetDrawingXRel() - xRelShift);
-        if (std::find(adjustedAccids.begin(), adjustedAccids.end(), this) == adjustedAccids.end())
-            adjustedAccids.push_back(this);
+        adjustedAccids.insert(this);
         // We have some accidentals on the left, check again with all of these
         if (!leftAccids.empty()) {
             std::vector<Accid *> leftAccidsSubset;
@@ -295,8 +294,6 @@ int Accid::ResetHorizontalAlignment(FunctorParams *functorParams)
     LayerElement::ResetHorizontalAlignment(functorParams);
     PositionInterface::InterfaceResetHorizontalAlignment(functorParams, this);
 
-    m_isDrawingOctave = false;
-    m_drawingOctave = NULL;
     m_drawingUnison = NULL;
 
     return FUNCTOR_CONTINUE;

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -112,6 +112,8 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
 
     const int unit = doc->GetDrawingUnit(staffSize);
     int horizontalMargin = doc->GetRightMargin(ACCID) * unit;
+    const int verticalMargin = unit / 4;
+
     // Reduce spacing for successive accidentals
     if (element->Is(ACCID)) {
         horizontalMargin *= 0.66;
@@ -125,9 +127,8 @@ void Accid::AdjustX(LayerElement *element, const Doc *doc, int staffSize, std::v
             horizontalMargin = std::max(horizontalMargin, value);
         }
     }
-    const int verticalMargin = unit / 4;
 
-    if (!this->VerticalSelfOverlap(element, verticalMargin)) {
+    if (!this->VerticalSelfOverlap(element, 0)) {
         this->AdjustToLedgerLines(doc, element, staffSize);
         return;
     }

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1515,7 +1515,7 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
     }
 
     const int count = (int)m_accidSpace.size();
-    const int middle = (count % 2) ? (count / 2) + 1 : (count / 2);
+    const int middle = (count / 2) + (count % 2);
     // Zig-zag processing
     for (int i = 0, j = count - 1; i < middle; ++i, --j) {
         // top one - but skip if already adjusted (i.e. octaves)

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1516,16 +1516,16 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
     // Zig-zag processing
     for (int i = 0, j = count - 1; i < middle; ++i, --j) {
         // top one - but skip if already adjusted (i.e. octaves)
-        if (adjustedAccids.count(m_accidSpace.at(j)) == 0) {
-            this->AdjustAccidWithAccidSpace(m_accidSpace.at(j), params->m_doc, staffSize, adjustedAccids);
+        if (adjustedAccids.count(m_accidSpace.at(i)) == 0) {
+            this->AdjustAccidWithAccidSpace(m_accidSpace.at(i), params->m_doc, staffSize, adjustedAccids);
         }
 
         // Break with odd number of elements once the middle is reached
         if (i == j) break;
 
         // bottom one - but skip if already adjusted
-        if (adjustedAccids.count(m_accidSpace.at(i)) == 0) {
-            this->AdjustAccidWithAccidSpace(m_accidSpace.at(i), params->m_doc, staffSize, adjustedAccids);
+        if (adjustedAccids.count(m_accidSpace.at(j)) == 0) {
+            this->AdjustAccidWithAccidSpace(m_accidSpace.at(j), params->m_doc, staffSize, adjustedAccids);
         }
     }
 

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -1496,11 +1496,14 @@ int AlignmentReference::AdjustAccidX(FunctorParams *functorParams)
             this->AdjustAccidWithAccidSpace(*octaveIter, params->m_doc, staffSize, adjustedAccids);
             minDrawingX = std::min(minDrawingX, (*octaveIter)->GetDrawingX());
         }
-        // Finally, align the accidentals
+        // Finally, align the accidentals whenever the adjustment is not too large
         for (auto octaveIter = range.first; octaveIter != range.second; ++octaveIter) {
             const int dist = (*octaveIter)->GetDrawingX() - minDrawingX;
-            if (dist > 0) {
-                (*octaveIter)->SetDrawingXRel((*octaveIter)->GetDrawingXRel() - dist);
+            if ((dist > 0) && (*octaveIter)->HasContentHorizontalBB()) {
+                const int accidWidth = (*octaveIter)->GetContentRight() - (*octaveIter)->GetContentLeft();
+                if (dist < accidWidth / 2) {
+                    (*octaveIter)->SetDrawingXRel((*octaveIter)->GetDrawingXRel() - dist);
+                }
             }
         }
     }


### PR DESCRIPTION
With this PR octave accidentals are aligned only, if the resulting shift is small.

In the following example the alignment is triggered in the second chord, among the flats in the third chord, but not in the first chord.

| Before | After |
| ------ | ----- |
| <img width="423" alt="Before" src="https://user-images.githubusercontent.com/63608463/221796157-d40c4e06-581e-4bad-8b5c-7f4cffbb80c9.png"> | <img width="422" alt="After" src="https://user-images.githubusercontent.com/63608463/221796214-08fc1c63-43c7-4dfe-9b8e-6e6c43422896.png"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>accidentals in chords with adjacent notes</title>
         </titleStmt>
         <pubStmt />
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note oct="6" pname="d" accid="f" />
                              <note oct="5" pname="c" />
                              <note oct="5" pname="d" accid="f" />
                              <note oct="4" pname="d" accid="f" />
                           </chord>
                           <chord dur="4">
                              <note oct="6" pname="d" accid="f" />
                              <note oct="5" pname="d" accid="f" />
                              <note oct="4" pname="d" accid="f" />
                           </chord>
                           <chord dur="4">
                              <note oct="6" pname="d" accid="f" />
                              <note oct="5" pname="d" accid="s" />
                              <note oct="4" pname="d" accid="f" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

Closes #3276 .

<img width="242" alt="Issue" src="https://user-images.githubusercontent.com/63608463/221796806-cb766d02-f317-4131-b69e-8364d1303249.png">

On the technical side, we get rid of the members `m_isDrawingOctave` and `m_drawingOctave` which saves a bit of memory. Also we track `adjustedAccids` as set which is more suitable.

