### PR TITLE
Improve cluster chord overlap

### DIFF
--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -486,6 +486,9 @@ int Chord::AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElemen
         if (((margin >= 0) && (overlap > margin)) || ((margin <= 0) && (overlap < margin))) {
             margin = overlap;
         }
+        else if ((margin < 0) && (this->m_clusters.size() > 0)) {
+            margin = overlap;
+        }
         if (isInUnison) ++actualElementsInUnison;
     }
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -486,7 +486,7 @@ int Chord::AdjustOverlappingLayers(const Doc *doc, const std::vector<LayerElemen
         if (((margin >= 0) && (overlap > margin)) || ((margin <= 0) && (overlap < margin))) {
             margin = overlap;
         }
-        else if ((margin < 0) && (this->m_clusters.size() > 0)) {
+        else if ((margin < 0) && (m_clusters.size() > 0)) {
             margin = overlap;
         }
         if (isInUnison) ++actualElementsInUnison;


### PR DESCRIPTION
closes #2809 

![image](https://user-images.githubusercontent.com/1819669/233564340-c8890d55-a59c-4ed6-bc22-468a51576b09.png)

Example from second message in the issue had already been fixed prior to this change:
![image](https://user-images.githubusercontent.com/1819669/233565834-f4ebc638-6188-4eaf-b285-fae0db60e7c5.png)
