### PR TITLE
Improve endpoint location for broken slurs

### DIFF
--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -341,7 +341,7 @@ protected:
 
 public:
     /**
-     * The spanning type of the positionner for spanning control elements
+     * The spanning type of the positioner for spanning control elements
      */
     char m_spanningType;
 };

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -329,6 +329,9 @@ private:
     void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility,
         bool isBelow, char spanningType) const;
 
+    // Calculate the full and partial shift radii
+    std::pair<double, double> CalcShiftRadii(bool forShiftLeft, double flexibility, char spanningType) const;
+
     // Determine a quadratic interpolation function between zero and one and evaluate it
     double CalcQuadraticInterpolation(double zeroAt, double oneAt, double arg) const;
 

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -252,11 +252,13 @@ private:
     // Calculate the endpoint coordinates depending on the curve direction and spanning type of the slur
     std::pair<Point, Point> CalcEndPoints(const Doc *doc, const Staff *staff, NearEndCollision *nearEndCollision,
         int x1, int x2, curvature_CURVEDIR drawingCurveDir, char spanningType) const;
+    // Consider the melodic direction for the break location?
+    bool ConsiderMelodicDirection() const;
     // Retrieve the start and end note locations of the slur
     std::pair<int, int> GetStartEndLocs(
         const Note *startNote, const Chord *startChord, const Note *endNote, const Chord *endChord) const;
-    // Calculate the break location at system start/end and the pitch difference
-    std::pair<int, int> CalcBrokenLoc(const Staff *staff, int startLoc, int endLoc) const;
+    // Calculate the pitch difference used to adjust for melodic direction
+    int CalcPitchDifference(const Staff *staff, int startLoc, int endLoc) const;
     // Check if the slur resembles portato
     PortatoSlurType IsPortatoSlur(const Doc *doc, const Note *startNote, const Chord *startChord) const;
     // Check if the slur starts or ends on a beam

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -326,8 +326,8 @@ private:
      */
     ///@{
     // Shift end points for collisions nearby
-    void ShiftEndPoints(
-        int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility, bool isBelow) const;
+    void ShiftEndPoints(int &shiftLeft, int &shiftRight, double ratio, int intersection, double flexibility,
+        bool isBelow, char spanningType) const;
 
     // Determine a quadratic interpolation function between zero and one and evaluate it
     double CalcQuadraticInterpolation(double zeroAt, double oneAt, double arg) const;


