### PR TITLE
fix: check fTrem attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [unreleased]
+* Support for `fTrem@unitdur` (@eNote-GmbH)
 
 ## [4.1.0] - 2023-12-15
 * Support for staves ordered by `scoreDef`

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -150,8 +150,8 @@ void View::DrawFTremSegment(DeviceContext *dc, Staff *staff, FTrem *fTrem)
         secondElement->m_x += (m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize)) / 2;
     }
 
-    // Number of bars to draw
-    const int allBars = fTrem->GetBeams();
+    // Number of beams to draw
+    const int allBars = fTrem->HasBeams() ? fTrem->GetBeams() : fTrem->GetUnitdur() - DURATION_4;
     int floatingBars = fTrem->HasBeamsFloat() ? fTrem->GetBeamsFloat() : 0;
     int fullBars = allBars - floatingBars;
 


### PR DESCRIPTION
This PR adds a check for `@beams` on `fTrem` with fallback to `@unitdur`. Previously some weird encodings lead to endless loops.