### PR TITLE
 Add support for `@letterspacing`

### DIFF
--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -133,6 +133,7 @@ public:
     FontInfo()
     {
         m_pointSize = 0;
+        m_letterSpacing = 0.0;
         m_family = 0; // was wxFONTFAMILY_DEFAULT;
         m_style = FONTSTYLE_NONE;
         m_weight = FONTWEIGHT_NONE;
@@ -147,6 +148,7 @@ public:
 
     // accessors and modifiers for the font elements
     int GetPointSize() const { return m_pointSize; }
+    int GetLetterSpacing() const { return m_letterSpacing; }
     data_FONTSTYLE GetStyle() const { return m_style; }
     data_FONTWEIGHT GetWeight() const { return m_weight; }
     bool GetUnderlined() const { return m_underlined; }
@@ -158,6 +160,7 @@ public:
     SmuflTextFont GetSmuflFont() const { return m_smuflFont; }
 
     void SetPointSize(int pointSize) { m_pointSize = pointSize; }
+    void SetLetterSpacing(double letterSpacing) { m_letterSpacing = letterSpacing; }
     void SetStyle(data_FONTSTYLE style) { m_style = style; }
     void SetWeight(data_FONTWEIGHT weight) { m_weight = weight; }
     void SetUnderlined(bool underlined) { m_underlined = underlined; }
@@ -171,6 +174,7 @@ public:
 
 private:
     int m_pointSize;
+    int m_letterSpacing;
     int m_family;
     data_FONTSTYLE m_style;
     data_FONTWEIGHT m_weight;

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -101,6 +101,7 @@ public:
         m_verticalShift = false;
         m_alignment = HORIZONTALALIGNMENT_left;
         m_pointSize = 0;
+        m_letterSpacing = 0;
         m_actualWidth = 0;
         m_enclose = TEXTRENDITION_NONE;
         m_textEnclose = ENCLOSURE_NONE;
@@ -119,6 +120,7 @@ public:
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;
+    int m_letterSpacing;
     std::vector<TextElement *> m_enclosedRend;
     data_TEXTRENDITION m_enclose;
     data_ENCLOSURE m_textEnclose;

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -101,7 +101,6 @@ public:
         m_verticalShift = false;
         m_alignment = HORIZONTALALIGNMENT_left;
         m_pointSize = 0;
-        m_letterSpacing = 0;
         m_actualWidth = 0;
         m_enclose = TEXTRENDITION_NONE;
         m_textEnclose = ENCLOSURE_NONE;
@@ -120,7 +119,6 @@ public:
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;
-    int m_letterSpacing;
     std::vector<TextElement *> m_enclosedRend;
     data_TEXTRENDITION m_enclose;
     data_ENCLOSURE m_textEnclose;

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -316,6 +316,12 @@ void DeviceContext::AddGlyphToTextExtend(const Glyph *glyph, TextExtend *extend)
     tmp = advX * m_fontStack.top()->GetPointSize();
     advX = ceil(tmp / (double)glyph->GetUnitsPerEm());
 
+    const int letterSpacing = m_fontStack.top()->GetLetterSpacing();
+    // This is not the first letter, add a letter spacing
+    if ((letterSpacing != 0) && (extend->m_width > 0)) {
+        extend->m_width += letterSpacing;
+    }
+
     // Changed because the width should only be the sum of advX
     // Alternatively we could add what is below 0 for the first and what is beyond the advx for the last
     // extend->m_width += std::max(partialWidth + x, advX);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1372,7 +1372,7 @@ Options::Options()
     this->Register(&m_lyricTopMinMargin, "lyricTopMinMargin", &m_generalLayout);
 
     m_lyricWordSpace.SetInfo("Lyric word space", "The lyric word space length");
-    m_lyricWordSpace.Init(1.20, 0.50, 10.00);
+    m_lyricWordSpace.Init(1.20, 0.00, 10.00);
     this->Register(&m_lyricWordSpace, "lyricWordSpace", &m_generalLayout);
 
     m_lyricVerseCollapse.SetInfo("Lyric verse collapse", "Collapse empty verse lines in lyrics");

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -969,6 +969,10 @@ void SvgDeviceContext::DrawText(
     if (m_fontStack.top()->GetPointSize() != 0) {
         textChild.append_attribute("font-size") = StringFormat("%dpx", m_fontStack.top()->GetPointSize()).c_str();
     }
+    if (m_fontStack.top()->GetLetterSpacing() != 0.0) {
+        textChild.append_attribute("letter-spacing")
+            = StringFormat("%dpx", m_fontStack.top()->GetLetterSpacing()).c_str();
+    }
     textChild.text().set(svgText.c_str());
 
     if ((x != 0) && (y != 0) && (x != VRV_UNSET) && (y != VRV_UNSET) && (width != 0) && (height != 0)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1762,6 +1762,9 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     if (syl->GetStart() && syl->GetStart()->GetDrawingCueSize()) {
         currentFont.SetPointSize(m_doc->GetCueSize(currentFont.GetPointSize()));
     }
+    if (syl->HasLetterspacing()) {
+        currentFont.SetLetterSpacing(syl->GetLetterspacing() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
+    }
     dc->SetFont(&currentFont);
 
     TextDrawingParams params;

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -127,6 +127,7 @@ void View::DrawDynamString(DeviceContext *dc, const std::u32string &str, TextDra
                 bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(smuflStr);
                 vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
                 vrvTxt.SetStyle(FONTSTYLE_normal);
+                vrvTxt.SetLetterSpacing(90);
                 dc->SetFont(&vrvTxt);
                 this->DrawTextString(dc, smuflStr, params);
                 dc->ResetFont();
@@ -417,6 +418,10 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
     }
     if (rend->HasFontweight()) {
         rendFont.SetWeight(rend->GetFontweight());
+        customFont = true;
+    }
+    if (rend->HasLetterspacing()) {
+        rendFont.SetLetterSpacing(rend->GetLetterspacing() * m_doc->GetDrawingUnit(100));
         customFont = true;
     }
 


### PR DESCRIPTION
* Added on `syl` and `rend`
* The value is in MEI vu (default for data.MEASUREMENTSIGNED)

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Letter spacing in lyrics</title>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2023-12-11" />
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Letter spacing in lyrics can be controlled with syl@letterspacing. The value should be given as MEI vu.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="4.1.0" label="0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" keysig="1f" meter.count="4" meter.unit="4">
                        <label>Alto</label>
                        <labelAbbr>A.</labelAbbr>
                        <clef shape="G" line="2" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n123yyhr" dur="4" oct="4" pname="f">
                              <verse n="1">
                                 <syl con="d" wordpos="i">Nor</syl>
                              </verse>
                           </note>
                           <note xml:id="nfbyegi" dur="4" oct="4" pname="g">
                              <verse n="1">
                                 <syl wordpos="t">mal</syl>
                              </verse>
                           </note>
                           <note xml:id="n1307hjq" dur="4" oct="4" pname="a">
                              <verse n="1">
                                 <syl letterspacing="2.000000" con="d" wordpos="i">wid</syl>
                              </verse>
                           </note>
                           <note xml:id="n1l7mqx4" dur="4" oct="4" pname="b">
                              <verse n="1">
                                 <syl letterspacing="2.000000" wordpos="t">der</syl>
                              </verse>
                              <accid accid.ges="f" />
                           </note>
                        </layer>
                     </staff>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1x8gfg1" dur="4" oct="5" pname="c">
                              <verse n="1">
                                 <syl letterspacing="-0.200000" con="d" wordpos="i">nar</syl>
                              </verse>
                           </note>
                           <note xml:id="n1tuzjas" dur="4" oct="4" pname="b">
                              <verse n="1">
                                 <syl letterspacing="-0.200000" con="d" wordpos="m">row</syl>
                              </verse>
                              <accid accid.ges="f" />
                           </note>
                           <rest dur="4" />
                           <note dur="4" oct="4" pname="g" />
                        </layer>
                     </staff>
                  </measure>
                  <measure right="end" n="3">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n6lxgga" dur="2" oct="4" pname="f" />
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<img width="666" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/86bd1d46-1af1-465e-9683-8ee973c742a2">

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Letter spacing</title>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2023-12-11" />
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Letter spacing can be controlled with rend@letterspacing.</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="4.1.0" label="0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" keysig="1f" meter.count="4" meter.unit="4">
                        <clef shape="G" line="2" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1312x8i" dur="4" oct="4" pname="f" />
                           <note dur="4" oct="4" pname="g" />
                           <note dur="4" oct="4" pname="a" />
                           <note xml:id="n13uobqg" dur="4" oct="4" pname="b">
                              <accid accid.ges="f" />
                           </note>
                        </layer>
                     </staff>
                     <tempo startid="#n1312x8i" midi.bpm="63.000000">
                        <rend>Normal spacing</rend>
                     </tempo>
                     <dir type="mscore-playtech-annotation" startid="#n13uobqg">
                        <rend letterspacing="2.000000">wider</rend>
                     </dir>
                  </measure>
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="5" pname="c" />
                           <note xml:id="nwmr6bu" dur="4" oct="4" pname="b">
                              <accid accid.ges="f" />
                           </note>
                           <note dur="4" oct="4" pname="a" />
                           <note dur="4" oct="4" pname="g" />
                        </layer>
                     </staff>
                     <dir type="mscore-playtech-annotation" startid="#nwmr6bu">
                        <rend letterspacing="-0.200000">narrower spacing</rend>
                     </dir>
                  </measure>
                  <measure right="end" n="3">
                     <staff n="1">
                        <layer n="1">
                           <note dur="2" oct="4" pname="f" />
                           <rest dur="2" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<img width="555" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/7a7150c8-1748-4267-a8bd-b47ef3cd85d2">
