### PR TITLE
Avoid bar line collisions on single line staff

### DIFF
--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -433,9 +433,10 @@ void FloatingPositioner::CalcDrawingYRel(
             }
         }
 
-        if (this->GetObject()->Is(FERMATA) && (staffAlignment->GetStaff()->m_drawingLines == 1)) {
-            minStaffDistance = 2.5 * unit;
+        if (staffAlignment->GetStaff()->m_drawingLines == 1) {
+            minStaffDistance += 2.5 * unit;
         }
+
         if (m_place == STAFFREL_above) {
             yRel = this->GetContentY1();
             yRel -= doc->GetBottomMargin(m_object->GetClassId()) * unit;


### PR DESCRIPTION
This PR adjusts the minimal staff distance to prevent collisions of floating elements with bar lines on the single line staff.

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/63608463/223352965-a751ac67-1917-41c2-bda0-7e1823f437f7.png) | ![After](https://user-images.githubusercontent.com/63608463/223352987-6cd514b1-ec5f-4c75-a073-f13ecf897d3a.png) |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title/>
        <respStmt>
          <persName role="encoder">Klaus Rettinghaus</persName>
        </respStmt>
      </titleStmt>
      <pubStmt>
        <date isodate="2021-06-16" type="encoding-date">2021-06-16</date>
      </pubStmt>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp>
              <staffDef xml:id="P2" n="2" lines="1">
                <label>Gran Cassa</label>
                <clef shape="perc"/>
                <meterSig count="3" unit="4"/>
              </staffDef>
            </staffGrp>
          </scoreDef>
          <section>
            <section>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <multiRest num="7"/>
                  </layer>
                </staff>
              </measure>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <mRest xml:id="second_fermata"/>
                  </layer>
                </staff>
                <fermata staff="2" startid="#second_fermata"/>
              </measure>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <multiRest num="8"/>
                  </layer>
                </staff>
              </measure>
              <measure corresp="#none" right="dbl">
                <staff n="2">
                  <layer n="1">
                    <multiRest num="4"/>
                  </layer>
                </staff>
                <reh staff="2" tstamp="0">
                  <rend rend="box" fontsize="130%" fontstyle="normal" fontweight="bold" halign="center">A</rend>
                </reh>
              </measure>
            </section>
            <section>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <multiRest num="4"/>
                  </layer>
                </staff>
              </measure>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <multiRest num="16"/>
                  </layer>
                </staff>
                <tempo staff="2" tstamp="1.0">Much much faster</tempo>
              </measure>
              <measure corresp="#none">
                <staff n="2">
                  <layer n="1">
                    <note dur="1" loc="0" ornam="t"/>
                  </layer>
                </staff>
              </measure>
            </section>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

