### PR TITLE
Revert stack usage for filters and direction

### DIFF
--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -8,8 +8,6 @@
 #ifndef __VRV_FUNCTOR_H__
 #define __VRV_FUNCTOR_H__
 
-#include <stack>
-
 #include "comparison.h"
 #include "functorinterface.h"
 #include "vrvdef.h"
@@ -45,26 +43,13 @@ public:
     ///@}
 
     /**
-     * Getters/Setters for the filters
+     * Getters/Setters for the properties
      */
     ///@{
-    Filters *GetFilters() { return m_filters.empty() ? NULL : m_filters.top(); }
-    void PushFilters(Filters *filters) { m_filters.push(filters); }
-    void PopFilters() { m_filters.pop(); }
-    ///@}
-
-    /**
-     * Getters/Setters for the visibility
-     */
-    ///@{
+    Filters *GetFilters() { return m_filters; }
+    void SetFilters(Filters *filters) { m_filters = filters; }
     bool VisibleOnly() const { return m_visibleOnly; }
     void SetVisibleOnly(bool visibleOnly) { m_visibleOnly = visibleOnly; }
-    ///@}
-
-    /**
-     * Getters/Setters for the direction
-     */
-    ///@{
     bool GetDirection() const { return m_direction; }
     void SetDirection(bool direction) { m_direction = direction; }
     ///@}
@@ -81,8 +66,8 @@ public:
 private:
     // The functor code
     FunctorCode m_code = FUNCTOR_CONTINUE;
-    // The filter stack
-    std::stack<Filters *> m_filters;
+    // The filters
+    Filters *m_filters = NULL;
     // Visible only flag
     bool m_visibleOnly = true;
     // Direction

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -29,7 +29,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    FunctorBase(){};
+    FunctorBase() {}
     virtual ~FunctorBase() = default;
     ///@}
 
@@ -43,15 +43,32 @@ public:
     ///@}
 
     /**
-     * Getters/Setters for the properties
+     * Getter/Setter for the visibility
      */
     ///@{
-    Filters *GetFilters() { return m_filters; }
-    void SetFilters(Filters *filters) { m_filters = filters; }
     bool VisibleOnly() const { return m_visibleOnly; }
     void SetVisibleOnly(bool visibleOnly) { m_visibleOnly = visibleOnly; }
+    ///@}
+
+    /**
+     * Getters/Setters for the filters and direction
+     * Here setters return the previous value
+     */
+    ///@{
+    Filters *GetFilters() const { return m_filters; }
+    Filters *SetFilters(Filters *filters)
+    {
+        Filters *previous = m_filters;
+        m_filters = filters;
+        return previous;
+    }
     bool GetDirection() const { return m_direction; }
-    void SetDirection(bool direction) { m_direction = direction; }
+    bool SetDirection(bool direction)
+    {
+        bool previous = m_direction;
+        m_direction = direction;
+        return previous;
+    }
     ///@}
 
     /**
@@ -87,7 +104,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    Functor(){};
+    Functor() {}
     virtual ~Functor() = default;
     ///@}
 
@@ -112,7 +129,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    ConstFunctor(){};
+    ConstFunctor() {}
     virtual ~ConstFunctor() = default;
     ///@}
 

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -65,9 +65,8 @@ public:
      * Getters/Setters for the direction
      */
     ///@{
