### PR TITLE
Fix issue #3622: wrong lyrics position in midi output for <syl> in notes <= quarter

### DIFF
--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -798,7 +798,7 @@ FunctorCode GenerateMIDIFunctor::VisitStaffDef(const StaffDef *staffDef)
 
 FunctorCode GenerateMIDIFunctor::VisitSyl(const Syl *syl)
 {
-    const int startTime = m_totalTime + m_lastNote->GetScoreTimeOnset();
+    const double startTime = m_totalTime + m_lastNote->GetScoreTimeOnset();
     const std::string sylText = UTF32to8(syl->GetText());
 
     m_midiFile->addLyric(m_midiTrack, startTime * m_midiFile->getTPQ(), sylText);


### PR DESCRIPTION
This is happening due to use an integer for measure startTime, that depending on the file tpq will lead to decimal values for short duration notes