### PR TITLE
Humdrum: Hide bracket and number when tuplet notes are suppressed with `yy`

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -20134,6 +20134,21 @@ void HumdrumInput::insertTuplet(std::vector<std::string> &elements, std::vector<
         // if explicitly requested:
         tuplet->SetNumVisible(BOOLEAN_false);
     }
+
+    // Hide bracket and number if all data tokens of tuplet are suppressed with yy signifier
+    bool allTokensAreHidden = true;
+    for (int i = 0; i < (int)tgs.size(); ++i) {
+        const hum::HTp token = tgs.at(i).token;
+        if (token->isData() && token->find("yy") == std::string::npos) {
+            allTokensAreHidden = false;
+            break;
+        }
+    }
+    if (allTokensAreHidden) {
+        tuplet->SetBracketVisible(BOOLEAN_false);
+        tuplet->SetNumVisible(BOOLEAN_false);
+    }
+
     hum::HumNum base = tg.numbase;
     // if (!base.isPowerOfTwo()) {
     //     tuplet->SetNumFormat(tupletVis_NUMFORMAT_ratio);


### PR DESCRIPTION
Currently when all notes of a tuplet are suppressed with `yy` the bracket and numbers will still be visible. This PR changes this behavior: if at least one note in the tuplet is not suppressed with `yy` bracket and numbers visibility will be taken from the config as before. But if all data tokens are suppressed with `yy` they will be forced to be hidden.

Demo score:

```tsv
**kern
*clefG2
=
3.gL
6g
3g
=
3.gLyy
6gyy
3gyy
=
3.gLyy
6g
3gyy
*-
```

Before:

<img width="446" alt="Bildschirm­foto 2023-03-25 um 00 30 30" src="https://user-images.githubusercontent.com/865594/227661300-a6cb2a90-655c-40d7-b6f3-9d6f7d865438.png">

After:

<img width="449" alt="Bildschirm­foto 2023-03-25 um 00 29 45" src="https://user-images.githubusercontent.com/865594/227661292-e1574aaf-bae4-44ce-a9ea-0416cb4a91b7.png">