### PR TITLE
MusicXML: When computing vgrp, consider relative-y in addition to default-y.

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2103,7 +2103,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
     if (containsWords && !containsTempo && !containsDynamics) {
         pugi::xpath_node_set words = node.select_nodes("direction-type/*[self::words or self::coda or self::segno]");
         defaultY = words.first().node().attribute("default-y").as_int();
-        defaultY = (defaultY*10) + words.first().node().attribute("relative-y").as_int();
+        defaultY = (defaultY * 10) + words.first().node().attribute("relative-y").as_int();
         std::string wordStr = words.first().node().text().as_string();
         if (wordStr.rfind("cresc", 0) == 0 || wordStr.rfind("dim", 0) == 0 || wordStr.rfind("decresc", 0) == 0) {
             containsDynamics = true;
@@ -2186,7 +2186,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
         TextRendition(dynamics, dynam);
         if (defaultY == 0) {
             defaultY = dynamics.first().node().attribute("default-y").as_int();
-            defaultY = (defaultY*10) + dynamics.first().node().attribute("relative-y").as_int();
+            defaultY = (defaultY * 10) + dynamics.first().node().attribute("relative-y").as_int();
         }
         // parse the default_y attribute and transform to vgrp value, to vertically align dynamics and directives
         defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
@@ -2289,7 +2289,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(1 + staffOffset)));
             }
             int defaultY = wedge->node().attribute("default-y").as_int();
-            defaultY = (defaultY*10) + wedge->node().attribute("relative-y").as_int();
+            defaultY = (defaultY * 10) + wedge->node().attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align hairpins
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
             hairpin->SetVgrp(defaultY);
@@ -2393,7 +2393,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             pedal->SetTstamp(timeStamp);
             if (pedalType == "stop") pedal->SetTstamp(timeStamp - 0.1);
             int defaultY = xmlPedal.attribute("default-y").as_int();
-            defaultY = (defaultY*10) + xmlPedal.attribute("relative-y").as_int();
+            defaultY = (defaultY * 10) + xmlPedal.attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
             pedal->SetVgrp(defaultY);
@@ -3303,7 +3303,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         // place
         dynam->SetPlace(dynam->AttPlacementRelStaff::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         int defaultY = xmlDynam.attribute("default-y").as_int();
-        defaultY = (defaultY*10) + xmlDynam.attribute("relative-y").as_int();
+        defaultY = (defaultY * 10) + xmlDynam.attribute("relative-y").as_int();
         defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
         dynam->SetVgrp(defaultY);
         std::string dynamStr;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2103,6 +2103,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
     if (containsWords && !containsTempo && !containsDynamics) {
         pugi::xpath_node_set words = node.select_nodes("direction-type/*[self::words or self::coda or self::segno]");
         defaultY = words.first().node().attribute("default-y").as_int();
+        defaultY += words.first().node().attribute("relative-y").as_int();
         std::string wordStr = words.first().node().text().as_string();
         if (wordStr.rfind("cresc", 0) == 0 || wordStr.rfind("dim", 0) == 0 || wordStr.rfind("decresc", 0) == 0) {
             containsDynamics = true;
@@ -2184,6 +2185,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
 
         TextRendition(dynamics, dynam);
         if (defaultY == 0) defaultY = dynamics.first().node().attribute("default-y").as_int();
+        defaultY += dynamics.first().node().attribute("relative-y").as_int();
         // parse the default_y attribute and transform to vgrp value, to vertically align dynamics and directives
         defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
         dynam->SetVgrp(defaultY);
@@ -2285,6 +2287,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(1 + staffOffset)));
             }
             int defaultY = wedge->node().attribute("default-y").as_int();
+            defaultY += wedge->node().attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align hairpins
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
             hairpin->SetVgrp(defaultY);
@@ -2388,6 +2391,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             pedal->SetTstamp(timeStamp);
             if (pedalType == "stop") pedal->SetTstamp(timeStamp - 0.1);
             int defaultY = xmlPedal.attribute("default-y").as_int();
+            defaultY += xmlPedal.attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
             defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
             pedal->SetVgrp(defaultY);
