### PR TITLE
Use stack for functor filters and direction

### DIFF
--- a/include/vrv/findlayerelementsfunctor.h
+++ b/include/vrv/findlayerelementsfunctor.h
@@ -231,7 +231,7 @@ private:
 
 /**
  * This class goes through all layer elements of the layer and returns the next/previous element
- * relative to the specified layer element.
+ * (depending on traversal direction) relative to the specified layer element.
  * It will search recursively through children elements until note, chord or ftrem is found.
  * It can be used to look into neighboring layers as well, but only the first element will be checked.
  */
@@ -241,7 +241,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    GetRelativeLayerElementFunctor(int elementIndex, bool searchDirection, bool anotherLayer);
+    GetRelativeLayerElementFunctor(int elementIndex, bool anotherLayer);
     virtual ~GetRelativeLayerElementFunctor() = default;
     ///@}
 
@@ -273,8 +273,6 @@ private:
     const LayerElement *m_relativeElement;
     // The index of the layer element that is being compared to (starting point)
     int m_initialElementIndex;
-    // The direction of search - BACKWARD is for previous element, FORWARD - next
-    bool m_searchDirection;
     // The flag to indicate whether search is done in the same layer as the given element, or in neighboring one
     bool m_isInNeighboringLayer;
 };

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -8,6 +8,8 @@
 #ifndef __VRV_FUNCTOR_H__
 #define __VRV_FUNCTOR_H__
 
+#include <stack>
+
 #include "comparison.h"
 #include "functorinterface.h"
 #include "vrvdef.h"
@@ -43,13 +45,26 @@ public:
     ///@}
 
     /**
-     * Getters/Setters for the properties
+     * Getters/Setters for the filters
      */
     ///@{
-    Filters *GetFilters() { return m_filters; }
-    void SetFilters(Filters *filters) { m_filters = filters; }
+    Filters *GetFilters() { return m_filters.empty() ? NULL : m_filters.top(); }
+    void PushFilters(Filters *filters) { m_filters.push(filters); }
+    void PopFilters() { m_filters.pop(); }
+    ///@}
+
+    /**
+     * Getters/Setters for the visibility
+     */
+    ///@{
     bool VisibleOnly() const { return m_visibleOnly; }
     void SetVisibleOnly(bool visibleOnly) { m_visibleOnly = visibleOnly; }
+    ///@}
+
+    /**
+     * Getters/Setters for the direction
+     */
+    ///@{
     bool GetDirection() const { return m_direction; }
     void SetDirection(bool direction) { m_direction = direction; }
     ///@}
@@ -66,8 +81,8 @@ public:
 private:
     // The functor code
     FunctorCode m_code = FUNCTOR_CONTINUE;
-    // The filters
-    Filters *m_filters = NULL;
+    // The filter stack
+    std::stack<Filters *> m_filters;
     // Visible only flag
     bool m_visibleOnly = true;
     // Direction

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -65,8 +65,9 @@ public:
      * Getters/Setters for the direction
      */
     ///@{
