### PR TITLE
Parallelisation for functors

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -1470,6 +1470,10 @@
 		E76046C128D4829000C36204 /* calcledgerlinesfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E76046BF28D4829000C36204 /* calcledgerlinesfunctor.cpp */; };
 		E76046C228D496B300C36204 /* calcledgerlinesfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E76046BF28D4829000C36204 /* calcledgerlinesfunctor.cpp */; };
 		E76046C328D496B400C36204 /* calcledgerlinesfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E76046BF28D4829000C36204 /* calcledgerlinesfunctor.cpp */; };
+		E7605A2E2B6EF47E00903A6A /* functor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E7605A2D2B6EF47E00903A6A /* functor.cpp */; };
+		E7605A2F2B6EF47E00903A6A /* functor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E7605A2D2B6EF47E00903A6A /* functor.cpp */; };
+		E7605A302B6EF47E00903A6A /* functor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E7605A2D2B6EF47E00903A6A /* functor.cpp */; };
+		E7605A312B6EF47E00903A6A /* functor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E7605A2D2B6EF47E00903A6A /* functor.cpp */; };
 		E763EF3F29E939C00029E56D /* convertfunctor.h in Headers */ = {isa = PBXBuildFile; fileRef = E763EF3E29E939C00029E56D /* convertfunctor.h */; };
 		E763EF4029E939C00029E56D /* convertfunctor.h in Headers */ = {isa = PBXBuildFile; fileRef = E763EF3E29E939C00029E56D /* convertfunctor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E763EF4229E939FB0029E56D /* convertfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E763EF4129E939FB0029E56D /* convertfunctor.cpp */; };
@@ -2206,6 +2210,7 @@
 		E75EA9FC29CC3A88003A97A7 /* calcarticfunctor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = calcarticfunctor.cpp; path = src/calcarticfunctor.cpp; sourceTree = "<group>"; };
 		E76046BC28D4828200C36204 /* calcledgerlinesfunctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = calcledgerlinesfunctor.h; path = include/vrv/calcledgerlinesfunctor.h; sourceTree = "<group>"; };
 		E76046BF28D4829000C36204 /* calcledgerlinesfunctor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = calcledgerlinesfunctor.cpp; path = src/calcledgerlinesfunctor.cpp; sourceTree = "<group>"; };
+		E7605A2D2B6EF47E00903A6A /* functor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = functor.cpp; path = src/functor.cpp; sourceTree = "<group>"; };
 		E763EF3E29E939C00029E56D /* convertfunctor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = convertfunctor.h; path = include/vrv/convertfunctor.h; sourceTree = "<group>"; };
 		E763EF4129E939FB0029E56D /* convertfunctor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = convertfunctor.cpp; path = src/convertfunctor.cpp; sourceTree = "<group>"; };
 		E765675828BBFBA400BC6490 /* functorinterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = functorinterface.h; path = include/vrv/functorinterface.h; sourceTree = "<group>"; };
@@ -3036,6 +3041,7 @@
 				E74A806528BC97D5005274E7 /* findfunctor.h */,
 				E722106528F856C4002CD6E9 /* findlayerelementsfunctor.cpp */,
 				E722106228F8569F002CD6E9 /* findlayerelementsfunctor.h */,
+				E7605A2D2B6EF47E00903A6A /* functor.cpp */,
 				E765675B28BC019F00BC6490 /* functor.h */,
 				E74A806828BC9842005274E7 /* functorinterface.cpp */,
 				E765675828BBFBA400BC6490 /* functorinterface.h */,
@@ -4153,6 +4159,7 @@
 				4DEC4D9721C81E3B00D1D273 /* expan.cpp in Sources */,
 				4D766EFF20ACAD6D006875D8 /* neume.cpp in Sources */,
 				4D1694581E3A44F300569BF4 /* accid.cpp in Sources */,
+				E7605A2F2B6EF47E00903A6A /* functor.cpp in Sources */,
 				4DACC9912990F29A00B55913 /* atts_critapp.cpp in Sources */,
 				4D1694591E3A44F300569BF4 /* custos.cpp in Sources */,
 				4D16945A1E3A44F300569BF4 /* dot.cpp in Sources */,
@@ -4430,6 +4437,7 @@
 				4DC34BA819BC4A83006175CD /* accid.cpp in Sources */,
 				4DC34BAA19BC4A83006175CD /* custos.cpp in Sources */,
 				4D7927D020ECCC6D0002A45D /* view_slur.cpp in Sources */,
