### PR TITLE
Keep mismatched measures alive

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -277,9 +277,8 @@ private:
      * Add a Measure to the section.
      * If the measure already exists it will move all its content.
      * The measure can contain only staves. Other elements must be stacked on m_floatingElements.
-     * Returns true if the measure was added to the tree (did not exist before)
      */
-    bool AddMeasure(Section *section, Measure *measure, int i);
+    void AddMeasure(Section *section, Measure *measure, int i);
 
     /*
      * Add a Layer element to the layer or to the LayerElement at the top of m_elementStack.
@@ -558,6 +557,11 @@ private:
     std::map<Measure *, int> m_measureCounts;
     /* measure rests */
     std::map<int, int> m_multiRests;
+
+    /*
+     * Objects that were not successfully added and should be destroyed at the end of the import
+     */
+    ListOfObjects m_garbage;
 
 #endif // NO_MUSICXML_SUPPORT
 };

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -109,7 +109,13 @@ enum class MetronomeElements { BEAT_UNIT, BEAT_UNIT_DOT, PER_MINUTE, SEPARATOR }
 
 MusicXmlInput::MusicXmlInput(Doc *doc) : Input(doc) {}
 
-MusicXmlInput::~MusicXmlInput() {}
+MusicXmlInput::~MusicXmlInput()
+{
+    // Clean the collected garbage
+    for (Object *object : m_garbage) {
+        delete object;
+    }
+}
 
 #ifndef NO_MUSICXML_SUPPORT
 
@@ -340,7 +346,7 @@ void MusicXmlInput::InsertClefIntoObject(Object *parent, Clef *clef, Object *lay
     }
 }
 
-bool MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
+void MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
 {
     assert(section);
     assert(i >= 0);
@@ -381,12 +387,13 @@ bool MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
             measure->ClearRelinquishedChildren();
         }
         else {
+            // The measure was not transferred and not added to the tree. Its entire content will be deleted at the end.
             LogError("MusicXML import: Mismatching measure number %s", measure->GetN().c_str());
-
-            // Keep the measure alive as ghost. Its content was not transferred, so we cannot delete it.
-            return true;
         }
         contentMeasure = existingMeasure;
+
+        m_measureCounts.erase(measure);
+        m_garbage.push_back(measure);
     }
 
     // Handle endings
@@ -407,8 +414,6 @@ bool MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
     }
     m_currentEndingStart.reset();
     m_currentEndingStop.reset();
-
-    return (contentMeasure == measure);
 }
 
 void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int duration)
@@ -1565,11 +1570,7 @@ bool MusicXmlInput::ReadMusicXmlPart(pugi::xml_node node, Section *section, shor
             m_measureCounts[measure] = i;
             ReadMusicXmlMeasure(xmlMeasure.node(), section, measure, nbStaves, staffOffset, i);
             // Add the measure to the system - if already there from a previous part we'll just merge the content
-            if (!AddMeasure(section, measure, i)) {
-                // If content was transferred to existing measure, clean up
-                m_measureCounts.erase(measure);
-                delete measure;
-            }
+            AddMeasure(section, measure, i);
         }
         else {
             // Handle barline parsing for the multirests (where barline would be defined in last measure of the mRest)

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -382,6 +382,9 @@ bool MusicXmlInput::AddMeasure(Section *section, Measure *measure, int i)
         }
         else {
             LogError("MusicXML import: Mismatching measure number %s", measure->GetN().c_str());
+
+            // Keep the measure alive as ghost. Its content was not transferred, so we cannot delete it.
+            return true;
         }
         contentMeasure = existingMeasure;
     }


### PR DESCRIPTION
This PR fixes another edge case in the MusicXML importer: if a measure cannot be matched, it should not be deleted. Otherwise pointers are dangling in the other data structures of the importer.
We resolve this by collecting measures as garbage which is cleaned at the very end of the import.