### PR TITLE
Add support for NoScoreEffect node in CMME

### DIFF
--- a/src/iocmme.cpp
+++ b/src/iocmme.cpp
@@ -668,6 +668,12 @@ void CmmeInput::CreateMensuration(pugi::xml_node mensurationNode)
         mensur->m_unsupported.push_back(std::make_pair("fontsize", "small"));
     }
 
+    /// Mesuration/NoScoreEffect to @type = cmme_no_score_effect
+    pugi::xml_node noScoreEffect = mensurationNode.child("NoScoreEffect");
+    if (noScoreEffect != NULL) {
+        mensur->SetType("cmme_no_score_effect");
+    }
+
     /// Mensuration/Number/Num to @num and Number/Den to @numbase
     /// However, Number/Den cannot be entered in the CMME Editor.
     /// It can only be added in the XML manually and imported into the CMME Editor,

--- a/src/iocmme.cpp
+++ b/src/iocmme.cpp
@@ -292,9 +292,9 @@ void CmmeInput::ReadEvents(pugi::xml_node eventsNode)
         else if (name == "Dot") {
             CreateDot(eventNode);
         }
-	else if (name == "LineEnd") {
-	  CreateBreak(eventNode);
-	}
+        else if (name == "LineEnd") {
+            CreateBreak(eventNode);
+        }
         else if (name == "Mensuration") {
             CreateMensuration(eventNode);
         }
@@ -449,12 +449,13 @@ void CmmeInput::CreateBreak(pugi::xml_node breakNode)
 {
     assert(m_currentContainer);
 
-    // This is either a system or page break (usually only 
+    // This is either a system or page break (usually only
     // in one part, so not easy to visualise in score)
-    if (breakNode.select_node("./PageEnd")){
+    if (breakNode.select_node("./PageEnd")) {
         GenericLayerElement *pb = new GenericLayerElement("pb");
         m_currentContainer->AddChild(pb);
-    } else {
+    }
+    else {
         GenericLayerElement *sb = new GenericLayerElement("sb");
         m_currentContainer->AddChild(sb);
     }


### PR DESCRIPTION
The `<NoScoreEffect>` node in CMME's `<Mensuration>` is converted into `@type = no_score_effect` in the MEI `<mensur>` element.