### PR TITLE
Chords encoded with note@loc

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -190,7 +190,7 @@ public:
     /**
      * Returns a single integer representing pitch and octave.
      */
-    int GetDiatonicPitch() const { return this->GetPname() + (int)this->GetOct() * 7; }
+    int GetDiatonicPitch() const;
 
     /**
      * Get the stem up / stem down attachment point.

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -496,8 +496,10 @@ Clef *Layer::GetCurrentClef()
 const Clef *Layer::GetCurrentClef() const
 {
     const Staff *staff = vrv_cast<const Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff && staff->m_drawingStaffDef && staff->m_drawingStaffDef->GetCurrentClef());
-    return staff->m_drawingStaffDef->GetCurrentClef();
+    if (staff && staff->m_drawingStaffDef) {
+        return staff->m_drawingStaffDef->GetCurrentClef();
+    }
+    return NULL;
 }
 
 KeySig *Layer::GetCurrentKeySig()

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -352,6 +352,18 @@ void Note::SetNoteGroup(ChordNoteGroup *noteGroup, int position)
     m_noteGroupPosition = position;
 }
 
+int Note::GetDiatonicPitch() const
+{
+    if (this->HasOct()) {
+        const int pitch = this->HasPname() ? (this->GetPname() - 1) : 0;
+        return this->GetOct() * 7 + pitch;
+    }
+    else if (this->HasLoc()) {
+        return this->GetLoc();
+    }
+    return 0;
+}
+
 Point Note::GetStemUpSE(const Doc *doc, int staffSize, bool isCueSize) const
 {
     int defaultYShift = doc->GetDrawingUnit(staffSize) / 4;

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -359,7 +359,20 @@ int Note::GetDiatonicPitch() const
         return this->GetOct() * 7 + pitch;
     }
     else if (this->HasLoc()) {
-        return this->GetLoc();
+        // WARNING: Getting the correct clef loc offset does not work at an early stage of the processing.
+        // It requires that m_drawingStaffDef is set on staff and that m_crossStaff + m_crossLayer are calculated.
+        // However, in many cases we are only interested in a relative pitch value. Then this is still fine.
+        const Layer *layer = vrv_cast<const Layer *>(this->GetFirstAncestor(LAYER));
+        const LayerElement *layerElementY = this;
+        if (m_crossStaff && m_crossLayer) {
+            layerElementY = m_crossLayer->GetAtPos(this->GetDrawingX());
+            layer = m_crossLayer;
+        }
+        assert(layer);
+
+        const int clefLocOffset = layer->GetClefLocOffset(layerElementY);
+
+        return this->GetLoc() + OCTAVE_OFFSET * 7 - clefLocOffset;
     }
     return 0;
 }


### PR DESCRIPTION
This PR considers `note@loc` in the calculation of diatonic pitch. This fixes an issue with chords.

| Before | After |
| ------ | ----- |
| <img width="1252" alt="Before" src="https://github.com/rism-digital/verovio/assets/63608463/22b1442b-124d-4294-a620-e34f616162db"> | <img width="1282" alt="After" src="https://github.com/rism-digital/verovio/assets/63608463/15e11a86-0b70-478a-bb9f-f8624aa875d6"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
            <date isodate="2023-05-24">2023-05-24</date>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5">
                        <clef shape="C" line="1" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="c" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="d" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="e" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="f" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="g" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="a" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="4" pname="b" />
                           </chord>
                           <chord dur="4">
                              <note oct="4" pname="c" />
                              <note oct="5" pname="c" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
                  <measure>
                     <staff n="1">
                        <layer n="1">
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="0" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="1" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="2" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="3" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="4" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="5" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="6" />
                           </chord>
                           <chord dur="4">
                              <note loc="0" />
                              <note loc="7" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
