### PR TITLE
Change decimal formatting

### DIFF
--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -32,7 +32,7 @@ std::string Att::StrToStr(std::string str) const
 
 std::string Att::DblToStr(double data) const
 {
-    return StringFormat("%f", data);
+    return StringFormat("%.10g", round(data * 10000.0) / 10000.0);
 }
 
 std::string Att::IntToStr(int data) const
@@ -365,7 +365,7 @@ data_KEYSIGNATURE Att::StrToKeysignature(const std::string &value, bool logWarni
 
 std::string Att::MeasurebeatToStr(data_MEASUREBEAT data) const
 {
-    return StringFormat("%dm+%.4f", data.first, data.second);
+    return StringFormat("%dm+%.10g", data.first, round(data.second * 10000.0) / 10000.0);
 }
 
 data_MEASUREBEAT Att::StrToMeasurebeat(std::string value, bool) const

--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -32,7 +32,9 @@ std::string Att::StrToStr(std::string str) const
 
 std::string Att::DblToStr(double data) const
 {
-    return StringFormat("%.10g", round(data * 10000.0) / 10000.0);
+    std::stringstream sstream;
+    sstream << round(data * 10000.0) / 10000.0;
+    return sstream.str();
 }
 
 std::string Att::IntToStr(int data) const
@@ -365,7 +367,9 @@ data_KEYSIGNATURE Att::StrToKeysignature(const std::string &value, bool logWarni
 
 std::string Att::MeasurebeatToStr(data_MEASUREBEAT data) const
 {
-    return StringFormat("%dm+%.10g", data.first, round(data.second * 10000.0) / 10000.0);
+    std::stringstream sstream;
+    sstream << data.first << "m+" << round(data.second * 10000.0) / 10000.0;
+    return sstream.str();
 }
 
 data_MEASUREBEAT Att::StrToMeasurebeat(std::string value, bool) const


### PR DESCRIPTION
~The PR switches `%.10g` formatting decimal with a precision limited to 4 digits after the `.`.~

[Changing my mind: using `stringstream` with no relevant figures limitation]

This applies to `@tstamp` or `@tstamp2`, for example, and avoids the trailing zeros. See previous discussions [here](https://github.com/rism-digital/verovio/issues/922) and [there](https://github.com/rism-digital/verovio/issues/975)

The output will be `tstamp="1"` or `tstamp="1.75"` instead of `tstamp="1.0000"` or `tstamp="1.7500"` respectively.

~This implementation avoids the use of `stringstream`, which I find over the top. It sets an arbitrary limit to 10 significant numbers - if the value is larger that `999,999`, then the number of digits after the `.` will be reduced. We can adjust the value (or even change to stringstream) if a case where the loss would have an impact can be identified, but this looks quite unrealistic to me.~