### PR TITLE
Add keySig color support

### DIFF
--- a/bindings/iOS/all.h
+++ b/bindings/iOS/all.h
@@ -3,8 +3,11 @@
 #import <VerovioFramework/beam.h>
 #import <VerovioFramework/calcalignmentxposfunctor.h>
 #import <VerovioFramework/altsyminterface.h>
+#import <VerovioFramework/adjustfloatingpositionerfunctor.h>
 #import <VerovioFramework/timeinterface.h>
+#import <VerovioFramework/calcarticfunctor.h>
 #import <VerovioFramework/chord.h>
+#import <VerovioFramework/adjustarticfunctor.h>
 #import <VerovioFramework/pghead2.h>
 #import <VerovioFramework/areaposinterface.h>
 #import <VerovioFramework/harm.h>
@@ -23,6 +26,7 @@
 #import <VerovioFramework/beatrpt.h>
 #import <VerovioFramework/expansionmap.h>
 #import <VerovioFramework/page.h>
+#import <VerovioFramework/adjustyposfunctor.h>
 #import <VerovioFramework/bracketspan.h>
 #import <VerovioFramework/reg.h>
 #import <VerovioFramework/multirest.h>
@@ -68,6 +72,7 @@
 #import <VerovioFramework/runningelement.h>
 #import <VerovioFramework/setscoredeffunctor.h>
 #import <VerovioFramework/adjusttupletsxfunctor.h>
+#import <VerovioFramework/adjusttupletsyfunctor.h>
 #import <VerovioFramework/expan.h>
 #import <VerovioFramework/gliss.h>
 #import <VerovioFramework/findfunctor.h>
@@ -79,6 +84,7 @@
 #import <VerovioFramework/devicecontextbase.h>
 #import <VerovioFramework/pitchinterface.h>
 #import <VerovioFramework/plistinterface.h>
+#import <VerovioFramework/calcligaturenoteposfunctor.h>
 #import <VerovioFramework/adjustaccidxfunctor.h>
 #import <VerovioFramework/phrase.h>
 #import <VerovioFramework/mrest.h>
@@ -90,6 +96,7 @@
 #import <VerovioFramework/proport.h>
 #import <VerovioFramework/choice.h>
 #import <VerovioFramework/fermata.h>
+#import <VerovioFramework/adjustslursfunctor.h>
 #import <VerovioFramework/facsimile.h>
 #import <VerovioFramework/tabdursym.h>
 #import <VerovioFramework/pgfoot.h>
@@ -114,6 +121,7 @@
 #import <VerovioFramework/trill.h>
 #import <VerovioFramework/docselection.h>
 #import <VerovioFramework/tabgrp.h>
+#import <VerovioFramework/adjustxrelfortranscriptionfunctor.h>
 #import <VerovioFramework/scoredef.h>
 #import <VerovioFramework/view.h>
 #import <VerovioFramework/options.h>
@@ -130,6 +138,7 @@
 #import <VerovioFramework/git_commit.h>
 #import <VerovioFramework/functor.h>
 #import <VerovioFramework/rend.h>
+#import <VerovioFramework/justifyfunctor.h>
 #import <VerovioFramework/pagemilestone.h>
 #import <VerovioFramework/adjustsylspacingfunctor.h>
 #import <VerovioFramework/adjustclefchangesfunctor.h>
@@ -154,7 +163,9 @@
 #import <VerovioFramework/adjustdotsfunctor.h>
 #import <VerovioFramework/metersiggrp.h>
 #import <VerovioFramework/custos.h>
+#import <VerovioFramework/castofffunctor.h>
 #import <VerovioFramework/adjustxposfunctor.h>
+#import <VerovioFramework/calcbboxoverflowsfunctor.h>
 #import <VerovioFramework/mrpt2.h>
 #import <VerovioFramework/adjustlayersfunctor.h>
 #import <VerovioFramework/unclear.h>
@@ -207,6 +218,7 @@
 #import <VerovioFramework/timestamp.h>
 #import <VerovioFramework/glyph.h>
 #import <VerovioFramework/libmei.h>
