### PR TITLE
Improvement of the neume rendering

### DIFF
--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -65,6 +65,16 @@ public:
     ///@}
 
     /**
+     * Calclulate the pitch or loc difference between to nc.
+     * The Pitch difference takes precedence over the loc difference.
+     */
+    int PitchOrLocDifferenceTo(const Nc *nc) const;
+
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
      * Interface for class functor visitation
      */
     ///@{

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -319,6 +319,9 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitLayerElement(LayerElement *layerE
         if (nc->HasPname() && nc->HasOct()) {
             loc = PitchInterface::CalcLoc(nc->GetPname(), nc->GetOct(), layerY->GetClefLocOffset(nc));
         }
+        else if (nc->HasLoc()) {
+            loc = nc->GetLoc();
+        }
         int yRel = staffY->CalcPitchPosYRel(m_doc, loc);
         nc->SetDrawingLoc(loc);
         nc->SetDrawingYRel(yRel);

--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -254,7 +254,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
         // Make sure we have at least one glyph
         nc->m_drawingGlyphs.resize(1);
 
-        const int pitchDifference = (previousNc) ? nc->PitchDifferenceTo(previousNc) : 0;
+        int pitchDifference = (previousNc) ? nc->PitchOrLocDifferenceTo(previousNc) : 0;
         bool overlapWithPrevious = (pitchDifference == 0) ? false : true;
 
         if (hasLiquescent) {

--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -230,6 +230,8 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
     if (m_doc->GetOptions()->m_neumeAsNote.GetValue()) return FUNCTOR_SIBLINGS;
 
     ListOfObjects ncs = neume->FindAllDescendantsByType(NC);
+    
+    Staff *staff = neume->GetAncestorStaff();
 
     int xRel = 0;
 
@@ -248,33 +250,33 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
         if (hasLiquescent) {
             nc->m_drawingGlyphs.resize(3);
             if (nc->GetCurve() == curvatureDirection_CURVE_c) {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E995_chantAuctumDesc;
-                nc->m_drawingGlyphs[1].m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-                nc->m_drawingGlyphs[2].m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-                nc->m_drawingGlyphs[2].m_xOffset = 0.8;
-                nc->m_drawingGlyphs[1].m_yOffset = -1.5;
-                nc->m_drawingGlyphs[2].m_yOffset = -1.75;
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E995_chantAuctumDesc;
+                nc->m_drawingGlyphs.at(1).m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
+                nc->m_drawingGlyphs.at(2).m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
+                nc->m_drawingGlyphs.at(2).m_xOffset = 0.8;
+                nc->m_drawingGlyphs.at(1).m_yOffset = -1.5;
+                nc->m_drawingGlyphs.at(2).m_yOffset = -1.75;
             }
             else if (nc->GetCurve() == curvatureDirection_CURVE_a) {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E994_chantAuctumAsc;
-                nc->m_drawingGlyphs[1].m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-                nc->m_drawingGlyphs[2].m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
-                nc->m_drawingGlyphs[2].m_xOffset = 0.8;
-                nc->m_drawingGlyphs[1].m_yOffset = 0.5;
-                nc->m_drawingGlyphs[2].m_yOffset = 0.75;
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E994_chantAuctumAsc;
+                nc->m_drawingGlyphs.at(1).m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
+                nc->m_drawingGlyphs.at(2).m_fontNo = SMUFL_E9BE_chantConnectingLineAsc3rd;
+                nc->m_drawingGlyphs.at(2).m_xOffset = 0.8;
+                nc->m_drawingGlyphs.at(1).m_yOffset = 0.5;
+                nc->m_drawingGlyphs.at(2).m_yOffset = 0.75;
             }
             else {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E9A1_chantPunctumDeminutum;
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9A1_chantPunctumDeminutum;
             }
         }
         else if (hasOriscus) {
-            nc->m_drawingGlyphs[0].m_fontNo = SMUFL_EA2A_medRenOriscusCMN;
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_EA2A_medRenOriscusCMN;
         }
         else if (hasQuilisma) {
-            nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E99B_chantQuilisma;
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E99B_chantQuilisma;
         }
         else {
-            nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E990_chantPunctum;
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E990_chantPunctum;
 
             Neume *neume = vrv_cast<Neume *>(nc->GetFirstAncestor(NEUME));
             assert(neume);
@@ -282,7 +284,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
 
             // Check if nc is part of a ligature or is an inclinatum
             if (nc->HasTilt() && nc->GetTilt() == COMPASSDIRECTION_se) {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E991_chantPunctumInclinatum;
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E991_chantPunctumInclinatum;
             }
             else if (nc->GetLigated() == BOOLEAN_true) {
                 int pitchDifference = 0;
@@ -294,7 +296,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
                     Nc *lastNc = dynamic_cast<Nc *>(neume->GetChild(position > 0 ? position - 1 : 0));
                     assert(lastNc);
                     pitchDifference = nc->PitchDifferenceTo(lastNc);
-                    nc->m_drawingGlyphs[0].m_yOffset = -pitchDifference;
+                    nc->m_drawingGlyphs.at(0).m_yOffset = -pitchDifference;
                 }
                 else {
                     isFirst = true;
@@ -303,26 +305,26 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
                         Nc *nextNc = dynamic_cast<Nc *>(nextSibling);
                         assert(nextNc);
                         pitchDifference = nextNc->PitchDifferenceTo(nc);
-                        nc->m_drawingGlyphs[0].m_yOffset = pitchDifference;
+                        nc->m_drawingGlyphs.at(0).m_yOffset = pitchDifference;
                     }
                 }
 
                 // set the glyph
                 switch (pitchDifference) {
                     case -1:
-                        nc->m_drawingGlyphs[0].m_fontNo
+                        nc->m_drawingGlyphs.at(0).m_fontNo
                             = isFirst ? SMUFL_E9B4_chantEntryLineAsc2nd : SMUFL_E9B9_chantLigaturaDesc2nd;
                         break;
                     case -2:
-                        nc->m_drawingGlyphs[0].m_fontNo
+                        nc->m_drawingGlyphs.at(0).m_fontNo
                             = isFirst ? SMUFL_E9B5_chantEntryLineAsc3rd : SMUFL_E9BA_chantLigaturaDesc3rd;
                         break;
                     case -3:
-                        nc->m_drawingGlyphs[0].m_fontNo
+                        nc->m_drawingGlyphs.at(0).m_fontNo
                             = isFirst ? SMUFL_E9B6_chantEntryLineAsc4th : SMUFL_E9BB_chantLigaturaDesc4th;
                         break;
                     case -4:
-                        nc->m_drawingGlyphs[0].m_fontNo
+                        nc->m_drawingGlyphs.at(0).m_fontNo
                             = isFirst ? SMUFL_E9B7_chantEntryLineAsc5th : SMUFL_E9BC_chantLigaturaDesc5th;
                         break;
                     default: break;
@@ -331,19 +333,19 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
 
             // If the nc is supposed to be a virga and currently is being rendered as a punctum
             // change it to a virga
-            if (nc->GetTilt() == COMPASSDIRECTION_s && nc->m_drawingGlyphs[0].m_fontNo == SMUFL_E990_chantPunctum) {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E996_chantPunctumVirga;
+            if (nc->GetTilt() == COMPASSDIRECTION_s && nc->m_drawingGlyphs.at(0).m_fontNo == SMUFL_E990_chantPunctum) {
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E996_chantPunctumVirga;
             }
 
             else if (nc->GetTilt() == COMPASSDIRECTION_n
-                && nc->m_drawingGlyphs[0].m_fontNo == SMUFL_E990_chantPunctum) {
-                nc->m_drawingGlyphs[0].m_fontNo = SMUFL_E997_chantPunctumVirgaReversed;
+                && nc->m_drawingGlyphs.at(0).m_fontNo == SMUFL_E990_chantPunctum) {
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E997_chantPunctumVirgaReversed;
             }
         }
 
         nc->SetDrawingXRel(xRel);
         // The first glyph set the spacing
-        xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs[0].m_fontNo, 100, false);
+        xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staff->m_drawingStaffSize, false);
     }
 
     return FUNCTOR_SIBLINGS;

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -67,6 +67,15 @@ void Nc::Reset()
     this->ResetNcForm();
 }
 
