### PR TITLE
Fix Humdrum processing with mensural data

### DIFF
--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -164,6 +164,7 @@ public:
     Score *GetCorrespondingScore(const Object *object);
     const Score *GetCorrespondingScore(const Object *object) const;
     // Generic version that does not necessarily rely on precalculated visible scores
+    Score *GetCorrespondingScore(const Object *object, const std::list<Score *> &scores);
     const Score *GetCorrespondingScore(const Object *object, const std::list<Score *> &scores) const;
     ///@}
 

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -163,6 +163,8 @@ public:
     ///@{
     Score *GetCorrespondingScore(const Object *object);
     const Score *GetCorrespondingScore(const Object *object) const;
+    // Generic version that does not necessarily rely on precalculated visible scores
+    const Score *GetCorrespondingScore(const Object *object, const std::list<Score *> &scores) const;
     ///@}
 
     /**

--- a/include/vrv/setscoredeffunctor.h
+++ b/include/vrv/setscoredeffunctor.h
@@ -88,6 +88,7 @@ public:
      */
     ///@{
     FunctorCode VisitPageEnd(Page *page) override;
+    FunctorCode VisitScore(Score *score) override;
     ///@}
 
 protected:
@@ -97,7 +98,8 @@ private:
 public:
     //
 private:
-    //
+    // The list of all scores
+    std::list<Score *> m_scores;
 };
 
 //----------------------------------------------------------------------------

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1291,9 +1291,6 @@ void Doc::ConvertToCastOffMensuralDoc(bool castOff)
         m_isMensuralMusicOnly = false;
     }
 
-    // Calling Doc::PrepareData is expected to collect visible scores
-    assert(m_dataPreparationDone);
-
     // Make sure the document is not cast-off
     this->UnCastOffDoc();
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1523,10 +1523,15 @@ Score *Doc::GetCorrespondingScore(const Object *object)
 
 const Score *Doc::GetCorrespondingScore(const Object *object) const
 {
-    assert(!m_visibleScores.empty());
+    return this->GetCorrespondingScore(object, m_visibleScores);
+}
 
-    const Score *correspondingScore = m_visibleScores.front();
-    for (Score *score : m_visibleScores) {
+const Score *Doc::GetCorrespondingScore(const Object *object, const std::list<Score *> &scores) const
+{
+    assert(!scores.empty());
+
+    const Score *correspondingScore = scores.front();
+    for (Score *score : scores) {
         if ((score == object) || Object::IsPreOrdered(score, object)) {
             correspondingScore = score;
         }

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -1526,6 +1526,11 @@ const Score *Doc::GetCorrespondingScore(const Object *object) const
     return this->GetCorrespondingScore(object, m_visibleScores);
 }
 
+Score *Doc::GetCorrespondingScore(const Object *object, const std::list<Score *> &scores)
+{
+    return const_cast<Score *>(std::as_const(*this).GetCorrespondingScore(object, scores));
+}
+
 const Score *Doc::GetCorrespondingScore(const Object *object, const std::list<Score *> &scores) const
 {
     assert(!scores.empty());

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -31612,7 +31612,6 @@ void HumdrumInput::finalizeDocument(Doc *doc)
     if (m_mens) {
         doc->SetMensuralMusicOnly(true);
         doc->m_notationType = NOTATIONTYPE_mensural;
-        doc->PrepareData();
         doc->ConvertToCastOffMensuralDoc(true);
     }
 }

--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -68,11 +68,18 @@ FunctorCode ScoreDefSetCurrentPageFunctor::VisitPageEnd(Page *page)
 {
     const Object *firstSystem = page->GetFirst(SYSTEM);
     const Object *reference = firstSystem ? firstSystem : page;
-    page->m_score = m_doc->GetCorrespondingScore(reference);
+    page->m_score = m_doc->GetCorrespondingScore(reference, m_scores);
 
     const Object *lastSystem = page->GetLast(SYSTEM);
     reference = lastSystem ? lastSystem : page;
-    page->m_scoreEnd = m_doc->GetCorrespondingScore(reference);
+    page->m_scoreEnd = m_doc->GetCorrespondingScore(reference, m_scores);
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode ScoreDefSetCurrentPageFunctor::VisitScore(Score *score)
+{
+    m_scores.push_back(score);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -48,7 +48,6 @@ void SystemAligner::Reset()
     m_spacingTypes.clear();
     m_system = NULL;
 
-    ArrayOfObjects &children = this->GetChildrenForModification();
     m_bottomAlignment = new StaffAlignment();
     m_bottomAlignment->SetStaff(NULL, NULL, this->GetAboveSpacingType(NULL));
     m_bottomAlignment->SetParentSystem(this->GetSystem());


### PR DESCRIPTION
This PR fixes the Humdrum crash triggered by running the `ScoreDefSetCurrentPageFunctor` outside the usual layout. The functor was relying on precalculated visible scores which are not available in this scenario. This dependency is now removed in the PR: the functor tracks scores itself and hence can be called from `unusual` places. Closes #3553 . 