### PR TITLE
iohumdrum.cpp rejects valid single-character turns (e.g. "4aS").

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -25525,7 +25525,7 @@ void HumdrumInput::addTurn(hum::HTp token, const string &tok, int noteIndex)
         }
     }
 
-    if (turnstart == turnend) {
+    if (turnstart == -1) {
         return;
     }
     std::string turnstr = tok.substr(turnstart, turnend - turnstart + 1);


### PR DESCRIPTION
Beethoven piano sonata01-2.krn has two of these.