### PR TITLE
add basic support for oriscus and quilisma

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -1376,6 +1376,7 @@
 		BD87768627CE8A1A005B97EA /* layerdef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD87768227CE8A11005B97EA /* layerdef.cpp */; };
 		BD87768727CE8A21005B97EA /* layerdef.h in Headers */ = {isa = PBXBuildFile; fileRef = BD87768127CE89FA005B97EA /* layerdef.h */; };
 		BD87768827CE8A21005B97EA /* layerdef.h in Headers */ = {isa = PBXBuildFile; fileRef = BD87768127CE89FA005B97EA /* layerdef.h */; };
+		BD96F7CD2C04A708001CFF6F /* quilisma.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7CB2C04A708001CFF6F /* quilisma.cpp */; };
 		BDA81C21268B38760065B802 /* metersiggrp.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA81C20268B386C0065B802 /* metersiggrp.h */; };
 		BDA81C22268B38770065B802 /* metersiggrp.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA81C20268B386C0065B802 /* metersiggrp.h */; };
 		BDA81C24268B38A10065B802 /* metersiggrp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDA81C23268B38A10065B802 /* metersiggrp.cpp */; };
@@ -2181,6 +2182,8 @@
 		BD2E4D992875881B00B04350 /* stem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = stem.h; path = include/vrv/stem.h; sourceTree = "<group>"; };
 		BD87768127CE89FA005B97EA /* layerdef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = layerdef.h; path = include/vrv/layerdef.h; sourceTree = "<group>"; };
 		BD87768227CE8A11005B97EA /* layerdef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = layerdef.cpp; path = src/layerdef.cpp; sourceTree = "<group>"; };
+		BD96F7CB2C04A708001CFF6F /* quilisma.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = quilisma.cpp; path = src/quilisma.cpp; sourceTree = "<group>"; };
+		BD96F7CE2C04A76F001CFF6F /* quilisma.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quilisma.h; path = include/vrv/quilisma.h; sourceTree = "<group>"; };
 		BDA81C20268B386C0065B802 /* metersiggrp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = metersiggrp.h; path = include/vrv/metersiggrp.h; sourceTree = "<group>"; };
 		BDA81C23268B38A10065B802 /* metersiggrp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = metersiggrp.cpp; path = src/metersiggrp.cpp; sourceTree = "<group>"; };
 		BDC366C52576AF9300E4D826 /* grpsym.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = grpsym.cpp; path = src/grpsym.cpp; sourceTree = "<group>"; };
@@ -2991,6 +2994,8 @@
 				4D674B3E255F40AC008AEF4C /* plica.h */,
 				1579B3421B15033100B16F5C /* proport.cpp */,
 				1579B3411B15031D00B16F5C /* proport.h */,
+				BD96F7CB2C04A708001CFF6F /* quilisma.cpp */,
+				BD96F7CE2C04A76F001CFF6F /* quilisma.h */,
 				8F086ED1188539540037FD8E /* rest.cpp */,
 				8F59292818854BF800FE51AD /* rest.h */,
 				4DB3072E1AC9ED2500EE0982 /* space.cpp */,
@@ -4399,6 +4404,7 @@
 				4DEC4D8221C804E000D1D273 /* app.cpp in Sources */,
 				4DB787632022F0B700394520 /* jsonxx.cc in Sources */,
 				4DACCA132990F2E600B55913 /* att.cpp in Sources */,
+				BD96F7CD2C04A708001CFF6F /* quilisma.cpp in Sources */,
 				4DEEDE641E617C930087E8BC /* elementpart.cpp in Sources */,
 				4D95D4F61D71866200B2B856 /* controlelement.cpp in Sources */,
 				BDC366C72576AF9300E4D826 /* grpsym.cpp in Sources */,

--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -1377,6 +1377,17 @@
 		BD87768727CE8A21005B97EA /* layerdef.h in Headers */ = {isa = PBXBuildFile; fileRef = BD87768127CE89FA005B97EA /* layerdef.h */; };
 		BD87768827CE8A21005B97EA /* layerdef.h in Headers */ = {isa = PBXBuildFile; fileRef = BD87768127CE89FA005B97EA /* layerdef.h */; };
 		BD96F7CD2C04A708001CFF6F /* quilisma.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7CB2C04A708001CFF6F /* quilisma.cpp */; };
