### PR TITLE
Fix order of children in the MEI output

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -370,6 +370,18 @@ public:
     virtual void AddChild(Object *object);
 
     /**
+     * Return the child order for a the given ClassId.
+     * By default, a child is added at the end, but a class can override the method to order them.
+     * The overriden method specifies a static vector with the expected order of ClassIds.
+     */
+    virtual int GetInsertOrderFor(ClassId classId) const { return VRV_UNSET; }
+
+    /**
+     * Find the order from an overriden GetInsertOrderFor method.
+     */
+    int GetInsertOrderForIn(ClassId classId, const std::vector<ClassId> &order) const;
+
+    /**
      * Return the index position of the object in its parent (-1 if not found)
      */
     int GetIdx() const;

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -149,7 +149,15 @@ public:
     std::string GetClassName() const override { return "ScoreDef"; }
     ///@}
 
+    /**
+     * Check if a object is allowed as child.
+     */
     bool IsSupportedChild(Object *object) override;
+
+    /**
+     * Return an order for the given ClassId.
+     */
+    int GetInsertOrderFor(ClassId classId) const override;
 
     /**
      * Replace the scoreDef with the content of the newScoreDef.

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -53,6 +53,11 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
+     * Return an order for the given ClassId.
+     */
+    int GetInsertOrderFor(ClassId classId) const override;
+
+    /**
      * @name Setter and getter of the drawing visible flag
      */
     ///@{

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -58,6 +58,11 @@ public:
     ///@}
 
     /**
+     * Return an order for the given ClassId.
+     */
+    int GetInsertOrderFor(ClassId classId) const override;
+
+    /**
      * @name Setter and getter of the drawing visible flag
      */
     ///@{

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -802,8 +802,27 @@ void Object::AddChild(Object *child)
     }
 
     child->SetParent(this);
-    m_children.push_back(child);
+    const int insertOrder = this->GetInsertOrderFor(child->GetClassId());
+    if (m_children.empty() || insertOrder == VRV_UNSET) {
+        m_children.push_back(child);
+    }
+    else {
+        int i = 0;
+        for (const Object *existingChild : m_children) {
+            if (this->GetInsertOrderFor(existingChild->GetClassId()) > insertOrder) break;
+            ++i;
+        }
+        i = std::min(i, (int)m_children.size());
+        m_children.insert(m_children.begin() + i, child);
+    }
     Modify();
+}
+
+int Object::GetInsertOrderForIn(ClassId classId, const std::vector<ClassId> &order) const
+{
+    std::vector<ClassId>::const_iterator classIdIt = std::find(order.begin(), order.end(), classId);
+    if (classIdIt == order.end()) return VRV_UNSET;
+    return static_cast<int>(std::distance(order.begin(), classIdIt));
 }
 
 int Object::GetDrawingX() const

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -803,13 +803,15 @@ void Object::AddChild(Object *child)
 
     child->SetParent(this);
     const int insertOrder = this->GetInsertOrderFor(child->GetClassId());