-    bool GetDirection() const { return m_direction.empty() ? FORWARD : m_direction.top(); }
-    void PushDirection(bool direction) { m_direction.push(direction); }
-    void PopDirection() { m_direction.pop(); }
+    bool GetDirection() const { return m_direction; }
+    void SetDirection(bool direction) { m_direction = direction; }
     ///@}
 
     /**
@@ -86,8 +85,8 @@ private:
     std::stack<Filters *> m_filters;
     // Visible only flag
     bool m_visibleOnly = true;
-    // The direction stack
-    std::stack<bool> m_direction;
+    // Direction
+    bool m_direction = FORWARD;
 };
 
 //----------------------------------------------------------------------------

--- a/src/adjustarpegfunctor.cpp
+++ b/src/adjustarpegfunctor.cpp
@@ -173,10 +173,9 @@ FunctorCode AdjustArpegFunctor::VisitMeasureEnd(Measure *measure)
     if (!m_alignmentArpegTuples.empty()) {
         m_measureAligner = &measure->m_measureAligner;
         // Process backwards on measure aligner, then reset to previous direction
-        const bool direction = this->GetDirection();
-        this->SetDirection(BACKWARD);
+        const bool previousDirection = this->SetDirection(BACKWARD);
         m_measureAligner->Process(*this);
-        this->SetDirection(direction);
+        this->SetDirection(previousDirection);
         m_alignmentArpegTuples.clear();
     }
 

--- a/src/adjustarpegfunctor.cpp
+++ b/src/adjustarpegfunctor.cpp
@@ -172,10 +172,11 @@ FunctorCode AdjustArpegFunctor::VisitMeasureEnd(Measure *measure)
 {
     if (!m_alignmentArpegTuples.empty()) {
         m_measureAligner = &measure->m_measureAligner;
-        // Process backwards on measure aligner
-        this->PushDirection(BACKWARD);
+        // Process backwards on measure aligner, then reset to previous direction
+        const bool direction = this->GetDirection();
+        this->SetDirection(BACKWARD);
         m_measureAligner->Process(*this);
-        this->PopDirection();
+        this->SetDirection(direction);
         m_alignmentArpegTuples.clear();
     }
 

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -100,8 +100,9 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
+    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->PushFilters(&filters);
+    this->SetFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -118,7 +119,7 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->PopFilters();
+    this->SetFilters(previousFilters);
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -100,9 +100,8 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    Filters *previousFilters = this->SetFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -48,7 +48,8 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         MeasureAligner *measureAligner = vrv_cast<MeasureAligner *>(alignment->GetFirstAncestor(MEASURE_ALIGNER));
         assert(measureAligner);
 
-        this->PushDirection(BACKWARD);
+        bool previousDirection = this->GetDirection();
+        this->SetDirection(BACKWARD);
         Filters filters;
         this->PushFilters(&filters);
 
@@ -108,7 +109,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
             }
         }
 
-        this->PopDirection();
+        this->SetDirection(previousDirection);
         this->PopFilters();
 
         // Change the flag back
@@ -141,14 +142,15 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignmentReference(AlignmentReference *
     // Because we are processing grace notes alignment backward (see VisitAlignment) we need
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
-    this->PushDirection(FORWARD);
+    bool previousDirection = this->GetDirection();
+    this->SetDirection(FORWARD);
     this->PushFilters(NULL);
 
     for (auto child : alignmentReference->GetChildren()) {
         child->Process(*this);
     }
 
-    this->PopDirection();
+    this->SetDirection(previousDirection);
     this->PopFilters();
 
     return FUNCTOR_SIBLINGS;
@@ -205,7 +207,8 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
     m_rightDefaultAlignment = NULL;
 
     // We process it backward because we want to get the rightDefaultAlignment
-    this->PushDirection(BACKWARD);
+    bool previousDirection = this->GetDirection();
+    this->SetDirection(BACKWARD);
     measure->m_measureAligner.Process(*this);
 
     // We need to process the staves in the reverse order
@@ -220,7 +223,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
     m_staffNs = staffNsReversed;
     m_measureTieEndpoints = measure->GetInternalTieEndpoints();
     measure->m_measureAligner.Process(*this);
-    this->PopDirection();
+    this->SetDirection(previousDirection);
 
     // Put params back
     m_staffNs = staffNs;

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -48,11 +48,9 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         MeasureAligner *measureAligner = vrv_cast<MeasureAligner *>(alignment->GetFirstAncestor(MEASURE_ALIGNER));
         assert(measureAligner);
 
-        bool previousDirection = this->GetDirection();
-        Filters *previousFilters = this->GetFilters();
-        this->SetDirection(BACKWARD);
+        const bool previousDirection = this->SetDirection(BACKWARD);
         Filters filters;
-        this->SetFilters(&filters);
+        Filters *previousFilters = this->SetFilters(&filters);
 
         std::vector<int>::iterator iter;
         for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -143,10 +141,8 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignmentReference(AlignmentReference *
     // Because we are processing grace notes alignment backward (see VisitAlignment) we need
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
-    bool previousDirection = this->GetDirection();
-    Filters *previousFilters = this->GetFilters();
-    this->SetDirection(FORWARD);
-    this->SetFilters(NULL);
+    const bool previousDirection = this->SetDirection(FORWARD);
+    Filters *previousFilters = this->SetFilters(NULL);
 
     for (auto child : alignmentReference->GetChildren()) {
         child->Process(*this);
@@ -209,8 +205,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
     m_rightDefaultAlignment = NULL;
 
     // We process it backward because we want to get the rightDefaultAlignment
-    bool previousDirection = this->GetDirection();
-    this->SetDirection(BACKWARD);
+    const bool previousDirection = this->SetDirection(BACKWARD);
     measure->m_measureAligner.Process(*this);
 
     // We need to process the staves in the reverse order

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -49,9 +49,10 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         assert(measureAligner);
 
         bool previousDirection = this->GetDirection();
+        Filters *previousFilters = this->GetFilters();
         this->SetDirection(BACKWARD);
         Filters filters;
-        this->PushFilters(&filters);
+        this->SetFilters(&filters);
 
         std::vector<int>::iterator iter;
         for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -110,7 +111,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignment(Alignment *alignment)
         }
 
         this->SetDirection(previousDirection);
-        this->PopFilters();
+        this->SetFilters(previousFilters);
 
         // Change the flag back
         m_isGraceAlignment = false;
@@ -143,15 +144,16 @@ FunctorCode AdjustGraceXPosFunctor::VisitAlignmentReference(AlignmentReference *
     // to process the children (LayerElement) "by hand" in FORWARD manner
     // (filters can be NULL because filtering was already applied in the parent)
     bool previousDirection = this->GetDirection();
+    Filters *previousFilters = this->GetFilters();
     this->SetDirection(FORWARD);
-    this->PushFilters(NULL);
+    this->SetFilters(NULL);
 
     for (auto child : alignmentReference->GetChildren()) {
         child->Process(*this);
     }
 
     this->SetDirection(previousDirection);
-    this->PopFilters();
+    this->SetFilters(previousFilters);
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -123,8 +123,9 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
+    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->PushFilters(&filters);
+    this->SetFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {
@@ -141,7 +142,7 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->PopFilters();
+    this->SetFilters(previousFilters);
 
     return FUNCTOR_SIBLINGS;
 }

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -123,9 +123,8 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
 {
     if (!measure->HasAlignmentRefWithMultipleLayers()) return FUNCTOR_SIBLINGS;
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    Filters *previousFilters = this->SetFilters(&filters);
 
     std::vector<int>::iterator iter;
     for (iter = m_staffNs.begin(); iter != m_staffNs.end(); ++iter) {

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -214,9 +214,8 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
 
     const bool hasSystemStartLine = measure->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine();
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    Filters *previousFilters = this->SetFilters(&filters);
 
     for (auto staffN : m_staffNs) {
         m_minPos = 0;

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -214,8 +214,9 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
 
     const bool hasSystemStartLine = measure->IsFirstInSystem() && system->GetDrawingScoreDef()->HasSystemStartLine();
 
+    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->PushFilters(&filters);
+    this->SetFilters(&filters);
 
     for (auto staffN : m_staffNs) {
         m_minPos = 0;
@@ -247,7 +248,7 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
         measure->m_measureAligner.Process(*this);
     }
 
-    this->PopFilters();
+    this->SetFilters(previousFilters);
 
     int minMeasureWidth = m_doc->GetOptions()->m_unit.GetValue() * m_doc->GetOptions()->m_measureMinWidth.GetValue();
     // First try to see if we have a double measure length element

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -294,8 +294,9 @@ FunctorCode ConvertToCastOffMensuralFunctor::VisitMeasure(Measure *measure)
     }
     m_targetSubSystem->AddChild(targetMeasure);
 
+    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->PushFilters(&filters);
+    this->SetFilters(&filters);
 
     // Now we can process by layer and move their content to (measure) segments
     for (const auto &staves : m_layerTree->child) {
@@ -312,7 +313,7 @@ FunctorCode ConvertToCastOffMensuralFunctor::VisitMeasure(Measure *measure)
         }
     }
 
-    this->PopFilters();
+    this->SetFilters(previousFilters);
 
     m_targetMeasure = NULL;
     m_targetSubSystem = NULL;

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -294,9 +294,8 @@ FunctorCode ConvertToCastOffMensuralFunctor::VisitMeasure(Measure *measure)
     }
     m_targetSubSystem->AddChild(targetMeasure);
 
-    Filters *previousFilters = this->GetFilters();
     Filters filters;
-    this->SetFilters(&filters);
+    Filters *previousFilters = this->SetFilters(&filters);
 
     // Now we can process by layer and move their content to (measure) segments
     for (const auto &staves : m_layerTree->child) {

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -364,7 +364,7 @@ void Doc::CalculateTimemap()
 
     // Adjust the duration of tied notes
     InitTimemapTiesFunctor initTimemapTies;
-    initTimemapTies.PushDirection(BACKWARD);
+    initTimemapTies.SetDirection(BACKWARD);
     this->Process(initTimemapTies);
 
     m_timemapTempo = m_options->m_midiTempoAdjustment.GetValue();
@@ -583,9 +583,8 @@ void Doc::PrepareData()
 
     // Try to match all spanning elements (slur, tie, etc) by processing backwards
     PrepareTimeSpanningFunctor prepareTimeSpanning;
-    prepareTimeSpanning.PushDirection(BACKWARD);
+    prepareTimeSpanning.SetDirection(BACKWARD);
     this->Process(prepareTimeSpanning);
-    prepareTimeSpanning.PopDirection();
     prepareTimeSpanning.SetDataCollectionCompleted();
 
     // First we try backwards because normally the spanning elements are at the end of
@@ -595,6 +594,7 @@ void Doc::PrepareData()
     // but this time without filling the list (that is only will the remaining elements)
     const ListOfSpanningInterOwnerPairs &interfaceOwnerPairs = prepareTimeSpanning.GetInterfaceOwnerPairs();
     if (!interfaceOwnerPairs.empty()) {
+        prepareTimeSpanning.SetDirection(FORWARD);
         this->Process(prepareTimeSpanning);
     }
 
@@ -616,7 +616,7 @@ void Doc::PrepareData()
 
     // Try to match all time pointing elements (tempo, fermata, etc) by processing backwards
     PrepareTimePointingFunctor prepareTimePointing;
-    prepareTimePointing.PushDirection(BACKWARD);
+    prepareTimePointing.SetDirection(BACKWARD);
     this->Process(prepareTimePointing);
 
     /************ Resolve @tstamp / tstamp2 ************/
