### PR TITLE
Calculate lyric hyphen length

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -702,7 +702,6 @@ public:
     OptionDbl m_ledgerLineThickness;
     OptionDbl m_ledgerLineExtension;
     OptionIntMap m_lyricElision;
-    OptionDbl m_lyricHyphenLength;
     OptionDbl m_lyricLineThickness;
     OptionBool m_lyricNoStartHyphen;
     OptionDbl m_lyricSize;

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -73,9 +73,9 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
-     * Calculate the dash length based on the text fonts hyphen length
+     * Calculate the hyphen length using the text font
      */
-    int CalcDashLength(Doc *doc, int staffSize);
+    int CalcHyphenLength(Doc *doc, int staffSize);
 
     /**
      * Calculate the spacing needed depending on the @worpos and @con

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -85,6 +85,15 @@ public:
     int GetDrawingWidth() const;
     int GetDrawingHeight() const;
 
+    //----------------//
+    // Static methods //
+    //----------------//
+
+    /**
+     * Adjust proportionally to the lyric size
+     */
+    static void AdjustToLyricSize(const Doc *doc, int &value);
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -73,6 +73,11 @@ public:
     bool IsSupportedChild(Object *object) override;
 
     /**
+     * Calculate the dash length based on the text fonts hyphen length
+     */
+    int CalcDashLength(Doc *doc, int staffSize);
+
+    /**
      * Calculate the spacing needed depending on the @worpos and @con
      */
     int CalcConnectorSpacing(Doc *doc, int staffSize);

--- a/src/adjustharmgrpsspacingfunctor.cpp
+++ b/src/adjustharmgrpsspacingfunctor.cpp
@@ -11,6 +11,7 @@
 
 #include "doc.h"
 #include "harm.h"
+#include "syl.h"
 #include "system.h"
 #include "vrv.h"
 
@@ -105,9 +106,7 @@ FunctorCode AdjustHarmGrpsSpacingFunctor::VisitHarm(Harm *harm)
     int overlap = m_previousHarmPositioner->GetContentRight() - (harmPositioner->GetContentLeft() + xShift);
     // Two units as default spacing
     int wordSpace = 2 * m_doc->GetDrawingUnit(100);
-
-    // Adjust it proportionally to the lyric size
-    wordSpace *= m_doc->GetOptions()->m_lyricSize.GetValue() / m_doc->GetOptions()->m_lyricSize.GetDefault();
+    Syl::AdjustToLyricSize(m_doc, wordSpace);
     overlap += wordSpace;
 
     if (overlap > 0) {

--- a/src/adjustsylspacingfunctor.cpp
+++ b/src/adjustsylspacingfunctor.cpp
@@ -112,8 +112,7 @@ FunctorCode AdjustSylSpacingFunctor::VisitVerse(Verse *verse)
     ListOfObjects syls = verse->FindAllDescendantsByType(SYL);
 
     int shift = m_doc->GetDrawingUnit(m_staffSize);
-    // Adjust it proportionally to the lyric size
-    shift *= m_doc->GetOptions()->m_lyricSize.GetValue() / m_doc->GetOptions()->m_lyricSize.GetDefault();
+    Syl::AdjustToLyricSize(m_doc, shift);
 
     int previousSylShift = 0;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1358,10 +1358,6 @@ Options::Options()
     m_lyricElision.Init(ELISION_regular, &Option::s_elision);
     this->Register(&m_lyricElision, "lyricElision", &m_generalLayout);
 
-    m_lyricHyphenLength.SetInfo("Lyric hyphen length", "The lyric hyphen and dash length");
-    m_lyricHyphenLength.Init(1.20, 0.50, 3.00);
-    this->Register(&m_lyricHyphenLength, "lyricHyphenLength", &m_generalLayout);
-
     m_lyricLineThickness.SetInfo("Lyric line thickness", "The lyric extender line thickness");
     m_lyricLineThickness.Init(0.25, 0.10, 0.50);
     this->Register(&m_lyricLineThickness, "lyricLineThickness", &m_generalLayout);

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -81,6 +81,12 @@ bool Syl::IsSupportedChild(Object *child)
     return true;
 }
 
+int Syl::CalcDashLength(Doc *doc, int staffSize)
+{
+    FontInfo *lyricFont = doc->GetDrawingLyricFont(staffSize);
+    return doc->GetTextGlyphWidth(L'-', lyricFont, false);
+}
+
 int Syl::CalcConnectorSpacing(Doc *doc, int staffSize)
 {
     assert(doc);

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -81,10 +81,16 @@ bool Syl::IsSupportedChild(Object *child)
     return true;
 }
 
-int Syl::CalcDashLength(Doc *doc, int staffSize)
+int Syl::CalcHyphenLength(Doc *doc, int staffSize)
 {
     FontInfo *lyricFont = doc->GetDrawingLyricFont(staffSize);
-    return doc->GetTextGlyphWidth(L'-', lyricFont, false);
+    int dashLength = doc->GetTextGlyphWidth(L'-', lyricFont, false);
+
+    // Adjust it proportionally to the lyric size
+    const OptionDbl &lyricSize = doc->GetOptions()->m_lyricSize;
+    dashLength *= lyricSize.GetValue() / lyricSize.GetDefault();
+
+    return dashLength;
 }
 
 int Syl::CalcConnectorSpacing(Doc *doc, int staffSize)
