### PR TITLE
Fix dynamics placed between with slurs

### DIFF
--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -439,7 +439,6 @@ FunctorCode AdjustFloatingPositionersBetweenFunctor::VisitStaffAlignment(StaffAl
         const ArrayOfBoundingBoxes &overflowBoxes = staffAlignment->GetBBoxesAbove();
         auto i = overflowBoxes.begin();
         auto end = overflowBoxes.end();
-        bool adjusted = false;
         while (i != end) {
 
             // find all the overflowing elements from the staff that overlap horizontally
@@ -447,20 +446,14 @@ FunctorCode AdjustFloatingPositionersBetweenFunctor::VisitStaffAlignment(StaffAl
                 i, end, [positioner](BoundingBox *elem) { return positioner->HorizontalContentOverlap(elem); });
             if (i != end) {
                 // update the yRel accordingly
-                int y = positioner->GetSpaceBelow(m_doc, staffAlignment, *i);
-                if (y < diffY) {
-                    diffY = y;
-                    adjusted = true;
+                const int spaceY = positioner->GetSpaceBelow(m_doc, staffAlignment, *i);
+                if (spaceY != VRV_UNSET) {
+                    diffY = std::min(diffY, spaceY);
                 }
                 ++i;
             }
         }
-        if (!adjusted) {
-            positioner->SetDrawingYRel(centerYRel);
-        }
-        else {
-            positioner->SetDrawingYRel(positioner->GetDrawingYRel() + diffY);
-        }
+        positioner->SetDrawingYRel(positioner->GetDrawingYRel() + diffY);
     }
 
     m_previousStaffAlignment = staffAlignment;

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -565,18 +565,8 @@ int FloatingPositioner::GetSpaceBelow(
 {
     if (m_place != STAFFREL_between) return VRV_UNSET;
 
-    int staffSize = staffAlignment->GetStaffSize();
-
-    const FloatingCurvePositioner *curve = dynamic_cast<const FloatingCurvePositioner *>(horizOverlappingBBox);
-    if (curve) {
-        assert(curve->m_object);
-    }
-    int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
-
-    if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
-        // For now ignore curves
-        return 0;
-    }
+    const int staffSize = staffAlignment->GetStaffSize();
+    const int margin = doc->GetBottomMargin(m_object->GetClassId()) * doc->GetDrawingUnit(staffSize);
 
     return this->GetContentBottom() - horizOverlappingBBox->GetSelfTop() - margin;
 }


### PR DESCRIPTION
This PR improves the adjustment of between dynamics in the presence of curves (ties, slurs) on the other staff. 
Closes #3364 

| Slur above | Slur below | No slur |
| ------- | ------- | ------ |
| <img width="430" alt="Slur-above" src="https://user-images.githubusercontent.com/63608463/231463468-86c60530-b03d-4e5f-bcac-3ec577a90668.png"> | <img width="441" alt="Slur-below" src="https://user-images.githubusercontent.com/63608463/231463536-dbc6c5b2-45a6-4b75-ab35-86edef57c403.png"> | <img width="436" alt="No-slur" src="https://user-images.githubusercontent.com/63608463/231463586-b626bc75-e2c5-40ad-8a02-bd9d278cb743.png"> |
