### PR TITLE
Fix resource path long option

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -72,6 +72,8 @@ bool optionExists(const std::string &option, int argc, char **argv, std::string 
     return false;
 }
 
+#define OPTION_TO_GETOPT(opt, has_arg) { vrv::FromCamelCase(opt.GetKey()).c_str(), has_arg, 0, opt.GetShortOption() }
+
 int main(int argc, char **argv)
 {
     std::string infile;
@@ -89,18 +91,20 @@ int main(int argc, char **argv)
     // The fonts will be loaded later with Resources::InitFonts()
     vrv::Toolkit toolkit(false);
 
+    vrv::Options *options = toolkit.GetOptionsObj();
+
     static struct option base_options[] = { //
-        { "all-pages", no_argument, 0, 'a' }, //
-        { "input-from", required_argument, 0, 'f' }, //
-        { "help", required_argument, 0, 'h' }, //
-        { "log-level", required_argument, 0, 'l' }, //
-        { "outfile", required_argument, 0, 'o' }, //
-        { "page", required_argument, 0, 'p' }, //
-        { "resource-path", required_argument, 0, 'r' }, //
-        { "scale", required_argument, 0, 's' }, //
-        { "output-to", required_argument, 0, 't' }, //
-        { "version", no_argument, 0, 'v' }, //
-        { "xml-id-seed", required_argument, 0, 'x' }, //
+        OPTION_TO_GETOPT(options->m_allPages, no_argument), //
+        OPTION_TO_GETOPT(options->m_inputFrom, required_argument), //
+        OPTION_TO_GETOPT(options->m_help, required_argument), //
+        OPTION_TO_GETOPT(options->m_logLevel, required_argument), //
+        OPTION_TO_GETOPT(options->m_outfile, required_argument), //
+        OPTION_TO_GETOPT(options->m_page, required_argument), //
+        OPTION_TO_GETOPT(options->m_resourcePath, required_argument), //
+        OPTION_TO_GETOPT(options->m_scale, required_argument), //
+        OPTION_TO_GETOPT(options->m_outputTo, required_argument), //
+        OPTION_TO_GETOPT(options->m_version, no_argument), //
+        OPTION_TO_GETOPT(options->m_xmlIdSeed, required_argument), //
         // standard input - long options only or - as filename
         { "stdin", no_argument, 0, 'z' }, //
         { 0, 0, 0, 0 }
@@ -108,7 +112,6 @@ int main(int argc, char **argv)
 
     int baseSize = sizeof(base_options) / sizeof(option);
 
-    vrv::Options *options = toolkit.GetOptionsObj();
     const vrv::MapOfStrOptions *params = options->GetItems();
     int mapSize = (int)params->size();
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
         { "log-level", required_argument, 0, 'l' }, //
         { "outfile", required_argument, 0, 'o' }, //
         { "page", required_argument, 0, 'p' }, //
-        { "resources", required_argument, 0, 'r' }, //
+        { "resource-path", required_argument, 0, 'r' }, //
         { "scale", required_argument, 0, 's' }, //
         { "output-to", required_argument, 0, 't' }, //
         { "version", no_argument, 0, 'v' }, //

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -72,7 +72,10 @@ bool optionExists(const std::string &option, int argc, char **argv, std::string 
     return false;
 }
 
-#define OPTION_TO_GETOPT(opt, has_arg) { vrv::FromCamelCase(opt.GetKey()).c_str(), has_arg, 0, opt.GetShortOption() }
+#define OPTION_TO_GETOPT(opt, has_arg)                                                                                 \
+    {                                                                                                                  \
+        vrv::FromCamelCase(opt.GetKey()).c_str(), has_arg, 0, opt.GetShortOption()                                     \
+    }
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
both `verovio -h base` and [online documentation](https://book.verovio.org/installing-or-building-from-sources/command-line.html#building-on-macos-or-linux) advertise `--resource-path` as long option for `-r`, but it doesn't work and the actual long option is `--resources`. This is due to the options being defined on two places (currently out of sync), one definition being used to print help, the other to actually parse the command line arguments.

This PR consists of two commits. The first one is the minimal change required to make the `--resource-path` option work as promised by the documentation. The latter is a refactoring which eliminates (most of) the code duplication that was at the root of the issue.