### PR TITLE
Implement note@glyph.num, @glyph.name, @altsym for tablature.

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -13,6 +13,7 @@
 //----------------------------------------------------------------------------
 
 #include "accid.h"
+#include "altsyminterface.h"
 #include "atts_analytical.h"
 #include "atts_externalsymbols.h"
 #include "atts_frettab.h"
@@ -45,6 +46,7 @@ class Verse;
  */
 class Note : public LayerElement,
              public StemmedDrawingInterface,
+             public AltSymInterface,
              public DurationInterface,
              public PitchInterface,
              public PositionInterface,
@@ -80,6 +82,8 @@ public:
      * @name Getter to interfaces
      */
     ///@{
+    AltSymInterface *GetAltSymInterface() override { return vrv_cast<AltSymInterface *>(this); }
+    const AltSymInterface *GetAltSymInterface() const override { return vrv_cast<const AltSymInterface *>(this); }
     DurationInterface *GetDurationInterface() override { return vrv_cast<DurationInterface *>(this); }
     const DurationInterface *GetDurationInterface() const override { return vrv_cast<const DurationInterface *>(this); }
     PitchInterface *GetPitchInterface() override { return vrv_cast<PitchInterface *>(this); }

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -232,7 +232,7 @@ protected:
     void DrawMeterSigGrp(DeviceContext *dc, Layer *layer, Staff *staff);
     void DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *system, int yOffset);
     void DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
-    void DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, System *system);
+    void DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, Measure *measure, System *system);
     void DrawLayer(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure);
     void DrawLayerList(DeviceContext *dc, Layer *layer, Staff *staff, Measure *measure, const ClassId classId);
     void DrawLayerDefLabels(

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2721,6 +2721,7 @@ void MEIOutput::WriteNote(pugi::xml_node currentNode, Note *note)
     assert(note);
 
     this->WriteLayerElement(currentNode, note);
+    this->WriteAltSymInterface(currentNode, note);
     this->WriteDurationInterface(currentNode, note);
     this->WritePitchInterface(currentNode, note);
     this->WritePositionInterface(currentNode, note);
@@ -6823,6 +6824,7 @@ bool MEIInput::ReadNote(Object *parent, pugi::xml_node note)
         }
     }
 
+    this->ReadAltSymInterface(note, vrvNote);
     this->ReadDurationInterface(note, vrvNote);
     this->ReadPitchInterface(note, vrvNote);
     this->ReadPositionInterface(note, vrvNote);
@@ -7115,6 +7117,9 @@ bool MEIInput::ReadSymbolDefChildren(Object *parent, pugi::xml_node parentNode, 
         }
         else if (elementName == "svg") {
             success = this->ReadSvg(parent, xmlElement);
+        }
+        else if (elementName == "symbol") {
+            success = this->ReadSymbol(parent, xmlElement);
         }
         // xml comment
         else if (elementName == "") {

--- a/src/symboldef.cpp
+++ b/src/symboldef.cpp
@@ -16,6 +16,7 @@
 #include "doc.h"
 #include "graphic.h"
 #include "svg.h"
+#include "symbol.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -47,6 +48,9 @@ bool SymbolDef::IsSupportedChild(Object *child)
     }
     else if (child->Is(SVG)) {
         assert(dynamic_cast<Svg *>(child));
+    }
+    else if (child->Is(SYMBOL)) {
+        assert(dynamic_cast<Symbol *>(child));
     }
     else {
         return false;

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1242,9 +1242,7 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
         staff->SetFromFacsimile(m_doc);
     }
 
-    if ((staffDef && (staffDef->GetLinesVisible() != BOOLEAN_false)) || staff->IsTabLuteGerman()) {
-        this->DrawStaffLines(dc, staff, measure, system);
-    }
+    this->DrawStaffLines(dc, staff, staffDef, measure, system);
 
     if (staffDef && (m_doc->GetType() != Facs)) {
         this->DrawStaffDef(dc, staff, measure);
@@ -1274,7 +1272,7 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
     dc->EndGraphic(staff, this);
 }
 
-void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, System *system)
+void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, Measure *measure, System *system)
 {
     assert(dc);
     assert(staff);
@@ -1302,14 +1300,18 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, Measure *measure, Sys
     dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), AxSOLID);
     dc->SetBrush(m_currentColor, AxSOLID);
 
-    if (staff->IsTabLuteGerman()) {
+    // If German lute tablature the default is @lines.visible="false", but setting @lines.visible="true"
+    // will draw the staff lines.
+    // For anything other than German lute tablature the default is @lines.visible="true"
+    if (staff->IsTabLuteGerman() && staffDef->GetLinesVisible() != BOOLEAN_true) {
         // German tablature has no staff, just a single base line
         // But internally we maintain the fiction of an invisible staff as a coordinate system
         SegmentedLine line(x1, x2);
         y1 -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
         this->DrawHorizontalSegmentedLine(dc, y1, line, lineWidth);
     }
-    else {
+    else if (staffDef->GetLinesVisible() != BOOLEAN_false) {
+        // draw staff lines
         for (j = 0; j < staff->m_drawingLines; ++j) {
             // Skewed lines - with Facs (neumes) only for now
             if (y1 != y2) {


### PR DESCRIPTION

Implement &lt;note&gt;@glyph.num, @glyph.name, @altsym for all tablature types.
Add add &lt;symbol&gt; as child to &lt;symbolDef&gt; (new for MEI 5.0).
Allow German tablature staff to be shown if @lines.visible="true", as agreed in the E-Laute discussion.

**Changes**

iomei.cpp add AltSymInterface as baseclass to support @altsym. Add &lt;symbol&gt; as child to &lt;symbolDef&gt;

note.cpp add AltSymInterface as baseclass to support @altsym. Implement @glyph.num, @glyph.name, @altsym for tablature.

note.h add AltSymInterface as baseclass to support @altsym

symboldef.cpp add &lt;symbol&gt; as child to &lt;symbolDef&gt;

view.cpp allow German tablature staff to be shown if @lines.visible="true"

view.h allow German tablature staff to be shown if @lines.visible="true"

Note that for tablature I have only implemented the &lt;symbol&gt; child of &lt;symbolDef&gt;.  Any other children are ignored, e.g. &lt;graphic&gt;.

The test.mei file uses &lt;note&gt;@glyph.num, @glyph.name and @altsym to demonstrate German lute tablature using Hans Judenkünig's variant ABC.

[test.zip](https://github.com/rism-digital/verovio/files/14054452/test.zip)