+				E7605A2E2B6EF47E00903A6A /* functor.cpp in Sources */,
 				4D81351E2322C41800F59C01 /* keyaccid.cpp in Sources */,
 				BD2E4D95287587FD00B04350 /* stem.cpp in Sources */,
 				E77C198328CD31AD00F5BADA /* calcdotsfunctor.cpp in Sources */,
@@ -4720,6 +4728,7 @@
 				4DC34BAD19BC4A83006175CD /* dot.cpp in Sources */,
 				4D2073FD22A3BCE000E0765F /* tabgrp.cpp in Sources */,
 				4D7927D220ECCC6D0002A45D /* view_slur.cpp in Sources */,
+				E7605A302B6EF47E00903A6A /* functor.cpp in Sources */,
 				4DACC9922990F29A00B55913 /* atts_critapp.cpp in Sources */,
 				4DB3D8B91F83D0C600B5FC2B /* systemmilestone.cpp in Sources */,
 				4D2073FA22A3BCE000E0765F /* tabdursym.cpp in Sources */,
@@ -5004,6 +5013,7 @@
 				BB4C4B7F22A932DF001F6AF0 /* fb.cpp in Sources */,
 				BB4C4BA322A932E5001F6AF0 /* textdirinterface.cpp in Sources */,
 				BB4C4B3922A932CF001F6AF0 /* turn.cpp in Sources */,
+				E7605A312B6EF47E00903A6A /* functor.cpp in Sources */,
 				4DACC9932990F29A00B55913 /* atts_critapp.cpp in Sources */,
 				BB4C4BA122A932E5001F6AF0 /* scoredefinterface.cpp in Sources */,
 				BB4C4B4322A932D7001F6AF0 /* beatrpt.cpp in Sources */,

--- a/include/vrv/adjustslursfunctor.h
+++ b/include/vrv/adjustslursfunctor.h
@@ -62,6 +62,15 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::SystemParallel; }
+    AdjustSlursFunctor *CloneFunctor() const override { return new AdjustSlursFunctor(*this); }
+    void MergeFunctor(const Functor *functor) override;
+    ///@}
+
+    /*
      * Check existence of cross-staff slurs
      */
     bool HasCrossStaffSlurs() const { return m_crossStaffSlurs; }

--- a/include/vrv/calcbboxoverflowsfunctor.h
+++ b/include/vrv/calcbboxoverflowsfunctor.h
@@ -36,6 +36,14 @@ public:
     bool ImplementsEndInterface() const override { return true; }
 
     /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::SystemParallel; }
+    CalcBBoxOverflowsFunctor *CloneFunctor() const override { return new CalcBBoxOverflowsFunctor(*this); }
+    ///@}
+
+    /*
      * Functor interface
      */
     ///@{

--- a/include/vrv/calcdotsfunctor.h
+++ b/include/vrv/calcdotsfunctor.h
@@ -35,6 +35,14 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::MeasureParallel; }
+    CalcDotsFunctor *CloneFunctor() const override { return new CalcDotsFunctor(*this); }
+    ///@}
+
+    /*
      * Functor interface
      */
     ///@{

--- a/include/vrv/calcstemfunctor.h
+++ b/include/vrv/calcstemfunctor.h
@@ -35,6 +35,14 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::MeasureParallel; }
+    CalcStemFunctor *CloneFunctor() const override { return new CalcStemFunctor(*this); }
+    ///@}
+
+    /*
      * Functor interface
      */
     ///@{

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -174,6 +174,11 @@ public:
      */
     Doc *GetDoc() { return m_doc; }
 
+    /*
+     * Get the maximal number of threads
+     */
+    int GetMaxNumberOfThreads() const final;
+
 private:
     //
 public:
@@ -207,6 +212,11 @@ public:
      * Getter for the document
      */
     const Doc *GetDoc() const { return m_doc; }