@@ -3297,6 +3301,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         // place
         dynam->SetPlace(dynam->AttPlacementRelStaff::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         int defaultY = xmlDynam.attribute("default-y").as_int();
+        defaultY += xmlDynam.attribute("relative-y").as_int();
         defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
         dynam->SetVgrp(defaultY);
         std::string dynamStr;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2103,7 +2103,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
     if (containsWords && !containsTempo && !containsDynamics) {
         pugi::xpath_node_set words = node.select_nodes("direction-type/*[self::words or self::coda or self::segno]");
         defaultY = words.first().node().attribute("default-y").as_int();
-        defaultY += words.first().node().attribute("relative-y").as_int();
+        defaultY = (defaultY*10) + words.first().node().attribute("relative-y").as_int();
         std::string wordStr = words.first().node().text().as_string();
         if (wordStr.rfind("cresc", 0) == 0 || wordStr.rfind("dim", 0) == 0 || wordStr.rfind("decresc", 0) == 0) {
             containsDynamics = true;
@@ -2129,7 +2129,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             }
 
             TextRendition(words, dir);
-            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
+            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
             dir->SetVgrp(defaultY);
             m_controlElements.push_back({ measureNum, dir });
             m_dirStack.push_back(dir);
@@ -2184,10 +2184,12 @@ void MusicXmlInput::ReadMusicXmlDirection(
         }
 
         TextRendition(dynamics, dynam);
-        if (defaultY == 0) defaultY = dynamics.first().node().attribute("default-y").as_int();
-        defaultY += dynamics.first().node().attribute("relative-y").as_int();
+        if (defaultY == 0) {
+            defaultY = dynamics.first().node().attribute("default-y").as_int();
+            defaultY = (defaultY*10) + dynamics.first().node().attribute("relative-y").as_int();
+        }
         // parse the default_y attribute and transform to vgrp value, to vertically align dynamics and directives
-        defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
+        defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
         dynam->SetVgrp(defaultY);
         m_controlElements.push_back({ measureNum, dynam });
         m_dynamStack.push_back(dynam);
@@ -2287,9 +2289,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
                 hairpin->SetStaff(hairpin->AttStaffIdent::StrToXsdPositiveIntegerList(std::to_string(1 + staffOffset)));
             }
             int defaultY = wedge->node().attribute("default-y").as_int();
-            defaultY += wedge->node().attribute("relative-y").as_int();
+            defaultY = (defaultY*10) + wedge->node().attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align hairpins
-            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
+            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
             hairpin->SetVgrp(defaultY);
             // match new hairpin to existing hairpin stop
             for (auto iter = m_hairpinStopStack.begin(); iter != m_hairpinStopStack.end(); ++iter) {
@@ -2391,9 +2393,9 @@ void MusicXmlInput::ReadMusicXmlDirection(
             pedal->SetTstamp(timeStamp);
             if (pedalType == "stop") pedal->SetTstamp(timeStamp - 0.1);
             int defaultY = xmlPedal.attribute("default-y").as_int();
-            defaultY += xmlPedal.attribute("relative-y").as_int();
+            defaultY = (defaultY*10) + xmlPedal.attribute("relative-y").as_int();
             // parse the default_y attribute and transform to vgrp value, to vertically align pedal starts and stops
-            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
+            defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
             pedal->SetVgrp(defaultY);
             m_controlElements.push_back({ measureNum, pedal });
             m_pedalStack.push_back(pedal);
@@ -3301,8 +3303,8 @@ void MusicXmlInput::ReadMusicXmlNote(
         // place
         dynam->SetPlace(dynam->AttPlacementRelStaff::StrToStaffrel(xmlDynam.attribute("placement").as_string()));
         int defaultY = xmlDynam.attribute("default-y").as_int();
-        defaultY += xmlDynam.attribute("relative-y").as_int();
-        defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 200;
+        defaultY = (defaultY*10) + xmlDynam.attribute("relative-y").as_int();
+        defaultY = (defaultY < 0) ? std::abs(defaultY) : defaultY + 2000;
         dynam->SetVgrp(defaultY);
         std::string dynamStr;
         for (pugi::xml_node xmlDynamPart : xmlDynam.children()) {


### PR DESCRIPTION
This simple PR fixes an issue related to overlapping elements during the computation of `vgrp`.

For example, this piece of MusicXML, generated with MuseScore, assigns the same `default-y` value to both dynamics, which leads to their rendering on top of each other.

```xml
      <direction placement="below">
        <direction-type>
          <dynamics default-x="50.82" default-y="-40.00" relative-x="-12.52" relative-y="-51.19">
            <sfz/>
          </dynamics>
        </direction-type>
        <sound dynamics="124.44"/>
      </direction>
      <direction placement="below">
        <direction-type>
          <dynamics default-x="30.10" default-y="-40.00" relative-x="-10.25" relative-y="-22.72">
            <pp/>
          </dynamics>
        </direction-type>
```

In the example, both `vgrp` values were computed as 40, resulting in the following:

![broken](https://github.com/rism-digital/verovio/assets/6640057/1ea5e691-1328-4a13-9774-8ff0430a7ccb)

With the applied patch, `relative-y` is taken into consideration, resulting in two distinct `vgrp` values, leading to the following outcome:

![fixed](https://github.com/rism-digital/verovio/assets/6640057/32a1ec90-3c38-4925-90fb-379c26f31ba5)

I have also confirmed that the same issue arises in other instances where `vgrp` is utilized. The identical solution has been implemented there as well.
