### PR TITLE
Cross staff artic placement fix

### DIFF
--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -434,12 +434,13 @@ int Artic::AdjustArtic(FunctorParams *functorParams)
         yOut = std::max(yIn, 0);
     }
     else {
+        const bool isStemDown = stem && (stem->GetDrawingStemDir() == STEMDIRECTION_down);
         int yBelowStem = params->m_parent->GetDrawingBottom(params->m_doc, staff->m_drawingStaffSize, false)
             - staff->GetDrawingY();
-        if (flag && stem && (stem->GetDrawingStemDir() == STEMDIRECTION_down))
-            yBelowStem += flag->GetStemDownNW(params->m_doc, staff->m_drawingStaffSize, false).y;
+        if (flag && isStemDown) yBelowStem += flag->GetStemDownNW(params->m_doc, staff->m_drawingStaffSize, false).y;
         yIn = std::min(yBelowStem, 0);
-        if (beam && beam->m_crossStaffContent && beam->m_drawingPlace == BEAMPLACE_mixed) yIn -= beam->m_beamWidthBlack;
+        if (beam && beam->m_crossStaffContent && (beam->m_drawingPlace == BEAMPLACE_mixed) && isStemDown)
+            yIn -= beam->m_beamWidthBlack;
         yOut = std::min(yIn, -staffHeight);
     }
 

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -439,8 +439,9 @@ int Artic::AdjustArtic(FunctorParams *functorParams)
             - staff->GetDrawingY();
         if (flag && isStemDown) yBelowStem += flag->GetStemDownNW(params->m_doc, staff->m_drawingStaffSize, false).y;
         yIn = std::min(yBelowStem, 0);
-        if (beam && beam->m_crossStaffContent && (beam->m_drawingPlace == BEAMPLACE_mixed) && isStemDown)
+        if (beam && beam->m_crossStaffContent && (beam->m_drawingPlace == BEAMPLACE_mixed) && isStemDown) {
             yIn -= beam->m_beamWidthBlack;
+        }
         yOut = std::min(yIn, -staffHeight);
     }
 


### PR DESCRIPTION
closes #2810 

Blue notes had already been fixed before, this change improves artic on red note:
![image](https://user-images.githubusercontent.com/1819669/227187823-76ef0de4-c526-4dea-8c8d-30673b3e6241.png)
