### PR TITLE
Fix alignment of clefs within layers

### DIFF
--- a/include/vrv/adjustxposfunctor.h
+++ b/include/vrv/adjustxposfunctor.h
@@ -107,6 +107,8 @@ private:
     int m_staffN;
     // The current staff size
     int m_staffSize;
+    // The current staff is neume
+    bool m_isNeumeStaff;
     // The list of staffN in the top-level scoreDef
     std::vector<int> m_staffNs;
     // The bounding boxes in the previous aligner

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -126,7 +126,7 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
         return FUNCTOR_SIBLINGS;
     }
 
-    if (layerElement->GetAlignment()->GetType() == ALIGNMENT_CLEF) {
+    if ((layerElement->GetAlignment()->GetType() == ALIGNMENT_CLEF) && !m_isNeumeStaff) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -232,6 +232,7 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
         m_currentAlignment.Reset();
         StaffAlignment *staffAlignment = system->m_systemAligner.GetStaffAlignmentForStaffN(staffN);
         m_staffSize = (staffAlignment) ? staffAlignment->GetStaffSize() : 100;
+        m_isNeumeStaff = (staffAlignment && staffAlignment->GetStaff()) ? staffAlignment->GetStaff()->IsNeume() : false;
 
         // Prevent collisions of scoredef clefs with thick barlines
         if (hasSystemStartLine) {

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -394,7 +394,7 @@ FunctorCode AlignHorizontallyFunctor::VisitMeasureEnd(Measure *measure)
 
     if (m_hasMultipleLayer) measure->HasAlignmentRefWithMultipleLayers(true);
 
-    measure->m_measureAligner.LogDebugTree(3);
+    //measure->m_measureAligner.LogDebugTree(3);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -394,7 +394,7 @@ FunctorCode AlignHorizontallyFunctor::VisitMeasureEnd(Measure *measure)
 
     if (m_hasMultipleLayer) measure->HasAlignmentRefWithMultipleLayers(true);
 
-    //measure->m_measureAligner.LogDebugTree(3);
+    // measure->m_measureAligner.LogDebugTree(3);
 
     return FUNCTOR_CONTINUE;
 }


### PR DESCRIPTION
<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Neumes</title>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2024-07-05" />
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>Rendering of neume notation without pname</annot>
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="4.3.0">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" notationtype="neume" lines="1" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <clef line="1" shape="C"/>
                        <syllable>
                           <syl con="d" wordpos="i">di</syl>
                           <neume>
                              <nc loc="0" />
                              <nc loc="1" tilt="ne" />
                              <nc loc="-1" />
                              <nc loc="1" />
                              <nc loc="2" tilt="ne" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl wordpos="t">cit</syl>
                           <neume>
                              <nc loc="0" />
                              <nc loc="-1" curve="c" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl con="d" wordpos="i">spon</syl>
                           <neume>
                              <nc loc="-2" />
                              <nc loc="-1" tilt="ne" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl wordpos="t">so</syl>
                           <neume>
                              <nc loc="-2" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl con="d" wordpos="i">ser</syl>
                           <neume>
                              <nc loc="0" />
                              <nc loc="-1" curve="c" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl con="d" wordpos="m">va</syl>
                           <neume>
                              <nc loc="1" />
                              <nc loc="3" tilt="ne" />
                              <nc loc="2" />
                           </neume>
                        </syllable>
                        <syllable>
                           <syl wordpos="t">sti</syl>
                           <neume>
                              <nc loc="1" />
                           </neume>
                        </syllable>
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

Before

<img width="908" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/78d622e0-0b34-4de3-9df1-6287e798f62c">

After

<img width="908" alt="image" src="https://github.com/rism-digital/verovio/assets/689412/a226d59a-7499-4cfa-a87f-24fb4c7ea626">
