### PR TITLE
Improve system cast off

### DIFF
--- a/include/vrv/castofffunctor.h
+++ b/include/vrv/castofffunctor.h
@@ -136,7 +136,11 @@ public:
 protected:
     //
 private:
-    //
+    /*
+     * Returns the available height for system drawing on the current page
+     */
+    int GetAvailableDrawingHeight() const;
+
 public:
     //
 private:
@@ -144,6 +148,8 @@ private:
     Page *m_contentPage;
     // The current page
     Page *m_currentPage;
+    // Indicates whether the current page is the first
+    bool m_firstCastOffPage;
     // The cumulated shift (m_drawingYRel of the first system of the current page)
     int m_shift;
     // The page heights


### PR DESCRIPTION
This MR improves the system cast off, particularly on the first page. In the previous implementation the page header was taken twice into account, preventing in some cases that an additional system was added to the first page even though there was enough space.

Some examples without vertical justification to highlight the issue and the improvement:

| Before | After |
| --- | --- |
| <img width="896" alt="Beethoven-before" src="https://github.com/user-attachments/assets/8bb7a958-c230-499c-8e7b-494ea3fda89d"> | <img width="905" alt="Beethoven-after" src="https://github.com/user-attachments/assets/38c4c5f3-b06e-4a0a-8d79-0baea10f4fbe"> |
| <img width="914" alt="Doctor-before" src="https://github.com/user-attachments/assets/5fede512-49b7-41d0-bdb3-51033b1162e7"> | <img width="911" alt="Doctor-after" src="https://github.com/user-attachments/assets/c245b7e3-6f65-4d11-af43-387981065fae"> |
