### PR TITLE
Implementation for generic layer elements

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -326,6 +326,12 @@
 		4D64137E2035F68600BB630E /* mdiv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64137D2035F68600BB630E /* mdiv.cpp */; };
 		4D64137F2035F68600BB630E /* mdiv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64137D2035F68600BB630E /* mdiv.cpp */; };
 		4D6413802035F68600BB630E /* mdiv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64137D2035F68600BB630E /* mdiv.cpp */; };
+		4D64793F2C9C0F1C00CD9539 /* genericlayerelement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */; };
+		4D6479412C9C0F4200CD9539 /* genericlayerelement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */; };
+		4D6479422C9C0F4300CD9539 /* genericlayerelement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */; };
+		4D6479432C9C0F4400CD9539 /* genericlayerelement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */; };
+		4D6479442C9C0F4700CD9539 /* genericlayerelement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6479402C9C0F2D00CD9539 /* genericlayerelement.h */; };
+		4D6479452C9C0F4800CD9539 /* genericlayerelement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6479402C9C0F2D00CD9539 /* genericlayerelement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D674B3F255F40AC008AEF4C /* plica.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D674B3E255F40AC008AEF4C /* plica.h */; };
 		4D674B40255F40AC008AEF4C /* plica.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D674B3E255F40AC008AEF4C /* plica.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4D674B46255F40B7008AEF4C /* plica.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D674B45255F40B7008AEF4C /* plica.cpp */; };
@@ -1871,6 +1877,8 @@
 		4D6413772035F58200BB630E /* pages.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = pages.cpp; path = src/pages.cpp; sourceTree = "<group>"; };
 		4D64137B2035F67C00BB630E /* mdiv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mdiv.h; path = include/vrv/mdiv.h; sourceTree = "<group>"; };
 		4D64137D2035F68600BB630E /* mdiv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mdiv.cpp; path = src/mdiv.cpp; sourceTree = "<group>"; };
+		4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = genericlayerelement.cpp; path = src/genericlayerelement.cpp; sourceTree = "<group>"; };
+		4D6479402C9C0F2D00CD9539 /* genericlayerelement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = genericlayerelement.h; path = include/vrv/genericlayerelement.h; sourceTree = "<group>"; };
 		4D674B3E255F40AC008AEF4C /* plica.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = plica.h; path = include/vrv/plica.h; sourceTree = "<group>"; };
 		4D674B45255F40B7008AEF4C /* plica.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = plica.cpp; path = src/plica.cpp; sourceTree = "<group>"; };
 		4D6DF9F420E1071E00C12BBD /* subst.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = subst.cpp; path = src/subst.cpp; sourceTree = "<group>"; };
@@ -2983,6 +2991,8 @@
 				4DEEDE621E617C880087E8BC /* elementpart.h */,
 				409B3DD81F2D1C2A0098A265 /* ftrem.cpp */,
 				409B3DD71F2D1C0C0098A265 /* ftrem.h */,
+				4D64793E2C9C0F1C00CD9539 /* genericlayerelement.cpp */,
+				4D6479402C9C0F2D00CD9539 /* genericlayerelement.h */,
 				400FEDD2206FA743000D3233 /* gracegrp.cpp */,
 				400FEDD1206FA742000D3233 /* gracegrp.h */,
 				4D1BD1B421908D6B000D35B2 /* halfmrpt.cpp */,
@@ -3338,6 +3348,7 @@
 				4DB3D8FB1F83D1F700B5FC2B /* floatingobject.h in Headers */,
 				4D49924F2926B4E9007E3431 /* toolkitdef.h in Headers */,
 				4D94721D20CA701000C780C8 /* linkinginterface.h in Headers */,
+				4D6479442C9C0F4700CD9539 /* genericlayerelement.h in Headers */,
 				403BEFF7206C00F800D022D5 /* multirpt.h in Headers */,
 				4DC12A751F73FF92000440E9 /* runningelement.h in Headers */,
 				4DB3D8DD1F83D14B00B5FC2B /* artic.h in Headers */,
@@ -3496,6 +3507,7 @@
 				BB4C4B9C22A932E5001F6AF0 /* pitchinterface.h in Headers */,
 				4DACC9E92990F29A00B55913 /* atts_fingering.h in Headers */,
 				BB4C4A9422A9328F001F6AF0 /* doc.h in Headers */,