@@ -98,10 +104,7 @@ int Syl::CalcConnectorSpacing(Doc *doc, int staffSize)
 
     // We have a word connector - the space have to be wide enough
     if ((pos == sylLog_WORDPOS_i) || (pos == sylLog_WORDPOS_m)) {
-        int hyphen = doc->GetDrawingUnit(staffSize) * doc->GetOptions()->m_lyricHyphenLength.GetValue();
-        // Adjust it proportionally to the lyric size
-        hyphen *= doc->GetOptions()->m_lyricSize.GetValue() / doc->GetOptions()->m_lyricSize.GetDefault();
-        spacing = (2 * hyphen);
+        spacing = 2 * this->CalcHyphenLength(doc, staffSize);
     }
     // Elision
     else if (con == sylLog_CON_b) {

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -86,9 +86,7 @@ int Syl::CalcHyphenLength(Doc *doc, int staffSize)
     FontInfo *lyricFont = doc->GetDrawingLyricFont(staffSize);
     int dashLength = doc->GetTextGlyphWidth(L'-', lyricFont, false);
 
-    // Adjust it proportionally to the lyric size
-    const OptionDbl &lyricSize = doc->GetOptions()->m_lyricSize;
-    dashLength *= lyricSize.GetValue() / lyricSize.GetDefault();
+    Syl::AdjustToLyricSize(doc, dashLength);
 
     return dashLength;
 }
@@ -110,22 +108,18 @@ int Syl::CalcConnectorSpacing(Doc *doc, int staffSize)
     else if (con == sylLog_CON_b) {
         if (doc->GetOptions()->m_lyricElision.GetValue() == ELISION_unicode) {
             // Equivalent spacing with 0x230F
-            spacing += doc->GetDrawingUnit(staffSize) * 2.2;
+            spacing = doc->GetDrawingUnit(staffSize) * 2.2;
         }
         else {
             // Calculate the elision space with the current music font
-            int elisionSpace = doc->GetGlyphAdvX(doc->GetOptions()->m_lyricElision.GetValue(), staffSize, false);
-            // Adjust it proportionally to the lyric size
-            elisionSpace *= doc->GetOptions()->m_lyricSize.GetValue() / doc->GetOptions()->m_lyricSize.GetDefault();
-            spacing = elisionSpace;
+            spacing = doc->GetGlyphAdvX(doc->GetOptions()->m_lyricElision.GetValue(), staffSize, false);
+            Syl::AdjustToLyricSize(doc, spacing);
         }
     }
     // Spacing of words as set in the staff according to the staff and font sizes
     else {
-        int wordSpace = doc->GetDrawingUnit(staffSize) * doc->GetOptions()->m_lyricWordSpace.GetValue();
-        // Adjust it proportionally to the lyric size
-        wordSpace *= doc->GetOptions()->m_lyricSize.GetValue() / doc->GetOptions()->m_lyricSize.GetDefault();
-        spacing = wordSpace;
+        spacing = doc->GetDrawingUnit(staffSize) * doc->GetOptions()->m_lyricWordSpace.GetValue();
+        Syl::AdjustToLyricSize(doc, spacing);
     }
 
     return spacing;
@@ -145,6 +139,12 @@ int Syl::GetDrawingHeight() const
         return FacsimileInterface::GetHeight();
     }
     return 0;
+}
+
+void Syl::AdjustToLyricSize(const Doc *doc, int &value)
+{
+    const OptionDbl &lyricSize = doc->GetOptions()->m_lyricSize;
+    value *= lyricSize.GetValue() / lyricSize.GetDefault();
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1285,9 +1285,7 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
         y += (m_options->m_lyricSize.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize) / 5);
 
         // the length of the dash and the space between them
-        int dashLength = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_lyricHyphenLength.GetValue();
-        // Adjust it proportionally to the lyric size
-        dashLength *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
+        const int dashLength = syl->CalcHyphenLength(m_doc, staff->m_drawingStaffSize);
         const int halfDashLength = dashLength / 2;
 
         const int dashSpace = m_doc->GetDrawingStaffSize(staff->m_drawingStaffSize) * 5 / 3;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1183,8 +1183,8 @@ void View::DrawFConnector(DeviceContext *dc, F *f, int x1, int x2, Staff *staff,
     dc->DeactivateGraphic();
 
     int width = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    // Adjust it proportionally to the lyric size
-    width *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
+    Syl::AdjustToLyricSize(m_doc, width);
+
     this->DrawFilledRectangle(dc, x1, y, x2, y + width);
 
     dc->ReactivateGraphic();
@@ -1277,8 +1277,7 @@ void View::DrawSylConnectorLines(DeviceContext *dc, int x1, int x2, int y, Syl *
     }
 
     int thickness = m_options->m_lyricLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    // Adjust it proportionally to the lyric size
-    thickness *= m_options->m_lyricSize.GetValue() / m_options->m_lyricSize.GetDefault();
+    Syl::AdjustToLyricSize(m_doc, thickness);
 
     if (syl->GetCon() == sylLog_CON_d) {
 


### PR DESCRIPTION
This PR calculates the lyric hyphen length from the (lyric) text font. This makes the option `--lyric-hyphen-length` obsolete. 