+#import <VerovioFramework/adjuststaffoverlapfunctor.h>
 #import <VerovioFramework/dir.h>
 #import <VerovioFramework/findlayerelementsfunctor.h>
 #import <VerovioFramework/scoredefinterface.h>
@@ -217,6 +229,7 @@
 #import <VerovioFramework/note.h>
 #import <VerovioFramework/positioninterface.h>
 #import <VerovioFramework/halfmrpt.h>
+#import <VerovioFramework/adjustbeamsfunctor.h>
 #import <VerovioFramework/calcchordnoteheadsfunctor.h>
 #import <VerovioFramework/textdirinterface.h>
 #import <VerovioFramework/vrvdef.h>

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -44,6 +44,7 @@ struct KeyAccidInfo {
 class KeySig : public LayerElement,
                public ObjectListInterface,
                public AttAccidental,
+               public AttColor,
                public AttPitch,
                public AttKeySigAnl,
                public AttKeySigLog,

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2484,7 +2484,7 @@ void MEIOutput::WriteKeySig(pugi::xml_node currentNode, KeySig *keySig)
     // Only write att values if representing an attribute or in MEI basic
     if (!this->IsTreeObject(keySig)) {
         InstKeySigDefaultAnl attKeySigDefaultAnl;
-        // Broken in MEI 4.0.2 - waiting for a fix
+        // Broken in MEI 5.0.0-dev - waiting for a fix
         // attKeySigDefaultAnl.SetKeyAccid(keySig->GetAccid());
         attKeySigDefaultAnl.SetKeyMode(keySig->GetMode());
         attKeySigDefaultAnl.SetKeyPname(keySig->GetPname());
@@ -2505,6 +2505,7 @@ void MEIOutput::WriteKeySig(pugi::xml_node currentNode, KeySig *keySig)
     keySig->WriteAccidental(currentNode);
     keySig->WritePitch(currentNode);
     keySig->WriteKeySigAnl(currentNode);
+    keySig->WriteColor(currentNode);
     keySig->WriteKeySigLog(currentNode);
     keySig->WriteKeySigVis(currentNode);
     keySig->WriteVisibility(currentNode);
@@ -6421,6 +6422,7 @@ bool MEIInput::ReadKeySig(Object *parent, pugi::xml_node keySig)
     vrvKeySig->ReadAccidental(keySig);
     vrvKeySig->ReadPitch(keySig);
     vrvKeySig->ReadKeySigAnl(keySig);
+    vrvKeySig->ReadColor(keySig);
     vrvKeySig->ReadKeySigLog(keySig);
     vrvKeySig->ReadKeySigVis(keySig);
     vrvKeySig->ReadVisibility(keySig);

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -77,6 +77,7 @@ KeySig::KeySig()
     : LayerElement(KEYSIG, "keysig-")
     , ObjectListInterface()
     , AttAccidental()
+    , AttColor()
     , AttPitch()
     , AttKeySigAnl()
     , AttKeySigLog()
@@ -84,6 +85,7 @@ KeySig::KeySig()
     , AttVisibility()
 {
     this->RegisterAttClass(ATT_ACCIDENTAL);
+    this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_PITCH);
     this->RegisterAttClass(ATT_KEYSIGANL);
     this->RegisterAttClass(ATT_KEYSIGLOG);
@@ -99,6 +101,7 @@ void KeySig::Reset()
 {
     LayerElement::Reset();
     this->ResetAccidental();
+    this->ResetColor();
     this->ResetPitch();
     this->ResetKeySigAnl();
     this->ResetKeySigLog();


### PR DESCRIPTION
 addresses #3374

<img width="881" alt="image" src="https://user-images.githubusercontent.com/7693447/232235729-10fd4745-09ef-42ba-b427-492f45668d7e.png">

NB: Currently we use Verovio custom graphics for `keyAccid`, so coloring there is not supported.

Additionally this removes (empty) SVG Bounding Boxes from milestone elements.