### PR TITLE
Restructure accidental adjustment

### DIFF
--- a/include/vrv/adjustaccidxfunctor.h
+++ b/include/vrv/adjustaccidxfunctor.h
@@ -46,12 +46,30 @@ public:
 protected:
     //
 private:
-    //
+    /*
+     * Get the accidentals for adjustment
+     */
+    std::vector<Accid *> GetAccidentalsForAdjustment(AlignmentReference *alignmentReference) const;
+
+    /**
+     * Sets whether the accidental should be aligned with all elements of the alignmentReference
+     * or elements from the same layer only.
+     */
+    void SetAccidLayerAlignment(Accid *accid, const AlignmentReference *alignmentReference) const;
+
+    /**
+     * Adjust an accidental horizontally
+     */
+    void AdjustAccidWithSpace(Accid *accid, AlignmentReference *alignmentReference, int staffSize);
+
 public:
     //
 private:
     // The current measure
     Measure *m_currentMeasure;
+
+    // The accidentals that were already adjusted
+    std::set<Accid *> m_adjustedAccids;
 };
 
 } // namespace vrv

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -326,10 +326,10 @@ public:
     bool HasCrossStaffElements() const;
 
     /**
-     * Set whether accidentals should be aligned with all elements of alignmentReference or elements from same layer
-     * only. Set for each accidental in accidSpace separately
+     * Sets whether the accidental should be aligned with all elements of the alignmentReference
+     * or elements from same the layer only.
      */
-    void SetAccidLayerAlignment();
+    void SetAccidLayerAlignment(Accid *accid);
 
     //----------//
     // Functors //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -290,16 +290,6 @@ public:
     void AddChild(Object *object) override;
 
     /**
-     * Get the accidentals for spacing
-     */
-    std::vector<Accid *> GetAccidSpace();
-
-    /**
-     * See AdjustAccidXFunctor
-     */
-    void AdjustAccidWithAccidSpace(Accid *accid, const Doc *doc, int staffSize, std::set<Accid *> &adjustedAccids);
-
-    /**
      * Return true if one of objects overlaps with accidentals from current reference (i.e. if there are accidentals)
      */
     bool HasAccidVerticalOverlap(const ArrayOfConstObjects &objects) const;
@@ -313,12 +303,6 @@ public:
      * Return true if the reference has elements from cross-staff.
      */
     bool HasCrossStaffElements() const;
-
-    /**
-     * Sets whether the accidental should be aligned with all elements of the alignmentReference
-     * or elements from same the layer only.
-     */
-    void SetAccidLayerAlignment(Accid *accid);
 
     //----------//
     // Functors //

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -169,12 +169,6 @@ public:
     std::pair<int, int> GetAlignmentTopBottom() const;
 
     /**
-     * Add an accidental to the accidSpace of the AlignmentReference holding it.
-     * The Alignment has to have a AlignmentReference holding it.
-     */
-    void AddToAccidSpace(Accid *accid);
-
-    /**
      * Return true if there is vertical overlap with accidentals from another alignment for specific staffN
      */
     bool HasAccidVerticalOverlap(const Alignment *otherAlignment, int staffN) const;
@@ -296,11 +290,6 @@ public:
     void AddChild(Object *object) override;
 
     /**
-     * Add an accidental to the accidSpace of the AlignmentReference.
-     */
-    void AddToAccidSpace(Accid *accid);
-
-    /**
      * Get the accidentals for spacing
      */
     std::vector<Accid *> GetAccidSpace();
@@ -348,11 +337,7 @@ public:
 private:
     //
 public:
-    /**
-     * The accid space of the AlignmentReference.
-     */
-    std::vector<Accid *> m_accidSpace;
-
+    //
 private:
     /**
      *

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -301,6 +301,11 @@ public:
     void AddToAccidSpace(Accid *accid);
 
     /**
+     * Get the accidentals for spacing
+     */
+    std::vector<Accid *> GetAccidSpace();
+
+    /**
      * See AdjustAccidXFunctor
      */
     void AdjustAccidWithAccidSpace(Accid *accid, const Doc *doc, int staffSize, std::set<Accid *> &adjustedAccids);

