### PR TITLE
Move option usage to toolkit

### DIFF
--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -101,7 +101,7 @@ public:
      *
      * @return the version number as a string
      */
-    std::string GetVersion();
+    std::string GetVersion() const;
 
     /**
      * Reset the seed used to generate MEI \@xml:id attribute values
@@ -241,6 +241,16 @@ public:
      * Reset all options to default values
      */
     void ResetOptions();
+
+    /**
+     * Print formatted option usage for specific category (with max/min/default values) to output stream.
+     */
+    void GetOptionUsage(const std::string &category, std::ostream &output) const;
+
+    /**
+     * Get all usage for all option categories as string.
+     */
+    std::string GetOptionUsageString() const;
 
     /**
      * Set the scale option.
@@ -724,6 +734,11 @@ protected:
      * Identify the input file type for auto loading of input data
      */
     FileFormat IdentifyInputFrom(const std::string &data);
+
+    /**
+     * Print formatted option usage for specific option to output stream.
+     */
+    void GetOptionUsageOutput(vrv::Option *option, std::ostream &output) const;
 
     /**
      * Resets the vrv::logBuffer.

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -245,7 +245,7 @@ public:
     /**
      * Print formatted option usage for specific category (with max/min/default values) to output stream.
      */
-    void GetOptionUsage(const std::string &category, std::ostream &output) const;
+    void PrintOptionUsage(const std::string &category, std::ostream &output) const;
 
     /**
      * Get all usage for all option categories as string.
@@ -738,7 +738,7 @@ protected:
     /**
      * Print formatted option usage for specific option to output stream.
      */
-    void GetOptionUsageOutput(vrv::Option *option, std::ostream &output) const;
+    void PrintOptionUsageOutput(const vrv::Option *option, std::ostream &output) const;
 
     /**
      * Resets the vrv::logBuffer.

--- a/include/vrv/vrv.h
+++ b/include/vrv/vrv.h
@@ -112,6 +112,16 @@ std::string GetVersion();
 std::string BaseEncodeInt(uint32_t value, uint8_t base);
 
 /**
+ * Convert string from camelCase.
+ */
+std::string FromCamelCase(const std::string &s);
+
+/**
+ * Convert string to camelCase.
+ */
+std::string ToCamelCase(const std::string &s);
+
+/**
  *
  */
 extern LogLevel logLevel;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1112,6 +1112,145 @@ void Toolkit::ResetOptions()
     this->SetFont(m_options->m_font.GetValue());
 }
 
