### PR TITLE
Track tempo ticks in MIDI to avoid duplicate tempo events

### DIFF
--- a/include/vrv/midifunctor.h
+++ b/include/vrv/midifunctor.h
@@ -279,6 +279,13 @@ public:
     bool ImplementsEndInterface() const override { return true; }
 
     /*
+     * Getter for properties
+     */
+    ///@{
+    std::set<int> GetTempoEventTicks() const { return m_tempoEventTicks; }
+    ///@}
+
+    /*
      * Setter for various properties
      */
     ///@{
@@ -287,6 +294,7 @@ public:
     void SetCurrentTempo(double tempo) { m_currentTempo = tempo; }
     void SetDeferredNotes(const std::map<const Note *, double> &deferredNotes) { m_deferredNotes = deferredNotes; }
     void SetStaffN(int staffN) { m_staffN = staffN; }
+    void SetTempoEventTicks(const std::set<int> &ticks) { m_tempoEventTicks = ticks; }
     void SetTrack(int track) { m_midiTrack = track; }
     void SetTransSemi(int transSemi) { m_transSemi = transSemi; }
     ///@}
@@ -345,6 +353,9 @@ private:
     int m_transSemi;
     // The current tempo
     double m_currentTempo;
+    // Tempo events are always added on track 0
+    // This set contains the ticks of all added tempo events to avoid multiple events at the same time
+    std::set<int> m_tempoEventTicks;
     // The last (non grace) note that was performed
     const Note *m_lastNote;
     // Expanded notes due to ornaments and tremolandi

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -406,15 +406,18 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
     }
 
     double tempo = MIDI_TEMPO;
+    std::set<int> tempoEventTicks; // track the ticks of added tempo events
 
     // set MIDI tempo
     ScoreDef *scoreDef = this->GetFirstVisibleScore()->GetScoreDef();
     if (scoreDef->HasMidiBpm()) {
         tempo = scoreDef->GetMidiBpm();
+        tempoEventTicks.insert(0);
         midiFile->addTempo(0, 0, tempo);
     }
     else if (scoreDef->HasMm()) {
         tempo = Tempo::CalcTempo(scoreDef);
+        tempoEventTicks.insert(0);
         midiFile->addTempo(0, 0, tempo);
     }
 
@@ -522,6 +525,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
             generateMIDI.SetChannel(midiChannel);
             generateMIDI.SetTrack(midiTrack);
             generateMIDI.SetStaffN(staves->first);
+            generateMIDI.SetTempoEventTicks(tempoEventTicks);
             generateMIDI.SetTransSemi(transSemi);
             generateMIDI.SetCurrentTempo(tempo);
             generateMIDI.SetDeferredNotes(initMIDI.GetDeferredNotes());
@@ -529,6 +533,8 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
 
             // LogDebug("Exporting track %d ----------------", midiTrack);
             this->Process(generateMIDI);
+
+            tempoEventTicks = generateMIDI.GetTempoEventTicks();
         }
     }
 }

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -562,7 +562,11 @@ FunctorCode GenerateMIDIFunctor::VisitMeasure(const Measure *measure)
 
     if (measure->GetCurrentTempo() != m_currentTempo) {
         m_currentTempo = measure->GetCurrentTempo();
-        m_midiFile->addTempo(0, m_totalTime * m_midiFile->getTPQ(), m_currentTempo);
+        const int tick = m_totalTime * m_midiFile->getTPQ();
+        // Check if there was already a tempo event added for the given tick
+        if (m_tempoEventTicks.insert(tick).second) {
+            m_midiFile->addTempo(0, tick, m_currentTempo);
+        }
     }
 
     return FUNCTOR_CONTINUE;


### PR DESCRIPTION
This MR adds the tracking of tempo ticks in the `GenerateMIDIFunctor` to avoid having multiple tempo events at the same time. Closes #3776 .