+		BD96F7D12C04B297001CFF6F /* oriscus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7D02C04B297001CFF6F /* oriscus.cpp */; };
+		BD96F7D22C04B2B2001CFF6F /* quilisma.h in Headers */ = {isa = PBXBuildFile; fileRef = BD96F7CE2C04A76F001CFF6F /* quilisma.h */; };
+		BD96F7D32C04B2B3001CFF6F /* quilisma.h in Headers */ = {isa = PBXBuildFile; fileRef = BD96F7CE2C04A76F001CFF6F /* quilisma.h */; };
+		BD96F7D42C04B2B6001CFF6F /* quilisma.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7CB2C04A708001CFF6F /* quilisma.cpp */; };
+		BD96F7D52C04B2B6001CFF6F /* quilisma.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7CB2C04A708001CFF6F /* quilisma.cpp */; };
+		BD96F7D62C04B2B7001CFF6F /* quilisma.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7CB2C04A708001CFF6F /* quilisma.cpp */; };
+		BD96F7D72C04B2EE001CFF6F /* oriscus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7D02C04B297001CFF6F /* oriscus.cpp */; };
+		BD96F7D82C04B2EE001CFF6F /* oriscus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7D02C04B297001CFF6F /* oriscus.cpp */; };
+		BD96F7D92C04B2EF001CFF6F /* oriscus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BD96F7D02C04B297001CFF6F /* oriscus.cpp */; };
+		BD96F7DA2C04B2F2001CFF6F /* oriscus.h in Headers */ = {isa = PBXBuildFile; fileRef = BD96F7CF2C04B26D001CFF6F /* oriscus.h */; };
+		BD96F7DB2C04B2F2001CFF6F /* oriscus.h in Headers */ = {isa = PBXBuildFile; fileRef = BD96F7CF2C04B26D001CFF6F /* oriscus.h */; };
 		BDA81C21268B38760065B802 /* metersiggrp.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA81C20268B386C0065B802 /* metersiggrp.h */; };
 		BDA81C22268B38770065B802 /* metersiggrp.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA81C20268B386C0065B802 /* metersiggrp.h */; };
 		BDA81C24268B38A10065B802 /* metersiggrp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDA81C23268B38A10065B802 /* metersiggrp.cpp */; };
@@ -2184,6 +2195,8 @@
 		BD87768227CE8A11005B97EA /* layerdef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = layerdef.cpp; path = src/layerdef.cpp; sourceTree = "<group>"; };
 		BD96F7CB2C04A708001CFF6F /* quilisma.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = quilisma.cpp; path = src/quilisma.cpp; sourceTree = "<group>"; };
 		BD96F7CE2C04A76F001CFF6F /* quilisma.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = quilisma.h; path = include/vrv/quilisma.h; sourceTree = "<group>"; };
+		BD96F7CF2C04B26D001CFF6F /* oriscus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = oriscus.h; path = include/vrv/oriscus.h; sourceTree = "<group>"; };
+		BD96F7D02C04B297001CFF6F /* oriscus.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = oriscus.cpp; path = src/oriscus.cpp; sourceTree = "<group>"; };
 		BDA81C20268B386C0065B802 /* metersiggrp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = metersiggrp.h; path = include/vrv/metersiggrp.h; sourceTree = "<group>"; };
 		BDA81C23268B38A10065B802 /* metersiggrp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = metersiggrp.cpp; path = src/metersiggrp.cpp; sourceTree = "<group>"; };
 		BDC366C52576AF9300E4D826 /* grpsym.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = grpsym.cpp; path = src/grpsym.cpp; sourceTree = "<group>"; };
@@ -2990,6 +3003,8 @@
 				4D766EF420ACAD41006875D8 /* neume.h */,
 				8F086ECC188539540037FD8E /* note.cpp */,
 				8F59292318854BF800FE51AD /* note.h */,
