### PR TITLE
Measure rests in two layers

### DIFF
--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -112,9 +112,16 @@ FunctorCode LayerElementsInTimeSpanFunctor::VisitLayerElement(const LayerElement
     if ((!m_allLayersButCurrent && (currentLayer != m_layer)) || (m_allLayersButCurrent && (currentLayer == m_layer))) {
         return FUNCTOR_SIBLINGS;
     }
-    if (!currentLayer || layerElement->IsScoreDefElement() || layerElement->Is(MREST)) return FUNCTOR_SIBLINGS;
-    if (!layerElement->GetDurationInterface() || layerElement->Is({ MSPACE, SPACE }) || layerElement->HasSameasLink())
+    if (!currentLayer || layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
+
+    if (layerElement->HasSameasLink()) return FUNCTOR_CONTINUE;
+
+    if (layerElement->Is(MREST)) {
+        m_elements.push_back(layerElement);
         return FUNCTOR_CONTINUE;
+    }
+
+    if (!layerElement->GetDurationInterface() || layerElement->Is({ MSPACE, SPACE })) return FUNCTOR_CONTINUE;
 
     const double duration = !layerElement->GetFirstAncestor(CHORD)
         ? layerElement->GetAlignmentDuration(m_mensur, m_meterSig)

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -119,11 +119,14 @@ int MRest::GetOptimalLayerLocation(const Layer *layer, int defaultLocation) cons
             int loc = rest->GetDrawingLoc();
             locations.push_back(loc);
         }
+        else if (element->Is(MREST)) {
+            locations.push_back(4);
+        }
     }
     // if there are no other elements - just return default location
     if (locations.empty()) return defaultLocation;
 
-    const int locAdjust = isTopLayer ? 3 : -2;
+    const int locAdjust = isTopLayer ? 4 : -3;
     int extremePoint = isTopLayer ? *std::max_element(locations.begin(), locations.end())
                                   : *std::min_element(locations.begin(), locations.end());
     extremePoint += locAdjust;


### PR DESCRIPTION
This PR improves the case when both layers contain measure rests.

| Before | After |
| ------ | ----- |
| <img width="508" alt="Before" src="https://user-images.githubusercontent.com/63608463/228859362-9b646fdb-e40a-47a0-87d9-417cd6c4d23b.png"> | <img width="536" alt="After" src="https://user-images.githubusercontent.com/63608463/228859429-a1b344c6-1e3f-46be-9ba0-22339ce510dc.png"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Measures rests in different layers</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2023-03-29">2023-03-29</date>
         </pubStmt>
         <notesStmt>
            <annot>Measure rests in multiple layers are rendered as several distinct rests.</annot>
         </notesStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" key.sig="0" meter.count="4" meter.unit="4" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest />
                        </layer>
                        <layer n="2">
                           <mRest />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <mRest xml:id="upperRest" />
                        </layer>
                        <layer n="2">
                           <mRest xml:id="lowerRest" sameas="#upperRest" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

