### PR TITLE
Fix issue #3589 GLT de-emphasise dividing lines

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1307,8 +1307,9 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, M
         // German tablature has no staff, just a single base line
         // But internally we maintain the fiction of an invisible staff as a coordinate system
         SegmentedLine line(x1, x2);
-        y1 -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * staff->m_drawingLines;
-        this->DrawHorizontalSegmentedLine(dc, y1, line, lineWidth);
+        // Issue #3589 move base line slightly further down and reduce thickness
+        y1 -= (m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * staff->m_drawingLines) * 11 / 10;
+        this->DrawHorizontalSegmentedLine(dc, y1, line, lineWidth / 2);
     }
     else if (staffDef->GetLinesVisible() != BOOLEAN_false) {
         // draw staff lines
@@ -1321,11 +1322,12 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, M
                 y2 -= m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
             }
             else {
-                const bool isFrenchOrItalianTablature = (staff->IsTabLuteFrench() || staff->IsTabLuteItalian());
+                const bool isFrenchOrGermanOrItalianTablature
+                    = (staff->IsTabLuteFrench() || staff->IsTabLuteGerman() || staff->IsTabLuteItalian());
                 SegmentedLine line(x1, x2);
-                // We do not need to do this during layout calculation - and only with tablature but not for French or
-                // Italian tablature
-                if (!dc->Is(BBOX_DEVICE_CONTEXT) && staff->IsTablature() && !isFrenchOrItalianTablature) {
+                // We do not need to do this during layout calculation - and only with guitar tablature but not for
+                // French, German or Italian lute tablature
+                if (!dc->Is(BBOX_DEVICE_CONTEXT) && staff->IsTablature() && !isFrenchOrGermanOrItalianTablature) {
                     Object fullLine;
                     fullLine.SetParent(system);
                     fullLine.UpdateContentBBoxY(y1 + (lineWidth / 2), y1 - (lineWidth / 2));


### PR DESCRIPTION
Fix issue #3589 Slightly move dividing lines down and reduce line thickness.  (Also added a trivial but unconnected fix for when @lines.visible="true" for GLT).

Leipzig font before this pull request
![before-Leipzig](https://github.com/rism-digital/verovio/assets/76966668/3dfed84b-dacd-4e2c-b9d4-1dc5bbe138f0)
 
Leipzig font after this pull request, slight lower and thinner dividing lines 
![after-Leipzig](https://github.com/rism-digital/verovio/assets/76966668/dd69301b-c33f-481b-9e12-807938fa85e1)

Bravura font before this pull request
![before-Bravura](https://github.com/rism-digital/verovio/assets/76966668/50be7639-bd74-4642-975b-7cf4741317e3)

Bravura font after this pull request, slight lower and thinner dividing lines 
![after-Bravura](https://github.com/rism-digital/verovio/assets/76966668/1126a38f-68e6-490a-b859-a6a81f7038fc)





