### PR TITLE
Three Humdrum input fixes

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -24880,8 +24880,8 @@ template <class ELEMENT> void HumdrumInput::convertVerses(ELEMENT element, hum::
             hre.replaceDestructive(value, "&#xFC;", "u2", "g"); // u-umlaut
             hre.replaceDestructive(value, "&#xE4;", "a2", "g"); // a-umlaut
             hre.replaceDestructive(value, "&#xF6;", "o2", "g"); // o-umlaut
-            hre.replaceDestructive(value, "\\s+$", ""); // trailing spaces
-            hre.replaceDestructive(value, "^\\s+", ""); // leading spaces
+            hre.replaceDestructive(value, "", "\\s+$"); // trailing spaces
+            hre.replaceDestructive(value, "", "^\\s+"); // leading spaces
             hre.replaceDestructive(value, "-", "\\s+-$"); // trailing space before hyphen
             hre.replaceDestructive(value, "-", "^-\\s+"); // leaning spaces after hyphen
             if (!value.empty()) {

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -25353,6 +25353,7 @@ template <class ELEMENT> void HumdrumInput::setRhythmFromDuration(ELEMENT elemen
 template <class ELEMENT>
 void HumdrumInput::setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::HumNum visdur, hum::HumNum gesdur)
 {
+    bool durGesSet = false;
     pair<data_DURATION, int> visDurAndDots = getDurAndDots(visdur);
     element->SetDur(visDurAndDots.first);
     if (visDurAndDots.second != 0) {
@@ -25361,8 +25362,14 @@ void HumdrumInput::setVisualAndGesturalRhythmFromDuration(ELEMENT element, hum::
     pair<data_DURATION, int> gesDurAndDots = getDurAndDots(gesdur);
     if (gesDurAndDots.first != visDurAndDots.first) {
         element->SetDurGes(gesDurAndDots.first);
+        durGesSet = true;
     }
-    if (gesDurAndDots.second != visDurAndDots.second) {
+    if (!durGesSet) {
+        if (gesDurAndDots.second != visDurAndDots.second) {
+            element->SetDotsGes(gesDurAndDots.second);
+        }
+    }
+    else {
         element->SetDotsGes(gesDurAndDots.second);
     }
 }
@@ -25419,14 +25426,15 @@ template <class ELEMENT> hum::HumNum HumdrumInput::convertRhythm(ELEMENT element
 
     if (!vstring.empty()) {
         int visualdotcount = characterCountInSubtoken(vstring, '.');
-        if (visualdotcount > 0) {
-            element->SetDots(visualdotcount);
-        }
         int gesturaldotcount = characterCountInSubtoken(tstring, '.');
-        if (gesturaldotcount != visualdotcount) {
-            element->SetDotsGes(gesturaldotcount);
+        // It would be prettier to avoid @dots.ges="0" if @dots is not set,
+        // but we cannot tell from here whether @dots will be set (the
+        // call to setRhythmFromDuration() can set @dots unexpectedly).
+        // So we always set @dots.ges if @dur.ges is going to be set.
+        if (visualdotcount != 0) {
             element->SetDots(visualdotcount);
         }
+        element->SetDotsGes(gesturaldotcount);
     }
     else {
         int dotcount = characterCountInSubtoken(tstring, '.');
@@ -25450,9 +25458,10 @@ template <class ELEMENT> hum::HumNum HumdrumInput::convertRhythm(ELEMENT element
         dur /= 4; // convert duration to whole-note units
         int logicaldurdots = (int)std::count(logicaldur.begin(), logicaldur.end(), '.');
         int visualdurdots = (int)std::count(visualdur.begin(), visualdur.end(), '.');
-        if (visualdurdots != logicaldurdots) {
-            element->SetDotsGes(logicaldurdots);
+        if (visualdurdots != 0) {
+            element->SetDots(visualdurdots);
         }
+        element->SetDotsGes(logicaldurdots);
         std::string typestring = token->getValue("auto", "MEI", "type");
         if (typestring.empty()) {
             element->SetType("overfill");

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -6820,7 +6820,7 @@ void HumdrumInput::setTimeSig(StaffDef *part, const std::string &timesig, const 
             vrvmeter->SetVisible(BOOLEAN_false);
         }
     }
-    if (timetok->find("yy") != std::string::npos) {
+    if (timetok && timetok->find("yy") != std::string::npos) {
         vrvmeter->SetVisible(BOOLEAN_false);
     }
 


### PR DESCRIPTION
1. Check timetok for NULL before looking for "yy" in it.
2. Be non-ambiguous about @dots.ges in the presence of @dur.ges (don't assume processors will default missing @dots.ges to 0, _or_ to @dots).
3. Fix two **silbe replaceDestructive() calls that had their string params reversed (they were inserting the pattern they were trying to remove).