### PR TITLE
Fix for #2763

### DIFF
--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -296,6 +296,10 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         // The time will be reset to 0.0 when starting a new layer anyway
         if (layerElement->Is(TIMESTAMP_ATTR)) {
             m_time = duration;
+            // When a tstamp is pointing to the end of a measure, then use the right barline alignment
+            if (m_time == this->m_measureAligner->GetRightAlignment()->GetTime()) {
+                type = ALIGNMENT_MEASURE_RIGHT_BARLINE;
+            }
         }
         else {
             m_measureAligner->SetMaxTime(m_time + duration);


### PR DESCRIPTION
Use right barline alignment for corresponding tstamp. Differs from #3371 

![image](https://user-images.githubusercontent.com/689412/233618912-48361b6c-766a-43b0-a785-ad9f73cffe0a.png)
