### PR TITLE
Remove exceptions when setting options

### DIFF
--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -57,6 +57,11 @@ LogLevel StrToLogLevel(const std::string &level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
+ * Utility for check the string is a number
+ */
+bool IsNumber(const std::string value);
+
+/**
  * Extract the ID from any URI
  */
 std::string ExtractIDFragment(std::string refID);

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -57,9 +57,9 @@ LogLevel StrToLogLevel(const std::string &level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
- * Utility for check the string is a number
+ * Utility to check if the string is a number
  */
-bool IsNumber(const std::string value);
+bool IsNumber(const std::string &value);
 
 /**
  * Extract the ID from any URI

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -57,9 +57,14 @@ LogLevel StrToLogLevel(const std::string &level);
 bool AreEqual(double dFirstVal, double dSecondVal);
 
 /**
- * Utility to check if the string is a number
+ * Utility to check if the string is a valid integer for std::stoi
  */
-bool IsNumber(const std::string &value);
+bool IsValidInteger(const std::string &value);
+
+/**
+ * Utility to check if the string is valid double for std::stod
+ */
+bool IsValidDouble(const std::string &value);
 
 /**
  * Extract the ID from any URI

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -252,16 +252,13 @@ void OptionDbl::Init(double defaultValue, double minValue, double maxValue, bool
 
 bool OptionDbl::SetValue(const std::string &value)
 {
-    // Convert string to double
-    double number = 0.0;
-    try {
-        number = std::stod(value);
-    }
-    catch (const std::exception &e) {
+    if (!IsNumber(value)) {
         LogError("Unable to set parameter value %s for '%s'; conversion to double failed", value.c_str(),
             this->GetKey().c_str());
         return false;
     }
+    // Convert string to double
+    double number = std::stod(value);
 
     // Check bounds and set the value
     return this->SetValue(number);
@@ -340,16 +337,13 @@ bool OptionInt::SetValueDbl(double value)
 
 bool OptionInt::SetValue(const std::string &value)
 {
-    // Convert string to int
-    int number = 0;
-    try {
-        number = std::stoi(value);
-    }
-    catch (const std::exception &e) {
+    if (!IsNumber(value)) {
         LogError("Unable to set parameter value %s for '%s'; conversion to integer failed", value.c_str(),
             this->GetKey().c_str());
         return false;
     }
+    // Convert string to int
+    int number = std::stoi(value);
 
     // Check bounds and set the value
     return this->SetValue(number);
@@ -848,13 +842,13 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
             path.push_back(val.get<jsonxx::Object>().get<jsonxx::Value>(*iter));
         }
         else if (val.is<jsonxx::Array>()) {
-            try {
+            if (IsNumber(*iter)) {
                 const int index = std::stoi(*iter);
                 if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index)) break;
 
                 path.push_back(val.get<jsonxx::Array>().get<jsonxx::Value>(index));
             }
-            catch (const std::logic_error &) {
+            else {
                 // invalid index, leaving
                 break;
             }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -252,7 +252,7 @@ void OptionDbl::Init(double defaultValue, double minValue, double maxValue, bool
 
 bool OptionDbl::SetValue(const std::string &value)
 {
-    if (!IsNumber(value)) {
+    if (!IsValidDouble(value)) {
         LogError("Unable to set parameter value %s for '%s'; conversion to double failed", value.c_str(),
             this->GetKey().c_str());
         return false;
@@ -337,7 +337,7 @@ bool OptionInt::SetValueDbl(double value)
 
 bool OptionInt::SetValue(const std::string &value)
 {
-    if (!IsNumber(value)) {
+    if (!IsValidInteger(value)) {
         LogError("Unable to set parameter value %s for '%s'; conversion to integer failed", value.c_str(),
             this->GetKey().c_str());
         return false;
@@ -842,7 +842,7 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
             path.push_back(val.get<jsonxx::Object>().get<jsonxx::Value>(*iter));
         }
         else if (val.is<jsonxx::Array>()) {
-            if (IsNumber(*iter)) {
+            if (IsValidDouble(*iter)) {
                 const int index = std::stoi(*iter);
                 if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index)) break;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -258,7 +258,7 @@ bool OptionDbl::SetValue(const std::string &value)
         return false;
     }
     // Convert string to double
-    double number = std::stod(value);
+    double number = std::strtod(value.c_str(), NULL);
 
     // Check bounds and set the value
     return this->SetValue(number);
@@ -343,7 +343,7 @@ bool OptionInt::SetValue(const std::string &value)
         return false;
     }
     // Convert string to int
-    int number = std::stoi(value);
+    int number = (int)std::strtol(value.c_str(), NULL, 10);
 
     // Check bounds and set the value
     return this->SetValue(number);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -842,8 +842,8 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
             path.push_back(val.get<jsonxx::Object>().get<jsonxx::Value>(jsonNode));
         }
         else if (val.is<jsonxx::Array>()) {
-            if (IsValidDouble(jsonNode)) {
-                const int index = std::strtod(jsonNode.c_str(), NULL);
+            if (IsValidInteger(jsonNode)) {
+                const int index = (int)std::strtol(jsonNode.c_str(), NULL, 10);
                 if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index)) break;
 
                 path.push_back(val.get<jsonxx::Array>().get<jsonxx::Value>(index));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -836,14 +836,14 @@ OptionJson::JsonPath OptionJson::StringPath2NodePath(
     }
     path.reserve(jsonNodePath.size());
     path.push_back(const_cast<jsonxx::Value &>(obj.get<jsonxx::Value>(jsonNodePath.front())));
-    for (auto iter = jsonNodePath.begin() + 1; iter != jsonNodePath.end(); ++iter) {
+    for (const std::string &jsonNode : jsonNodePath) {
         jsonxx::Value &val = path.back();
-        if (val.is<jsonxx::Object>() && val.get<jsonxx::Object>().has<jsonxx::Value>(*iter)) {
-            path.push_back(val.get<jsonxx::Object>().get<jsonxx::Value>(*iter));
+        if (val.is<jsonxx::Object>() && val.get<jsonxx::Object>().has<jsonxx::Value>(jsonNode)) {
+            path.push_back(val.get<jsonxx::Object>().get<jsonxx::Value>(jsonNode));
         }
         else if (val.is<jsonxx::Array>()) {
-            if (IsValidDouble(*iter)) {
-                const int index = std::stoi(*iter);
+            if (IsValidDouble(jsonNode)) {
+                const int index = std::strtod(jsonNode.c_str(), NULL);
                 if (!val.get<jsonxx::Array>().has<jsonxx::Value>(index)) break;
 
                 path.push_back(val.get<jsonxx::Array>().get<jsonxx::Value>(index));

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -243,7 +243,7 @@ bool IsValidInteger(const std::string &value)
 bool IsValidDouble(const std::string &value)
 {
     // Accept "1.0" " 1.0 " ".0"  "1." "+1.0" "-1.0"
-    std::regex re("^\\s*[+-]?(\\d+\\.?\\d*|\\.?\\d+)\\s*$");
+    std::regex re("^\\s*[+-]?(?:\\d+\\.?\\d*|\\.\\d+)\\s*$");
     return std::regex_match(value, re);
 }
 

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -235,12 +235,14 @@ bool AreEqual(double dFirstVal, double dSecondVal)
 
 bool IsValidInteger(const std::string &value)
 {
+    // Accept "1" " 1 " "+1" "-1" "1." "1.0"
     std::regex re("^\\s*[+-]?\\d+\\.?\\d*\\s*$");
     return std::regex_match(value, re);
 }
 
 bool IsValidDouble(const std::string &value)
 {
+    // Accept "1.0" " 1.0 " ".0"  "1." "+1.0" "-1.0"
     std::regex re("^\\s*[+-]?(\\d+\\.?\\d*|\\.?\\d+)\\s*$");
     return std::regex_match(value, re);
 }

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -236,14 +236,14 @@ bool AreEqual(double dFirstVal, double dSecondVal)
 bool IsValidInteger(const std::string &value)
 {
     // Accept "1" " 1 " "+1" "-1" "1." "1.0"
-    std::regex re("^\\s*[+-]?\\d+\\.?\\d*\\s*$");
+    std::regex re(R"(^\s*[+-]?\d+\.?\d*\s*$)");
     return std::regex_match(value, re);
 }
 
 bool IsValidDouble(const std::string &value)
 {
     // Accept "1.0" " 1.0 " ".0"  "1." "+1.0" "-1.0"
-    std::regex re("^\\s*[+-]?(?:\\d+\\.?\\d*|\\.\\d+)\\s*$");
+    std::regex re(R"(^\s*[+-]?(?:\d+\.?\d*|\.\d+)\s*$)");
     return std::regex_match(value, re);
 }
 

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -233,7 +233,7 @@ bool AreEqual(double dFirstVal, double dSecondVal)
     return std::fabs(dFirstVal - dSecondVal) < 1E-3;
 }
 
-bool IsNumber(const std::string value)
+bool IsNumber(const std::string &value)
 {
     std::regex re("^\\s*[+-]?(\\d+\\.?|\\.?\\d+)\\d*\\s*$");
     return std::regex_match(value, re);

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -15,6 +15,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <locale>
+#include <regex>
 #include <sstream>
 #include <vector>
 
@@ -230,6 +231,12 @@ std::string StringFormatVariable(const char *format, va_list arg)
 bool AreEqual(double dFirstVal, double dSecondVal)
 {
     return std::fabs(dFirstVal - dSecondVal) < 1E-3;
+}
+
+bool IsNumber(const std::string value)
+{
+    std::regex re("^\\s*[+-]?(\\d+\\.?|\\.?\\d+)\\d*\\s*$");
+    return std::regex_match(value, re);
 }
 
 std::string ExtractIDFragment(std::string refID)

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -233,9 +233,15 @@ bool AreEqual(double dFirstVal, double dSecondVal)
     return std::fabs(dFirstVal - dSecondVal) < 1E-3;
 }
 
-bool IsNumber(const std::string &value)
+bool IsValidInteger(const std::string &value)
 {
-    std::regex re("^\\s*[+-]?(\\d+\\.?|\\.?\\d+)\\d*\\s*$");
+    std::regex re("^\\s*[+-]?\\d+\\.?\\d*\\s*$");
+    return std::regex_match(value, re);
+}
+
+bool IsValidDouble(const std::string &value)
+{
+    std::regex re("^\\s*[+-]?(\\d+\\.?\\d*|\\.?\\d+)\\s*$");
     return std::regex_match(value, re);
 }
 


### PR DESCRIPTION
Instead of catching `std::stoi` and `std::stod` exception, we preliminary check the content of the string with a regex.