-    bool GetDirection() const { return m_direction; }
-    void SetDirection(bool direction) { m_direction = direction; }
+    bool GetDirection() const { return m_direction.empty() ? FORWARD : m_direction.top(); }
+    void PushDirection(bool direction) { m_direction.push(direction); }
+    void PopDirection() { m_direction.pop(); }
     ///@}
 
     /**
@@ -85,8 +86,8 @@ private:
     std::stack<Filters *> m_filters;
     // Visible only flag
     bool m_visibleOnly = true;
-    // Direction
-    bool m_direction = FORWARD;
+    // The direction stack
+    std::stack<bool> m_direction;
 };
 
 //----------------------------------------------------------------------------

--- a/src/adjustarpegfunctor.cpp
+++ b/src/adjustarpegfunctor.cpp
@@ -172,11 +172,10 @@ FunctorCode AdjustArpegFunctor::VisitMeasureEnd(Measure *measure)
 {
     if (!m_alignmentArpegTuples.empty()) {
         m_measureAligner = &measure->m_measureAligner;
-        // Process backwards on measure aligner, then reset to previous direction
-        const bool direction = this->GetDirection();
-        this->SetDirection(BACKWARD);
+        // Process backwards on measure aligner
+        this->PushDirection(BACKWARD);
         m_measureAligner->Process(*this);
-        this->SetDirection(direction);
+        this->PopDirection();
         m_alignmentArpegTuples.clear();
     }
 

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -100,9 +100,8 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    this->PushFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -119,7 +118,7 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->SetFilters(previousFilters);
+    this->PopFilters();
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -48,8 +48,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         MeasureAligner *measureAligner = vrv_cast<MeasureAligner *>(alignment->GetFirstAncestor(MEASURE_ALIGNER));
         assert(measureAligner);
 
-        bool previousDirection = this->GetDirection();
-        this->SetDirection(BACKWARD);
+        this->PushDirection(BACKWARD);
         Filters filters;
         this->PushFilters(&filters);
 
@@ -109,7 +108,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
             }
         }
 
-        this->SetDirection(previousDirection);
+        this->PopDirection();
         this->PopFilters();
 
         // Change the flag back
@@ -142,15 +141,14 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignmentReference(AlignmentReference *
     // Because we are processing grace notes alignment backward (see VisitAlignment) we need
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
-    bool previousDirection = this->GetDirection();
-    this->SetDirection(FORWARD);
+    this->PushDirection(FORWARD);
     this->PushFilters(NULL);
 
     for (auto child : alignmentReference->GetChildren()) {
         child->Process(*this);
     }
 
-    this->SetDirection(previousDirection);
+    this->PopDirection();
     this->PopFilters();
 
     return FUNCTOR_SIBLINGS;
@@ -207,8 +205,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
     m_rightDefaultAlignment = NULL;
 
     // We process it backward because we want to get the rightDefaultAlignment
-    bool previousDirection = this->GetDirection();
-    this->SetDirection(BACKWARD);
+    this->PushDirection(BACKWARD);
     measure->m_measureAligner.Process(*this);
 
     // We need to process the staves in the reverse order
@@ -223,7 +220,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
     m_staffNs = staffNsReversed;
     m_measureTieEndpoints = measure->GetInternalTieEndpoints();
     measure->m_measureAligner.Process(*this);
-    this->SetDirection(previousDirection);
+    this->PopDirection();
 
     // Put params back
     m_staffNs = staffNs;

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -49,10 +49,9 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         assert(measureAligner);
 
         bool previousDirection = this->GetDirection();
-        Filters *previousFilters = this->GetFilters();
         this->SetDirection(BACKWARD);
         Filters filters;
-        this->SetFilters(&filters);
+        this->PushFilters(&filters);
 
         std::vector<int>::iterator iter;
         for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -111,7 +110,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         }
 
         this->SetDirection(previousDirection);
-        this->SetFilters(previousFilters);
+        this->PopFilters();
 
         // Change the flag back
         m_isGraceAlignment = false;
@@ -144,16 +143,15 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignmentReference(AlignmentReference *
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
     bool previousDirection = this->GetDirection();
-    Filters *previousFilters = this->GetFilters();
     this->SetDirection(FORWARD);
-    this->SetFilters(NULL);
+    this->PushFilters(NULL);
 
     for (auto child : alignmentReference->GetChildren()) {
         child->Process(*this);
     }
 
     this->SetDirection(previousDirection);
-    this->SetFilters(previousFilters);
+    this->PopFilters();
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -123,9 +123,8 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    this->PushFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -142,7 +141,7 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->SetFilters(previousFilters);
+    this->PopFilters();
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -214,9 +214,8 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
 
     const bool hasSystemStartLine = measure->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine();
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    this->PushFilters(&filters);
 
     for (auto staffN : m_staffNs) {
         m_minPos = 0;
@@ -248,7 +247,7 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->SetFilters(previousFilters);
+    this->PopFilters();
 
     int minMeasureWidth = m_doc->GetOptions()->m_unit.GetValue() * m_doc->GetOptions()->m_measureMinWidth.GetValue();
     // First try to see if we have a double measure length element

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -284,9 +284,8 @@ FunctorCode ConvertToCastOffMensuralFunctor::VisitMeasure(Measure *measure)
     }
     m_targetSubSystem->AddChild(targetMeasure);
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    this->PushFilters(&filters);
 
     // Now we can process by layer and move their content to (measure) segments
     for (const auto &staves : m_layerTree->child) {
@@ -303,7 +302,7 @@ FunctorCode ConvertToCastOffMensuralFunctor::VisitMeasure(Measure *measure)
         }
     }
 
-    this->SetFilters(previousFilters);
+    this->PopFilters();
 
     m_targetMeasure = NULL;
     m_targetSubSystem = NULL;

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -491,7 +491,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             filters.Add(&matchLayer);
 
             GenerateMIDIFunctor generateMIDI(midiFile);
-            generateMIDI.SetFilters(&filters);
+            generateMIDI.PushFilters(&filters);
 
             generateMIDI.SetChannel(midiChannel);
             generateMIDI.SetTrack(midiTrack);
@@ -721,7 +721,7 @@ void Doc::PrepareData()
             filters.Add(&matchLayer);
 
             PreparePointersByLayerFunctor preparePointersByLayer;
-            preparePointersByLayer.SetFilters(&filters);
+            preparePointersByLayer.PushFilters(&filters);
             this->Process(preparePointersByLayer);
         }
     }
@@ -733,6 +733,7 @@ void Doc::PrepareData()
     prepareDelayedTurns.SetDataCollectionCompleted();
 
     if (!prepareDelayedTurns.GetDelayedTurns().empty()) {
+        prepareDelayedTurns.PushFilters(&filters);
         for (staves = layerTree.child.begin(); staves != layerTree.child.end(); ++staves) {
             for (layers = staves->second.child.begin(); layers != staves->second.child.end(); ++layers) {
                 filters.Clear();
@@ -742,7 +743,6 @@ void Doc::PrepareData()
                 filters.Add(&matchStaff);
                 filters.Add(&matchLayer);
 
-                prepareDelayedTurns.SetFilters(&filters);
                 prepareDelayedTurns.ResetCurrent();
                 this->Process(prepareDelayedTurns);
             }
@@ -768,7 +768,7 @@ void Doc::PrepareData()
                 // The first pass sets m_drawingFirstNote and m_drawingLastNote for each syl
                 // m_drawingLastNote is set only if the syl has a forward connector
                 PrepareLyricsFunctor prepareLyrics;
-                prepareLyrics.SetFilters(&filters);
+                prepareLyrics.PushFilters(&filters);
                 this->Process(prepareLyrics);
             }
         }
@@ -802,7 +802,7 @@ void Doc::PrepareData()
 
             // We set multiNumber to NONE for indicated we need to look at the staffDef when reaching the first staff
             PrepareRptFunctor prepareRpt(this);
-            prepareRpt.SetFilters(&filters);
+            prepareRpt.PushFilters(&filters);
             this->Process(prepareRpt);
         }
     }
@@ -1348,7 +1348,7 @@ void Doc::ConvertMarkupDoc(bool permanent)
                 filters.Add(&matchLayer);
 
                 ConvertMarkupAnalyticalFunctor convertMarkupAnalytical(permanent);
-                convertMarkupAnalytical.SetFilters(&filters);
+                convertMarkupAnalytical.PushFilters(&filters);
                 this->Process(convertMarkupAnalytical);
 
                 // After having processed one layer, we check if we have open ties - if yes, we

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -362,7 +362,7 @@ void Doc::CalculateTimemap()
 
     // Adjust the duration of tied notes
     InitTimemapTiesFunctor initTimemapTies;
-    initTimemapTies.SetDirection(BACKWARD);
+    initTimemapTies.PushDirection(BACKWARD);
     this->Process(initTimemapTies);
 
     m_timemapTempo = m_options->m_midiTempoAdjustment.GetValue();
@@ -581,8 +581,9 @@ void Doc::PrepareData()
 
     // Try to match all spanning elements (slur, tie, etc) by processing backwards
     PrepareTimeSpanningFunctor prepareTimeSpanning;
-    prepareTimeSpanning.SetDirection(BACKWARD);
+    prepareTimeSpanning.PushDirection(BACKWARD);
     this->Process(prepareTimeSpanning);
+    prepareTimeSpanning.PopDirection();
     prepareTimeSpanning.SetDataCollectionCompleted();
 
     // First we try backwards because normally the spanning elements are at the end of
@@ -592,7 +593,6 @@ void Doc::PrepareData()
     // but this time without filling the list (that is only will the remaining elements)
     const ListOfSpanningInterOwnerPairs &interfaceOwnerPairs = prepareTimeSpanning.GetInterfaceOwnerPairs();
     if (!interfaceOwnerPairs.empty()) {
-        prepareTimeSpanning.SetDirection(FORWARD);
         this->Process(prepareTimeSpanning);
     }
 
@@ -614,7 +614,7 @@ void Doc::PrepareData()
 
     // Try to match all time pointing elements (tempo, fermata, etc) by processing backwards
     PrepareTimePointingFunctor prepareTimePointing;
-    prepareTimePointing.SetDirection(BACKWARD);
+    prepareTimePointing.PushDirection(BACKWARD);
     this->Process(prepareTimePointing);
 
     /************ Resolve @tstamp / tstamp2 ************/