+
+    /*
+     * Get the maximal number of threads
+     */
+    int GetMaxNumberOfThreads() const final;
 
 private:
     //

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -16,6 +16,9 @@ namespace vrv {
 
 class Doc;
 
+// Helper enum classes
+enum class ProcessingStrategy { Sequential, MeasureParallel, SystemParallel };
+
 //----------------------------------------------------------------------------
 // FunctorBase
 //----------------------------------------------------------------------------
@@ -75,6 +78,14 @@ public:
      * Return true if the functor implements the end interface
      */
     virtual bool ImplementsEndInterface() const = 0;
+
+    /**
+     * Override to enable parallel functor processing
+     */
+    ///@{
+    virtual ProcessingStrategy GetProcessingStrategy() const { return ProcessingStrategy::Sequential; }
+    virtual int GetMaxNumberOfThreads() const { return 1; }
+    ///@}
 
 private:
     //

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -95,7 +95,7 @@ public:
      * Returns the object class on which parallelization is applied
      * Additionally checks if we have more than one thread
      */
-    std::optional<ClassId> GetParallelizationClass() const;
+    std::optional<ClassId> GetConcurrentClass() const;
 
 private:
     //

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -119,6 +119,18 @@ public:
     virtual ~Functor() = default;
     ///@}
 
+    /**
+     * Copy child classes
+     * Must be overridden in order to use it (e.g. during parallelization)
+     */
+    virtual Functor *CloneFunctor() const;
+
+    /**
+     * Merge child classes, i.e. combine the state of the functor passed in with the current one
+     * The default implementation only considers the functor code
+     */
+    virtual void MergeFunctor(const Functor &functor);
+
 private:
     //
 public:
@@ -143,6 +155,18 @@ public:
     ConstFunctor() {}
     virtual ~ConstFunctor() = default;
     ///@}
+
+    /**
+     * Copy child classes
+     * Must be overridden in order to use it (e.g. during parallelization)
+     */
+    virtual ConstFunctor *CloneFunctor() const;
+
+    /**
+     * Merge child classes, i.e. combine the state of the functor passed in with the current one
+     * The default implementation only considers the functor code
+     */
+    virtual void MergeFunctor(const ConstFunctor &functor);
 
 private:
     //

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -139,7 +139,7 @@ public:
      * Merge child classes, i.e. combine the state of the functor passed in with the current one
      * The default implementation only considers the functor code
      */
-    virtual void MergeFunctor(const Functor &functor);
+    virtual void MergeFunctor(const Functor *functor);
 
 private:
     //
@@ -176,7 +176,7 @@ public:
      * Merge child classes, i.e. combine the state of the functor passed in with the current one
      * The default implementation only considers the functor code
      */
-    virtual void MergeFunctor(const ConstFunctor &functor);
+    virtual void MergeFunctor(const ConstFunctor *functor);
 
 private:
     //

--- a/include/vrv/functor.h
+++ b/include/vrv/functor.h
@@ -8,6 +8,10 @@
 #ifndef __VRV_FUNCTOR_H__
 #define __VRV_FUNCTOR_H__
 
+#include <optional>
+
+//----------------------------------------------------------------------------
+
 #include "comparison.h"
 #include "functorinterface.h"
 #include "vrvdef.h"
@@ -86,6 +90,12 @@ public:
     virtual ProcessingStrategy GetProcessingStrategy() const { return ProcessingStrategy::Sequential; }
     virtual int GetMaxNumberOfThreads() const { return 1; }
     ///@}
+
+    /**
+     * Returns the object class on which parallelization is applied
+     * Additionally checks if we have more than one thread
+     */
+    std::optional<ClassId> GetParallelizationClass() const;
 
 private:
     //

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -646,7 +646,9 @@ public:
      */
     ///@{
     void Process(Functor &functor, int deepness = UNLIMITED_DEPTH, bool skipFirst = false);
+    void ProcessChildren(Functor &functor, int deepness);
     void Process(ConstFunctor &functor, int deepness = UNLIMITED_DEPTH, bool skipFirst = false) const;
+    void ProcessChildren(ConstFunctor &functor, int deepness) const;
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -647,8 +647,10 @@ public:
     ///@{
     void Process(Functor &functor, int deepness = UNLIMITED_DEPTH, bool skipFirst = false);
     void ProcessChildren(Functor &functor, int deepness);
+    void ProcessInParallel(Functor &functor, int deepness, const ArrayOfObjects &objects);
     void Process(ConstFunctor &functor, int deepness = UNLIMITED_DEPTH, bool skipFirst = false) const;
     void ProcessChildren(ConstFunctor &functor, int deepness) const;
+    void ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayOfConstObjects &objects);
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -650,7 +650,7 @@ public:
     void ProcessInParallel(Functor &functor, int deepness, const ArrayOfObjects &objects);
     void Process(ConstFunctor &functor, int deepness = UNLIMITED_DEPTH, bool skipFirst = false) const;
     void ProcessChildren(ConstFunctor &functor, int deepness) const;
