### PR TITLE
Add rendring for al niente on hairpins

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2218,6 +2218,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     if (measureDifference >= 0) {
                         iter->first->SetTstamp2(std::pair<int, double>(measureDifference, timeStamp));
                     }
+                    if (wedge->node().attribute("niente")) {
+                        iter->first->SetNiente(ConvertWordToBool(wedge->node().attribute("niente").as_string()));
+                    }
                     if (wedge->node().attribute("spread")) {
                         data_MEASUREMENTSIGNED opening;
                         opening.SetVu(wedge->node().attribute("spread").as_double() / 5);

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -627,7 +627,7 @@ void View::DrawHairpin(
 
     const int cap = (style == AxDOT) ? AxCAP_ROUND : AxCAP_SQUARE;
 
-    dc->SetPen(m_currentColour, hairpinThickness, style, 0, 0, cap, AxJOIN_BEVEL);
+    dc->SetPen(m_currentColour, hairpinThickness, style, 0, 0, cap, AxJOIN_MITER);
 
     if ((startY == 0) && !niente) {
         Point p[3];

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -535,7 +535,7 @@ void View::DrawHairpin(
 
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const hairpinLog_FORM form = hairpin->GetForm();
-    const bool niente = (hairpin->GetNiente() == BOOLEAN_true);
+    const bool niente = (hairpin->HasNiente()) ? (hairpin->GetNiente() == BOOLEAN_true) : false;
 
     int adjustedX1 = x1;
     if (leftLink) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -646,12 +646,12 @@ void View::DrawHairpin(
     else {
         if (niente) {
             dc->SetBrush(m_currentColour, AxTRANSPARENT);
-            if ((startY == 0) && (spanningType == SPANNING_START)) {
+            if (startY == 0) {
                 dc->DrawCircle(ToDeviceContextX(x1), ToDeviceContextY(y), unit / 2);
                 startY = unit * endY / (x2 - x1) / 2;
                 x1 += unit / 2;
             }
-            else if ((endY == 0) && (spanningType == SPANNING_END)) {
+            else if (endY == 0) {
                 dc->DrawCircle(ToDeviceContextX(x2), ToDeviceContextY(y), unit / 2);
                 endY = unit * startY / (x2 - x1) / 2;
                 x2 -= unit / 2;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -535,7 +535,7 @@ void View::DrawHairpin(
 
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const hairpinLog_FORM form = hairpin->GetForm();
-    const bool niente = hairpin->GetNiente() == BOOLEAN_true;
+    const bool niente = (hairpin->GetNiente() == BOOLEAN_true);
 
     int adjustedX1 = x1;
     if (leftLink) {
@@ -602,7 +602,7 @@ void View::DrawHairpin(
     if (hairpin->GetPlace() != STAFFREL_within) {
         int shiftY = -(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
         if (hairpin->GetPlace() != STAFFREL_between) {
-            shiftY += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+            shiftY += unit;
         }
         y += shiftY;
     }
@@ -616,8 +616,7 @@ void View::DrawHairpin(
         dc->StartGraphic(hairpin, "", hairpin->GetID(), SPANNING);
     }
 
-    const double hairpinThickness
-        = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_hairpinThickness.GetValue();
+    const double hairpinThickness = m_options->m_hairpinThickness.GetValue() * unit;
 
     int style;
     switch (hairpin->GetLform()) {
@@ -647,12 +646,12 @@ void View::DrawHairpin(
     else {
         if (niente) {
             dc->SetBrush(m_currentColour, AxTRANSPARENT);
-            if (startY == 0) {
+            if ((startY == 0) && (spanningType == SPANNING_START)) {
                 dc->DrawCircle(ToDeviceContextX(x1), ToDeviceContextY(y), unit / 2);
                 startY = unit * endY / (x2 - x1) / 2;
                 x1 += unit / 2;
             }
-            else {
+            else if ((endY == 0) && (spanningType == SPANNING_END)) {
                 dc->DrawCircle(ToDeviceContextX(x2), ToDeviceContextY(y), unit / 2);
                 endY = unit * startY / (x2 - x1) / 2;
                 x2 -= unit / 2;


### PR DESCRIPTION
This adds rendering for al niente circles to hairpins.

![hairpin-al-niente](https://user-images.githubusercontent.com/7693447/235140709-5570654b-fd68-4d46-a3b2-415c706cdf2c.png)

(Example from Gould, will be added to test suite.)
