### PR TITLE
Fix a few bugs in latest develop-humdrum branch

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -25534,7 +25534,7 @@ void HumdrumInput::addTurn(hum::HTp token, const string &tok, int noteIndex)
     std::string noteid = getLocationId("note", token, noteIndex);
     turn->SetStartid("#" + noteid);
 
-    turn->SetForm(invertedQ ? turnLog_FORM_lower : turnLog_FORM_lower);
+    turn->SetForm(invertedQ ? turnLog_FORM_lower : turnLog_FORM_upper);
 
     if (m_signifiers.above) {
         if (turnend < (int)token->size() - 1) {

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -197,13 +197,14 @@ LayerElement *Layer::GetAtPos(int x)
 const LayerElement *Layer::GetAtPos(int x) const
 {
     const Object *first = this->GetFirst();
-    if (!first || !first->IsLayerElement()) return NULL;
+    if (!first) return NULL;
 
     if (first->IsEditorialElement()) {
         IsEditorialElementComparison cmp;
         cmp.ReverseComparison();
         first = this->FindDescendantByComparison(&cmp);
     }
+    if (!first || !first->IsLayerElement()) return NULL;
 
     const LayerElement *element = vrv_cast<const LayerElement *>(first);
     assert(element);

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -197,12 +197,13 @@ LayerElement *Layer::GetAtPos(int x)
 const LayerElement *Layer::GetAtPos(int x) const
 {
     const Object *first = this->GetFirst();
+    if (!first || !first->IsLayerElement()) return NULL;
+
     if (first->IsEditorialElement()) {
         IsEditorialElementComparison cmp;
         cmp.ReverseComparison();
         first = this->FindDescendantByComparison(&cmp);
     }
-    if (!first || !first->IsLayerElement()) return NULL;
 
     const LayerElement *element = vrv_cast<const LayerElement *>(first);
     assert(element);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -1001,7 +1001,7 @@ int LayerElement::CalcLayerOverlap(const Doc *doc, int direction, int y1, int y2
             const int currentTop = this->GetDrawingTop(doc, staff->m_drawingStaffSize);
             if (currentTop <= elementBottom) continue;
             const StemmedDrawingInterface *stemInterface = layerElement->GetStemmedDrawingInterface();
-            if (sameDirElement || (stemInterface && (stemInterface->GetDrawingStemDir() == STEMDIRECTION_down))) {
+            if (stemInterface && (sameDirElement || (stemInterface->GetDrawingStemDir() == STEMDIRECTION_down))) {
                 if (currentTop - stemInterface->GetDrawingStemLen() > currentTop) continue;
                 leftMargin = unit + y1 - elementTop;
                 rightMargin = unit + y2 - elementTop;


### PR DESCRIPTION
1. Fix typo when setting turn@form (every turn's form was set to lower).
2. Fix crash in LayerElement::CalcLayerOverlap when sameDirElement is true, but stemInterface is NULL.
3. Fix crash in Layer::GetAtPos when this->GetFirst() returns NULL, by moving the NULL check a bit earlier.