### PR TITLE
Update clang-format-action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run clang-format style check for C/C++ programs.
-        uses: jidicula/clang-format-action@v4.9.0
+        uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: "15"
+          clang-format-version: "18"
           check-path: ${{ matrix.path['check'] }}
           exclude-regex: ${{ matrix.path['exclude'] }}

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -50,7 +50,7 @@ public:
      */
     ///@{
     void SetBackground(int color, int style = AxSOLID) override;
-    void SetBackgroundImage(void *image, double opacity = 1.0) override{};
+    void SetBackgroundImage(void *image, double opacity = 1.0) override {};
     void SetBackgroundMode(int mode) override;
     void SetTextForeground(int color) override;
     void SetTextBackground(int color) override;
@@ -87,7 +87,7 @@ public:
     void DrawSpline(int n, Point points[]) override;
     void DrawGraphicUri(int x, int y, int width, int height, const std::string &uri) override;
     void DrawSvgShape(int x, int y, int width, int height, double scale, pugi::xml_node svg) override;
-    void DrawBackgroundImage(int x = 0, int y = 0) override{};
+    void DrawBackgroundImage(int x = 0, int y = 0) override {};
     ///@}
 
     /**
@@ -150,7 +150,7 @@ public:
      * @name Method for adding description element
      */
     ///@{
-    void AddDescription(const std::string &text) override{};
+    void AddDescription(const std::string &text) override {};
     ///@}
 
 private:

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -207,7 +207,7 @@ public:
      * Special method for forcing bounding boxes to be updated
      * Used for invisible elements (e.g., <space>) that needs to be take into account in spacing
      */
-    virtual void DrawPlaceholder(int x, int y){};
+    virtual void DrawPlaceholder(int x, int y) {};
 
     /**
      * @name Method for starting and ending a text
@@ -258,14 +258,14 @@ public:
      * For example, the method can be used for grouping shapes in <g></g> in SVG
      */
     ///@{
-    virtual void StartCustomGraphic(const std::string &name, std::string gClass = "", std::string gId = ""){};
-    virtual void EndCustomGraphic(){};
+    virtual void StartCustomGraphic(const std::string &name, std::string gClass = "", std::string gId = "") {};
+    virtual void EndCustomGraphic() {};
     ///@}
 
     /**
      * Method for changing the color of a custom graphic
      */
-    virtual void SetCustomGraphicColor(const std::string &color){};
+    virtual void SetCustomGraphicColor(const std::string &color) {};
 
     /**
      * @name Methods for re-starting and ending a graphic for objects drawn in separate steps
@@ -308,7 +308,7 @@ public:
      * @name Method for adding description element
      */
     ///@{
-    virtual void AddDescription(const std::string &text){};
+    virtual void AddDescription(const std::string &text) {};
     ///@}
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -296,7 +296,7 @@ public:
     /**
      * Helper function to set shortening for elements with beam interface
      */
-    virtual void SetElementShortening(int shortening){};
+    virtual void SetElementShortening(int shortening) {};
 
     /**
      * Get the stem mod for the element (if any)

--- a/include/vrv/lb.h
+++ b/include/vrv/lb.h
@@ -37,7 +37,7 @@ public:
     /**
      * Lb is an empty element
      */
-    void AddChild(Object *object) override{};
+    void AddChild(Object *object) override {};
 
     /**
      * Interface for class functor visitation

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -122,7 +122,7 @@ public:
     virtual void DoRefresh() {}
     virtual void DoResize() {}
     virtual void DoReset() {}
-    virtual void OnPageChange(){};
+    virtual void OnPageChange() {};
     ///@}
 
     /**

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -333,9 +333,8 @@ std::pair<int, int> BeamSegment::GetMinimalStemLength(const BeamDrawingInterface
     const auto [topOffset, bottomOffset] = this->GetVerticalOffset(beamInterface);
 
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
-    const auto isNoteOrChord = [](BeamElementCoord *coord) {
-        return (coord->m_element && coord->m_element->Is({ CHORD, NOTE }));
-    };
+    const auto isNoteOrChord
+        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->Is({ CHORD, NOTE })); };
 
     using CoordIt = ArrayOfBeamElementCoords::const_iterator;
     for (CoordIt it = m_beamElementCoordRefs.begin(); it != m_beamElementCoordRefs.end(); ++it) {
@@ -460,9 +459,8 @@ void BeamSegment::AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterf
     // set to store durations of relevant notes (it's ordered, so min duration is going to be first)
     std::set<int> noteDurations;
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
-    const auto isNoteOrChord = [](BeamElementCoord *coord) {
-        return (coord->m_element && coord->m_element->Is({ CHORD, NOTE }));
-    };
+    const auto isNoteOrChord
+        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->Is({ CHORD, NOTE })); };
     // iterators
     using CoordIt = ArrayOfBeamElementCoords::iterator;
     using CoordReverseIt = ArrayOfBeamElementCoords::reverse_iterator;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -111,13 +111,11 @@ jsonxx::Object Option::ToJson() const
     const OptionBool *optBool = dynamic_cast<const OptionBool *>(this);
 
     if (optBool) {
-        opt << "type"
-            << "bool";
+        opt << "type" << "bool";
         opt << "default" << optBool->GetDefault();
     }
     else if (optDbl) {
-        opt << "type"
-            << "double";
+        opt << "type" << "double";
         jsonxx::Value value(optDbl->GetDefault());
         value.precision_ = 2;
         opt << "default" << value;
@@ -129,20 +127,17 @@ jsonxx::Object Option::ToJson() const
         opt << "max" << value;
     }
     else if (optInt) {
-        opt << "type"
-            << "int";
+        opt << "type" << "int";
         opt << "default" << optInt->GetDefault();
         opt << "min" << optInt->GetMin();
         opt << "max" << optInt->GetMax();
     }
     else if (optString) {
-        opt << "type"
-            << "std::string";
+        opt << "type" << "std::string";
         opt << "default" << optString->GetDefault();
     }
     else if (optArray) {
-        opt << "type"
-            << "array";
+        opt << "type" << "array";
         std::vector<std::string> strValues = optArray->GetDefault();
         std::vector<std::string>::iterator strIter;
         jsonxx::Array values;
@@ -152,8 +147,7 @@ jsonxx::Object Option::ToJson() const
         opt << "default" << values;
     }
     else if (optIntMap) {
-        opt << "type"
-            << "std::string-list";
+        opt << "type" << "std::string-list";
         opt << "default" << optIntMap->GetDefaultStrValue();
         std::vector<std::string> strValues = optIntMap->GetStrValues(false);
         std::vector<std::string>::iterator strIter;


### PR DESCRIPTION
This PR updates the `clang-format-action` to the latest version and moves checks to `clang-format` version 18. Previous versions of `clang-format` missed to check for a space after `override`, where we had some inconsistencies.