### PR TITLE
Add support for numeral harmonics in MusicXML

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2590,6 +2590,10 @@ void MusicXmlInput::ReadMusicXmlHarmony(pugi::xml_node node, Measure *measure, c
     int durOffset = 0;
 
     std::string harmText = GetContentOfChild(node, "root/root-step");
+    if (harmText.empty()) {
+        pugi::xml_node numeral = node.select_node("numeral/numeral-root").node();
+        harmText = numeral.attribute("text") ? numeral.attribute("text").as_string() : numeral.text().as_string();
+    }
     pugi::xpath_node alter = node.select_node("root/root-alter");
     if (alter) harmText += ConvertAlterToSymbol(GetContent(alter.node()));
     pugi::xml_node kind = node.child("kind");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2590,11 +2590,12 @@ void MusicXmlInput::ReadMusicXmlHarmony(pugi::xml_node node, Measure *measure, c
     int durOffset = 0;
 
     std::string harmText = GetContentOfChild(node, "root/root-step");
+    pugi::xpath_node alter = node.select_node("root/root-alter");
     if (harmText.empty()) {
         pugi::xml_node numeral = node.select_node("numeral/numeral-root").node();
         harmText = numeral.attribute("text") ? numeral.attribute("text").as_string() : numeral.text().as_string();
+        alter = node.select_node("numeral/numeral-alter");
     }
-    pugi::xpath_node alter = node.select_node("root/root-alter");
     if (alter) harmText += ConvertAlterToSymbol(GetContent(alter.node()));
     pugi::xml_node kind = node.child("kind");
     if (kind) {


### PR DESCRIPTION
This PR adds basic support for MusicXML harmonics that use the `numeral` element.