### PR TITLE
Fix crash from NULL check

### DIFF
--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -995,7 +995,7 @@ int LayerElement::CalcLayerOverlap(const Doc *doc, int direction, int y1, int y2
             const int currentBottom = this->GetDrawingBottom(doc, staff->m_drawingStaffSize);
             if (currentBottom >= elementTop) continue;
             const StemmedDrawingInterface *stemInterface = layerElement->GetStemmedDrawingInterface();
-            if (sameDirElement || (stemInterface && (stemInterface->GetDrawingStemDir() == STEMDIRECTION_up))) {
+            if (stemInterface && (sameDirElement || (stemInterface->GetDrawingStemDir() == STEMDIRECTION_up))) {
                 if (elementBottom - stemInterface->GetDrawingStemLen() < currentBottom) continue;
                 leftMargin = unit + y1 - elementBottom;
                 rightMargin = unit + y2 - elementBottom;


### PR DESCRIPTION
Hi

There seems to be a check in `layerelement.cpp` that got the null check mixed up. (similar to PR #3413)

(also is there a way to check if such things were solved in other branches apart from manually checking? thanks!)