### PR TITLE
Add support for repeatMark

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -886,6 +886,12 @@
 		4DFB3E8823ABDFC200D688C7 /* pitchinflection.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DFB3E8423ABDFC200D688C7 /* pitchinflection.cpp */; };
 		4DFB3E8A23ABDFDA00D688C7 /* pitchinflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFB3E8923ABDFDA00D688C7 /* pitchinflection.h */; };
 		4DFB3E8B23ABDFDA00D688C7 /* pitchinflection.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFB3E8923ABDFDA00D688C7 /* pitchinflection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DFD82FB2A38398200A3E20B /* repeatmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD82FA2A38398200A3E20B /* repeatmark.cpp */; };
+		4DFD82FC2A38398200A3E20B /* repeatmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD82FA2A38398200A3E20B /* repeatmark.cpp */; };
+		4DFD82FD2A38398200A3E20B /* repeatmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD82FA2A38398200A3E20B /* repeatmark.cpp */; };
+		4DFD82FE2A38398200A3E20B /* repeatmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DFD82FA2A38398200A3E20B /* repeatmark.cpp */; };
+		4DFD83002A38399C00A3E20B /* repeatmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFD82FF2A38399C00A3E20B /* repeatmark.h */; };
+		4DFD83012A38399C00A3E20B /* repeatmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DFD82FF2A38399C00A3E20B /* repeatmark.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8F086EE2188539540037FD8E /* verticalaligner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8F086EB6188539540037FD8E /* verticalaligner.cpp */; };
 		8F086EE4188539540037FD8E /* barline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8F086EB8188539540037FD8E /* barline.cpp */; };
 		8F086EE5188539540037FD8E /* bboxdevicecontext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8F086EB9188539540037FD8E /* bboxdevicecontext.cpp */; };
@@ -2048,6 +2054,8 @@
 		4DF4407C1D511D0200152B7E /* systemmilestone.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = systemmilestone.cpp; path = src/systemmilestone.cpp; sourceTree = "<group>"; };
 		4DFB3E8423ABDFC200D688C7 /* pitchinflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pitchinflection.cpp; path = src/pitchinflection.cpp; sourceTree = "<group>"; };
 		4DFB3E8923ABDFDA00D688C7 /* pitchinflection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = pitchinflection.h; path = include/vrv/pitchinflection.h; sourceTree = "<group>"; };
+		4DFD82FA2A38398200A3E20B /* repeatmark.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = repeatmark.cpp; path = src/repeatmark.cpp; sourceTree = "<group>"; };
+		4DFD82FF2A38399C00A3E20B /* repeatmark.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = repeatmark.h; path = include/vrv/repeatmark.h; sourceTree = "<group>"; };
 		8F086EA9188534680037FD8E /* Verovio */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Verovio; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F086EB6188539540037FD8E /* verticalaligner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; name = verticalaligner.cpp; path = src/verticalaligner.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		8F086EB8188539540037FD8E /* barline.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = barline.cpp; path = src/barline.cpp; sourceTree = "<group>"; };
@@ -2674,6 +2682,8 @@
 				4DFB3E8923ABDFDA00D688C7 /* pitchinflection.h */,
 				40ACDEA824079F9000F82B8C /* reh.cpp */,
 				40ACDEA524079F5E00F82B8C /* reh.h */,
+				4DFD82FA2A38398200A3E20B /* repeatmark.cpp */,
+				4DFD82FF2A38399C00A3E20B /* repeatmark.h */,
 				8F086ED3188539540037FD8E /* slur.cpp */,
 				8F59292A18854BF800FE51AD /* slur.h */,
 				4DB351121C8040B1002DD057 /* tempo.cpp */,
@@ -3273,6 +3283,7 @@
 				4DACC9B22990F29A00B55913 /* atts_cmnornaments.h in Headers */,
 				4DC12A891F74111E000440E9 /* pgfoot.h in Headers */,
 				4DB3D8C91F83D10300B5FC2B /* dir.h in Headers */,
+				4DFD83002A38399C00A3E20B /* repeatmark.h in Headers */,
 				BD05622F2518CD12004057EB /* beamspan.h in Headers */,
 				4DEC4DDA21C8295700D1D273 /* damage.h in Headers */,
 				4DACC9CE2990F29A00B55913 /* atts_mei.h in Headers */,
@@ -3543,6 +3554,7 @@
 				4D79643226C6AA720026288B /* featureextractor.h in Headers */,
 				4DACC9EB2990F29A00B55913 /* attmodule.h in Headers */,
 				BB4C4ABC22A932B6001F6AF0 /* instrdef.h in Headers */,
+				4DFD83012A38399C00A3E20B /* repeatmark.h in Headers */,
 				BB4C4B7622A932D7001F6AF0 /* syl.h in Headers */,
 				E73E86262A069C640089DF74 /* transposefunctor.h in Headers */,
 				BB4C4AEA22A932BC001F6AF0 /* del.h in Headers */,