--- a/src/adjustaccidxfunctor.cpp
+++ b/src/adjustaccidxfunctor.cpp
@@ -35,28 +35,29 @@ FunctorCode AdjustAccidXFunctor::VisitAlignment(Alignment *alignment)
 
 FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *alignmentReference)
 {
-    std::vector<Accid *> accidSpace = alignmentReference->GetAccidSpace();
-    if (accidSpace.empty()) return FUNCTOR_SIBLINGS;
+    m_adjustedAccids.clear();
+
+    std::vector<Accid *> accids = this->GetAccidentalsForAdjustment(alignmentReference);
+    if (accids.empty()) return FUNCTOR_SIBLINGS;
 
     assert(m_doc);
     StaffDef *staffDef = m_doc->GetCurrentScoreDef()->GetStaffDef(alignmentReference->GetN());
     int staffSize = (staffDef && staffDef->HasScale()) ? staffDef->GetScale() : 100;
 
-    std::sort(accidSpace.begin(), accidSpace.end(), AccidSpaceSort());
+    std::sort(accids.begin(), accids.end(), AccidSpaceSort());
     // process accid layer alignment
-    for (Accid *accid : accidSpace) {
-        alignmentReference->SetAccidLayerAlignment(accid);
+    for (Accid *accid : accids) {
+        this->SetAccidLayerAlignment(accid, alignmentReference);
     }
 
     // Detect accids which are an octave apart => they will be grouped together in the multiset
     std::multiset<Accid *, AccidOctaveSort> octaveEquivalence;
-    std::copy(accidSpace.begin(), accidSpace.end(), std::inserter(octaveEquivalence, octaveEquivalence.begin()));
+    std::copy(accids.begin(), accids.end(), std::inserter(octaveEquivalence, octaveEquivalence.begin()));
 
-    std::set<Accid *> adjustedAccids;
     // Align the octaves
-    for (Accid *accid : accidSpace) {
+    for (Accid *accid : accids) {
         // Skip any accid that was already adjusted
-        if (adjustedAccids.count(accid) > 0) continue;
+        if (m_adjustedAccids.count(accid) > 0) continue;
         auto range = octaveEquivalence.equal_range(accid);
         // Handle at least two octave accids without unisons
         int octaveAccidCount = 0;
@@ -70,7 +71,7 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
         // Now adjust the octave accids and store the left most position
         int minDrawingX = -VRV_UNSET;
         for (auto octaveIter = range.first; octaveIter != range.second; ++octaveIter) {
-            alignmentReference->AdjustAccidWithAccidSpace(*octaveIter, m_doc, staffSize, adjustedAccids);
+            this->AdjustAccidWithSpace(*octaveIter, alignmentReference, staffSize);
             minDrawingX = std::min(minDrawingX, (*octaveIter)->GetDrawingX());
         }
         // Finally, align the accidentals whenever the adjustment is not too large
@@ -86,26 +87,26 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
     }
 
     // Align accidentals for unison notes if any of them are present
-    for (Accid *accid : accidSpace) {
+    for (Accid *accid : accids) {
         if (accid->GetDrawingUnisonAccid() == NULL) continue;
         accid->SetDrawingXRel(accid->GetDrawingUnisonAccid()->GetDrawingXRel());
     }
 
-    const int count = (int)accidSpace.size();
+    const int count = (int)accids.size();
     const int middle = (count / 2) + (count % 2);
     // Zig-zag processing
     for (int i = 0, j = count - 1; i < middle; ++i, --j) {
         // top one - but skip if already adjusted (i.e. octaves)
-        if (adjustedAccids.count(accidSpace.at(i)) == 0) {
-            alignmentReference->AdjustAccidWithAccidSpace(accidSpace.at(i), m_doc, staffSize, adjustedAccids);
+        if (m_adjustedAccids.count(accids.at(i)) == 0) {
+            this->AdjustAccidWithSpace(accids.at(i), alignmentReference, staffSize);
         }
 
         // Break with odd number of elements once the middle is reached
         if (i == j) break;
 
         // bottom one - but skip if already adjusted
-        if (adjustedAccids.count(accidSpace.at(j)) == 0) {
-            alignmentReference->AdjustAccidWithAccidSpace(accidSpace.at(j), m_doc, staffSize, adjustedAccids);
+        if (m_adjustedAccids.count(accids.at(j)) == 0) {
+            this->AdjustAccidWithSpace(accids.at(j), alignmentReference, staffSize);
         }
     }
 
@@ -119,6 +120,64 @@ FunctorCode AdjustAccidXFunctor::VisitMeasure(Measure *measure)
     measure->m_measureAligner.Process(*this);
 
     return FUNCTOR_CONTINUE;
+}
+
+std::vector<Accid *> AdjustAccidXFunctor::GetAccidentalsForAdjustment(AlignmentReference *alignmentReference) const
+{
+    std::vector<Accid *> accidentals;
+    for (Object *child : alignmentReference->GetChildren()) {
+        if (child->Is(ACCID)) {
+            Accid *accid = vrv_cast<Accid *>(child);
+            if (accid->HasAccid()) accidentals.push_back(accid);
+        }
+    }
+    return accidentals;
+}
+
+void AdjustAccidXFunctor::SetAccidLayerAlignment(Accid *accid, const AlignmentReference *alignmentReference) const
+{
+    if (accid->IsAlignedWithSameLayer()) return;
+
+    const ArrayOfConstObjects &children = alignmentReference->GetChildren();
+    Note *parentNote = vrv_cast<Note *>(accid->GetFirstAncestor(NOTE));
+    const bool hasUnisonOverlap = std::any_of(children.begin(), children.end(), [parentNote](const Object *object) {
+        if (!object->Is(NOTE)) return false;
+        const Note *otherNote = vrv_cast<const Note *>(object);
+        // in case notes are in unison but have different accidentals
+        return parentNote && parentNote->IsUnisonWith(otherNote, true) && !parentNote->IsUnisonWith(otherNote, false);
+    });
+
+    if (!hasUnisonOverlap) return;
+
+    Chord *chord = parentNote->IsChordTone();
+    // no chord, so align only parent note
+    if (!chord) {
+        accid->IsAlignedWithSameLayer(true);
+        return;
+    }
+    // we have chord ancestor, so need to align all of its accidentals
+    ListOfObjects accidentals = chord->FindAllDescendantsByType(ACCID);
+    std::for_each(accidentals.begin(), accidentals.end(), [](Object *object) {
+        Accid *accid = vrv_cast<Accid *>(object);
+        accid->IsAlignedWithSameLayer(true);
+    });
+}
+
+void AdjustAccidXFunctor::AdjustAccidWithSpace(Accid *accid, AlignmentReference *alignmentReference, int staffSize)
+{
+    std::vector<Accid *> leftAccids;
+    const ArrayOfObjects &children = alignmentReference->GetChildren();
+
+    // bottom one
+    for (Object *child : children) {
+        // if accidental has unison overlap, ignore elements on other layers for overlap
+        if (accid->IsAlignedWithSameLayer() && (accid->GetFirstAncestor(LAYER) != child->GetFirstAncestor(LAYER)))
+            continue;
+        accid->AdjustX(dynamic_cast<LayerElement *>(child), m_doc, staffSize, leftAccids, m_adjustedAccids);
+    }
+
+    // Mark as adjusted (even if position was not altered)
+    m_adjustedAccids.insert(accid);
 }
 
 } // namespace vrv

--- a/src/adjustaccidxfunctor.cpp
+++ b/src/adjustaccidxfunctor.cpp
@@ -35,7 +35,7 @@ FunctorCode AdjustAccidXFunctor::VisitAlignment(Alignment *alignment)
 
 FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *alignmentReference)
 {
-    std::vector<Accid *> &accidSpace = alignmentReference->m_accidSpace;
+    std::vector<Accid *> accidSpace = alignmentReference->GetAccidSpace();
     if (accidSpace.empty()) return FUNCTOR_SIBLINGS;
 
     assert(m_doc);
@@ -44,7 +44,9 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
 
     std::sort(accidSpace.begin(), accidSpace.end(), AccidSpaceSort());
     // process accid layer alignment
-    alignmentReference->SetAccidLayerAlignment();
+    for (Accid *accid : accidSpace) {
+        alignmentReference->SetAccidLayerAlignment(accid);
+    }
 
     // Detect accids which are an octave apart => they will be grouped together in the multiset
     std::multiset<Accid *, AccidOctaveSort> octaveEquivalence;

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -46,22 +46,7 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitLayerElement(LayerElement *layerE
     if (layerElement->Is(ACCID)) {
         Accid *accid = vrv_cast<Accid *>(layerElement);
         assert(accid);
-        Note *note = vrv_cast<Note *>(accid->GetFirstAncestor(NOTE));
-        // We should probably also avoid to add editorial accidentals to the accid space
-        // However, since they are placed above by View::DrawNote it works without avoiding it
-        if (note) {
-            if (note->HasGraceAlignment()) {
-                note->GetGraceAlignment()->AddToAccidSpace(accid);
-            }
-            else {
-                accid->GetAlignment()->AddToAccidSpace(accid);
-            }
-        }
-        else if (accid->GetFirstAncestor(CUSTOS)) {
-            accid->GetAlignment()->AddToAccidSpace(
-                accid); // If this is not added, the accidental is drawn an octave below the custos
-        }
-        else {
+        if (!accid->GetFirstAncestor(NOTE) && !accid->GetFirstAncestor(CUSTOS)) {
             // do something for accid that are not children of a note - e.g., mensural?
             accid->SetDrawingYRel(staffY->CalcPitchPosYRel(m_doc, accid->CalcDrawingLoc(layerY, layerElementY)));
         }

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -735,18 +735,6 @@ std::pair<int, int> Alignment::GetAlignmentTopBottom() const
     return { min, max };
 }
 
-void Alignment::AddToAccidSpace(Accid *accid)
-{
-    assert(accid);
-
-    // Do not added them if no @accid (e.g., @accid.ges only)
-    if (!accid->HasAccid()) return;
-
-    AlignmentReference *reference = this->GetReferenceWithElement(accid);
-    assert(reference);
-    reference->AddToAccidSpace(accid);
-}
-
 int Alignment::HorizontalSpaceForDuration(
     double intervalTime, int maxActualDur, double spacingLinear, double spacingNonLinear)
 {
@@ -807,7 +795,6 @@ void AlignmentReference::Reset()
     Object::Reset();
     this->ResetNInteger();
 
-    m_accidSpace.clear();
     m_layerCount = 0;
 }
 
@@ -842,15 +829,6 @@ void AlignmentReference::AddChild(Object *child)
     assert(child->GetParent() && this->IsReferenceObject());
     children.push_back(child);
     Modify();
-}
-
-void AlignmentReference::AddToAccidSpace(Accid *accid)
-{
-    assert(accid);
-
-    if (std::find(m_accidSpace.begin(), m_accidSpace.end(), accid) != m_accidSpace.end()) return;
-
-    m_accidSpace.push_back(accid);
 }
 
 std::vector<Accid *> AlignmentReference::GetAccidSpace()

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -853,6 +853,18 @@ void AlignmentReference::AddToAccidSpace(Accid *accid)
     m_accidSpace.push_back(accid);
 }
 
+std::vector<Accid *> AlignmentReference::GetAccidSpace()
+{
+    std::vector<Accid *> accidentals;
+    for (Object *child : this->GetChildren()) {
+        if (child->Is(ACCID)) {
+            Accid *accid = vrv_cast<Accid *>(child);
+            if (accid->HasAccid()) accidentals.push_back(accid);
+        }
+    }
+    return accidentals;
+}
+
 void AlignmentReference::AdjustAccidWithAccidSpace(
     Accid *accid, const Doc *doc, int staffSize, std::set<Accid *> &adjustedAccids)
 {


### PR DESCRIPTION
This PR moves the code for accidental adjustment from `AlignmentReference` into the `AdjustAccidXFunctor`. We also get rid of the `m_accidSpace` container member which saves a bit of memory. No changes in behaviour expected.