@@ -638,8 +638,9 @@ void Doc::PrepareData()
 
     // If we have some left process again backward
     if (!prepareLinking.GetSameasIDPairs().empty() || !prepareLinking.GetStemSameasIDPairs().empty()) {
-        prepareLinking.SetDirection(BACKWARD);
+        prepareLinking.PushDirection(BACKWARD);
         this->Process(prepareLinking);
+        prepareLinking.PopDirection();
     }
 
     // If some are still there, then it is probably an issue in the encoding
@@ -879,10 +880,10 @@ void Doc::ScoreDefSetCurrentDoc(bool force)
     // First we need to set Page::m_score and Page::m_scoreEnd
     // We do it by going BACKWARD, with a depth limit of 3 (we want to hit the Score elements)
     ScoreDefSetCurrentPageFunctor scoreDefSetCurrentPage(this);
-    scoreDefSetCurrentPage.SetDirection(BACKWARD);
+    scoreDefSetCurrentPage.PushDirection(BACKWARD);
     this->Process(scoreDefSetCurrentPage, 3);
+    scoreDefSetCurrentPage.PopDirection();
     // Do it again FORWARD to set Page::m_scoreEnd - relies on Page::m_score not being NULL
-    scoreDefSetCurrentPage.SetDirection(FORWARD);
     this->Process(scoreDefSetCurrentPage, 3);
 
     ScoreDefSetCurrentFunctor scoreDefSetCurrent(this);