-    void ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayOfConstObjects &objects);
+    void ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayOfConstObjects &objects) const;
     ///@}
 
     /**

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -632,6 +632,7 @@ public:
     OptionBool m_incip;
     OptionBool m_justifyVertically;
     OptionBool m_landscape;
+    OptionInt m_maxThreads;
     OptionDbl m_minLastJustification;
     OptionBool m_mmOutput;
     OptionBool m_moveScoreDefinitionToStaff;

--- a/include/vrv/resetfunctor.h
+++ b/include/vrv/resetfunctor.h
@@ -110,6 +110,17 @@ public:
     bool ImplementsEndInterface() const override { return false; }
 
     /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::MeasureParallel; }
+    ResetHorizontalAlignmentFunctor *CloneFunctor() const override
+    {
+        return new ResetHorizontalAlignmentFunctor(*this);
+    }
+    ///@}
+
+    /*
      * Functor interface
      */
     ///@{
@@ -166,6 +177,14 @@ public:
      * Abstract base implementation
      */
     bool ImplementsEndInterface() const override { return false; }
+
+    /*
+     * Enable parallelization
+     */
+    ///@{
+    ProcessingStrategy GetProcessingStrategy() const override { return ProcessingStrategy::MeasureParallel; }
+    ResetVerticalAlignmentFunctor *CloneFunctor() const override { return new ResetVerticalAlignmentFunctor(*this); }
+    ///@}
 
     /*
      * Functor interface

--- a/src/adjustslursfunctor.cpp
+++ b/src/adjustslursfunctor.cpp
@@ -30,6 +30,14 @@ AdjustSlursFunctor::AdjustSlursFunctor(Doc *doc) : DocFunctor(doc)
     this->ResetCurrent();
 }
 
+void AdjustSlursFunctor::MergeFunctor(const Functor *functor)
+{
+    const AdjustSlursFunctor *adjustSlursFunctor = dynamic_cast<const AdjustSlursFunctor *>(functor);
+    if (adjustSlursFunctor && adjustSlursFunctor->HasCrossStaffSlurs()) {
+        m_crossStaffSlurs = true;
+    }
+}
+
 void AdjustSlursFunctor::ResetCurrent()
 {
     m_currentCurve = NULL;

--- a/src/adjustslursfunctor.cpp
+++ b/src/adjustslursfunctor.cpp
@@ -32,6 +32,8 @@ AdjustSlursFunctor::AdjustSlursFunctor(Doc *doc) : DocFunctor(doc)
 
 void AdjustSlursFunctor::MergeFunctor(const Functor *functor)
 {
+    Functor::MergeFunctor(functor);
+
     const AdjustSlursFunctor *adjustSlursFunctor = dynamic_cast<const AdjustSlursFunctor *>(functor);
     if (adjustSlursFunctor && adjustSlursFunctor->HasCrossStaffSlurs()) {
         m_crossStaffSlurs = true;

--- a/src/functor.cpp
+++ b/src/functor.cpp
@@ -14,6 +14,22 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
+// FunctorBase
+//----------------------------------------------------------------------------
+
+std::optional<ClassId> FunctorBase::GetParallelizationClass() const
+{
+    if (this->GetMaxNumberOfThreads() > 1) {
+        switch (this->GetProcessingStrategy()) {
+            case ProcessingStrategy::MeasureParallel: return MEASURE;
+            case ProcessingStrategy::SystemParallel: return SYSTEM;
+            default: break;
+        }
+    }
+    return std::nullopt;
+}
+
+//----------------------------------------------------------------------------
 // Functor
 //----------------------------------------------------------------------------
 

--- a/src/functor.cpp
+++ b/src/functor.cpp
@@ -39,9 +39,9 @@ Functor *Functor::CloneFunctor() const
     return NULL;
 }
 
-void Functor::MergeFunctor(const Functor &functor)
+void Functor::MergeFunctor(const Functor *functor)
 {
-    if (functor.GetCode() == FUNCTOR_STOP) {
+    if (functor->GetCode() == FUNCTOR_STOP) {
         this->SetCode(FUNCTOR_STOP);
     }
 }
@@ -56,9 +56,9 @@ ConstFunctor *ConstFunctor::CloneFunctor() const
     return NULL;
 }
 
-void ConstFunctor::MergeFunctor(const ConstFunctor &functor)
+void ConstFunctor::MergeFunctor(const ConstFunctor *functor)
 {
-    if (functor.GetCode() == FUNCTOR_STOP) {
+    if (functor->GetCode() == FUNCTOR_STOP) {
         this->SetCode(FUNCTOR_STOP);
     }
 }

--- a/src/functor.cpp
+++ b/src/functor.cpp
@@ -17,7 +17,7 @@ namespace vrv {
 // FunctorBase
 //----------------------------------------------------------------------------
 
-std::optional<ClassId> FunctorBase::GetParallelizationClass() const
+std::optional<ClassId> FunctorBase::GetConcurrentClass() const
 {
     if (this->GetMaxNumberOfThreads() > 1) {
         switch (this->GetProcessingStrategy()) {

--- a/src/functor.cpp
+++ b/src/functor.cpp
@@ -14,6 +14,40 @@
 namespace vrv {
 
 //----------------------------------------------------------------------------
+// Functor
+//----------------------------------------------------------------------------
+
+Functor *Functor::CloneFunctor() const
+{
+    assert(false);
+    return NULL;
+}
+
+void Functor::MergeFunctor(const Functor &functor)
+{
+    if (functor.GetCode() == FUNCTOR_STOP) {
+        this->SetCode(FUNCTOR_STOP);
+    }
+}
+
+//----------------------------------------------------------------------------
+// ConstFunctor
+//----------------------------------------------------------------------------
+
+ConstFunctor *ConstFunctor::CloneFunctor() const
+{
+    assert(false);
+    return NULL;
+}
+
+void ConstFunctor::MergeFunctor(const ConstFunctor &functor)
+{
+    if (functor.GetCode() == FUNCTOR_STOP) {
+        this->SetCode(FUNCTOR_STOP);
+    }
+}
+
+//----------------------------------------------------------------------------
 // DocFunctor
 //----------------------------------------------------------------------------
 

--- a/src/functor.cpp
+++ b/src/functor.cpp
@@ -1,0 +1,34 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        functor.cpp
+// Author:      David Bauer
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "functor.h"
+
+//----------------------------------------------------------------------------
+
+#include "doc.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// DocFunctor
+//----------------------------------------------------------------------------
+
+int DocFunctor::GetMaxNumberOfThreads() const
+{
+    return m_doc->GetOptions()->m_maxThreads.GetValue();
+}
+
+//----------------------------------------------------------------------------
+// DocConstFunctor
+//----------------------------------------------------------------------------
+
+int DocConstFunctor::GetMaxNumberOfThreads() const
+{
+    return m_doc->GetOptions()->m_maxThreads.GetValue();
+}
+
+} // namespace vrv

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1039,43 +1039,48 @@ void Object::Process(Functor &functor, int deepness, bool skipFirst)
     --deepness;
 
     if (!this->SkipChildren(functor.VisibleOnly())) {
-        // Objects which will be processed in parallel are collected here
-        ArrayOfObjects parallelProcessed;
-        const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
-        // We need a pointer to the array for the option to work on a reversed copy
-        ArrayOfObjects *children = &m_children;
-        Filters *filters = functor.GetFilters();
-        if (functor.GetDirection() == BACKWARD) {
-            for (ArrayOfObjects::reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
-                // we will end here if there is no filter at all or for the current child type
-                if (this->FiltersApply(filters, *iter)) {
-                    if (branchClass && (*iter)->Is(*branchClass)) {
-                        parallelProcessed.push_back(*iter);
-                    }
-                    else {
-                        (*iter)->Process(functor, deepness);
-                    }
-                }
-            }
-        }
-        else {
-            for (ArrayOfObjects::iterator iter = children->begin(); iter != children->end(); ++iter) {
-                // we will end here if there is no filter at all or for the current child type
-                if (this->FiltersApply(filters, *iter)) {
-                    if (branchClass && (*iter)->Is(*branchClass)) {
-                        parallelProcessed.push_back(*iter);
-                    }
-                    else {
-                        (*iter)->Process(functor, deepness);
-                    }
-                }
-            }
-        }
+        this->ProcessChildren(functor, deepness);
     }
 
     if (functor.ImplementsEndInterface() && !skipFirst) {
         FunctorCode code = this->AcceptEnd(functor);
         functor.SetCode(code);
+    }
+}
+
+void Object::ProcessChildren(Functor &functor, int deepness)
+{
+    // Objects which will be processed in parallel are collected here
+    ArrayOfObjects parallelProcessed;
+    const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
+    // We need a pointer to the array for the option to work on a reversed copy
+    ArrayOfObjects *children = &m_children;
+    Filters *filters = functor.GetFilters();
+    if (functor.GetDirection() == BACKWARD) {
+        for (ArrayOfObjects::reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
+            // we will end here if there is no filter at all or for the current child type
+            if (this->FiltersApply(filters, *iter)) {
+                if (branchClass && (*iter)->Is(*branchClass)) {
+                    parallelProcessed.push_back(*iter);
+                }
+                else {
+                    (*iter)->Process(functor, deepness);
+                }
+            }
+        }
+    }
+    else {
+        for (ArrayOfObjects::iterator iter = children->begin(); iter != children->end(); ++iter) {
+            // we will end here if there is no filter at all or for the current child type
+            if (this->FiltersApply(filters, *iter)) {
+                if (branchClass && (*iter)->Is(*branchClass)) {
+                    parallelProcessed.push_back(*iter);
+                }
+                else {
+                    (*iter)->Process(functor, deepness);
+                }
+            }
+        }
     }
 }
 
@@ -1106,43 +1111,48 @@ void Object::Process(ConstFunctor &functor, int deepness, bool skipFirst) const
     --deepness;
 
     if (!this->SkipChildren(functor.VisibleOnly())) {
-        // Objects which will be processed in parallel are collected here
-        ArrayOfConstObjects parallelProcessed;
-        const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
-        // We need a pointer to the array for the option to work on a reversed copy
-        const ArrayOfObjects *children = &m_children;
-        Filters *filters = functor.GetFilters();
-        if (functor.GetDirection() == BACKWARD) {
-            for (ArrayOfObjects::const_reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
-                // we will end here if there is no filter at all or for the current child type
-                if (this->FiltersApply(filters, *iter)) {
-                    if (branchClass && (*iter)->Is(*branchClass)) {
-                        parallelProcessed.push_back(*iter);
-                    }
-                    else {
-                        (*iter)->Process(functor, deepness);
-                    }
-                }
-            }
-        }
-        else {
-            for (ArrayOfObjects::const_iterator iter = children->begin(); iter != children->end(); ++iter) {
-                // we will end here if there is no filter at all or for the current child type
-                if (this->FiltersApply(filters, *iter)) {
-                    if (branchClass && (*iter)->Is(*branchClass)) {
-                        parallelProcessed.push_back(*iter);
-                    }
-                    else {
-                        (*iter)->Process(functor, deepness);
-                    }
-                }
-            }
-        }
+        this->ProcessChildren(functor, deepness);
     }
 
     if (functor.ImplementsEndInterface() && !skipFirst) {
         FunctorCode code = this->AcceptEnd(functor);
         functor.SetCode(code);
+    }
+}
+
+void Object::ProcessChildren(ConstFunctor &functor, int deepness) const
+{
+    // Objects which will be processed in parallel are collected here
+    ArrayOfConstObjects parallelProcessed;
+    const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
+    // We need a pointer to the array for the option to work on a reversed copy
+    const ArrayOfObjects *children = &m_children;
+    Filters *filters = functor.GetFilters();
+    if (functor.GetDirection() == BACKWARD) {
+        for (ArrayOfObjects::const_reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
+            // we will end here if there is no filter at all or for the current child type
+            if (this->FiltersApply(filters, *iter)) {
+                if (branchClass && (*iter)->Is(*branchClass)) {
+                    parallelProcessed.push_back(*iter);
+                }
+                else {
+                    (*iter)->Process(functor, deepness);
+                }
+            }
+        }
+    }
+    else {
+        for (ArrayOfObjects::const_iterator iter = children->begin(); iter != children->end(); ++iter) {
+            // we will end here if there is no filter at all or for the current child type
+            if (this->FiltersApply(filters, *iter)) {
+                if (branchClass && (*iter)->Is(*branchClass)) {
+                    parallelProcessed.push_back(*iter);
+                }
+                else {
+                    (*iter)->Process(functor, deepness);
+                }
+            }
+        }
     }
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1103,7 +1103,10 @@ void Object::ProcessInParallel(Functor &functor, int deepness, const ArrayOfObje
     }
 
     // Clone the functor for each task
-    std::vector<Functor *> functorClones(concurrency, functor.CloneFunctor());
+    std::vector<Functor *> functorClones;
+    for (int taskIndex = 0; taskIndex < concurrency; ++taskIndex) {
+        functorClones.push_back(functor.CloneFunctor());
+    }
 
     // Launch parallel tasks
     std::vector<std::future<void>> futures;
@@ -1214,7 +1217,10 @@ void Object::ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayO
     }
 
     // Clone the functor for each task
-    std::vector<ConstFunctor *> functorClones(concurrency, functor.CloneFunctor());
+    std::vector<ConstFunctor *> functorClones;
+    for (int taskIndex = 0; taskIndex < concurrency; ++taskIndex) {
+        functorClones.push_back(functor.CloneFunctor());
+    }
 
     // Launch parallel tasks
     std::vector<std::future<void>> futures;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1039,6 +1039,9 @@ void Object::Process(Functor &functor, int deepness, bool skipFirst)
     --deepness;
 
     if (!this->SkipChildren(functor.VisibleOnly())) {
+        // Objects which will be processed in parallel are collected here
+        ArrayOfObjects parallelProcessed;
+        const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
         // We need a pointer to the array for the option to work on a reversed copy
         ArrayOfObjects *children = &m_children;
         Filters *filters = functor.GetFilters();
@@ -1046,7 +1049,12 @@ void Object::Process(Functor &functor, int deepness, bool skipFirst)
             for (ArrayOfObjects::reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
                 // we will end here if there is no filter at all or for the current child type
                 if (this->FiltersApply(filters, *iter)) {
-                    (*iter)->Process(functor, deepness);
+                    if (branchClass && (*iter)->Is(*branchClass)) {
+                        parallelProcessed.push_back(*iter);
+                    }
+                    else {
+                        (*iter)->Process(functor, deepness);
+                    }
                 }
             }
         }
@@ -1054,7 +1062,12 @@ void Object::Process(Functor &functor, int deepness, bool skipFirst)
             for (ArrayOfObjects::iterator iter = children->begin(); iter != children->end(); ++iter) {
                 // we will end here if there is no filter at all or for the current child type
                 if (this->FiltersApply(filters, *iter)) {
-                    (*iter)->Process(functor, deepness);
+                    if (branchClass && (*iter)->Is(*branchClass)) {
+                        parallelProcessed.push_back(*iter);
+                    }
+                    else {
+                        (*iter)->Process(functor, deepness);
+                    }
                 }
             }
         }
@@ -1093,6 +1106,9 @@ void Object::Process(ConstFunctor &functor, int deepness, bool skipFirst) const
     --deepness;
 
     if (!this->SkipChildren(functor.VisibleOnly())) {
+        // Objects which will be processed in parallel are collected here
+        ArrayOfConstObjects parallelProcessed;
+        const std::optional<ClassId> branchClass = functor.GetParallelizationClass();
         // We need a pointer to the array for the option to work on a reversed copy
         const ArrayOfObjects *children = &m_children;
         Filters *filters = functor.GetFilters();
@@ -1100,7 +1116,12 @@ void Object::Process(ConstFunctor &functor, int deepness, bool skipFirst) const
             for (ArrayOfObjects::const_reverse_iterator iter = children->rbegin(); iter != children->rend(); ++iter) {
                 // we will end here if there is no filter at all or for the current child type
                 if (this->FiltersApply(filters, *iter)) {
-                    (*iter)->Process(functor, deepness);
+                    if (branchClass && (*iter)->Is(*branchClass)) {
+                        parallelProcessed.push_back(*iter);
+                    }
+                    else {
+                        (*iter)->Process(functor, deepness);
+                    }
                 }
             }
         }
@@ -1108,7 +1129,12 @@ void Object::Process(ConstFunctor &functor, int deepness, bool skipFirst) const
             for (ArrayOfObjects::const_iterator iter = children->begin(); iter != children->end(); ++iter) {
                 // we will end here if there is no filter at all or for the current child type
                 if (this->FiltersApply(filters, *iter)) {
-                    (*iter)->Process(functor, deepness);
+                    if (branchClass && (*iter)->Is(*branchClass)) {
+                        parallelProcessed.push_back(*iter);
+                    }
+                    else {
+                        (*iter)->Process(functor, deepness);
+                    }
                 }
             }
         }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1084,6 +1084,10 @@ void Object::ProcessChildren(Functor &functor, int deepness)
             }
         }
     }
+    // Perform parallel processing
+    if (!parallelProcessed.empty()) {
+        this->ProcessInParallel(functor, deepness, parallelProcessed);
+    }
 }
 
 void Object::ProcessInParallel(Functor &functor, int deepness, const ArrayOfObjects &objects)
@@ -1191,9 +1195,13 @@ void Object::ProcessChildren(ConstFunctor &functor, int deepness) const
             }
         }
     }
+    // Perform parallel processing
+    if (!parallelProcessed.empty()) {
+        this->ProcessInParallel(functor, deepness, parallelProcessed);
+    }
 }
 
-void Object::ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayOfConstObjects &objects)
+void Object::ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayOfConstObjects &objects) const
 {
     const int hardwareLimit = static_cast<int>(std::thread::hardware_concurrency());
     const int concurrency = std::min(functor.GetMaxNumberOfThreads(), hardwareLimit);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1123,7 +1123,7 @@ void Object::ProcessInParallel(Functor &functor, int deepness, const ArrayOfObje
         future.get();
     }
     for (Functor *clone : functorClones) {
-        functor.MergeFunctor(*clone);
+        functor.MergeFunctor(clone);
         delete clone;
     }
 }
@@ -1237,7 +1237,7 @@ void Object::ProcessInParallel(ConstFunctor &functor, int deepness, const ArrayO
         future.get();
     }
     for (ConstFunctor *clone : functorClones) {
-        functor.MergeFunctor(*clone);
+        functor.MergeFunctor(clone);
         delete clone;
     }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1050,6 +1050,11 @@ Options::Options()
     m_landscape.Init(false);
     this->Register(&m_landscape, "landscape", &m_general);
 
+    m_maxThreads.SetInfo(
+        "Maximal number of threads", "The maximal number of threads (values above 1 activate parallelization)");
+    m_maxThreads.Init(1, 1, 256);
+    this->Register(&m_maxThreads, "maxThreads", &m_general);
+
     m_minLastJustification.SetInfo("Minimum last-system-justification width",
         "The last system is only justified if the unjustified width is greater than this percent");
     m_minLastJustification.Init(0.8, 0.0, 1.0);


### PR DESCRIPTION
This PR adds the functionality to process functors in parallel and enables parallelisation for a few functors where this is straightforward. It should be seen as a starting point to demonstrate how parallelisation can be exploited. To parallelise a significant part of the layout requires a lot more work.

A bit of profiling shows that we actually achieve mild runtime improvements by processing in parallel.
For a medium sized piece (10 pages):

| Number of threads | ResetAligner runtime [ms] | LayoutVertically runtime [ms] |
| ------ | ------ | ------ |
| 1 | 52 | 121 |
| 2 | 36 | 101 |
| 4 | 38 | 100 |
| 8 | 35 | 103 |

For a large piece (266 pages):

| Number of threads | ResetAligner runtime [ms] | LayoutVertically runtime [ms] |
| ------ | ------ | ------ |
| 1 | 845 | 1560 |
| 2 | 635 | 1400 |
| 4 | 657 | 1230 |
| 8 | 651 | 1430 |

Further remarks:
- Parallelisation is switched on by setting the new `--max-threads` option.
- It is enabled on a functor by overriding the methods `GetProcessingStrategy` and `CloneFunctor`. The first one decides whether concurrent processing happens on measures (horizontal layout) or systems (vertical layout). The second one clones the functor before parallel processing and is quite similar to `Object::Clone`.
- The method `MergeFunctor` can be overridden and is designed to merge the results of the calculation on several functors into one functor again (after parallel processing). One example where this makes sense is the `m_crossStaffSlurs` flag in `AdjustSlurs`.
- It seems tempting to simply add parallelisation to all functors by adding the appropriate methods. However, several functors cannot be parallelised in a straightforward way. One obstacle is if the functor keeps information that lives outside measures or systems (e.g., overriding `VisitScore` or `VisitPage`) or transports information from one measure/system to the next (e.g., `PrepareTimeSpanning` or `GenerateMIDI`). Another obstacle is if the functor changes global information (e.g. in the document). This might lead to undefined behaviour and requires mutex protection. One needs to carefully check which data is changed by the functor before adding parallelisation.
- The entire processing code in `Object` is currently duplicated for const and non-const functors. Not sure if we want to simplify this with templates.