@@ -4075,6 +4087,7 @@
 				4D16944F1E3A44F300569BF4 /* timeinterface.cpp in Sources */,
 				4D6331F61F46D2CB00A0D6BF /* arpeg.cpp in Sources */,
 				4D674B47255F40B7008AEF4C /* plica.cpp in Sources */,
+				4DFD82FC2A38398200A3E20B /* repeatmark.cpp in Sources */,
 				4D1694511E3A44F300569BF4 /* glyph.cpp in Sources */,
 				4D1694521E3A44F300569BF4 /* syl.cpp in Sources */,
 				E7876F2329C0A709002147DC /* adjusttupletsxfunctor.cpp in Sources */,
@@ -4135,6 +4148,7 @@
 				4DC12A781F7400B9000440E9 /* runningelement.cpp in Sources */,
 				4DA0EAEE22BB77C300A7EBEB /* editortoolkit_cmn.cpp in Sources */,
 				E78F204A29D98D2300CD5910 /* adjustxrelfortranscriptionfunctor.cpp in Sources */,
+				4DFD82FB2A38398200A3E20B /* repeatmark.cpp in Sources */,
 				4DACC9FC2990F29A00B55913 /* atts_fingering.cpp in Sources */,
 				4DC12A631F73F898000440E9 /* pghead2.cpp in Sources */,
 				4DACC9EC2990F29A00B55913 /* atts_shared.cpp in Sources */,
@@ -4634,6 +4648,7 @@
 				4DB3D8DC1F83D14900B5FC2B /* artic.cpp in Sources */,
 				4D674B48255F40B7008AEF4C /* plica.cpp in Sources */,
 				4D9A9C1F19A1DE2000028D93 /* syl.cpp in Sources */,
+				4DFD82FD2A38398200A3E20B /* repeatmark.cpp in Sources */,
 				4DC3B9E9239E2AE3007F185E /* transposition.cpp in Sources */,
 				40ACDEAB24079F9000F82B8C /* reh.cpp in Sources */,
 				E7876F2229C0A708002147DC /* adjusttupletsxfunctor.cpp in Sources */,
@@ -4914,6 +4929,7 @@
 				BB4C4AFD22A932BC001F6AF0 /* subst.cpp in Sources */,
 				BB4C4BBE22A932FC001F6AF0 /* MidiFile.cpp in Sources */,
 				4D674B49255F40B7008AEF4C /* plica.cpp in Sources */,
+				4DFD82FE2A38398200A3E20B /* repeatmark.cpp in Sources */,
 				BB4C4A9C22A9328F001F6AF0 /* options.cpp in Sources */,
 				4DC3B9E8239E2AE2007F185E /* transposition.cpp in Sources */,
 				E7876F2129C0A708002147DC /* adjusttupletsxfunctor.cpp in Sources */,

--- a/include/vrv/functorinterface.h
+++ b/include/vrv/functorinterface.h
@@ -101,6 +101,7 @@ class Phrase;
 class PitchInflection;
 class Plica;
 class Proport;
+class RepeatMark;
 class Reh;
 class Rend;
 class Rest;
@@ -316,6 +317,8 @@ public:
     virtual FunctorCode VisitPitchInflectionEnd(PitchInflection *pitchInflection);
     virtual FunctorCode VisitReh(Reh *reh);
     virtual FunctorCode VisitRehEnd(Reh *reh);
+    virtual FunctorCode VisitRepeatMark(RepeatMark *repeatMark);
+    virtual FunctorCode VisitRepeatMarkEnd(RepeatMark *repeatMark);
     virtual FunctorCode VisitSlur(Slur *slur);
     virtual FunctorCode VisitSlurEnd(Slur *slur);
     virtual FunctorCode VisitTempo(Tempo *tempo);
@@ -671,6 +674,8 @@ public:
     virtual FunctorCode VisitPitchInflectionEnd(const PitchInflection *pitchInflection);
     virtual FunctorCode VisitReh(const Reh *reh);
     virtual FunctorCode VisitRehEnd(const Reh *reh);
+    virtual FunctorCode VisitRepeatMark(const RepeatMark *repeatMark);
+    virtual FunctorCode VisitRepeatMarkEnd(const RepeatMark *repeatMark);
     virtual FunctorCode VisitSlur(const Slur *slur);
     virtual FunctorCode VisitSlurEnd(const Slur *slur);
     virtual FunctorCode VisitTempo(const Tempo *tempo);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -125,6 +125,7 @@ class Ref;
 class Reg;
 class Reh;
 class Rend;
+class RepeatMark;
 class Rest;
 class Restore;
 class RunningElement;
@@ -443,6 +444,7 @@ private:
     void WritePhrase(pugi::xml_node currentNode, Phrase *phrase);
     void WritePitchInflection(pugi::xml_node currentNode, PitchInflection *pitchInflection);
     void WriteReh(pugi::xml_node currentNode, Reh *reh);
