### PR TITLE
Flats and ledger lines

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -161,6 +161,9 @@ public:
     int GetCutOutBottom(const Resources &resources) const;
     int GetCutOutLeft(const Resources &resources) const;
     int GetCutOutRight(const Resources &resources) const;
+    // Restricted version which only considers the cutout rectangles from the top or bottom
+    int GetCutOutLeft(const Resources &resources, bool fromTop) const;
+    int GetCutOutRight(const Resources &resources, bool fromTop) const;
     ///@}
 
     /**
@@ -267,13 +270,16 @@ public:
 
 private:
     /**
-     * Get the rectangles covering the inside of a bounding box given two anchors (e.g., NW and NE, or NE and SE)
-     * Looks at the anchors for the smufl glpyh (if any) and return the number of rectangles needed to represent the
+     * Get the rectangles covering the inside of a bounding box given one or two anchors (e.g., NW and NE, or NE and SE)
+     * Looks at the anchors for the smufl glyph (if any) and return the number of rectangles needed to represent the
      * bounding box.
-     * Return 1 with no smufl glyph or no anchor, 2 with on anchor point, and 3 with 2 anchor points.
+     * Return 1 with no smufl glyph or no anchor, 2 with one anchor point, and 3 with 2 anchor points.
      */
+    ///@{
+    int GetRectangles(const SMuFLGlyphAnchor &anchor, Point rect[2][2], const Resources &resources) const;
     int GetRectangles(const SMuFLGlyphAnchor &anchor1, const SMuFLGlyphAnchor &anchor2, Point rect[3][2],
         const Resources &resources) const;
+    ///@}
 
     /**
      * Calculate the rectangles with 2 anchor points.

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -91,14 +91,21 @@ void Accid::AdjustToLedgerLines(const Doc *doc, LayerElement *element, int staff
     const int rightMargin = doc->GetRightMargin(ACCID) * unit;
     if (element->Is(NOTE) && chord && chord->HasAdjacentNotesInStaff(staff)) {
         const int horizontalMargin = doc->GetOptions()->m_ledgerLineExtension.GetValue() * unit + 0.5 * rightMargin;
-        const int drawingUnit = doc->GetDrawingUnit(staffSize);
         const int staffTop = staff->GetDrawingY();
         const int staffBottom = staffTop - doc->GetDrawingStaffSize(staffSize);
         if (this->HorizontalContentOverlap(element, 0)) {
-            if (((this->GetContentTop() > staffTop + 2 * drawingUnit) && (this->GetDrawingY() < element->GetDrawingY()))
-                || ((this->GetContentBottom() < staffBottom - 2 * drawingUnit)
+            if (((this->GetContentTop() > staffTop + 2 * unit) && (this->GetDrawingY() < element->GetDrawingY()))
+                || ((this->GetContentBottom() < staffBottom - 2 * unit)
                     && (this->GetDrawingY() > element->GetDrawingY()))) {
-                const int xRelShift = this->GetSelfRight() - element->GetSelfLeft() + horizontalMargin;
+                int right = this->GetSelfRight();
+                // Special case: Reduce shift for flats intersecting only the first ledger line above the staff
+                if ((this->GetAccid() == ACCIDENTAL_WRITTEN_f) || (this->GetAccid() == ACCIDENTAL_WRITTEN_ff)) {
+                    if ((this->GetContentTop() > staffTop + 2 * unit)
+                        && (this->GetContentTop() < staffTop + 4 * unit)) {
+                        right = this->GetCutOutRight(doc->GetResources(), true);
+                    }
+                }
+                const int xRelShift = right - element->GetSelfLeft() + horizontalMargin;
                 if (xRelShift > 0) this->SetDrawingXRel(this->GetDrawingXRel() - xRelShift);
             }
         }


### PR DESCRIPTION
This PR refines collision avoidance between ledger lines and accidentals with large cutout, i.e. flats.

| Before | After |
| ------ | ----- |
| <img width="364" alt="Before" src="https://github.com/rism-digital/verovio/assets/63608463/5ea575f1-ef44-4f59-a076-2e856269d093"> | <img width="356" alt="After" src="https://github.com/rism-digital/verovio/assets/63608463/6bbe6119-e68f-4d73-a933-9fd1ebd46570"> |

<details>
<summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
  <meiHead>
    <fileDesc>
      <titleStmt>
        <title/>
      </titleStmt>
      <pubStmt/>
    </fileDesc>
    <encodingDesc>
      <appInfo>
        <application isodate="2021-07-06T21:10:01" version="3.5.0-dev-cfdb185">
          <name>Verovio</name>
          <p>Transcoded from Humdrum</p>
        </application>
      </appInfo>
    </encodingDesc>
    <workList>
      <work>
        <title/>
      </work>
    </workList>
  </meiHead>
  <music>
    <body>
      <mdiv>
        <score>
          <scoreDef>
            <staffGrp>
              <staffDef n="1" lines="5">
                <clef shape="G" line="2"/>
              </staffDef>
            </staffGrp>
          </scoreDef>
          <section>
            <measure>
              <staff n="1">
                <layer n="1">
                  <beam>
                    <chord dur="8">
                      <note oct="5" pname="e">
                        <accid accid="f" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="e">
                        <accid accid="ff" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="e">
                        <accid accid="n" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="e">
                        <accid accid="s" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="f">
                        <accid accid="n" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="f">
                        <accid accid="s" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="g">
                        <accid accid="n" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                    <chord dur="8">
                      <note oct="5" pname="g">
                        <accid accid="s" func="caution"/>
                      </note>
                      <note oct="6" pname="f"/>
                      <note oct="6" pname="g"/>
                    </chord>
                  </beam>
                </layer>
              </staff>
            </measure>
          </section>
        </score>
      </mdiv>
    </body>
  </music>
</mei>
```
</details>