@@ -640,9 +640,8 @@ void Doc::PrepareData()
 
     // If we have some left process again backward
     if (!prepareLinking.GetSameasIDPairs().empty() || !prepareLinking.GetStemSameasIDPairs().empty()) {
-        prepareLinking.PushDirection(BACKWARD);
+        prepareLinking.SetDirection(BACKWARD);
         this->Process(prepareLinking);
-        prepareLinking.PopDirection();
     }
 
     // If some are still there, then it is probably an issue in the encoding
@@ -881,10 +880,10 @@ void Doc::ScoreDefSetCurrentDoc(bool force)
     // First we need to set Page::m_score and Page::m_scoreEnd
     // We do it by going BACKWARD, with a depth limit of 3 (we want to hit the Score elements)
     ScoreDefSetCurrentPageFunctor scoreDefSetCurrentPage(this);
-    scoreDefSetCurrentPage.PushDirection(BACKWARD);
+    scoreDefSetCurrentPage.SetDirection(BACKWARD);
     this->Process(scoreDefSetCurrentPage, 3);
-    scoreDefSetCurrentPage.PopDirection();
     // Do it again FORWARD to set Page::m_scoreEnd - relies on Page::m_score not being NULL
+    scoreDefSetCurrentPage.SetDirection(FORWARD);
     this->Process(scoreDefSetCurrentPage, 3);
 
     ScoreDefSetCurrentFunctor scoreDefSetCurrent(this);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -493,7 +493,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             filters.Add(&matchLayer);
 
             GenerateMIDIFunctor generateMIDI(midiFile);
