### PR TITLE
Integrate latest changes for the neume editor

### DIFF
--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -347,16 +347,19 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
             }
         }
 
-        // If the nc overlaps with the previous, move it back from a line width
-        if (overlapWithPrevious) {
-            xRel -= lineWidth;
-        }
+        // xRel remains unset with facsimile
+        if (!m_doc->HasFacsimile()) {
+            // If the nc overlaps with the previous, move it back from a line width
+            if (overlapWithPrevious) {
+                xRel -= lineWidth;
+            }
 
-        nc->SetDrawingXRel(xRel);
-        // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be added
-        // between the two nc
-        if (!previousLig) {
-            xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
+            nc->SetDrawingXRel(xRel);
+            // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be
+            // added between the two nc
+            if (!previousLig) {
+                xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
+            }
         }
 
         previousNc = nc;

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -679,7 +679,6 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 
         SortStaves();
 
-        m_doc->GetDrawingPage()->ResetAligners();
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -679,6 +679,8 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
 
         SortStaves();
 
+        m_doc->GetDrawingPage()->LayOutTranscription(true);
+      
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -4251,6 +4251,14 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj, Clef *clef)
         }
         pi->SetOct(3);
 
+        // The default octave = 3, but the actual octave is calculated by
+        // taking into account the displacement of the clef
+        int octave = 3;
+        if (clef->GetDis() && clef->GetDisPlace()) {
+            octave += (clef->GetDisPlace() == STAFFREL_basic_above ? 1 : -1) * (clef->GetDis() / 7);
+        }
+        pi->SetOct(octave);
+
         const int staffSize = m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
 
         const int pitchDifference

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -1251,7 +1251,8 @@ bool EditorToolkitNeume::Insert(std::string elementType, std::string staffId, in
     }
     layer->ReorderByXPos();
 
-    m_doc->GetDrawingPage()->LayOutPitchPos();
+    m_doc->GetDrawingPage()->LayOutTranscription(true);
+
     if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
     m_editInfo.import("status", status);
@@ -3518,6 +3519,7 @@ bool EditorToolkitNeume::ToggleLigature(std::vector<std::string> elementIds)
         return false;
     }
 
+    m_doc->GetDrawingPage()->LayOutTranscription(true);
     if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
     m_editInfo.import("status", "OK");

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -680,7 +680,7 @@ bool EditorToolkitNeume::Drag(std::string elementId, int x, int y)
         SortStaves();
 
         m_doc->GetDrawingPage()->LayOutTranscription(true);
-      
+
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
 
         return true; // Can't reorder by layer since staves contain layers

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -253,6 +253,9 @@ void Page::LayOutTranscription(bool force)
     CalcAlignmentPitchPosFunctor calcAlignmentPitchPos(doc);
     this->Process(calcAlignmentPitchPos);
 
+    CalcLigatureOrNeumePosFunctor calcLigatureOrNeumePos(doc);
+    this->Process(calcLigatureOrNeumePos);
+
     CalcStemFunctor calcStem(doc);
     this->Process(calcStem);
 
@@ -262,13 +265,15 @@ void Page::LayOutTranscription(bool force)
     CalcDotsFunctor calcDots(doc);
     this->Process(calcDots);
 
-    // Render it for filling the bounding box
-    View view;
-    view.SetDoc(doc);
-    BBoxDeviceContext bBoxDC(&view, 0, 0, BBOX_HORIZONTAL_ONLY);
-    // Do not do the layout in this view - otherwise we will loop...
-    view.SetPage(this->GetIdx(), false);
-    view.DrawCurrentPage(&bBoxDC, false);
+    if (!m_layoutDone) {
+        // Render it for filling the bounding box
+        View view;
+        view.SetDoc(doc);
+        BBoxDeviceContext bBoxDC(&view, 0, 0, BBOX_HORIZONTAL_ONLY);
+        // Do not do the layout in this view - otherwise we will loop...
+        view.SetPage(this->GetIdx(), false);
+        view.DrawCurrentPage(&bBoxDC, false);
+    }
 
     AdjustXRelForTranscriptionFunctor adjustXRelForTranscription;
     this->Process(adjustXRelForTranscription);


### PR DESCRIPTION
* Avoid setting `xRel` for neume when facsimile is set
* Use `Page::LayOutTranscription`
* Calculate clef displacement when inserting custos

No change in the test-suite expected