### PR TITLE
Humdrum: Hide rests with extra duration with `yy` signifier

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -11244,20 +11244,21 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                     // (so not an mRest), and update the visual duration
                     // of the rest because there will be invisible rests
                     // added in later measure(s).
-					if (trest->find("yy") != std::string::npos) {
-						Space *irest = new Space();
-						if (m_doc->GetOptions()->m_humType.GetValue()) {
-							embedQstampInClass(irest, trest, *trest);
-						}
-						setLocationId(irest, trest);
-						appendElement(elements, pointers, irest);
-						convertRhythm(irest, trest);
-					} else {
-						Rest *rest = new Rest;
-						setLocationId(rest, trest);
-						appendElement(layer, rest);
-						convertRest(rest, trest, -1, staffindex);
-					}
+                    if (trest->find("yy") != std::string::npos) {
+                        Space *irest = new Space();
+                        if (m_doc->GetOptions()->m_humType.GetValue()) {
+                            embedQstampInClass(irest, trest, *trest);
+                        }
+                        setLocationId(irest, trest);
+                        appendElement(elements, pointers, irest);
+                        convertRhythm(irest, trest);
+                    }
+                    else {
+                        Rest *rest = new Rest;
+                        setLocationId(rest, trest);
+                        appendElement(layer, rest);
+                        convertRest(rest, trest, -1, staffindex);
+                    }
                 }
                 else {
                     std::cerr << "Strange error for adding rest " << trest << std::endl;

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -11244,10 +11244,20 @@ bool HumdrumInput::fillContentsOfLayer(int track, int startline, int endline, in
                     // (so not an mRest), and update the visual duration
                     // of the rest because there will be invisible rests
                     // added in later measure(s).
-                    Rest *rest = new Rest;
-                    setLocationId(rest, trest);
-                    appendElement(layer, rest);
-                    convertRest(rest, trest, -1, staffindex);
+					if (trest->find("yy") != std::string::npos) {
+						Space *irest = new Space();
+						if (m_doc->GetOptions()->m_humType.GetValue()) {
+							embedQstampInClass(irest, trest, *trest);
+						}
+						setLocationId(irest, trest);
+						appendElement(elements, pointers, irest);
+						convertRhythm(irest, trest);
+					} else {
+						Rest *rest = new Rest;
+						setLocationId(rest, trest);
+						appendElement(layer, rest);
+						convertRest(rest, trest, -1, staffindex);
+					}
                 }
                 else {
                     std::cerr << "Strange error for adding rest " << trest << std::endl;


### PR DESCRIPTION
A small code review would be good for this one, as I do not really know what `embedQstampInClass()`, `appendElement(elements, pointers, irest)` and `convertRhythm(irest, trest)` does. But I took it from a few lines above and it seems to work.

<details>
  <summary>Click for MEI for the demo score</summary>

```tsv
**kern	**text	**kern	**text	**kern	**text
*clefC3	*	*clefC2	*	*clefG2	*
*k[]	*	*k[]	*	*k[]	*
*M2/1	*	*M2/1	*	*M2/1	*
*met(C|)	*	*met(C|)	*	*met(C|)	*
=1	=1	=1	=1	=1	=1
1r	.	00ryy	.	1dd	Se-
1g	Se-	.	.	2dd	-lig
.	.	.	.	2dd	zu
=2	=2	=2	=2	=2	=2
2g	-lig	.	.	1b	prei-
2g	zu	.	.	.	.
2e	prei-	.	.	2cc	-sen
2f	-sen	.	.	2a	ist
=3	=3	=3	=3	=3	=3
1e	ist	0r	.	2g	der
.	.	.	.	2a	.
1d	der	.	.	4b	.
.	.	.	.	4cc	.
.	.	.	.	8b	.
.	.	.	.	8a	.
.	.	.	.	4b	.
=4	=4	=4	=4	=4	=4
1c	mann/	1g	Se-	2ee	mann/
.	.	.	.	2ee	se-
2r	.	2g	-lig	2dd	-lig
[2c	ist	2g	zu	2ee	zu
=5	=5	=5	=5	=5	=5
*-	*-	*-	*-	*-	*-
```
</details>

Before:

<img width="1033" alt="Bildschirm­foto 2023-03-22 um 21 49 46" src="https://user-images.githubusercontent.com/865594/227036800-f01ca062-a8ee-48b6-96dd-5af815d67d47.png">

After:

<img width="1036" alt="Bildschirm­foto 2023-03-22 um 21 49 27" src="https://user-images.githubusercontent.com/865594/227036831-f05e496c-31ee-4ee5-998d-45e04e18f23c.png">
