### PR TITLE
Improve delayed turns

### DIFF
--- a/include/vrv/functorparams.h
+++ b/include/vrv/functorparams.h
@@ -2200,10 +2200,12 @@ public:
     {
         m_initMap = true;
         m_previousElement = NULL;
+        m_currentChord = NULL;
         m_currentTurn = NULL;
     }
     bool m_initMap;
     LayerElement *m_previousElement;
+    Chord *m_currentChord;
     Turn *m_currentTurn;
     std::map<LayerElement *, Turn *> m_delayedTurns;
 };

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2409,7 +2409,7 @@ int LayerElement::PrepareDelayedTurns(FunctorParams *functorParams)
 
     if (params->m_previousElement) {
         assert(params->m_currentTurn);
-        if (this->Is(NOTE)) {
+        if (this->Is(NOTE) && params->m_currentChord) {
             Note *note = vrv_cast<Note *>(this);
             if (note->IsChordTone() == params->m_currentChord) return FUNCTOR_CONTINUE;
         }

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -2409,7 +2409,12 @@ int LayerElement::PrepareDelayedTurns(FunctorParams *functorParams)
 
     if (params->m_previousElement) {
         assert(params->m_currentTurn);
+        if (this->Is(NOTE)) {
+            Note *note = vrv_cast<Note *>(this);
+            if (note->IsChordTone() == params->m_currentChord) return FUNCTOR_CONTINUE;
+        }
         params->m_currentTurn->m_drawingEndElement = this;
+        params->m_currentChord = NULL;
         params->m_currentTurn = NULL;
         params->m_previousElement = NULL;
     }
@@ -2417,6 +2422,14 @@ int LayerElement::PrepareDelayedTurns(FunctorParams *functorParams)
     if (params->m_delayedTurns.count(this)) {
         params->m_previousElement = this;
         params->m_currentTurn = params->m_delayedTurns.at(this);
+        if (this->Is(CHORD)) {
+            return FUNCTOR_SIBLINGS;
+        }
+        else if (this->Is(NOTE)) {
+            Note *note = vrv_cast<Note *>(this);
+            Chord *chord = note->IsChordTone();
+            if (chord) params->m_currentChord = chord;
+        }
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
closes #3266 

Delayed turns now work with both chords (didn’t work before) and notes within chords:
![image](https://user-images.githubusercontent.com/1819669/222461631-2586a17a-c485-4e00-9e39-832d740fd2ae.png)