+void Toolkit::GetOptionUsageOutput(vrv::Option *option, std::ostream &output) const
+{
+    if (!option) return;
+    std::string option_str = " ";
+    if (option->GetShortOption()) {
+        option_str.append("-");
+        option_str.push_back(option->GetShortOption());
+        option_str.append(", ");
+    }
+
+    if (!option->GetKey().empty()) {
+        option_str.append("--");
+        option_str.append(vrv::FromCamelCase(option->GetKey()));
+    }
+
+    const vrv::OptionDbl *optDbl = dynamic_cast<const vrv::OptionDbl *>(option);
+    const vrv::OptionInt *optInt = dynamic_cast<const vrv::OptionInt *>(option);
+    const vrv::OptionIntMap *optIntMap = dynamic_cast<const vrv::OptionIntMap *>(option);
+    const vrv::OptionString *optString = dynamic_cast<const vrv::OptionString *>(option);
+    const vrv::OptionArray *optArray = dynamic_cast<const vrv::OptionArray *>(option);
+    const vrv::OptionBool *optBool = dynamic_cast<const vrv::OptionBool *>(option);
+
+    if (typeid(*optDbl) == typeid(OptionDbl)) {
+        option_str.append(" <f>");
+    }
+    else if (optInt) {
+        option_str.append(" <i>");
+    }
+    else if (optString) {
+        option_str.append(" <s>");
+    }
+    else if (optArray) {
+        option_str.append("* <s>");
+    }
+    else if (!optBool) {
+        option_str.append(" <s>");
+    }
+
+    const int helpTabs = 32;
+    if (option_str.size() < helpTabs) {
+        option_str.insert(option_str.end(), helpTabs - option_str.size(), ' ');
+    }
+    else {
+        option_str.append("\t");
+    }
+
+    output << option_str << option->GetDescription();
+    if (optInt && (optInt->GetMin() != optInt->GetMax())) {
+        output << " (default: " << optInt->GetDefault();
+        output << "; min: " << optInt->GetMin();
+        output << "; max: " << optInt->GetMax() << ")";
+    }
+    if (optDbl && (optDbl->GetMin() != optDbl->GetMax())) {
+        output << std::fixed << " (default: " << optDbl->GetDefault();
+        output << std::fixed << "; min: " << optDbl->GetMin();
+        output << std::fixed << "; max: " << optDbl->GetMax() << ")";
+    }
+    if (optString) {
+        output << " (default: \"" << optString->GetDefault() << "\")";
+    }
+    if (optIntMap) {
+        output << " (default: \"" << optIntMap->GetDefaultStrValue()
+               << "\"; other values: " << optIntMap->GetStrValuesAsStr(true) << ")";
+    }
+    output << std::endl;
+}
+
+void Toolkit::GetOptionUsage(const std::string &category, std::ostream &output) const
+{
+    // map of all categories and expected string arguments for them
+    const std::map<vrv::OptionsCategory, std::string> categories = { { vrv::OptionsCategory::Base, "base" },
+        { vrv::OptionsCategory::General, "general" }, { vrv::OptionsCategory::Layout, "layout" },
+        { vrv::OptionsCategory::Margins, "margins" }, { vrv::OptionsCategory::Midi, "midi" },
+        { vrv::OptionsCategory::Selectors, "selectors" }, { vrv::OptionsCategory::Full, "full" } };
+
+    output.precision(2);
+    // display_version();
+    output << "Verovio " << this->GetVersion() << std::endl;
+    output << std::endl << "Example usage:" << std::endl << std::endl;
+    output << " verovio [-s scale] [-r resource-path] [-o outfile] infile" << std::endl << std::endl;
+
+    auto it = std::find_if(
+        categories.begin(), categories.end(), [&category](const std::pair<vrv::OptionsCategory, std::string> &value) {
+            return std::equal(value.second.begin(), value.second.end(), category.begin(), category.end(),
+                [](const char a, const char b) { return a == tolower(b); });
+        });
+
+    if (it == categories.end()) {
+        std::string optionStr;
+        output << "Help manual categories: " << std::endl;
+        // Print base group options
+        optionStr.append(" -h ");
+        optionStr.append(categories.at(m_options->m_baseOptions.GetCategory()));
+        optionStr.append("\t");
+        optionStr.append(m_options->m_baseOptions.GetLabel());
+        optionStr.append("\n");
+
+        const std::vector<vrv::OptionGrp *> *grps = m_options->GetGrps();
+        // Print each group one by one
+        for (const auto group : *grps) {
+            optionStr.append(" -h ");
+            optionStr.append(categories.at(group->GetCategory()));
+            optionStr.append("\t");
+            optionStr.append(group->GetLabel());
+            optionStr.append("\n");
+        }
+        optionStr.append(" -h full\tPrint all help manual and exit");
+        output << optionStr << std::endl;
+    }
+    else {
+        output << "Options (marked as * are repeatable)" << std::endl;
+        if ((it->first == vrv::OptionsCategory::Base) || (it->first == vrv::OptionsCategory::Full)) {
+            const std::vector<vrv::Option *> *baseOptions = m_options->GetBaseOptions();
+            for (vrv::Option *option : *baseOptions) {
+                this->GetOptionUsageOutput(option, output);
+            }
+        }
+        const std::vector<vrv::OptionGrp *> *grps = m_options->GetGrps();
+        for (const auto group : *grps) {
+            if (it->first == group->GetCategory() || (it->first == vrv::OptionsCategory::Full)) {
+                // Options with long forms only
+                output << std::endl << group->GetLabel() << std::endl;
+                const std::vector<vrv::Option *> *options = group->GetOptions();
+
+                for (vrv::Option *option : *options) {
+                    this->GetOptionUsageOutput(option, output);
+                }
+            }
+        }
+    }
+}
+
+std::string Toolkit::GetOptionUsageString() const
+{
+    stringstream ss;
+    this->GetOptionUsage("full", ss);
+    return ss.str();
+}
+
 std::string Toolkit::GetElementAttr(const std::string &xmlId)
 {
     jsonxx::Object o;
@@ -1221,7 +1360,7 @@ std::string Toolkit::GetLog()
     return str;
 }
 
