### PR TITLE
Proportions in CMME to MEI

### DIFF
--- a/include/vrv/iocmme.h
+++ b/include/vrv/iocmme.h
@@ -69,6 +69,7 @@ private:
     void CreateKeySig(pugi::xml_node keyNode);
     void CreateMensuration(pugi::xml_node mensurationNode);
     void CreateOriginalText(pugi::xml_node originalTextNode);
+    void CreateProport(pugi::xml_node proportNode);
     void CreateNote(pugi::xml_node noteNode);
     void CreateRest(pugi::xml_node restNode);
 

--- a/src/iocmme.cpp
+++ b/src/iocmme.cpp
@@ -641,6 +641,14 @@ void CmmeInput::CreateMensuration(pugi::xml_node mensurationNode)
     data_ORIENTATION orient = orientationMap.contains(orientation) ? orientationMap.at(orientation) : ORIENTATION_NONE;
     mensur->SetOrient(orient);
 
+    /// Mensuration/Small to @fontsize=small (not yet rendered in Verovio).
+    /// In the long run, we should add @size to att.mensur.vis because we have @mensur.size for <staffDef>, see class
+    /// att.mensural.vis
+    pugi::xml_node smallNode = mensurationNode.child("Small");
+    if (smallNode != NULL) {
+        mensur->m_unsupported.push_back(std::make_pair("fontsize", "small"));
+    }
+
     /// Mensuration/Number/Num to @num and Number/Den to @numbase
     /// However, Number/Den cannot be entered in the CMME Editor.
     /// It can only be added in the XML manually and imported into the CMME Editor,


### PR DESCRIPTION
Add support for encoding CMME `<TempoChange>` as an MEI proportion `<proport>` element with `@type = cmme_tempo_change` following the MEI `<mensur>` element, and for encoding CMME `<Proportion>` as a simple MEI `<proport>` element (not following any mensuration sign at all) with `@type = cmme_proportion`.