### PR TITLE
Only shrink to fit

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -76,7 +76,7 @@ void View::DrawCurrentPage(DeviceContext *dc, bool background)
     // The page one has previously been set by Object::ScoreDefSetCurrent
     m_drawingScoreDef = m_currentPage->m_drawingScoreDef;
 
-    if (m_options->m_shrinkToFit.GetValue()) {
+    if ((m_doc->GetAdjustedDrawingPageHeight() > dc->GetHeight()) && m_options->m_shrinkToFit.GetValue()) {
         dc->SetContentHeight(m_doc->GetAdjustedDrawingPageHeight());
     }
     else {


### PR DESCRIPTION
The `shrinkToFit` option lead to vertically centered content when it did not fill the page. This small fix extends the viewBox only if the content actually exceeds the page height.