### PR TITLE
Fix MusicXML diminuendo <wedge> spread handling

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2229,10 +2229,12 @@ void MusicXmlInput::ReadMusicXmlDirection(
                     if (wedge->node().attribute("niente")) {
                         iter->first->SetNiente(ConvertWordToBool(wedge->node().attribute("niente").as_string()));
                     }
-                    if (wedge->node().attribute("spread")) {
-                        data_MEASUREMENTSIGNED opening;
-                        opening.SetVu(wedge->node().attribute("spread").as_double() / 5);
-                        iter->first->SetOpening(opening);
+                    if (iter->first->GetForm() == hairpinLog_FORM_cres) {
+                        if (wedge->node().attribute("spread")) {
+                            data_MEASUREMENTSIGNED opening;
+                            opening.SetVu(wedge->node().attribute("spread").as_double() / 5);
+                            iter->first->SetOpening(opening);
+                        }
                     }
                     matchedWedge = true;
                     m_hairpinStack.erase(iter);
@@ -2252,6 +2254,11 @@ void MusicXmlInput::ReadMusicXmlDirection(
             }
             else if (HasAttributeWithValue(wedge->node(), "type", "diminuendo")) {
                 hairpin->SetForm(hairpinLog_FORM_dim);
+                if (wedge->node().attribute("spread")) {
+                    data_MEASUREMENTSIGNED opening;
+                    opening.SetVu(wedge->node().attribute("spread").as_double() / 5);
+                    hairpin->SetOpening(opening);
+                }
             }
             else {
                 delete hairpin;


### PR DESCRIPTION
The [MusicXML standard](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/wedge/) specifies that the `spread` attribute at the start of a crescendo and the end of a diminuendo is ignored. However, the current code only reads `spread` at the end of a `<wedge>` pair, which means it handles the spread of diminuendos wrongly.

This fix changes the behavior of `MusicXmlInput` so it sets the opening of a hairpin at the end for diminuendos or the start for crescendos. The followings show the result of this fix. [Test MusicXML files](https://github.com/rism-digital/verovio/files/11671536/Test.MusicXML.files.zip) are made by modifying `<wedge>` elements in `BeetAnGeSample.musicxml` from the example set on [musicxml.com](https://www.musicxml.com/music-in-musicxml/example-set/).

* `test-narrow-wedge.musicxml` (Made by replacing `spread="15"` with `spread="5"`)

| Before fix | After fix |
| --- | --- |
| ![test-narrow-wedge before](https://github.com/rism-digital/verovio/assets/17005454/6bd8920a-09a1-4437-8ee9-e1e0112b98c8) | ![test-narrow-wedge after](https://github.com/rism-digital/verovio/assets/17005454/b086cfe9-49d5-4862-bbf8-cf98f9f983ff) |

* `test-spread-0-at-dim-stop.musicxml` (Made by adding `spread="0"` to the end `<wedge>` of diminuendos)

| Before fix | After fix |
| --- | --- |
| ![test-spread-0-at-dim-stop before](https://github.com/rism-digital/verovio/assets/17005454/3ea93fbf-81c9-4751-a072-72f163efb39f) | ![test-spread-0-at-dim-stop after](https://github.com/rism-digital/verovio/assets/17005454/fc4c71a4-cd87-46b0-94be-7d9d7584ad87) |

