### PR TITLE
Improve header from MusicXML import

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -477,7 +477,7 @@ private:
     static int PitchToMidi(const std::string &step, int alter, int octave);
     static void MidiToPitch(int midi, std::string &step, int &alter, int &octave);
     ///@}
-private:
+
     /* octave offset */
     std::vector<int> m_octDis;
     /* measure repeats */

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -310,7 +310,7 @@ void Doc::GenerateMEIHeader(bool meiBasic)
         // projectDesc
         pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.text().set(StringFormat("MEI encoded with Verovio.").c_str());
+        p1.text().set(StringFormat("MEI encoded with Verovio").c_str());
     }
 }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -310,7 +310,7 @@ void Doc::GenerateMEIHeader(bool meiBasic)
         // projectDesc
         pugi::xml_node projectDesc = encodingDesc.append_child("projectDesc");
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.text().set(StringFormat("MEI encoded with Verovio").c_str());
+        p1.text().set(StringFormat("MEI encoded with Verovio.").c_str());
     }
 }
 

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -912,7 +912,7 @@ void ABCInput::CreateHeader()
     pugi::xml_node appName = app.append_child("name");
     appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    appText.text().set("Transcoded from abc music.");
+    appText.text().set("Transcoded from abc music");
 
     // isodate and version //
     const time_t t = time(0); // get time now

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -910,9 +910,9 @@ void ABCInput::CreateHeader()
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
     pugi::xml_node app = appInfo.append_child("application");
     pugi::xml_node appName = app.append_child("name");
