### PR TITLE
Fix dots on unisons

### DIFF
--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -22,7 +22,7 @@ class TupletNum;
 //----------------------------------------------------------------------------
 
 /**
- * This class models a group of dots as a layer element part and has not direct MEI equivlatent.
+ * This class models a group of dots as a layer element part and has no direct MEI equivalent.
  */
 class Dots : public LayerElement, public AttAugmentDots {
 public:
@@ -92,7 +92,7 @@ private:
 //----------------------------------------------------------------------------
 
 /**
- * This class models a stem as a layer element part and has not direct MEI equivlatent.
+ * This class models a stem as a layer element part and has no direct MEI equivalent.
  */
 class Flag : public LayerElement {
 public:
@@ -144,7 +144,7 @@ private:
 //----------------------------------------------------------------------------
 
 /**
- * This class models a bracket as a layer element part and has not direct MEI equivlatent.
+ * This class models a bracket as a layer element part and has no direct MEI equivalent.
  * It is used to represent tuplet brackets.
  */
 class TupletBracket : public LayerElement, public AttTupletVis {
@@ -243,7 +243,7 @@ private:
 //----------------------------------------------------------------------------
 
 /**
- * This class models a tuplet num as a layer element part and has not direct MEI equivlatent.
+ * This class models a tuplet num as a layer element part and has no direct MEI equivalent.
  * It is used to represent tuplet number
  */
 class TupletNum : public LayerElement, public AttNumberPlacement, public AttTupletVis {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -901,13 +901,16 @@ MapOfDotLocs LayerElement::CalcOptimalDotLocations()
 
     // Special treatment for two layers
     if (layerCount == 2) {
-        // Find the first note on the other layer
+        // Find the first note on the other layer, but in the same staff
         Alignment *alignment = this->GetAlignment();
+        const Staff *currentStaff = this->GetAncestorStaff(RESOLVE_CROSS_STAFF);
         const int currentLayerN = abs(this->GetAlignmentLayerN());
         ListOfObjects notes = alignment->FindAllDescendantsByType(NOTE, false);
-        auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayerN](Object *obj) {
-            const int otherLayerN = abs(vrv_cast<Note *>(obj)->GetAlignmentLayerN());
-            return (currentLayerN != otherLayerN);
+        auto noteIt = std::find_if(notes.cbegin(), notes.cend(), [currentLayerN, currentStaff](Object *obj) {
+            const Note *otherNote = vrv_cast<Note *>(obj);
+            const Staff *otherStaff = otherNote->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+            const int otherLayerN = abs(otherNote->GetAlignmentLayerN());
+            return ((currentLayerN != otherLayerN) && (currentStaff == otherStaff));
         });
 
         if (noteIt != notes.cend()) {


### PR DESCRIPTION
This PR fixes an issue with dots on unisons by properly checking the staff when looking for the unison partner.

Some examples from the issue:

<img width="180" alt="Dots1" src="https://github.com/user-attachments/assets/ad9e8985-6a9f-487c-947b-be5ad7992805">
<img width="500" alt="Dots2" src="https://github.com/user-attachments/assets/d9bf68f5-a1f2-4517-bb36-b62fa29d52f7">
<img width="200" alt="Dots3" src="https://github.com/user-attachments/assets/253a6b1a-44b9-42bb-98b0-e52724e26100">
<img width="300" alt="Dots4" src="https://github.com/user-attachments/assets/9a35a1de-bf23-49aa-a555-f6b89faab271">
<img width="200" alt="Dots5" src="https://github.com/user-attachments/assets/db2d6212-08aa-456b-918b-2488ea6d0ca5">

Closes #3705 .
