### PR TITLE
MusicXML import: measure-numbering

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3701,7 +3701,7 @@ void MusicXmlInput::ReadMusicXmlPrint(pugi::xml_node node, Section *section)
         Sb *sb = new Sb();
         section->AddChild(sb);
     }
-    
+
     if (std::string(node.child("measure-numbering").text().as_string()) == "none") {
         m_doc->GetCurrentScoreDef()->SetMnumVisible(BOOLEAN_false);
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3701,6 +3701,10 @@ void MusicXmlInput::ReadMusicXmlPrint(pugi::xml_node node, Section *section)
         Sb *sb = new Sb();
         section->AddChild(sb);
     }
+    
+    if (std::string(node.child("measure-numbering").text().as_string()) == "none") {
+        m_doc->GetCurrentScoreDef()->SetMnumVisible(BOOLEAN_false);
+    }
 }
 
 bool MusicXmlInput::ReadMusicXmlBeamsAndTuplets(const pugi::xml_node &node, Layer *layer, bool isChord)


### PR DESCRIPTION
This small PR adds support for turning off measure numbering in MusicXML import.