### PR TITLE
Refactor PAE Duration handling

### DIFF
--- a/include/vrv/featureextractor.h
+++ b/include/vrv/featureextractor.h
@@ -55,6 +55,7 @@ public:
     std::list<const Note *> m_previousNotes;
 
     jsonxx::Array m_pitchesChromatic;
+    jsonxx::Array m_pitchesChromaticWithDuration;
     jsonxx::Array m_pitchesDiatonic;
     jsonxx::Array m_pitchesIds;
 

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -91,6 +91,10 @@ public:
      */
     bool WriteObjectEnd(Object *object) override;
 
+    /**
+     * Helper method to return a string representation of the PAE duration.
+     */
+    static std::string GetPaeDur(data_DURATION dur, int ndots);
 private:
     /**
      * @name Methods for writing containers (measures, staff, etc) scoreDef and related.

--- a/include/vrv/iopae.h
+++ b/include/vrv/iopae.h
@@ -95,6 +95,7 @@ public:
      * Helper method to return a string representation of the PAE duration.
      */
     static std::string GetPaeDur(data_DURATION dur, int ndots);
+
 private:
     /**
      * @name Methods for writing containers (measures, staff, etc) scoreDef and related.

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -72,9 +72,9 @@ void FeatureExtractor::Extract(const Object *object)
 
         std::stringstream pitch;
         std::stringstream pitchWithDuration;
-        
+
         pitchWithDuration << PAEOutput::GetPaeDur(note->GetDur(), note->GetDots());
-        
+
         data_OCTAVE oct = note->GetOct();
         char octSign = (oct > 3) ? '\'' : ',';
         int signCount = (oct > 3) ? (oct - 3) : (4 - oct);

--- a/src/featureextractor.cpp
+++ b/src/featureextractor.cpp
@@ -17,6 +17,7 @@
 #include "chord.h"
 #include "doc.h"
 #include "gracegrp.h"
+#include "iopae.h"
 #include "layer.h"
 #include "mdiv.h"
 #include "measure.h"
@@ -70,10 +71,16 @@ void FeatureExtractor::Extract(const Object *object)
         }
 
         std::stringstream pitch;
+        std::stringstream pitchWithDuration;
+        
+        pitchWithDuration << PAEOutput::GetPaeDur(note->GetDur(), note->GetDots());
+        
         data_OCTAVE oct = note->GetOct();
         char octSign = (oct > 3) ? '\'' : ',';
         int signCount = (oct > 3) ? (oct - 3) : (4 - oct);
-        pitch << std::string(signCount, octSign);
+        std::string octaves = std::string(signCount, octSign);
+        pitch << octaves;
+        pitchWithDuration << octaves;
 
         const Accid *accid = vrv_cast<const Accid *>(note->FindDescendantByType(ACCID));
         if (accid) {
@@ -98,13 +105,16 @@ void FeatureExtractor::Extract(const Object *object)
                 default: accidStr = accidStrWritten;
             }
             pitch << accidStr;
+            pitchWithDuration << accidStr;
         }
 
         std::string pname = note->AttPitch::PitchnameToStr(note->GetPname());
         std::transform(pname.begin(), pname.end(), pname.begin(), ::toupper);
         pitch << pname;
+        pitchWithDuration << pname;
 
         m_pitchesChromatic << pitch.str();
+        m_pitchesChromaticWithDuration << pitchWithDuration.str();
         m_pitchesDiatonic << pname;
         jsonxx::Array pitchesIds;
         pitchesIds << note->GetID();
@@ -145,6 +155,7 @@ void FeatureExtractor::ToJson(std::string &output)
 {
     jsonxx::Object o;
 
+    o << "pitchesChromaticWithDuration" << m_pitchesChromaticWithDuration;
     o << "pitchesChromatic" << m_pitchesChromatic;
     o << "pitchesDiatonic" << m_pitchesDiatonic;
     o << "pitchesIds" << m_pitchesIds;

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -566,7 +566,7 @@ std::string PAEOutput::GetPaeDur(data_DURATION ndur, int ndots)
         case (DURATION_semifusa): dur = "6"; break;
         default: LogWarning("Unsupported duration"); dur = "4";
     }
-    
+
     if (ndots > 0) {
         dur += std::string(ndots, '.');
     }

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -582,7 +582,7 @@ void PAEOutput::WriteDur(DurationInterface *interface)
     if ((interface->GetDur() != m_currentDur) || (ndots != m_currentDots)) {
         m_currentDur = interface->GetDur();
         m_currentDots = ndots;
-        m_streamStringOutput << GetPaeDur(interface->GetDur(), m_currentDots);
+        m_streamStringOutput << PAEOutput::GetPaeDur(interface->GetDur(), m_currentDots);
     }
 }
 

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -542,6 +542,38 @@ void PAEOutput::WriteTupletEnd(Tuplet *tuplet)
     m_streamStringOutput << ";" << tuplet->GetNum() << ")";
 }
 
+std::string PAEOutput::GetPaeDur(data_DURATION ndur, int ndots)
+{
+    std::string dur;
+    switch (ndur) {
+        case (DURATION_long): dur = "0"; break;
+        case (DURATION_breve): dur = "9"; break;
+        case (DURATION_1): dur = "1"; break;
+        case (DURATION_2): dur = "2"; break;
+        case (DURATION_4): dur = "4"; break;
+        case (DURATION_8): dur = "8"; break;
+        case (DURATION_16): dur = "6"; break;
+        case (DURATION_32): dur = "3"; break;
+        case (DURATION_64): dur = "5"; break;
+        case (DURATION_128): dur = "7"; break;
+        case (DURATION_maxima): dur = "0"; break;
+        case (DURATION_longa): dur = "0"; break;
+        case (DURATION_brevis): dur = "9"; break;
+        case (DURATION_semibrevis): dur = "1"; break;
+        case (DURATION_minima): dur = "2"; break;
+        case (DURATION_semiminima): dur = "4"; break;
+        case (DURATION_fusa): dur = "8"; break;
+        case (DURATION_semifusa): dur = "6"; break;
+        default: LogWarning("Unsupported duration"); dur = "4";
+    }
+    
+    if (ndots > 0) {
+        dur += std::string(ndots, '.');
+    }
+
+    return dur;
+}
+
 void PAEOutput::WriteDur(DurationInterface *interface)
 {
     assert(interface);
@@ -550,30 +582,7 @@ void PAEOutput::WriteDur(DurationInterface *interface)
     if ((interface->GetDur() != m_currentDur) || (ndots != m_currentDots)) {
         m_currentDur = interface->GetDur();
         m_currentDots = ndots;
-        std::string dur;
-        switch (m_currentDur) {
-            case (DURATION_long): dur = "0"; break;
-            case (DURATION_breve): dur = "9"; break;
-            case (DURATION_1): dur = "1"; break;
-            case (DURATION_2): dur = "2"; break;
-            case (DURATION_4): dur = "4"; break;
-            case (DURATION_8): dur = "8"; break;
-            case (DURATION_16): dur = "6"; break;
-            case (DURATION_32): dur = "3"; break;
-            case (DURATION_64): dur = "5"; break;
-            case (DURATION_128): dur = "7"; break;
-            case (DURATION_maxima): dur = "0"; break;
-            case (DURATION_longa): dur = "0"; break;
-            case (DURATION_brevis): dur = "9"; break;
-            case (DURATION_semibrevis): dur = "1"; break;
-            case (DURATION_minima): dur = "2"; break;
-            case (DURATION_semiminima): dur = "4"; break;
-            case (DURATION_fusa): dur = "8"; break;
-            case (DURATION_semifusa): dur = "6"; break;
-            default: LogWarning("Unsupported duration"); dur = "4";
-        }
-        m_streamStringOutput << dur;
-        m_streamStringOutput << std::string(m_currentDots, '.');
+        m_streamStringOutput << GetPaeDur(interface->GetDur(), m_currentDots);
     }
 }
 


### PR DESCRIPTION
This change extracts the PAE duration handling into a static method that can be used to convert durations to their PAE representations.

It also adds a new feature to the feature extractor that includes the note duration on the PAE note.