### PR TITLE
Resolve collisions between slurs and dots

### DIFF
--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -225,8 +225,8 @@ SpannedElements Slur::CollectSpannedElements(const Staff *staff, int xMin, int x
     FindSpannedLayerElementsParams findSpannedLayerElementsParams(this);
     findSpannedLayerElementsParams.m_minPos = xMin;
     findSpannedLayerElementsParams.m_maxPos = xMax;
-    findSpannedLayerElementsParams.m_classIds = { ACCID, ARTIC, CHORD, CLEF, FLAG, GLISS, NOTE, STEM, TUPLET_BRACKET,
-        TUPLET_NUM }; // Ties should be handled separately
+    findSpannedLayerElementsParams.m_classIds = { ACCID, ARTIC, CHORD, CLEF, DOT, DOTS, FLAG, GLISS, NOTE, STEM,
+        TUPLET_BRACKET, TUPLET_NUM }; // Ties should be handled separately
 
     std::set<int> staffNumbers;
     staffNumbers.emplace(staff->GetN());


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| <img width="977" alt="Before" src="https://user-images.githubusercontent.com/63608463/224290078-37f55448-b3aa-4487-aebc-34d228b99ec2.png"> | <img width="957" alt="After" src="https://user-images.githubusercontent.com/63608463/224290111-550c3d0e-8be8-4545-84e8-6a685c43e4bb.png"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://dme.mozarteum.at/DME/schemata/mei-DME-4.0.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://dme.mozarteum.at/DME/schemata/mei-DME-4.0.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
  <meiHead>
      <fileDesc>
         <titleStmt>
         </titleStmt>
         <pubStmt>
         </pubStmt>
      </fileDesc>
  </meiHead>
  <music>
      <body>
         <mdiv n="2" xml:id="mdiv_330002">
            <score xml:id="score_330002">
               <scoreDef key.mode="major"
                         key.pname="f"
                         key.sig="1f"
                         meter.count="3"
                         meter.unit="4"
                         xml:id="scoreDef_01">
                  <staffGrp bar.thru="true"
                            decls="#instrVoice_1"
                            doxml.id="d27e33"
                            symbol="brace"
                            xml:id="staffGrp_01">
                     <staffDef clef.line="2"
                               clef.shape="G"
                               decls="#upper"
                               lines="5"
                               n="1"
                               xml:id="staffDef_P1"/>
                     <staffDef clef.line="4"
                               clef.shape="F"
                               decls="#lower"
                               lines="5"
                               n="2"
                               xml:id="staffDef_P2"/>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section_andante_cantabile">
                  <section xml:id="section_A_m0-8a">
                     <measure facs="#zoneOf_m57_k330_002" n="57" xml:id="m57_k330_002">
                        <staff decls="#upper" n="1" xml:id="staff_14268">
                           <layer n="1" xml:id="layer_14274">
                              <note doxml.id="d27e2509"
                                    dur="4"
                                    oct="5"
                                    pname="d"
                                    tstamp="1"
                                    xml:id="note_14280"/>
                              <beam xml:id="beam_14286">
                                 <note doxml.id="d27e2511"
                                       dur="8"
                                       oct="5"
                                       pname="c"
                                       tstamp="2"
                                       xml:id="note_14292"/>
                                 <note dots="1"
                                       doxml.id="d27e2515"
                                       dur="16"
                                       oct="5"
                                       pname="f"
                                       tstamp="2.5"
                                       xml:id="note_14298"/>
                                 <note doxml.id="d27e2517"
                                       dur="32"
                                       oct="5"
                                       pname="c"
                                       tstamp="2.875"
                                       xml:id="note_14304"/>
                              </beam>
                              <beam xml:id="beam_14310">
                                 <note dots="1"
                                       doxml.id="d27e2519"
                                       dur="16"
                                       oct="5"
                                       pname="a"
                                       tstamp="3"
                                       xml:id="note_14316"/>
                                 <note doxml.id="d27e2521"
                                       dur="32"
                                       oct="5"
                                       pname="f"
                                       tstamp="3.375"
                                       xml:id="note_14322"/>
                                 <note dots="1"
                                       doxml.id="d27e2523"
                                       dur="16"
                                       oct="5"
                                       pname="c"
                                       tstamp="3.5"
                                       xml:id="note_14328"/>
                                 <note doxml.id="d27e2525"
                                       dur="32"
                                       oct="4"
                                       pname="a"
                                       tstamp="3.875"
                                       xml:id="note_14334"/>
                              </beam>
                           </layer>
                        </staff>
                        <staff decls="#lower" n="2" xml:id="staff_14340">
                           <layer n="1" xml:id="layer_14364">
                              <chord doxml.id="d27e2529"
                                     dur="4"
                                     stem.dir="up"
                                     tstamp="1"
                                     xml:id="chord_14370">
                                 <note doxml.id="d27e2529" oct="4" pname="d" xml:id="note_14376"/>
                                 <note accid.ges="f"
                                       doxml.id="d27e2532"
                                       oct="3"
                                       pname="b"
                                       xml:id="note_14382"/>
                              </chord>
                              <chord doxml.id="d27e2536"
                                     dur="4"
                                     stem.dir="up"
                                     tstamp="2"
                                     xml:id="chord_14388">
                                 <note doxml.id="d27e2536" oct="4" pname="c" xml:id="note_14394"/>
                                 <note doxml.id="d27e2538" oct="3" pname="a" xml:id="note_14400"/>
                              </chord>
                              <rest doxml.id="d27e2540" dur="4" tstamp="3" xml:id="rest_14406"/>
                           </layer>
                           <layer n="2" xml:id="layer_14346">
                              <note doxml.id="d27e2534"
                                    dur="2"
                                    oct="3"
                                    pname="f"
                                    tstamp="1"
                                    xml:id="note_14352"/>
                              <space doxml.id="d27e2540" dur="4" tstamp="3" xml:id="space_14358"/>
                           </layer>
                        </staff>
                        <supplied resp="#NMA-editors" source="#source_B" xml:id="supplied_14413">
                           <dynam doxml.id="d27e2506"
                                  staff="1"
                                  startid="#note_14280"
                                  xml:id="dynam_14412">p</dynam>
                        </supplied>
                        <dynam doxml.id="d27e2513" staff="1" tstamp="2.5" xml:id="dynam_14424">cresc.</dynam>
                        <slur endid="#note_14292"
                              staff="1"
                              startid="#note_14280"
                              xml:id="slur_14436"/>
                        <slur endid="#note_14304"
                              staff="1"
                              startid="#note_14298"
                              xml:id="slur_14442"/>
                        <slur endid="#note_14322"
                              staff="1"
                              startid="#note_14316"
                              xml:id="slur_14448"/>
                        <slur endid="#note_14334"
                              staff="1"
                              startid="#note_14328"
                              xml:id="slur_14454"/>
                        <slur endid="#chord_14388"
                              staff="2"
                              startid="#chord_14370"
                              xml:id="slur_14455"/>
                     </measure>
                     <measure facs="#zoneOf_m58_k330_002" n="58" xml:id="m58_k330_002">
                        <staff decls="#upper" n="1" xml:id="staff_14466">
                           <layer n="1" xml:id="layer_14472">
                              <beam xml:id="beam_14478">
                                 <note dots="1"
                                       doxml.id="d27e2546"
                                       dur="8"
                                       oct="5"
                                       pname="c"
                                       tstamp="1"
                                       xml:id="note_14484"/>
                                 <note accid="n"
                                       doxml.id="d27e2548"
                                       dur="16"
                                       oct="4"
                                       pname="b"
                                       tstamp="1.75"
                                       xml:id="note_14490"/>
                              </beam>
                              <note accid="f"
                                    doxml.id="d27e2550"
                                    dur="8"
                                    oct="4"
                                    pname="b"
                                    stem.dir="down"
                                    tstamp="2"
                                    xml:id="note_14496"/>
                              <beam xml:id="beam_14502">
                                 <note doxml.id="d27e2555"
                                       dur="8"
                                       oct="4"
                                       pname="g"
                                       tstamp="2.5"
                                       xml:id="note_14508"/>
                                 <note doxml.id="d27e2559"
                                       dur="8"
                                       oct="4"
                                       pname="a"
                                       tstamp="3"
                                       xml:id="note_14514"/>
                                 <note accid.ges="f"
                                       doxml.id="d27e2567"
                                       dur="8"
                                       oct="4"
                                       pname="b"
                                       tstamp="3.5"
                                       xml:id="note_14520"/>
                              </beam>
                           </layer>
                           <layer n="2" xml:id="layer_14526">
                              <space dur="4" tstamp="1" xml:id="space_14532"/>
                              <space dur="8" tstamp="2" xml:id="space_14538"/>
                              <beam xml:id="beam_14544">
                                 <note dots="1"
                                       doxml.id="d27e2552"
                                       dur="16"
                                       oct="4"
                                       pname="e"
                                       tstamp="2.5"
                                       xml:id="note_14550"/>
                                 <note doxml.id="d27e2557"
                                       dur="32"
                                       oct="4"
                                       pname="c"
                                       tstamp="2.875"
                                       xml:id="note_14556"/>
                              </beam>
                              <beam xml:id="beam_14562">
                                 <note dots="1"
                                       doxml.id="d27e2561"
                                       dur="16"
                                       oct="4"
                                       pname="f"
                                       tstamp="3"
                                       xml:id="note_14568"/>
                                 <note doxml.id="d27e2563"
                                       dur="32"
                                       oct="4"
                                       pname="c"
                                       tstamp="3.375"
                                       xml:id="note_14574"/>
                                 <note dots="1"
                                       doxml.id="d27e2565"
                                       dur="16"
                                       oct="4"
                                       pname="g"
                                       tstamp="3.5"
                                       xml:id="note_14580"/>
                                 <note doxml.id="d27e2569"
                                       dur="32"
                                       oct="4"
                                       pname="c"
                                       tstamp="3.875"
                                       xml:id="note_14586"/>
                              </beam>
                           </layer>
                        </staff>
                        <staff decls="#lower" n="2" xml:id="staff_14592">
                           <layer n="1" xml:id="layer_14598">
                              <chord dots="1"
                                     doxml.id="d27e2575"
                                     dur="4"
                                     tstamp="1"
                                     xml:id="chord_14604">
                                 <note doxml.id="d27e2575" oct="4" pname="c" xml:id="note_14610"/>
                                 <note doxml.id="d27e2578" oct="3" pname="g" xml:id="note_14616"/>
                                 <note doxml.id="d27e2580" oct="3" pname="e" xml:id="note_14622"/>
                              </chord>
                              <beam xml:id="beam_14628">
                                 <chord doxml.id="d27e2582" dur="8" tstamp="2.5" xml:id="chord_14634">
                                    <note accid.ges="f"
                                          doxml.id="d27e2582"
                                          oct="3"
                                          pname="b"
                                          xml:id="note_14640"/>
                                    <note accid.ges="f"
                                          doxml.id="d27e2584"
                                          oct="2"
                                          pname="b"
                                          xml:id="note_14646"/>
                                 </chord>
                                 <chord doxml.id="d27e2586" dur="8" tstamp="3" xml:id="chord_14652">
                                    <note doxml.id="d27e2586" oct="3" pname="a" xml:id="note_14658"/>
                                    <note doxml.id="d27e2588" oct="2" pname="a" xml:id="note_14664"/>
                                 </chord>
                                 <chord doxml.id="d27e2590" dur="8" tstamp="3.5" xml:id="chord_14670">
                                    <note doxml.id="d27e2590" oct="3" pname="g" xml:id="note_14676"/>
                                    <note doxml.id="d27e2592" oct="2" pname="g" xml:id="note_14682"/>
                                 </chord>
                              </beam>
                           </layer>
                        </staff>
                        <dynam doxml.id="d27e2544"
                               staff="1"
                               startid="#note_14484"
                               xml:id="dynam_14688">f</dynam>
                        <dynam doxml.id="d27e2573"
                               staff="2"
                               startid="#chord_14604"
                               xml:id="dynam_14700">f</dynam>
                        <slur endid="#note_14496"
                              staff="1"
                              startid="#note_14484"
                              xml:id="slur_14712"/>
                        <slur endid="#note_14520"
                              staff="1"
                              startid="#note_14508"
                              xml:id="slur_14718"/>
                     </measure>
                  </section>
               </section>
            </score>
         </mdiv>
      </body>
  </music>
</mei>
```
</details>
