### PR TITLE
Fix nc and accid jumping after dragging staff

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -679,7 +679,6 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 
         SortStaves();
 
-        m_doc->GetDrawingPage()->ResetAligners();
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers


### PR DESCRIPTION
- Remove reset aligners after dragging staff

Refs: https://github.com/DDMAL/Neon/issues/1231