### PR TITLE
Change vertical justification of last page

### DIFF
--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -166,9 +166,9 @@ private:
     void AdjustSylSpacingByVerse(const IntTree &verseTree, Doc *doc);
 
     /**
-     * Check whether vertical justification is required for the current page
+     * Reduces the justifiable height based on the --justification-max-vertical option
      */
-    bool IsJustificationRequired(const Doc *doc);
+    void ReduceJustifiableHeight(const Doc *doc);
 
     //
 public:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1353,7 +1353,7 @@ Options::Options()
 
     m_justificationMaxVertical.SetInfo("Maximum ratio of justifiable height for page",
         "Maximum ratio of justifiable height to page height that can be used for the vertical justification");
-    m_justificationMaxVertical.Init(0.3, 0.0, 1.0);
+    m_justificationMaxVertical.Init(0.2, 0.0, 1.0);
     this->Register(&m_justificationMaxVertical, "justificationMaxVertical", &m_generalLayout);
 
     m_ledgerLineThickness.SetInfo("Ledger line thickness", "The thickness of the ledger lines");


### PR DESCRIPTION
This MR changes the vertical justification of the last page which is somewhat tricky. Before, it was based on the justification applied to the previous page. However, this causes problems, if all pages are loaded and only the last page is rendered (see #3631). If the document consists of a single page, then the justification was completely omitted, whenever there were just a few staves.

With the changes, the justification is mostly based on the given `--justification-max-vertical` ratio. The default value of this option is reduced to 0.2 which is more realistic. The max ratio is reduced on the last page based on the number of systems rendered there and the number of systems on the previous page. This approach does not require that the previous page was rendered.

Closes #3631 .

<img width="400" alt="Lindenbaum-justified" src="https://github.com/user-attachments/assets/80c5f4d1-1fce-4a69-b490-769cf1e5b26a">
