### PR TITLE
Skip settings for neon neume line

### DIFF
--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -95,7 +95,7 @@ Measure::Measure(MeasureType measureMusic, int logMeasureNb)
 
     this->Reset();
 
-    if (!this->IsMeasuredMusic()) this->SetRight(BARRENDITION_invis);
+    if (!this->IsMeasuredMusic() && !this->IsNeumeLine()) this->SetRight(BARRENDITION_invis);
 }
 
 Measure::~Measure()

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1736,7 +1736,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
         return;
     }
 
-    if (!m_doc->IsFacs()) {
+    if (!m_doc->IsFacs() && !m_doc->IsNeumeLines()) {
         syl->SetDrawingYRel(this->GetSylYRel(syl->m_drawingVerse, staff));
     }
 


### PR DESCRIPTION
This fixes drawing syl bounding box and reading MEI for neon.