### PR TITLE
Add iomanip include in humlib.h

### DIFF
--- a/include/hum/humlib.h
+++ b/include/hum/humlib.h
@@ -1,7 +1,7 @@
 //
 // Programmer:    Craig Stuart Sapp <craig@ccrma.stanford.edu>
 // Creation Date: Sat Aug  8 12:24:49 PDT 2015
-// Last Modified: Sat Apr 15 11:52:53 PDT 2023
+// Last Modified: Tue Aug 22 12:10:30 PDT 2023
 // Filename:      humlib.h
 // URL:           https://github.com/craigsapp/humlib/blob/master/include/humlib.h
 // Syntax:        C++11
@@ -50,6 +50,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctime>
 #include <fstream>
 #include <functional>
+#include <iomanip>
 #include <iostream>
 #include <list>
 #include <locale>


### PR DESCRIPTION
Hi,
First of all, thank you for this great library!

I was trying to compile the project via CMake by following the reference book instructions for Linux, but it seems there's a missing include in the `humlib.h` file, and I got these errors:
```
error: ‘setw’ is not a member of ‘std’; did you mean ‘set’?
error: ‘setfill’ is not a member of ‘std’; did you mean ‘fill’?
```
Which can be easily solved by including `iomanip` at the top of the file.