+				BD96F7D02C04B297001CFF6F /* oriscus.cpp */,
+				BD96F7CF2C04B26D001CFF6F /* oriscus.h */,
 				4D674B45255F40B7008AEF4C /* plica.cpp */,
 				4D674B3E255F40AC008AEF4C /* plica.h */,
 				1579B3421B15033100B16F5C /* proport.cpp */,
@@ -3190,6 +3205,7 @@
 				8F59293918854BF800FE51AD /* clef.h in Headers */,
 				4DA0EADB22BB77AF00A7EBEB /* editortoolkit_neume.h in Headers */,
 				BD6E5C41290007CE0039B0F1 /* graphic.h in Headers */,
+				BD96F7DA2C04B2F2001CFF6F /* oriscus.h in Headers */,
 				4DB3D89A1F7C326800B5FC2B /* fb.h in Headers */,
 				4D1D733E1A1D08CD001E08F6 /* glyph.h in Headers */,
 				E7908E9F298582090004C1F9 /* alignfunctor.h in Headers */,
@@ -3312,6 +3328,7 @@
 				E7A1640A29AF344B0099BD6A /* adjustharmgrpsspacingfunctor.h in Headers */,
 				E7770F8329D0D9F600A9BECF /* adjustslursfunctor.h in Headers */,
 				4DB3D8F11F83D1AA00B5FC2B /* fig.h in Headers */,
+				BD96F7D22C04B2B2001CFF6F /* quilisma.h in Headers */,
 				4DBDD67B2939E1D7009EC466 /* symboltable.h in Headers */,
 				4DACC9402990ED2600B55913 /* libmei.h in Headers */,
 				4D89F90C201771A700A4D336 /* num.h in Headers */,
@@ -3504,6 +3521,7 @@
 				BB4C4B1422A932C8001F6AF0 /* section.h in Headers */,
 				BB4C4B8022A932DF001F6AF0 /* fb.h in Headers */,
 				BB4C4AF622A932BC001F6AF0 /* ref.h in Headers */,
+				BD96F7DB2C04B2F2001CFF6F /* oriscus.h in Headers */,
 				BB4C4B6022A932D7001F6AF0 /* mrest.h in Headers */,
 				4D723AF525E8DB0B0062E0A2 /* zip_file.hpp in Headers */,
 				E765675A28BBFBA400BC6490 /* functorinterface.h in Headers */,
@@ -3615,6 +3633,7 @@
 				4DFD83012A38399C00A3E20B /* repeatmark.h in Headers */,
 				BB4C4B7622A932D7001F6AF0 /* syl.h in Headers */,
 				E73E86262A069C640089DF74 /* transposefunctor.h in Headers */,
+				BD96F7D32C04B2B3001CFF6F /* quilisma.h in Headers */,
 				BB4C4AEA22A932BC001F6AF0 /* del.h in Headers */,
 				BB4C4B3422A932CF001F6AF0 /* tempo.h in Headers */,
 				4DACC9E12990F29A00B55913 /* attconverter.h in Headers */,
@@ -3933,6 +3952,7 @@
 				4D1694001E3A44F300569BF4 /* toolkit.cpp in Sources */,
 				4DACC99B2990F29A00B55913 /* atts_header.cpp in Sources */,
 				4DACC9A32990F29A00B55913 /* atts_cmnornaments.cpp in Sources */,
+				BD96F7D72C04B2EE001CFF6F /* oriscus.cpp in Sources */,
 				4DEC4D9F21C81E9400D1D273 /* orig.cpp in Sources */,
 				E722106828F85981002CD6E9 /* findlayerelementsfunctor.cpp in Sources */,
 				4D1694011E3A44F300569BF4 /* MidiEvent.cpp in Sources */,
@@ -4104,6 +4124,7 @@
 				4D3C3F0D294B89AF009993E6 /* ornam.cpp in Sources */,
 				4DACC9972990F29A00B55913 /* atts_facsimile.cpp in Sources */,
 				E7231E0629B64B33000A2BF3 /* adjustxoverflowfunctor.cpp in Sources */,
+				BD96F7D42C04B2B6001CFF6F /* quilisma.cpp in Sources */,
 				4D16943C1E3A44F300569BF4 /* view_beam.cpp in Sources */,
 				E7BCFFBA281298620012513D /* resources.cpp in Sources */,
 				40D45EC3204EEAFE009C1EC9 /* instrdef.cpp in Sources */,