-            generateMIDI.PushFilters(&filters);
+            generateMIDI.SetFilters(&filters);
 
             generateMIDI.SetChannel(midiChannel);
             generateMIDI.SetTrack(midiTrack);
@@ -722,7 +722,7 @@ void Doc::PrepareData()
             filters.Add(&matchLayer);
 
             PreparePointersByLayerFunctor preparePointersByLayer;
-            preparePointersByLayer.PushFilters(&filters);
+            preparePointersByLayer.SetFilters(&filters);
             this->Process(preparePointersByLayer);
         }
     }
@@ -734,7 +734,6 @@ void Doc::PrepareData()
     prepareDelayedTurns.SetDataCollectionCompleted();
 
     if (!prepareDelayedTurns.GetDelayedTurns().empty()) {
-        prepareDelayedTurns.PushFilters(&filters);
         for (staves = layerTree.child.begin(); staves != layerTree.child.end(); ++staves) {
             for (layers = staves->second.child.begin(); layers != staves->second.child.end(); ++layers) {
                 filters.Clear();
@@ -744,6 +743,7 @@ void Doc::PrepareData()
                 filters.Add(&matchStaff);
                 filters.Add(&matchLayer);
 
+                prepareDelayedTurns.SetFilters(&filters);
                 prepareDelayedTurns.ResetCurrent();
                 this->Process(prepareDelayedTurns);
             }
@@ -769,7 +769,7 @@ void Doc::PrepareData()
                 // The first pass sets m_drawingFirstNote and m_drawingLastNote for each syl
                 // m_drawingLastNote is set only if the syl has a forward connector
                 PrepareLyricsFunctor prepareLyrics;
-                prepareLyrics.PushFilters(&filters);
+                prepareLyrics.SetFilters(&filters);
                 this->Process(prepareLyrics);
             }
         }
