### PR TITLE
Enclosed octave numbers

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -716,6 +716,7 @@ public:
     OptionDbl m_multiRestThickness;
     OptionBool m_octaveAlternativeSymbols;
     OptionDbl m_octaveLineThickness;
+    OptionBool m_octaveNoSpanningParenthesis;
     OptionDbl m_pedalLineThickness;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -716,7 +716,7 @@ public:
     OptionDbl m_multiRestThickness;
     OptionBool m_octaveAlternativeSymbols;
     OptionDbl m_octaveLineThickness;
-    OptionBool m_octaveNoSpanningParenthesis;
+    OptionBool m_octaveNoSpanningParentheses;
     OptionDbl m_pedalLineThickness;
     OptionDbl m_repeatBarLineDotSeparation;
     OptionDbl m_repeatEndingLineThickness;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1396,10 +1396,10 @@ Options::Options()
     m_octaveLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_octaveLineThickness, "octaveLineThickness", &m_generalLayout);
 
-    m_octaveNoSpanningParenthesis.SetInfo(
+    m_octaveNoSpanningParentheses.SetInfo(
         "No parentheses on spanning octaves", "Do not enclose octaves that are spanning over systems with parentheses.");
-    m_octaveNoSpanningParenthesis.Init(false);
-    this->Register(&m_octaveNoSpanningParenthesis, "octaveNoSpanningParenthesis", &m_generalLayout);
+    m_octaveNoSpanningParentheses.Init(false);
+    this->Register(&m_octaveNoSpanningParentheses, "octaveNoSpanningParentheses", &m_generalLayout);
 
     m_pedalLineThickness.SetInfo("Pedal line thickness", "The thickness of the line used for piano pedaling");
     m_pedalLineThickness.Init(0.20, 0.10, 1.00);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1396,6 +1396,11 @@ Options::Options()
     m_octaveLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_octaveLineThickness, "octaveLineThickness", &m_generalLayout);
 
+    m_octaveNoSpanningParenthesis.SetInfo(
+        "No parentheses on spanning octaves", "Do not enclose octaves that are spanning over systems with parentheses.");
+    m_octaveNoSpanningParenthesis.Init(false);
+    this->Register(&m_octaveNoSpanningParenthesis, "octaveNoSpanningParenthesis", &m_generalLayout);
+
     m_pedalLineThickness.SetInfo("Pedal line thickness", "The thickness of the line used for piano pedaling");
     m_pedalLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_pedalLineThickness, "pedalLineThickness", &m_generalLayout);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1396,8 +1396,8 @@ Options::Options()
     m_octaveLineThickness.Init(0.20, 0.10, 1.00);
     this->Register(&m_octaveLineThickness, "octaveLineThickness", &m_generalLayout);
 
