### PR TITLE
Split transpose functor

### DIFF
--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -67,9 +67,13 @@ private:
     //
 public:
     //
-private:
+protected:
     // The transposer
     Transposer *m_transposer;
+    // The current KeySig for staffN (ScoreDef key signatures are mapped to -1)
+    std::map<int, const KeySig *> m_keySigForStaffN;
+
+private:
     // The transposition to be applied
     std::string m_transposition;
     // The mdiv selected for transposition
@@ -78,8 +82,6 @@ private:
     std::list<std::string> m_currentMdivIDs;
     // Transpose to sounding pitch by evaluating @trans.semi ?
     bool m_transposeToSoundingPitch;
-    // The current KeySig for staffN (ScoreDef key signatures are mapped to -1)
-    std::map<int, const KeySig *> m_keySigForStaffN;
     // The transposition interval for staffN
     std::map<int, int> m_transposeIntervalForStaffN;
 };

--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -123,7 +123,9 @@ public:
 protected:
     //
 private:
-    //
+    // Update the current transposition
+    void UpdateTranspositionFromStaffN(const AttNInteger *staffN);
+
 public:
     //
 private:

--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -78,6 +78,56 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// TransposeSelectedMdivFunctor
+//----------------------------------------------------------------------------
+
+/**
+ * This class transposes the selected mdiv.
+ */
+class TransposeSelectedMdivFunctor : public TransposeFunctor {
+public:
+    /**
+     * @name Constructors, destructors
+     */
+    ///@{
+    TransposeSelectedMdivFunctor(Doc *doc, Transposer *transposer);
+    virtual ~TransposeSelectedMdivFunctor() = default;
+    ///@}
+
+    /*
+     * Abstract base implementation
+     */
+    bool ImplementsEndInterface() const override { return false; }
+
+    /*
+     * Setter for the selected Mdiv
+     */
+    void SetSelectedMdivID(const std::string &selectedID) { m_selectedMdivID = selectedID; }
+
+    /*
+     * Functor interface
+     */
+    ///@{
+    FunctorCode VisitMdiv(Mdiv *mdiv) override;
+    FunctorCode VisitPageMilestone(PageMilestoneEnd *pageMilestoneEnd) override;
+    FunctorCode VisitScore(Score *score) override;
+    FunctorCode VisitSystem(System *system) override;
+    ///@}
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    // The mdiv selected for transposition
+    std::string m_selectedMdivID;
+    // The list of current (nested) mdivs
+    std::list<std::string> m_currentMdivIDs;
+};
+
+//----------------------------------------------------------------------------
 // TransposeToSoundingPitchFunctor
 //----------------------------------------------------------------------------
 

--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -32,7 +32,7 @@ public:
     /*
      * Abstract base implementation
      */
