### PR TITLE
Beams starting with rest

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -182,7 +182,8 @@ public:
      * A segment of the beam that matches horizontal position of the bounding box is taken to find whether there is
      * intersection.
      */
-    int Intersects(const BeamDrawingInterface *beamInterface, Accessor type, int margin = 0) const;
+    int Intersects(const BeamDrawingInterface *beamInterface, Accessor type, int margin = 0,
+        bool fromBeamContentSide = false) const;
 
     //----------------//
     // Static methods //

--- a/src/adjustbeamsfunctor.cpp
+++ b/src/adjustbeamsfunctor.cpp
@@ -298,7 +298,6 @@ FunctorCode AdjustBeamsFunctor::VisitRest(Rest *rest)
     if (!m_outerBeam) return FUNCTOR_SIBLINGS;
 
     // Calculate possible overlap for the rest with beams
-    int leftMargin = 0, rightMargin = 0;
     const int beams = m_outerBeam->GetBeamPartDuration(rest, false) - DUR_4;
     const int beamWidth = m_outerBeam->m_beamWidth;
     const int overlapMargin = rest->Intersects(m_outerBeam, SELF, beams * beamWidth, true) * m_directionBias;
@@ -336,11 +335,9 @@ FunctorCode AdjustBeamsFunctor::VisitRest(Rest *rest)
     }
 
     const int unit = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
-    const int unitChangeNumber = ((std::abs(overlapMargin) + unit / 6) / unit);
-    if (unitChangeNumber > 0) {
-        const int adjust = unitChangeNumber * unit * m_directionBias;
-        if (std::abs(adjust) > std::abs(m_overlapMargin)) m_overlapMargin = adjust;
-    }
+    const int unitChangeNumber = std::abs(overlapMargin) / unit + 1;
+    const int adjust = unitChangeNumber * unit * m_directionBias;
+    if (std::abs(adjust) > std::abs(m_overlapMargin)) m_overlapMargin = adjust;
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/adjustbeamsfunctor.cpp
+++ b/src/adjustbeamsfunctor.cpp
@@ -301,18 +301,10 @@ FunctorCode AdjustBeamsFunctor::VisitRest(Rest *rest)
     int leftMargin = 0, rightMargin = 0;
     const int beams = m_outerBeam->GetBeamPartDuration(rest, false) - DUR_4;
     const int beamWidth = m_outerBeam->m_beamWidth;
-    if (m_directionBias > 0) {
-        leftMargin = m_y1 - beams * beamWidth - rest->GetSelfTop();
-        rightMargin = m_y2 - beams * beamWidth - rest->GetSelfTop();
-    }
-    else {
-        leftMargin = rest->GetSelfBottom() - m_y1 - beams * beamWidth;
-        rightMargin = rest->GetSelfBottom() - m_y2 - beams * beamWidth;
-    }
+    const int overlapMargin = rest->Intersects(m_outerBeam, SELF, beams * beamWidth, true) * m_directionBias;
 
     // Adjust drawing location for the rest based on the overlap with beams.
     // Adjustment should be an even number, so that the rest is positioned properly
-    const int overlapMargin = std::min(leftMargin, rightMargin);
     if (overlapMargin >= 0) return FUNCTOR_CONTINUE;
 
     Staff *staff = rest->GetAncestorStaff();

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1108,7 +1108,7 @@ void BeamSegment::CalcAdjustPosition(const Staff *staff, const Doc *doc, const B
         }
     }
 
-    m_beamElementCoordRefs.at(0)->m_yBeam += adjust;
+    m_firstNoteOrChord->m_yBeam += adjust;
 
     this->CalcSetValues();
 }
@@ -1457,8 +1457,8 @@ void BeamSegment::CalcPartialFlagPlace()
 
 void BeamSegment::CalcSetValues()
 {
-    int startingX = m_beamElementCoordRefs.at(0)->m_x;
-    int startingY = m_beamElementCoordRefs.at(0)->m_yBeam;
+    const int startingX = m_firstNoteOrChord->m_x;
+    const int startingY = m_firstNoteOrChord->m_yBeam;
 
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         coord->m_yBeam = startingY + m_beamSlope * (coord->m_x - startingX);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -778,7 +778,8 @@ int BoundingBox::Intersects(const FloatingCurvePositioner *curve, Accessor type,
     return 0;
 }
 
-int BoundingBox::Intersects(const BeamDrawingInterface *beamInterface, Accessor type, const int margin) const
+int BoundingBox::Intersects(
+    const BeamDrawingInterface *beamInterface, Accessor type, int margin, bool fromBeamContentSide) const
 {
     assert(beamInterface);
     assert(beamInterface->HasCoords());
@@ -834,12 +835,15 @@ int BoundingBox::Intersects(const BeamDrawingInterface *beamInterface, Accessor 
     }
 
     // calculate vertical overlap of the BB with beam section
-    if (beamInterface->m_drawingPlace == BEAMPLACE_above) {
+    const bool beamAbove = (beamInterface->m_drawingPlace == BEAMPLACE_above);
+    const bool beamBelow = (beamInterface->m_drawingPlace == BEAMPLACE_below);
+
+    if ((beamAbove && !fromBeamContentSide) || (beamBelow && fromBeamContentSide)) {
         const int topY = std::max(leftIntersection.y, rightIntersection.y);
         const int shift = topY - this->GetBottomBy(type) + margin;
         return std::max(shift, 0);
     }
-    else if (beamInterface->m_drawingPlace == BEAMPLACE_below) {
+    else if ((beamBelow && !fromBeamContentSide) || (beamAbove && fromBeamContentSide)) {
         const int bottomY = std::min(leftIntersection.y, rightIntersection.y);
         const int shift = bottomY - this->GetTopBy(type) - margin;
         return std::min(shift, 0);


### PR DESCRIPTION
This PR fixes some issues with rests in beams, in particular when the beam content starts with a rest. Closes #3477 .

<img width="835" alt="RestsInBeams" src="https://github.com/rism-digital/verovio/assets/63608463/eff05d8a-82c7-4e97-8306-2c3f6f77cba6">
