### PR TITLE
Set correct fontstyle for SMuFL text

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -7065,7 +7065,7 @@ bool MEIInput::ReadRend(Object *parent, pugi::xml_node rend)
     if (m_meiversion <= meiVersion_MEIVERSION_5_0_0_dev) {
         UpgradeRendTo_5_0_0(rend);
     }
-    
+
     Rend *vrvRend = new Rend();
     this->ReadTextElement(rend, vrvRend);
 
@@ -8112,7 +8112,6 @@ void MEIInput::UpgradeLayerElementTo_5_0_0(pugi::xml_node element)
         element.attribute("ulx").set_name("coord.x1");
     }
 }
-
 
 void MEIInput::UpgradeRendTo_5_0_0(pugi::xml_node element)
 {

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -950,6 +950,9 @@ void SvgDeviceContext::DrawText(
                 this->VrvTextFont();
                 textChild.append_attribute("font-family") = m_fontStack.top()->GetFaceName().c_str();
             }
+            if (m_fontStack.top()->GetStyle() == FONTSTYLE_normal) {
+                textChild.append_attribute("font-style") = "normal";
+            }
         }
         else {
             textChild.append_attribute("font-family") = m_fontStack.top()->GetFaceName().c_str();


### PR DESCRIPTION
Fixes #3459

NB: Looks like we always store this style in `FontInfo` for SMuFL text. Maybe just hardcode this in the svg output directly instead?