### PR TITLE
Improve partial tuplets in beams

### DIFF
--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -279,13 +279,16 @@ void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
 
     Beam *beam = this->GetNumAlignedBeam();
     this->CalculateTupletNumCrossStaff(tupletNum);
+    // Additional checks are required if tuplet is fully cross-staff and is part of the cross-staff beam. If beam is not
+    // fully cross-staff and has more elements than tuplet does, we need to adjust tuplet number position accordingly to
+    // make sure that there is no overlap.
     bool isPartialBeamTuplet = false;
     if (beam && m_crossStaff) {
         const auto coords = beam->m_beamSegment.GetElementCoordRefs();
         ListOfObjects descendants;
         ClassIdsComparison comparison({ CHORD, NOTE, REST });
         this->FindAllDescendantsByComparison(&descendants, &comparison);
-        if ((beam->m_beamSegment.m_nbNotesOrChords > descendants.size())
+        if ((beam->m_beamSegment.m_nbNotesOrChords > static_cast<int>(descendants.size()))
             && std::any_of(coords->begin(), coords->end(),
                 [](const auto coord) { return NULL == coord->m_element->m_crossStaff; })) {
             if (!this->HasValidTupletNumPosition(tupletNum->m_crossStaff, beam->m_beamStaff)) {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -277,7 +277,23 @@ void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
         return;
     }
 
+    Beam *beam = this->GetNumAlignedBeam();
     this->CalculateTupletNumCrossStaff(tupletNum);
+    bool isPartialBeamTuplet = false;
+    if (beam && m_crossStaff) {
+        const auto coords = beam->m_beamSegment.GetElementCoordRefs();
+        ListOfObjects descendants;
+        ClassIdsComparison comparison({ CHORD, NOTE, REST });
+        this->FindAllDescendantsByComparison(&descendants, &comparison);
+        if ((beam->m_beamSegment.m_nbNotesOrChords > descendants.size())
+            && std::any_of(coords->begin(), coords->end(),
+                [](const auto coord) { return NULL == coord->m_element->m_crossStaff; })) {
+            if (!this->HasValidTupletNumPosition(tupletNum->m_crossStaff, beam->m_beamStaff)) {
+                tupletNum->m_crossStaff = beam->m_beamStaff;
+            }
+            isPartialBeamTuplet = true;
+        }
+    }
 
     const Staff *tupletNumStaff = tupletNum->m_crossStaff ? tupletNum->m_crossStaff : staff;
     const int staffSize = staff->m_drawingStaffSize;
@@ -288,7 +304,6 @@ void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
     const int numVerticalMargin = (m_drawingNumPos == STAFFREL_basic_above) ? doubleUnit : -doubleUnit;
     const int staffHeight = doc->GetDrawingStaffSize(staffSize);
     const int adjustedPosition = (m_drawingNumPos == STAFFREL_basic_above) ? 0 : -staffHeight;
-    Beam *beam = this->GetNumAlignedBeam();
     if (!beam) {
         tupletNum->SetDrawingYRel(adjustedPosition);
     }
@@ -303,7 +318,7 @@ void Tuplet::AdjustTupletNumY(const Doc *doc, const Staff *staff)
     int yRel = adjustTupletNumOverlapParams.m_yRel - yReference;
 
     // If we have a beam, see if we can move it to more appropriate position
-    if (beam && !m_crossStaff && !FindDescendantByType(ARTIC)) {
+    if (beam && (!m_crossStaff || isPartialBeamTuplet) && !this->FindDescendantByType(ARTIC)) {
         const int xMid = tupletNum->GetDrawingXMid(doc);
         const int yMid = beam->m_beamSegment.GetStartingY()
             + beam->m_beamSegment.m_beamSlope * (xMid - beam->m_beamSegment.GetStartingX());


### PR DESCRIPTION
closes #2880

![image](https://user-images.githubusercontent.com/1819669/226883332-e7a0d2eb-ac45-483a-809c-667c8d461373.png)

<details><summary>Example MEI:</summary>

```XML
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>...</title>
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2022-05-21T19:54:56" version="3.10.0-dev-6308e07">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp bar.thru="true" symbol="brace">
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                        <keySig pname="g" mode="major" sig="1s" />
                        <meterSig count="4" sym="common" unit="4" />
                     </staffDef>
                     <staffDef n="2" lines="5">
                        <clef shape="F" line="4" />
                        <keySig pname="g" mode="major" sig="1s" />
                        <meterSig count="4" sym="common" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="a" accid.ges="n" />
                              <note dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="false" num.format="count">
                                 <note dur="32" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1"/>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam>
                              <note dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="a" accid.ges="n" />
                              <note dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="false" num.format="count" num.place="below">
                                 <note dur="32" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1"/>
                     </staff>
                  </measure>
                  <!--  -->
                  <measure>
                     <staff n="1">
                        <layer n="1"/>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam>
                              <note dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="5" numbase="3" bracket.place="above" bracket.visible="false" num.format="count">
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" staff="1" dur="32" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="a" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              </tuplet>
                              <note dur="32" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1"/>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam>
                              <note dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="5" numbase="3" bracket.place="above" bracket.visible="false" num.format="count" num.place="below">
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" staff="1" dur="32" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="a" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              </tuplet>
                              <note dur="32" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <!--  -->
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam place="below">
                              <note dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="a" accid.ges="n" />
                              <note dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="false" num.format="count">
                                 <note dur="32" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1"/>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <beam place="below">
                              <note dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="a" accid.ges="n" />
                              <note dur="32" oct="4" pname="g" accid.ges="n" />
                              <note dur="32" oct="4" pname="e" accid.ges="n" />
                              <note breaksec="1" dur="32" staff="2" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="3" numbase="2" bracket.place="above" bracket.visible="false" num.format="count" num.place="below">
                                 <note dur="32" staff="2" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                                 <note dur="32" staff="2" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                              </tuplet>
                           </beam>
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1"/>
                     </staff>
                  </measure>
                  <!--  -->
                  <measure>
                     <staff n="1">
                        <layer n="1"/>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam place="below">
                              <note dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="5" numbase="3" bracket.place="above" bracket.visible="false" num.format="count">
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" staff="1" dur="32" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="a" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              </tuplet>
                              <note dur="32" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1"/>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <beam place="below">
                              <note dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              <tuplet num="5" numbase="3" bracket.place="above" bracket.visible="false" num.format="count" num.place="below">
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" staff="1" dur="32" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="a" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="g" accid.ges="n" />
                                 <note dur="32" staff="1" oct="4" pname="e" accid.ges="n" />
                                 <note breaksec="1" dur="32" oct="3" pname="a" stem.dir="up" accid.ges="n" />
                              </tuplet>
                              <note dur="32" oct="3" pname="g" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="f" stem.dir="up" accid.ges="n" />
                              <note dur="32" oct="3" pname="e" stem.dir="up" accid.ges="n" />
                           </beam>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```

</details>