+    void WriteRepeatMark(pugi::xml_node currentNode, RepeatMark *repeatMark);
     void WriteSlur(pugi::xml_node currentNode, Slur *slur);
     void WriteTempo(pugi::xml_node currentNode, Tempo *tempo);
     void WriteTie(pugi::xml_node currentNode, Tie *tie);
@@ -752,6 +754,7 @@ private:
     bool ReadPedal(Object *parent, pugi::xml_node pedal);
     bool ReadPhrase(Object *parent, pugi::xml_node phrase);
     bool ReadPitchInflection(Object *parent, pugi::xml_node pitchInflection);
+    bool ReadRepeatMark(Object *parent, pugi::xml_node repeatMark);
     bool ReadReh(Object *parent, pugi::xml_node reh);
     bool ReadSlur(Object *parent, pugi::xml_node slur);
     bool ReadTempo(Object *parent, pugi::xml_node tempo);

--- a/include/vrv/ornam.h
+++ b/include/vrv/ornam.h
@@ -22,7 +22,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 /**
- * This class models the MEI <turn> element.
+ * This class models the MEI <ornam> element.
  */
 class Ornam : public ControlElement,
               public TextListInterface,

--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -45,6 +45,7 @@ public:
     FunctorCode VisitChord(Chord *chord) override;
     FunctorCode VisitFloatingObject(FloatingObject *floatingObject) override;
     FunctorCode VisitKeySig(KeySig *keySig) override;
+    FunctorCode VisitRepeatMark(RepeatMark *repeatMark) override;
     FunctorCode VisitRunningElement(RunningElement *runningElement) override;
     FunctorCode VisitScore(Score *score) override;
     ///@}

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -1,0 +1,96 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        repeatmark.h
+// Author:      Laurent Pugin
+// Created:     2023
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_REPEATMARK_H__
+#define __VRV_REPEATMARK_H__
+
+#include "atts_cmn.h"
+#include "atts_externalsymbols.h"
+#include "controlelement.h"
+#include "textdirinterface.h"
+#include "timeinterface.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// RepeatMark
+//----------------------------------------------------------------------------
+
+/**
+ * This class models the MEI <ornam> element.
+ */
+class RepeatMark : public ControlElement,
+                   public TextListInterface,
+                   public TextDirInterface,
+                   public TimePointInterface,
+                   public AttColor,
+                   public AttExtSymAuth,
+                   public AttExtSymNames {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method reset all attribute classes
+     */
+    ///@{
+    RepeatMark();
+    virtual ~RepeatMark();
+    Object *Clone() const override { return new RepeatMark(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "RepeatMark"; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    TextDirInterface *GetTextDirInterface() override { return vrv_cast<TextDirInterface *>(this); }
+    const TextDirInterface *GetTextDirInterface() const override { return vrv_cast<const TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return vrv_cast<TimePointInterface *>(this); }
+    const TimePointInterface *GetTimePointInterface() const override
+    {
+        return vrv_cast<const TimePointInterface *>(this);
+    }
+    ///@}
+
+    /**
+     * Add an element (text, rend. etc.) to a ornam.
+     * Only supported elements will be actually added to the child list.
+     */
+    bool IsSupportedChild(Object *object) override;
+
+    /**
+     * Get the SMuFL glyph for the repeatMark based on func or glyph.num
+     */
+    char32_t GetMarkGlyph() const;
+
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    //
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -29,7 +29,8 @@ class RepeatMark : public ControlElement,
                    public TimePointInterface,
                    public AttColor,
                    public AttExtSymAuth,
-                   public AttExtSymNames {
+                   public AttExtSymNames,
+                   public AttRepeatMarkLog {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/resetfunctor.h
+++ b/include/vrv/resetfunctor.h
@@ -61,6 +61,7 @@ public:
     FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitMRest(MRest *mRest) override;
     FunctorCode VisitNote(Note *note) override;
+    FunctorCode VisitRepeatMark(RepeatMark *repeatMark) override;
     FunctorCode VisitRest(Rest *rest) override;
     FunctorCode VisitSection(Section *section) override;
     FunctorCode VisitSlur(Slur *slur) override;

--- a/include/vrv/savefunctor.h
+++ b/include/vrv/savefunctor.h
@@ -54,6 +54,8 @@ public:
     FunctorCode VisitObjectEnd(Object *object) override;
     FunctorCode VisitRunningElement(RunningElement *runningElement) override;
     FunctorCode VisitRunningElementEnd(RunningElement *runningElement) override;
+    FunctorCode VisitText(Text *text) override;
+    FunctorCode VisitTextEnd(Text *text) override;
     FunctorCode VisitTupletBracket(TupletBracket *tupletBracket) override;
     FunctorCode VisitTupletBracketEnd(TupletBracket *tupletBracket) override;
     FunctorCode VisitTupletNum(TupletNum *tupletNum) override;

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -45,6 +45,14 @@ public:
     ///@}
 
     /**
+     * @name Setter and getter of the generated flag
+     */
+    ///@{
+    bool IsGenerated() const { return m_isGenerated; }
+    void IsGenerated(bool isGenerated) { m_isGenerated = isGenerated; }
+    ///@}
+
+    /**
      * Interface for class functor visitation
      */
     ///@{
@@ -63,6 +71,10 @@ protected:
     std::u32string m_text;
 
 private:
+    /**
+     * Flag indicating whether or not the text content was generated
+     */
+    bool m_isGenerated;
 };
 
 } // namespace vrv

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -67,6 +67,7 @@ class PgHead2;
 class PitchInflection;
 class Reh;
 class Rend;
+class RepeatMark;
 class RunningElement;
 class Slur;
 class Staff;
@@ -427,7 +428,7 @@ protected:
         char32_t endGlyph, int x, int y, int height, bool cueSize);
     void DrawBreath(DeviceContext *dc, Breath *breath, Measure *measure, System *system);
     void DrawCaesura(DeviceContext *dc, Caesura *caesura, Measure *measure, System *system);
-    void DrawDirOrOrnam(DeviceContext *dc, ControlElement *element, Measure *measure, System *system);
+    void DrawControlElementText(DeviceContext *dc, ControlElement *element, Measure *measure, System *system);
     void DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *system);
     void DrawDynamSymbolOnly(DeviceContext *dc, Staff *staff, Dynam *dynam, const std::u32string &dynamSymbol,
         data_HORIZONTALALIGNMENT alignment, TextDrawingParams &params);
@@ -437,6 +438,7 @@ protected:
     void DrawMordent(DeviceContext *dc, Mordent *mordent, Measure *measure, System *system);
     void DrawPedal(DeviceContext *dc, Pedal *pedal, Measure *measure, System *system);
     void DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system);
