### PR TITLE
Update vrv.cpp

### DIFF
--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -211,12 +211,14 @@ void EnableLogToBuffer(bool value)
 
 std::string StringFormat(const char *fmt, ...)
 {
+    std::locale previousLocale = std::locale::global(std::locale("C"));
     std::string str(STRING_FORMAT_MAX_LEN, 0);
     va_list args;
     va_start(args, fmt);
     vsnprintf(&str[0], STRING_FORMAT_MAX_LEN, fmt, args);
     va_end(args);
     str.resize(strlen(str.data()));
+    std::locale::global(previousLocale);
     return str;
 }
 


### PR DESCRIPTION
To ensure correct code formatting for floating-point values, two lines of code have been added to the "StringFormat" method, temporarily resetting the compiler's std::locale configurations. This prevents formatting issues stemming from specific OS or development environment settings, ensuring consistent and accurate numerical representation in the C++ source code during program execution. (At least, they do on my machine; I hope it's the same on yours... :) )