### PR TITLE
Use SMuFL glyphs for open 7th .. 10th courses.  Partial fix of issue #2530

### DIFF
--- a/fonts/supported.xml
+++ b/fonts/supported.xml
@@ -2828,10 +2828,10 @@
         <glyph glyph-code="EBCA" smufl-name="luteFrenchFretL"/>
         <glyph glyph-code="EBCB" smufl-name="luteFrenchFretM"/>
         <glyph glyph-code="EBCC" smufl-name="luteFrenchFretN"/>
-        <!--<glyph glyph-code="EBCD" smufl-name="luteFrench7thCourse" />-->
-        <!--<glyph glyph-code="EBCE" smufl-name="luteFrench8thCourse" />-->
-        <!--<glyph glyph-code="EBCF" smufl-name="luteFrench9thCourse" />-->
-        <!--<glyph glyph-code="EBD0" smufl-name="luteFrench10thCourse" />-->
+        <glyph glyph-code="EBCD" smufl-name="luteFrench7thCourse"/>
+        <glyph glyph-code="EBCE" smufl-name="luteFrench8thCourse"/>
+        <glyph glyph-code="EBCF" smufl-name="luteFrench9thCourse"/>
+        <glyph glyph-code="EBD0" smufl-name="luteFrench10thCourse"/>
         <!--<glyph glyph-code="EBD1" smufl-name="luteFrenchMordentUpper" />-->
         <!--<glyph glyph-code="EBD2" smufl-name="luteFrenchMordentLower" />-->
         <!--<glyph glyph-code="EBD3" smufl-name="luteFrenchMordentInverted" />-->

--- a/include/vrv/smufl.h
+++ b/include/vrv/smufl.h
@@ -541,6 +541,10 @@ enum {
     SMUFL_EBCA_luteFrenchFretL = 0xEBCA,
     SMUFL_EBCB_luteFrenchFretM = 0xEBCB,
     SMUFL_EBCC_luteFrenchFretN = 0xEBCC,
+    SMUFL_EBCD_luteFrench7thCourse = 0xEBCD,
+    SMUFL_EBCE_luteFrench8thCourse = 0xEBCE,
+    SMUFL_EBCF_luteFrench9thCourse = 0xEBCF,
+    SMUFL_EBD0_luteFrench10thCourse = 0xEBD0,
     SMUFL_EBE0_luteItalianFret0 = 0xEBE0,
     SMUFL_EBE1_luteItalianFret1 = 0xEBE1,
     SMUFL_EBE2_luteItalianFret2 = 0xEBE2,
@@ -578,7 +582,7 @@ enum {
 };
 
 /** The number of glyphs for verification **/
-#define SMUFL_COUNT 553
+#define SMUFL_COUNT 557
 
 } // namespace vrv
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -297,8 +297,15 @@ std::u32string Note::GetTabFretString(data_NOTATIONTYPE notationType) const
             //      Temporary kludge, use SMUFL_EBE4_luteItalianFret4 ... .
             fretStr.push_back(SMUFL_EBE4_luteItalianFret4 + course - 11);
         }
+        else if (course >= 7 && fret == 0) {
+            // SMUFL has glyphs for 7th to 10th open courses
+            static_assert(SMUFL_EBCE_luteFrench8thCourse == SMUFL_EBCD_luteFrench7thCourse + 1);
+            static_assert(SMUFL_EBCF_luteFrench9thCourse == SMUFL_EBCD_luteFrench7thCourse + 2);
+            static_assert(SMUFL_EBD0_luteFrench10thCourse == SMUFL_EBCD_luteFrench7thCourse + 3);
+            fretStr = SMUFL_EBCD_luteFrench7thCourse + course - 7;
+        }
         else {
-            // courses 8..10 use slashes followed by fret letter
+            // stopped courses 8..10 use slashes followed by fret letter
             if (course >= 8) {
                 // TODO need SMUFL_xxxx_luteDiapasonSlash or 3 glyphs "/", "//", "///".
                 //      Temporary kludge, use SMUFL_E101_noteheadSlashHorizontalEnds, doesn't


### PR DESCRIPTION
Partial fix of  Tablature: French tab bass slashes ugly #2530 

After this fix, no ugly slashes on open diapasons.  However, there will still be ugly slashes on stopped diapasons.

![Screenshot_20230501_174651](https://user-images.githubusercontent.com/76966668/235732733-60257749-e46d-4548-a9e4-fcd8d26ad501.jpg)

Please re-generate fonts after merge, thanks.