### PR TITLE
Update MusicXML import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2807,28 +2807,20 @@ void MusicXmlInput::ReadMusicXmlNote(
 
         // accidental
         pugi::xml_node accidental = node.child("accidental");
+        if (!accidental) {
+            accidental = node.select_node("notations/accidental-mark").node();
+        }
         if (accidental) {
             Accid *accid = new Accid();
             accid->SetAccid(ConvertAccidentalToAccid(accidental.text().as_string()));
             accid->SetColor(accidental.attribute("color").as_string());
-            bool isAttribute = true;
-            if (HasAttributeWithValue(accidental, "cautionary", "yes")) {
-                accid->SetFunc(accidLog_FUNC_caution);
-                isAttribute = false;
-            }
-            if (HasAttributeWithValue(accidental, "editorial", "yes")) {
-                accid->SetFunc(accidLog_FUNC_edit);
-                isAttribute = false;
-            }
-            if (HasAttributeWithValue(accidental, "bracket", "yes")) {
-                accid->SetEnclose(ENCLOSURE_brack);
-                isAttribute = false;
-            }
-            if (HasAttributeWithValue(accidental, "parentheses", "yes")) {
-                accid->SetEnclose(ENCLOSURE_paren);
-                isAttribute = false;
-            }
-            accid->IsAttribute(isAttribute);
+            accid->SetGlyphName(accidental.attribute("smufl").as_string());
+            accid->SetPlace(accid->AttPlacementRelEvent::StrToStaffrel(accidental.attribute("placement").as_string()));
+            if (HasAttributeWithValue(accidental, "cautionary", "yes")) accid->SetFunc(accidLog_FUNC_caution);
+            if (HasAttributeWithValue(accidental, "editorial", "yes")) accid->SetFunc(accidLog_FUNC_edit);
+            if (HasAttributeWithValue(accidental, "bracket", "yes")) accid->SetEnclose(ENCLOSURE_brack);
+            if (HasAttributeWithValue(accidental, "parentheses", "yes")) accid->SetEnclose(ENCLOSURE_paren);
+            if (!strcmp(accidental.name(), "accidental-mark")) accid->SetOnstaff(BOOLEAN_false);
             note->AddChild(accid);
         }
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3169,7 +3169,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 const std::string technicalChildName = technicalChild.name();
 
                 // fingering is handled on the same level as breath marks, dynamics, etc. so we skip it here
-                if (technicalChildName == "fingering") continue;
+                if ((technicalChildName == "fingering") || (technicalChildName == "thumb-position")) continue;
                 if (technicalChildName == "string") continue; // handled with fret
 
                 if (technicalChildName == "fret") {
@@ -3222,12 +3222,9 @@ void MusicXmlInput::ReadMusicXmlNote(
                     pugi::xml_node articulation = technicalChild;
                     Artic *artic = new Artic();
                     artics.push_back(ConvertArticulations(articulation.name()));
-                    if (artics.back() == ARTICULATION_NONE) {
-                        delete artic;
-                        continue;
-                    }
-                    artic->SetArtic(artics);
+                    if (artics.back() != ARTICULATION_NONE) artic->SetArtic(artics);
                     artic->SetColor(articulation.attribute("color").as_string());
+                    artic->SetGlyphName(articulation.attribute("smufl").as_string());
                     artic->SetPlace(
                         artic->AttPlacementRelEvent::StrToStaffrel(articulation.attribute("placement").as_string()));
                     artic->SetType("technical");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2816,6 +2816,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             accid->SetColor(accidental.attribute("color").as_string());
             accid->SetGlyphName(accidental.attribute("smufl").as_string());
             accid->SetPlace(accid->AttPlacementRelEvent::StrToStaffrel(accidental.attribute("placement").as_string()));
+            if (accidental.attribute("id")) accid->SetID(accidental.attribute("id").as_string());
             if (HasAttributeWithValue(accidental, "cautionary", "yes")) accid->SetFunc(accidLog_FUNC_caution);
             if (HasAttributeWithValue(accidental, "editorial", "yes")) accid->SetFunc(accidLog_FUNC_edit);
             if (HasAttributeWithValue(accidental, "bracket", "yes")) accid->SetEnclose(ENCLOSURE_brack);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1887,7 +1887,7 @@ void MusicXmlInput::ReadMusicXmlBarLine(pugi::xml_node node, Measure *measure, c
             measure->SetLeft(BARRENDITION_rptstart);
         }
         else if (HasAttributeWithValue(node, "location", "middle")) {
-            LogWarning("MusicXML import: Unsupported barline location 'middle' in %s.", measure->GetN().c_str());
+            LogWarning("MusicXML import: Unsupported barline location 'middle' in %s", measure->GetN().c_str());
         }
         else {
             measure->SetRight(BARRENDITION_rptend);
@@ -2937,7 +2937,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 chord = vrv_cast<Chord *>(m_elementStackMap.at(layer).back());
             }
             if (!chord) {
-                LogError("MusicXML import: Chord starting point has not been found.");
+                LogError("MusicXML import: Chord starting point has not been found");
                 return;
             }
             // Mark a chord as cue=true if and only if all its child notes are cue.

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3255,7 +3255,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         breath->SetPlace(
             breath->AttPlacementRelStaff::StrToStaffrel(xmlBreath.node().attribute("placement").as_string()));
         breath->SetColor(xmlBreath.node().attribute("color").as_string());
-        breath->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 1.0);
+        breath->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 0.5);
     }
 
     // caesura
@@ -3267,7 +3267,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         caesura->SetPlace(
             caesura->AttPlacementRelStaff::StrToStaffrel(xmlCaesura.node().attribute("placement").as_string()));
         caesura->SetColor(xmlCaesura.node().attribute("color").as_string());
-        caesura->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 1.0);
+        caesura->SetTstamp((double)(m_durTotal) * (double)m_meterUnit / (double)(4 * m_ppq) + 0.5);
     }
 
     // dynamics

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -249,7 +249,7 @@ void View::DrawAccid(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     int x = accid->GetDrawingX();
     int y = accid->GetDrawingY();
 
-    if (accid->HasPlace() || (accid->GetFunc() == accidLog_FUNC_edit)) {
+    if (accid->HasPlace() || accid->HasOnstaff() || (accid->GetFunc() == accidLog_FUNC_edit)) {
         const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         const int staffTop = staff->GetDrawingY();
         const int staffBottom = staffTop - (staff->m_drawingLines - 1) * unit * 2;


### PR DESCRIPTION
This PR adds support for `accidental-mark` notations and `other-technical` elements with `smufl` attribute.

Includes small fix for `DrawAccid`.