-    m_octaveNoSpanningParentheses.SetInfo(
-        "No parentheses on spanning octaves", "Do not enclose octaves that are spanning over systems with parentheses.");
+    m_octaveNoSpanningParentheses.SetInfo("No parentheses on spanning octaves",
+        "Do not enclose octaves that are spanning over systems with parentheses.");
     m_octaveNoSpanningParentheses.Init(false);
     this->Register(&m_octaveNoSpanningParentheses, "octaveNoSpanningParentheses", &m_generalLayout);
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -673,7 +673,7 @@ void View::DrawOctave(
 
     if ((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE)) {
         x1 += (m_doc->GetGlyphWidth(SMUFL_E0A2_noteheadWhole, staff->m_drawingStaffSize, false) / 2);
-        if (!m_doc->GetOptions()->m_octaveNoSpanningParenthesis.GetValue()) {
+        if (!m_doc->GetOptions()->m_octaveNoSpanningParentheses.GetValue()) {
             x1 += m_doc->GetGlyphWidth(SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
         }
     }
@@ -707,7 +707,7 @@ void View::DrawOctave(
     const int octaveX = altSymbols ? x1 - extend.m_width / 2 : x1 - extend.m_width;
     this->DrawSmuflCode(dc, octaveX, yCode, code, staff->m_drawingStaffSize, false);
     if (((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE))
-        && !m_doc->GetOptions()->m_octaveNoSpanningParenthesis.GetValue()) {
+        && !m_doc->GetOptions()->m_octaveNoSpanningParentheses.GetValue()) {
         const int leftWidth = m_doc->GetGlyphWidth(SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
         const int rightWidth = m_doc->GetGlyphWidth(SMUFL_E51B_octaveParensRight, staff->m_drawingStaffSize, false);
         const int octaveWidth = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, false);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -715,7 +715,7 @@ void View::DrawOctave(
             dc, octaveX - leftWidth, yCode, SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
         this->DrawSmuflCode(
             dc, octaveX + octaveWidth, yCode, SMUFL_E51B_octaveParensRight, staff->m_drawingStaffSize, false);
-        x1 += rightWidth / 2;
+        x1 += rightWidth;
     }
     dc->ResetFont();
 
@@ -724,7 +724,7 @@ void View::DrawOctave(
         const int gap = lineWidth * 4;
 
         // adjust is to avoid the figure to touch the line
-        x1 += m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) + lineWidth;
+        x1 += lineWidth;
         if (altSymbols) x1 += extend.m_width / 2;
 
         dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, gap, AxCAP_SQUARE);
@@ -749,11 +749,14 @@ void View::DrawOctave(
         y1 += (disPlace == STAFFREL_basic_above) ? -lineWidth / 2 : lineWidth / 2;
         y2 = (disPlace == STAFFREL_basic_above) ? y1 - unit * 2 : y1 + unit * 2;
 
-        if (x1 > x2) {
+        if (x1 + unit > x2) {
             // make sure we have a minimal extender line
-            x2 = x1 + lineWidth + m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            x2 = x1 + unit - lineWidth / 2;
         }
-        dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
+        else {
+            dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
+        }
+
         octave->SetDrawingExtenderX(x1, x2);
 
         if (octave->GetLendsym() != LINESTARTENDSYMBOL_none) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -667,11 +667,15 @@ void View::DrawOctave(
 
     int y1 = octave->GetDrawingY();
     int y2 = y1;
+    const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
     /********** adjust the start / end positions ***********/
 
     if ((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE)) {
         x1 += (m_doc->GetGlyphWidth(SMUFL_E0A2_noteheadWhole, staff->m_drawingStaffSize, false) / 2);
+        if (!m_doc->GetOptions()->m_octaveNoSpanningParenthesis.GetValue()) {
+            x1 += m_doc->GetGlyphWidth(SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
+        }
     }
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
@@ -702,10 +706,20 @@ void View::DrawOctave(
     const int yCode = (disPlace == STAFFREL_basic_above) ? y1 - extend.m_height : y1;
     const int octaveX = altSymbols ? x1 - extend.m_width / 2 : x1 - extend.m_width;
     this->DrawSmuflCode(dc, octaveX, yCode, code, staff->m_drawingStaffSize, false);
+    if (((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE))
+        && !m_doc->GetOptions()->m_octaveNoSpanningParenthesis.GetValue()) {
+        const int leftWidth = m_doc->GetGlyphWidth(SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
+        const int rightWidth = m_doc->GetGlyphWidth(SMUFL_E51B_octaveParensRight, staff->m_drawingStaffSize, false);
+        const int octaveWidth = m_doc->GetGlyphWidth(code, staff->m_drawingStaffSize, false);
+        this->DrawSmuflCode(
+            dc, octaveX - leftWidth, yCode, SMUFL_E51A_octaveParensLeft, staff->m_drawingStaffSize, false);
+        this->DrawSmuflCode(
+            dc, octaveX + octaveWidth, yCode, SMUFL_E51B_octaveParensRight, staff->m_drawingStaffSize, false);
+        x1 += rightWidth / 2;
+    }
     dc->ResetFont();
 
     if (octave->GetExtender() != BOOLEAN_false) {
-        const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         const int lineWidth = octave->GetLineWidth(m_doc, unit);
         const int gap = lineWidth * 4;
 


### PR DESCRIPTION
Changed code to enclose octave numbers in parentheses when they are spanning systems.
![image](https://user-images.githubusercontent.com/1819669/221921761-4a786ded-b9f2-4a27-85bc-6228b720ffdf.png)

Added option `--octave-no-spanning-parentheses` has been added (disabled by default). It allows drawing octave numbers as before - without parentheses.
