### PR TITLE
Fix MIDI tempo

### DIFF
--- a/include/vrv/midifunctor.h
+++ b/include/vrv/midifunctor.h
@@ -118,7 +118,9 @@ public:
 protected:
     //
 private:
-    //
+    // Returns the current tempo with adjustment
+    double GetAdjustedTempo() const { return m_currentTempo * m_tempoAdjustment; }
+
 public:
     //
 private:

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -230,13 +230,13 @@ FunctorCode InitMaxMeasureDurationFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode InitMaxMeasureDurationFunctor::VisitMeasureEnd(Measure *measure)
 {
-    measure->SetCurrentTempo(m_currentTempo);
+    const double tempo = this->GetAdjustedTempo();
+    measure->SetCurrentTempo(tempo);
 
     const double scoreTimeIncrement
         = measure->m_measureAligner.GetRightAlignment()->GetTime() * m_multiRestFactor * DURATION_4 / DUR_MAX;
-    m_currentTempo = m_currentTempo * m_tempoAdjustment;
     m_currentScoreTime += scoreTimeIncrement;
-    m_currentRealTimeSeconds += scoreTimeIncrement * 60.0 / m_currentTempo;
+    m_currentRealTimeSeconds += scoreTimeIncrement * 60.0 / tempo;
     m_multiRestFactor = 1;
 
     return FUNCTOR_CONTINUE;

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -230,6 +230,8 @@ FunctorCode InitMaxMeasureDurationFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode InitMaxMeasureDurationFunctor::VisitMeasureEnd(Measure *measure)
 {
+    measure->SetCurrentTempo(m_currentTempo);
+
     const double scoreTimeIncrement
         = measure->m_measureAligner.GetRightAlignment()->GetTime() * m_multiRestFactor * DURATION_4 / DUR_MAX;
     m_currentTempo = m_currentTempo * m_tempoAdjustment;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -951,8 +951,6 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     KeySig *keySig = vrv_cast<KeySig *>(element);
     assert(keySig);
 
-    int x, y;
-
     Clef *clef = layer->GetClef(element);
     if (!clef) {
         keySig->SetEmptyBB();
@@ -981,7 +979,7 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
         return;
     }
 
-    x = element->GetDrawingX();
+    int x = element->GetDrawingX();
     // HARDCODED
     const int step = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * TEMP_KEYSIG_STEP;
 


### PR DESCRIPTION
This PR fixes some issues with the MIDI tempo that were introduced with the functor refactoring. Closes #3457 .
- Any values of `@midi.bpm` were ignored, since `Measure::SetCurrentTempo` was never called.
- The factor from the option `--midi-tempo-adjustment` was repeatedly applied in each measure. Thus the tempo became increasingly fast or slow.

The time map output from the example in the bug report should now be correct.
<details>
<summary> Show time map </summary>

```json
[
	{
		"on": [
			"note-L5F2",
			"note-L5F1" 
		],
		"qstamp": 0,
		"tempo": "20.000000",
		"tstamp": 0 
	},
	{
		"off": [
			"note-L5F2",
			"note-L5F1" 
		],
		"on": [
			"note-L6F2",
			"note-L6F1" 
		],
		"qstamp": 1,
		"tstamp": 3000 
	},
	{
		"off": [
			"note-L6F2",
			"note-L6F1" 
		],
		"on": [
			"note-L7F2",
			"note-L7F1" 
		],
		"qstamp": 2,
		"tstamp": 6000 
	},
	{
		"off": [
			"note-L7F2",
			"note-L7F1" 
		],
		"on": [
			"note-L8F2",
			"note-L8F1" 
		],
		"qstamp": 3,
		"tstamp": 9000 
	},
	{
		"off": [
			"note-L8F2",
			"note-L8F1" 
		],
		"on": [
			"note-L10F2",
			"note-L10F1" 
		],
		"qstamp": 4,
		"tstamp": 12000 
	},
	{
		"off": [
			"note-L10F2",
			"note-L10F1" 
		],
		"on": [
			"note-L11F2",
			"note-L11F1" 
		],
		"qstamp": 5,
		"tstamp": 15000 
	},
	{
		"off": [
			"note-L11F2",
			"note-L11F1" 
		],
		"on": [
			"note-L12F2",
			"note-L12F1" 
		],
		"qstamp": 6,
		"tstamp": 18000 
	},
	{
		"off": [
			"note-L12F2",
			"note-L12F1" 
		],
		"on": [
			"note-L13F2",
			"note-L13F1" 
		],
		"qstamp": 7,
		"tstamp": 21000 
	},
	{
		"off": [
			"note-L13F2",
			"note-L13F1" 
		],
		"qstamp": 8,
		"tstamp": 24000 
	} 
] 
```
</details>
