### PR TITLE
Refactoring of the Nc drawing code into a data preparation functor

### DIFF
--- a/include/vrv/adjustneumexfunctor.h
+++ b/include/vrv/adjustneumexfunctor.h
@@ -54,8 +54,10 @@ private:
 public:
     //
 private:
-    /** The minimu position of the next syl */
+    /** The minimum position of the next syl */
     int m_minPos;
+    /** The minimum position of the next neume */
+    int m_neumeMinPos;
 };
 
 } // namespace vrv

--- a/include/vrv/calcligatureorneumeposfunctor.h
+++ b/include/vrv/calcligatureorneumeposfunctor.h
@@ -39,6 +39,7 @@ public:
      */
     ///@{
     FunctorCode VisitLigature(Ligature *ligature) override;
+    FunctorCode VisitNeume(Neume *neume) override;
     ///@}
 
 protected:

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -74,7 +74,25 @@ public:
     FunctorCode AcceptEnd(ConstFunctor &functor) const override;
     ///@}
 
+    /**
+     * A Structure holding a glyph paramter for the nc.
+     * One single nc might need more than one glyph (e.g., liquescent).
+     * Set in CalcLigatureOrNeumePosFunctor::VisitNeume
+     */
+    struct DrawingGlyph {
+        wchar_t m_fontNo = 0;
+        float m_xOffset = 0.0;
+        float m_yOffset = 0.0;
+    };
+
 private:
+    //
+public:
+    /** Drawing glyphs */
+    std::vector<DrawingGlyph> m_drawingGlyphs;
+
+private:
+    //
 };
 
 } // namespace vrv

--- a/include/vrv/resetfunctor.h
+++ b/include/vrv/resetfunctor.h
@@ -62,6 +62,7 @@ public:
     FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitMRest(MRest *mRest) override;
     FunctorCode VisitNote(Note *note) override;
+    FunctorCode VisitNc(Nc *nc) override;
     FunctorCode VisitObject(Object *object) override;
     FunctorCode VisitRepeatMark(RepeatMark *repeatMark) override;
     FunctorCode VisitRest(Rest *rest) override;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -429,6 +429,7 @@ protected:
      */
     ///@{
     void DrawNcAsNotehead(DeviceContext *dc, Nc *nc, Layer *layer, Staff *staff, Measure *measure);