+				4D6479452C9C0F4800CD9539 /* genericlayerelement.h in Headers */,
 				BB4C4A9922A9328F001F6AF0 /* horizontalaligner.h in Headers */,
 				BB4C4AAE22A932A6001F6AF0 /* iobase.h in Headers */,
 				BB4C4BAA22A932EB001F6AF0 /* view.h in Headers */,
@@ -4155,6 +4167,7 @@
 				E7BCFFBA281298620012513D /* resources.cpp in Sources */,
 				40D45EC3204EEAFE009C1EC9 /* instrdef.cpp in Sources */,
 				4DACC9ED2990F29A00B55913 /* atts_shared.cpp in Sources */,
+				4D6479412C9C0F4200CD9539 /* genericlayerelement.cpp in Sources */,
 				4D16943D1E3A44F300569BF4 /* view_element.cpp in Sources */,
 				4DACC9AB2990F29A00B55913 /* attmodule.cpp in Sources */,
 				4D16943E1E3A44F300569BF4 /* view_graph.cpp in Sources */,
@@ -4431,6 +4444,7 @@
 				8F086F0A188539540037FD8E /* view_page.cpp in Sources */,
 				E7876F2029C0A702002147DC /* adjusttupletsxfunctor.cpp in Sources */,
 				E79C87C3269440570098FE85 /* lv.cpp in Sources */,
+				4D64793F2C9C0F1C00CD9539 /* genericlayerelement.cpp in Sources */,
 				4D7AFDC72A5554A100835ED1 /* divline.cpp in Sources */,
 				4DEC4DA621C81ED400D1D273 /* reg.cpp in Sources */,
 				8F086F0B188539540037FD8E /* view_tuplet.cpp in Sources */,
@@ -4732,6 +4746,7 @@
 				4DB3D8F31F83D1C600B5FC2B /* scoredefinterface.cpp in Sources */,
 				4D2461DD246BE2E8002BBCCD /* expansionmap.cpp in Sources */,
 				E7BCFFB5281297980012513D /* resources.cpp in Sources */,
+				4D6479422C9C0F4300CD9539 /* genericlayerelement.cpp in Sources */,
 				4DACC9EE2990F29A00B55913 /* atts_shared.cpp in Sources */,
 				8F3DD32018854AFB0051330C /* devicecontext.cpp in Sources */,
 				4DACC9AC2990F29A00B55913 /* attmodule.cpp in Sources */,
@@ -5021,6 +5036,7 @@
 				BB4C4AB722A932A6001F6AF0 /* iomusxml.cpp in Sources */,
 				4DACC9EF2990F29A00B55913 /* atts_shared.cpp in Sources */,
 				BB4C4BC322A9330D001F6AF0 /* pugixml.cpp in Sources */,
+				4D6479432C9C0F4400CD9539 /* genericlayerelement.cpp in Sources */,
 				4DACC9AD2990F29A00B55913 /* attmodule.cpp in Sources */,
 				4D2E758B22BC2B5B004C51F0 /* tabgrp.cpp in Sources */,
 				4D2E758D22BC2B5B004C51F0 /* tabdursym.cpp in Sources */,

--- a/include/vrv/functorinterface.h
+++ b/include/vrv/functorinterface.h
@@ -48,6 +48,7 @@ class Fig;
 class Flag;
 class FloatingObject;
 class FTrem;
+class GenericLayerElement;
 class Gliss;
 class GraceAligner;
 class GraceGrp;
@@ -361,6 +362,8 @@ public:
     virtual FunctorCode VisitFlagEnd(Flag *flag);
     virtual FunctorCode VisitFTrem(FTrem *fTrem);
     virtual FunctorCode VisitFTremEnd(FTrem *fTrem);
+    virtual FunctorCode VisitGenericLayerElement(GenericLayerElement *genericLayerElement);
+    virtual FunctorCode VisitGenericLayerElementEnd(GenericLayerElement *genericLayerElement);
     virtual FunctorCode VisitGraceGrp(GraceGrp *graceGrp);
     virtual FunctorCode VisitGraceGrpEnd(GraceGrp *graceGrp);
     virtual FunctorCode VisitHalfmRpt(HalfmRpt *halfmRpt);
@@ -718,6 +721,8 @@ public:
     virtual FunctorCode VisitFlagEnd(const Flag *flag);
     virtual FunctorCode VisitFTrem(const FTrem *fTrem);
     virtual FunctorCode VisitFTremEnd(const FTrem *fTrem);
