### PR TITLE
Fix #3828 Italian lute tablature bass notes.

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -166,7 +166,7 @@ public:
      * @name Return the smufl string to use for a note give the notation type
      */
     ///@{
-    std::u32string GetTabFretString(data_NOTATIONTYPE notationType, int &overline, int &strike) const;
+    std::u32string GetTabFretString(data_NOTATIONTYPE notationType, int &overline, int &strike, int &underline) const;
     ///@}
 
     /**

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -63,7 +63,9 @@ int Tuning::CalcPitchPos(
         case NOTATIONTYPE_tab_lute_french:
             // all courses >= 7 are positioned above line 0
             return (lines - std::min(course, 7)) * 2 + 1; // above the line
-        case NOTATIONTYPE_tab_lute_italian: return (course - 1) * 2;
+        case NOTATIONTYPE_tab_lute_italian:
+            // all courses >= 7 are positioned on line 7
+            return (std::min(course, 7) - 1) * 2;
         case NOTATIONTYPE_tab_lute_german:
             if (loc != MEI_UNSET) {
                 return loc;


### PR DESCRIPTION
Fix issue #3828.   Implement the proposal given in the issue.  The existing Italian tablature code uses the CMN ledger line handling which calculates the length of the ledger line based on the note head - not applicable to tablature as there are no note heads, hence the wrong ledger line length.  This code draws its own ledger lines.

Same example as in issue #3828 - 13 course lute open strings in Italian lute tablature.

![bassdemo-after mei](https://github.com/user-attachments/assets/a0c81834-54c8-4831-ab33-8e1dde45659a)

Another before-and-after example is given in the issue.