### PR TITLE
Humdrum: Improvements for suppressed tokens with `yy` signifier

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -24089,6 +24089,11 @@ std::vector<hum::HTp> HumdrumInput::getVerseAbbrLabels(hum::HTp token, int staff
 
 template <class ELEMENT> void HumdrumInput::convertVerses(ELEMENT element, hum::HTp token)
 {
+	// Ignore verse when token is suppressed with yy signifier
+	if (token->find("yy") != std::string::npos) {
+		return;
+	}
+
     int staff = m_rkern[token->getTrack()];
     std::vector<humaux::StaffStateVariables> &ss = m_staffstates;
     if (!ss[staff].verse) {

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -1924,6 +1924,11 @@ Tie *HumdrumInput::addHangingTieToNextItem(hum::HTp token, int subindex, hum::Hu
 void HumdrumInput::processHangingTieEnd(
     Note *note, hum::HTp token, const std::string &tstring, int subindex, hum::HumNum meterunit)
 {
+    // Ignore tie when token is suppressed with yy signifier
+    if (token->find("yy") != std::string::npos) {
+        return;
+    }
+
     Tie *tie = NULL;
     hum::HumNum position = token->getDurationFromStart();
     if (position == 0) {

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -24089,10 +24089,10 @@ std::vector<hum::HTp> HumdrumInput::getVerseAbbrLabels(hum::HTp token, int staff
 
 template <class ELEMENT> void HumdrumInput::convertVerses(ELEMENT element, hum::HTp token)
 {
-	// Ignore verse when token is suppressed with yy signifier
-	if (token->find("yy") != std::string::npos) {
-		return;
-	}
+    // Ignore verse when token is suppressed with yy signifier
+    if (token->find("yy") != std::string::npos) {
+        return;
+    }
 
     int staff = m_rkern[token->getTrack()];
     std::vector<humaux::StaffStateVariables> &ss = m_staffstates;


### PR DESCRIPTION
Sometimes with system breaks a dash for syllable separation was still displayed when the related notes was suppressed with `yy`.

Demo file: https://github.com/WolfgangDrescher/lassus-geistliche-psalmen/blob/master/kern/02-quare-fremuerunt-gentes.krn

```
cat 02-quare-fremuerunt-gentes.krn | shed -s 3 -e 's/^(.+)$/$1yy/D s/^.+$//L s/^.+$//I' | myank -m 1-5 | ./verovio --stdin -o output.svg
```

Before:

<img width="1032" alt="Bildschirm­foto 2023-03-25 um 20 19 20" src="https://user-images.githubusercontent.com/865594/227737788-41d2debb-691b-44a3-824a-7dd9a0adf40d.png">

After:

<img width="1033" alt="Bildschirm­foto 2023-03-25 um 20 21 03" src="https://user-images.githubusercontent.com/865594/227737800-bef62186-868b-4cf4-a7a5-162773225a6d.png">

---

Same for hanging tie ends:

```
cat 02-quare-fremuerunt-gentes.krn | shed -s 5 -e 's/^(.+)$/$1yy/D s/^.+$//L s/^.+$//I' | myank -m 7 | ./verovio --stdin -o output.svg
```

Before:

<img width="368" alt="Bildschirm­foto 2023-03-25 um 20 25 33" src="https://user-images.githubusercontent.com/865594/227737869-896927ea-4da4-424c-b550-b2d5a4100038.png">

After:

<img width="370" alt="Bildschirm­foto 2023-03-25 um 20 26 22" src="https://user-images.githubusercontent.com/865594/227737882-2cb136ad-b254-4fa0-879b-fa2477719f14.png">