### PR TITLE
Unify spelling and shrink size of SVG

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -49,11 +49,11 @@ public:
      * @name Setters
      */
     ///@{
-    void SetBackground(int colour, int style = AxSOLID) override;
+    void SetBackground(int color, int style = AxSOLID) override;
     void SetBackgroundImage(void *image, double opacity = 1.0) override{};
     void SetBackgroundMode(int mode) override;
-    void SetTextForeground(int colour) override;
-    void SetTextBackground(int colour) override;
+    void SetTextForeground(int color) override;
+    void SetTextBackground(int color) override;
     void SetLogicalOrigin(int x, int y) override;
     void SetUserScale(double xScale, double yScale);
     ///@}

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -50,7 +50,7 @@ static inline double RadToDeg(double deg)
  *  MusWxDC - a wrapper to wxDCs with wxWidgets;
  *  SvgDeviceContext - a non-gui file DC;
  *  MusCairoDC - a wrapper to a Cairo surface;
- * The class uses int-based colour encoding (instead of wxColour in wxDC).
+ * The class uses int-based color encoding (instead of wxColor in wxDC).
  * It uses FontInfo (instead of wxFont in wxDC).
  */
 
@@ -137,20 +137,20 @@ public:
      * Non-virtual methods cannot be overridden and manage the Pen, Brush and FontInfo stacks
      */
     ///@{
-    void SetBrush(int colour, int opacity);
+    void SetBrush(int color, int opacity);
     void SetPen(
-        int colour, int width, int style, int dashLength = 0, int gapLength = 0, int lineCap = 0, int lineJoin = 0);
+        int color, int width, int style, int dashLength = 0, int gapLength = 0, int lineCap = 0, int lineJoin = 0);
     void SetFont(FontInfo *font);
     void SetPushBack() { m_pushBack = true; }
     void ResetBrush();
     void ResetPen();
     void ResetFont();
     void ResetPushBack() { m_pushBack = false; }
-    virtual void SetBackground(int colour, int style = AxSOLID) = 0;
+    virtual void SetBackground(int color, int style = AxSOLID) = 0;
     virtual void SetBackgroundImage(void *image, double opacity = 1.0) = 0;
     virtual void SetBackgroundMode(int mode) = 0;
-    virtual void SetTextForeground(int colour) = 0;
-    virtual void SetTextBackground(int colour) = 0;
+    virtual void SetTextForeground(int color) = 0;
+    virtual void SetTextBackground(int color) = 0;
     virtual void SetLogicalOrigin(int x, int y) = 0;
     ///}
 
@@ -317,7 +317,7 @@ public:
     // Static methods //
     //----------------//
 