+    virtual FunctorCode VisitGenericLayerElement(const GenericLayerElement *genericLayerElement);
+    virtual FunctorCode VisitGenericLayerElementEnd(const GenericLayerElement *genericLayerElement);
     virtual FunctorCode VisitGraceGrp(const GraceGrp *graceGrp);
     virtual FunctorCode VisitGraceGrpEnd(const GraceGrp *graceGrp);
     virtual FunctorCode VisitHalfmRpt(const HalfmRpt *halfmRpt);

--- a/include/vrv/genericlayerelement.h
+++ b/include/vrv/genericlayerelement.h
@@ -27,11 +27,17 @@ public:
      */
     ///@{
     GenericLayerElement();
+    GenericLayerElement(const std::string &name);
     virtual ~GenericLayerElement();
     Object *Clone() const override { return new GenericLayerElement(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Space"; }
+    std::string GetClassName() const override { return m_className; }
     ///@}
+
+    /**
+     * Return the MEI element original name
+     */
+    std::string GetMEIName() const { return m_meiName; }
 
     //----------//
     // Functors //
@@ -48,7 +54,11 @@ public:
     ///@}
 
 private:
-    //
+    /** The class name */
+    std::string m_className;
+    /** The MEI element name */
+    std::string m_meiName;
+
 public:
     //
 private:

--- a/include/vrv/genericlayerelement.h
+++ b/include/vrv/genericlayerelement.h
@@ -1,0 +1,59 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        genericlayerelement.h
+// Author:      Laurent Pugin
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_GENERICLAYERELEMENT_H__
+#define __VRV_GENERICLAYERELEMENT_H__
+
+#include "layerelement.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// GenericLayerElement
+//----------------------------------------------------------------------------
+
+/**
+ * This class holds generic elements existing within MEI <layer> but not supported by Verovio
+ */
+class GenericLayerElement : public LayerElement {
+public:
+    /**
+     * @name Constructors, destructors, reset and class name methods
+     * Reset method resets all attribute classes
+     */
+    ///@{
+    GenericLayerElement();
+    virtual ~GenericLayerElement();
+    Object *Clone() const override { return new GenericLayerElement(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "Space"; }
+    ///@}
+
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
+private:
+    //
+public:
+    //
+private:
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -65,6 +65,7 @@ class Fing;
 class Fermata;
 class FloatingElement;
 class FTrem;
+class GenericLayerElement;
 class Gliss;
 class GraceGrp;
 class Graphic;
@@ -395,6 +396,7 @@ private:
     void WriteDivLine(pugi::xml_node currentNode, DivLine *divLine);
     void WriteDot(pugi::xml_node currentNode, Dot *dot);
     void WriteFTrem(pugi::xml_node currentNode, FTrem *fTrem);
+    void WriteGenericLayerElement(pugi::xml_node currentNode, GenericLayerElement *element);
     void WriteGraceGrp(pugi::xml_node currentNode, GraceGrp *graceGrp);
     void WriteHalfmRpt(pugi::xml_node currentNode, HalfmRpt *halfmRpt);
     void WriteKeyAccid(pugi::xml_node currentNode, KeyAccid *keyAccid);
@@ -708,6 +710,7 @@ private:
     bool ReadDivLine(Object *parent, pugi::xml_node divLine);
     bool ReadDot(Object *parent, pugi::xml_node dot);
     bool ReadFTrem(Object *parent, pugi::xml_node fTrem);
+    bool ReadGenericLayerElement(Object *parent, pugi::xml_node element);
     bool ReadGraceGrp(Object *parent, pugi::xml_node graceGrp);
     bool ReadHalfmRpt(Object *parent, pugi::xml_node halfmRpt);
     bool ReadKeyAccid(Object *parent, pugi::xml_node keyAccid);

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -321,6 +321,8 @@ protected:
     void DrawDots(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawDurationElement(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawFlag(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
+    void DrawGenericLayerElement(
+        DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawGraceGrp(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawHalfmRpt(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);
     void DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -220,6 +220,7 @@ enum ClassId : uint16_t {
     DOTS,
     FLAG,
     FTREM,
+    GENERIC_ELEMENT,
     GRACEGRP,
     HALFMRPT,
     KEYSIG,

--- a/src/functorinterface.cpp
+++ b/src/functorinterface.cpp
@@ -40,6 +40,7 @@
 #include "fig.h"
 #include "fing.h"
 #include "ftrem.h"
+#include "genericlayerelement.h"
 #include "gliss.h"
 #include "gracegrp.h"
 #include "grpsym.h"
@@ -893,6 +894,16 @@ FunctorCode FunctorInterface::VisitGraceGrp(GraceGrp *graceGrp)
 FunctorCode FunctorInterface::VisitGraceGrpEnd(GraceGrp *graceGrp)
 {
     return this->VisitLayerElementEnd(graceGrp);
+}
+
+FunctorCode FunctorInterface::VisitGenericLayerElement(GenericLayerElement *genericLayerElement)
+{
+    return this->VisitLayerElement(genericLayerElement);
+}
+
+FunctorCode FunctorInterface::VisitGenericLayerElementEnd(GenericLayerElement *genericLayerElement)
+{
+    return this->VisitLayerElementEnd(genericLayerElement);
 }
 
 FunctorCode FunctorInterface::VisitHalfmRpt(HalfmRpt *halfmRpt)
@@ -2177,6 +2188,16 @@ FunctorCode ConstFunctorInterface::VisitGraceGrp(const GraceGrp *graceGrp)
 FunctorCode ConstFunctorInterface::VisitGraceGrpEnd(const GraceGrp *graceGrp)
 {
     return this->VisitLayerElementEnd(graceGrp);
+}
+
+FunctorCode ConstFunctorInterface::VisitGenericLayerElement(const GenericLayerElement *genericLayerElement)
+{
+    return this->VisitLayerElement(genericLayerElement);
+}
+
+FunctorCode ConstFunctorInterface::VisitGenericLayerElementEnd(const GenericLayerElement *genericLayerElement)
+{
+    return this->VisitLayerElementEnd(genericLayerElement);
 }
 
 FunctorCode ConstFunctorInterface::VisitHalfmRpt(const HalfmRpt *halfmRpt)

--- a/src/genericlayerelement.cpp
+++ b/src/genericlayerelement.cpp
@@ -1,0 +1,63 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        genericlayerelement.cpp
+// Author:      Laurent Pugin
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "genericlayerelement.h"
+//----------------------------------------------------------------------------
+
+#include <cassert>
+#include <math.h>
+
+//----------------------------------------------------------------------------
+
+#include "functor.h"
+#include "vrv.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// Space
+//----------------------------------------------------------------------------
+
+// static const ClassRegistrar<GenericLayerElement> s_factory("generic", GENERIC_ELEMENT);
+
+GenericLayerElement::GenericLayerElement() : LayerElement(GENERIC_ELEMENT, "generic-")
+{
+    this->Reset();
+}
+
+GenericLayerElement::~GenericLayerElement() {}
+
+void GenericLayerElement::Reset()
+{
+    LayerElement::Reset();
+}
+
+//----------------------------------------------------------------------------
+// Functors methods
+//----------------------------------------------------------------------------
+
+FunctorCode GenericLayerElement::Accept(Functor &functor)
+{
+    return functor.VisitGenericLayerElement(this);
+}
+
+FunctorCode GenericLayerElement::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitGenericLayerElement(this);
+}
+
+FunctorCode GenericLayerElement::AcceptEnd(Functor &functor)
+{
+    return functor.VisitGenericLayerElementEnd(this);
+}
+
+FunctorCode GenericLayerElement::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitGenericLayerElementEnd(this);
+}
+
+} // namespace vrv

--- a/src/genericlayerelement.cpp
+++ b/src/genericlayerelement.cpp
@@ -26,6 +26,16 @@ namespace vrv {
 
 GenericLayerElement::GenericLayerElement() : LayerElement(GENERIC_ELEMENT, "generic-")
 {
+    LogError("Creating generic element without name");
+    m_className = "[unspecified]";
+    this->Reset();
+}
+
+GenericLayerElement::GenericLayerElement(const std::string &name) : LayerElement(GENERIC_ELEMENT, name + "-")
+{
+    m_meiName = name;
+    m_className = name;
+    std::transform(m_className.begin(), m_className.begin() + 1, m_className.begin(), ::toupper);
     this->Reset();
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -56,6 +56,7 @@
 #include "findfunctor.h"
 #include "fing.h"
 #include "ftrem.h"
+#include "genericlayerelement.h"
 #include "gliss.h"
 #include "gracegrp.h"
 #include "graphic.h"
@@ -638,6 +639,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
         else if (object->Is(FTREM)) {
             m_currentNode = m_currentNode.append_child("fTrem");
             this->WriteFTrem(m_currentNode, vrv_cast<FTrem *>(object));
+        }
+        else if (object->Is(GENERIC_ELEMENT)) {
+            m_currentNode = m_currentNode.append_child("generic");
+            this->WriteGenericLayerElement(m_currentNode, vrv_cast<GenericLayerElement *>(object));
         }
         else if (object->Is(GRACEGRP)) {
             m_currentNode = m_currentNode.append_child("graceGrp");
@@ -2509,6 +2514,15 @@ void MEIOutput::WriteFTrem(pugi::xml_node currentNode, FTrem *fTrem)
     this->WriteLayerElement(currentNode, fTrem);
     fTrem->WriteFTremVis(currentNode);
     fTrem->WriteTremMeasured(currentNode);
+}
+
+void MEIOutput::WriteGenericLayerElement(pugi::xml_node currentNode, GenericLayerElement *element)
+{
+    assert(element);
+
+    currentNode.set_name(element->GetMEIName().c_str());
+
+    this->WriteLayerElement(currentNode, element);
 }
 
 void MEIOutput::WriteGraceGrp(pugi::xml_node currentNode, GraceGrp *graceGrp)
@@ -6318,11 +6332,17 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         else if (elementName == "multiRpt") {
             success = this->ReadMultiRpt(parent, xmlElement);
         }
+        else if (elementName == "pb") {
+            success = this->ReadGenericLayerElement(parent, xmlElement);
+        }
         else if (elementName == "plica") {
             success = this->ReadPlica(parent, xmlElement);
         }
         else if (elementName == "proport") {
             success = this->ReadProport(parent, xmlElement);
+        }
+        else if (elementName == "sb") {
+            success = this->ReadGenericLayerElement(parent, xmlElement);
         }
         else if (elementName == "space") {
             success = this->ReadSpace(parent, xmlElement);
@@ -6629,6 +6649,16 @@ bool MEIInput::ReadFTrem(Object *parent, pugi::xml_node fTrem)
     parent->AddChild(vrvFTrem);
     this->ReadUnsupportedAttr(fTrem, vrvFTrem);
     return this->ReadLayerChildren(vrvFTrem, fTrem, vrvFTrem);
+}
+
+bool MEIInput::ReadGenericLayerElement(Object *parent, pugi::xml_node element)
+{
+    GenericLayerElement *vrvElement = new GenericLayerElement(element.name());
+    this->ReadLayerElement(element, vrvElement);
+
+    parent->AddChild(vrvElement);
+    this->ReadUnsupportedAttr(element, vrvElement);
+    return true;
 }
 
 bool MEIInput::ReadGraceGrp(Object *parent, pugi::xml_node graceGrp)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -127,6 +127,9 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     else if (element->Is(FLAG)) {
         this->DrawFlag(dc, element, layer, staff, measure);
     }
+    else if (element->Is(GENERIC_ELEMENT)) {
+        this->DrawGenericLayerElement(dc, element, layer, staff, measure);
+    }
     else if (element->Is(GRACEGRP)) {
         this->DrawGraceGrp(dc, element, layer, staff, measure);
     }
@@ -886,6 +889,20 @@ void View::DrawFlag(DeviceContext *dc, LayerElement *element, Layer *layer, Staf
 
     char32_t code = flag->GetFlagGlyph(stem->GetDrawingStemDir());
     this->DrawSmuflCode(dc, x, y, code, staff->GetDrawingStaffNotationSize(), flag->GetDrawingCueSize());
+
+    dc->EndGraphic(element, this);
+}
+
+void View::DrawGenericLayerElement(
+    DeviceContext *dc, LayerElement *element, Layer *layer, Staff *staff, Measure *measure)
+{
+    assert(dc);
+    assert(element);
+    assert(layer);
+    assert(staff);
+    assert(measure);
+
+    dc->StartGraphic(element, "", element->GetID());
 
     dc->EndGraphic(element, this);
 }


### PR DESCRIPTION
Allow `<sb>` and `<pb>` within `<layer>` to be read and written as generic objects but with not effect on layout rendering. All attributes are preserved.