### PR TITLE
Humdrum: Set id for rests with extra duration

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -11210,6 +11210,7 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                     // of the rest because there will be invisible rests
                     // added in later measure(s).
                     Rest *rest = new Rest;
+					setLocationId(rest, trest);
                     appendElement(layer, rest);
                     convertRest(rest, trest, -1, staffindex);
                 }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -11210,7 +11210,7 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                     // of the rest because there will be invisible rests
                     // added in later measure(s).
                     Rest *rest = new Rest;
-					setLocationId(rest, trest);
+                    setLocationId(rest, trest);
                     appendElement(layer, rest);
                     convertRest(rest, trest, -1, staffindex);
                 }


### PR DESCRIPTION
This PR changes the `xml:id` format for rests that overfill the measure duration for this format: `rest-L4F1`. This will allow to make those rests clickable in VHV e.g. in combination with IIIF `*xywh` interpretations.

Demo score:

<img width="585" alt="Bildschirm­foto 2023-03-19 um 16 56 39" src="https://user-images.githubusercontent.com/865594/226188170-1ba0e00b-0715-401e-bfc4-5062b12e99ca.png">

```tsv
**kern
*M2/1
=1
00r
=2
.
=3
1r
00r
=4
.
1r
==
*-
```

<details>
  <summary>Click for MEI of the demo score without the fix</summary>

```tsv
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2023-03-19T16:49:45" version="3.16.0-dev-e9e7d10-dirty">
               <name>Verovio</name>
               <p>Transcoded from Humdrum</p>
            </application>
         </appInfo>
      </encodingDesc>
      <workList>
         <work>
            <title />
         </work>
      </workList>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m15afhdd">
            <score xml:id="sg594yw">
               <scoreDef xml:id="s1if8kcs" midi.bpm="400.000000">
                  <staffGrp xml:id="s1y0yuin">
                     <staffDef xml:id="staffdef-L1F1" n="1" lines="5">
                        <clef xml:id="c15i1haq" />
                        <meterSig xml:id="metersig-L2F1" count="2" unit="1" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-L1F1">
                  <measure xml:id="measure-L1" n="1">
                     <staff xml:id="staff-L1F1" n="1">
                        <layer xml:id="layer-L1F1N1" n="1">
                           <rest xml:id="r1m44j82" type="straddle" dur.ges="breve" dur="long" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L5" n="2">
                     <staff xml:id="staff-L5F1N1" n="1">
                        <layer xml:id="layer-L5F1N1" n="1">
                           <space xml:id="s8i3btr" type="straddle" dur="breve" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L7" n="3">
                     <staff xml:id="staff-L7F1N1" n="1">
                        <layer xml:id="layer-L7F1N1" n="1">
                           <rest xml:id="rest-L8F1" dur="1" />
                           <rest xml:id="rest-L9F1" type="straddle" dur.ges="breve" dur="long" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L10" right="end" n="4">
                     <staff xml:id="staff-L10F1N1" n="1">
                        <layer xml:id="layer-L10F1N1" n="1">
                           <space xml:id="s1aqzh7n" type="straddle" dur="breve" />
                           <rest xml:id="rest-L12F1" dur="1" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
  <summary>Click for MEI of the demo score with the fix</summary>

```tsv
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2023-03-19T16:50:08" version="3.16.0-dev-e9e7d10-dirty">
               <name>Verovio</name>
               <p>Transcoded from Humdrum</p>
            </application>
         </appInfo>
      </encodingDesc>
      <workList>
         <work>
            <title />
         </work>
      </workList>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="m12lrf0j">
            <score xml:id="s1iqg8si">
               <scoreDef xml:id="sse4999" midi.bpm="400.000000">
                  <staffGrp xml:id="s1isf5y2">
                     <staffDef xml:id="staffdef-L1F1" n="1" lines="5">
                        <clef xml:id="c1sfhgdc" />
                        <meterSig xml:id="metersig-L2F1" count="2" unit="1" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="section-L1F1">
                  <measure xml:id="measure-L1" n="1">
                     <staff xml:id="staff-L1F1" n="1">
                        <layer xml:id="layer-L1F1N1" n="1">
                           <rest xml:id="rest-L4F1" type="straddle" dur.ges="breve" dur="long" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L5" n="2">
                     <staff xml:id="staff-L5F1N1" n="1">
                        <layer xml:id="layer-L5F1N1" n="1">
                           <space xml:id="s199jwvy" type="straddle" dur="breve" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L7" n="3">
                     <staff xml:id="staff-L7F1N1" n="1">
                        <layer xml:id="layer-L7F1N1" n="1">
                           <rest xml:id="rest-L8F1" dur="1" />
                           <rest xml:id="rest-L9F1" type="straddle" dur.ges="breve" dur="long" />
                        </layer>
                     </staff>
                  </measure>
                  <measure xml:id="measure-L10" right="end" n="4">
                     <staff xml:id="staff-L10F1N1" n="1">
                        <layer xml:id="layer-L10F1N1" n="1">
                           <space xml:id="s1jx2d64" type="straddle" dur="breve" />
                           <rest xml:id="rest-L12F1" dur="1" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<img width="1270" alt="Bildschirm­foto 2023-03-19 um 17 00 13" src="https://user-images.githubusercontent.com/865594/226188352-0126bda8-1623-42e1-985c-b1576ac4e2ee.png">

