### PR TITLE
Humdrum: Improve element visibility for suppressed tokens

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -20228,6 +20228,11 @@ Beam *HumdrumInput::insertBeam(
     std::vector<std::string> &elements, std::vector<void *> &pointers, const humaux::HumdrumBeamAndTuplet &tg)
 {
     Beam *beam = new Beam();
+    if (tg.token->find("yy") != std::string::npos) {
+        // Ignore beam when token is suppressed with yy signifier
+        beam->SetType("invisible");
+        beam->SetColor("transparent");
+    }
     appendElement(elements, pointers, beam);
     elements.push_back("beam");
     pointers.push_back((void *)beam);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -20248,6 +20248,11 @@ Beam *HumdrumInput::insertGBeam(
     std::vector<std::string> &elements, std::vector<void *> &pointers, const humaux::HumdrumBeamAndTuplet &tg)
 {
     Beam *gbeam = new Beam();
+    if (tg.token->find("yy") != std::string::npos) {
+        // Ignore beam when token is suppressed with yy signifier
+        gbeam->SetType("invisible");
+        gbeam->SetColor("transparent");
+    }
     appendElement(elements, pointers, gbeam);
     elements.push_back("gbeam");
     pointers.push_back((void *)gbeam);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -20249,7 +20249,7 @@ Beam *HumdrumInput::insertGBeam(
 {
     Beam *gbeam = new Beam();
     if (tg.token->find("yy") != std::string::npos) {
-        // Ignore beam when token is suppressed with yy signifier
+        // Ignore grace note beam when token is suppressed with yy signifier
         gbeam->SetType("invisible");
         gbeam->SetColor("transparent");
     }

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -20241,7 +20241,7 @@ Beam *HumdrumInput::insertBeam(
 
 //////////////////////////////
 //
-// HumdrumInput::insertGBeam --
+// HumdrumInput::insertGBeam -- insert beam for grace notes
 //
 
 Beam *HumdrumInput::insertGBeam(

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -26249,6 +26249,10 @@ void HumdrumInput::addTrill(Object *linked, hum::HTp token)
 
 void HumdrumInput::processTieStart(Note *note, hum::HTp token, const std::string &tstring, int subindex)
 {
+    // Ignore tie when token is suppressed with yy signifier
+    if (token->find("yy") != std::string::npos) {
+        return;
+    }
     if (token->isMensLike()) {
         return;
     }


### PR DESCRIPTION
Demo data:

```tsv
**kern	**kern
=7	=7
*^	*^
2B;yyy	2GG;yy	2g;yy	2d;yyy
=:|!	=:|!	=:|!	=:|!
*	*	*	*
4dyy	4GGyy	4byy	[4gyy
=8	=8	=8	=8
4dyy	4GGyy	4byy	8gL]yy
.	.	.	8f#Jyy
4cyy	4AAyy	4ccyy	8eLyy
.	.	.	8f#Jyy
8BLyy	4BByy	4ddyy	[4gyy
8AJyy	.	.	.
=9	=9	=9	=9
8BLyy	4.BByy	4.ddyy	8gL]yy
8cJyy	.	.	8aJyy
4dyy	.	.	8gLyy
.	8AAyy	8ccyy	8f#Jyy
4dyy	4GGyy	4byy	4gyy
=10	=10	=10	=10
2d;yyy	2D;yy	2a;yy	2f#;yyy
4Byy	[4Eyy	4gyy	4eyy
=	=	=	=
*v	*v	*	*
*	*v	*v
*-	*-
```


Before:

<img width="576" alt="Bildschirmfoto 2023-05-30 um 21 59 48" src="https://github.com/rism-digital/verovio/assets/865594/4da9786d-7728-4e3f-9aff-8973329327c3">

After:

<img width="576" alt="Bildschirmfoto 2023-05-30 um 22 01 27" src="https://github.com/rism-digital/verovio/assets/865594/43c779e5-a069-4bc7-9369-9b3594dbe376">

## Questions:

* @craigsapp Should I implement this for `HumdrumInput::insertGBeam` as well?
* I'm not sure if this could also be relevant for `HumdrumInput::insertBeamSpan`
* `beam->SetType("invisible");` does not seem to have any effect for the element visibility and there is no `beam::SetVisible` member for beams. I fixed this for now with `beam->SetColor("transparent")` but I'm sure there must be a better solution. Any suggestions?