### PR TITLE
MusicXML: allow short multi-measure rests to be blocks

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1658,9 +1658,17 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
     for (pugi::xml_node::iterator it = node.begin(); it != node.end(); ++it) {
         // first check if there is a multi measure rest
         if (it->select_node(".//multiple-rest")) {
-            const int multiRestLength = it->select_node(".//multiple-rest").node().text().as_int();
+            const pugi::xml_node multiRestNode = it->select_node(".//multiple-rest").node();
+            const int multiRestLength = multiRestNode.text().as_int();
+            const std::string symbols = multiRestNode.attribute("use-symbols").as_string();
             MultiRest *multiRest = new MultiRest;
-            if (it->select_node(".//multiple-rest[@use-symbols='yes']")) multiRest->SetBlock(BOOLEAN_false);
+            if (symbols == "no") {
+                // default by MusicXML specification
+                multiRest->SetBlock(BOOLEAN_true);
+            }
+            else if (symbols == "yes") {
+                multiRest->SetBlock(BOOLEAN_false);
+            }
             multiRest->SetNum(multiRestLength);
             Layer *layer = SelectLayer(1, measure);
             AddLayerElement(layer, multiRest);


### PR DESCRIPTION
This PR improves the handling of the `use-symbols` attribute for MusicXML's `multiple-rest` element, so we allow short multiRest to be block rests explicitly.