### PR TITLE
base options: also argument requirement governed by the Option object

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -122,6 +122,7 @@ public:
     void SetShortOption(char shortOption, bool isCmdOnly);
     char GetShortOption() const { return m_shortOption; }
     bool IsCmdOnly() const { return m_isCmdOnly; }
+    bool IsArgumentRequired() const { return true; }
 
     /**
      * Return a JSON object for the option
@@ -185,6 +186,8 @@ public:
     bool GetValue() const { return m_value; }
     bool GetDefault() const { return m_defaultValue; }
     bool SetValue(bool value);
+
+    bool IsArgumentRequired() const { return false; }
 
 private:
     //
@@ -593,7 +596,7 @@ public:
     // These options are only given for documentation - except for m_scale
     // They are ordered by short option alphabetical order
     OptionBool m_standardOutput;
-    OptionBool m_help;
+    OptionString m_help;
     OptionBool m_allPages;
     OptionString m_inputFrom;
     OptionString m_logLevel;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -905,7 +905,7 @@ Options::Options()
     m_baseOptions.AddOption(&m_standardOutput);
 
     m_help.SetInfo("Help", "Display this message");
-    m_help.Init(false);
+    m_help.Init("");
     m_help.SetKey("help");
     m_help.SetShortOption('h', true);
     m_baseOptions.AddOption(&m_help);

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -72,9 +72,10 @@ bool optionExists(const std::string &option, int argc, char **argv, std::string 
     return false;
 }
 
-#define OPTION_TO_GETOPT(opt, has_arg)                                                                                 \
+#define OPTION_TO_GETOPT(opt)                                                                                          \
     {                                                                                                                  \
-        vrv::FromCamelCase(opt.GetKey()).c_str(), has_arg, 0, opt.GetShortOption()                                     \
+        vrv::FromCamelCase(opt.GetKey()).c_str(), opt.IsArgumentRequired() ? required_argument : no_argument, 0,       \
+            opt.GetShortOption()                                                                                       \
     }
 
 int main(int argc, char **argv)
@@ -97,17 +98,17 @@ int main(int argc, char **argv)
     vrv::Options *options = toolkit.GetOptionsObj();
 
     static struct option base_options[] = { //
-        OPTION_TO_GETOPT(options->m_allPages, no_argument), //
-        OPTION_TO_GETOPT(options->m_inputFrom, required_argument), //
-        OPTION_TO_GETOPT(options->m_help, required_argument), //
-        OPTION_TO_GETOPT(options->m_logLevel, required_argument), //
-        OPTION_TO_GETOPT(options->m_outfile, required_argument), //
-        OPTION_TO_GETOPT(options->m_page, required_argument), //
-        OPTION_TO_GETOPT(options->m_resourcePath, required_argument), //
-        OPTION_TO_GETOPT(options->m_scale, required_argument), //
-        OPTION_TO_GETOPT(options->m_outputTo, required_argument), //
-        OPTION_TO_GETOPT(options->m_version, no_argument), //
-        OPTION_TO_GETOPT(options->m_xmlIdSeed, required_argument), //
+        OPTION_TO_GETOPT(options->m_allPages), //
+        OPTION_TO_GETOPT(options->m_inputFrom), //
+        OPTION_TO_GETOPT(options->m_help), //
+        OPTION_TO_GETOPT(options->m_logLevel), //
+        OPTION_TO_GETOPT(options->m_outfile), //
+        OPTION_TO_GETOPT(options->m_page), //
+        OPTION_TO_GETOPT(options->m_resourcePath), //
+        OPTION_TO_GETOPT(options->m_scale), //
+        OPTION_TO_GETOPT(options->m_outputTo), //
+        OPTION_TO_GETOPT(options->m_version), //
+        OPTION_TO_GETOPT(options->m_xmlIdSeed), //
         // standard input - long options only or - as filename
         { "stdin", no_argument, 0, 'z' }, //
         { 0, 0, 0, 0 }


### PR DESCRIPTION
In #3580 I was removing, as far as possible, code duplication regarding definition of the base options. But I left the `required_argument` / `no_argument` specification in `main.cpp`, as I wasn't confident that my understanding of the context is sufficient not to accidentally break something. Having read a bit more, I propose one more refactoring to get rid of this last bit of duplicate definition. Let the `Option` objects specify also if they require a command line argument or not.