+    void DrawNcGlyphs(DeviceContext *dc, Nc *nc, Staff *staff);
     ///@}
 
     /**

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -394,7 +394,7 @@ FunctorCode AlignHorizontallyFunctor::VisitMeasureEnd(Measure *measure)
 
     if (m_hasMultipleLayer) measure->HasAlignmentRefWithMultipleLayers(true);
 
-    // measure->m_measureAligner.LogDebugTree(3);
+    measure->m_measureAligner.LogDebugTree(3);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/resetfunctor.cpp
+++ b/src/resetfunctor.cpp
@@ -23,6 +23,7 @@
 #include "layer.h"
 #include "ligature.h"
 #include "mrest.h"
+#include "nc.h"
 #include "octave.h"
 #include "page.h"
 #include "repeatmark.h"
@@ -340,6 +341,18 @@ FunctorCode ResetDataFunctor::VisitNote(Note *note)
     note->SetStemSameasNote(NULL);
     note->SetStemSameasRole(SAMEAS_NONE);
 
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode ResetDataFunctor::VisitNc(Nc *nc)
+{
+    // Call parent one too
+    this->VisitLayerElement(nc);
+
+    nc->m_drawingGlyphs.clear();
+
+    // We want the list of the ObjectListInterface to be regenerated
+    nc->Modify();
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -33,12 +33,6 @@
 
 namespace vrv {
 
-struct NcDrawingParams {
-    wchar_t fontNo = 0;
-    float xOffset = 0;
-    float yOffset = 0;
-};
-
 void View::DrawSyllable(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)
 {
     assert(dc);
@@ -220,8 +214,6 @@ void View::DrawOriscus(DeviceContext *dc, LayerElement *element, Layer *layer, S
     assert(staff);
     assert(measure);
 
-    NcDrawingParams params;
-
     dc->StartGraphic(element, "", element->GetID());
 
     dc->EndGraphic(element, this);
@@ -233,8 +225,6 @@ void View::DrawQuilisma(DeviceContext *dc, LayerElement *element, Layer *layer, 
     assert(layer);
     assert(staff);
     assert(measure);
-
-    NcDrawingParams params;
 
     dc->StartGraphic(element, "", element->GetID());
 

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -69,48 +69,7 @@ void View::DrawLiquescent(DeviceContext *dc, LayerElement *element, Layer *layer
     assert(staff);
     assert(measure);
 
-    NcDrawingParams params[3];
-
     dc->StartGraphic(element, "", element->GetID());
-
-    Nc *nc = dynamic_cast<Nc *>(element->GetParent());
-
-    if (nc->GetCurve() == curvatureDirection_CURVE_c) {
-        params[0].fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-        params[1].fontNo = SMUFL_E995_chantAuctumDesc;
-        params[2].fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-        params[2].xOffset = 0.8;
-        params[0].yOffset = -1.5;
-        params[2].yOffset = -1.75;
-    }
-    else if (nc->GetCurve() == curvatureDirection_CURVE_a) {
-        params[0].fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-        params[1].fontNo = SMUFL_E994_chantAuctumAsc;
-        params[2].fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-        params[2].xOffset = 0.8;
-        params[0].yOffset = 0.5;
-        params[2].yOffset = 0.75;
-    }
-    else {
-        params[0].fontNo = SMUFL_E9A1_chantPunctumDeminutum;
-    }
-
-    const int noteHeight
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_HEIGHT_TO_STAFF_SIZE_RATIO);
-    const int noteWidth
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_WIDTH_TO_STAFF_SIZE_RATIO);
-
-    int noteX = nc->GetDrawingX();
-    int noteY = nc->GetDrawingY();
-
-    if (staff->HasDrawingRotation()) {
-        noteY -= staff->GetDrawingRotationOffsetFor(noteX);
-    }
-
-    for (int i = 0; i < static_cast<int>(sizeof(params)); ++i) {
-        DrawSmuflCode(dc, noteX + params[i].xOffset * noteWidth, noteY + params[i].yOffset * noteHeight,
-            params[i].fontNo, staff->m_drawingStaffSize, false, true);
-    }
 
     dc->EndGraphic(element, this);
 }
@@ -130,104 +89,9 @@ void View::DrawNc(DeviceContext *dc, LayerElement *element, Layer *layer, Staff 
         return;
     }
 
-    NcDrawingParams params;
-
     dc->StartGraphic(element, "", element->GetID());
 
-    const bool hasLiquescent = (nc->FindDescendantByType(LIQUESCENT));
-    const bool hasOriscus = (nc->FindDescendantByType(ORISCUS));
-    const bool hasQuilisma = (nc->FindDescendantByType(QUILISMA));
-
-    /******************************************************************/
-
-    if (!hasLiquescent && !hasOriscus && !hasQuilisma) {
-
-        params.fontNo = SMUFL_E990_chantPunctum;
-
-        Neume *neume = vrv_cast<Neume *>(nc->GetFirstAncestor(NEUME));
-        assert(neume);
-        int position = neume->GetChildIndex(element);
-
-        // Check if nc is part of a ligature or is an inclinatum
-        if (nc->HasTilt() && nc->GetTilt() == COMPASSDIRECTION_se) {
-            params.fontNo = SMUFL_E991_chantPunctumInclinatum;
-        }
-        else if (nc->GetLigated() == BOOLEAN_true) {
-            int pitchDifference = 0;
-            bool isFirst;
-            int ligCount = neume->GetLigatureCount(position);
-
-            if (ligCount % 2 == 0) {
-                isFirst = false;
-                Nc *lastNc = dynamic_cast<Nc *>(neume->GetChild(position > 0 ? position - 1 : 0));
-                assert(lastNc);
-                pitchDifference = nc->PitchDifferenceTo(lastNc);
-                params.xOffset = -1;
-                params.yOffset = -pitchDifference;
-            }
-            else {
-                isFirst = true;
-                Object *nextSibling = neume->GetChild(position + 1);
-                if (nextSibling != NULL) {
-                    Nc *nextNc = dynamic_cast<Nc *>(nextSibling);
-                    assert(nextNc);
-                    pitchDifference = nextNc->PitchDifferenceTo(nc);
-                    params.yOffset = pitchDifference;
-                }
-            }
-
-            // set the glyph
-            switch (pitchDifference) {
-                case -1:
-                    params.fontNo = isFirst ? SMUFL_E9B4_chantEntryLineAsc2nd : SMUFL_E9B9_chantLigaturaDesc2nd;
-                    break;
-                case -2:
-                    params.fontNo = isFirst ? SMUFL_E9B5_chantEntryLineAsc3rd : SMUFL_E9BA_chantLigaturaDesc3rd;
-                    break;
-                case -3:
-                    params.fontNo = isFirst ? SMUFL_E9B6_chantEntryLineAsc4th : SMUFL_E9BB_chantLigaturaDesc4th;
-                    break;
-                case -4:
-                    params.fontNo = isFirst ? SMUFL_E9B7_chantEntryLineAsc5th : SMUFL_E9BC_chantLigaturaDesc5th;
-                    break;
-                default: break;
-            }
-        }
-
-        // If the nc is supposed to be a virga and currently is being rendered as a punctum
-        // change it to a virga
-        if (nc->GetTilt() == COMPASSDIRECTION_s && params.fontNo == SMUFL_E990_chantPunctum) {
-            params.fontNo = SMUFL_E996_chantPunctumVirga;
-        }
-
-        else if (nc->GetTilt() == COMPASSDIRECTION_n && params.fontNo == SMUFL_E990_chantPunctum) {
-            params.fontNo = SMUFL_E997_chantPunctumVirgaReversed;
-        }
-
-        const int noteHeight
-            = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_HEIGHT_TO_STAFF_SIZE_RATIO);
-        const int noteWidth
-            = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_WIDTH_TO_STAFF_SIZE_RATIO);
-
-        int noteX = nc->GetDrawingX();
-        int noteY = nc->GetDrawingY();
-
-        if (nc->HasFacs() && m_doc->IsNeumeLines()) {
-            params.xOffset = 0;
-        }
-        // Not sure about this if - the nc pname and oct are going to be ignored
-        else if (neume->HasFacs() && m_doc->IsNeumeLines()) {
-            noteY = staff->GetDrawingY();
-            noteX = neume->GetDrawingX() + position * noteWidth;
-        }
-
-        if (staff->HasDrawingRotation()) {
-            noteY -= staff->GetDrawingRotationOffsetFor(noteX);
-        }
-
-        DrawSmuflCode(dc, noteX + params.xOffset * noteWidth, noteY + params.yOffset * noteHeight, params.fontNo,
-            staff->m_drawingStaffSize, false, true);
-    }
+    this->DrawNcGlyphs(dc, nc, staff);
 
     /******************************************************************/
 