+    // no child or no order specify, the child is appended at the end
     if (m_children.empty() || insertOrder == VRV_UNSET) {
         m_children.push_back(child);
     }
     else {
         int i = 0;
         for (const Object *existingChild : m_children) {
-            if (this->GetInsertOrderFor(existingChild->GetClassId()) > insertOrder) break;
+            // By doing abs() we convert VRV_UNSET to a positive and insert anything with an insertOrder before it
+            if (abs(this->GetInsertOrderFor(existingChild->GetClassId())) > insertOrder) break;
             ++i;
         }
         i = std::min(i, (int)m_children.size());

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -272,6 +272,7 @@ bool ScoreDef::IsSupportedChild(Object *child)
     else if (child->Is(STAFFGRP)) {
         assert(dynamic_cast<StaffGrp *>(child));
     }
+    // Mensur is actually not allowed as child of scoreDef in MEI
     else if (child->Is(MENSUR)) {
         assert(dynamic_cast<Mensur *>(child));
     }
@@ -297,7 +298,7 @@ int ScoreDef::GetInsertOrderFor(ClassId classId) const
 {
 
     static const std::vector s_order(
-        { SYMBOLTABLE, CLEF, KEYSIG, METERSIGGRP, METERSIG, PGHEAD, PGFOOT, PGHEAD2, PGFOOT2, STAFFGRP, GRPSYM });
+        { SYMBOLTABLE, CLEF, KEYSIG, METERSIGGRP, METERSIG, MENSUR, PGHEAD, PGFOOT, PGHEAD2, PGFOOT2, STAFFGRP, GRPSYM });
     return this->GetInsertOrderForIn(classId, s_order);
 }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -297,8 +297,8 @@ bool ScoreDef::IsSupportedChild(Object *child)
 int ScoreDef::GetInsertOrderFor(ClassId classId) const
 {
 
-    static const std::vector s_order(
-        { SYMBOLTABLE, CLEF, KEYSIG, METERSIGGRP, METERSIG, MENSUR, PGHEAD, PGFOOT, PGHEAD2, PGFOOT2, STAFFGRP, GRPSYM });
+    static const std::vector s_order({ SYMBOLTABLE, CLEF, KEYSIG, METERSIGGRP, METERSIG, MENSUR, PGHEAD, PGFOOT,
+        PGHEAD2, PGFOOT2, STAFFGRP, GRPSYM });
     return this->GetInsertOrderForIn(classId, s_order);
 }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -259,6 +259,7 @@ void ScoreDef::Reset()
 
 bool ScoreDef::IsSupportedChild(Object *child)
 {
+    // Clef is actually not allowed as child of scoreDef in MEI
     if (child->Is(CLEF)) {
         assert(dynamic_cast<Clef *>(child));
     }
@@ -293,6 +294,14 @@ bool ScoreDef::IsSupportedChild(Object *child)
         return false;
     }
     return true;
+}
+
+int ScoreDef::GetInsertOrderFor(ClassId classId) const
+{
+
+    static const std::vector s_order(
+        { SYMBOLTABLE, CLEF, KEYSIG, METERSIGGRP, METERSIG, PGHEAD, PGFOOT, PGHEAD2, PGFOOT2, STAFFGRP, GRPSYM });
+    return this->GetInsertOrderForIn(classId, s_order);
 }
 
 void ScoreDef::ReplaceDrawingValues(const ScoreDef *newScoreDef)

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -281,9 +281,6 @@ bool ScoreDef::IsSupportedChild(Object *child)
     else if (child->Is(METERSIGGRP)) {
         assert(dynamic_cast<MeterSigGrp *>(child));
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
-    }
     else if (child->IsRunningElement()) {
         assert(dynamic_cast<RunningElement *>(child));
     }

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -114,6 +114,13 @@ bool StaffDef::IsSupportedChild(Object *child)
     return true;
 }
 
+int StaffDef::GetInsertOrderFor(ClassId classId) const
+{
+    // Anything else goes at the end
+    static const std::vector s_order({ LABEL, LABELABBR });
+    return this->GetInsertOrderForIn(classId, s_order);
+}
+
 bool StaffDef::HasLayerDefWithLabel() const
 {
     // First get all the staffGrps

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -97,6 +97,13 @@ bool StaffGrp::IsSupportedChild(Object *child)
     return true;
 }
 
+int StaffGrp::GetInsertOrderFor(ClassId classId) const
+{
+    // Anything else goes at the end
+    static const std::vector s_order({ GRPSYM, LABEL, LABELABBR, INSTRDEF });
+    return this->GetInsertOrderForIn(classId, s_order);
+}
+
 void StaffGrp::FilterList(ListOfConstObjects &childList) const
 {
     // We want to keep only staffDef


### PR DESCRIPTION
The PR adds a `Object::GetInsertOrderFor` virtual method for controlling order of the children in some classes. This fixes cases where the data would not be valid because of wrong order of the children.

When overriding `GetInsertOrderFor` we can specify some requirements. Eg:
```cpp
int StaffGrp::GetInsertOrderFor(ClassId classId) const
{
    // Anything else goes at the end
    static const std::vector s_order({ GRPSYM, LABEL, LABELABBR, INSTRDEF });
    return this->GetInsertOrderForIn(classId, s_order);
}
```

This is not perfect but will fix most of the issues.