### PR TITLE
Angled tuplet brackets

### DIFF
--- a/include/vrv/adjusttupletsyfunctor.h
+++ b/include/vrv/adjusttupletsyfunctor.h
@@ -57,6 +57,9 @@ private:
      */
     void AdjustTupletBracketBeamY(Tuplet *tuplet, TupletBracket *bracket, const Beam *beam, const Staff *staff) const;
 
+    // Calculate the vertical bracket adjustment based on a list of point obstacles
+    int CalcBracketShift(Point referencePos, double slope, int sign, const std::list<Point> &obstacles) const;
+
 public:
     //
 private:

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -742,6 +742,7 @@ public:
     OptionDbl m_tieEndpointThickness;
     OptionDbl m_tieMidpointThickness;
     OptionDbl m_tieMinLength;
+    OptionBool m_tupletAngledOnBeams;
     OptionDbl m_tupletBracketThickness;
     OptionBool m_tupletNumHead;
 

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -18,6 +18,9 @@ namespace vrv {
 class Note;
 class TupletBracket;
 
+// Helper enum classes
+enum class MelodicDirection { None, Up, Down };
+
 //----------------------------------------------------------------------------
 // Tuplet
 //----------------------------------------------------------------------------
@@ -88,6 +91,11 @@ public:
     void AddInnerSlur(const FloatingCurvePositioner *slur) { m_innerSlurs.insert(slur); }
     void ResetInnerSlurs() { m_innerSlurs.clear(); }
     ///@}
+
+    /**
+     * Determine the melodic direction
+     */
+    MelodicDirection GetMelodicDirection() const;
 
     /**
      * Calculate the position of the bracket and the num looking at the stem direction or at the encoded values (if

--- a/src/adjusttupletsyfunctor.cpp
+++ b/src/adjusttupletsyfunctor.cpp
@@ -96,8 +96,13 @@ void AdjustTupletsYFunctor::AdjustTupletBracketY(Tuplet *tuplet, const Staff *st
 
     // Now try different angles and possibly find a better position
     const int bracketWidth = tupletBracket->GetDrawingXRight() - tupletBracket->GetDrawingXLeft();
+    const MelodicDirection direction = tuplet->GetMelodicDirection();
     for (int tilt : { -4, -2, 2, 4 }) {
         if (bracketWidth == 0) continue;
+        // Drop if angle does not fit to the melodic direction
+        if ((direction == MelodicDirection::Up) && (tilt < 0)) continue;
+        if ((direction == MelodicDirection::Down) && (tilt > 0)) continue;
+        // Calculate the shift for the angle
         const double slope = tilt * unit / double(bracketWidth);
         const int shift = this->CalcBracketShift(referencePos, slope, sign, obstacles);
         // Drop angled brackets that would go into the staff

--- a/src/adjusttupletsyfunctor.cpp
+++ b/src/adjusttupletsyfunctor.cpp
@@ -94,25 +94,27 @@ void AdjustTupletsYFunctor::AdjustTupletBracketY(Tuplet *tuplet, const Staff *st
     int optimalTilt = 0;
     int optimalShift = horizontalBracketShift;
 
-    // Now try different angles and possibly find a better position
-    const int bracketWidth = tupletBracket->GetDrawingXRight() - tupletBracket->GetDrawingXLeft();
-    const MelodicDirection direction = tuplet->GetMelodicDirection();
-    for (int tilt : { -4, -2, 2, 4 }) {
-        if (bracketWidth == 0) continue;
-        // Drop if angle does not fit to the melodic direction
-        if ((direction == MelodicDirection::Up) && (tilt < 0)) continue;
-        if ((direction == MelodicDirection::Down) && (tilt > 0)) continue;
-        // Calculate the shift for the angle
-        const double slope = tilt * unit / double(bracketWidth);
-        const int shift = this->CalcBracketShift(referencePos, slope, sign, obstacles);
-        // Drop angled brackets that would go into the staff
-        if (shift < abs(tilt) * unit / 2) continue;
-        // Drop angled brackets where the midpoint is moved only slightly closer to the staff
-        if (shift > horizontalBracketShift - abs(tilt) * unit / 4) continue;
-        // Update the optimal tilt
-        if (shift < optimalShift) {
-            optimalShift = shift;
-            optimalTilt = tilt;
+    if (!m_doc->GetOptions()->m_tupletAngledOnBeams.GetValue()) {
+        // Now try different angles and possibly find a better position
+        const int bracketWidth = tupletBracket->GetDrawingXRight() - tupletBracket->GetDrawingXLeft();
+        const MelodicDirection direction = tuplet->GetMelodicDirection();
+        for (int tilt : { -4, -2, 2, 4 }) {
+            if (bracketWidth == 0) continue;
+            // Drop if angle does not fit to the melodic direction
+            if ((direction == MelodicDirection::Up) && (tilt < 0)) continue;
+            if ((direction == MelodicDirection::Down) && (tilt > 0)) continue;
+            // Calculate the shift for the angle
+            const double slope = tilt * unit / double(bracketWidth);
+            const int shift = this->CalcBracketShift(referencePos, slope, sign, obstacles);
+            // Drop angled brackets that would go into the staff
+            if (shift < abs(tilt) * unit / 2) continue;
+            // Drop angled brackets where the midpoint is moved only slightly closer to the staff
+            if (shift > horizontalBracketShift - abs(tilt) * unit / 4) continue;
+            // Update the optimal tilt
+            if (shift < optimalShift) {
+                optimalShift = shift;
+                optimalTilt = tilt;
+            }
         }
     }
 

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -180,7 +180,7 @@ int TupletBracket::GetDrawingYLeft() const
             + m_drawingYRelLeft;
     }
     else {
-        return this->GetDrawingY();
+        return this->GetDrawingY() + m_drawingYRelLeft;
     }
 }
 
@@ -198,7 +198,7 @@ int TupletBracket::GetDrawingYRight() const
             + m_drawingYRelRight;
     }
     else {
-        return this->GetDrawingY();
+        return this->GetDrawingY() + m_drawingYRelRight;
     }
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1524,6 +1524,10 @@ Options::Options()
     m_tieMinLength.Init(2.0, 0.0, 10.0);
     this->Register(&m_tieMinLength, "tieMinLength", &m_generalLayout);
 
+    m_tupletAngledOnBeams.SetInfo("Tuplet angled on beams", "Tuplet brackets angled on beams only");
+    m_tupletAngledOnBeams.Init(false);
+    this->Register(&m_tupletAngledOnBeams, "tupletAngledOnBeams", &m_generalLayout);
+
     m_tupletBracketThickness.SetInfo("Tuplet bracket thickness", "The thickness of the tuplet bracket");
     m_tupletBracketThickness.Init(0.2, 0.1, 0.8);
     this->Register(&m_tupletBracketThickness, "tupletBracketThickness", &m_generalLayout);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -156,6 +156,27 @@ void Tuplet::FilterList(ListOfConstObjects &childList) const
     }
 }
 
+MelodicDirection Tuplet::GetMelodicDirection() const
+{
+    const LayerElement *leftElement = this->GetDrawingLeft();
+    const Note *leftNote = NULL;
+    if (leftElement->Is(NOTE)) leftNote = vrv_cast<const Note *>(leftElement);
+    if (leftElement->Is(CHORD)) leftNote = vrv_cast<const Chord *>(leftElement)->GetTopNote();
+
+    const LayerElement *rightElement = this->GetDrawingRight();
+    const Note *rightNote = NULL;
+    if (rightElement->Is(NOTE)) rightNote = vrv_cast<const Note *>(rightElement);
+    if (rightElement->Is(CHORD)) rightNote = vrv_cast<const Chord *>(rightElement)->GetTopNote();
+
+    if (leftNote && rightNote) {
+        const int leftPitch = leftNote->GetDiatonicPitch();
+        const int rightPitch = rightNote->GetDiatonicPitch();
+        if (leftPitch < rightPitch) return MelodicDirection::Up;
+        if (leftPitch > rightPitch) return MelodicDirection::Down;
+    }
+    return MelodicDirection::None;
+}
+
 void Tuplet::CalculateTupletNumCrossStaff(LayerElement *layerElement)
 {
     assert(layerElement);

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -267,29 +267,27 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
 
     // The first step is to calculate all the stem directions
     // cycle into the elements and count the up and down dirs
-    ListOfObjects::const_iterator iter = tupletChildren.begin();
-    while (iter != tupletChildren.end()) {
-        if ((*iter)->Is(CHORD)) {
-            Chord *currentChord = vrv_cast<Chord *>(*iter);
+    for (Object *child : tupletChildren) {
+        if (child->Is(CHORD)) {
+            Chord *currentChord = vrv_cast<Chord *>(child);
             assert(currentChord);
             if (currentChord->GetDrawingStemDir() == STEMDIRECTION_up) {
-                ups++;
+                ++ups;
             }
             else {
-                downs++;
+                ++downs;
             }
         }
-        else if ((*iter)->Is(NOTE)) {
-            Note *currentNote = vrv_cast<Note *>(*iter);
+        else if (child->Is(NOTE)) {
+            Note *currentNote = vrv_cast<Note *>(child);
             assert(currentNote);
             if (!currentNote->IsChordTone() && (currentNote->GetDrawingStemDir() == STEMDIRECTION_up)) {
-                ups++;
+                ++ups;
             }
             if (!currentNote->IsChordTone() && (currentNote->GetDrawingStemDir() == STEMDIRECTION_down)) {
-                downs++;
+                ++downs;
             }
         }
-        ++iter;
     }
     // true means up
     m_drawingBracketPos = ups > downs ? STAFFREL_basic_above : STAFFREL_basic_below;
@@ -303,8 +301,6 @@ void Tuplet::CalcDrawingBracketAndNumPos(bool tupletNumHead)
     if (m_drawingNumPos == STAFFREL_basic_NONE) {
         m_drawingNumPos = m_drawingBracketPos;
     }
-
-    return;
 }
 
 void Tuplet::GetDrawingLeftRightXRel(int &xRelLeft, int &xRelRight, const Doc *doc) const

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -101,8 +101,8 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     const int lineWidth
         = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * m_options->m_tupletBracketThickness.GetValue();
-    const int xLeft = tuplet->GetDrawingLeft()->GetDrawingX() + tupletBracket->GetDrawingXRelLeft() + lineWidth / 2;
-    const int xRight = tuplet->GetDrawingRight()->GetDrawingX() + tupletBracket->GetDrawingXRelRight() - lineWidth / 2;
+    const int xLeft = tupletBracket->GetDrawingXLeft() + lineWidth / 2;
+    const int xRight = tupletBracket->GetDrawingXRight() - lineWidth / 2;
     const int yLeft = tupletBracket->GetDrawingYLeft();
     const int yRight = tupletBracket->GetDrawingYRight();
     int bracketHeight = (tuplet->GetDrawingBracketPos() == STAFFREL_basic_above) ? -1 : 1;


### PR DESCRIPTION
This PR introduces angled tuplet brackets that are not beam aligned (i.e. on the other side of the beam or without).

| Before | After |
| ------ | ----- |
| <img width="826" alt="Before" src="https://github.com/rism-digital/verovio/assets/63608463/5541f118-8083-42e5-a9b0-5d3366d88e42"> | <img width="841" alt="After" src="https://github.com/rism-digital/verovio/assets/63608463/f17fd5d9-ea4b-4fa5-8a7b-0f5664da2d74"> |

<details>
<summary> Show MEI </summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title></title>
         </titleStmt>
         <pubStmt>
            <date isodate="2023-05-10">2023-05-10</date>
            <respStmt>
               <persName role="encoder">Klaus Rettinghaus</persName>
            </respStmt>
         </pubStmt>
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <beam>
                                 <note dur="8" oct="4" pname="e" stem.dir="down" />
                                 <note dur="8" oct="4" pname="b" stem.dir="down" />
                                 <note dur="8" oct="5" pname="f" stem.dir="down" />
                              </beam>
                           </tuplet>
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <note dur="8" oct="4" pname="e" stem.dir="down" />
                              <note dur="8" oct="4" pname="b" stem.dir="down" />
                              <note dur="8" oct="5" pname="f" stem.dir="down" />
                           </tuplet>
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <beam>
                                 <note dur="8" oct="4" pname="e" stem.dir="up" />
                                 <note dur="8" oct="4" pname="b" stem.dir="up" />
                                 <note dur="8" oct="5" pname="f" stem.dir="up" />
                              </beam>
                           </tuplet>
                           <tuplet num="3" numbase="2" bracket.visible="true">
                              <note dur="8" oct="4" pname="e" stem.dir="up" />
                              <note dur="8" oct="4" pname="b" stem.dir="up" />
                              <note dur="8" oct="5" pname="f" stem.dir="up" />
                           </tuplet>
                           <tuplet num="3" numbase="2" bracket.visible="true" bracket.place="above">
                              <beam>
                                 <note dur="8" oct="5" pname="e" stem.dir="down" />
                                 <note dur="8" oct="5" pname="b" stem.dir="down" />
                                 <note dur="8" oct="6" pname="f" stem.dir="down" />
                              </beam>
                           </tuplet>
                           <tuplet num="3" numbase="2" bracket.visible="true" bracket.place="above">
                              <note dur="8" oct="5" pname="e" stem.dir="down" />
                              <note dur="8" oct="5" pname="b" stem.dir="down" />
                              <note dur="8" oct="6" pname="f" stem.dir="down" />
                           </tuplet>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

This improves one part of the issue #2684 :
<img width="528" alt="2684" src="https://github.com/rism-digital/verovio/assets/63608463/f9ec6c14-f0f9-47bc-ac58-fc0ef6f14525">