@@ -360,26 +224,6 @@ void View::DrawOriscus(DeviceContext *dc, LayerElement *element, Layer *layer, S
 
     dc->StartGraphic(element, "", element->GetID());
 
-    Nc *nc = dynamic_cast<Nc *>(element->GetParent());
-    assert(nc);
-
-    params.fontNo = SMUFL_EA2A_medRenOriscusCMN;
-
-    const int noteHeight
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_HEIGHT_TO_STAFF_SIZE_RATIO);
-    const int noteWidth
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_WIDTH_TO_STAFF_SIZE_RATIO);
-
-    int noteX = nc->GetDrawingX();
-    int noteY = nc->GetDrawingY();
-
-    if (staff->HasDrawingRotation()) {
-        noteY -= staff->GetDrawingRotationOffsetFor(noteX);
-    }
-
-    DrawSmuflCode(dc, noteX + params.xOffset * noteWidth, noteY + params.yOffset * noteHeight, params.fontNo,
-        staff->m_drawingStaffSize, false, true);
-
     dc->EndGraphic(element, this);
 }
 
@@ -394,9 +238,14 @@ void View::DrawQuilisma(DeviceContext *dc, LayerElement *element, Layer *layer, 
 
     dc->StartGraphic(element, "", element->GetID());
 
-    Nc *nc = dynamic_cast<Nc *>(element->GetParent());
+    dc->EndGraphic(element, this);
+}
 
-    params.fontNo = SMUFL_E99B_chantQuilisma;
+void View::DrawNcGlyphs(DeviceContext *dc, Nc *nc, Staff *staff)
+{
+    assert(dc);
+    assert(nc);
+    assert(staff);
 
     const int noteHeight
         = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_HEIGHT_TO_STAFF_SIZE_RATIO);
@@ -410,10 +259,10 @@ void View::DrawQuilisma(DeviceContext *dc, LayerElement *element, Layer *layer, 
         noteY -= staff->GetDrawingRotationOffsetFor(noteX);
     }
 
-    DrawSmuflCode(dc, noteX + params.xOffset * noteWidth, noteY + params.yOffset * noteHeight, params.fontNo,
-        staff->m_drawingStaffSize, false, true);
-
-    dc->EndGraphic(element, this);
+    for (auto &glyph : nc->m_drawingGlyphs) {
+        DrawSmuflCode(dc, noteX + glyph.m_xOffset * noteWidth, noteY + glyph.m_yOffset * noteHeight, glyph.m_fontNo,
+            staff->m_drawingStaffSize, false, true);
+    }
 }
 
 } // namespace vrv


### PR DESCRIPTION
In order to adjust the spacing of neumes when not using the facsimile, setting the glyphs to be applied must be done before the rendering. This refactoring move some of the drawing code into the `CalcLigatureOrNeumePosFunctor` and caches the values into `Nc::m_drawingGlyphs`.

Fixes #3722.

Pinging @yinanazhou.