### PR TITLE
Fix crash for unmatched plist ID

### DIFF
--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -327,11 +327,11 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
-     * Getter and modifier for the interface / id tuples
+     * Getter and modifier for the interface / id pairs
      */
     ///@{
-    const ArrayOfPlistInterfaceIDTuples &GetInterfaceIDTuples() const { return m_interfaceIDTuples; }
-    void InsertInterfaceIDTuple(const std::string &elementID, PlistInterface *interface);
+    const ArrayOfPlistInterfaceIDPairs &GetInterfaceIDPairs() const { return m_interfaceIDPairs; }
+    void InsertInterfaceIDPair(const std::string &elementID, PlistInterface *interface);
     ///@}
 
     /*
@@ -348,8 +348,8 @@ private:
 public:
     //
 private:
-    // Holds the interface / id tuples to match
-    ArrayOfPlistInterfaceIDTuples m_interfaceIDTuples;
+    // Holds the interface / id pairs to match
+    ArrayOfPlistInterfaceIDPairs m_interfaceIDPairs;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -332,7 +332,6 @@ public:
     ///@{
     const ArrayOfPlistInterfaceIDTuples &GetInterfaceIDTuples() const { return m_interfaceIDTuples; }
     void InsertInterfaceIDTuple(const std::string &elementID, PlistInterface *interface);
-    void ClearInterfaceIDTuples() { m_interfaceIDTuples.clear(); }
     ///@}
 
     /*

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -348,7 +348,7 @@ typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceIDPa
 
 typedef std::map<std::string, Note *> MapOfNoteIDPairs;
 
-typedef std::vector<std::tuple<PlistInterface *, std::string, Object *>> ArrayOfPlistInterfaceIDTuples;
+typedef std::vector<std::tuple<PlistInterface *, std::string>> ArrayOfPlistInterfaceIDTuples;
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -348,7 +348,7 @@ typedef std::multimap<std::string, LinkingInterface *> MapOfLinkingInterfaceIDPa
 
 typedef std::map<std::string, Note *> MapOfNoteIDPairs;
 
-typedef std::vector<std::tuple<PlistInterface *, std::string>> ArrayOfPlistInterfaceIDTuples;
+typedef std::vector<std::pair<PlistInterface *, std::string>> ArrayOfPlistInterfaceIDPairs;
 
 typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -663,14 +663,13 @@ void Doc::PrepareData()
     preparePlist.SetDataCollectionCompleted();
 
     // Process plist after all pairs have been collected
-    if (!preparePlist.GetInterfaceIDTuples().empty()) {
+    if (!preparePlist.GetInterfaceIDPairs().empty()) {
         this->Process(preparePlist);
     }
 
     // If some are still there, then it is probably an issue in the encoding
-    if (!preparePlist.GetInterfaceIDTuples().empty()) {
-        LogWarning(
-            "%d element(s) with a @plist could not match the target", preparePlist.GetInterfaceIDTuples().size());
+    if (!preparePlist.GetInterfaceIDPairs().empty()) {
+        LogWarning("%d element(s) with a @plist could not match the target", preparePlist.GetInterfaceIDPairs().size());
     }
 
     /************ Resolve cross staff ************/

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -665,11 +665,6 @@ void Doc::PrepareData()
     // Process plist after all pairs have been collected
     if (!preparePlist.GetInterfaceIDTuples().empty()) {
         this->Process(preparePlist);
-
-        for (const auto &[plistInterface, id, objectReference] : preparePlist.GetInterfaceIDTuples()) {
-            plistInterface->SetRef(objectReference);
-        }
-        preparePlist.ClearInterfaceIDTuples();
     }
 
     // If some are still there, then it is probably an issue in the encoding

