### PR TITLE
Use measure indices

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -99,6 +99,11 @@ public:
     bool GenerateHeader();
 
     /**
+     * Generate the measure indices
+     */
+    void GenerateMeasureIndices();
+
+    /**
      * Generate measure numbers from measure attributes
      */
     bool GenerateMeasureNumbers();

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -69,6 +69,14 @@ public:
     bool IsMeasuredMusic() const { return m_measuredMusic; }
 
     /**
+     * Get and set the measure index
+     */
+    ///@{
+    int GetIndex() const { return m_index; }
+    void SetIndex(int index) { m_index = index; }
+    ///@}
+
+    /**
      * Methods for adding allowed content
      */
     bool IsSupportedChild(Object *object) override;
@@ -553,7 +561,15 @@ protected:
     ///@}
 
 private:
+    /**
+     * Indicates measured music (otherwise we have fake measures)
+     */
     bool m_measuredMusic;
+
+    /**
+     * The unique measure index
+     */
+    int m_index;
 
     /**
      * @name The measure barlines (left and right) used when drawing

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -244,6 +244,16 @@ bool Doc::GenerateHeader()
     return true;
 }
 
+void Doc::GenerateMeasureIndices()
+{
+    ListOfObjects measures = this->FindAllDescendantsByType(MEASURE, false);
+
+    int index = 0;
+    for (Object *object : measures) {
+        vrv_cast<Measure *>(object)->SetIndex(++index);
+    }
+}
+
 bool Doc::GenerateMeasureNumbers()
 {
     ListOfObjects measures = this->FindAllDescendantsByType(MEASURE, false);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -75,6 +75,8 @@ Measure::Measure(bool measureMusic, int logMeasureNb)
     this->RegisterAttClass(ATT_TYPED);
 
     m_measuredMusic = measureMusic;
+    m_index = VRV_UNSET;
+
     // We set parent to it because we want to access the parent doc from the aligners
     m_measureAligner.SetParent(this);
     // Idem for timestamps

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -1910,7 +1910,7 @@ bool Slur::ConsiderMelodicDirection() const
 
     // Return true if the slur starts in the last measure and ends in the first measure of the next system
     if (startMeasure && endMeasure) {
-        return (startMeasure->IsLastInSystem() && endMeasure->IsFirstInSystem() && (startMeasure != endMeasure));
+        return (startMeasure->IsLastInSystem() && (endMeasure->GetIndex() == startMeasure->GetIndex() + 1));
     }
     return false;
 }

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -258,7 +258,7 @@ bool TimeSpanningInterface::IsOrdered(const LayerElement *start, const LayerElem
         return Object::IsPreOrdered(start->GetAlignment(), end->GetAlignment());
     }
     else {
-        return Object::IsPreOrdered(startMeasure, endMeasure);
+        return (startMeasure->GetIndex() < endMeasure->GetIndex());
     }
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -695,6 +695,9 @@ bool Toolkit::LoadData(const std::string &data)
         }
     }
 
+    // generate the measure indices
+    m_doc.GenerateMeasureIndices();
+
     bool adjustPageHeight = m_options->m_adjustPageHeight.GetValue();
     int footerOption = m_options->m_footer.GetValue();
     // With adjusted page height, show the footer if explicitly set (i.e., not with "auto")


### PR DESCRIPTION
This PR adds indices to measures. They are convenient to determine the order of measures and to quickly check, whether two measures are consecutive without doing some complicated tree search.