### PR TITLE
fix JSON "\uXXXX" parsing

### DIFF
--- a/src/json/jsonxx.cc
+++ b/src/json/jsonxx.cc
@@ -116,28 +116,51 @@ bool parse_string(std::istream& input, String& value) {
                     break;
                 case 'u': {
                         int i;
-                        std::stringstream ss;
-                        for( i = 0; (!input.eof() && input.good()) && i < 4; ++i ) {
-                            input.get(ch);
-                            ss << std::hex << ch;
-                        }
-                        if (input.good() && (ss >> i)) {
-                            // Encode codepoint via utf-8.
-                            if (i < 0x80) {
-                                value.push_back(static_cast<char>(i));
-                            } else if (i < 0x800) {
-                                value.push_back(static_cast<char>((i >> 6) | 0xc0));
-                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
-                            } else if (i < 0x10000) {
-                                value.push_back(static_cast<char>((i >> 12) | 0xe0));
-                                value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
-                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
-                            } else {
-                                value.push_back(static_cast<char>((i >> 18) | 0xf0));
-                                value.push_back(static_cast<char>(((i >> 12) & 0x3f) | 0x80));
-                                value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
-                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                        {
+                            std::stringstream ss;
+                            for (i = 0; (!input.eof() && input.good()) && i < 4; ++i) {
+                                input.get(ch);
+                                ss << std::hex << ch;
                             }
+                            if (!input.good() || !(ss >> i)) {
+                                break;
+                            }
+                        }
+
+                        // Decode UTF-16 surrogate pair.
+                        if (0xd800 <= i && i <= 0xdbff) {
+                            if (!match("\\u", input)) {
+                                break;
+                            }
+                            int j;
+                            std::stringstream ss;
+                            for (j = 0; (!input.eof() && input.good()) && j < 4; ++j) {
+                                input.get(ch);
+                                ss << std::hex << ch;
+                            }
+                            if (!input.good() || !(ss >> j)) {
+                                break;
+                            }
+                            i = static_cast<int>(
+                                (static_cast<unsigned int>(i) << 10) +
+                                static_cast<unsigned int>(j) - 0x35fdc00u);
+                        }
+
+                        // Encode codepoint via UTF-8.
+                        if (i < 0x80) {
+                            value.push_back(static_cast<char>(i));
+                        } else if (i < 0x800) {
+                            value.push_back(static_cast<char>((i >> 6) | 0xc0));
+                            value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                        } else if (i < 0x10000) {
+                            value.push_back(static_cast<char>((i >> 12) | 0xe0));
+                            value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
+                            value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                        } else {
+                            value.push_back(static_cast<char>((i >> 18) | 0xf0));
+                            value.push_back(static_cast<char>(((i >> 12) & 0x3f) | 0x80));
+                            value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
+                            value.push_back(static_cast<char>((i & 0x3f) | 0x80));
                         }
                     }
                     break;

--- a/src/json/jsonxx.cc
+++ b/src/json/jsonxx.cc
@@ -121,8 +121,24 @@ bool parse_string(std::istream& input, String& value) {
                             input.get(ch);
                             ss << std::hex << ch;
                         }
-                        if( input.good() && (ss >> i) )
-                            value.push_back(static_cast<char>(i));
+                        if (input.good() && (ss >> i)) {
+                            // Encode codepoint via utf-8.
+                            if (i < 0x80) {
+                                value.push_back(static_cast<char>(i));
+                            } else if (i < 0x800) {
+                                value.push_back(static_cast<char>((i >> 6) | 0xc0));
+                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                            } else if (i < 0x10000) {
+                                value.push_back(static_cast<char>((i >> 12) | 0xe0));
+                                value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
+                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                            } else {
+                                value.push_back(static_cast<char>((i >> 18) | 0xf0));
+                                value.push_back(static_cast<char>(((i >> 12) & 0x3f) | 0x80));
+                                value.push_back(static_cast<char>(((i >> 6) & 0x3f) | 0x80));
+                                value.push_back(static_cast<char>((i & 0x3f) | 0x80));
+                            }
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
The included [JSON++ library](https://github.com/hjiang/jsonxx) is archived, so I am submitting the patch here.  Is there somewhere else I should instead target?

This applies utf-8 encoding to unicode hex codepoint escape sequences, avoiding invalid symbols/crashes for non-ASCII codepoints.

I do not think this issue directly impacts normal Verovio usage.  We discovered the issue while utilizing the embedded JSON library in some of our own code.