### PR TITLE
Improve runtime of time spanning functor

### DIFF
--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -493,18 +493,23 @@ public:
     FunctorCode VisitF(F *f) override;
     FunctorCode VisitFloatingObject(FloatingObject *floatingObject) override;
     FunctorCode VisitLayerElement(LayerElement *layerElement) override;
+    FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitMeasureEnd(Measure *measure) override;
     ///@}
 
 protected:
     //
 private:
-    //
+    // Delegates to the pseudo functor of the interface
+    FunctorCode CallPseudoFunctor(Object *timeSpanningObject);
+
 public:
     //
 private:
     // The interface list that holds the current elements to match
     ListOfSpanningInterOwnerPairs m_timeSpanningInterfaces;
+    // Indicates whether we currently traverse a measure
+    bool m_insideMeasure;
 };
 
 //----------------------------------------------------------------------------

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -609,18 +609,16 @@ void Doc::PrepareData()
 
     // Try to match all spanning elements (slur, tie, etc) by processing backwards
     PrepareTimeSpanningFunctor prepareTimeSpanning;
-    prepareTimeSpanning.SetDirection(BACKWARD);
     this->Process(prepareTimeSpanning);
     prepareTimeSpanning.SetDataCollectionCompleted();
 
-    // First we try backwards because normally the spanning elements are at the end of
-    // the measure. However, in some case, one (or both) end points will appear afterwards
-    // in the encoding. For these, the previous iteration will not have resolved the link and
-    // the spanning elements will remain in the timeSpanningElements array. We try again forwards
-    // but this time without filling the list (that is only will the remaining elements)
+    // First we try a forward pass which should collect most of the spanning elements.
+    // However, in some cases, one (or both) end points might appear a few measures
+    // before the spanning element in the encoding. For these, the previous iteration will not have resolved the link
+    // and the spanning elements will remain in the timeSpanningElements array. We try again forwards but this time
+    // without filling the list (that is only resolving remaining elements).
     const ListOfSpanningInterOwnerPairs &interfaceOwnerPairs = prepareTimeSpanning.GetInterfaceOwnerPairs();
     if (!interfaceOwnerPairs.empty()) {
-        prepareTimeSpanning.SetDirection(FORWARD);
         this->Process(prepareTimeSpanning);
     }
 


### PR DESCRIPTION
This PR started with the observation that on a large file (about 260 pages) the `PrepareTimeSpanning` was the slowest of all functors - which seemed counterintuitive. The PR improves the functor runtime, especially for larger files:

| File size [number of pages] | Functor runtime before [ms] | Functor runtime after [ms] |
| ---- | ------ | ------ |
| 10 | 18 | 3 |
| 266 | 2700 | 46 |

To somehow understand the runtime issue, consider the following example. There are two kind of spanning elements: those that live in one measure and those that extend over several measures. 

<img width="500" alt="TimeSpanning" src="https://github.com/rism-digital/verovio/assets/63608463/40b18eee-93f6-49a9-81f3-1e53f0e8e0aa">

With functor traversal we will visit _start note, end note, tie_ for the green tie. This is good, since it means that by traversing backwards we can directly resolve endpoints. However, for the red slur we will visit _start note, slur, end note_. This is bad, since (independent of the traversal direction) we will always miss one endpoint in the first pass. So the slur must be kept in a list for the remaining pass and this is costly since each element in the list is ID compared against each layer element that is visited.

To improve the algorithm, we always pass forward, but collect all time spanning descendants at the begin of each measure. So both the red slur and green tie in the example above are collected before we visit its start and end note. This allows to resolve pretty much all time spanning elements in one go, if they are encoded in a sensible way (i.e. the element is encoded in the measure where it starts).

Open question: we still keep some code to resolve time spanning elements which are encoded outside of a measure (see `VisitFloatingObject` and `VisitF`). I simply did not know whether this is possible in MEI.


