### PR TITLE
Fix alignment after staff dragging

### DIFF
--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -347,16 +347,19 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
             }
         }
 
-        // If the nc overlaps with the previous, move it back from a line width
-        if (overlapWithPrevious) {
-            xRel -= lineWidth;
-        }
+        // xRel remains unset with facsimile
+        if (!m_doc->HasFacsimile()) {
+            // If the nc overlaps with the previous, move it back from a line width
+            if (overlapWithPrevious) {
+                xRel -= lineWidth;
+            }
 
-        nc->SetDrawingXRel(xRel);
-        // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be added
-        // between the two nc
-        if (!previousLig) {
-            xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
+            nc->SetDrawingXRel(xRel);
+            // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be
+            // added between the two nc
+            if (!previousLig) {
+                xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
+            }
         }
 
         previousNc = nc;

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -679,7 +679,6 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 
         SortStaves();
 
-        m_doc->GetDrawingPage()->ResetAligners();
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -679,6 +679,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 
         SortStaves();
 
+        m_doc->GetDrawingPage()->LayOutTranscription(true);
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -253,6 +253,9 @@ void Page::LayOutTranscription(bool force)
     CalcAlignmentPitchPosFunctor calcAlignmentPitchPos(doc);
     this->Process(calcAlignmentPitchPos);
 
+    CalcLigatureOrNeumePosFunctor calcLigatureOrNeumePos(doc);
+    this->Process(calcLigatureOrNeumePos);
+
     CalcStemFunctor calcStem(doc);
     this->Process(calcStem);
 
@@ -262,13 +265,15 @@ void Page::LayOutTranscription(bool force)
     CalcDotsFunctor calcDots(doc);
     this->Process(calcDots);
 
-    // Render it for filling the bounding box
-    View view;
-    view.SetDoc(doc);
-    BBoxDeviceContext bBoxDC(&view, 0, 0, BBOX_HORIZONTAL_ONLY);
-    // Do not do the layout in this view - otherwise we will loop...
-    view.SetPage(this->GetIdx(), false);
-    view.DrawCurrentPage(&bBoxDC, false);
+    if (!m_layoutDone) {
+        // Render it for filling the bounding box
+        View view;
+        view.SetDoc(doc);
+        BBoxDeviceContext bBoxDC(&view, 0, 0, BBOX_HORIZONTAL_ONLY);
+        // Do not do the layout in this view - otherwise we will loop...
+        view.SetPage(this->GetIdx(), false);
+        view.DrawCurrentPage(&bBoxDC, false);
+    }
 
     AdjustXRelForTranscriptionFunctor adjustXRelForTranscription;
     this->Process(adjustXRelForTranscription);


### PR DESCRIPTION
- Adjust nc spacing
- Adjust `X/YRel` in reset aligners

Refs: https://github.com/DDMAL/Neon/issues/1231