@@ -803,7 +803,7 @@ void Doc::PrepareData()
 
             // We set multiNumber to NONE for indicated we need to look at the staffDef when reaching the first staff
             PrepareRptFunctor prepareRpt(this);
-            prepareRpt.PushFilters(&filters);
+            prepareRpt.SetFilters(&filters);
             this->Process(prepareRpt);
         }
     }
@@ -1349,7 +1349,7 @@ void Doc::ConvertMarkupDoc(bool permanent)
                 filters.Add(&matchLayer);
 
                 ConvertMarkupAnalyticalFunctor convertMarkupAnalytical(permanent);
-                convertMarkupAnalytical.PushFilters(&filters);
+                convertMarkupAnalytical.SetFilters(&filters);
                 this->Process(convertMarkupAnalytical);
 
                 // After having processed one layer, we check if we have open ties - if yes, we

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -664,7 +664,7 @@ void Alignment::GetLeftRight(int staffN, int &minLeft, int &maxRight, const std:
         Filters filters;
         AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staffN);
         filters.Add(&matchStaff);
-        getAlignmentLeftRight.PushFilters(&filters);
+        getAlignmentLeftRight.SetFilters(&filters);
         this->Process(getAlignmentLeftRight);
     }
     else {

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -400,7 +400,7 @@ std::set<int> Layer::GetLayersNInTimeSpan(double time, double duration, const Me
     Filters filters;
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staff);
     filters.Add(&matchStaff);
-    layersInTimeSpan.PushFilters(&filters);
+    layersInTimeSpan.SetFilters(&filters);
 
     measure->m_measureAligner.Process(layersInTimeSpan);
 
@@ -482,7 +482,7 @@ ListOfConstObjects Layer::GetLayerElementsInTimeSpan(
     Filters filters;
     AttNIntegerComparison matchStaff(ALIGNMENT_REFERENCE, staff);
     filters.Add(&matchStaff);
-    layerElementsInTimeSpan.PushFilters(&filters);
+    layerElementsInTimeSpan.SetFilters(&filters);
 
     measure->m_measureAligner.Process(layerElementsInTimeSpan);
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -590,7 +590,7 @@ Object *Object::FindDescendantByID(const std::string &id, int deepness, bool dir
 const Object *Object::FindDescendantByID(const std::string &id, int deepness, bool direction) const
 {
     FindByIDFunctor findByID(id);
-    findByID.PushDirection(direction);
+    findByID.SetDirection(direction);
     this->Process(findByID, deepness, true);
     return findByID.GetElement();
 }
@@ -614,7 +614,7 @@ Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness,
 const Object *Object::FindDescendantByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     FindByComparisonFunctor findByComparison(comparison);
-    findByComparison.PushDirection(direction);
+    findByComparison.SetDirection(direction);
     this->Process(findByComparison, deepness, true);
     return findByComparison.GetElement();
 }
@@ -628,7 +628,7 @@ Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int de
 const Object *Object::FindDescendantExtremeByComparison(Comparison *comparison, int deepness, bool direction) const
 {
     FindExtremeByComparisonFunctor findExtremeByComparison(comparison);
-    findExtremeByComparison.PushDirection(direction);
+    findExtremeByComparison.SetDirection(direction);
     this->Process(findExtremeByComparison, deepness, true);
     return findExtremeByComparison.GetElement();
 }
@@ -661,7 +661,7 @@ void Object::FindAllDescendantsByComparison(
     if (clear) objects->clear();
 
     FindAllByComparisonFunctor findAllByComparison(comparison, objects);
-    findAllByComparison.PushDirection(direction);
+    findAllByComparison.SetDirection(direction);
     this->Process(findAllByComparison, deepness, true);
 }
 
@@ -672,7 +672,7 @@ void Object::FindAllDescendantsByComparison(
     if (clear) objects->clear();
 
     FindAllConstByComparisonFunctor findAllConstByComparison(comparison, objects);
-    findAllConstByComparison.PushDirection(direction);
+    findAllConstByComparison.SetDirection(direction);
     this->Process(findAllConstByComparison, deepness, true);
 }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -757,7 +757,7 @@ void Page::AdjustSylSpacingByVerse(const IntTree &verseTree, Doc *doc)
                 filters = { &matchStaff, &matchLayer, &matchVerse };
 
                 AdjustSylSpacingFunctor adjustSylSpacing(doc);
-                adjustSylSpacing.PushFilters(&filters);
+                adjustSylSpacing.SetFilters(&filters);
                 this->Process(adjustSylSpacing);
             }
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -402,7 +402,7 @@ int Rest::GetLocationRelativeToCurrentLayer(const Staff *currentStaff, const Lay
     // Get previous and next elements from the current layer
     if (currentLayer->GetFirstChildNot(REST)) {
         GetRelativeLayerElementFunctor getRelativeLayerElementBackwards(this->GetIdx(), false);
-        getRelativeLayerElementBackwards.PushDirection(BACKWARD);
+        getRelativeLayerElementBackwards.SetDirection(BACKWARD);
         currentLayer->Process(getRelativeLayerElementBackwards);
         previousElement = getRelativeLayerElementBackwards.GetRelativeElement();
 
@@ -474,7 +474,7 @@ int Rest::GetFirstRelativeElementLocation(
 
     // Get last element if it's previous layer, get first one otherwise
     GetRelativeLayerElementFunctor getRelativeLayerElement(this->GetIdx(), true);
-    getRelativeLayerElement.PushDirection(!isPrevious);
+    getRelativeLayerElement.SetDirection(!isPrevious);
     (*layerIter)->Process(getRelativeLayerElement);
 
     const Object *lastLayerElement = getRelativeLayerElement.GetRelativeElement();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -462,7 +462,7 @@ void System::ConvertToUnCastOffMensuralSystem()
 
     Filters filters;
     ConvertToUnCastOffMensuralFunctor convertToUnCastOffMensural;
-    convertToUnCastOffMensural.PushFilters(&filters);
+    convertToUnCastOffMensural.SetFilters(&filters);
 
     // Now we can process by layer and move their content to (measure) segments
     for (const auto &staves : layerTree.child) {


### PR DESCRIPTION
This PR reverts the usage of stacks for functor filters and direction (see #3414). The problem is that we loose some performance due to this. Apparently, the stack versions of `GetDirection` and `GetFilters` are slower and they are time critical (they appear in `Object::Process`).