### PR TITLE
Setup.py: Use sh instead of bash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ def get_commit():
     """Call tools/get_git_commit.sh on any platform."""
     if os.path.exists('./tools'):
         print('running tools/get_git_commit.sh')
-        os.system('bash -c "cd tools; ./get_git_commit.sh"')
+        os.system('sh -c "cd tools; ./get_git_commit.sh"')
     else:
         print('tools directory is missing')
 


### PR DESCRIPTION
(Fixes python builds on systems without bash, and every posix-compliant system should have sh installed)

Will soon be using this patch in alpine linux builds: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/50943 and https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/51088