### PR TITLE
Set locale once in toolkit

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -652,6 +652,7 @@ public:
     OptionBool m_preserveAnalyticalMarkup;
     OptionBool m_removeIds;
     OptionBool m_scaleToPageSize;
+    OptionBool m_setLocale;
     OptionBool m_showRuntime;
     OptionBool m_shrinkToFit;
     OptionIntMap m_smuflTextFont;

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -790,7 +790,7 @@ private:
 
     Options *m_options;
 
-    std::locale m_previousLocale;
+    std::optional<std::locale> m_previousLocale;
 
     /**
      * The C buffer string.

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -733,6 +733,14 @@ public:
     int GetOutputTo() { return m_outputTo; }
 
     /**
+     * Setting the global locale.
+     */
+    ///@{
+    void SetLocale();
+    void ResetLocale();
+    ///@}
+
+    /**
      * Measuring runtime.
      *
      * @ingroup nodoc

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -790,6 +790,8 @@ private:
 
     Options *m_options;
 
+    std::locale m_previousLocale;
+
     /**
      * The C buffer string.
      */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1135,6 +1135,10 @@ Options::Options()
     m_scaleToPageSize.Init(false);
     this->Register(&m_scaleToPageSize, "scaleToPageSize", &m_general);
 
+    m_setLocale.SetInfo("Set the global locale", "Changes the global locale to C (this is not thread-safe)");
+    m_setLocale.Init(false);
+    this->Register(&m_setLocale, "setLocale", &m_general);
+
     m_showRuntime.SetInfo("Show runtime on CLI", "Display the total runtime on command-line");
     m_showRuntime.Init(false);
     this->Register(&m_showRuntime, "showRuntime", &m_general);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -85,9 +85,7 @@ Toolkit::Toolkit(bool initFont)
 
 Toolkit::~Toolkit()
 {
-    if (m_previousLocale) {
-        std::locale::global(*m_previousLocale);
-    }
+    this->ResetLocale();
 
     if (m_humdrumBuffer) {
         free(m_humdrumBuffer);
@@ -1140,6 +1138,8 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
 
     m_options->Sync();
 
+    this->SetLocale();
+
     // Forcing font resource to be reset if the font is given in the options
     if (json.has<jsonxx::Array>("fontAddCustom")) {
         Resources &resources = m_doc.GetResourcesForModification();
@@ -1155,11 +1155,6 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
     if (json.has<jsonxx::Boolean>("fontLoadAll")) {
         Resources &resources = m_doc.GetResourcesForModification();
         resources.LoadAll();
-    }
-
-    if (m_options->m_setLocale.GetValue() && !m_previousLocale) {
-        // Required for proper formatting, e.g., in StringFormat (see vrv.cpp)
-        m_previousLocale = std::locale::global(std::locale::classic());
     }
 
     return true;
@@ -2158,6 +2153,21 @@ std::string Toolkit::ConvertHumdrumToMIDI(const std::string &humdrumData)
 #else
     return "TVRoZAAAAAYAAQAAAGRNVHJrAAAADQCQPHCBSJA8AAD/LwA=";
 #endif
+}
+
+void Toolkit::SetLocale()
+{
+    if (m_options->m_setLocale.GetValue() && !m_previousLocale) {
+        // Required for proper formatting, e.g., in StringFormat (see vrv.cpp)
+        m_previousLocale = std::locale::global(std::locale::classic());
+    }
+}
+
+void Toolkit::ResetLocale()
+{
+    if (m_previousLocale) {
+        std::locale::global(*m_previousLocale);
+    }
 }
 
 void Toolkit::InitClock()

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -69,9 +69,6 @@ Toolkit::Toolkit(bool initFont)
     m_humdrumBuffer = NULL;
     m_cString = NULL;
 
-    // Required for proper formatting, e.g., in StringFormat (see vrv.cpp)
-    m_previousLocale = std::locale::global(std::locale::classic());
-
     if (initFont) {
         Resources &resources = m_doc.GetResourcesForModification();
         resources.InitFonts();
@@ -88,7 +85,9 @@ Toolkit::Toolkit(bool initFont)
 
 Toolkit::~Toolkit()
 {
-    std::locale::global(m_previousLocale);
+    if (m_previousLocale) {
+        std::locale::global(*m_previousLocale);
+    }
 
     if (m_humdrumBuffer) {
         free(m_humdrumBuffer);
@@ -1156,6 +1155,11 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
     if (json.has<jsonxx::Boolean>("fontLoadAll")) {
         Resources &resources = m_doc.GetResourcesForModification();
         resources.LoadAll();
+    }
+
+    if (m_options->m_setLocale.GetValue() && !m_previousLocale) {
+        // Required for proper formatting, e.g., in StringFormat (see vrv.cpp)
+        m_previousLocale = std::locale::global(std::locale::classic());
     }
 
     return true;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -69,6 +69,9 @@ Toolkit::Toolkit(bool initFont)
     m_humdrumBuffer = NULL;
     m_cString = NULL;
 
+    // Required for proper formatting, e.g., in StringFormat (see vrv.cpp)
+    m_previousLocale = std::locale::global(std::locale::classic());
+
     if (initFont) {
         Resources &resources = m_doc.GetResourcesForModification();
         resources.InitFonts();
@@ -85,6 +88,8 @@ Toolkit::Toolkit(bool initFont)
 
 Toolkit::~Toolkit()
 {
+    std::locale::global(m_previousLocale);
+
     if (m_humdrumBuffer) {
         free(m_humdrumBuffer);
         m_humdrumBuffer = NULL;

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -211,14 +211,12 @@ void EnableLogToBuffer(bool value)
 
 std::string StringFormat(const char *fmt, ...)
 {
-    std::locale previousLocale = std::locale::global(std::locale("C"));
     std::string str(STRING_FORMAT_MAX_LEN, 0);
     va_list args;
     va_start(args, fmt);
     vsnprintf(&str[0], STRING_FORMAT_MAX_LEN, fmt, args);
     va_end(args);
     str.resize(strlen(str.data()));
-    std::locale::global(previousLocale);
     return str;
 }
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -259,6 +259,8 @@ int main(int argc, char **argv)
     }
     options->Sync();
 
+    toolkit.SetLocale();
+
     if (show_version) {
         display_version();
         exit(0);


### PR DESCRIPTION
This PR addresses the changes introduced in #3611 . The problem is that setting and resetting the locale a few thousand times is not a good idea, performance-wise. Verovio now spends over 10 % of runtime in `StringFormat` due to this.

<img width="1165" alt="heaviest-stack-trace" src="https://github.com/rism-digital/verovio/assets/63608463/ccd6a686-5915-4e05-a260-bf3f599714aa">

<img width="706" alt="StringFormat" src="https://github.com/rism-digital/verovio/assets/63608463/0ea8578a-3a97-40ce-a31c-57090a54a4f6">

Instead we add an option `--set-locale`. If included, the locale is changed once in `Toolkit::SetOptions` and reset in the toolkit destructor.

@ammatwain Can you please check whether this still fixes your locale issues? I could not really test it from Qt. Note that the process locale is kept changed during toolkit lifetime. I hope that this does not interfere with your application.