### PR TITLE
Humdrum: Fix key labels for harms

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8752,8 +8752,8 @@ void HumdrumInput::addHarmLabel(
     std::string tempChar;
     for (int i = 0; i < (int)label.size(); i++) {
         switch (label[i]) {
-            case '#': output += output += U"\u266f"; break; // unicode sharp
-            case '-': output += output += U"\u266d"; break; // unicode flat
+            case '#': output += U"\u266f"; break; // unicode sharp
+            case '-': output += U"\u266d"; break; // unicode flat
             default: tempChar = label[i]; output += UTF8to32(tempChar);
         }
     }


### PR DESCRIPTION
Before:

<img width="1034" alt="Bildschirmfoto 2023-06-16 um 12 03 12" src="https://github.com/rism-digital/verovio/assets/865594/0a5ba295-e306-4782-b8a5-34b6d5f5eb96">

After:

<img width="1033" alt="Bildschirmfoto 2023-06-16 um 12 02 38" src="https://github.com/rism-digital/verovio/assets/865594/ff1438ac-16dd-4f8d-a181-138763d2c500">

Demo data:

```
**kern	**deg
*	*arr
*	*circ
=	=
*C-:	*C-:
4c	1+
*C:	*C:
4c	1
*C#:	*C#:
4c	1-
=	=
*D-:	*D-:
4c	7
*D:	*D:
4c	7-
*D#:	*D#:
4c	7--
=	=
*E-:	*E-:
4c	6
*E:	*E:
4c	6-
*E#:	*E#:
4c	6--
=	=
*F-:	*F-:
4c	5+
*F:	*F:
4c	5
*F#:	*F#:
4c	5-
=	=
*G-:	*G-:
4c	4+
*G:	*G:
4c	4
*G#:	*G#:
4c	4-
=	=
*A-:	*A-:
4c	3
*A:	*A:
4c	3-
*A#:	*A#:
4c	3--
=	=
*B-:	*B-:
4c	2
*B:	*B:
4c	2-
*B#:	*B#:
4c	2--
=	=
*-	*-

```