--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -247,13 +247,10 @@ FunctorCode FindSpannedLayerElementsFunctor::VisitMeasure(const Measure *measure
 // GetRelativeLayerElementFunctor
 //----------------------------------------------------------------------------
 
-GetRelativeLayerElementFunctor::GetRelativeLayerElementFunctor(
-    int elementIndex, bool searchDirection, bool anotherLayer)
-    : ConstFunctor()
+GetRelativeLayerElementFunctor::GetRelativeLayerElementFunctor(int elementIndex, bool anotherLayer) : ConstFunctor()
 {
     m_relativeElement = NULL;
     m_initialElementIndex = elementIndex;
-    m_searchDirection = searchDirection;
     m_isInNeighboringLayer = anotherLayer;
 }
 
@@ -263,8 +260,9 @@ FunctorCode GetRelativeLayerElementFunctor::VisitLayerElement(const LayerElement
     // processed (e.g. ignore index children of beams, since they have their own indices irrelevant to the one that
     // has been passed inside this functor)
     if (!m_isInNeighboringLayer && layerElement->GetParent()->Is(LAYER)) {
-        if ((m_searchDirection == FORWARD) && (layerElement->GetIdx() < m_initialElementIndex)) return FUNCTOR_SIBLINGS;
-        if ((m_searchDirection == BACKWARD) && (layerElement->GetIdx() > m_initialElementIndex))
+        if ((this->GetDirection() == FORWARD) && (layerElement->GetIdx() < m_initialElementIndex))
+            return FUNCTOR_SIBLINGS;
+        if ((this->GetDirection() == BACKWARD) && (layerElement->GetIdx() > m_initialElementIndex))
             return FUNCTOR_SIBLINGS;
     }
 

--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -260,10 +260,12 @@ FunctorCode GetRelativeLayerElementFunctor::VisitLayerElement(const LayerElement
     // processed (e.g. ignore index children of beams, since they have their own indices irrelevant to the one that
     // has been passed inside this functor)
     if (!m_isInNeighboringLayer && layerElement->GetParent()->Is(LAYER)) {
-        if ((this->GetDirection() == FORWARD) && (layerElement->GetIdx() < m_initialElementIndex))
+        if ((this->GetDirection() == FORWARD) && (layerElement->GetIdx() < m_initialElementIndex)) {
             return FUNCTOR_SIBLINGS;
-        if ((this->GetDirection() == BACKWARD) && (layerElement->GetIdx() > m_initialElementIndex))
+        }
+        if ((this->GetDirection() == BACKWARD) && (layerElement->GetIdx() > m_initialElementIndex)) {
             return FUNCTOR_SIBLINGS;
+        }
     }
 
     if (layerElement->Is({ NOTE, CHORD, FTREM })) {

--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -263,8 +263,9 @@ FunctorCode GetRelativeLayerElementFunctor::VisitLayerElement(const LayerElement
     // processed (e.g. ignore index children of beams, since they have their own indices irrelevant to the one that
     // has been passed inside this functor)
     if (!m_isInNeighboringLayer && layerElement->GetParent()->Is(LAYER)) {
-        if (m_searchDirection == FORWARD && (layerElement->GetIdx() < m_initialElementIndex)) return FUNCTOR_SIBLINGS;
-        if (m_searchDirection == BACKWARD && (layerElement->GetIdx() > m_initialElementIndex)) return FUNCTOR_SIBLINGS;
+        if ((m_searchDirection == FORWARD) && (layerElement->GetIdx() < m_initialElementIndex)) return FUNCTOR_SIBLINGS;
+        if ((m_searchDirection == BACKWARD) && (layerElement->GetIdx() > m_initialElementIndex))
+            return FUNCTOR_SIBLINGS;
     }
 
     if (layerElement->Is({ NOTE, CHORD, FTREM })) {

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -664,7 +664,7 @@ void Alignment::GetLeftRight(int staffN, int &minLeft, int &maxRight, const std:
         Filters filters;
         AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
         filters.Add(&matchStaff);
-        getAlignmentLeftRight.SetFilters(&filters);
+        getAlignmentLeftRight.PushFilters(&filters);
         this->Process(getAlignmentLeftRight);
     }
     else {

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -399,7 +399,7 @@ std::set<int> Layer::GetLayersNInTimeSpan(double time, double duration, const Me
     Filters filters;
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staff);
     filters.Add(&matchStaff);
-    layersInTimeSpan.SetFilters(&filters);
+    layersInTimeSpan.PushFilters(&filters);
 
     measure->m_measureAligner.Process(layersInTimeSpan);
 
@@ -481,7 +481,7 @@ ListOfConstObjects Layer::GetLayerElementsInTimeSpan(
     Filters filters;
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staff);
     filters.Add(&matchStaff);
-    layerElementsInTimeSpan.SetFilters(&filters);
+    layerElementsInTimeSpan.PushFilters(&filters);
 
     measure->m_measureAligner.Process(layerElementsInTimeSpan);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -590,7 +590,7 @@ Object *Object::FindDescendantByID(const std::string &id, int deepness, bool dir
 const Object *Object::FindDescendantByID(const std::string &id, int deepness, bool direction) const
 {
     FindByIDFunctor findByID(id);
-    findByID.SetDirection(direction);
+    findByID.PushDirection(direction);
     this->Process(findByID, deepness, true);
     return findByID.GetElement();
 }
@@ -614,7 +614,7 @@ Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness,
 const Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     FindByComparisonFunctor findByComparison(comparison);
-    findByComparison.SetDirection(direction);
+    findByComparison.PushDirection(direction);
     this->Process(findByComparison, deepness, true);
     return findByComparison.GetElement();
 }
@@ -628,7 +628,7 @@ Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int de
 const Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     FindExtremeByComparisonFunctor findExtremeByComparison(comparison);
-    findExtremeByComparison.SetDirection(direction);
+    findExtremeByComparison.PushDirection(direction);
     this->Process(findExtremeByComparison, deepness, true);
     return findExtremeByComparison.GetElement();
 }
@@ -661,7 +661,7 @@ void Object::FindAllDescendantsByComparison(
     if (clear) objects->clear();
 
     FindAllByComparisonFunctor findAllByComparison(comparison, objects);
-    findAllByComparison.SetDirection(direction);
+    findAllByComparison.PushDirection(direction);
     this->Process(findAllByComparison, deepness, true);
 }
 
@@ -672,7 +672,7 @@ void Object::FindAllDescendantsByComparison(
     if (clear) objects->clear();
 
     FindAllConstByComparisonFunctor findAllConstByComparison(comparison, objects);
-    findAllConstByComparison.SetDirection(direction);
+    findAllConstByComparison.PushDirection(direction);
     this->Process(findAllConstByComparison, deepness, true);
 }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -759,7 +759,7 @@ void Page::AdjustSylSpacingByVerse(const IntTree &verseTree, Doc *doc)
                 filters = { &matchStaff, &matchLayer, &matchVerse };
 
                 AdjustSylSpacingFunctor adjustSylSpacing(doc);
-                adjustSylSpacing.SetFilters(&filters);
+                adjustSylSpacing.PushFilters(&filters);
                 this->Process(adjustSylSpacing);
             }
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -399,7 +399,7 @@ int Rest::GetLocationRelativeToCurrentLayer(const Staff *currentStaff, const Lay
     // Get previous and next elements from the current layer
     if (currentLayer->GetFirstChildNot(REST)) {
         GetRelativeLayerElementFunctor getRelativeLayerElementBackwards(this->GetIdx(), BACKWARD, false);
-        getRelativeLayerElementBackwards.SetDirection(BACKWARD);
+        getRelativeLayerElementBackwards.PushDirection(BACKWARD);
         currentLayer->Process(getRelativeLayerElementBackwards);
         previousElement = getRelativeLayerElementBackwards.GetRelativeElement();
 
@@ -471,7 +471,7 @@ int Rest::GetFirstRelativeElementLocation(
 
     // Get last element if it's previous layer, get first one otherwise
     GetRelativeLayerElementFunctor getRelativeLayerElement(this->GetIdx(), !isPrevious, true);
-    getRelativeLayerElement.SetDirection(!isPrevious);
+    getRelativeLayerElement.PushDirection(!isPrevious);
     (*layerIter)->Process(getRelativeLayerElement);
 
     const Object *lastLayerElement = getRelativeLayerElement.GetRelativeElement();

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -398,13 +398,13 @@ int Rest::GetLocationRelativeToCurrentLayer(const Staff *currentStaff, const Lay
     const Object *nextElement = NULL;
     // Get previous and next elements from the current layer
     if (currentLayer->GetFirstChildNot(REST)) {
-        GetRelativeLayerElementFunctor getRelativeLayerElementBackwards(this->GetIdx(), BACKWARD, false);
+        GetRelativeLayerElementFunctor getRelativeLayerElementBackwards(this->GetIdx(), false);
         getRelativeLayerElementBackwards.PushDirection(BACKWARD);
         currentLayer->Process(getRelativeLayerElementBackwards);
         previousElement = getRelativeLayerElementBackwards.GetRelativeElement();
 
         // search in other direction
-        GetRelativeLayerElementFunctor getRelativeLayerElementForwards(this->GetIdx(), FORWARD, false);
+        GetRelativeLayerElementFunctor getRelativeLayerElementForwards(this->GetIdx(), false);
         currentLayer->Process(getRelativeLayerElementForwards);
         nextElement = getRelativeLayerElementForwards.GetRelativeElement();
     }
@@ -470,7 +470,7 @@ int Rest::GetFirstRelativeElementLocation(
     if (((int)layers.size() != currentStaff->GetChildCount(LAYER)) || (layerIter == layers.end())) return VRV_UNSET;
 
     // Get last element if it's previous layer, get first one otherwise
-    GetRelativeLayerElementFunctor getRelativeLayerElement(this->GetIdx(), !isPrevious, true);
+    GetRelativeLayerElementFunctor getRelativeLayerElement(this->GetIdx(), true);
     getRelativeLayerElement.PushDirection(!isPrevious);
     (*layerIter)->Process(getRelativeLayerElement);
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -458,7 +458,7 @@ void System::ConvertToUnCastOffMensuralSystem()
 
     Filters filters;
     ConvertToUnCastOffMensuralFunctor convertToUnCastOffMensural;
-    convertToUnCastOffMensural.SetFilters(&filters);
+    convertToUnCastOffMensural.PushFilters(&filters);
 
     // Now we can process by layer and move their content to (measure) segments
     for (const auto &staves : layerTree.child) {


### PR DESCRIPTION
This PR introduces a stack for functor filters and direction. This simplifies a bit the client code for filtered redirection, i.e. we don't have to keep track of previous filters and directions.