+int Nc::PitchOrLocDifferenceTo(const Nc *nc) const
+{
+    int difference = this->PitchDifferenceTo(nc);
+    if ((difference == 0) && this->HasLoc() && nc->HasLoc()) {
+        difference = this->GetLoc() - nc->GetLoc();
+    }
+    return difference;
+}
+
 FunctorCode Nc::Accept(Functor &functor)
 {
     return functor.VisitNc(this);

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -237,21 +237,16 @@ void View::DrawNcGlyphs(DeviceContext *dc, Nc *nc, Staff *staff)
     assert(nc);
     assert(staff);
 
-    const int noteHeight
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_HEIGHT_TO_STAFF_SIZE_RATIO);
-    const int noteWidth
-        = (int)(m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) / NOTE_WIDTH_TO_STAFF_SIZE_RATIO);
-
-    int noteX = nc->GetDrawingX();
-    int noteY = nc->GetDrawingY();
+    int ncX = nc->GetDrawingX();
+    int ncY = nc->GetDrawingY();
 
     if (staff->HasDrawingRotation()) {
-        noteY -= staff->GetDrawingRotationOffsetFor(noteX);
+        ncY -= staff->GetDrawingRotationOffsetFor(ncX);
     }
 
     for (auto &glyph : nc->m_drawingGlyphs) {
-        DrawSmuflCode(dc, noteX + glyph.m_xOffset * noteWidth, noteY + glyph.m_yOffset * noteHeight, glyph.m_fontNo,
-            staff->m_drawingStaffSize, false, true);
+        DrawSmuflCode(
+            dc, ncX + glyph.m_xOffset, ncY + glyph.m_yOffset, glyph.m_fontNo, staff->m_drawingStaffSize, false, true);
     }
 }
 


### PR DESCRIPTION
* Refactoring of the ligature calculation
* Improve offsets and positions of liquescent glyphs
* Adjust x position of nc

Before

<img width="863" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/e6f12a75-5d91-4c1c-99ff-abb6b424548c">

After

<img width="863" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/5a54dcfc-e2d2-41e2-8329-6b387ef092fb">

Also fixes support for `nc@loc`. Fixes #3723 

Before

<img width="863" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/3376d691-f77e-4fd9-ad75-a03deeffe7e8">


After

<img width="863" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/277d1b45-954b-4604-a20e-b185674b6604">