-    appName.append_child(pugi::node_pcdata).set_value("Verovio");
+    appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    appText.append_child(pugi::node_pcdata).set_value("Transcoded from abc music.");
+    appText.text().set("Transcoded from abc music.");
 
     // isodate and version //
     const time_t t = time(0); // get time now

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -177,7 +177,7 @@ void ABCInput::ParseABC(std::istream &infile)
 /**********************************
  *
  * SetBarLine
- * Translation from ABC to verovio representaion:
+ * Translation from ABC to Verovio representaion:
  *
  BARRENDITION_single     |
  BARRENDITION_end        |]
@@ -912,7 +912,7 @@ void ABCInput::CreateHeader()
     pugi::xml_node appName = app.append_child("name");
     appName.append_child(pugi::node_pcdata).set_value("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    appText.append_child(pugi::node_pcdata).set_value("Transcoded from abc music");
+    appText.append_child(pugi::node_pcdata).set_value("Transcoded from abc music.");
 
     // isodate and version //
     const time_t t = time(0); // get time now

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1210,7 +1210,6 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     }
 
     pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
-    pubStmt.append_child(pugi::node_pcdata);
 
     pugi::xml_node respStmt = titleStmt.append_child("respStmt");
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1246,7 +1246,7 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     pugi::xml_node appName = app.append_child("name");
     appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    appText.text().set("Transcoded from MusicXML.");
+    appText.text().set("Transcoded from MusicXML");
 
     if (!m_doc->GetOptions()->m_removeIds.GetValue()) {
         GenerateID(meiHead);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1236,9 +1236,7 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
         pugi::xml_node availability = pubStmt.append_child("availability");
         for (pugi::xpath_node_set::const_iterator it = rightsSet.begin(); it != rightsSet.end(); ++it) {
             pugi::xpath_node rights = *it;
-            availability.append_child("distributor")
-                .append_child(pugi::node_pcdata)
-                .set_value(rights.node().text().as_string());
+            availability.append_child("distributor").text().set(rights.node().text().as_string());
         }
     }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -547,8 +547,7 @@ void MusicXmlInput::FillSpace(Layer *layer, int dur)
 
 void MusicXmlInput::GenerateID(pugi::xml_node node)
 {
-    std::string id = StringFormat("%s-%s", node.name(), Object::GenerateHashID().c_str()).c_str();
-    std::transform(id.begin(), id.end(), id.begin(), ::tolower);
+    std::string id = std::string(node.name()).at(0) + Object::GenerateHashID();
     node.append_attribute("xml:id").set_value(id.c_str());
 }
 
@@ -1245,17 +1244,20 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     }
 
     pugi::xml_node encodingDesc = meiHead.append_child("encodingDesc");
-    GenerateID(encodingDesc);
     pugi::xml_node appInfo = encodingDesc.append_child("appInfo");
-    GenerateID(appInfo);
     pugi::xml_node app = appInfo.append_child("application");
-    GenerateID(app);
     pugi::xml_node appName = app.append_child("name");
-    GenerateID(appName);
     appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    GenerateID(appText);
     appText.text().set("Transcoded from MusicXML");
+
+    if (!m_doc->GetOptions()->m_removeIds.GetValue()) {
+        GenerateID(encodingDesc);
+        GenerateID(appInfo);
+        GenerateID(app);
+        GenerateID(appName);
+        GenerateID(appText);
+    }
 
     // isodate and version
     time_t t = time(0); // get time now

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1248,7 +1248,7 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     pugi::xml_node appName = app.append_child("name");
     appName.text().set("Verovio");
     pugi::xml_node appText = app.append_child("p");
-    appText.text().set("Transcoded from MusicXML");
+    appText.text().set("Transcoded from MusicXML.");
 
     if (!m_doc->GetOptions()->m_removeIds.GetValue()) {
         GenerateID(meiHead);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1252,6 +1252,10 @@ void MusicXmlInput::ReadMusicXmlTitle(pugi::xml_node root)
     appText.text().set("Transcoded from MusicXML");
 
     if (!m_doc->GetOptions()->m_removeIds.GetValue()) {
+        GenerateID(meiHead);
+        GenerateID(fileDesc);
+        GenerateID(titleStmt);
+        GenerateID(pubStmt);
         GenerateID(encodingDesc);
         GenerateID(appInfo);
         GenerateID(app);

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2783,7 +2783,7 @@ bool PAEInput::Import(const std::string &input)
     pugi::xml_node projectDesc = m_doc->m_header.first_child().select_node("//projectDesc").node();
     if (projectDesc) {
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.text().set("Converted from Plaine and Easie to MEI");
+        p1.text().set("Converted from Plaine and Easie to MEI.");
     }
 
     bool success = true;
@@ -3241,27 +3241,19 @@ void PAEInput::ParseHeader(jsonxx::Object &header)
         }
         pugi::xml_node incip = work.append_child("incip");
         if (header.has<jsonxx::String>("role")) {
-            incip.append_child("role")
-                .append_child(pugi::node_pcdata)
-                .set_value(header.get<jsonxx::String>("role").c_str());
+            incip.append_child("role").text().set(header.get<jsonxx::String>("role").c_str());
         }
         if (header.has<jsonxx::String>("scoring") || header.has<jsonxx::String>("voice_intrument")) {
             pugi::xml_node perfResList = incip.append_child("perfResList");
             if (header.has<jsonxx::String>("voice_instrument")) {
-                perfResList.append_child("perfRes")
-                    .append_child(pugi::node_pcdata)
-                    .set_value(header.get<jsonxx::String>("voice_instrument").c_str());
+                perfResList.append_child("perfRes").text().set(header.get<jsonxx::String>("voice_instrument").c_str());
             }
             if (header.has<jsonxx::String>("scoring")) {
-                perfResList.append_child("perfRes")
-                    .append_child(pugi::node_pcdata)
-                    .set_value(header.get<jsonxx::String>("scoring").c_str());
+                perfResList.append_child("perfRes").text().set(header.get<jsonxx::String>("scoring").c_str());
             }
         }
         if (header.has<jsonxx::String>("key_mode")) {
-            incip.append_child("key")
-                .append_child(pugi::node_pcdata)
-                .set_value(header.get<jsonxx::String>("key_mode").c_str());
+            incip.append_child("key").text().set(header.get<jsonxx::String>("key_mode").c_str());
         }
         if (header.has<jsonxx::Array>("text_incipits")) {
             pugi::xml_node incipText = incip.append_child("incipText");

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2783,7 +2783,7 @@ bool PAEInput::Import(const std::string &input)
     pugi::xml_node projectDesc = m_doc->m_header.first_child().select_node("//projectDesc").node();
     if (projectDesc) {
         pugi::xml_node p1 = projectDesc.append_child("p");
-        p1.text().set("Converted from Plaine and Easie to MEI.");
+        p1.text().set("Converted from Plaine and Easie to MEI");
     }
 
     bool success = true;

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -201,8 +201,7 @@ void SvgDeviceContext::Commit(bool xml_declaration)
 
     // add description statement
     pugi::xml_node desc = m_svgNode.prepend_child("desc");
-    desc.append_child(pugi::node_pcdata)
-        .set_value(StringFormat("Engraved by Verovio %s", GetVersion().c_str()).c_str());
+    desc.text().set(StringFormat("Engraved by Verovio %s", GetVersion().c_str()).c_str());
 
     // save the glyph data to m_outdata
     std::string indent = (m_indent == -1) ? "\t" : std::string(m_indent, ' ');
@@ -438,8 +437,7 @@ void SvgDeviceContext::StartPage()
     if (this->UseGlobalStyling()) {
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
-        m_currentNode.append_child(pugi::node_pcdata)
-            .set_value("g.page-margin{font-family:Times,serif;} "
+        m_currentNode.text().set("g.page-margin{font-family:Times,serif;} "
                        //"g.page-margin{background: pink;} "
                        //"g.bounding-box{stroke:red; stroke-width:10} "
                        //"g.content-bounding-box{stroke:blue; stroke-width:10} "

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -438,11 +438,11 @@ void SvgDeviceContext::StartPage()
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
         m_currentNode.text().set("g.page-margin{font-family:Times,serif;} "
-                       //"g.page-margin{background: pink;} "
-                       //"g.bounding-box{stroke:red; stroke-width:10} "
-                       //"g.content-bounding-box{stroke:blue; stroke-width:10} "
-                       "g.ending, g.fing, g.reh, g.tempo{font-weight:bold;} g.dir, g.dynam, "
-                       "g.mNum{font-style:italic;} g.label{font-weight:normal;}");
+                                 //"g.page-margin{background: pink;} "
+                                 //"g.bounding-box{stroke:red; stroke-width:10} "
+                                 //"g.content-bounding-box{stroke:blue; stroke-width:10} "
+                                 "g.ending, g.fing, g.reh, g.tempo{font-weight:bold;} g.dir, g.dynam, "
+                                 "g.mNum{font-style:italic;} g.label{font-weight:normal;}");
         m_currentNode = m_svgNodeStack.back();
     }
 


### PR DESCRIPTION
This refines the generation of `xml:id` values for the `meiHead` from MusicXML import to be in line with all other ids. Also it no suppresses those ids now when the `--remove-ids` option is being used.

Also it simplifies some remaining `pugi::node_pcdata` by using `text().set()`.