### PR TITLE
Fix issue 3700 Render rest in a <tabGrp>

### DIFF
--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_REST_H__
 #define __VRV_REST_H__
 
+#include "altsyminterface.h"
 #include "atts_externalsymbols.h"
 #include "atts_mensural.h"
 #include "durationinterface.h"
@@ -34,6 +35,7 @@ enum RestNotePlace { RNP_UNSET = -1, RNP_noteInSpace, RNP_noteOnLine };
  * This class models the MEI <rest> element.
  */
 class Rest : public LayerElement,
+             public AltSymInterface,
              public DurationInterface,
              public PositionInterface,
              public AttColor,
@@ -69,6 +71,7 @@ public:
      * @name Getter to interfaces
      */
     ///@{
+    AltSymInterface *GetAltSymInterface() override { return vrv_cast<AltSymInterface *>(this); }
     PositionInterface *GetPositionInterface() override { return vrv_cast<PositionInterface *>(this); }
     const PositionInterface *GetPositionInterface() const override { return vrv_cast<const PositionInterface *>(this); }
     DurationInterface *GetDurationInterface() override { return vrv_cast<DurationInterface *>(this); }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2747,6 +2747,7 @@ void MEIOutput::WriteRest(pugi::xml_node currentNode, Rest *rest)
     assert(rest);
 
     this->WriteLayerElement(currentNode, rest);
+    this->WriteAltSymInterface(currentNode, rest);
     this->WriteDurationInterface(currentNode, rest);
     this->WritePositionInterface(currentNode, rest);
     rest->WriteColor(currentNode);
@@ -3774,6 +3775,9 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
             return true;
         }
         if (element == "note") {
+            return true;
+        }
+        if (element == "rest") {
             return true;
         }
         else {
@@ -6898,6 +6902,7 @@ bool MEIInput::ReadRest(Object *parent, pugi::xml_node rest)
         }
     }
 
+    this->ReadAltSymInterface(rest, vrvRest);
     this->ReadDurationInterface(rest, vrvRest);
     this->ReadPositionInterface(rest, vrvRest);
     vrvRest->ReadColor(rest);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -22,6 +22,7 @@
 #include "layer.h"
 #include "smufl.h"
 #include "staff.h"
+#include "symboldef.h"
 #include "system.h"
 #include "transposition.h"
 #include "vrv.h"
@@ -153,6 +154,7 @@ static const ClassRegistrar<Rest> s_factory("rest", REST);
 
 Rest::Rest()
     : LayerElement(REST, "rest-")
+    , AltSymInterface()
     , DurationInterface()
     , PositionInterface()
     , AttColor()
@@ -161,6 +163,7 @@ Rest::Rest()
     , AttExtSymNames()
     , AttRestVisMensural()
 {
+    this->RegisterInterface(AltSymInterface::GetAttClasses(), AltSymInterface::IsInterface());
     this->RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     this->RegisterAttClass(ATT_COLOR);
@@ -176,6 +179,7 @@ Rest::~Rest() {}
 void Rest::Reset()
 {
     LayerElement::Reset();
+    AltSymInterface::Reset();
     DurationInterface::Reset();
     PositionInterface::Reset();
     this->ResetColor();
@@ -240,6 +244,23 @@ char32_t Rest::GetRestGlyph(const int duration) const
     else if (this->HasGlyphName()) {
         char32_t code = resources->GetGlyphCode(this->GetGlyphName());
         if (NULL != resources->GetGlyph(code)) return code;
+    }
+    // If there is @altsym (third priority)
+    else if (this->HasAltsym() && this->HasAltSymbolDef()) {
+        const SymbolDef *symbolDef = this->GetAltSymbolDef();
+        const Symbol *symbol = vrv_cast<const Symbol *>(symbolDef->GetFirst(SYMBOL));
+        if (symbol != NULL) {
+            // If there is @glyph.num, return glyph based on it (fourth priority)
+            if (symbol->HasGlyphNum()) {
+                const char32_t code = symbol->GetGlyphNum();
+                if (NULL != resources->GetGlyph(code)) return code;
+            }
+            // If there is @glyph.name (fifth priority)
+            else if (symbol->HasGlyphName()) {
+                const char32_t code = resources->GetGlyphCode(symbol->GetGlyphName());
+                if (NULL != resources->GetGlyph(code)) return code;
+            }
+        }
     }
 
     if (this->IsMensuralDur()) {

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -16,6 +16,7 @@
 #include "editorial.h"
 #include "functor.h"
 #include "note.h"
+#include "rest.h"
 #include "tabdursym.h"
 
 namespace vrv {
@@ -45,6 +46,9 @@ bool TabGrp::IsSupportedChild(Object *child)
 {
     if (child->Is(NOTE)) {
         assert(dynamic_cast<Note *>(child));
+    }
+    else if (child->Is(REST)) {
+        assert(dynamic_cast<Rest *>(child));
     }
     else if (child->Is(TABDURSYM)) {
         assert(dynamic_cast<TabDurSym *>(child));

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -53,6 +53,7 @@
 #include "stem.h"
 #include "syl.h"
 #include "system.h"
+#include "tabgrp.h"
 #include "tie.h"
 #include "tuplet.h"
 #include "verse.h"
@@ -1568,10 +1569,20 @@ void View::DrawRest(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
     const int staffSize = staff->GetDrawingStaffNotationSize();
     int drawingDur = rest->GetActualDur();
     if (drawingDur == DUR_NONE) {
-        if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
-            LogWarning("Missing duration for rest '%s'", rest->GetID().c_str());
+        // in tablature the @dur is in the parent TabGrp
+        if (staff->IsTablature()) {
+            TabGrp *tabGrp = vrv_cast<TabGrp *>(rest->GetFirstAncestor(TABGRP));
+            if (tabGrp != NULL) {
+                drawingDur = tabGrp->GetActualDur();
+            }
         }
-        drawingDur = DUR_4;
+
+        if (drawingDur == DUR_NONE) {
+            if (!dc->Is(BBOX_DEVICE_CONTEXT)) {
+                LogWarning("Missing duration for rest '%s'", rest->GetID().c_str());
+            }
+            drawingDur = DUR_4;
+        }
     }
     const char32_t drawingGlyph = rest->GetRestGlyph(drawingDur);
 


### PR DESCRIPTION
Allow &lt;rest&gt; in &lt;tabGrp&gt;.   If &lt;rest&gt; does not specify attribute dur then use the dur from the parent &lt;tabGrp&gt;.   Enable attribute altsym in &lt;rest&gt;.

Example from issue #3700 extended to use German tablature and altsym for the &lt;rest&gt;'s glyph.   The correct glyph to use would probably be U+EE1E "Minima Rest Buxheimer Orgelbuch" but this is not currently available, so I've substituted U+E4BC "Marcato-tenuto above" it is the wrong glyph but it demonstrates the altsym in the &lt;rest&gt; working.

![issue-3700-example mei_001](https://github.com/user-attachments/assets/bc452960-1828-4aa1-b6be-4661f133d4a2)
[issue-3700-example.mei.txt](https://github.com/user-attachments/files/16238908/issue-3700-example.mei.txt)