### PR DESCRIPTION
This PR improves the endpoint location for broken slurs:
- Consideration of melodic direction is restricted to short slurs. (see https://github.com/rism-digital/verovio/pull/2482)
- Endpoints obtain full flexibility to avoid obstacles. This should avoid weird slur shapes.

| Before | After |
| ------  | ----- |
| <img width="1037" alt="Before" src="https://user-images.githubusercontent.com/63608463/222760578-0c28196a-38d8-4e3e-9361-2ea7a70d0ec6.png"> | <img width="1053" alt="After" src="https://user-images.githubusercontent.com/63608463/222760622-9d7e4f74-5748-431f-9ab9-66e3dd85eabd.png"> |

<details>
<summary> Show MEI (only measures 1-23) </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Gymnopédie No. 1</title>
            <respStmt>
               <persName role="composer">Erik Satie (1866–1925)</persName>
            </respStmt>
         </titleStmt>
         <pubStmt><date isodate="2022-08-23" type="encoding-date">2022-08-23</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m1i9mt8g">
            <score xml:id="s12sxyi9">
               <scoreDef xml:id="s1vqxscp">
                  <staffGrp xml:id="sxp2h3h">
                     <staffGrp xml:id="P1" bar.thru="true">
                        <label xml:id="lbodot4">Piano</label>
                        <instrDef xml:id="idxlb1q" midi.channel="0" midi.instrnum="0" midi.volume="78.00%" />
                        <staffDef xml:id="s1chxxwe" n="1" lines="5" ppq="1">
                           <clef xml:id="cn7yhuw" shape="G" line="2" />
                           <keySig xml:id="k1fwx33" sig="2s" />
                           <meterSig xml:id="m8zern1" count="3" unit="4" />
                        </staffDef>
                        <staffDef xml:id="sriimvj" n="2" lines="5" ppq="1">
                           <clef xml:id="cmbnfkz" shape="F" line="4" />
                           <keySig xml:id="k1ic4z2e" sig="2s" />
                           <meterSig xml:id="m1grr1qn" count="3" unit="4" />
                        </staffDef>
                        <grpSym xml:id="gv6t4ho" symbol="brace" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xml:id="syvjkzl">
                  <pb xml:id="pe61657" />
                  <measure xml:id="m1lyekvs" n="1">
                     <staff xml:id="s17luvzo" n="1">
                        <layer xml:id="lmno1ot" n="1">
                           <mRest xml:id="m16od4mp" />
                        </layer>
                        <layer xml:id="l10sne7a" n="2">
                           <rest xml:id="r115y3hf" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c11d0chq" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n1mi2x2q" oct="3" pname="b" staff="2" />
                              <note xml:id="n175rab0" oct="4" pname="d" />
                              <note xml:id="nbprysc" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="scy6ul5" n="2">
                        <layer xml:id="lxu4yyw" n="2">
                           <note xml:id="ni651j2" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="d759vtf" place="below" staff="1" tstamp="1.000000" val="33" vgrp="40">pp</dynam>
                     <tempo xml:id="t19977do" place="above" staff="1" tstamp="1.000000" xml:lang="it" midi.bpm="54.000000">
                        <rend xml:id="rb52zs7" fontweight="bold">Lent et douloureux</rend>
                     </tempo>
                  </measure>
                  <measure xml:id="m1h6vza3" n="2">
                     <staff xml:id="s18iye7i" n="1">
                        <layer xml:id="lnxe863" n="1">
                           <mRest xml:id="m14cw0x1" />
                        </layer>
                        <layer xml:id="lidawv7" n="2">
                           <rest xml:id="r1rj73fn" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1o4quez" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n5dvo0w" oct="3" pname="a" staff="2" />
                              <note xml:id="n1jwrasi" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n12wu8i8" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s19excm2" n="2">
                        <layer xml:id="l1kcep69" n="2">
                           <note xml:id="nsz3ylx" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m4k30iw" n="3">
                     <staff xml:id="s1c9exq1" n="1">
                        <layer xml:id="l1x8yk7q" n="1">
                           <mRest xml:id="m1etn3lm" />
                        </layer>
                        <layer xml:id="lr9d2s3" n="2">
                           <rest xml:id="r1skn8fz" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cyxa2d3" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="njao4zh" oct="3" pname="b" staff="2" />
                              <note xml:id="nj45uq5" oct="4" pname="d" />
                              <note xml:id="n165rtj" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s5nf2tz" n="2">
                        <layer xml:id="lj1821e" n="2">
                           <note xml:id="n1sqgz8x" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mos28k2" n="4">
                     <staff xml:id="sqh4kum" n="1">
                        <layer xml:id="l1cwjyha" n="1">
                           <mRest xml:id="m1qmqsd4" />
                        </layer>
                        <layer xml:id="lj6g3rz" n="2">
                           <rest xml:id="r1ew2ofr" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1mmso7h" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="nsl88b" oct="3" pname="a" staff="2" />
                              <note xml:id="n5968ob" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n117dsy3" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="sdxd1qh" n="2">
                        <layer xml:id="lpwdzxx" n="2">
                           <note xml:id="n1iobdjl" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m1occb3v" n="5">
                     <staff xml:id="s1hnkpip" n="1">
                        <layer xml:id="lrjo0a8" n="1">
                           <rest xml:id="rzmrehk" dur.ppq="1" dur="4" />
                           <note xml:id="nkdmwze" dur.ppq="1" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                           <note xml:id="n1vk2oey" dur.ppq="1" dur="4" oct="5" pname="a" stem.dir="up" />
                        </layer>
                        <layer xml:id="l107h2qt" n="2">
                           <rest xml:id="rypxtnl" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1at6rjz" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n1nhyedd" oct="3" pname="b" staff="2" />
                              <note xml:id="ngzl07e" oct="4" pname="d" />
                              <note xml:id="n1sf56vh" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="ss4rc0a" n="2">
                        <layer xml:id="lvztmxu" n="2">
                           <note xml:id="n43ljec" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="dpgfxhb" place="above" staff="1" tstamp="2.000000" val="33" vgrp="234">pp</dynam>
                     <hairpin xml:id="hueowjz" staff="1" tstamp="2.000000" tstamp2="2m+2.5000" form="cres" place="above" vgrp="254" />
                     <slur xml:id="s1wmw81b" startid="#nkdmwze" endid="#nvd6h6g" curvedir="above" />
                  </measure>
                  <sb xml:id="s4se83d" />
                  <measure xml:id="m1wjze4s" n="6">
                     <staff xml:id="s1ynwakb" n="1">
                        <layer xml:id="ldhyj1u" n="1">
                           <note xml:id="not0k96" dur.ppq="1" dur="4" oct="5" pname="g" stem.dir="up" />
                           <note xml:id="n6brl0r" dur.ppq="1" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                           <note xml:id="n1hg3hni" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l1ayecbr" n="2">
                           <rest xml:id="r1t10onx" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cp98b4d" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="nezjzuu" oct="3" pname="a" staff="2" />
                              <note xml:id="n18sw0i1" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n1llgf6p" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1p5lafy" n="2">
                        <layer xml:id="ly9pz4e" n="2">
                           <note xml:id="n1204r84" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="mk284ta" n="7">
                     <staff xml:id="sz0jgh1" n="1">
                        <layer xml:id="l1sp2r3u" n="1">
                           <note xml:id="n1in5954" dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="up" />
                           <note xml:id="na5w4ao" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="up" accid.ges="s" />
                           <note xml:id="n13gyx7j" dur.ppq="1" dur="4" oct="5" pname="d" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1ukq70c" n="2">
                           <rest xml:id="r1oabzlx" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cehobzw" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n7oeo7g" oct="3" pname="b" staff="2" />
                              <note xml:id="n1tolrlm" oct="4" pname="d" />
                              <note xml:id="nashym5" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1hatihz" n="2">
                        <layer xml:id="l8170s6" n="2">
                           <note xml:id="n70vj4c" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="d1ef63lf" place="above" staff="1" tstamp="3.000000" val="49" vgrp="270">p</dynam>
                     <hairpin xml:id="h1rbjlc1" staff="1" tstamp="3.000000" tstamp2="1m+3.5000" form="dim" place="below" vgrp="60" />
                  </measure>
                  <measure xml:id="m19vmjgb" n="8">
                     <staff xml:id="s12s251m" n="1">
                        <layer xml:id="l1duibk9" n="1">
                           <note xml:id="nqvsqx2" dots="1" dur.ppq="3" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1tcp64w" n="2">
                           <rest xml:id="rfhbo6m" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cvuaqcd" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n5m6jz6" oct="3" pname="a" staff="2" />
                              <note xml:id="n1p33s8r" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n1nxbl1z" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s4vlww7" n="2">
                        <layer xml:id="lrqyap5" n="2">
                           <note xml:id="n1o00l82" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m54jyv7" n="9">
                     <staff xml:id="sgq32q6" n="1">
                        <layer xml:id="l14qfcah" n="1">
                           <note xml:id="nvd6h6g" dots="1" dur.ppq="3" dur="2" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l7dho3w" n="2">
                           <rest xml:id="rf9dhm9" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cfh6nmy" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n10j181l" oct="3" pname="b" staff="2" />
                              <note xml:id="n1quxxis" oct="4" pname="d" />
                              <note xml:id="n1gmmy8j" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="szzocv8" n="2">
                        <layer xml:id="l13bog3o" n="2">
                           <note xml:id="n1ust9hb" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <tie xml:id="txf1v3g" startid="#nvd6h6g" endid="#n1mad6z4" />
                     <dynam xml:id="dxqfqy9" place="above" staff="2" tstamp="1.9" val="56">f</dynam>
                  </measure>
                  <measure xml:id="m1lc8547" n="10">
                     <staff xml:id="sw37357" n="1">
                        <layer xml:id="l1fbqacb" n="1">
                           <note xml:id="n1mad6z4" dots="1" dur.ppq="3" dur="2" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l1r1byz5" n="2">
                           <rest xml:id="r1aq6ikb" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c66ffnu" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n3ol766" oct="3" pname="a" staff="2" />
                              <note xml:id="nlpjfr1" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n1iejqzi" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="sep8v77" n="2">
                        <layer xml:id="l1db1bh" n="2">
                           <note xml:id="n14jxj0y" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                     <tie xml:id="txf1v4g" startid="#n1mad6z4" endid="#n146op7i" />
                  </measure>
                  <sb xml:id="s2v3tek" />
                  <measure xml:id="mhnhvgd" n="11">
                     <staff xml:id="s136bis9" n="1">
                        <layer xml:id="leewgw1" n="1">
                           <note xml:id="n146op7i" dots="1" dur.ppq="3" dur="2" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l1xh1ack" n="2">
                           <rest xml:id="ruv91nc" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="czgou3" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n1016g5p" oct="3" pname="b" staff="2" />
                              <note xml:id="n1soryic" oct="4" pname="d" />
                              <note xml:id="n1loos21" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1nw1mab" n="2">
                        <layer xml:id="l25mbxh" n="2">
                           <note xml:id="n1egbpe9" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <tie xml:id="txf1v5g" startid="#n146op7i" endid="#n14rhc25" />
                  </measure>
                  <measure xml:id="m12igy9q" n="12">
                     <staff xml:id="s1ue78xa" n="1">
                        <layer xml:id="l1umftg5" n="1">
                           <note xml:id="n14rhc25" dots="1" dur.ppq="3" dur="2" oct="4" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l1f6wxd1" n="2">
                           <rest xml:id="rmjk4r0" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c2m55xb" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="nfh5vgx" oct="3" pname="a" staff="2" />
                              <note xml:id="n14cbcap" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="ngv12q3" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1t2b32f" n="2">
                        <layer xml:id="l1fvcxbs" n="2">
                           <note xml:id="neu5jau" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="msq67b4" n="13">
                     <staff xml:id="s18vojqn" n="1">
                        <layer xml:id="ledcewb" n="1">
                           <rest xml:id="r7rysfs" dur.ppq="1" dur="4" />
                           <note xml:id="n1ojmvh7" dur.ppq="1" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                           <note xml:id="n1lmjika" dur.ppq="1" dur="4" oct="5" pname="a" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1taey6z" n="2">
                           <rest xml:id="r1oxxpnq" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cmgtgxl" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n1ache9f" oct="3" pname="b" staff="2" />
                              <note xml:id="n5lv0ow" oct="4" pname="d" />
                              <note xml:id="nw0qtri" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s9sylsk" n="2">
                        <layer xml:id="lexorn5" n="2">
                           <note xml:id="n1wuwrta" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="dkh1ga4" place="above" staff="1" tstamp="1.000000" val="33" vgrp="244">pp</dynam>
                     <hairpin xml:id="h9h66v0" staff="1" tstamp="2.000000" tstamp2="2m+3.5000" form="cres" place="above" vgrp="264" />
                     <slur xml:id="s1up5mgj" startid="#n1ojmvh7" endid="#nrgqt18" curvedir="above" />
                  </measure>
                  <measure xml:id="m15hl1nh" n="14">
                     <staff xml:id="s1fjgred" n="1">
                        <layer xml:id="l1eqx5hz" n="1">
                           <note xml:id="nd7q7vr" dur.ppq="1" dur="4" oct="5" pname="g" stem.dir="up" />
                           <note xml:id="nrppkdq" dur.ppq="1" dur="4" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                           <note xml:id="nhumqca" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l10rta3p" n="2">
                           <rest xml:id="r1nxgpz9" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1r5h9oq" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n9ztty2" oct="3" pname="a" staff="2" />
                              <note xml:id="n1ktejht" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="n1ifln6l" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="sxvy1x9" n="2">
                        <layer xml:id="l1vlvbfr" n="2">
                           <note xml:id="nlyhqae" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m1zm2y0" n="15">
                     <staff xml:id="se0scnv" n="1">
                        <layer xml:id="l11xv87m" n="1">
                           <note xml:id="nldgyij" dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="up" />
                           <note xml:id="n1ht0jlh" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="up" accid.ges="s" />
                           <note xml:id="nzn99zn" dur.ppq="1" dur="4" oct="5" pname="d" stem.dir="up" />
                        </layer>
                        <layer xml:id="liloli9" n="2">
                           <rest xml:id="r19zs7vi" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cura2g8" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="nsdgxm8" oct="3" pname="b" staff="2" />
                              <note xml:id="n4yzrqf" oct="4" pname="d" />
                              <note xml:id="njufoeh" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s8bo6oz" n="2">
                        <layer xml:id="l17ko1z7" n="2">
                           <note xml:id="n1m0gtsn" dots="1" dur.ppq="3" dur="2" oct="2" pname="g" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <sb xml:id="s4ynj6x" />
                  <measure xml:id="mrgr1ac" n="16">
                     <staff xml:id="s1fltc28" n="1">
                        <layer xml:id="l1wtqevf" n="1">
                           <note xml:id="nlaygjq" dots="1" dur.ppq="3" dur="2" oct="4" pname="a" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1p1s6ko" n="2">
                           <rest xml:id="r5lbqqf" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1b64uej" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n1hh29sh" oct="3" pname="a" staff="2" />
                              <note xml:id="n1tt80dn" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="nqwd4t8" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1kjirid" n="2">
                        <layer xml:id="lpdg64v" n="2">
                           <note xml:id="n1b1xa46" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                     <hairpin xml:id="hl8oet8" staff="1" tstamp="1.000000" tstamp2="2m+3.5000" form="dim" place="below" vgrp="65" />
                  </measure>
                  <measure xml:id="mgzou8e" n="17">
                     <staff xml:id="s1onfzko" n="1">
                        <layer xml:id="l1g1jz4g" n="1">
                           <note xml:id="n1k4d8zw" dots="1" dur.ppq="3" dur="2" oct="5" pname="c" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l3sbys6" n="2">
                           <rest xml:id="rwyj4yh" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="chrz4zm" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n71z0im" oct="3" pname="a" staff="2" />
                              <note xml:id="n1m1fyzy" oct="4" pname="c" accid.ges="s" />
                              <note xml:id="njyo5w5" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1ya6iza" n="2">
                        <layer xml:id="l1rxns3y" n="2">
                           <note xml:id="n1utepg9" dots="1" dur.ppq="3" dur="2" oct="2" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m10jhcw4" n="18">
                     <staff xml:id="syubhiv" n="1">
                        <layer xml:id="l1l79hje" n="1">
                           <note xml:id="n1h9m2ts" dots="1" dur.ppq="3" dur="2" oct="5" pname="f" stem.dir="up" accid.ges="s" />
                        </layer>
                        <layer xml:id="l1tz6s68" n="2">
                           <rest xml:id="r19lll44" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="clltxl1" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n9tgf16" oct="3" pname="b" staff="2" />
                              <note xml:id="nrchi1y" oct="4" pname="d" />
                              <note xml:id="naw2juz" oct="4" pname="f" accid.ges="s" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1iid4nk" n="2">
                        <layer xml:id="laukoci" n="2">
                           <note xml:id="nvh79o8" dots="1" dur.ppq="3" dur="2" oct="1" pname="b" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m1t6kjse" n="19">
                     <staff xml:id="s1d98rgn" n="1">
                        <layer xml:id="llqy4ln" n="1">
                           <note xml:id="nrgqt18" dots="1" dur.ppq="3" dur="2" oct="4" pname="e" stem.dir="up" />
                        </layer>
                        <layer xml:id="l98kadw" n="2">
                           <rest xml:id="r1u19k82" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c116tlss" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n691d7k" oct="3" pname="g" staff="2" />
                              <note xml:id="nx6s5yc" oct="3" pname="b" staff="2" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s7hrdvi" n="2">
                        <layer xml:id="l1dojptj" n="2">
                           <note xml:id="n19mhb6i" dots="1" dur.ppq="3" dur="2" oct="2" pname="e" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="d27649d" place="below" staff="1" tstamp="1.000000" val="33" vgrp="52">pp</dynam>
                     <hairpin xml:id="h1e54p6y" staff="1" tstamp="1.000000" tstamp2="2m+3.5000" form="cres" place="below" vgrp="72" />
                     <tie xml:id="to309hg" startid="#nrgqt18" endid="#n8156m6" />
                  </measure>
                  <measure xml:id="m23fvpe" n="20">
                     <staff xml:id="s1l6yf6g" n="1">
                        <layer xml:id="lcnzreb" n="1">
                           <note xml:id="n8156m6" dots="1" dur.ppq="3" dur="2" oct="4" pname="e" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1207xmy" n="2">
                           <rest xml:id="rbxijp6" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1xnwg2y" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n8168xa" oct="3" pname="b" staff="2" />
                              <note xml:id="nezpp37" oct="4" pname="d" />
                              <note xml:id="n1neeoy1" oct="4" pname="g" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1dkfgl8" n="2">
                        <layer xml:id="lrhvwns" n="2">
                           <note xml:id="np7119t" dots="1" dur.ppq="3" dur="2" oct="2" pname="e" stem.dir="down" />
                        </layer>
                     </staff>
                     <tie xml:id="to309hg" startid="#n8156m6" endid="#n1ep1sd0" />
                  </measure>
                  <sb xml:id="s13x7nw8" />
                  <measure xml:id="m6b1ize" n="21">
                     <staff xml:id="s1u3s8mm" n="1">
                        <layer xml:id="laz3el" n="1">
                           <note xml:id="n1ep1sd0" dots="1" dur.ppq="3" dur="2" oct="4" pname="e" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1fmxif1" n="2">
                           <rest xml:id="r1yll3h2" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cqc3msp" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="n41fck7" oct="3" pname="f" accid="n" staff="2" />
                              <note xml:id="n185pg27" oct="3" pname="a" staff="2" />
                              <note xml:id="njetput" oct="4" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="s1sfzscu" n="2">
                        <layer xml:id="l90bel6" n="2">
                           <note xml:id="nkp2m2s" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="m1xca8v8" n="22">
                     <staff xml:id="swbvbfv" n="1">
                        <layer xml:id="l19ywig7" n="1">
                           <note xml:id="n1o4afnb" dur.ppq="1" dur="4" oct="4" pname="a" stem.dir="up" />
                           <note xml:id="nx5f95n" dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="up" />
                           <note xml:id="n15trfif" dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="up" accid="n" />
                        </layer>
                        <layer xml:id="l1fhkeiq" n="2">
                           <rest xml:id="r1781w7x" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="cmmcxej" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="nbkh0u4" oct="3" pname="a" staff="2" />
                              <note xml:id="n1vrdifg" oct="4" pname="c" accid="n" />
                              <note xml:id="n1pgxc88" oct="4" pname="e" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="su2xka1" n="2">
                        <layer xml:id="l16zi9ee" n="2">
                           <note xml:id="n9946ug" dots="1" dur.ppq="3" dur="2" oct="1" pname="a" stem.dir="down" />
                        </layer>
                     </staff>
                     <dynam xml:id="d4kqney" place="above" staff="1" tstamp="1.000000" val="49" vgrp="235">p</dynam>
                     <hairpin xml:id="hjbkp0l" staff="1" tstamp="1.000000" tstamp2="2m+3.5000" form="cres" place="above" vgrp="255" />
                     <slur xml:id="s16r820s" startid="#n1o4afnb" endid="#nfeukm3" curvedir="above" />
                  </measure>
                  <measure xml:id="msxzpds" n="23">
                     <staff xml:id="s1e4nnci" n="1">
                        <layer xml:id="l1m2rxc7" n="1">
                           <note xml:id="ngzps7f" dur.ppq="1" dur="4" oct="5" pname="e" stem.dir="up" />
                           <note xml:id="n1caf3k1" dur.ppq="1" dur="4" oct="5" pname="d" stem.dir="up" />
                           <note xml:id="nhrjapd" dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="up" />
                        </layer>
                        <layer xml:id="l1i1wrz5" n="2">
                           <rest xml:id="rbdocb2" dur.ppq="1" dur="4" />
                           <chord stem.len="5" xml:id="c1a9vww0" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="ne7yh89" oct="3" pname="g" staff="2" />
                              <note xml:id="n1qmlu20" oct="3" pname="b" staff="2" />
                              <note xml:id="n9cbbem" oct="4" pname="e" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="sejs9se" n="2">
                        <layer xml:id="l1yyidx0" n="2">
                           <note xml:id="n1di3pxw" dots="1" dur.ppq="3" dur="2" oct="2" pname="d" stem.dir="down" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>