--- a/src/plistinterface.cpp
+++ b/src/plistinterface.cpp
@@ -106,7 +106,7 @@ FunctorCode PlistInterface::InterfacePreparePlist(PreparePlistFunctor &functor, 
 
     std::vector<std::string>::iterator iter;
     for (iter = m_ids.begin(); iter != m_ids.end(); ++iter) {
-        functor.InsertInterfaceIDTuple(*iter, this);
+        functor.InsertInterfaceIDPair(*iter, this);
     }
 
     return FUNCTOR_CONTINUE;

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -490,7 +490,7 @@ FunctorCode PreparePlistFunctor::VisitObject(Object *object)
         auto iter = std::find_if(m_interfaceIDPairs.begin(), m_interfaceIDPairs.end(),
             [&id](const std::pair<PlistInterface *, std::string> &pair) { return (pair.second == id); });
         if (iter != m_interfaceIDPairs.end()) {
-            // Set reference for matched tuple and erase it from the list
+            // Set reference for matched pair and erase it from the list
             iter->first->SetRef(object);
             m_interfaceIDPairs.erase(iter);
         }

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -469,9 +469,9 @@ void PrepareLinkingFunctor::ResolveStemSameas(Note *note)
 
 PreparePlistFunctor::PreparePlistFunctor() : Functor(), CollectAndProcess() {}
 
-void PreparePlistFunctor::InsertInterfaceIDTuple(const std::string &elementID, PlistInterface *interface)
+void PreparePlistFunctor::InsertInterfaceIDPair(const std::string &elementID, PlistInterface *interface)
 {
-    m_interfaceIDTuples.push_back(std::make_tuple(interface, elementID));
+    m_interfaceIDPairs.push_back(std::make_pair(interface, elementID));
 }
 
 FunctorCode PreparePlistFunctor::VisitObject(Object *object)
@@ -487,13 +487,12 @@ FunctorCode PreparePlistFunctor::VisitObject(Object *object)
         if (!object->IsLayerElement()) return FUNCTOR_CONTINUE;
 
         const std::string &id = object->GetID();
-        auto i = std::find_if(m_interfaceIDTuples.begin(), m_interfaceIDTuples.end(),
-            [&id](std::tuple<PlistInterface *, std::string> tuple) { return (std::get<1>(tuple) == id); });
-        if (i != m_interfaceIDTuples.end()) {
+        auto iter = std::find_if(m_interfaceIDPairs.begin(), m_interfaceIDPairs.end(),
+            [&id](const std::pair<PlistInterface *, std::string> &pair) { return (pair.second == id); });
+        if (iter != m_interfaceIDPairs.end()) {
             // Set reference for matched tuple and erase it from the list
-            PlistInterface *interface = std::get<0>(*i);
-            interface->SetRef(object);
-            m_interfaceIDTuples.erase(i);
+            iter->first->SetRef(object);
+            m_interfaceIDPairs.erase(iter);
         }
     }
 

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -471,7 +471,7 @@ PreparePlistFunctor::PreparePlistFunctor() : Functor(), CollectAndProcess() {}
 
 void PreparePlistFunctor::InsertInterfaceIDTuple(const std::string &elementID, PlistInterface *interface)
 {
-    m_interfaceIDTuples.push_back(std::make_tuple(interface, elementID, (Object *)NULL));
+    m_interfaceIDTuples.push_back(std::make_tuple(interface, elementID));
 }
 
 FunctorCode PreparePlistFunctor::VisitObject(Object *object)
@@ -486,11 +486,14 @@ FunctorCode PreparePlistFunctor::VisitObject(Object *object)
     else {
         if (!object->IsLayerElement()) return FUNCTOR_CONTINUE;
 
-        std::string id = object->GetID();
+        const std::string &id = object->GetID();
         auto i = std::find_if(m_interfaceIDTuples.begin(), m_interfaceIDTuples.end(),
-            [&id](std::tuple<PlistInterface *, std::string, Object *> tuple) { return (std::get<1>(tuple) == id); });
+            [&id](std::tuple<PlistInterface *, std::string> tuple) { return (std::get<1>(tuple) == id); });
         if (i != m_interfaceIDTuples.end()) {
-            std::get<2>(*i) = object;
+            // Set reference for matched tuple and erase it from the list
+            PlistInterface *interface = std::get<0>(*i);
+            interface->SetRef(object);
+            m_interfaceIDTuples.erase(i);
         }
     }
 

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -393,7 +393,6 @@ void ScoreDef::ReplaceDrawingValues(const StaffDef *newStaffDef)
             if (newStaffDef->HasMensurInfo()) {
                 // If there is a mensur and the meterSig
                 // is invisible, then print mensur instead
-                data_METERFORM meterForm = meterSig->GetForm();
                 if (meterSig->GetVisible() == BOOLEAN_false) {
                     staffDef->SetDrawMeterSig(false);
                     staffDef->SetDrawMensur(true);


### PR DESCRIPTION
This PR fixes the crash whenever there is an unmatched ID in `@plist`. This is now gracefully handled with a warning.

<details>
<summary>Show MEI example (variation of beamspan-001)</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Beam span</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="editor">Laurent Pugin</persName>
               <persName role="encoder">Andriy Makarchuk</persName>
            </respStmt>
            <date isodate="2022-02-15">2022-01-15</date>
            <pubPlace>
               <ref target="https://github.com/rism-digital/verovio/pull/2640" />
            </pubPlace>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>BeamSpans can be cross-staff and cross-measure.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="3.9.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="120" key.mode="major" key.sig="2f" meter.count="4" meter.unit="2" meter.sym="common">
                  <staffGrp symbol="brace" bar.thru="true">
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2">
                        <instrDef midi.channel="0" midi.instrnum="0" />
                     </staffDef>
                     <staffDef n="2" lines="5" clef.shape="F" clef.line="4">
                        <instrDef midi.channel="1" midi.instrnum="0" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure metcon="false" n="222">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="c01" dur="32" oct="4" pname="g" stem.dir="up" />
                           <note xml:id="c02" dur="32" oct="4" pname="f" stem.dir="up" />
                           <note xml:id="c03" dur="32" oct="4" pname="e" stem.dir="up" />
                           <note xml:id="c04" dur="32" oct="4" pname="d" stem.dir="up" />
                           <note xml:id="c05" dur="32" oct="4" pname="c" stem.dir="up" />
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                        </layer>
                     </staff>
                     <beamSpan startid="#c01" endid="#c16" plist="#c01 #c02 #c03 #c04 #c05 #c13 #c14 #c15 #c16 #c123"/>
                  </measure>
                  <measure metcon="false" n="223">
                     <staff n="1">
                        <layer n="1">
                        </layer>
                     </staff>
                     <staff n="2">
                        <layer n="1">
                           <note xml:id="c13" dur="32" oct="3" pname="b" stem.dir="up" />
                           <note xml:id="c14" dur="32" oct="3" pname="a" stem.dir="up" />
                           <note xml:id="c15" dur="32" oct="3" pname="g" stem.dir="up" />
                           <note xml:id="c16" dur="32" oct="3" pname="f" stem.dir="up" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>