### PR TITLE
fix doubled g in SVG

### DIFF
--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -98,8 +98,6 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
     // TabGrp *tabGrp = note->IsTabGrpNote();
     // assert(tabGrp);
 
-    dc->StartGraphic(note, "", note->GetID());
-
     int x = element->GetDrawingX();
     int y = element->GetDrawingY();
 
@@ -152,8 +150,6 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     // Draw children (nothing yet)
     this->DrawLayerChildren(dc, note, layer, staff, measure);
-
-    dc->EndGraphic(note, this);
 }
 
 void View::DrawTabDurSym(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)


### PR DESCRIPTION
removes the extra `startGraphic` in `DrawTabNote` (already handled in `DrawDurationElement`)

closes #3600