@@ -4425,6 +4446,7 @@
 				4D1EB6A12A2A40B400AF2F98 /* textlayoutelement.cpp in Sources */,
 				4D09D3ED1EA8AD8500A420E6 /* horizontalaligner.cpp in Sources */,
 				4DEC4DA221C81EB300D1D273 /* rdg.cpp in Sources */,
+				BD96F7D12C04B297001CFF6F /* oriscus.cpp in Sources */,
 				4D9A9C19199F561200028D93 /* verse.cpp in Sources */,
 				E76046C328D496B400C36204 /* calcledgerlinesfunctor.cpp in Sources */,
 				E76A9D4A29A74E4B0044682D /* adjustdotsfunctor.cpp in Sources */,
@@ -4503,6 +4525,7 @@
 				8F3DD36018854B390051330C /* view_beam.cpp in Sources */,
 				4DACC99C2990F29A00B55913 /* atts_header.cpp in Sources */,
 				4DACC9A42990F29A00B55913 /* atts_cmnornaments.cpp in Sources */,
+				BD96F7D82C04B2EE001CFF6F /* oriscus.cpp in Sources */,
 				8F3DD36218854B390051330C /* view_element.cpp in Sources */,
 				4DB3D8E11F83D15900B5FC2B /* chord.cpp in Sources */,
 				40C2E4252052A6FA0003625F /* sb.cpp in Sources */,
@@ -4674,6 +4697,7 @@
 				4DA0EAEC22BB77C300A7EBEB /* editortoolkit_neume.cpp in Sources */,
 				8F3DD31E18854AFB0051330C /* bboxdevicecontext.cpp in Sources */,
 				4DACC9982990F29A00B55913 /* atts_facsimile.cpp in Sources */,
+				BD96F7D52C04B2B6001CFF6F /* quilisma.cpp in Sources */,
 				E7231E0729B64B33000A2BF3 /* adjustxoverflowfunctor.cpp in Sources */,
 				4DB3D8F31F83D1C600B5FC2B /* scoredefinterface.cpp in Sources */,
 				4D2461DD246BE2E8002BBCCD /* expansionmap.cpp in Sources */,
@@ -4788,6 +4812,7 @@
 				BB4C4BBC22A932FC001F6AF0 /* MidiEventList.cpp in Sources */,
 				4DACC99D2990F29A00B55913 /* atts_header.cpp in Sources */,
 				4DACC9A52990F29A00B55913 /* atts_cmnornaments.cpp in Sources */,
+				BD96F7D92C04B2EF001CFF6F /* oriscus.cpp in Sources */,
 				BB4C4B9122A932DF001F6AF0 /* textelement.cpp in Sources */,
 				BB4C4B0922A932C3001F6AF0 /* pghead.cpp in Sources */,
 				E722106728F856C4002CD6E9 /* findlayerelementsfunctor.cpp in Sources */,
@@ -4959,6 +4984,7 @@
 				4DACC9992990F29A00B55913 /* atts_facsimile.cpp in Sources */,
 				BB4C4AB922A932A6001F6AF0 /* iopae.cpp in Sources */,
 				E7231E0829B64B34000A2BF3 /* adjustxoverflowfunctor.cpp in Sources */,
+				BD96F7D62C04B2B7001CFF6F /* quilisma.cpp in Sources */,
 				BB4C4ABB22A932B6001F6AF0 /* instrdef.cpp in Sources */,
 				BB4C4AB722A932A6001F6AF0 /* iomusxml.cpp in Sources */,
 				4DACC9EF2990F29A00B55913 /* atts_shared.cpp in Sources */,

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -121,6 +121,7 @@ class Plica;
 class PlistInterface;
 class PositionInterface;
 class Proport;
+class Quilisma;
 class Rdg;
 class Ref;
 class Reg;
@@ -412,6 +413,7 @@ private:
     void WriteNote(pugi::xml_node currentNode, Note *note);
     void WritePlica(pugi::xml_node currentNode, Plica *plica);
     void WriteProport(pugi::xml_node currentNode, Proport *proport);