+    void DrawRepeatMark(DeviceContext *dc, RepeatMark *repeatMark, Measure *measure, System *system);
     void DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *system);
     void DrawTrill(DeviceContext *dc, Trill *trill, Measure *measure, System *system);
     void DrawTurn(DeviceContext *dc, Turn *turn, Measure *measure, System *system);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -198,6 +198,7 @@ enum ClassId : uint16_t {
     PHRASE,
     PITCHINFLECTION,
     REH,
+    REPEATMARK,
     SLUR,
     TEMPO,
     TIE,

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -214,6 +214,9 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
     adjustFloatingPositionerGrps.SetPlace(STAFFREL_below);
     system->m_systemAligner.Process(adjustFloatingPositionerGrps);
 
+    m_classId = REPEATMARK;
+    system->m_systemAligner.Process(*this);
+
     m_classId = TEMPO;
     system->m_systemAligner.Process(*this);
 

--- a/src/adjustxoverflowfunctor.cpp
+++ b/src/adjustxoverflowfunctor.cpp
@@ -32,7 +32,7 @@ AdjustXOverflowFunctor::AdjustXOverflowFunctor(int margin) : Functor()
 
 FunctorCode AdjustXOverflowFunctor::VisitControlElement(ControlElement *controlElement)
 {
-    if (!controlElement->Is({ DIR, DYNAM, ORNAM, TEMPO })) {
+    if (!controlElement->Is({ DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -82,7 +82,7 @@ data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment() const
 data_STAFFREL ControlElement::GetLayerPlace(data_STAFFREL defaultValue) const
 {
     // Do this only for the following elements
-    if (!this->Is({ TRILL, MORDENT, ORNAM, TURN })) return defaultValue;
+    if (!this->Is({ TRILL, MORDENT, ORNAM, REPEATMARK, TURN })) return defaultValue;
 
     const TimePointInterface *interface = this->GetTimePointInterface();
     assert(interface);

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -33,6 +33,7 @@
 #include "pedal.h"
 #include "pitchinflection.h"
 #include "reh.h"
+#include "repeatmark.h"
 #include "slur.h"
 #include "staff.h"
 #include "tempo.h"
@@ -313,6 +314,13 @@ FloatingPositioner::FloatingPositioner(FloatingObject *object, StaffAlignment *a
         assert(reh);
         // reh above by default
         m_place = (reh->GetPlace() != STAFFREL_NONE) ? reh->GetPlace() : STAFFREL_above;
+    }
+    else if (object->Is(REPEATMARK)) {
+        RepeatMark *repeatMark = vrv_cast<RepeatMark *>(object);
+        assert(repeatMark);
+        // repeatMark above by default
+        m_place = (repeatMark->GetPlace() != STAFFREL_NONE) ? repeatMark->GetPlace()
+                                                            : repeatMark->GetLayerPlace(STAFFREL_above);
     }
     else if (object->Is(TEMPO)) {
         Tempo *tempo = vrv_cast<Tempo *>(object);

--- a/src/functorinterface.cpp
+++ b/src/functorinterface.cpp
@@ -89,6 +89,7 @@
 #include "proport.h"
 #include "reh.h"
 #include "rend.h"
+#include "repeatmark.h"
 #include "rest.h"
 #include "sb.h"
 #include "score.h"
@@ -692,6 +693,16 @@ FunctorCode FunctorInterface::VisitReh(Reh *reh)
 FunctorCode FunctorInterface::VisitRehEnd(Reh *reh)
 {
     return this->VisitControlElementEnd(reh);
+}
+
+FunctorCode FunctorInterface::VisitRepeatMark(RepeatMark *repeatMark)
+{
+    return this->VisitControlElement(repeatMark);
+}
+
+FunctorCode FunctorInterface::VisitRepeatMarkEnd(RepeatMark *repeatMark)
+{
+    return this->VisitControlElementEnd(repeatMark);
 }
 
 FunctorCode FunctorInterface::VisitSlur(Slur *slur)
@@ -1966,6 +1977,16 @@ FunctorCode ConstFunctorInterface::VisitReh(const Reh *reh)
 FunctorCode ConstFunctorInterface::VisitRehEnd(const Reh *reh)
 {
     return this->VisitControlElementEnd(reh);
+}
+
+FunctorCode ConstFunctorInterface::VisitRepeatMark(const RepeatMark *repeatMark)
+{
+    return this->VisitControlElement(repeatMark);
+}
+
+FunctorCode ConstFunctorInterface::VisitRepeatMarkEnd(const RepeatMark *repeatMark)
+{
+    return this->VisitControlElementEnd(repeatMark);
 }
 
 FunctorCode ConstFunctorInterface::VisitSlur(const Slur *slur)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3381,7 +3381,7 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         }
     }
     // filter for dir or tempo
-    else if (filterParent->Is({ DIR, ORNAM, TEMPO })) {
+    else if (filterParent->Is({ DIR, ORNAM, REPEATMARK, TEMPO })) {
         if (element == "") {
             return true;
         }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -112,8 +112,8 @@
 #include "ref.h"
 #include "reg.h"
 #include "reh.h"
-#include "repeatmark.h"
 #include "rend.h"
+#include "repeatmark.h"
 #include "rest.h"
 #include "restore.h"
 #include "sb.h"
@@ -2188,6 +2188,7 @@ void MEIOutput::WriteRepeatMark(pugi::xml_node currentNode, RepeatMark *repeatMa
     repeatMark->WriteColor(currentNode);
     repeatMark->WriteExtSymAuth(currentNode);
     repeatMark->WriteExtSymNames(currentNode);
+    repeatMark->WriteRepeatMarkLog(currentNode);
 }
 
 void MEIOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
@@ -5812,6 +5813,7 @@ bool MEIInput::ReadRepeatMark(Object *parent, pugi::xml_node repeatMark)
     vrvRepeatMark->ReadColor(repeatMark);
     vrvRepeatMark->ReadExtSymAuth(repeatMark);
     vrvRepeatMark->ReadExtSymNames(repeatMark);
+    vrvRepeatMark->ReadRepeatMarkLog(repeatMark);
 
     parent->AddChild(vrvRepeatMark);
     this->ReadUnsupportedAttr(repeatMark, vrvRepeatMark);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -112,6 +112,7 @@
 #include "ref.h"
 #include "reg.h"
 #include "reh.h"
+#include "repeatmark.h"
 #include "rend.h"
 #include "rest.h"
 #include "restore.h"
@@ -549,6 +550,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
     else if (object->Is(REH)) {
         m_currentNode = m_currentNode.append_child("reh");
         this->WriteReh(m_currentNode, vrv_cast<Reh *>(object));
+    }
+    else if (object->Is(REPEATMARK)) {
+        m_currentNode = m_currentNode.append_child("repeatMark");
+        this->WriteRepeatMark(m_currentNode, vrv_cast<RepeatMark *>(object));
     }
     else if (object->Is(SLUR)) {
         m_currentNode = m_currentNode.append_child("slur");
@@ -2171,6 +2176,18 @@ void MEIOutput::WriteReh(pugi::xml_node currentNode, Reh *reh)
     reh->WriteColor(currentNode);
     reh->WriteLang(currentNode);
     reh->WriteVerticalGroup(currentNode);
+}
+
+void MEIOutput::WriteRepeatMark(pugi::xml_node currentNode, RepeatMark *repeatMark)
+{
+    assert(repeatMark);
+
+    this->WriteControlElement(currentNode, repeatMark);
+    this->WriteTextDirInterface(currentNode, repeatMark);
+    this->WriteTimePointInterface(currentNode, repeatMark);
+    repeatMark->WriteColor(currentNode);
+    repeatMark->WriteExtSymAuth(currentNode);
+    repeatMark->WriteExtSymNames(currentNode);
 }
 
 void MEIOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
@@ -5341,6 +5358,9 @@ bool MEIInput::ReadMeasureChildren(Object *parent, pugi::xml_node parentNode)
         else if (currentName == "reh") {
             success = this->ReadReh(parent, current);
         }
+        else if (currentName == "repeatMark") {
+            success = this->ReadRepeatMark(parent, current);
+        }
         else if (currentName == "slur") {
             success = this->ReadSlur(parent, current);
         }
@@ -5780,6 +5800,22 @@ bool MEIInput::ReadReh(Object *parent, pugi::xml_node reh)
     parent->AddChild(vrvReh);
     this->ReadUnsupportedAttr(reh, vrvReh);
     return this->ReadTextChildren(vrvReh, reh, vrvReh);
+}
+
+bool MEIInput::ReadRepeatMark(Object *parent, pugi::xml_node repeatMark)
+{
+    RepeatMark *vrvRepeatMark = new RepeatMark();
+    this->ReadControlElement(repeatMark, vrvRepeatMark);
+
+    this->ReadTextDirInterface(repeatMark, vrvRepeatMark);
+    this->ReadTimePointInterface(repeatMark, vrvRepeatMark);
+    vrvRepeatMark->ReadColor(repeatMark);
+    vrvRepeatMark->ReadExtSymAuth(repeatMark);
+    vrvRepeatMark->ReadExtSymNames(repeatMark);
+
+    parent->AddChild(vrvRepeatMark);
+    this->ReadUnsupportedAttr(repeatMark, vrvRepeatMark);
+    return this->ReadTextChildren(vrvRepeatMark, repeatMark, vrvRepeatMark);
 }
 
 bool MEIInput::ReadSlur(Object *parent, pugi::xml_node slur)

--- a/src/ornam.cpp
+++ b/src/ornam.cpp
@@ -60,7 +60,6 @@ void Ornam::Reset()
     this->ResetExtSymAuth();
     this->ResetExtSymNames();
     this->ResetOrnamentAccid();
-    this->ResetPlacementRelStaff();
 }
 
 bool Ornam::IsSupportedChild(Object *child)

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -88,7 +88,7 @@ FunctorCode PrepareDataInitializationFunctor::VisitRepeatMark(RepeatMark *repeat
     // Call parent one too
     this->VisitControlElement(repeatMark);
 
-    if (repeatMark->GetChildCount() == 0) {
+    if (repeatMark->GetChildCount() == 0 && repeatMark->HasFunc() && repeatMark->GetFunc() == repeatMarkLog_FUNC_fine) {
         Text *fine = new Text();
         fine->IsGenerated(true);
         fine->SetText(U"Fine");

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -27,6 +27,7 @@
 #include "pedal.h"
 #include "plistinterface.h"
 #include "reh.h"
+#include "repeatmark.h"
 #include "rest.h"
 #include "runningelement.h"
 #include "score.h"
@@ -38,6 +39,7 @@
 #include "system.h"
 #include "tabdursym.h"
 #include "tabgrp.h"
+#include "text.h"
 #include "timestamp.h"
 #include "tuplet.h"
 #include "turn.h"
@@ -77,6 +79,21 @@ FunctorCode PrepareDataInitializationFunctor::VisitKeySig(KeySig *keySig)
 {
     // Clear and regenerate attribute children
     keySig->GenerateKeyAccidAttribChildren();
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode PrepareDataInitializationFunctor::VisitRepeatMark(RepeatMark *repeatMark)
+{
+    // Call parent one too
+    this->VisitControlElement(repeatMark);
+
+    if (repeatMark->GetChildCount() == 0) {
+        Text *fine = new Text();
+        fine->IsGenerated(true);
+        fine->SetText(U"Fine");
+        repeatMark->AddChild(fine);
+    }
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -37,12 +37,14 @@ RepeatMark::RepeatMark()
     , AttColor()
     , AttExtSymAuth()
     , AttExtSymNames()
+    , AttRepeatMarkLog()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_EXTSYMAUTH);
     this->RegisterAttClass(ATT_EXTSYMNAMES);
+    this->RegisterAttClass(ATT_REPEATMARKLOG);
 
     this->Reset();
 }
@@ -57,6 +59,7 @@ void RepeatMark::Reset()
     this->ResetColor();
     this->ResetExtSymAuth();
     this->ResetExtSymNames();
+    this->ResetRepeatMarkLog();
 }
 
 bool RepeatMark::IsSupportedChild(Object *child)

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -92,7 +92,13 @@ char32_t RepeatMark::GetMarkGlyph() const
         if (NULL != resources->GetGlyph(code)) return code;
     }
 
-    return SMUFL_E567_ornamentTurn;
+    switch (this->GetFunc()) {
+        case (repeatMarkLog_FUNC_coda): return SMUFL_E048_coda;
+        case (repeatMarkLog_FUNC_segno): return SMUFL_E047_segno;
+        case (repeatMarkLog_FUNC_daCapo): return SMUFL_E046_daCapo;
+        case (repeatMarkLog_FUNC_dalSegno): return SMUFL_E045_dalSegno;
+        default: return SMUFL_E047_segno;
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -1,0 +1,119 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        repeatmark.cpp
+// Author:      Laurent Pugin
+// Created:     2023
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "repeatmark.h"
+
+//----------------------------------------------------------------------------
+
+#include <cassert>
+
+//----------------------------------------------------------------------------
+
+#include "editorial.h"
+#include "functor.h"
+#include "layerelement.h"
+#include "resources.h"
+#include "smufl.h"
+#include "symbol.h"
+#include "text.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// RepeatMark
+//----------------------------------------------------------------------------
+
+static const ClassRegistrar<RepeatMark> s_factory("repeatMark", REPEATMARK);
+
+RepeatMark::RepeatMark()
+    : ControlElement(REPEATMARK, "repeatMark-")
+    , TextListInterface()
+    , TextDirInterface()
+    , TimePointInterface()
+    , AttColor()
+    , AttExtSymAuth()
+    , AttExtSymNames()
+{
+    this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
+    this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
+    this->RegisterAttClass(ATT_COLOR);
+    this->RegisterAttClass(ATT_EXTSYMAUTH);
+    this->RegisterAttClass(ATT_EXTSYMNAMES);
+
+    this->Reset();
+}
+
+RepeatMark::~RepeatMark() {}
+
+void RepeatMark::Reset()
+{
+    ControlElement::Reset();
+    TextDirInterface::Reset();
+    TimePointInterface::Reset();
+    this->ResetColor();
+    this->ResetExtSymAuth();
+    this->ResetExtSymNames();
+}
+
+bool RepeatMark::IsSupportedChild(Object *child)
+{
+    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
+        assert(dynamic_cast<TextElement *>(child));
+    }
+    else if (child->IsEditorialElement()) {
+        assert(dynamic_cast<EditorialElement *>(child));
+    }
+    else {
+        return false;
+    }
+    return true;
+}
+
+char32_t RepeatMark::GetMarkGlyph() const
+{
+    const Resources *resources = this->GetDocResources();
+    if (!resources) return 0;
+
+    // If there is glyph.num, prioritize it
+    if (this->HasGlyphNum()) {
+        char32_t code = this->GetGlyphNum();
+        if (NULL != resources->GetGlyph(code)) return code;
+    }
+    // If there is glyph.name (second priority)
+    else if (this->HasGlyphName()) {
+        char32_t code = resources->GetGlyphCode(this->GetGlyphName());
+        if (NULL != resources->GetGlyph(code)) return code;
+    }
+
+    return SMUFL_E567_ornamentTurn;
+}
+
+//----------------------------------------------------------------------------
+// RepeatMark functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode RepeatMark::Accept(Functor &functor)
+{
+    return functor.VisitRepeatMark(this);
+}
+
+FunctorCode RepeatMark::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitRepeatMark(this);
+}
+
+FunctorCode RepeatMark::AcceptEnd(Functor &functor)
+{
+    return functor.VisitRepeatMarkEnd(this);
+}
+
+FunctorCode RepeatMark::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitRepeatMarkEnd(this);
+}
+
+} // namespace vrv

--- a/src/resetfunctor.cpp
+++ b/src/resetfunctor.cpp
@@ -24,6 +24,7 @@
 #include "mrest.h"
 #include "octave.h"
 #include "page.h"
+#include "repeatmark.h"
 #include "rest.h"
 #include "runningelement.h"
 #include "section.h"
@@ -306,6 +307,16 @@ FunctorCode ResetDataFunctor::VisitNote(Note *note)
     note->SetFlippedNotehead(false);
     note->SetStemSameasNote(NULL);
     note->SetStemSameasRole(SAMEAS_NONE);
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode ResetDataFunctor::VisitRepeatMark(RepeatMark *repeatMark)
+{
+    // Call parent one too
+    this->VisitControlElement(repeatMark);
+
+    // For now doing nothing, but we should eventually remove generated text when the @func is not 'fine' anymore
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/savefunctor.cpp
+++ b/src/savefunctor.cpp
@@ -14,6 +14,7 @@
 #include "mdiv.h"
 #include "mnum.h"
 #include "runningelement.h"
+#include "text.h"
 
 //----------------------------------------------------------------------------
 
@@ -146,6 +147,26 @@ FunctorCode SaveFunctor::VisitRunningElementEnd(RunningElement *runningElement)
     }
     else {
         return this->VisitObjectEnd(runningElement);
+    }
+}
+
+FunctorCode SaveFunctor::VisitText(Text *text)
+{
+    if (text->IsGenerated()) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return this->VisitObject(text);
+    }
+}
+
+FunctorCode SaveFunctor::VisitTextEnd(Text *text)
+{
+    if (text->IsGenerated()) {
+        return FUNCTOR_SIBLINGS;
+    }
+    else {
+        return this->VisitObjectEnd(text);
     }
 }
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -33,6 +33,8 @@ Text::~Text() {}
 void Text::Reset()
 {
     TextElement::Reset();
+
+    m_isGenerated = false;
 }
 
 FunctorCode Text::Accept(Functor &functor)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2500,11 +2500,6 @@ void View::DrawRepeatMark(DeviceContext *dc, RepeatMark *repeatMark, Measure *me
 
         const int y = repeatMark->GetDrawingY();
 
-        const int turnHeight = (symbolDef) ? symbolDef->GetSymbolHeight(m_doc, staffSize, false)
-                                           : m_doc->GetGlyphHeight(code, staffSize, false);
-        const int turnWidth = (symbolDef) ? symbolDef->GetSymbolWidth(m_doc, staffSize, false)
-                                          : m_doc->GetGlyphWidth(code, staffSize, false);
-
         dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, false));
 
         if (symbolDef) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -2462,7 +2462,7 @@ void View::DrawRepeatMark(DeviceContext *dc, RepeatMark *repeatMark, Measure *me
     assert(measure);
     assert(repeatMark);
 
-    // Cannot draw a turn that has no start position
+    // Cannot draw a mark that has no start position
     if (!repeatMark->GetStart()) return;
 
     if (repeatMark->GetChildCount() > 0) {
@@ -2477,13 +2477,13 @@ void View::DrawRepeatMark(DeviceContext *dc, RepeatMark *repeatMark, Measure *me
         symbolDef = repeatMark->GetAltSymbolDef();
     }
 
-    int x = repeatMark->GetStart()->GetDrawingX() + repeatMark->GetStart()->GetDrawingRadius(m_doc);
+    const int x = repeatMark->GetStart()->GetDrawingX() + repeatMark->GetStart()->GetDrawingRadius(m_doc);
 
     // set norm as default
-    int code = repeatMark->GetMarkGlyph();
+    const int code = repeatMark->GetMarkGlyph();
 
     data_HORIZONTALALIGNMENT alignment = HORIZONTALALIGNMENT_center;
-    // center the turn only with @startid
+    // center the mark only with @startid
     if (repeatMark->GetStart()->Is(TIMESTAMP_ATTR)) {
         alignment = HORIZONTALALIGNMENT_left;
     }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -489,7 +489,7 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
     }
 
     // special case where we want to replace some unicode music points to SMuFL
-    if (text->GetFirstAncestor(DIR) || text->GetFirstAncestor(ORNAM)) {
+    if (text->GetFirstAncestor(DIR) || text->GetFirstAncestor(ORNAM) || text->GetFirstAncestor(REPEATMARK)) {
         this->DrawDirString(dc, text->GetText(), params);
     }
     else if (text->GetFirstAncestor(DYNAM)) {


### PR DESCRIPTION
The PR adds support for the newly added MEI element `<repeatMark>`.

Default rendering relies on `@func`

<img width="1027" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/87b447af-34a2-45a9-9a5d-7ae45ef51362">

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Repeat marks example</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2023-06-13" />
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>Verovio supports repeat marks encoded with repeatMark@func.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.16.0" label="1">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef keysig="4f" meter.sym="common">
                        <staffGrp>
                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure n="1">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="coda"/>
                        </measure>
                        <measure n="4">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="segno"/>
                        </measure>
                        <measure n="2">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="daCapo"/>
                        </measure>
                        <measure n="5">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="dalSegno"/>
                        </measure>
                        <measure n="5" right="dbl">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="fine"/>
                        </measure>
                        <measure right="end" n="2">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>

```

</details>

Custom rendering can be achieved with `@glyph.*` attributes or with explicit textual content

<img width="1027" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/de5db504-99b4-4ad5-9ab5-392934fd47bd">

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Repeat marks with symbols and text example</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2023-06-13" />
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>Verovio supports repeat marks encoded symbols or text content.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="3.16.0" label="1">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef keysig="4f" meter.sym="common">
                        <staffGrp>
                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure n="1">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="coda" glyph.auth="smufl" glyph.name="codaSquare"/>
                        </measure>
                        <measure n="2">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="segno" glyph.auth="smufl" glyph.num="U+E04A"/>
                        </measure>
                        <measure n="3">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="daCapo"><rend fontstyle="italic">Da capo al fine</rend></repeatMark>
                        </measure>
                        <measure n="4">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                        </measure>
                        <measure n="5">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="dalSegno">Dal <symbol glyph.auth="smufl" glyph.name="segno" color="orange"/> al fine</repeatMark>
                        </measure>
                        <measure n="6">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                        </measure>
                        <measure n="7" right="dbl">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                            <repeatMark tstamp="0.0" staff="1" func="fine">(Fine)</repeatMark>
                        </measure>
                        <measure right="end" n="8">
                            <staff n="1">
                                <layer n="1">
                                    <mRest />
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```

</details>