-std::string Toolkit::GetVersion()
+std::string Toolkit::GetVersion() const
 {
     return vrv::GetVersion();
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1112,7 +1112,7 @@ void Toolkit::ResetOptions()
     this->SetFont(m_options->m_font.GetValue());
 }
 
-void Toolkit::GetOptionUsageOutput(vrv::Option *option, std::ostream &output) const
+void Toolkit::PrintOptionUsageOutput(const vrv::Option *option, std::ostream &output) const
 {
     if (!option) return;
     std::string option_str = " ";
@@ -1134,7 +1134,7 @@ void Toolkit::GetOptionUsageOutput(vrv::Option *option, std::ostream &output) co
     const vrv::OptionArray *optArray = dynamic_cast<const vrv::OptionArray *>(option);
     const vrv::OptionBool *optBool = dynamic_cast<const vrv::OptionBool *>(option);
 
-    if (typeid(*optDbl) == typeid(OptionDbl)) {
+    if (optDbl) {
         option_str.append(" <f>");
     }
     else if (optInt) {
@@ -1166,8 +1166,8 @@ void Toolkit::GetOptionUsageOutput(vrv::Option *option, std::ostream &output) co
     }
     if (optDbl && (optDbl->GetMin() != optDbl->GetMax())) {
         output << std::fixed << " (default: " << optDbl->GetDefault();
-        output << std::fixed << "; min: " << optDbl->GetMin();
-        output << std::fixed << "; max: " << optDbl->GetMax() << ")";
+        output << "; min: " << optDbl->GetMin();
+        output << "; max: " << optDbl->GetMax() << ")";
     }
     if (optString) {
         output << " (default: \"" << optString->GetDefault() << "\")";
@@ -1179,7 +1179,7 @@ void Toolkit::GetOptionUsageOutput(vrv::Option *option, std::ostream &output) co
     output << std::endl;
 }
 
-void Toolkit::GetOptionUsage(const std::string &category, std::ostream &output) const
+void Toolkit::PrintOptionUsage(const std::string &category, std::ostream &output) const
 {
     // map of all categories and expected string arguments for them
     const std::map<vrv::OptionsCategory, std::string> categories = { { vrv::OptionsCategory::Base, "base" },
@@ -1246,8 +1246,8 @@ void Toolkit::GetOptionUsage(const std::string &category, std::ostream &output) 
 
 std::string Toolkit::GetOptionUsageString() const
 {
-    stringstream ss;
-    this->GetOptionUsage("full", ss);
+    std::stringstream ss;
+    this->PrintOptionUsage("full", ss);
     return ss.str();
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1226,7 +1226,7 @@ void Toolkit::PrintOptionUsage(const std::string &category, std::ostream &output
         if ((it->first == vrv::OptionsCategory::Base) || (it->first == vrv::OptionsCategory::Full)) {
             const std::vector<vrv::Option *> *baseOptions = m_options->GetBaseOptions();
             for (vrv::Option *option : *baseOptions) {
-                this->GetOptionUsageOutput(option, output);
+                this->PrintOptionUsageOutput(option, output);
             }
         }
         const std::vector<vrv::OptionGrp *> *grps = m_options->GetGrps();
@@ -1237,7 +1237,7 @@ void Toolkit::PrintOptionUsage(const std::string &category, std::ostream &output
                 const std::vector<vrv::Option *> *options = group->GetOptions();
 
                 for (vrv::Option *option : *options) {
-                    this->GetOptionUsageOutput(option, output);
+                    this->PrintOptionUsageOutput(option, output);
                 }
             }
         }

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -314,6 +314,35 @@ std::string BaseEncodeInt(uint32_t value, uint8_t base)
     return base62;
 }
 
+std::string FromCamelCase(const std::string &s)
+{
+    std::regex regExp1("(.)([A-Z][a-z]+)");
+    std::regex regExp2("([a-z0-9])([A-Z])");
+
+    std::string result = s;
+    result = std::regex_replace(result, regExp1, "$1-$2");
+    result = std::regex_replace(result, regExp2, "$1-$2");
+
+    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+    return result;
+}
+
+std::string ToCamelCase(const std::string &s)
+{
+    std::istringstream iss(s);
+    std::string token;
+    std::string result;
+
+    while (getline(iss, token, '-')) {
+        token[0] = toupper(token[0]);
+        result += token;
+    }
+
+    result[0] = tolower(result[0]);
+
+    return result;
+}
+
 //----------------------------------------------------------------------------
 // Notation type checks
 //----------------------------------------------------------------------------

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -29,8 +29,6 @@
 
 #include "jsonxx.h"
 
-#define HELP_TABS 32
-
 // Some redundant code to get basenames
 // and remove extensions
 // possible that it is not in std??
@@ -49,35 +47,6 @@ std::string removeExtension(std::string const &filename)
     return pivot == filename.rend() ? filename : std::string(filename.begin(), pivot.base() - 1);
 }
 
-std::string fromCamelCase(const std::string &s)
-{
-    std::regex regExp1("(.)([A-Z][a-z]+)");
-    std::regex regExp2("([a-z0-9])([A-Z])");
-
-    std::string result = s;
-    result = std::regex_replace(result, regExp1, "$1-$2");
-    result = std::regex_replace(result, regExp2, "$1-$2");
-
-    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
-    return result;
-}
-
-std::string toCamelCase(const std::string &s)
-{
-    std::istringstream iss(s);
-    std::string token;
-    std::string result;
-
-    while (getline(iss, token, '-')) {
-        token[0] = toupper(token[0]);
-        result += token;
-    }
-
-    result[0] = tolower(result[0]);
-
-    return result;
-}
-
 bool dir_exists(std::string dir)
 {
     struct stat st;
@@ -89,141 +58,9 @@ bool dir_exists(std::string dir)
     }
 }
 
-void display_option(vrv::Option *option)
-{
-    std::string option_str = " ";
-
-    if (option->GetShortOption()) {
-        option_str.append("-");
-        option_str.push_back(option->GetShortOption());
-        option_str.append(", ");
-    }
-
-    if (!option->GetKey().empty()) {
-        option_str.append("--");
-        option_str.append(fromCamelCase(option->GetKey()));
-    }
-
-    const vrv::OptionDbl *optDbl = dynamic_cast<const vrv::OptionDbl *>(option);
-    const vrv::OptionInt *optInt = dynamic_cast<const vrv::OptionInt *>(option);
-    const vrv::OptionIntMap *optIntMap = dynamic_cast<const vrv::OptionIntMap *>(option);
-    const vrv::OptionString *optString = dynamic_cast<const vrv::OptionString *>(option);
-    const vrv::OptionArray *optArray = dynamic_cast<const vrv::OptionArray *>(option);
-    const vrv::OptionBool *optBool = dynamic_cast<const vrv::OptionBool *>(option);
-
-    if (optDbl) {
-        option_str.append(" <f>");
-    }
-    else if (optInt) {
-        option_str.append(" <i>");
-    }
-    else if (optString) {
-        option_str.append(" <s>");
-    }
-    else if (optArray) {
-        option_str.append("* <s>");
-    }
-    else if (!optBool) {
-        option_str.append(" <s>");
-    }
-
-    if (option_str.size() < HELP_TABS) {
-        option_str.insert(option_str.end(), HELP_TABS - option_str.size(), ' ');
-    }
-    else {
-        option_str.append("\t");
-    }
-
-    std::cout << option_str << option->GetDescription();
-
-    if (optInt && (optInt->GetMin() != optInt->GetMax())) {
-        std::cout << " (default: " << optInt->GetDefault();
-        std::cout << "; min: " << optInt->GetMin();
-        std::cout << "; max: " << optInt->GetMax() << ")";
-    }
-    if (optDbl && (optDbl->GetMin() != optDbl->GetMax())) {
-        std::cout << std::fixed << " (default: " << optDbl->GetDefault();
-        std::cout << std::fixed << "; min: " << optDbl->GetMin();
-        std::cout << std::fixed << "; max: " << optDbl->GetMax() << ")";
-    }
-    if (optString) {
-        std::cout << " (default: \"" << optString->GetDefault() << "\")";
-    }
-    if (optIntMap) {
-        std::cout << " (default: \"" << optIntMap->GetDefaultStrValue()
-                  << "\"; other values: " << optIntMap->GetStrValuesAsStr(true) << ")";
-    }
-    std::cout << std::endl;
-}
-
 void display_version()
 {
     std::cout << "Verovio " << vrv::GetVersion() << std::endl;
-}
-
-void display_usage(const vrv::Options *options, const std::string &category)
-{
-    // map of all categories and expected string arguments for them
-    const std::map<vrv::OptionsCategory, std::string> categories = { { vrv::OptionsCategory::Base, "base" },
-        { vrv::OptionsCategory::General, "general" }, { vrv::OptionsCategory::Layout, "layout" },
-        { vrv::OptionsCategory::Margins, "margins" }, { vrv::OptionsCategory::Midi, "midi" },
-        { vrv::OptionsCategory::Selectors, "selectors" }, { vrv::OptionsCategory::Full, "full" } };
-
-    std::cout.precision(2);
-
-    display_version();
-    std::cout << std::endl << "Example usage:" << std::endl << std::endl;
-    std::cout << " verovio [-s scale] [-r resource-path] [-o outfile] infile" << std::endl << std::endl;
-
-    auto it = std::find_if(
-        categories.begin(), categories.end(), [&category](const std::pair<vrv::OptionsCategory, std::string> &value) {
-            return std::equal(value.second.begin(), value.second.end(), category.begin(), category.end(),
-                [](const char a, const char b) { return a == tolower(b); });
-        });
-
-    if (it == categories.end()) {
-        std::string optionStr;
-        std::cout << "Help manual categories: " << std::endl;
-        // Print base group options
-        optionStr.append(" -h ");
-        optionStr.append(categories.at(options->m_baseOptions.GetCategory()));
-        optionStr.append("\t");
-        optionStr.append(options->m_baseOptions.GetLabel());
-        optionStr.append("\n");
-
-        const std::vector<vrv::OptionGrp *> *grps = options->GetGrps();
-        // Print each group one by one
-        for (const auto group : *grps) {
-            optionStr.append(" -h ");
-            optionStr.append(categories.at(group->GetCategory()));
-            optionStr.append("\t");
-            optionStr.append(group->GetLabel());
-            optionStr.append("\n");
-        }
-        optionStr.append(" -h full\tPrint all help manual and exit");
-        std::cout << optionStr << std::endl;
-    }
-    else {
-        std::cout << "Options (marked as * are repeatable)" << std::endl;
-        if ((it->first == vrv::OptionsCategory::Base) || (it->first == vrv::OptionsCategory::Full)) {
-            const std::vector<vrv::Option *> *baseOptions = options->GetBaseOptions();
-            for (vrv::Option *option : *baseOptions) {
-                display_option(option);
-            }
-        }
-        const std::vector<vrv::OptionGrp *> *grps = options->GetGrps();
-        for (const auto group : *grps) {
-            if (it->first == group->GetCategory() || (it->first == vrv::OptionsCategory::Full)) {
-                // Options with long forms only
-                std::cout << std::endl << group->GetLabel() << std::endl;
-                const std::vector<vrv::Option *> *options = group->GetOptions();
-
-                for (vrv::Option *option : *options) {
-                    display_option(option);
-                }
-            }
-        }
-    }
 }
 
 bool optionExists(const std::string &option, int argc, char **argv, std::string &badOption)
@@ -277,7 +114,8 @@ int main(int argc, char **argv)
 
     if (argc < 2) {
         std::cerr << "Expected one input file but found none." << std::endl << std::endl;
-        display_usage(options, "");
+        //display_usage(options, "");
+        toolkit.GetOptionUsage("", std::cout);
         exit(1);
     }
 
@@ -292,9 +130,9 @@ int main(int argc, char **argv)
     vrv::MapOfStrOptions::const_iterator iter;
     for (iter = params->begin(); iter != params->end(); ++iter) {
         // Double check that back and forth convertion is correct
-        assert(toCamelCase(fromCamelCase(iter->first)) == iter->first);
+        assert(vrv::ToCamelCase(vrv::FromCamelCase(iter->first)) == iter->first);
 
-        optNames.push_back(fromCamelCase(iter->first));
+        optNames.push_back(vrv::FromCamelCase(iter->first));
         long_options[i].name = optNames.at(i).c_str();
         vrv::OptionBool *optBool = dynamic_cast<vrv::OptionBool *>(iter->second);
         long_options[i].has_arg = (optBool) ? no_argument : required_argument;
@@ -322,7 +160,7 @@ int main(int argc, char **argv)
         switch (c) {
             case 0:
                 key = long_options[option_index].name;
-                opt = params->at(toCamelCase(key));
+                opt = params->at(vrv::ToCamelCase(key));
                 optBool = dynamic_cast<vrv::OptionBool *>(opt);
                 if (std::string badOption; !optionExists("--" + key, argc, argv, badOption)) {
                     vrv::LogError("Unrecognized option %s has been skipped.", badOption.c_str());
@@ -387,12 +225,12 @@ int main(int argc, char **argv)
                 break;
 
             case 'h':
-                display_usage(options, optarg);
+                toolkit.GetOptionUsage(optarg, std::cout);
                 exit(0);
                 break;
 
             case '?':
-                display_usage(options, "");
+                toolkit.GetOptionUsage("", std::cout);
                 exit(1);
                 break;
 
@@ -417,7 +255,7 @@ int main(int argc, char **argv)
     }
     else if (infile != "-") {
         std::cerr << "Incorrect number of arguments: expected one input file but found none." << std::endl << std::endl;
-        display_usage(options, "base");
+        toolkit.GetOptionUsage("base", std::cout);
         exit(1);
     }
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -114,7 +114,6 @@ int main(int argc, char **argv)
 
     if (argc < 2) {
         std::cerr << "Expected one input file but found none." << std::endl << std::endl;
-        //display_usage(options, "");
         toolkit.PrintOptionUsage("", std::cout);
         exit(1);
     }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv)
     if (argc < 2) {
         std::cerr << "Expected one input file but found none." << std::endl << std::endl;
         //display_usage(options, "");
-        toolkit.GetOptionUsage("", std::cout);
+        toolkit.PrintOptionUsage("", std::cout);
         exit(1);
     }
 
@@ -225,12 +225,12 @@ int main(int argc, char **argv)
                 break;
 
             case 'h':
-                toolkit.GetOptionUsage(optarg, std::cout);
+                toolkit.PrintOptionUsage(optarg, std::cout);
                 exit(0);
                 break;
 
             case '?':
-                toolkit.GetOptionUsage("", std::cout);
+                toolkit.PrintOptionUsage("", std::cout);
                 exit(1);
                 break;
 
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
     }
     else if (infile != "-") {
         std::cerr << "Incorrect number of arguments: expected one input file but found none." << std::endl << std::endl;
-        toolkit.GetOptionUsage("base", std::cout);
+        toolkit.PrintOptionUsage("base", std::cout);
         exit(1);
     }
 


### PR DESCRIPTION
Moved option help/usage messages to toolkit and changed code to make it more generic, allowing different targets of output (to stdout, string, etc.). Added toolkit method to get usage as string, getting all information about all options (description, default/min/max values, categories).
Moved camelCase functions to vrv.cpp file making them more widely accessible.