### PR TITLE
Make LoadFile, LoadZipData and LoadZipFile reset the log buffer

### DIFF
--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -770,6 +770,11 @@ protected:
      */
     void ResetLogBuffer();
 
+    /**
+     * Load a string data with or without resetting the log buffer
+     */
+    bool LoadData(const std::string &data, bool resetLogBuffer);
+
 private:
     bool SetFont(const std::string &fontName);
     bool IsUTF16(const std::string &filename);


### PR DESCRIPTION
This is meant to resolve the issue raised [here](https://github.com/rism-digital/verovio/issues/3768) since the log buffer should be reset when `loadFile` is being called.