### PR TITLE
fix ties from Dorico

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3148,7 +3148,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         }
 
         // ties
-        ReadMusicXmlTies(notations.node(), layer, note, measureNum);
+        ReadMusicXmlTies(node, layer, note, measureNum);
 
         // articulation
         std::vector<data_ARTICULATION> artics;
@@ -3834,7 +3834,8 @@ void MusicXmlInput::ReadMusicXmlBeamStart(const pugi::xml_node &node, const pugi
 void MusicXmlInput::ReadMusicXmlTies(
     const pugi::xml_node &node, Layer *layer, Note *note, const std::string &measureNum)
 {
-    for (pugi::xml_node xmlTie : node.children("tied")) {
+    pugi::xpath_node ties = node.select_node("notations[tied]");
+    for (pugi::xml_node xmlTie : ties.node().children("tied")) {
         std::string tieType = xmlTie.attribute("type").as_string();
 
         if (tieType.empty()) {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3834,8 +3834,9 @@ void MusicXmlInput::ReadMusicXmlBeamStart(const pugi::xml_node &node, const pugi
 void MusicXmlInput::ReadMusicXmlTies(
     const pugi::xml_node &node, Layer *layer, Note *note, const std::string &measureNum)
 {
-    pugi::xpath_node ties = node.select_node("notations[tied]");
-    for (pugi::xml_node xmlTie : ties.node().children("tied")) {
+    pugi::xpath_node_set xmlTies = node.select_nodes("notations/tied");
+    for (pugi::xpath_node_set::const_iterator it = xmlTies.begin(); it != xmlTies.end(); ++it) {
+        pugi::xml_node xmlTie = (*it).node();
         std::string tieType = xmlTie.attribute("type").as_string();
 
         if (tieType.empty()) {


### PR DESCRIPTION
Small change to the MusicXML import to catch all ties exported from Dorico, which puts them into a separate `notations` element.