### PR TITLE
Enable takt barlines and import from Volpiano

### DIFF
--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -9,6 +9,7 @@
 #define __VRV_BARLINE_H__
 
 #include "atts_shared.h"
+#include "atts_visual.h"
 #include "layerelement.h"
 
 namespace vrv {
@@ -27,6 +28,7 @@ enum class BarLinePosition { None, Left, Right };
  */
 class BarLine : public LayerElement,
                 public AttBarLineLog,
+                public AttBarLineVis,
                 public AttColor,
                 public AttNNumberLike,
                 public AttVisibility {

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -33,7 +33,8 @@ namespace vrv {
 
 static const ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
-BarLine::BarLine() : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
+BarLine::BarLine()
+    : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BARLINELOG);
     this->RegisterAttClass(ATT_BARLINEVIS);

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -33,9 +33,10 @@ namespace vrv {
 
 static const ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
-BarLine::BarLine() : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
+BarLine::BarLine() : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BARLINELOG);
+    this->RegisterAttClass(ATT_BARLINEVIS);
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_VISIBILITY);
 
@@ -43,9 +44,10 @@ BarLine::BarLine() : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttColor(
 }
 
 BarLine::BarLine(ClassId classId)
-    : LayerElement(classId, "bline-"), AttBarLineLog(), AttColor(), AttNNumberLike(), AttVisibility()
+    : LayerElement(classId, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BARLINELOG);
+    this->RegisterAttClass(ATT_BARLINEVIS);
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_VISIBILITY);
 
@@ -59,6 +61,7 @@ void BarLine::Reset()
     LayerElement::Reset();
 
     this->ResetBarLineLog();
+    this->ResetBarLineVis();
     this->ResetColor();
     this->ResetVisibility();
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2381,6 +2381,7 @@ void MEIOutput::WriteBarLine(pugi::xml_node currentNode, BarLine *barLine)
 
     this->WriteLayerElement(currentNode, barLine);
     barLine->WriteBarLineLog(currentNode);
+    barLine->WriteBarLineVis(currentNode);
     barLine->WriteColor(currentNode);
     barLine->WriteNNumberLike(currentNode);
     barLine->WriteVisibility(currentNode);
@@ -6428,6 +6429,7 @@ bool MEIInput::ReadBarLine(Object *parent, pugi::xml_node barLine)
     this->ReadLayerElement(barLine, vrvBarLine);
 
     vrvBarLine->ReadBarLineLog(barLine);
+    vrvBarLine->ReadBarLineVis(barLine);
     vrvBarLine->ReadColor(barLine);
     vrvBarLine->ReadNNumberLike(barLine);
     vrvBarLine->ReadVisibility(barLine);

--- a/src/iovolpiano.cpp
+++ b/src/iovolpiano.cpp
@@ -126,7 +126,7 @@ bool VolpianoInput::Import(const std::string &volpiano)
             layer->AddChild(end);
         }
         else if (ch == '6') {
-            // not supported yet
+            LogWarning("Volpiano '6' barline is not supported");
         }
         else if (ch == '7') {
             BarLine *takt = new BarLine();

--- a/src/iovolpiano.cpp
+++ b/src/iovolpiano.cpp
@@ -120,6 +120,14 @@ bool VolpianoInput::Import(const std::string &volpiano)
             dbl->SetForm(BARRENDITION_dbl);
             layer->AddChild(dbl);
         }
+        else if (ch == '5') {
+            BarLine *end = new BarLine();
+            end->SetForm(BARRENDITION_end);
+            layer->AddChild(end);
+        }
+        else if (ch == '6') {
+            // not supported yet
+        }
         else if (ch == '7') {
             BarLine *takt = new BarLine();
             takt->SetMethod(BARMETHOD_takt);

--- a/src/iovolpiano.cpp
+++ b/src/iovolpiano.cpp
@@ -16,6 +16,7 @@
 
 //----------------------------------------------------------------------------
 
+#include "barline.h"
 #include "clef.h"
 #include "doc.h"
 #include "layer.h"
@@ -109,6 +110,20 @@ bool VolpianoInput::Import(const std::string &volpiano)
         }
         else if (ch == 'I' || ch == 'W' || ch == 'X' || ch == 'Y' || ch == 'Z') {
             accidVal = ACCIDENTAL_WRITTEN_n;
+        }
+        else if (ch == '3') {
+            BarLine *single = new BarLine();
+            layer->AddChild(single);
+        }
+        else if (ch == '4') {
+            BarLine *dbl = new BarLine();
+            dbl->SetForm(BARRENDITION_dbl);
+            layer->AddChild(dbl);
+        }
+        else if (ch == '7') {
+            BarLine *takt = new BarLine();
+            takt->SetMethod(BARMETHOD_takt);
+            layer->AddChild(takt);
         }
     }
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -420,11 +420,24 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
         barLine->SetEmptyBB();
         return;
     }
-
+    StaffDef *drawingStaffDef = staff->m_drawingStaffDef;
+    // Determine the method
+    assert(drawingStaffDef);
+    auto [hasMethod, method] = barLine->GetMethod(drawingStaffDef);
+    if (barLine->HasMethod()) {
+        LogWarning("Hat Methode!");
+        method = barLine->AttBarLineVis::GetMethod();
+    }
+    
     dc->StartGraphic(element, "", element->GetID());
 
-    const int yTop = staff->GetDrawingY();
-    const int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    int yTop = staff->GetDrawingY();
+    int yBottom = yTop - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+
+    if (method == BARMETHOD_takt) {
+        yTop += m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
+        yBottom = yTop - m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize);
+    }
 
     const int offset = (yTop == yBottom) ? m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) : 0;
 

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -428,7 +428,7 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
         LogWarning("Hat Methode!");
         method = barLine->AttBarLineVis::GetMethod();
     }
-    
+
     dc->StartGraphic(element, "", element->GetID());
 
     int yTop = staff->GetDrawingY();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -425,7 +425,6 @@ void View::DrawBarLine(DeviceContext *dc, LayerElement *element, Layer *layer, S
     assert(drawingStaffDef);
     auto [hasMethod, method] = barLine->GetMethod(drawingStaffDef);
     if (barLine->HasMethod()) {
-        LogWarning("Hat Methode!");
         method = barLine->AttBarLineVis::GetMethod();
     }
 


### PR DESCRIPTION
This PR adds reading/writing of visual attributes for `barLine`, enabling to draw single barlines as takt. 
Also it adds basic import for barlines to Volpiano support (including breaks, which are shown as takt barlines).

### Example
`1---dcd---3---fef---7---dcd---4---fef---77---`

![image](https://github.com/user-attachments/assets/324c56fa-a401-4388-b39c-f30069abd031)
