### PR TITLE
Use spaceship operator for fractions

### DIFF
--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -88,15 +88,9 @@ public:
 
     /** Equality operator */
     bool operator==(const Fraction &other) const;
-    /** Less than operator */
-    bool operator<(const Fraction &other) const;
-    /** Less than or equal operator */
-    bool operator<=(const Fraction &other) const;
-    /** Greater than operator */
-    bool operator>(const Fraction &other) const;
-    /** Greater than or equal operator */
-    bool operator>=(const Fraction &other) const;
-
+    /** Ordering operator */
+    std::strong_ordering operator<=>(const Fraction &other) const;
+    
     /** Getters */
     int GetNumerator() const { return m_numerator; }
     int GetDenominator() const { return m_denominator; }
@@ -114,7 +108,7 @@ public:
     // Static methods //
     //----------------//
 
-    /** Reduce the faction represented by the two numbers */
+    /** Reduce the fraction represented by the two numbers */
     static void Reduce(int &numerator, int &denominator);
 
 private:

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -90,7 +90,7 @@ public:
     bool operator==(const Fraction &other) const;
     /** Ordering operator */
     std::strong_ordering operator<=>(const Fraction &other) const;
-    
+
     /** Getters */
     int GetNumerator() const { return m_numerator; }
     int GetDenominator() const { return m_denominator; }

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -94,24 +94,9 @@ bool Fraction::operator==(const Fraction &other) const
     return m_numerator * other.m_denominator == other.m_numerator * m_denominator;
 }
 
-bool Fraction::operator<(const Fraction &other) const
+std::strong_ordering Fraction::operator<=>(const Fraction &other) const
 {
-    return m_numerator * other.m_denominator < other.m_numerator * m_denominator;
-}
-
-bool Fraction::operator<=(const Fraction &other) const
-{
-    return m_numerator * other.m_denominator <= other.m_numerator * m_denominator;
-}
-
-bool Fraction::operator>(const Fraction &other) const
-{
-    return m_numerator * other.m_denominator > other.m_numerator * m_denominator;
-}
-
-bool Fraction::operator>=(const Fraction &other) const
-{
-    return m_numerator * other.m_denominator >= other.m_numerator * m_denominator;
+    return m_numerator * other.m_denominator <=> other.m_numerator * m_denominator;
 }
 
 double Fraction::ToDouble() const


### PR DESCRIPTION
This PR introduces the C++20 spaceship operator to the new `Fraction` class. There should be no changes in behaviour, I simply wanted to try this out. 

Lessons learned on my side:
- Equality comparison still needs to be defined. It is only default generated [whenever the spaceship operator is default](https://stackoverflow.com/questions/60681266/three-way-comparison-replaces-all-others-comparison-operators-except) (lexicographic order). The latter is not the case for `Fraction`: we define our own spaceship operator.
- The order on fractions should be _strong_, since they are always internally reduced.