### PR TITLE
Add override to virtual methods and simplify LedgerLine class

### DIFF
--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -43,7 +43,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
     /**
      * Use to set the alignment for the Measure BarLine members.

--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -37,7 +37,7 @@ public:
     ///@{
     DivLine();
     virtual ~DivLine();
-    virtual Object *Clone() const { return new DivLine(*this); }
+    Object *Clone() const override { return new DivLine(*this); }
     void Reset() override;
     virtual std::string GetClassName() const { return "DivLine"; }
     ///@}
@@ -84,7 +84,7 @@ public:
     ///@{
     DivLineAttr();
     virtual ~DivLineAttr();
-    virtual Object *Clone() const { return new DivLineAttr(*this); }
+    Object *Clone() const override { return new DivLineAttr(*this); }
     virtual std::string GetClassName() const { return "DivLineAttr"; }
     ///@}
 

--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -39,7 +39,7 @@ public:
     virtual ~DivLine();
     Object *Clone() const override { return new DivLine(*this); }
     void Reset() override;
-    virtual std::string GetClassName() const { return "DivLine"; }
+    std::string GetClassName() const override { return "DivLine"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -85,7 +85,7 @@ public:
     DivLineAttr();
     virtual ~DivLineAttr();
     Object *Clone() const override { return new DivLineAttr(*this); }
-    virtual std::string GetClassName() const { return "DivLineAttr"; }
+    std::string GetClassName() const override { return "DivLineAttr"; }
     ///@}
 
     // void SetLeft() { m_isLeft = true; }

--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -38,7 +38,7 @@ public:
     DivLine();
     virtual ~DivLine();
     virtual Object *Clone() const { return new DivLine(*this); }
-    virtual void Reset();
+    void Reset() override;
     virtual std::string GetClassName() const { return "DivLine"; }
     ///@}
 

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -80,7 +80,7 @@ public:
 
     /**
      * Return true if the element has to be aligned horizontally
-     * It typically set to false for mRest, mRpt, etc.
+     * It is typically set to false for mRest, mRpt, etc.
      */
     virtual bool HasToBeAligned() const { return false; }
 

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -30,7 +30,7 @@ public:
     Liquescent();
     virtual ~Liquescent();
     virtual Object *Clone() const { return new Liquescent(*this); }
-    virtual void Reset();
+    void Reset() override;
     virtual std::string GetClassName() const { return "Liquescent"; }
     ///@}
 

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -29,7 +29,7 @@ public:
     ///@{
     Liquescent();
     virtual ~Liquescent();
-    virtual Object *Clone() const { return new Liquescent(*this); }
+    Object *Clone() const override { return new Liquescent(*this); }
     void Reset() override;
     virtual std::string GetClassName() const { return "Liquescent"; }
     ///@}

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -38,7 +38,7 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -42,7 +42,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
 private:
     //

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -31,7 +31,7 @@ public:
     virtual ~Liquescent();
     Object *Clone() const override { return new Liquescent(*this); }
     void Reset() override;