+    void WriteQuilisma(pugi::xml_node currentNode, Quilisma *quilisma);
     void WriteRest(pugi::xml_node currentNode, Rest *rest);
     void WriteSpace(pugi::xml_node currentNode, Space *space);
     void WriteStem(pugi::xml_node currentNode, Stem *stem);
@@ -723,6 +725,7 @@ private:
     bool ReadNote(Object *parent, pugi::xml_node note);
     bool ReadPlica(Object *parent, pugi::xml_node plica);
     bool ReadProport(Object *parent, pugi::xml_node proport);
+    bool ReadQuilisma(Object *parent, pugi::xml_node quilisma);
     bool ReadRest(Object *parent, pugi::xml_node rest);
     bool ReadSpace(Object *parent, pugi::xml_node space);
     bool ReadStem(Object *parent, pugi::xml_node stem);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -105,6 +105,7 @@ class Note;
 class Num;
 class Octave;
 class Orig;
+class Oriscus;
 class Ornam;
 class Page;
 class PageElement;
@@ -411,6 +412,7 @@ private:
     void WriteNc(pugi::xml_node currentNode, Nc *nc);
     void WriteNeume(pugi::xml_node currentNode, Neume *neume);
     void WriteNote(pugi::xml_node currentNode, Note *note);
+    void WriteOriscus(pugi::xml_node currentNode, Oriscus *oriscus);
     void WritePlica(pugi::xml_node currentNode, Plica *plica);
     void WriteProport(pugi::xml_node currentNode, Proport *proport);
     void WriteQuilisma(pugi::xml_node currentNode, Quilisma *quilisma);
@@ -723,6 +725,7 @@ private:
     bool ReadNc(Object *parent, pugi::xml_node nc);
     bool ReadNeume(Object *parent, pugi::xml_node note);
     bool ReadNote(Object *parent, pugi::xml_node note);
