### PR TITLE
Fix/java build

### DIFF
--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -29,11 +29,11 @@
                <goal>run</goal>
              </goals>
              <configuration>
-               <tasks>
+               <target>
                  <property name="native.classpath" refid="maven.compile.classpath" />
                  <echo file="${project.build.directory}/compile-classpath" message="${native.classpath}" />
                  <exec dir="." executable="./build.sh" failonerror="true"/>
-               </tasks>
+               </target>
              </configuration>
            </execution>
          </executions>


### PR DESCRIPTION
Building the Java Toolkit failed

Apache Maven 3.9.5 (57804ffe001d7215b5e7bcb531cf83df38f93546)
Java version: 21, openjdk.jdk
OS name: "mac os x", version: "12.6.5", arch: "aarch64", family: "mac"

Maven reported to use `target` elements instead of `task` elements in the `pom.xml`

This PR changes the pom accordingly