-    /** Colour conversion method **/
+    /** Color conversion method **/
     static int RGB2Int(char red, char green, char blue) { return (red << 16 | green << 8 | blue); }
 
 private:

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -71,11 +71,11 @@ enum {
 class Pen {
 public:
     Pen()
-        : m_penColour(0), m_penWidth(0), m_dashLength(0), m_gapLength(0), m_lineCap(0), m_lineJoin(0), m_penOpacity(0.0)
+        : m_penColor(0), m_penWidth(0), m_dashLength(0), m_gapLength(0), m_lineCap(0), m_lineJoin(0), m_penOpacity(0.0)
     {
     }
-    Pen(int colour, int width, float opacity, int dashLength, int gapLength, int lineCap, int lineJoin)
-        : m_penColour(colour)
+    Pen(int color, int width, float opacity, int dashLength, int gapLength, int lineCap, int lineJoin)
+        : m_penColor(color)
         , m_penWidth(width)
         , m_dashLength(dashLength)
         , m_gapLength(gapLength)
@@ -85,8 +85,8 @@ public:
     {
     }
 
-    int GetColour() const { return m_penColour; }
-    void SetColour(int colour) { m_penColour = colour; }
+    int GetColor() const { return m_penColor; }
+    void SetColor(int color) { m_penColor = color; }
     int GetWidth() const { return m_penWidth; }
     void SetWidth(int width) { m_penWidth = width; }
     int GetDashLength() const { return m_dashLength; }
@@ -101,22 +101,22 @@ public:
     void SetOpacity(float opacity) { m_penOpacity = opacity; }
 
 private:
-    int m_penColour, m_penWidth, m_dashLength, m_gapLength, m_lineCap, m_lineJoin;
+    int m_penColor, m_penWidth, m_dashLength, m_gapLength, m_lineCap, m_lineJoin;
     float m_penOpacity;
 };
 
 class Brush {
 public:
-    Brush() : m_brushColour(0), m_brushOpacity(0.0) {}
-    Brush(int colour, float opacity) : m_brushColour(colour), m_brushOpacity(opacity) {}
+    Brush() : m_brushColor(0), m_brushOpacity(0.0) {}
+    Brush(int color, float opacity) : m_brushColor(color), m_brushOpacity(opacity) {}
 
-    int GetColour() const { return m_brushColour; }
-    void SetColour(int colour) { m_brushColour = colour; }
+    int GetColor() const { return m_brushColor; }
+    void SetColor(int color) { m_brushColor = color; }
     float GetOpacity() const { return m_brushOpacity; }
     void SetOpacity(float opacity) { m_brushOpacity = opacity; }
 
 private:
-    int m_brushColour;
+    int m_brushColor;
     float m_brushOpacity;
 };
 

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -52,11 +52,11 @@ public:
      * @name Setters
      */
     ///@{
-    void SetBackground(int colour, int style = AxSOLID) override;
+    void SetBackground(int color, int style = AxSOLID) override;
     void SetBackgroundImage(void *image, double opacity = 1.0) override;
     void SetBackgroundMode(int mode) override;
-    void SetTextForeground(int colour) override;
-    void SetTextBackground(int colour) override;
+    void SetTextForeground(int color) override;
+    void SetTextBackground(int color) override;
     void SetLogicalOrigin(int x, int y) override;
     ///@}
 
@@ -286,7 +286,7 @@ private:
 
     void WriteLine(std::string);
 
-    std::string GetColour(int colour);
+    std::string GetColor(int color);
 
     pugi::xml_node AddChild(std::string name);
 

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -660,10 +660,10 @@ public:
 
 protected:
     /**
-     * The colour currently being used when drawing.
+     * The color currently being used when drawing.
      * It can change when drawing the m_currentElement, for example
      */
-    int m_currentColour;
+    int m_currentColor;
 
     /**
      * Control the handling of slurs

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -92,7 +92,7 @@ void BBoxDeviceContext::StartPage() {}
 
 void BBoxDeviceContext::EndPage() {}
 
-void BBoxDeviceContext::SetBackground(int colour, int style)
+void BBoxDeviceContext::SetBackground(int color, int style)
 {
     // nothing to do, we do not handle Background
 }
@@ -102,9 +102,9 @@ void BBoxDeviceContext::SetBackgroundMode(int mode)
     // nothing to do, we do not handle Background Mode
 }
 
-void BBoxDeviceContext::SetTextForeground(int colour) {}
+void BBoxDeviceContext::SetTextForeground(int color) {}
 
-void BBoxDeviceContext::SetTextBackground(int colour)
+void BBoxDeviceContext::SetTextBackground(int color)
 {
     // nothing to do, we do not handle Text Background Mode
 }

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -129,7 +129,7 @@ const Resources *DeviceContext::GetResources(bool showWarning) const
     return m_resources;
 }
 
-void DeviceContext::SetPen(int colour, int width, int style, int dashLength, int gapLength, int lineCap, int lineJoin)
+void DeviceContext::SetPen(int color, int width, int style, int dashLength, int gapLength, int lineCap, int lineJoin)
 {
     float opacityValue;
 
@@ -154,10 +154,10 @@ void DeviceContext::SetPen(int colour, int width, int style, int dashLength, int
         default: opacityValue = 1.0; // solid brush by default
     }
 
-    m_penStack.push(Pen(colour, width, opacityValue, dashLength, gapLength, lineCap, lineJoin));
+    m_penStack.push(Pen(color, width, opacityValue, dashLength, gapLength, lineCap, lineJoin));
 }
 
-void DeviceContext::SetBrush(int colour, int opacity)
+void DeviceContext::SetBrush(int color, int opacity)
 {
     float opacityValue;
 
@@ -167,7 +167,7 @@ void DeviceContext::SetBrush(int colour, int opacity)
         default: opacityValue = 1.0; // solid brush by default
     }
 
-    m_brushStack.push(Brush(colour, opacityValue));
+    m_brushStack.push(Brush(color, opacityValue));
 }
 
 void DeviceContext::SetFont(FontInfo *font)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -319,8 +319,8 @@ void SvgDeviceContext::StartGraphic(
 
     // m_currentNode.append_attribute("style") = StringFormat("stroke: #%s; stroke-opacity: %f; fill: #%s; fill-opacity:
     // %f;",
-    // this->GetColour(currentPen.GetColour()).c_str(), currentPen.GetOpacity(),
-    // this->GetColour(currentBrush.GetColour()).c_str(), currentBrush.GetOpacity()).c_str();
+    // this->GetColor(currentPen.GetColor()).c_str(), currentPen.GetOpacity(),
+    // this->GetColor(currentBrush.GetColor()).c_str(), currentBrush.GetOpacity()).c_str();
 }
 
 void SvgDeviceContext::StartCustomGraphic(std::string name, std::string gClass, std::string gId)
@@ -503,7 +503,7 @@ void SvgDeviceContext::EndPage()
     m_currentNode = m_svgNodeStack.back();
 }
 
-void SvgDeviceContext::SetBackground(int colour, int style)
+void SvgDeviceContext::SetBackground(int color, int style)
 {
     // nothing to do, we do not handle Background
 }
@@ -515,12 +515,12 @@ void SvgDeviceContext::SetBackgroundMode(int mode)
     // nothing to do, we do not handle Background Mode
 }
 
-void SvgDeviceContext::SetTextForeground(int colour)
+void SvgDeviceContext::SetTextForeground(int color)
 {
-    m_brushStack.top().SetColour(colour); // we use the brush colour for text
+    m_brushStack.top().SetColor(color); // we use the brush color for text
 }
 
-void SvgDeviceContext::SetTextBackground(int colour)
+void SvgDeviceContext::SetTextBackground(int color)
 {
     // nothing to do, we do not handle Text Background Mode
 }
@@ -587,7 +587,7 @@ void SvgDeviceContext::DrawQuadBezierPath(Point bezier[3])
         bezier[1].x, bezier[1].y, bezier[2].x, bezier[2].y)
                                           .c_str();
     pathChild.append_attribute("fill") = "none";
-    pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+    pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
     pathChild.append_attribute("stroke-linejoin") = "round";
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
@@ -603,7 +603,7 @@ void SvgDeviceContext::DrawCubicBezierPath(Point bezier[4])
         )
                                           .c_str();
     pathChild.append_attribute("fill") = "none";
-    pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+    pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
     pathChild.append_attribute("stroke-linejoin") = "round";
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
@@ -621,7 +621,7 @@ void SvgDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2
               .c_str();
     // pathChild.append_attribute("fill") = "currentColor";
     // pathChild.append_attribute("fill-opacity") = "1";
-    pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+    pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
     pathChild.append_attribute("stroke-linejoin") = "round";
     // pathChild.append_attribute("stroke-opacity") = "1";
@@ -653,7 +653,7 @@ void SvgDeviceContext::DrawEllipse(int x, int y, int width, int height)
     if (currentPen.GetOpacity() != 1.0) ellipseChild.append_attribute("stroke-opacity") = currentPen.GetOpacity();
     if (currentPen.GetWidth() > 0) {
         ellipseChild.append_attribute("stroke-width") = currentPen.GetWidth();
-        ellipseChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+        ellipseChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     }
 }
 
@@ -716,7 +716,7 @@ void SvgDeviceContext::DrawEllipticArc(int x, int y, int width, int height, doub
     if (currentPen.GetOpacity() != 1.0) pathChild.append_attribute("stroke-opacity") = currentPen.GetOpacity();
     if (currentPen.GetWidth() > 0) {
         pathChild.append_attribute("stroke-width") = currentPen.GetWidth();
-        pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+        pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     }
 }
 
@@ -724,7 +724,7 @@ void SvgDeviceContext::DrawLine(int x1, int y1, int x2, int y2)
 {
     pugi::xml_node pathChild = AddChild("path");
     pathChild.append_attribute("d") = StringFormat("M%d %d L%d %d", x1, y1, x2, y2).c_str();
-    pathChild.append_attribute("stroke") = this->GetColour(m_penStack.top().GetColour()).c_str();
+    pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     if (m_penStack.top().GetWidth() > 1) pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
     this->AppendStrokeLineCap(pathChild, m_penStack.top());
     this->AppendStrokeDashArray(pathChild, m_penStack.top());
@@ -738,7 +738,7 @@ void SvgDeviceContext::DrawPolyline(int n, Point points[], int xOffset, int yOff
     pugi::xml_node polylineChild = AddChild("polyline");
 
     if (currentPen.GetWidth() > 0) {
-        polylineChild.append_attribute("stroke") = this->GetColour(currentPen.GetColour()).c_str();
+        polylineChild.append_attribute("stroke") = this->GetColor(currentPen.GetColor()).c_str();
     }
     if (currentPen.GetWidth() > 1) {
         polylineChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
@@ -771,7 +771,7 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffs
     pugi::xml_node polygonChild = AddChild("polygon");
 
     if (currentPen.GetWidth() > 0) {
-        polygonChild.append_attribute("stroke") = this->GetColour(currentPen.GetColour()).c_str();
+        polygonChild.append_attribute("stroke") = this->GetColor(currentPen.GetColor()).c_str();
     }
     if (currentPen.GetWidth() > 1) {
         polygonChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
@@ -783,8 +783,8 @@ void SvgDeviceContext::DrawPolygon(int n, Point points[], int xOffset, int yOffs
     this->AppendStrokeLineJoin(polygonChild, currentPen);
     this->AppendStrokeDashArray(polygonChild, currentPen);
 
-    if (currentBrush.GetColour() != AxNONE)
-        polygonChild.append_attribute("fill") = this->GetColour(currentBrush.GetColour()).c_str();
+    if (currentBrush.GetColor() != AxNONE)
+        polygonChild.append_attribute("fill") = this->GetColor(currentBrush.GetColor()).c_str();
     if (currentBrush.GetOpacity() != 1.0)
         polygonChild.append_attribute("fill-opacity") = StringFormat("%f", currentBrush.GetOpacity()).c_str();
 
@@ -807,7 +807,7 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
     if (m_penStack.size()) {
         Pen currentPen = m_penStack.top();
         if (currentPen.GetWidth() > 0)
-            rectChild.append_attribute("stroke") = this->GetColour(currentPen.GetColour()).c_str();
+            rectChild.append_attribute("stroke") = this->GetColor(currentPen.GetColor()).c_str();
         if (currentPen.GetWidth() > 1)
             rectChild.append_attribute("stroke-width") = StringFormat("%d", currentPen.GetWidth()).c_str();
         if (currentPen.GetOpacity() != 1.0)
@@ -816,8 +816,8 @@ void SvgDeviceContext::DrawRoundedRectangle(int x, int y, int width, int height,
 
     if (m_brushStack.size()) {
         Brush currentBrush = m_brushStack.top();
-        if (currentBrush.GetColour() != AxNONE)
-            rectChild.append_attribute("fill") = this->GetColour(currentBrush.GetColour()).c_str();
+        if (currentBrush.GetColor() != AxNONE)
+            rectChild.append_attribute("fill") = this->GetColor(currentBrush.GetColor()).c_str();
         if (currentBrush.GetOpacity() != 1.0)
             rectChild.append_attribute("fill-opacity") = StringFormat("%f", currentBrush.GetOpacity()).c_str();
     }
@@ -1121,13 +1121,13 @@ void SvgDeviceContext::AppendAdditionalAttributes(Object *object)
     }
 }
 
-std::string SvgDeviceContext::GetColour(int colour)
+std::string SvgDeviceContext::GetColor(int color)
 {
     std::ostringstream ss;
     ss << "#";
     ss << std::hex;
 
-    switch (colour) {
+    switch (color) {
         case (AxNONE): return "currentColor";
         case (AxBLACK): return "#000000";
         case (AxWHITE): return "#FFFFFF";
@@ -1137,9 +1137,9 @@ std::string SvgDeviceContext::GetColour(int colour)
         case (AxCYAN): return "#00FFFF";
         case (AxLIGHT_GREY): return "#777777";
         default:
-            int blue = (colour & 255);
-            int green = (colour >> 8) & 255;
-            int red = (colour >> 16) & 255;
+            int blue = (color & 255);
+            int green = (color >> 8) & 255;
+            int red = (color >> 16) & 255;
             ss << red << green << blue;
             // std::strin = wxDecToHex(char(red)) + wxDecToHex(char(green)) + wxDecToHex(char(blue)) ;  // ax3
             return ss.str();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -751,7 +751,7 @@ void SvgDeviceContext::DrawPolyline(int n, Point points[], int xOffset, int yOff
     this->AppendStrokeLineJoin(polylineChild, currentPen);
     this->AppendStrokeDashArray(polylineChild, currentPen);
 
-    polylineChild.append_attribute("fill") = "none";
+    if (n > 2) polylineChild.append_attribute("fill") = "none";
 
     std::string pointsString;
     for (int i = 0; i < n; ++i) {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -31,7 +31,7 @@ View::View()
     m_pageIdx = 0;
     m_slurHandling = SlurHandling::Initialize;
 
-    m_currentColour = AxNONE;
+    m_currentColor = AxNONE;
     m_currentElement = NULL;
     m_currentLayer = NULL;
     m_currentMeasure = NULL;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -462,8 +462,8 @@ void View::DrawBracketSpan(
     x1 += lineWidth / 2;
     x2 -= lineWidth / 2;
 
-    dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
         if (!bracketSpan->GetStart()->Is(TIMESTAMP_ATTR)) {
@@ -494,11 +494,11 @@ void View::DrawBracketSpan(
     // We have a @lform - draw a full line
     if (bracketSpan->HasLform()) {
         if (bracketSpan->GetLform() == LINEFORM_dashed) {
-            dc->SetPen(m_currentColour, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE);
+            dc->SetPen(m_currentColor, lineWidth, AxLONG_DASH, 0, 0, AxCAP_SQUARE);
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
             // Adjust start and end
-            dc->SetPen(m_currentColour, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
+            dc->SetPen(m_currentColor, lineWidth, AxDOT, 0, 0, AxCAP_ROUND);
             x1 += unit + lineWidth * 2;
             x2 -= unit + lineWidth * 2;
             const int diff = (x2 - x1) % (lineWidth * 3 + 1);
@@ -627,7 +627,7 @@ void View::DrawHairpin(
 
     const int cap = (style == AxDOT) ? AxCAP_ROUND : AxCAP_SQUARE;
 
-    dc->SetPen(m_currentColour, hairpinThickness, style, 0, 0, cap, AxJOIN_MITER);
+    dc->SetPen(m_currentColor, hairpinThickness, style, 0, 0, cap, AxJOIN_MITER);
 
     if ((startY == 0) && !niente) {
         Point p[3];
@@ -645,7 +645,7 @@ void View::DrawHairpin(
     }
     else {
         if (niente) {
-            dc->SetBrush(m_currentColour, AxTRANSPARENT);
+            dc->SetBrush(m_currentColor, AxTRANSPARENT);
             if (startY == 0) {
                 dc->DrawCircle(ToDeviceContextX(x1), ToDeviceContextY(y), unit / 2);
                 startY = unit * endY / (x2 - x1) / 2;
@@ -753,12 +753,12 @@ void View::DrawOctave(
         x1 += lineWidth;
         if (altSymbols) x1 += extend.m_width / 2;
 
-        dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, gap, AxCAP_SQUARE);
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetPen(m_currentColor, lineWidth, AxSHORT_DASH, 0, gap, AxCAP_SQUARE);
+        dc->SetBrush(m_currentColor, AxSOLID);
         if (octave->HasLform()) {
             if (octave->GetLform() == LINEFORM_solid) {
-                dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE);
-                dc->SetBrush(m_currentColour, AxSOLID);
+                dc->SetPen(m_currentColor, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE);
+                dc->SetBrush(m_currentColor, AxSOLID);
             }
             else if (octave->GetLform() == LINEFORM_dotted) {
                 if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
@@ -766,8 +766,8 @@ void View::DrawOctave(
                     const int diff = (x2 - x1) % (gap + 1);
                     x2 += (gap - diff < diff) ? gap - diff : -diff;
                 }
-                dc->SetPen(m_currentColour, lineWidth * 3 / 2, AxDOT, 0, gap, AxCAP_ROUND);
-                dc->SetBrush(m_currentColour, AxSOLID);
+                dc->SetPen(m_currentColor, lineWidth * 3 / 2, AxDOT, 0, gap, AxCAP_ROUND);
+                dc->SetBrush(m_currentColor, AxSOLID);
             }
         }
 
@@ -790,12 +790,12 @@ void View::DrawOctave(
                 if (octave->GetLform() == LINEFORM_dotted) {
                     // make sure we have at least two dots for the dotted hook
                     dc->SetPen(
-                        m_currentColour, lineWidth * 3 / 2, AxDOT, 0, std::min(gap, unit * 2 - lineWidth), AxCAP_ROUND);
+                        m_currentColor, lineWidth * 3 / 2, AxDOT, 0, std::min(gap, unit * 2 - lineWidth), AxCAP_ROUND);
                     dc->DrawLine(
                         ToDeviceContextX(x2), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
                 }
                 else {
-                    dc->SetPen(m_currentColour, lineWidth, AxSOLID);
+                    dc->SetPen(m_currentColor, lineWidth, AxSOLID);
                     // Right hook
                     Point hookRight[3];
                     hookRight[0] = { ToDeviceContextX(x2), ToDeviceContextY(y2) };
@@ -898,8 +898,8 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
         dc->StartGraphic(pitchInflection, "spanning-pinflection", "");
     }
 
-    dc->SetPen(m_currentColour, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize), AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize), AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawQuadBezierPath(points);
     if (drawArrow) {
@@ -1629,7 +1629,7 @@ void View::DrawDirOrOrnam(DeviceContext *dc, ControlElement *element, Measure *m
             params.m_y -= m_doc->GetTextXHeight(&dirTxt, false) / 2;
         }
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&dirTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
@@ -1710,7 +1710,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             this->DrawDynamSymbolOnly(dc, staff, dynam, dynamSymbol, alignment, params);
         }
         else {
-            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetBrush(m_currentColor, AxSOLID);
             dc->SetFont(&dynamTxt);
 
             dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -1789,7 +1789,7 @@ void View::DrawFb(DeviceContext *dc, Staff *staff, Fb *fb, TextDrawingParams &pa
 
     fontDim->SetPointSize(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize)->GetPointSize());
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(fontDim);
 
     for (Object *current : fb->GetChildren()) {
@@ -1942,7 +1942,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
 
         fingTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&fingTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2070,21 +2070,21 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
             break;
         }
         case LINEFORM_dashed:
-            dc->SetPen(m_currentColour, lineWidth, AxSHORT_DASH, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
-            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetPen(m_currentColor, lineWidth, AxSHORT_DASH, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColor, AxSOLID);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_dotted:
-            dc->SetPen(m_currentColour, lineWidth * 3 / 2, AxDOT, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
-            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetPen(m_currentColor, lineWidth * 3 / 2, AxDOT, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColor, AxSOLID);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_solid: [[fallthrough]];
         default: {
-            dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
-            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetPen(m_currentColor, lineWidth, AxSOLID, 0, 0, AxCAP_ROUND, AxJOIN_ARCS);
+            dc->SetBrush(m_currentColor, AxSOLID);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
@@ -2146,7 +2146,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
 
             harmTxt.SetPointSize(params.m_pointSize);
 
-            dc->SetBrush(m_currentColour, AxSOLID);
+            dc->SetBrush(m_currentColor, AxSOLID);
             dc->SetFont(&harmTxt);
 
             dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2442,7 +2442,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
 
         rehTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&rehTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2504,7 +2504,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
             params.m_y -= m_doc->GetTextXHeight(&tempoTxt, false) / 2;
         }
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&tempoTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2911,7 +2911,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
             endX -= std::max(lineWidth + unit / 2 - rightBarLineWidth, 0);
         }
 
-        dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_MITER);
+        dc->SetPen(m_currentColor, lineWidth, AxSOLID, 0, 0, AxCAP_SQUARE, AxJOIN_MITER);
         Point p[4];
         p[0] = { ToDeviceContextX(startX), ToDeviceContextY(y1) };
         p[1] = { ToDeviceContextX(startX), ToDeviceContextY(y2) };

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -73,13 +73,13 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
         return;
     }
 
-    int previousColor = m_currentColour;
+    int previousColor = m_currentColor;
 
     if (element == m_currentElement) {
-        m_currentColour = AxRED;
+        m_currentColor = AxRED;
     }
     else {
-        m_currentColour = AxNONE;
+        m_currentColor = AxNONE;
     }
 
     if (element->Is(ACCID)) {
@@ -214,7 +214,7 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
         LogError("Element '%s' cannot be drawn", element->GetClassName().c_str());
     }
 
-    m_currentColour = previousColor;
+    m_currentColor = previousColor;
 }
 
 //----------------------------------------------------------------------------
@@ -1703,7 +1703,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     dc->StartGraphic(syl, "", syl->GetID());
     dc->DeactivateGraphicY();
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     FontInfo currentFont = *m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize);
     if (syl->HasFontweight()) {
@@ -1815,7 +1815,7 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         params.m_y = staff->GetDrawingY() + this->GetSylYRel(std::max(1, verse->GetN()), staff);
         params.m_pointSize = labelTxt.GetPointSize();
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&labelTxt);
 
         dc->StartGraphic(graphic, "", graphic->GetID());

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -28,8 +28,8 @@ void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width
 {
     assert(dc);
 
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x1), ToDeviceContextY(y2));
 
@@ -42,8 +42,8 @@ void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int wid
 {
     assert(dc);
 
-    dc->SetPen(m_currentColour, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, std::max(1, ToDeviceContextX(width)), AxSOLID, dashLength, gapLength);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
 
@@ -78,8 +78,8 @@ void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y
 
     std::swap(y1, y2);
 
-    dc->SetPen(m_currentColour, lineThickness, AxSOLID);
-    dc->SetBrush(m_currentColour, AxTRANSPARENT);
+    dc->SetPen(m_currentColor, lineThickness, AxSOLID);
+    dc->SetBrush(m_currentColor, AxTRANSPARENT);
 
     int width = x2 - x1;
     int height = y1 - y2;
@@ -100,7 +100,7 @@ void View::DrawPartFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, in
 
     std::swap(y1, y2);
 
-    // dc->SetPen(m_currentColour, 0, AxSOLID );
+    // dc->SetPen(m_currentColor, 0, AxSOLID );
     // dc->SetBrush(AxWHITE, AxTRANSPARENT);
     dc->SetPen(AxBLUE, 0, AxSOLID);
     dc->SetBrush(AxRED, AxTRANSPARENT);
@@ -120,8 +120,8 @@ void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int
     std::swap(y1, y2);
 
     const int penWidth = lineThickness;
-    dc->SetPen(m_currentColour, penWidth, AxSOLID);
-    dc->SetBrush(m_currentColour, AxTRANSPARENT);
+    dc->SetPen(m_currentColor, penWidth, AxSOLID);
+    dc->SetBrush(m_currentColor, AxTRANSPARENT);
 
     dc->DrawRoundedRectangle(
         ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
@@ -148,8 +148,8 @@ void View::DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2,
 
     std::swap(y1, y2);
 
-    dc->SetPen(m_currentColour, 0, AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, 0, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawRoundedRectangle(
         ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
@@ -166,8 +166,8 @@ void View::DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2,
 {
     Point p[4];
 
-    dc->SetPen(m_currentColour, 0, AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, 0, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     height = ToDeviceContextX(height);
     p[0].x = ToDeviceContextX(x1);
@@ -191,12 +191,12 @@ void View::DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width,
 {
     Point p[4];
 
-    dc->SetPen(m_currentColour, linewidth, AxSOLID);
+    dc->SetPen(m_currentColor, linewidth, AxSOLID);
     if (fill) {
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
     }
     else {
-        dc->SetBrush(m_currentColour, AxTRANSPARENT);
+        dc->SetBrush(m_currentColor, AxTRANSPARENT);
     }
 
     int dHeight = ToDeviceContextX(height);
@@ -221,8 +221,8 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
     int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
     if (dimin) r *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
-    dc->SetPen(m_currentColour, 0, AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, 0, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(y), r);
 
@@ -238,8 +238,8 @@ void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line,
     const int radius = std::max(barlineWidth, 2);
     int drawingPosition = top - interval / 2;
 
-    dc->SetPen(m_currentColour, 0, AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, 0, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     while (drawingPosition > bottom) {
         dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(drawingPosition), radius);
@@ -285,7 +285,7 @@ void View::DrawSmuflCode(DeviceContext *dc, int x, int y, char32_t code, int sta
     std::u32string str;
     str.push_back(code);
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     dc->DrawMusicText(str, ToDeviceContextX(x), ToDeviceContextY(y), setBBGlyph);
@@ -312,7 +312,7 @@ void View::DrawSmuflLine(
     // We add half a fill length for an average shorter / longer line result
     const int count = (length + fillWidth / 2 - startWidth - endWidth) / fillWidth;
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     std::u32string str;
@@ -342,7 +342,7 @@ void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::u32string s, da
 
     int xDC = ToDeviceContextX(x);
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     if (alignment == HORIZONTALALIGNMENT_center) {
@@ -384,12 +384,12 @@ void View::DrawThickBezierCurve(
     // Actually draw it
     if (penStyle == AxSOLID) {
         // Solid Thick Bezier Curves are made of two beziers, filled in.
-        dc->SetPen(m_currentColour, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
+        dc->SetPen(m_currentColor, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
         dc->DrawCubicBezierPathFilled(bez1, bez2);
     }
     else {
         // Dashed or Dotted Thick Bezier Curves have a uniform line width.
-        dc->SetPen(m_currentColour, thickness, penStyle);
+        dc->SetPen(m_currentColor, thickness, penStyle);
         dc->DrawCubicBezierPath(bez1);
     }
     dc->ResetPen();

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -568,7 +568,7 @@ void View::DrawLabels(
     params.m_y = y;
     params.m_pointSize = labelTxt.GetPointSize();
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(&labelTxt);
 
     dc->StartGraphic(graphic, "", graphic->GetID());
@@ -692,8 +692,8 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     bez2[2] = points[2];
     bez2[3] = points[3];
 
-    dc->SetPen(m_currentColour, std::max(1, penWidth), AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, std::max(1, penWidth), AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     dc->DrawCubicBezierPathFilled(bez1, bez2);
 
@@ -1202,7 +1202,7 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *sys
             mnumTxt.SetPointSize(m_doc->GetDrawingLyricFont(80)->GetPointSize());
         }
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&mnumTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -1296,8 +1296,8 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
     }
 
     const int lineWidth = m_doc->GetDrawingStaffLineWidth(staff->m_drawingStaffSize);
-    dc->SetPen(m_currentColour, ToDeviceContextX(lineWidth), AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     for (j = 0; j < staff->m_drawingLines; ++j) {
         // Skewed lines - with Facs (neumes) only for now
@@ -1364,8 +1364,8 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
         = m_doc->GetOptions()->m_ledgerLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     if (cueSize) lineWidth *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
-    dc->SetPen(m_currentColour, ToDeviceContextX(lineWidth), AxSOLID);
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
 
     for (const LedgerLine &line : lines) {
         for (const std::pair<int, int> &dash : line.m_dashes) {

--- a/src/view_running.cpp
+++ b/src/view_running.cpp
@@ -71,7 +71,7 @@ void View::DrawPgHeader(DeviceContext *dc, RunningElement *pgHeader)
 
     pgHeadTxt.SetPointSize(params.m_pointSize);
 
-    dc->SetBrush(m_currentColour, AxSOLID);
+    dc->SetBrush(m_currentColor, AxSOLID);
     dc->SetFont(&pgHeadTxt);
 
     this->DrawRunningChildren(dc, pgHeader, params);

--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -121,7 +121,7 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
         params.m_pointSize = m_doc->GetDrawingLyricFont(glyphSize)->GetPointSize() * 4 / 5;
         fretTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColour, AxSOLID);
+        dc->SetBrush(m_currentColor, AxSOLID);
         dc->SetFont(&fretTxt);
 
         params.m_y -= (m_doc->GetTextGlyphHeight(L'0', &fretTxt, drawingCueSize) / 2);

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -107,7 +107,7 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     const int yRight = tupletBracket->GetDrawingYRight();
     int bracketHeight = (tuplet->GetDrawingBracketPos() == STAFFREL_basic_above) ? -1 : 1;
 
-    dc->SetPen(m_currentColour, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
+    dc->SetPen(m_currentColor, lineWidth, AxSOLID, 0, 0, AxCAP_BUTT, AxJOIN_MITER);
 
     // Draw a bracket with a gap
     if (tupletBracket->GetAlignedNum() && tupletBracket->GetAlignedNum()->HasSelfBB()) {


### PR DESCRIPTION
This PR unifies the spelling of color in the code and makes the SVG a bit smaller by dropping trailing zeros.