### PR TITLE
Extend collision avoidance for inner slurs

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -141,8 +141,12 @@ bool Slur::HasInnerSlur(const Slur *innerSlur) const
     const LayerElement *innerEnd = innerSlur->GetEnd();
     if (!innerStart || !innerEnd) return false;
 
-    if (std::abs(start->GetAlignmentLayerN()) != std::abs(innerStart->GetAlignmentLayerN())) return false;
-    if (std::abs(end->GetAlignmentLayerN()) != std::abs(innerEnd->GetAlignmentLayerN())) return false;
+    std::set<int> admissibleLayers = { std::abs(start->GetAlignmentLayerN()), std::abs(end->GetAlignmentLayerN()) };
+    std::set<int> innerLayers
+        = { std::abs(innerStart->GetAlignmentLayerN()), std::abs(innerEnd->GetAlignmentLayerN()) };
+    if (!std::includes(admissibleLayers.begin(), admissibleLayers.end(), innerLayers.begin(), innerLayers.end())) {
+        return false;
+    }
 
     // Check the alignment
     if (this->IsOrdered(innerStart, start) || this->IsOrdered(end, innerEnd)) return false;

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -1056,12 +1056,10 @@ int StaffAlignment::AdjustSlurs(FunctorParams *functorParams)
             if (i == j) continue;
             Slur *secondSlur = vrv_cast<Slur *>(positioners[j]->GetObject());
             // Check if second slur is inner slur of first