-    bool ImplementsEndInterface() const override { return true; }
+    bool ImplementsEndInterface() const override { return false; }
 
     /*
      * Setter for various properties
@@ -40,7 +40,6 @@ public:
     ///@{
     void SetTransposition(const std::string &transposition) { m_transposition = transposition; }
     void SetSelectedMdivID(const std::string &selectedID) { m_selectedMdivID = selectedID; }
-    void SetTransposeToSoundingPitch() { m_transposeToSoundingPitch = true; }
     ///@}
 
     /*
@@ -54,10 +53,6 @@ public:
     FunctorCode VisitPageMilestone(PageMilestoneEnd *pageMilestoneEnd) override;
     FunctorCode VisitRest(Rest *rest) override;
     FunctorCode VisitScore(Score *score) override;
-    FunctorCode VisitScoreDef(ScoreDef *scoreDef) override;
-    FunctorCode VisitScoreDefEnd(ScoreDef *scoreDef) override;
-    FunctorCode VisitStaff(Staff *staff) override;
-    FunctorCode VisitStaffDef(StaffDef *staffDef) override;
     FunctorCode VisitSystem(System *system) override;
     ///@}
 
@@ -80,10 +75,6 @@ private:
     std::string m_selectedMdivID;
     // The list of current (nested) mdivs
     std::list<std::string> m_currentMdivIDs;
-    // Transpose to sounding pitch by evaluating @trans.semi ?
-    bool m_transposeToSoundingPitch;
-    // The transposition interval for staffN
-    std::map<int, int> m_transposeIntervalForStaffN;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -84,6 +84,51 @@ private:
     std::map<int, int> m_transposeIntervalForStaffN;
 };
 
+//----------------------------------------------------------------------------
+// TransposeToSoundingPitchFunctor
+//----------------------------------------------------------------------------
+
+/**
+ * This class transposes the content to sounding pitch (by evaluating @trans.semi).
+ */
+class TransposeToSoundingPitchFunctor : public TransposeFunctor {
+public:
+    /**
+     * @name Constructors, destructors
+     */
+    ///@{
+    TransposeToSoundingPitchFunctor(Doc *doc, Transposer *transposer);
+    virtual ~TransposeToSoundingPitchFunctor() = default;
+    ///@}
+
+    /*
+     * Abstract base implementation
+     */
+    bool ImplementsEndInterface() const override { return true; }
+
+    /*
+     * Functor interface
+     */
+    ///@{
+    FunctorCode VisitMdiv(Mdiv *mdiv) override;
+    FunctorCode VisitScore(Score *score) override;
+    FunctorCode VisitScoreDef(ScoreDef *scoreDef) override;
+    FunctorCode VisitScoreDefEnd(ScoreDef *scoreDef) override;
+    FunctorCode VisitStaff(Staff *staff) override;
+    FunctorCode VisitStaffDef(StaffDef *staffDef) override;
+    ///@}
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    // The transposition interval for staffN
+    std::map<int, int> m_transposeIntervalForStaffN;
+};
+
 } // namespace vrv
 
 #endif // __VRV_TRANSPOSEFUNCTOR_H__

--- a/include/vrv/transposefunctor.h
+++ b/include/vrv/transposefunctor.h
@@ -35,12 +35,9 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
-     * Setter for various properties
+     * Setter for the transposition
      */
-    ///@{
     void SetTransposition(const std::string &transposition) { m_transposition = transposition; }
