### PR TITLE
Humdrum import: **mxhm 'major-sixth' should be <harm> text "6", not "maj6"

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -12411,6 +12411,10 @@ void HumdrumInput::setMxHarmContent(Rend *rend, const std::string &content)
         kind = U"+";
         replacing = true;
     }
+    else if (kind == U"maj6") {
+        kind = U"6";
+        replacing = true;
+    }
     else if (kind == U"minor-seventh") {
         kind = U"m7";
         replacing = true;


### PR DESCRIPTION
C major-sixth should be <harm> text "C6", for example, not "Cmaj6".