### PR TITLE
More metadata fixes

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -509,12 +509,12 @@ public:
      * A copy of the back tree stored as pugi::xml_document
      */
     pugi::xml_document m_back;
-    
+
     /**
      * The music@decls value
      */
     std::string m_musicDecls;
-    
+
     /** The current page height */
     int m_drawingPageHeight;
     /** The current page width */

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -509,7 +509,12 @@ public:
      * A copy of the back tree stored as pugi::xml_document
      */
     pugi::xml_document m_back;
-
+    
+    /**
+     * The music@decls value
+     */
+    std::string m_musicDecls;
+    
     /** The current page height */
     int m_drawingPageHeight;
     /** The current page width */

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -466,8 +466,9 @@ struct DateWithErrors {
 };
 
 struct DateConstruct {
-    // constructType can be any of "" (invalid), "DateSingle" (one date), "DateRelative" (one date, qualifier="before" or "after"),
-    // "DateBetween" (two dates), "DateSelection" (N dates, qualifier="and" or "or"), or "DateConstructRange" (two DateConstructs).
+    // constructType can be any of "" (invalid), "DateSingle" (one date), "DateRelative"
+    // (one date, qualifier="before" or "after"), "DateBetween" (two dates), "DateSelection"
+    // (N dates, qualifier="and" or "or"), or "DateConstructRange" (two DateConstructs).
     std::string constructType; // if type is "", ignore everything here, the date construct was not parseable.
     std::string dateConstructError; // error of the entire DateConstruct
     std::string qualifier;
@@ -924,7 +925,6 @@ protected:
     int getBestItem(const std::vector<HumdrumReferenceItem> &items, const std::string &requiredLanguage);
     bool isStandardHumdrumKey(const std::string &key);
     void appendText(pugi::xml_node element, std::string text);
-
 
     /// Templates ///////////////////////////////////////////////////////////
     template <class ELEMENT> void verticalRest(ELEMENT rest, const std::string &token);

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -913,7 +913,8 @@ protected:
     std::map<std::string, std::string> isoDateAttributesFromHumdrumDate(
         const std::string &inHumdrumDate, bool edtf = false);
     DateConstruct dateConstructFromHumdrumDate(const std::string &dateString);
-    std::map<std::string, std::string> isoDateAttributesFromDateConstruct(const DateConstruct &date, bool edtf);
+    std::map<std::string, std::string> isoDateAttributesFromDateConstruct(
+        const DateConstruct &dateConstruct, bool edtf, bool isEdgeOfDateConstructRange = false);
     std::string isoDateFromDateWithErrors(const DateWithErrors &dateWithErrors, bool edtf);
     DateWithErrors dateWithErrorsFromHumdrumDate(const std::string &dateString);
     bool sanityCheckDate(int year, int month, int day, int hour, int minute, int second);

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -465,6 +465,16 @@ struct DateWithErrors {
     std::string secondError; // error of the second ("", "approximate", "uncertain")
 };
 
+struct DateConstruct {
+    // constructType can be any of "" (invalid), "DateSingle" (one date), "DateRelative" (one date, qualifier="before" or "after"),
+    // "DateBetween" (two dates), "DateSelection" (N dates, qualifier="and" or "or"), or "DateConstructRange" (two DateConstructs).
+    std::string constructType; // if type is "", ignore everything here, the date construct was not parseable.
+    std::string dateConstructError; // error of the entire DateConstruct
+    std::string qualifier;
+    std::vector<DateWithErrors> dates; // empty for "DateConstructRange"
+    std::vector<DateConstruct> dateConstructs; // only used for "DateConstructRange" (has two elements in that case)
+};
+
 //----------------------------------------------------------------------------
 // HumdrumInput
 //----------------------------------------------------------------------------
@@ -901,8 +911,10 @@ protected:
     void fillInIsoDate(pugi::xml_node element, const std::string &dateString);
     std::map<std::string, std::string> isoDateAttributesFromHumdrumDate(
         const std::string &inHumdrumDate, bool edtf = false);
+    DateConstruct dateConstructFromHumdrumDate(const std::string &dateString);
+    std::map<std::string, std::string> isoDateAttributesFromDateConstruct(const DateConstruct &date, bool edtf);
+    std::string isoDateFromDateWithErrors(const DateWithErrors &dateWithErrors, bool edtf);
     DateWithErrors dateWithErrorsFromHumdrumDate(const std::string &dateString);
-    std::string isoDateFromDateWithErrors(const DateWithErrors &date, bool edtf);
     bool sanityCheckDate(int year, int month, int day, int hour, int minute, int second);
     std::string stripDateError(std::string &value);
     std::string getTextListLanguage(const std::vector<HumdrumReferenceItem> &textItems);

--- a/include/vrv/iohumdrum.h
+++ b/include/vrv/iohumdrum.h
@@ -893,6 +893,7 @@ protected:
     void createEncodingDesc(pugi::xml_node meiHead);
     void createWorkList(pugi::xml_node meiHead);
     void createHumdrumVerbatimExtMeta(pugi::xml_node meiHead);
+    void createBackMatter();
     void createSimpleTitleElement();
     void createSimpleComposerElements();
     void createTitleElements(pugi::xml_node element);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -2781,8 +2781,9 @@ void HumdrumInput::createFileDesc(pugi::xml_node meiHead)
 
     pugi::xml_node pubStmt = fileDesc.append_child("pubStmt");
     pugi::xml_node unpub = pubStmt.append_child("unpub");
-    appendText(unpub, "This MEI file was created by Verovio's Humdrum converter. When published, this unpub element "
-               "should be removed, and the enclosing pubStmt element should be properly filled out.");
+    appendText(unpub,
+        "This MEI file was created by Verovio's Humdrum converter. When published, this unpub element "
+        "should be removed, and the enclosing pubStmt element should be properly filled out.");
 
     // If sourceDesc ends up with no children, we will fileDesc.remove_child(sourceDesc) to avoid an empty
     // <sourceDesc/>.
@@ -3148,15 +3149,10 @@ DateConstruct HumdrumInput::dateConstructFromHumdrumDate(const std::string &inHu
         }
 
         if (dateStrings[0].find_first_of("^") != std::string::npos
-                || dateStrings[1].find_first_of("^") != std::string::npos
-                || dateStrings[0][0] == '~'
-                || dateStrings[0][0] == '?'
-                || dateStrings[0][0] == '<'
-                || dateStrings[0][0] == '>'
-                || dateStrings[1][0] == '~'
-                || dateStrings[1][0] == '?'
-                || dateStrings[1][0] == '<'
-                || dateStrings[1][0] == '>') {
+            || dateStrings[1].find_first_of("^") != std::string::npos || dateStrings[0][0] == '~'
+            || dateStrings[0][0] == '?' || dateStrings[0][0] == '<' || dateStrings[0][0] == '>'
+            || dateStrings[1][0] == '~' || dateStrings[1][0] == '?' || dateStrings[1][0] == '<'
+            || dateStrings[1][0] == '>') {
             // It will require two DateConstructs to describe this date range, because one or both ends of
             // the range are either DateBetweens themselves (or DateRelatives), or have full date errors.
             typeNeeded = "DateConstructRange";
@@ -3228,7 +3224,8 @@ DateConstruct HumdrumInput::dateConstructFromHumdrumDate(const std::string &inHu
 // HumdrumInput::isoDateAttributesFromDateConstruct --
 //
 
-std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstruct(const DateConstruct &dateConstruct, bool edtf)
+std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstruct(
+    const DateConstruct &dateConstruct, bool edtf)
 {
     std::map<std::string, std::string> attribs;
 
@@ -3239,8 +3236,10 @@ std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstr
         if (!edtf) {
             return attribs;
         }
-        std::map<std::string, std::string> attribStart = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[0], edtf);
-        std::map<std::string, std::string> attribEnd = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[1], edtf);
+        std::map<std::string, std::string> attribStart
+            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[0], edtf);
+        std::map<std::string, std::string> attribEnd
+            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[1], edtf);
         attribs["startedtf"] = attribStart["edtf"];
         attribs["endedtf"] = attribEnd["edtf"];
         return attribs;