-    virtual std::string GetClassName() const { return "Liquescent"; }
+    std::string GetClassName() const override { return "Liquescent"; }
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -165,7 +165,7 @@ public:
     const Resources *GetDocResources() const;
 
     /**
-     * Reset the object, that is 1) removing all childs and 2) resetting all attributes.
+     * Reset the object, that is 1) removing all children and 2) resetting all attributes.
      * The method is virtual, so _always_ call the parent in the method overriding it.
      */
     virtual void Reset();

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -820,8 +820,8 @@ private:
 class ObjectListInterface {
 public:
     // constructors and destructors
-    ObjectListInterface(){};
-    virtual ~ObjectListInterface(){};
+    ObjectListInterface() {};
+    virtual ~ObjectListInterface() {};
     ObjectListInterface(const ObjectListInterface &listInterface); // copy constructor;
     ObjectListInterface &operator=(const ObjectListInterface &listInterface); // copy assignment;
 
@@ -919,8 +919,8 @@ private:
 class TextListInterface : public ObjectListInterface {
 public:
     // constructors and destructors
-    TextListInterface(){};
-    virtual ~TextListInterface(){};
+    TextListInterface() {};
+    virtual ~TextListInterface() {};
 
     /**
      * Returns a contatenated version of all the text children

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -820,8 +820,8 @@ private:
 class ObjectListInterface {
 public:
     // constructors and destructors
-    ObjectListInterface() {};
-    virtual ~ObjectListInterface() {};
+    ObjectListInterface() = default;
+    virtual ~ObjectListInterface() = default;
     ObjectListInterface(const ObjectListInterface &listInterface); // copy constructor;
     ObjectListInterface &operator=(const ObjectListInterface &listInterface); // copy assignment;
 
@@ -919,8 +919,8 @@ private:
 class TextListInterface : public ObjectListInterface {
 public:
     // constructors and destructors
-    TextListInterface() {};
-    virtual ~TextListInterface() {};
+    TextListInterface() = default;
+    virtual ~TextListInterface() = default;
 
     /**
      * Returns a contatenated version of all the text children

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -31,7 +31,7 @@ public:
     virtual ~Oriscus();
     Object *Clone() const override { return new Oriscus(*this); }
     void Reset() override;
-    virtual std::string GetClassName() const { return "Oriscus"; }
+    std::string GetClassName() const override { return "Oriscus"; }
     ///@}
 
     /**

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -30,7 +30,7 @@ public:
     Oriscus();
     virtual ~Oriscus();
     virtual Object *Clone() const { return new Oriscus(*this); }
-    virtual void Reset();
+    void Reset() override;
     virtual std::string GetClassName() const { return "Oriscus"; }
     ///@}
 

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -38,7 +38,7 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -29,7 +29,7 @@ public:
     ///@{
     Oriscus();
     virtual ~Oriscus();
-    virtual Object *Clone() const { return new Oriscus(*this); }
+    Object *Clone() const override { return new Oriscus(*this); }
     void Reset() override;
     virtual std::string GetClassName() const { return "Oriscus"; }
     ///@}

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -42,7 +42,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
 private:
     //

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -38,7 +38,7 @@ public:
      * @name Getter to interfaces
      */
     ///@{
-    virtual PitchInterface *GetPitchInterface() { return dynamic_cast<PitchInterface *>(this); }
+    PitchInterface *GetPitchInterface() override { return dynamic_cast<PitchInterface *>(this); }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -30,7 +30,7 @@ public:
     Quilisma();
     virtual ~Quilisma();
     virtual Object *Clone() const { return new Quilisma(*this); }
-    virtual void Reset();
+    void Reset() override;
     virtual std::string GetClassName() const { return "Quilisma"; }
     ///@}
 

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -42,7 +42,7 @@ public:
     ///@}
 
     /** Override the method since alignment is required */
-    virtual bool HasToBeAligned() const { return true; }
+    bool HasToBeAligned() const override { return true; }
 
 private:
     //

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -29,7 +29,7 @@ public:
     ///@{
     Quilisma();
     virtual ~Quilisma();
-    virtual Object *Clone() const { return new Quilisma(*this); }
+    Object *Clone() const override { return new Quilisma(*this); }
     void Reset() override;
     virtual std::string GetClassName() const { return "Quilisma"; }
     ///@}

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -31,7 +31,7 @@ public:
     virtual ~Quilisma();
     Object *Clone() const override { return new Quilisma(*this); }
     void Reset() override;
-    virtual std::string GetClassName() const { return "Quilisma"; }
+    std::string GetClassName() const override { return "Quilisma"; }
     ///@}
 
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -36,13 +36,8 @@ class LedgerLine {
 public:
     /**
      * @name Constructors, destructors, reset methods
-     * Reset method reset all attribute classes
      */
-    ///@{
-    LedgerLine();
-    virtual ~LedgerLine();
-    virtual void Reset();
-    ///@}
+    LedgerLine() = default;
 
     /**
      * Add a dash to the ledger line object.

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -298,18 +298,6 @@ int Staff::GetNearestInterStaffPosition(int y, const Doc *doc, data_STAFFREL pla
 // LedgerLine
 //----------------------------------------------------------------------------
 
-LedgerLine::LedgerLine()
-{
-    this->Reset();
-}
-
-LedgerLine::~LedgerLine() {}
-
-void LedgerLine::Reset()
-{
-    m_dashes.clear();
-}
-
 void LedgerLine::AddDash(int left, int right, int extension)
 {
     assert(left < right);


### PR DESCRIPTION
This PR adds `override` to several virtual methods and simplifies the `LedgerLine` class by removing unnecessary virtual methods there. This decreases memory consumption for `LedgerLine` objects.