### PR TITLE
Add --timemap option to pass json options to the command-line

### DIFF
--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -88,7 +88,7 @@ enum option_SMUFLTEXTFONT { SMUFLTEXTFONT_embedded = 0, SMUFLTEXTFONT_linked, SM
 // Option
 //----------------------------------------------------------------------------
 
-enum class OptionsCategory { None, Base, General, Layout, Mensural, Margins, Midi, Selectors, Full };
+enum class OptionsCategory { None, Base, General, Json, Layout, Mensural, Margins, Midi, Selectors, Full };
 
 /**
  * This class is a base class of each styling parameter
@@ -841,6 +841,13 @@ public:
 
     OptionBool m_ligatureAsBracket;
     OptionBool m_mensuralToMeasure;
+
+    /**
+     * Additional options for passing method JSON options to the command-line
+     */
+    OptionGrp m_jsonCmdLineOptions;
+
+    OptionString m_timemap;
 
     /**
      * Deprecated options

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -847,7 +847,7 @@ public:
      */
     OptionGrp m_jsonCmdLineOptions;
 
-    OptionString m_timemap;
+    OptionString m_timemapOptions;
 
     /**
      * Deprecated options

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1798,7 +1798,7 @@ Options::Options()
     m_topMarginPgFooter.Init(2.0, 0.0, 24.0);
     this->Register(&m_topMarginPgFooter, "topMarginPgFooter", &m_elementMargins);
 
-    /********* midi *********/
+    /********* MIDI *********/
 
     m_midi.SetLabel("Midi options", "5-midi");
     m_midi.SetCategory(OptionsCategory::Midi);
@@ -1812,7 +1812,7 @@ Options::Options()
     m_midiTempoAdjustment.Init(1.0, 0.2, 4.0);
     this->Register(&m_midiTempoAdjustment, "midiTempoAdjustment", &m_midi);
 
-    /********* General *********/
+    /********* Mensural *********/
 
     m_mensural.SetLabel("Mensural notation options", "6-mensural");
     m_mensural.SetCategory(OptionsCategory::Mensural);
@@ -1825,6 +1825,16 @@ Options::Options()
     m_mensuralToMeasure.SetInfo("Mensural to measure", "Convert mensural sections to measure-based MEI");
     m_mensuralToMeasure.Init(false);
     this->Register(&m_mensuralToMeasure, "mensuralToMeasure", &m_mensural);
+
+    /********* Method JSON options to the command-line *********/
+
+    m_jsonCmdLineOptions.SetLabel("Method JSON options for the command-line", "7-methodJson");
+    m_jsonCmdLineOptions.SetCategory(OptionsCategory::Json);
+    m_grps.push_back(&m_jsonCmdLineOptions);
+
+    m_timemap.SetInfo("Timemap options", "The JSON options to be passed when producing the timemap");
+    m_timemap.Init("{}");
+    this->Register(&m_timemap, "timemap", &m_jsonCmdLineOptions);
 
     /********* Deprecated options *********/
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1832,9 +1832,9 @@ Options::Options()
     m_jsonCmdLineOptions.SetCategory(OptionsCategory::Json);
     m_grps.push_back(&m_jsonCmdLineOptions);
 
-    m_timemap.SetInfo("Timemap options", "The JSON options to be passed when producing the timemap");
-    m_timemap.Init("{}");
-    this->Register(&m_timemap, "timemap", &m_jsonCmdLineOptions);
+    m_timemapOptions.SetInfo("Timemap options", "The JSON options to be passed when producing the timemap");
+    m_timemapOptions.Init("{}");
+    this->Register(&m_timemapOptions, "timemapOptions", &m_jsonCmdLineOptions);
 
     /********* Deprecated options *********/
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1303,11 +1303,11 @@ void Toolkit::PrintOptionUsageOutput(const vrv::Option *option, std::ostream &ou
 void Toolkit::PrintOptionUsage(const std::string &category, std::ostream &output) const
 {
     // map of all categories and expected string arguments for them
-    const std::map<vrv::OptionsCategory, std::string> categories
-        = { { vrv::OptionsCategory::Base, "base" }, { vrv::OptionsCategory::General, "general" },
-              { vrv::OptionsCategory::Layout, "layout" }, { vrv::OptionsCategory::Margins, "margins" },
-              { vrv::OptionsCategory::Mensural, "mensural" }, { vrv::OptionsCategory::Midi, "midi" },
-              { vrv::OptionsCategory::Selectors, "selectors" }, { vrv::OptionsCategory::Full, "full" } };
+    const std::map<vrv::OptionsCategory, std::string> categories = { { vrv::OptionsCategory::Base, "base" },
+        { vrv::OptionsCategory::General, "general" }, { vrv::OptionsCategory::Json, "json" },
+        { vrv::OptionsCategory::Layout, "layout" }, { vrv::OptionsCategory::Margins, "margins" },
+        { vrv::OptionsCategory::Mensural, "mensural" }, { vrv::OptionsCategory::Midi, "midi" },
+        { vrv::OptionsCategory::Selectors, "selectors" }, { vrv::OptionsCategory::Full, "full" } };
 
     output.precision(2);
     // display_version();

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -447,9 +447,9 @@ int main(int argc, char **argv)
         outfile += ".json";
         if (std_output) {
             std::string output;
-            std::cout << toolkit.RenderToTimemap();
+            std::cout << toolkit.RenderToTimemap(options->m_timemap.GetValue());
         }
-        else if (!toolkit.RenderToTimemapFile(outfile)) {
+        else if (!toolkit.RenderToTimemapFile(outfile, options->m_timemap.GetValue())) {
             std::cerr << "Unable to write timemap to " << outfile << "." << std::endl;
             exit(1);
         }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -447,9 +447,9 @@ int main(int argc, char **argv)
         outfile += ".json";
         if (std_output) {
             std::string output;
-            std::cout << toolkit.RenderToTimemap(options->m_timemap.GetValue());
+            std::cout << toolkit.RenderToTimemap(options->m_timemapOptions.GetValue());
         }
-        else if (!toolkit.RenderToTimemapFile(outfile, options->m_timemap.GetValue())) {
+        else if (!toolkit.RenderToTimemapFile(outfile, options->m_timemapOptions.GetValue())) {
             std::cerr << "Unable to write timemap to " << outfile << "." << std::endl;
             exit(1);
         }


### PR DESCRIPTION
Usage:
```bash
laurent@gromit tools % ./verovio -h json         
Verovio 4.4.0-dev-53bde0a-dirty

Example usage:

 verovio [-s scale] [-r resource-path] [-o outfile] infile

Options (marked as * are repeatable)

Method JSON options for the command-line
 --timemap-options <s>                  The JSON options to be passed when producing the timemap (default: "{}")
```

Example:
```
verovio --timemap-options "{'includeMeasures': true, 'includeRests': true}" inputfile
```