@@ -3327,7 +3326,6 @@ std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstr
     }
 
     return attribs;
-
 }
 //////////////////////////////
 //
@@ -4452,7 +4450,6 @@ void HumdrumInput::appendText(pugi::xml_node element, std::string text)
         }
         element.append_child(pugi::node_pcdata).set_value(s.c_str());
     }
-
 }
 
 //////////////////////////////

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -4062,6 +4062,7 @@ void HumdrumInput::createWorkList(pugi::xml_node meiHead)
         pugi::xml_node theWork = workList.append_child("work");
         std::string xmlId = StringFormat("work%d_encoded", workNumber++);
         theWork.append_attribute("xml:id") = xmlId.c_str();
+        m_doc->m_musicDecls = "#" + xmlId;
         theWork.append_attribute("type") = "encoded";
 
         // <identifier>

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -3078,6 +3078,12 @@ DateWithErrors HumdrumInput::dateWithErrorsFromHumdrumDate(const std::string &hu
         }
         try {
             if (value.size() > 0) {
+                // reject value that has extra chars that stoi will ignore silently
+                // (e.g. stoi("1910 (rev. 1923)") returns 1910).
+                if (!hre.match(value, "^\\d+$")) {
+                    date.valid = false;
+                    return date;
+                }
                 values[i] = stoi(value);
             }
         }
@@ -3652,6 +3658,7 @@ void HumdrumInput::createPrintedSource(pugi::xml_node sourceDesc)
             pugi::xml_node dateEl = imprint.append_child("date");
             dateEl.append_attribute("type") = "datePublished";
             dateEl.append_attribute("analog") = "humdrum:PDT";
