### PR TITLE
Add possibility to draw measure numbers in text boxes

### DIFF
--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -227,7 +227,7 @@ protected:
     void DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerLines &lines, bool below, bool cueSize);
     void DrawMeasure(DeviceContext *dc, Measure *measure, System *system);
     void DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff);
-    void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset);
+    void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *system, int yOffset);
     void DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
     void DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
     void DrawLayer(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1181,6 +1181,7 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
 
         // HARDCODED
         // we set mNum to a fixed height above the system and make it a bit smaller than other text
+        params.m_enclosedRend.clear();
         params.m_x = staff->GetDrawingX();
         params.m_y = staff->GetDrawingY() + yOffset;
         if (mnum->HasFontsize()) {
@@ -1208,6 +1209,9 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
         dc->EndText();
 
         dc->ResetFont();
+        dc->ResetBrush();
+
+        this->DrawTextEnclosure(dc, params, staff->m_drawingStaffSize);
 
         dc->EndGraphic(mnum, this);
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1080,7 +1080,7 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
                 }
                 // hardcoded offset for the mNum based on the lyric font size
                 const int yOffset = m_doc->GetDrawingLyricFont(60)->GetPointSize();
-                this->DrawMNum(dc, mnum, measure, std::max(symbolOffset, yOffset));
+                this->DrawMNum(dc, mnum, measure, system, std::max(symbolOffset, yOffset));
             }
         }
     }
@@ -1156,7 +1156,7 @@ void View::DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff)
     dc->EndGraphic(meterSigGrp, this);
 }
 
-void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset)
+void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *system, int yOffset)
 {
     assert(dc);
     assert(measure);
@@ -1164,6 +1164,10 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
 
     Staff *staff = measure->GetTopVisibleStaff();
     if (staff) {
+        // Only one FloatingPositioner on the top (visible) staff
+        if (!system->SetCurrentFloatingPositioner(staff->GetN(), mnum, staff, staff)) {
+            return;
+        }
 
         dc->StartGraphic(mnum, "", mnum->GetID());
 
@@ -1181,7 +1185,6 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, int yOffset
 
         // HARDCODED
         // we set mNum to a fixed height above the system and make it a bit smaller than other text
-        params.m_enclosedRend.clear();
         params.m_x = staff->GetDrawingX();
         params.m_y = staff->GetDrawingY() + yOffset;
         if (mnum->HasFontsize()) {


### PR DESCRIPTION
This PR adds possibility to draw measure numbers in text boxes.

![image](https://user-images.githubusercontent.com/7693447/235116357-080f9b0d-7e11-40ce-8617-2bb68335cb9e.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Enclosed measure number</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
               <corpName role="funder">eNote GmbH</corpName>
            </respStmt>
            <date isodate="2023-04-28">2023-04-28</date>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Measure numbers can be styled individually with rend elements.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.16.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="G" line="2" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <note oct="4" pname="f" />
                           <note oct="4" pname="a" />
                           <note oct="5" pname="c" />
                           <note oct="5" pname="e" />
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <mNum>
                        <rend rend="box" fontstyle="normal">42</rend>
                     </mNum>
                     <staff n="1">
                        <layer n="1">
                           <note oct="5" pname="e" />
                           <note oct="5" pname="c" />
                           <note oct="4" pname="a" />
                           <note oct="4" pname="f" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
