### PR TITLE
Fix guitar tab

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -506,6 +506,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         m_currentNode = m_currentNode.append_child("fing");
         this->WriteFing(m_currentNode, vrv_cast<Fing *>(object));
     }
+    else if (object->Is(GLISS)) {
+        m_currentNode = m_currentNode.append_child("gliss");
+        this->WriteGliss(m_currentNode, vrv_cast<Gliss *>(object));
+    }
     else if (object->Is(HAIRPIN)) {
         m_currentNode = m_currentNode.append_child("hairpin");
         this->WriteHairpin(m_currentNode, vrv_cast<Hairpin *>(object));
@@ -623,10 +627,6 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         else if (object->Is(FTREM)) {
             m_currentNode = m_currentNode.append_child("fTrem");
             this->WriteFTrem(m_currentNode, vrv_cast<FTrem *>(object));
-        }
-        else if (object->Is(GLISS)) {
-            m_currentNode = m_currentNode.append_child("gliss");
-            this->WriteGliss(m_currentNode, vrv_cast<Gliss *>(object));
         }
         else if (object->Is(GRACEGRP)) {
             m_currentNode = m_currentNode.append_child("graceGrp");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1353,6 +1353,7 @@ short int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(
             if (key) {
                 KeySig *meiKey = ConvertKey(key.node());
                 staffDef->AddChild(meiKey);
+                if (staffDef->GetNotationtype() == NOTATIONTYPE_tab_guitar) meiKey->IsAttribute(true);
             }
 
             // staff details

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1374,7 +1374,7 @@ short int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(
                 staffDef->SetScale(staffDef->AttScalable::StrToPercent(scaleStr + "%"));
             }
             // Tablature?
-            if (staffDetails.node().child("staff-tuning") || staffDef->GetNotationtype() == NOTATIONTYPE_tab_guitar) {
+            if (staffDetails.node().child("staff-tuning") || (staffDef->GetNotationtype() == NOTATIONTYPE_tab_guitar)) {
                 // tablature type.  MusicXML does not support German tablature.
                 if (HasAttributeWithValue(staffDetails.node(), "show-frets", "letters")) {
                     staffDef->SetNotationtype(NOTATIONTYPE_tab_lute_french);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1360,7 +1360,7 @@ short int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(
             xpath = StringFormat("staff-details[@number='%d']", i + 1);
             staffDetails = it->select_node(xpath.c_str());
             if (!staffDetails) {
-                staffDetails = it->select_node("staff-details");
+                staffDetails = it->select_node("staff-details[not(@number)]");
             }
             short int staffLines = staffDetails.node().select_node("staff-lines").node().text().as_int();
             if (staffLines) {

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -943,6 +943,11 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     assert(staff);
     assert(measure);
 
+    if (staff->IsTablature()) {
+        // Encoded keySig will not be shown on tablature
+        return;
+    }
+
     KeySig *keySig = vrv_cast<KeySig *>(element);
     assert(keySig);
 


### PR DESCRIPTION
This PR improves tablature import from MusicXML and suppresses key signatures in tablature notation. 
Also this fixes the `WriteObjectInternal` function, that led to crashes with `gliss` elements.