### PR TITLE
Prefer ellipse for circle-shaped text enclosure

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2954,6 +2954,7 @@ void View::DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params,
         }
         else if (params.m_enclose == TEXTRENDITION_circle) {
             if (height > width) {
+                // in this case draw a perfect circle
                 const int cx = x1 + (x2 - x1) / 2;
                 x1 = cx - height / 2;
                 x2 = cx + height / 2;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2953,13 +2953,14 @@ void View::DrawTextEnclosure(DeviceContext *dc, const TextDrawingParams &params,
             this->DrawDiamond(dc, x1 - width / 2, yCenter, height * sqrt(2), width * 2, false, lineThickness);
         }
         else if (params.m_enclose == TEXTRENDITION_circle) {
-            if (width > height) {
-                y1 -= (width - height) / 2;
-                y2 += (width - height) / 2;
+            if (height > width) {
+                const int cx = x1 + (x2 - x1) / 2;
+                x1 = cx - height / 2;
+                x2 = cx + height / 2;
             }
-            else if (height > width) {
-                x1 -= (height - width) / 2;
-                x2 += (height - width) / 2;
+            else if (height < width) {
+                x1 -= width / 8;
+                x2 += width / 8;
             }
             this->DrawNotFilledEllipse(dc, x1, y1, x2, y2, lineThickness);
         }


### PR DESCRIPTION
In light of https://github.com/music-encoding/music-encoding/pull/1100 this changes rendering of `rend="circle"` to ellipse, keeping the hight constant.