### PR TITLE
Add font fallback

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -439,7 +439,7 @@ void SvgDeviceContext::StartPage()
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
         m_currentNode.append_child(pugi::node_pcdata)
-            .set_value("g.page-margin{font-family:Times;} "
+            .set_value("g.page-margin{font-family:Times,serif;} "
                        //"g.page-margin{background: pink;} "
                        //"g.bounding-box{stroke:red; stroke-width:10} "
                        //"g.content-bounding-box{stroke:blue; stroke-width:10} "


### PR DESCRIPTION
This adds a "serif" fallback to the css font-family. This improves the output for conversion from SVG on systems without a "Times" font.

conversion to png 
before:

![image](https://user-images.githubusercontent.com/7693447/226298375-b80d7fea-d927-4d91-bfad-56425e724d48.png)

after:

![image](https://user-images.githubusercontent.com/7693447/226298464-6469b359-27c4-4f73-be6b-11bb5ae109af.png)
