### PR TITLE
Humdrum: Fix visual duration for overfilled terminal long notes

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -14307,7 +14307,8 @@ bool HumdrumInput::processOverfillingNotes(hum::HTp token)
     }
 
     std::string logical_rhythm = hum::Convert::durationToRecip(barend);
-    std::string visual_rhythm = hum::Convert::kernToRecip(token);
+    std::string visValue = token->getValue("LO", "N", "vis");
+    std::string visual_rhythm = visValue.empty() ? hum::Convert::kernToRecip(token) : visValue;
     token->setValue("auto", "N", "vis", visual_rhythm);
     token->setValue("auto", "MEI", "dur.logical", logical_rhythm);
     token->setValue("auto", "MEI", "type", "straddle");


### PR DESCRIPTION
Before:

<img width="560" alt="Bildschirm­foto 2023-03-14 um 12 04 32" src="https://user-images.githubusercontent.com/865594/224983291-13a34cc0-3d06-4c00-a13d-66be7b29954a.png">

After:

<img width="567" alt="Bildschirm­foto 2023-03-14 um 12 03 53" src="https://user-images.githubusercontent.com/865594/224983317-e3656db7-e460-41c4-a1a1-6769b09872ba.png">


Kern data:

```tsv
**kern	**text	**kern	**text	**kern	**text
*clefC4	*	*clefC3	*	*clefC1	*
*k[]	*	*k[]	*	*k[]	*
*e:phr	*	*e:phr	*	*e:phr	*
*M2/1	*	*M2/1	*	*M2/1	*
*met(C|)	*	*met(C|)	*	*met(C|)	*
*MM180	*	*MM180	*	*MM180	*
=25	=25	=25	=25	=25	=25
2c	eng-	3.e	-sten	00ell	not.
*	*	*	*Xij	*	*Xij
2A	-sten	6d	.	.	.
.	.	3c	.	.	.
2G#	mei-	2B	mei-	.	.
2A	-ner	2c	-ner	.	.
=26	=26	=26	=26	=26	=26
0Ell	not.	0Bll	not.	.	.
==	==	==	==	==	==
*-	*-	*-	*-	*-	*-
!!!RDF**kern: l = terminal long
!!!RDF**kern: i = editorial accidental
```

https://github.com/WolfgangDrescher/lassus-geistliche-psalmen/blob/master/kern/06-domine-ne-in-furore.krn