+            fillInIsoDate(dateEl, datePublished.value);
             appendText(dateEl, datePublished.value);
         }
 

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -3144,6 +3144,7 @@ DateWithErrors HumdrumInput::dateWithErrorsFromHumdrumDate(const std::string &hu
     DateWithErrors date;
     std::string dateString = humdrumDate;
 
+    // check if there's an error for the whole date
     if (!dateString.empty()) {
         if (dateString[0] == '~') {
             dateString.erase(0, 1);
@@ -3262,25 +3263,25 @@ std::string HumdrumInput::isoDateFromDateWithErrors(const DateWithErrors &date, 
             // ignore this and anything after this
             break;
         }
-        std::string suffix = "";
+        std::string prefix = "";
         if (!error.empty()) {
             if (!edtf) {
                 // non-EDTF ISO dates can't describe approximate/uncertain values.
                 return "";
             }
             if (error == "uncertain") {
-                suffix = "?";
+                prefix = "?";
             }
             else if (error == "approximate") {
-                suffix = "~";
+                prefix = "~";
             }
         }
         if (i == 0) {
-            std::string yearStr = StringFormat("%d%s", value, suffix.c_str());
+            std::string yearStr = StringFormat("%s%d", prefix.c_str(), value);
             dateParts.push_back(yearStr);
         }
         else {
-            std::string numStr = StringFormat("%02d%s", value, suffix.c_str());
+            std::string numStr = StringFormat("%s%02d", prefix.c_str(), value);
             dateParts.push_back(numStr);
         }
     }
@@ -3310,7 +3311,14 @@ std::string HumdrumInput::isoDateFromDateWithErrors(const DateWithErrors &date, 
             isodate += dateParts[i];
         }
     }
-
+    
+    if (date.dateError == "approximate") {
+        isodate += "~";
+    }
+    else if (date.dateError == "uncertain") {
+        isodate += "?";
+    }
+    
     return isodate;
 }
 

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -3225,7 +3225,7 @@ DateConstruct HumdrumInput::dateConstructFromHumdrumDate(const std::string &inHu
 //
 
 std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstruct(
-    const DateConstruct &dateConstruct, bool edtf)
+    const DateConstruct &dateConstruct, bool edtf, bool isEdgeOfDateConstructRange)
 {
     std::map<std::string, std::string> attribs;
 
@@ -3237,9 +3237,9 @@ std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstr
             return attribs;
         }
         std::map<std::string, std::string> attribStart
-            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[0], edtf);
+            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[0], edtf, true);
         std::map<std::string, std::string> attribEnd
-            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[1], edtf);
+            = isoDateAttributesFromDateConstruct(dateConstruct.dateConstructs[1], edtf, true);
         attribs["startedtf"] = attribStart["edtf"];
         attribs["endedtf"] = attribEnd["edtf"];
         return attribs;
@@ -3284,7 +3284,14 @@ std::map<std::string, std::string> HumdrumInput::isoDateAttributesFromDateConstr
     }
     else if (dateConstruct.constructType == "DateBetween") {
         if (edtf) {
-            attribs["edtf"] = isodates[0] + "/" + isodates[1];
+            if (isEdgeOfDateConstructRange) {
+                // DateBetween is actually a selection (one date, somewhere between these two dates)
+                attribs["edtf"] = "[" + isodates[0] + ".." + isodates[1] + "]";
+            }
+            else {
+                // DateBetween is a proper range (this entire range of dates)
+                attribs["edtf"] = isodates[0] + "/" + isodates[1];
+            }
         }
         else {
             attribs["startdate"] = isodates[0];

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1458,6 +1458,10 @@ bool MEIOutput::WriteDoc(Doc *doc)
     // ---- music ----
 
     pugi::xml_node music = m_mei.append_child("music");
+    if (!m_doc->m_musicDecls.empty()) {
+        music.append_attribute("decls") = m_doc->m_musicDecls.c_str();
+    }
+    
     Facsimile *facs = doc->GetFacsimile();
     if (!this->GetBasic() && (facs != NULL) && (facs->GetChildCount() > 0)) {
         pugi::xml_node facsimile = music.append_child("facsimile");

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1461,7 +1461,7 @@ bool MEIOutput::WriteDoc(Doc *doc)
     if (!m_doc->m_musicDecls.empty()) {
         music.append_attribute("decls") = m_doc->m_musicDecls.c_str();
     }
-    
+
     Facsimile *facs = doc->GetFacsimile();
     if (!this->GetBasic() && (facs != NULL) && (facs->GetChildCount() > 0)) {
         pugi::xml_node facsimile = music.append_child("facsimile");


### PR DESCRIPTION
Biggest change is a reworking of Humdrum date parsing to handle complex date ranges such as "!!!CDT:1750^1751-~1802/6" (which means composer birthdate is between 1750 and 1751, and composer death date is approximately June 1802).  Several other fixes as well.  Verovio and converter21 now produce exactly the same MEI metadata when converting Humdrum to MEI (tested on a few thousand Humdrum scores from various organizations).

I believe my Humdrum to MEI metadata work is now complete.