-    void SetSelectedMdivID(const std::string &selectedID) { m_selectedMdivID = selectedID; }
-    ///@}
 
     /*
      * Functor interface
@@ -50,10 +47,8 @@ public:
     FunctorCode VisitKeySig(KeySig *keySig) override;
     FunctorCode VisitMdiv(Mdiv *mdiv) override;
     FunctorCode VisitNote(Note *note) override;
-    FunctorCode VisitPageMilestone(PageMilestoneEnd *pageMilestoneEnd) override;
     FunctorCode VisitRest(Rest *rest) override;
     FunctorCode VisitScore(Score *score) override;
-    FunctorCode VisitSystem(System *system) override;
     ///@}
 
 protected:
@@ -71,10 +66,6 @@ protected:
 private:
     // The transposition to be applied
     std::string m_transposition;
-    // The mdiv selected for transposition
-    std::string m_selectedMdivID;
-    // The list of current (nested) mdivs
-    std::list<std::string> m_currentMdivIDs;
 };
 
 //----------------------------------------------------------------------------

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1369,15 +1369,14 @@ void Doc::TransposeDoc()
 
     const bool selectedOnly = m_options->m_transposeSelectedOnly.GetValue();
 
-    TransposeFunctor transpose(this, &transposer);
-    transpose.SetVisibleOnly(selectedOnly);
-
     if (m_options->m_transpose.IsSet()) {
         // Transpose the entire document
         if (m_options->m_transposeMdiv.IsSet()) {
             LogWarning("\"%s\" is ignored when \"%s\" is set as well. Please use only one of the two options.",
                 m_options->m_transposeMdiv.GetKey().c_str(), m_options->m_transpose.GetKey().c_str());
         }
+        TransposeFunctor transpose(this, &transposer);
+        transpose.SetVisibleOnly(selectedOnly);
         transpose.SetTransposition(m_options->m_transpose.GetValue());
         this->Process(transpose);
     }
@@ -1385,9 +1384,11 @@ void Doc::TransposeDoc()
         // Transpose mdivs individually
         std::set<std::string> ids = m_options->m_transposeMdiv.GetKeys();
         for (const std::string &id : ids) {
-            transpose.SetSelectedMdivID(id);
-            transpose.SetTransposition(m_options->m_transposeMdiv.GetStrValue({ id }));
-            this->Process(transpose);
+            TransposeSelectedMdivFunctor transposeSelectedMdiv(this, &transposer);
+            transposeSelectedMdiv.SetVisibleOnly(selectedOnly);
+            transposeSelectedMdiv.SetSelectedMdivID(id);
+            transposeSelectedMdiv.SetTransposition(m_options->m_transposeMdiv.GetStrValue({ id }));
+            this->Process(transposeSelectedMdiv);
         }
     }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1367,11 +1367,10 @@ void Doc::TransposeDoc()
     Transposer transposer;
     transposer.SetBase600(); // Set extended chromatic alteration mode (allowing more than double sharps/flats)
 
-    TransposeFunctor transpose(this, &transposer);
+    const bool selectedOnly = m_options->m_transposeSelectedOnly.GetValue();
 
-    if (m_options->m_transposeSelectedOnly.GetValue() == false) {
-        transpose.SetVisibleOnly(false);
-    }
+    TransposeFunctor transpose(this, &transposer);
+    transpose.SetVisibleOnly(selectedOnly);
 
     if (m_options->m_transpose.IsSet()) {
         // Transpose the entire document
@@ -1394,11 +1393,9 @@ void Doc::TransposeDoc()
 
     if (m_options->m_transposeToSoundingPitch.GetValue()) {
         // Transpose to sounding pitch
-        transpose.SetSelectedMdivID("");
-        transpose.SetTransposition("");
-        transposer.SetTransposition(0);
-        transpose.SetTransposeToSoundingPitch();
-        this->Process(transpose);
+        TransposeToSoundingPitchFunctor transposeToSoundingPitch(this, &transposer);
+        transposeToSoundingPitch.SetVisibleOnly(selectedOnly);
+        this->Process(transposeToSoundingPitch);
     }
 }
 

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -356,11 +356,7 @@ FunctorCode TransposeToSoundingPitchFunctor::VisitScoreDefEnd(ScoreDef *scoreDef
 
 FunctorCode TransposeToSoundingPitchFunctor::VisitStaff(Staff *staff)
 {
-    int transposeInterval = 0;
-    if (staff->HasN() && (m_transposeIntervalForStaffN.count(staff->GetN()) > 0)) {
-        transposeInterval = m_transposeIntervalForStaffN.at(staff->GetN());
-    }
-    m_transposer->SetTransposition(transposeInterval);
+    this->UpdateTranspositionFromStaffN(staff);
 
     return FUNCTOR_CONTINUE;
 }
@@ -385,14 +381,19 @@ FunctorCode TransposeToSoundingPitchFunctor::VisitStaffDef(StaffDef *staffDef)
         staffDef->ResetTransposition();
     }
     else {
-        int transposeInterval = 0;
-        if (staffDef->HasN() && (m_transposeIntervalForStaffN.count(staffDef->GetN()) > 0)) {
-            transposeInterval = m_transposeIntervalForStaffN.at(staffDef->GetN());
-        }
-        m_transposer->SetTransposition(transposeInterval);
+        this->UpdateTranspositionFromStaffN(staffDef);
     }
 
     return FUNCTOR_CONTINUE;
+}
+
+void TransposeToSoundingPitchFunctor::UpdateTranspositionFromStaffN(const AttNInteger *staffN)
+{
+    int transposeInterval = 0;
+    if (staffN->HasN() && (m_transposeIntervalForStaffN.count(staffN->GetN()) > 0)) {
+        transposeInterval = m_transposeIntervalForStaffN.at(staffN->GetN());
+    }
+    m_transposer->SetTransposition(transposeInterval);
 }
 
 } // namespace vrv

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -115,11 +115,6 @@ FunctorCode TransposeFunctor::VisitNote(Note *note)
     return FUNCTOR_SIBLINGS;
 }
 
-FunctorCode TransposeFunctor::VisitPageMilestone(PageMilestoneEnd *pageMilestoneEnd)
-{
-    return FUNCTOR_CONTINUE;
-}
-
 FunctorCode TransposeFunctor::VisitRest(Rest *rest)
 {
     if ((!rest->HasOloc() || !rest->HasPloc()) && !rest->HasLoc()) return FUNCTOR_SIBLINGS;
@@ -236,11 +231,6 @@ FunctorCode TransposeFunctor::VisitScore(Score *score)
     // Evaluate functor on scoreDef
     scoreDef->Process(*this);
 
-    return FUNCTOR_CONTINUE;
-}
-
-FunctorCode TransposeFunctor::VisitSystem(System *system)
-{
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -262,6 +262,35 @@ FunctorCode TransposeFunctor::VisitSystem(System *system)
 }
 
 //----------------------------------------------------------------------------
+// TransposeSelectedMdivFunctor
+//----------------------------------------------------------------------------
+
+TransposeSelectedMdivFunctor::TransposeSelectedMdivFunctor(Doc *doc, Transposer *transposer)
+    : TransposeFunctor(doc, transposer)
+{
+}
+
+FunctorCode TransposeSelectedMdivFunctor::VisitMdiv(Mdiv *mdiv)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeSelectedMdivFunctor::VisitPageMilestone(PageMilestoneEnd *pageMilestoneEnd)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeSelectedMdivFunctor::VisitScore(Score *score)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeSelectedMdivFunctor::VisitSystem(System *system)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+//----------------------------------------------------------------------------
 // TransposeToSoundingPitchFunctor
 //----------------------------------------------------------------------------
 

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -362,4 +362,43 @@ FunctorCode TransposeFunctor::VisitSystem(System *system)
     return FUNCTOR_CONTINUE;
 }
 
+//----------------------------------------------------------------------------
+// TransposeToSoundingPitchFunctor
+//----------------------------------------------------------------------------
+
+TransposeToSoundingPitchFunctor::TransposeToSoundingPitchFunctor(Doc *doc, Transposer *transposer)
+    : TransposeFunctor(doc, transposer)
+{
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitMdiv(Mdiv *mdiv)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitScore(Score *score)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitScoreDef(ScoreDef *scoreDef)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitScoreDefEnd(ScoreDef *scoreDef)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitStaff(Staff *staff)
+{
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode TransposeToSoundingPitchFunctor::VisitStaffDef(StaffDef *staffDef)
+{
+    return FUNCTOR_CONTINUE;
+}
+
 } // namespace vrv

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -29,7 +29,6 @@ namespace vrv {
 TransposeFunctor::TransposeFunctor(Doc *doc, Transposer *transposer) : DocFunctor(doc)
 {
     m_transposer = transposer;
-    m_transposeToSoundingPitch = false;
 }
 
 FunctorCode TransposeFunctor::VisitHarm(Harm *harm)
@@ -99,7 +98,6 @@ FunctorCode TransposeFunctor::VisitMdiv(Mdiv *mdiv)
 {
     m_currentMdivIDs.push_back(mdiv->GetID());
     m_keySigForStaffN.clear();
-    m_transposeIntervalForStaffN.clear();
 
     return FUNCTOR_CONTINUE;
 }
@@ -249,26 +247,6 @@ FunctorCode TransposeFunctor::VisitScore(Score *score)
     // Evaluate functor on scoreDef
     scoreDef->Process(*this);
 
-    return FUNCTOR_CONTINUE;
-}
-
-FunctorCode TransposeFunctor::VisitScoreDef(ScoreDef *scoreDef)
-{
-    return FUNCTOR_CONTINUE;
-}
-
-FunctorCode TransposeFunctor::VisitScoreDefEnd(ScoreDef *scoreDef)
-{
-    return FUNCTOR_CONTINUE;
-}
-
-FunctorCode TransposeFunctor::VisitStaff(Staff *staff)
-{
-    return FUNCTOR_CONTINUE;
-}
-
-FunctorCode TransposeFunctor::VisitStaffDef(StaffDef *staffDef)
-{
     return FUNCTOR_CONTINUE;
 }
 


### PR DESCRIPTION
This PR splits the transpose functor into:
- `TransposeFunctor` that transposes the entire document
- `TransposeSelectedMdivFunctor` (derived from `TransposeFunctor`) that transposes specific mdivs
- `TransposeToSoundingPitchFunctor` (derived from `TransposeFunctor`) that transposes to sounding pitch

The splitting reduces the complexity in the functor implementation. After the change everything should work as before.