### PR TITLE
Fix system spacing

### DIFF
--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -698,16 +698,11 @@ FunctorCode AlignSystemsFunctor::VisitSystem(System *system)
     assert(systemAligner.GetBottomAlignment());
 
     // No spacing for the first system
-    int systemSpacing = system->IsFirstInPage() ? 0 : m_systemSpacing;
-    if (systemSpacing) {
-        const int contentOverflow = m_prevBottomOverflow + systemAligner.GetOverflowAbove(m_doc);
-        const int clefOverflow = m_prevBottomClefOverflow + systemAligner.GetOverflowAbove(m_doc, true);
-        // Alignment is already pre-determined with staff alignment overflow
-        // We need to subtract them from the desired spacing
-        const int actualSpacing = systemSpacing - std::max(contentOverflow, clefOverflow);
-        // Ensure minimal white space between consecutive systems by adding one staff space
+    if (!system->IsFirstInPage()) {
+        // const int contentOverflow = m_prevBottomOverflow + systemAligner.GetOverflowAbove(m_doc);
+        // const int clefOverflow = m_prevBottomClefOverflow + systemAligner.GetOverflowAbove(m_doc, true);
         const int unit = m_doc->GetDrawingUnit(100);
-        m_shift -= std::max(actualSpacing, 2 * unit);
+        m_shift -= std::max(m_systemSpacing, 2 * unit);
     }
 
     system->SetDrawingYRel(m_shift);
@@ -720,6 +715,7 @@ FunctorCode AlignSystemsFunctor::VisitSystem(System *system)
         m_justificationSum -= m_doc->GetOptions()->m_justificationSystem.GetValue();
     }
 
+    // These are currently not used
     m_prevBottomOverflow = systemAligner.GetOverflowBelow(m_doc);
     m_prevBottomClefOverflow = systemAligner.GetOverflowBelow(m_doc, true);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1481,7 +1481,7 @@ Options::Options()
     this->Register(&m_spacingStaff, "spacingStaff", &m_generalLayout);
 
     m_spacingSystem.SetInfo("Spacing system", "The system minimal spacing in MEI units");
-    m_spacingSystem.Init(12, 0, 48);
+    m_spacingSystem.Init(4, 0, 48);
     this->Register(&m_spacingSystem, "spacingSystem", &m_generalLayout);
 
     m_staffLineWidth.SetInfo("Staff line width", "The staff line width in MEI units");


### PR DESCRIPTION
Previously, the staff overflow (above and below) was yielding a side effect and reducing the spacing. It is now fixed and the default system spacing is changed to 4 units instead of 12

Fixes #3363

Example in #3363 with `--page-width 1500`: in red, the spacing staff, in green the spacing system (default values) and in cyan the spacing added by the algorithm.

![image](https://user-images.githubusercontent.com/689412/234539032-b379ca1c-c632-4511-8c27-b94c3c3d18ea.png)
