### PR TITLE
Improve tie endpoints

### DIFF
--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -88,8 +88,8 @@ private:
     bool AdjustEnharmonicTies(const Doc *doc, const FloatingCurvePositioner *curve, Point bezier[4],
         const Note *startNote, const Note *endNote, curvature_CURVEDIR drawingCurveDir) const;
 
-    // Calculate initial position X position and return stem direction of the startNote
-    void CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *startParentChord,
+    // Calculate the initial X position and return true if the tie endpoints should be adjusted vertically
+    bool CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *startParentChord,
         const Chord *endParentChord, int spanningType, bool isOuterChordNote, Point &startPoint, Point &endPoint,
         curvature_CURVEDIR drawingCurveDir) const;
 

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -820,7 +820,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxTopY = boundingBox->GetTopBy(type);
-        if (boundingBox->Is(ACCID)) {
+        if (this->GetObject()->Is({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxTopY = boundingBox->GetCutOutTop(*resources);
@@ -857,7 +857,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxBottomY = boundingBox->GetBottomBy(type);
-        if (boundingBox->Is(ACCID)) {
+        if (this->GetObject()->Is({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxBottomY = boundingBox->GetCutOutBottom(*resources);

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -104,28 +104,29 @@ bool Tie::AdjustEnharmonicTies(const Doc *doc, const FloatingCurvePositioner *cu
     }
     if ((startNote->GetDrawingStemDir() == STEMDIRECTION_down) && (drawingCurveDir == curvature_CURVEDIR_below)) {
         bezier[3].x = endNote->GetDrawingX() - drawingUnit / 2;
-        bezier[3].y += overlap / 2;
     }
     else {
         bezier[3].x = endNote->GetDrawingX() + drawingRadius;
     }
 
+    const int endpointShift = overlap * 0.6;
     if (drawingCurveDir == curvature_CURVEDIR_below) {
         if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc()) {
-            bezier[0].y += overlap / 2;
+            bezier[0].y += endpointShift;
             bezier[3].y = bezier[0].y;
         }
         else if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc()) {
-            bezier[3].y += overlap / 2;
+            bezier[3].y += endpointShift;
             bezier[0].y = bezier[3].y;
         }
     }
     else if (drawingCurveDir == curvature_CURVEDIR_above) {
         if (startNote->GetDrawingLoc() > endNote->GetDrawingLoc()) {
+            bezier[0].y += endpointShift;
             bezier[3].y = bezier[0].y;
         }
         else if (startNote->GetDrawingLoc() < endNote->GetDrawingLoc()) {
-            bezier[3].y += overlap / 2;
+            bezier[3].y += endpointShift;
             bezier[0].y = bezier[3].y;
         }
     }

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -400,6 +400,16 @@ bool Tie::CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *st
                 endPoint.x -= r2 + drawingUnit / 2;
             }
         }
+        else {
+            // Prevent collisions with articulations
+            if (startNote && startNote->FindDescendantByType(ARTIC)) {
+                startPoint.x += r1;
+            }
+            if (endNote && endNote->FindDescendantByType(ARTIC)) {
+                endPoint.x -= r2;
+            }
+        }
+        // Prevent collisions with dots
         if (startParentChord && !isOuterChordNote && (startParentChord->GetDots() > 0)) {
             if (isShortTie) {
                 startPoint.x += drawingUnit;
@@ -433,6 +443,13 @@ bool Tie::CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *st
                 startPoint.x += 2 * drawingUnit * startParentChord->GetDots();
             }
         }
+        else {
+            // Prevent collisions with articulations
+            if (startNote && startNote->FindDescendantByType(ARTIC)) {
+                startPoint.x += r1;
+            }
+        }
+        // Prevent collisions with dots
         if (startParentChord && !isOuterChordNote && (startParentChord->GetDots() > 0)) {
             const Dots *dots = vrv_cast<const Dots *>(startParentChord->FindDescendantByType(DOTS));
             assert(dots);
@@ -456,6 +473,12 @@ bool Tie::CalculateXPosition(const Doc *doc, const Staff *staff, const Chord *st
             }
             else {
                 endPoint.x -= r2 + drawingUnit / 2;
+            }
+        }
+        else {
+            // Prevent collisions with articulations
+            if (endNote && endNote->FindDescendantByType(ARTIC)) {
+                endPoint.x -= r2;
             }
         }
     }


### PR DESCRIPTION
This PR improves the position of endpoints for ties between notes:
- The decision whether the endpoints are placed above/below or on the side of the note head now takes `--min-tie-length` into account.
- If placed above/below the notehead, collisions with articulations are avoided.
- Enharmonic ties are not allowed to partially intersect the accidental (as slurs would do).

From the examples in the test suite `tie-001` and `tie-009` should now look better:
<img width="1600" alt="tie-001" src="https://github.com/rism-digital/verovio/assets/63608463/d30405d4-9265-401e-9592-572282efbda4">
<img width="800" alt="tie-009" src="https://github.com/rism-digital/verovio/assets/63608463/c58dcc32-b718-4c54-9b2f-d2203ffbfb9b">


