### PR TITLE
Include Python 3.12

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -24,7 +24,7 @@ jobs:
       # Build the wheels for Linux, Windows and macOS
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         architecture: [x86, x64]
         include:
           - os: macos-latest
@@ -82,7 +82,7 @@ jobs:
       #===============================================#
       # wheels
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.1
+        uses: pypa/cibuildwheel@v2.16.1
         with:
           output-dir: wheelhouse
         env:


### PR DESCRIPTION
This PR updates the cibuildwheel action to latest version.
Also it includes Python 3.12 in the ci build and drops Python 3.7, which reached end-of-life.