### PR TITLE
Follow barline xRel

### DIFF
--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -246,6 +246,15 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
 
         m_measureTieEndpoints = measure->GetInternalTieEndpoints();
         measure->m_measureAligner.Process(*this);
+
+        // In some cases with low enough linear spacing xRel of barline might shift due to overlaps with previous
+        // alignments. Make sure that timestamp-only alignments that have the same time as barline follow its xRel. 
+        const Alignment *rightBar = measure->m_measureAligner.GetRightBarLineAlignment();
+        Alignment *rightBarDefault
+            = measure->m_measureAligner.GetAlignmentAtTime(rightBar->GetTime(), ALIGNMENT_DEFAULT);
+        if (rightBarDefault->HasTimestampOnly() && (rightBarDefault->GetXRel() != rightBar->GetXRel())) {
+            rightBarDefault->SetXRel(rightBar->GetXRel());
+        }
     }
 
     this->SetFilters(previousFilters);

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -248,7 +248,7 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
 
         // In some cases with low enough linear spacing xRel of barline might shift due to overlaps with previous
-        // alignments. Make sure that timestamp-only alignments that have the same time as barline follow its xRel. 
+        // alignments. Make sure that timestamp-only alignments that have the same time as barline follow its xRel.
         const Alignment *rightBar = measure->m_measureAligner.GetRightBarLineAlignment();
         Alignment *rightBarDefault
             = measure->m_measureAligner.GetAlignmentAtTime(rightBar->GetTime(), ALIGNMENT_DEFAULT);


### PR DESCRIPTION
closes #2763 
- changed code to make sure that timestamp-only alignments with the same time as barline follow its xRel
![image](https://user-images.githubusercontent.com/1819669/231164013-a458940f-5a64-4062-9f7e-4beacfbfb1eb.png)
