### PR TITLE
Update python-ci-wheel.yml [SKIP-CI]

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -108,7 +108,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS: brew update && brew install swig
           CIBW_BEFORE_ALL_WINDOWS: choco install swig -f -y
-          CIBW_BEFORE_BUILD: swig -version && bash -c 'cd tools; ./get_git_commit.sh' && swig -c++ -python -py3 ./bindings/python/verovio.i
+          CIBW_BEFORE_BUILD: swig -version && bash -c 'cd tools; ./get_git_commit.sh' && swig -c++ -python -py3 -fastproxy -olddefs ./bindings/python/verovio.i
 
       #===============================================#
       # Check build


### PR DESCRIPTION
Updates the GitHub action with new swig options.