+    bool ReadOriscus(Object *parent, pugi::xml_node oriscus);
     bool ReadPlica(Object *parent, pugi::xml_node plica);
     bool ReadProport(Object *parent, pugi::xml_node proport);
     bool ReadQuilisma(Object *parent, pugi::xml_node quilisma);

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -1,0 +1,56 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        oriscus.h
+// Author:      Klaus Rettinghaus
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_oriscus_H__
+#define __VRV_oriscus_H__
+
+#include "atts_analytical.h"
+#include "atts_shared.h"
+#include "layerelement.h"
+#include "pitchinterface.h"
+#include "positioninterface.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// oriscus
+//----------------------------------------------------------------------------
+
+class Oriscus : public LayerElement, public PitchInterface, public PositionInterface, public AttColor {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method resets all attribute classes
+     */
+    ///@{
+    Oriscus();
+    virtual ~Oriscus();
+    virtual Object *Clone() const { return new Oriscus(*this); }
+    virtual void Reset();
+    virtual std::string GetClassName() const { return "oriscus"; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    ///@}
+
+    /** Override the method since alignment is required */
+    virtual bool HasToBeAligned() const { return true; }
+
+private:
+    //
+public:
+    //
+private:
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -1,0 +1,56 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        quilisma.h
+// Author:      Klaus Rettinghaus
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_quilisma_H__
+#define __VRV_quilisma_H__
+
+#include "atts_analytical.h"
+#include "atts_shared.h"
+#include "layerelement.h"
+#include "pitchinterface.h"
+#include "positioninterface.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// quilisma
+//----------------------------------------------------------------------------
+
+class Quilisma : public LayerElement, public PitchInterface, public PositionInterface, public AttColor {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method resets all attribute classes
+     */
+    ///@{
+    Quilisma();
+    virtual ~Quilisma();
+    virtual Object *Clone() const { return new Quilisma(*this); }
+    virtual void Reset();
+    virtual std::string GetClassName() const { return "quilisma"; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    ///@}
+
+    /** Override the method since alignment is required */
+    virtual bool HasToBeAligned() const { return true; }
+
+private:
+    //
+public:
+    //
+private:
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -240,6 +240,7 @@ enum ClassId : uint16_t {
     NEUME,
     PLICA,
     PROPORT,
+    QUILISMA,
     REST,
     SPACE,
     STEM,

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -238,6 +238,7 @@ enum ClassId : uint16_t {
     NC,
     NOTE,
     NEUME,
+    ORISCUS,
     PLICA,
     PROPORT,
     QUILISMA,

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2585,6 +2585,7 @@ void MEIOutput::WriteLiquescent(pugi::xml_node currentNode, Liquescent *liquesce
 
     WriteLayerElement(currentNode, liquescent);
     WritePositionInterface(currentNode, liquescent);
+    liquescent->WriteColor(currentNode);
 }
 
 void MEIOutput::WriteMensur(pugi::xml_node currentNode, Mensur *mensur)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -7004,12 +7004,12 @@ bool MEIInput::ReadOriscus(Object *parent, pugi::xml_node oriscus)
     Oriscus *vrvOriscus = new Oriscus();
     this->ReadLayerElement(oriscus, vrvOriscus);
     this->ReadPositionInterface(oriscus, vrvOriscus);
-    
+
     vrvOriscus->ReadColor(oriscus);
 
     parent->AddChild(vrvOriscus);
     this->ReadUnsupportedAttr(oriscus, vrvOriscus);
-    
+
     return true;
 }
 
@@ -7018,12 +7018,12 @@ bool MEIInput::ReadQuilisma(Object *parent, pugi::xml_node quilisma)
     Quilisma *vrvQuilisma = new Quilisma();
     this->ReadLayerElement(quilisma, vrvQuilisma);
     this->ReadPositionInterface(quilisma, vrvQuilisma);
-    
+
     vrvQuilisma->ReadColor(quilisma);
 
     parent->AddChild(vrvQuilisma);
     this->ReadUnsupportedAttr(quilisma, vrvQuilisma);
-    
+
     return true;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -97,6 +97,7 @@
 #include "num.h"
 #include "octave.h"
 #include "orig.h"
+#include "oriscus.h"
 #include "ornam.h"
 #include "page.h"
 #include "pagemilestone.h"
@@ -711,6 +712,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         else if (object->Is(NOTE)) {
             m_currentNode = m_currentNode.append_child("note");
             this->WriteNote(m_currentNode, vrv_cast<Note *>(object));
+        }
+        else if (object->Is(ORISCUS)) {
+            m_currentNode = m_currentNode.append_child("oriscus");
+            this->WriteOriscus(m_currentNode, vrv_cast<Oriscus *>(object));
         }
         else if (object->Is(PLICA)) {
             m_currentNode = m_currentNode.append_child("plica");
@@ -2754,6 +2759,15 @@ void MEIOutput::WriteNote(pugi::xml_node currentNode, Note *note)
     note->WriteVisibility(currentNode);
 }
 
+void MEIOutput::WriteOriscus(pugi::xml_node currentNode, Oriscus *oriscus)
+{
+    assert(oriscus);
+
+    this->WriteLayerElement(currentNode, oriscus);
+    this->WritePitchInterface(currentNode, oriscus);
+    oriscus->WriteColor(currentNode);
+}
+
 void MEIOutput::WritePlica(pugi::xml_node currentNode, Plica *plica)
 {
     assert(plica);
@@ -3721,6 +3735,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
     // filter for nc
     else if (filterParent->Is(NC)) {
         if (element == "liquescent") {
+            return true;
+        }
+        else if (element == "oriscus") {
             return true;
         }
         else if (element == "quilisma") {
@@ -6273,6 +6290,9 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         else if (elementName == "note") {
             success = this->ReadNote(parent, xmlElement);
         }
+        else if (elementName == "oriscus") {
+            success = this->ReadOriscus(parent, xmlElement);
+        }
         else if (elementName == "quilisma") {
             success = this->ReadQuilisma(parent, xmlElement);
         }
@@ -6976,6 +6996,20 @@ bool MEIInput::ReadProport(Object *parent, pugi::xml_node proport)
 
     parent->AddChild(vrvProport);
     this->ReadUnsupportedAttr(proport, vrvProport);
+    return true;
+}
+
+bool MEIInput::ReadOriscus(Object *parent, pugi::xml_node oriscus)
+{
+    Oriscus *vrvOriscus = new Oriscus();
+    this->ReadLayerElement(oriscus, vrvOriscus);
+    this->ReadPositionInterface(oriscus, vrvOriscus);
+    
+    vrvOriscus->ReadColor(oriscus);
+
+    parent->AddChild(vrvOriscus);
+    this->ReadUnsupportedAttr(oriscus, vrvOriscus);
+    
     return true;
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -6672,6 +6672,8 @@ bool MEIInput::ReadLiquescent(Object *parent, pugi::xml_node liquescent)
     this->ReadLayerElement(liquescent, vrvLiquescent);
     this->ReadPositionInterface(liquescent, vrvLiquescent);
 
+    vrvLiquescent->ReadColor(liquescent);
+
     parent->AddChild(vrvLiquescent);
     this->ReadUnsupportedAttr(liquescent, vrvLiquescent);
     return true;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -109,6 +109,7 @@
 #include "pitchinflection.h"
 #include "plica.h"
 #include "proport.h"
+#include "quilisma.h"
 #include "rdg.h"
 #include "ref.h"
 #include "reg.h"
@@ -718,6 +719,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         else if (object->Is(PROPORT)) {
             m_currentNode = m_currentNode.append_child("proport");
             this->WriteProport(m_currentNode, vrv_cast<Proport *>(object));
+        }
+        else if (object->Is(QUILISMA)) {
+            m_currentNode = m_currentNode.append_child("quilisma");
+            this->WriteQuilisma(m_currentNode, vrv_cast<Quilisma *>(object));
         }
         else if (object->Is(REST)) {
             m_currentNode = m_currentNode.append_child("rest");
@@ -2748,20 +2753,6 @@ void MEIOutput::WriteNote(pugi::xml_node currentNode, Note *note)
     note->WriteVisibility(currentNode);
 }
 
-void MEIOutput::WriteRest(pugi::xml_node currentNode, Rest *rest)
-{
-    assert(rest);
-
-    this->WriteLayerElement(currentNode, rest);
-    this->WriteDurationInterface(currentNode, rest);
-    this->WritePositionInterface(currentNode, rest);
-    rest->WriteColor(currentNode);
-    rest->WriteCue(currentNode);
-    rest->WriteExtSymAuth(currentNode);
-    rest->WriteExtSymNames(currentNode);
-    rest->WriteRestVisMensural(currentNode);
-}
-
 void MEIOutput::WritePlica(pugi::xml_node currentNode, Plica *plica)
 {
     assert(plica);
@@ -2775,6 +2766,29 @@ void MEIOutput::WriteProport(pugi::xml_node currentNode, Proport *proport)
     assert(proport);
 
     this->WriteLayerElement(currentNode, proport);
+}
+
+void MEIOutput::WriteQuilisma(pugi::xml_node currentNode, Quilisma *quilisma)
+{
+    assert(quilisma);
+
+    this->WriteLayerElement(currentNode, quilisma);
+    this->WritePitchInterface(currentNode, quilisma);
+    quilisma->WriteColor(currentNode);
+}
+
+void MEIOutput::WriteRest(pugi::xml_node currentNode, Rest *rest)
+{
+    assert(rest);
+
+    this->WriteLayerElement(currentNode, rest);
+    this->WriteDurationInterface(currentNode, rest);
+    this->WritePositionInterface(currentNode, rest);
+    rest->WriteColor(currentNode);
+    rest->WriteCue(currentNode);
+    rest->WriteExtSymAuth(currentNode);
+    rest->WriteExtSymNames(currentNode);
+    rest->WriteRestVisMensural(currentNode);
 }
 
 void MEIOutput::WriteSpace(pugi::xml_node currentNode, Space *space)
@@ -3706,6 +3720,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
     // filter for nc
     else if (filterParent->Is(NC)) {
         if (element == "liquescent") {
+            return true;
+        }
+        else if (element == "quilisma") {
             return true;
         }
         else {
@@ -6255,6 +6272,9 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         else if (elementName == "note") {
             success = this->ReadNote(parent, xmlElement);
         }
+        else if (elementName == "quilisma") {
+            success = this->ReadQuilisma(parent, xmlElement);
+        }
         else if (elementName == "rest") {
             success = this->ReadRest(parent, xmlElement);
         }
@@ -6955,6 +6975,20 @@ bool MEIInput::ReadProport(Object *parent, pugi::xml_node proport)
 
     parent->AddChild(vrvProport);
     this->ReadUnsupportedAttr(proport, vrvProport);
+    return true;
+}
+
+bool MEIInput::ReadQuilisma(Object *parent, pugi::xml_node quilisma)
+{
+    Quilisma *vrvQuilisma = new Quilisma();
+    this->ReadLayerElement(quilisma, vrvQuilisma);
+    this->ReadPositionInterface(quilisma, vrvQuilisma);
+    
+    vrvQuilisma->ReadColor(quilisma);
+
+    parent->AddChild(vrvQuilisma);
+    this->ReadUnsupportedAttr(quilisma, vrvQuilisma);
+    
     return true;
 }
 

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -18,6 +18,7 @@
 #include "elementpart.h"
 #include "functor.h"
 #include "liquescent.h"
+#include "quilisma.h"
 #include "staff.h"
 #include "vrv.h"
 
@@ -89,6 +90,9 @@ bool Nc::IsSupportedChild(Object *child)
 {
     if (child->Is(LIQUESCENT)) {
         assert(dynamic_cast<Liquescent *>(child));
+    }
+    else if (child->Is(QUILISMA)) {
+        assert(dynamic_cast<Quilisma *>(child));
     }
     else {
         return false;

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -18,6 +18,7 @@
 #include "elementpart.h"
 #include "functor.h"
 #include "liquescent.h"
+#include "oriscus.h"
 #include "quilisma.h"
 #include "staff.h"
 #include "vrv.h"
@@ -90,6 +91,9 @@ bool Nc::IsSupportedChild(Object *child)
 {
     if (child->Is(LIQUESCENT)) {
         assert(dynamic_cast<Liquescent *>(child));
+    }
+    else if (child->Is(ORISCUS)) {
+        assert(dynamic_cast<Oriscus *>(child));
     }
     else if (child->Is(QUILISMA)) {
         assert(dynamic_cast<Quilisma *>(child));

--- a/src/oriscus.cpp
+++ b/src/oriscus.cpp
@@ -1,0 +1,46 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        oriscus.cpp
+// Author:      Klaus Rettinghaus
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "oriscus.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+#include "doc.h"
+#include "vrv.h"
+
+//------------/Users/rettinghaus/git/verovio----------------------------------------------------------------
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Oriscus
+//----------------------------------------------------------------------------
+
+Oriscus::Oriscus() : LayerElement(ORISCUS, "oriscus-"), PitchInterface(), PositionInterface(), AttColor()
+{
+    RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
+    RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+
+    Reset();
+}
+
+Oriscus::~Oriscus() {}
+
+void Oriscus::Reset()
+{
+    LayerElement::Reset();
+    PitchInterface::Reset();
+    PositionInterface::Reset();
+    ResetColor();
+}
+
+} // namespace vrv

--- a/src/quilisma.cpp
+++ b/src/quilisma.cpp
@@ -1,0 +1,46 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        quilisma.cpp
+// Author:      Klaus Rettinghaus
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "quilisma.h"
+
+//----------------------------------------------------------------------------
+
+#include <assert.h>
+
+//----------------------------------------------------------------------------
+
+#include "doc.h"
+#include "vrv.h"
+
+//----------------------------------------------------------------------------
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Quilisma
+//----------------------------------------------------------------------------
+
+Quilisma::Quilisma() : LayerElement(QUILISMA, "quilisma-"), PitchInterface(), PositionInterface(), AttColor()
+{
+    RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
+    RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
+    RegisterAttClass(ATT_COLOR);
+
+    Reset();
+}
+
+Quilisma::~Quilisma() {}
+
+void Quilisma::Reset()
+{
+    LayerElement::Reset();
+    PitchInterface::Reset();
+    PositionInterface::Reset();
+    ResetColor();
+}
+
+} // namespace vrv


### PR DESCRIPTION
This PR adds basic reading/writing support for `oriscus` and `quilisma` elements. 

Also it fixes missing/non functional support for liquescent color.

Relates to #3627. 