-            if (!positioners[i]->IsCrossStaff() && !positioners[j]->IsCrossStaff()) {
-                if (positioners[j]->GetSpanningType() == SPANNING_START_END) {
-                    if (firstSlur->HasInnerSlur(secondSlur)) {
-                        innerCurves.push_back(positioners[j]);
-                        continue;
-                    }
+            if (positioners[j]->GetSpanningType() == SPANNING_START_END) {
+                if (firstSlur->HasInnerSlur(secondSlur)) {
+                    innerCurves.push_back(positioners[j]);
+                    continue;
                 }
             }
             // Adjust positioning of slurs with common start/end


### PR DESCRIPTION
This PR extends the slur collision avoidance for inner slurs to cross staff cases.

| Before | After |
| ------ | ----- |
| <img width="935" alt="Before" src="https://user-images.githubusercontent.com/63608463/222721647-a5090f66-e125-4c3d-81fc-0362a1ffe3e3.png"> | <img width="948" alt="After" src="https://user-images.githubusercontent.com/63608463/222721674-9224f4f5-4ba7-424a-af59-e55983604ee4.png"> |

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Doctor Gradus ad Parnassum</title>
            <respStmt>
               <persName role="composer">Claude Debussy</persName>
            </respStmt>
         </titleStmt>
         <pubStmt><date isodate="2021-11-23" type="encoding-date">2021-11-23</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="encodingdesc-zfr6it">
         <appInfo xml:id="appinfo-69ebk5">
            <application xml:id="application-wp5fx1" isodate="2021-12-07T15:12:11" version="3.8.0-dev-95edd61">
               <name xml:id="name-zhu2ck">Verovio</name>
               <p xml:id="p-igu315">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="mgdhsc2">
            <score xml:id="s2m70wz">
               <scoreDef xml:id="s7x6nor">
                  <pgHead xml:id="pdedcn9">
                     <rend xml:id="r9xprj3" halign="center" valign="top">Doctor Gradus ad Parnassum</rend>
                     <rend xml:id="rw851on" halign="right" valign="bottom">Claude Debussy</rend>
                  </pgHead>
                  <staffGrp xml:id="sm4vhss">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <label xml:id="l5i3omn">Piano</label>
                        <labelAbbr xml:id="leas1pl">Pno.</labelAbbr>
                        <instrDef xml:id="is3v4ad" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef xml:id="s2lb6x8" n="1" lines="5" ppq="4">
                           <clef xml:id="cnh5uyl" shape="G" line="2" />
                           <keySig xml:id="kwgosc0" sig="0" />
                           <meterSig xml:id="mqtylua" count="4" unit="4" />
                        </staffDef>
                        <staffDef xml:id="su1yo2f" n="2" lines="5" ppq="4">
                           <clef xml:id="cni1ytl" shape="F" line="4" />
                           <keySig xml:id="kmnn26o" sig="0" />
                           <meterSig xml:id="mtova1d" count="4" unit="4" />
                        </staffDef>
                        <grpSym xml:id="gl6m3qx" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="stua0z5">
                  <measure xml:id="mr9enw2" n="28">
                     <staff xml:id="srl6w7a" n="1">
                        <layer xml:id="lvgtk9m" n="1">
                           <rest xml:id="r9jondt" dur.ppq="4" dur="4" />
                           <beam xml:id="btq10j0">
                              <note xml:id="ntp3tut" dur.ppq="2" dur="8" oct="5" pname="d" stem.dir="up" />
                              <note xml:id="nevny1y" dur.ppq="2" dur="8" oct="5" pname="e" stem.dir="up" />
                           </beam>
                           <note xml:id="ngxeh57" dur.ppq="8" dur="2" oct="5" pname="f" stem.dir="up" accid="s" />
                        </layer>
                     </staff>
                     <staff xml:id="ss921yh" n="2">
                        <layer xml:id="lwp9kl4" n="2">
                           <beam xml:id="bi0pry3">
                              <note xml:id="nk08i18" dur.ppq="1" dur="16" oct="3" pname="b" stem.dir="up" accid="f" />
                              <note xml:id="n5cg65o" dur.ppq="1" dur="16" staff="1" oct="4" pname="e" stem.dir="down" />
                              <note xml:id="nsgpbpx" dur.ppq="1" dur="16" staff="1" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="nj59vex" dur.ppq="1" dur="16" staff="1" oct="4" pname="b" stem.dir="down" />
                           </beam>
                           <beam xml:id="bpbwrur">
                              <note xml:id="nbr7f7s" dur.ppq="1" dur="16" staff="1" oct="5" pname="d" stem.dir="down" />
                              <note xml:id="n61ka43" dur.ppq="1" dur="16" staff="1" oct="4" pname="b" stem.dir="down" />
                              <note xml:id="nx6v6uo" dur.ppq="1" dur="16" staff="1" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="nuy1b3e" dur.ppq="1" dur="16" staff="1" oct="4" pname="e" stem.dir="down" />
                           </beam>
                           <beam xml:id="bby0z8a">
                              <note xml:id="ntmkjpm" dur.ppq="1" dur="16" staff="1" oct="5" pname="f" stem.dir="down" accid.ges="s" />
                              <note xml:id="nmedi7o" dur.ppq="1" dur="16" staff="1" oct="4" pname="b" stem.dir="down" />
                              <note xml:id="n1efcb8" dur.ppq="1" dur="16" staff="1" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="nusapwi" dur.ppq="1" dur="16" staff="1" oct="4" pname="e" stem.dir="down" />
                           </beam>
                           <beam xml:id="bp70ef6">
                              <note xml:id="nwzlx40" dur.ppq="1" dur="16" staff="1" oct="4" pname="e" stem.dir="down" />
                              <note xml:id="ngntc7v" dur.ppq="1" dur="16" staff="1" oct="4" pname="b" stem.dir="down" />
                              <note xml:id="nqgf5gp" dur.ppq="1" dur="16" staff="1" oct="4" pname="g" stem.dir="down" />
                              <note xml:id="nub8m7a" dur.ppq="1" dur="16" staff="1" oct="4" pname="e" stem.dir="down" />
                           </beam>
                        </layer>
                        <layer xml:id="lnk03v6" n="5">
                           <note xml:id="n8uv6q1" dur.ppq="16" dur="1" oct="3" pname="b" accid="f" />
                        </layer>
                     </staff>
                     <slur xml:id="spiu894" startid="#ntp3tut" endid="#ngxeh57" curvedir="above" />
                     <slur xml:id="shbqdlf" startid="#nk08i18" endid="#nub8m7a" curvedir="above" />
                     <hairpin xml:id="h11xb69" staff="1" tstamp="1.750000" tstamp2="0m+3.0000" form="cres" place="below" vgrp="86" />
                     <tie xml:id="tw03n2u" startid="#nusapwi" endid="#nwzlx40" />
                     <slur xml:id="sijtbt4" startid="#n8uv6q1" endid="#n7pvsfy" curvedir="below" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
