### PR TITLE
Fix transposition with beam span

### DIFF
--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -89,6 +89,7 @@ public:
      */
     ///@{
     const ArrayOfObjects &GetBeamedElements() const { return m_beamedElements; }
+    void ResetBeamedElements() { m_beamedElements.clear(); }
     void SetBeamedElements(const ArrayOfObjects &beamedElements) { m_beamedElements = beamedElements; }
     ///@}
 

--- a/include/vrv/resetfunctor.h
+++ b/include/vrv/resetfunctor.h
@@ -42,6 +42,7 @@ public:
     FunctorCode VisitArpeg(Arpeg *arpeg) override;
     FunctorCode VisitArtic(Artic *artic) override;
     FunctorCode VisitBeam(Beam *beam) override;
+    FunctorCode VisitBeamSpan(BeamSpan *beamSpan) override;
     FunctorCode VisitChord(Chord *chord) override;
     FunctorCode VisitControlElement(ControlElement *controlElement) override;
     FunctorCode VisitCustos(Custos *custos) override;

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -138,6 +138,8 @@ int Hairpin::CalcHeight(const Doc *doc, int staffSize, char spanningType, const 
 void Hairpin::SetLeftLink(ControlElement *leftLink)
 {
     m_leftLink = leftLink;
+    if (!leftLink) return;
+
     if (this->GetDrawingGrpId() != 0) {
         // LogDebug("Grp id LF already set %d", this->GetDrawingGrpId());
         return;
@@ -153,6 +155,8 @@ void Hairpin::SetLeftLink(ControlElement *leftLink)
 void Hairpin::SetRightLink(ControlElement *rightLink)
 {
     m_rightLink = rightLink;
+    if (!rightLink) return;
+
     int grpId = this->GetDrawingGrpId();
     if (grpId == 0) {
         grpId = this->SetDrawingGrpObject(this);

--- a/src/resetfunctor.cpp
+++ b/src/resetfunctor.cpp
@@ -91,6 +91,20 @@ FunctorCode ResetDataFunctor::VisitBeam(Beam *beam)
     return FUNCTOR_CONTINUE;
 }
 
+FunctorCode ResetDataFunctor::VisitBeamSpan(BeamSpan *beamSpan)
+{
+    // Call parent one too
+    this->VisitControlElement(beamSpan);
+    beamSpan->BeamDrawingInterface::Reset();
+    beamSpan->PlistInterface::InterfaceResetData(*this, beamSpan);
+
+    beamSpan->ResetBeamedElements();
+    beamSpan->ClearBeamSegments();
+    beamSpan->InitBeamSegments();
+
+    return FUNCTOR_CONTINUE;
+}
+
 FunctorCode ResetDataFunctor::VisitChord(Chord *chord)
 {
     // Call parent one too


### PR DESCRIPTION
This PR fixes the issue when transposing with beam span. Closes #3431 .

Running the examples from the issue with `--transpose +2`:

| Before | After |
| ------ | ----- |
| <img width="720" alt="Before1" src="https://github.com/rism-digital/verovio/assets/63608463/159094bd-044b-4f5e-82f1-a1a4f0804f1b"> | <img width="708" alt="After1" src="https://github.com/rism-digital/verovio/assets/63608463/5a4f9ae9-2298-4324-a856-37aaf515135a"> |
| _Crashing (failed assertion)_ | <img width="256" alt="After2" src="https://github.com/rism-digital/verovio/assets/63608463/b5b4496d-8b8f-4e96-95fc-87e91a66530c"> |

The underlying problem was that `ResetData` was not implemented for beam span.
