### PR TITLE
allow fTrem in beam

### DIFF
--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -19,6 +19,7 @@
 #include "btrem.h"
 #include "doc.h"
 #include "editorial.h"
+#include "ftrem.h"
 #include "functor.h"
 #include "gracegrp.h"
 #include "layer.h"
@@ -1633,6 +1634,9 @@ bool Beam::IsSupportedChild(Object *child)
     }
     else if (child->Is(CLEF)) {
         assert(dynamic_cast<Clef *>(child));
+    }
+    else if (child->Is(FTREM)) {
+        assert(dynamic_cast<FTrem *>(child));
     }
     else if (child->Is(GRACEGRP)) {
         assert(dynamic_cast<GraceGrp *>(child));

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -3533,6 +3533,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         else if (element == "clef") {
             return true;
         }
+        else if (element == "fTrem") {
+            return true;
+        }
         else if (element == "graceGrp") {
             return true;
         }

--- a/src/view_beam.cpp
+++ b/src/view_beam.cpp
@@ -49,6 +49,14 @@ void View::DrawBeam(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
         return;
     }
 
+    if (beam->GetFirst(FTREM)) {
+        // If there is a fTrem we ignore the beam and just handle its children
+        dc->StartGraphic(element, "", element->GetID());
+        this->DrawLayerChildren(dc, beam, layer, staff, measure);
+        dc->EndGraphic(element, this);
+        return;
+    }
+
     beam->m_beamSegment.InitCoordRefs(beam->GetElementCoords());
 
     data_BEAMPLACE initialPlace = beam->GetPlace();


### PR DESCRIPTION
MEI allows `fTrem` to be a child of a `beam`. This PR enables the processing of `fTrem` within a `beam`, but skips the drawing of the beam element for now to not get interfering beams.