### PR TITLE
Fix for overlap of fTrem beams with tuplet number

### DIFF
--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -170,9 +170,9 @@ void View::DrawFTremSegment(DeviceContext *dc, Staff *staff, FTrem *fTrem)
     int space = m_doc->GetDrawingBeamWidth(staff->m_drawingStaffSize, fTrem->m_cueSize);
     // for non-stem notes the bar should be shortened
     if (dur < DUR_2) {
-        x1 += 2 * space;
+        if (fTrem->m_drawingPlace == BEAMPLACE_below) x1 += 2 * space;
         y1 += 2 * space * fTrem->m_beamSegment.m_beamSlope;
-        x2 -= 2 * space;
+        if (fTrem->m_drawingPlace == BEAMPLACE_above) x2 -= 2 * space;
         y2 -= 2 * space * fTrem->m_beamSegment.m_beamSlope;
         // floating bars make no sense here
         fullBars = allBars;


### PR DESCRIPTION
Minor fix for overlaps that happens between fTrem beams and tuplet numbers. Additionally, changed how beams look in fTrem with semibreves.

![image](https://user-images.githubusercontent.com/1819669/226365885-1af152b9-be54-495b-b6f3-467b954e296c.png)

![image](https://user-images.githubusercontent.com/1819669/226365928-ce02a37a-b208-4df0-888b-ff1e1d723f27.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title/>
        <respStmt/>
      </titleStmt>
      <pubStmt/>
    </fileDesc>
  </meiHead>
  <music>
    <body>
      <mdiv xml:id="mu3zhmd">
        <score xml:id="spvr2ed">
          <scoreDef>
            <staffGrp xml:id="saxcj1g">
              <staffGrp xml:id="ssookh0">
                <staffGrp xml:id="s16dt69m">
                  <staffDef xml:id="P15" n="15" lines="5">
                    <label xml:id="l16drxl4">Violino I</label>
                    <clef xml:id="cm1im6b" shape="G" line="2"/>
                    <keySig xml:id="k1d86kac" mode="major" sig="3f"/>
                    <meterSig xml:id="m15x9440" count="2" unit="4"/>
                  </staffDef>
                </staffGrp>
              </staffGrp>
            </staffGrp>
          </scoreDef>
          <section xml:id="s1h82oca">
            <measure xml:id="m7oo9w5" n="266" corresp="#m7oo9w5">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="tcqom76" num="4" numbase="1" num.place="above" bracket.place="above" bracket.visible="false">
                    <fTrem xml:id="fr3t3qg" beams="2" beams.float="2">
                      <note xml:id="n1iaalrb" dur="2" oct="4" pname="g"/>
                      <note xml:id="n1i08e3s" dur="2" oct="4" pname="f" accid="s"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
              <dynam xml:id="d1twgtbb" staff="15" tstamp="1.0">
                <rend xml:id="rnqypxa" fontstyle="normal" fontweight="normal">pp</rend>
              </dynam>
            </measure>
            <measure xml:id="m1rajxbt" n="267" corresp="#m1rajxbt">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="t1lyc1jh" num="4" numbase="1" num.place="above" bracket.place="above" bracket.visible="false">
                    <fTrem xml:id="f1jzeji0" beams="2" beams.float="2">
                      <note xml:id="nhgxe06" dur="1" oct="4" pname="g"/>
                      <note xml:id="n19fafa8" dur="1" oct="4" pname="f" accid="s"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="m17oiu48" n="268" corresp="#m17oiu48">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="t1uoe3re" num="4" numbase="1" num.place="above" bracket.place="above" bracket.visible="false">
                    <fTrem xml:id="fab6qbl" beams="2" beams.float="2">
                      <note xml:id="nxrfl1a" dur="1" oct="4" pname="g"/>
                      <note xml:id="nb5kgjx" dur="1" oct="4" pname="f" accid="s"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="m1omfsnr" n="269" corresp="#m1omfsnr">
              <staff n="15">
                <layer n="1">
                  <beam xml:id="b1tgw71g">
                    <note xml:id="nbmakzt" dur="16" oct="4" pname="g">
                      <artic xml:id="a18hoian" artic="stacciss"/>
                    </note>
                    <note xml:id="n10v950g" dur="16" oct="4" pname="b" accid="n"/>
                    <note xml:id="nvznkvj" dur="16" oct="5" pname="c"/>
                    <note xml:id="n1vce2dd" dur="16" oct="4" pname="b"/>
                  </beam>
                  <beam xml:id="b1kjx2qg">
                    <note xml:id="n1b3cwte" dur="16" oct="5" pname="c"/>
                    <note xml:id="npo662l" dur="16" oct="4" pname="b"/>
                    <note xml:id="n1sggyxf" dur="16" oct="5" pname="c"/>
                    <note xml:id="nxv2b3q" dur="16" oct="4" pname="b"/>
                  </beam>
                </layer>
              </staff>
              <slur xml:id="s15r1e1m" startid="#n10v950g" endid="#nxv2b3q" curvedir="above"/>
            </measure>
            <measure xml:id="m133dehk" n="270" corresp="#m133dehk">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="t1j3y0y2" num="4" numbase="1" num.place="below" bracket.place="below" bracket.visible="false">
                    <fTrem xml:id="f112h7sk" beams="2" beams.float="2">
                      <note xml:id="n1xs9792" dur="1" oct="5" pname="c"/>
                      <note xml:id="n1ma0fzn" dur="1" oct="4" pname="b" accid="n"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="m1jr6my6" n="271" corresp="#m1jr6my6">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="tltcom6" num="4" numbase="1" num.place="below" bracket.place="below" bracket.visible="false">
                    <fTrem xml:id="f1o3j4vp" beams="2" beams.float="2">
                      <note xml:id="nm4hcsd" dur="1" oct="5" pname="c"/>
                      <note xml:id="n1c0ufic" dur="1" oct="4" pname="b" accid="n"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="muf7hb2" n="272" corresp="#muf7hb2">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="tbls354" num="4" numbase="1" num.place="below" bracket.place="below" bracket.visible="false">
                    <fTrem xml:id="fafjwoe" beams="2" beams.float="2">
                      <note xml:id="n17213qy" dur="1" oct="5" pname="c"/>
                      <note xml:id="n1n7nmz6" dur="1" oct="4" pname="b" accid="n"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="m1t9kbqq" n="273" corresp="#m1t9kbqq">
              <staff n="15">
                <layer n="1">
                  <beam xml:id="b1o94s27">
                    <note xml:id="n51ilm9" dur="16" oct="5" pname="c">
                      <artic xml:id="a1oihtyk" artic="stacciss"/>
                    </note>
                    <note xml:id="nyfwar3" dur="16" oct="3" pname="b" accid="n"/>
                    <note xml:id="n1q6q3ck" dur="16" oct="4" pname="c"/>
                    <note xml:id="ncqxx20" dur="16" oct="3" pname="b"/>
                  </beam>
                  <beam xml:id="bqtiop0">
                    <note xml:id="nn1kbq6" dur="16" oct="4" pname="c"/>
                    <note xml:id="nnbnswh" dur="16" oct="3" pname="b"/>
                    <note xml:id="nd8kx3h" dur="16" oct="4" pname="c"/>
                    <note xml:id="n10rm07e" dur="16" oct="3" pname="b"/>
                  </beam>
                </layer>
              </staff>
              <slur xml:id="s4cd24l" startid="#nyfwar3" endid="#n10rm07e" curvedir="below"/>
            </measure>
            <measure xml:id="m864tmd" n="274" corresp="#m864tmd">
              <staff n="15">
                <layer n="1">
                  <beam xml:id="bu3jh0j">
                    <note xml:id="n1tk0897" dur="16" oct="3" pname="b" accid="f"/>
                    <note xml:id="n1u2o72z" dur="16" oct="3" pname="a" accid="n"/>
                    <note xml:id="n10a16lj" dur="16" oct="3" pname="b" accid.ges="f"/>
                    <note xml:id="n1h1b5qf" dur="16" oct="3" pname="a"/>
                  </beam>
                  <beam xml:id="bfe9whm">
                    <note xml:id="n1vfcgbo" dur="16" oct="3" pname="b" accid.ges="f"/>
                    <note xml:id="nhlmtvz" dur="16" oct="3" pname="a"/>
                    <note xml:id="na0sm8n" dur="16" oct="3" pname="b" accid.ges="f"/>
                    <note xml:id="n1w9kwsx" dur="16" oct="3" pname="a"/>
                  </beam>
                </layer>
              </staff>
              <hairpin xml:id="h1be5nwd" staff="15" tstamp="1.0" tstamp2="2m+1.0000" form="cres"/>
              <slur xml:id="srzaa01" startid="#n1tk0897" endid="#n1w9kwsx" curvedir="below"/>
            </measure>
            <measure xml:id="m1wn5nox" n="275" corresp="#m1wn5nox">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="tjz3n" num="4" numbase="1" num.place="above" bracket.place="above" bracket.visible="false">
                    <fTrem xml:id="f131jy3w" beams="2" beams.float="2">
                      <note xml:id="n17y9n5s" dur="1" oct="3" pname="b" accid.ges="f"/>
                      <note xml:id="nmr475u" dur="1" oct="3" pname="a" accid="n"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
            </measure>
            <measure xml:id="meewzz9" n="276" corresp="#meewzz9">
              <staff n="15">
                <layer n="1">
                  <tuplet xml:id="t1qq6ztp" num="4" numbase="1" num.place="above" bracket.place="above" bracket.visible="false">
                    <fTrem xml:id="f1kjz870" beams="2" beams.float="2">
                      <note xml:id="n1crh42v" dur="1" oct="3" pname="b" accid.ges="f"/>
                      <note xml:id="nccjcoj" dur="1" oct="3" pname="a" accid="n"/>
                    </fTrem>
                  </tuplet>
                </layer>
              </staff>
              <hairpin xml:id="hb3buac" staff="15" tstamp="1.0" tstamp2="1m+1.2500" form="dim"/>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>

```

</details>