### PR TITLE
Add sanity check in MusicXML importer

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -425,6 +425,9 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
     else {
         m_elementStackMap.at(layer).back()->AddChild(element);
     }
+    // Recheck if AddChild was successful
+    if (!element->GetParent()) return;
+
     m_layerEndTimes[layer] = m_durTotal + duration;
     if (!element->Is({ BEAM, TUPLET })) {
         m_layerTimes[layer].emplace(m_durTotal + duration, element);


### PR DESCRIPTION
This PR adds a sanity check in the importer when adding layer element children. This fixes a crash in one of our examples. 

The problem was that if children are not successfully added, then we get into trouble later when resolving clef changes: `MusicXmlInput::InsertClefIntoObject` assumes that all layer elements within `m_layerTimes` have a parent.