### PR TITLE
Fix failed assertion on tstamp slur

### DIFF
--- a/src/calcslurdirectionfunctor.cpp
+++ b/src/calcslurdirectionfunctor.cpp
@@ -53,6 +53,9 @@ FunctorCode CalcSlurDirectionFunctor::VisitSlur(Slur *slur)
         if (slur->HasBulge()) {
             LogWarning("Mixed curve direction is ignored for slurs with prescribed bulge.");
         }
+        else if (start->Is(TIMESTAMP_ATTR) || end->Is(TIMESTAMP_ATTR)) {
+            LogWarning("Mixed curve direction is ignored for slurs with tstamp boundary.");
+        }
         else {
             const int startStaffN = start->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN();
             const int endStaffN = end->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN();

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -527,15 +527,17 @@ const Staff *Slur::CalculateExtremalStaff(const Staff *staff, int xMin, int xMax
 bool Slur::IsElementBelow(const LayerElement *element, const Staff *startStaff, const Staff *endStaff) const
 {
     assert(element);
-    assert(startStaff);
-    assert(endStaff);
+    // startStaff and endStaff may be NULL (if the boundary is a tstamp)
+    // however, slurs with tstamp should never have S-shape
 
     switch (this->GetDrawingCurveDir()) {
         case SlurCurveDirection::Above: return true;
         case SlurCurveDirection::Below: return false;
         case SlurCurveDirection::AboveBelow:
+            assert(startStaff);
             return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == startStaff->GetN());
         case SlurCurveDirection::BelowAbove:
+            assert(endStaff);
             return (element->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN() == endStaff->GetN());
         default: return false;
     }
@@ -544,15 +546,17 @@ bool Slur::IsElementBelow(const LayerElement *element, const Staff *startStaff, 
 bool Slur::IsElementBelow(const FloatingPositioner *positioner, const Staff *startStaff, const Staff *endStaff) const
 {
     assert(positioner);
-    assert(startStaff);
-    assert(endStaff);
+    // startStaff and endStaff may be NULL (if the boundary is a tstamp)
+    // however, slurs with tstamp should never have S-shape
 
     switch (this->GetDrawingCurveDir()) {
         case SlurCurveDirection::Above: return true;
         case SlurCurveDirection::Below: return false;
         case SlurCurveDirection::AboveBelow:
+            assert(startStaff);
             return (positioner->GetAlignment()->GetStaff()->GetN() == startStaff->GetN());
         case SlurCurveDirection::BelowAbove:
+            assert(endStaff);
             return (positioner->GetAlignment()->GetStaff()->GetN() == endStaff->GetN());
         default: return false;
     }


### PR DESCRIPTION
This PR fixes the following example which failed on assertion:

<img width="300" alt="tstamp-slur" src="https://github.com/user-attachments/assets/16fa68cc-0686-427a-a969-918da24cb36c">

<details><summary>Show MEI</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
   <meiHead>
      <fileDesc>
         <titleStmt />
         <pubStmt />
      </fileDesc>
   </meiHead>
   <music>
      <body>
         <mdiv n="1" type="placeholder" filename="C259_Chopin-Mazurka-op-33-no-3.mei">
            <score>
               <scoreDef xmlns="http://www.music-encoding.org/ns/mei">
                  <staffGrp xml:id="staffgrp-0000000654644337">
                     <staffGrp xml:id="S1" symbol="brace" bar.thru="true">
                        <staffDef xml:id="staffdef-0000001531587499" clef.shape="G" clef.line="2"
                           key.sig="2s" meter.count="3" meter.unit="4" n="1" lines="5" />
                        <staffDef xml:id="staffdef-0000000537857792" clef.shape="F" clef.line="4"
                           key.sig="2s" meter.count="3" meter.unit="4" n="2" lines="5" />
                     </staffGrp>
                  </staffGrp>
               </scoreDef>
               <section xmlns="http://www.music-encoding.org/ns/mei"
                  xml:id="section-0000001322498664">
                  <pb xml:id="pb-0000001380692662" />
                  <measure id="measure-4-1" n="3">
                     <staff xml:id="staff-0000001960143614" n="1">
                        <layer xml:id="layer-0000000998687890" n="1">
                           <beam xml:id="beam-0000001289571793">
                              <note xml:id="note-0000000784967379" dur="8" oct="4" pname="a"
                                 stem.dir="up" />
                              <note xml:id="note-0000001349886430" dur="8" oct="5" pname="d"
                                 stem.dir="up" />
                           </beam>
                           <beam xml:id="beam-0000001014002071">
                              <tuplet xml:id="tuplet-0000001058572017" num="3" numbase="2"
                                 bracket.visible="false">
                                 <note xml:id="note-0000000016647631" dur="8" oct="5" pname="d"
                                    stem.dir="up" />
                                 <note xml:id="note-0000002116681512" dur="8" oct="5" pname="e"
                                    stem.dir="up" />
                                 <note xml:id="note-0000000476770628" dur="8" oct="5" pname="d"
                                    stem.dir="up" />
                              </tuplet>
                           </beam>
                           <beam xml:id="beam-0000000800459704">
                              <note xml:id="note-0000000410356642" dur="8" oct="5" pname="c"
                                 stem.dir="up" accid.ges="s" />
                              <note xml:id="note-0000000039240249" dur="8" oct="4" pname="b"
                                 stem.dir="up" />
                           </beam>
                        </layer>
                        <layer xml:id="layer-0000001282286791" n="2">
                           <rest xml:id="rest-0000000091189956" dur="4" ploc="c" oloc="4" />
                           <note xml:id="note-0000001812366163" dur="4" oct="4" pname="f"
                              stem.dir="down" accid.ges="s" />
                           <note xml:id="note-0000000050940107" dur="4" oct="4" pname="f"
                              stem.dir="down" accid.ges="s">
                              <artic xml:id="artic-0000000497898196" artic="acc" />
                           </note>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000002080351638" n="2">
                        <layer xml:id="layer-0000000402131072" n="5">
                           <note xml:id="note-0000000614972480" dur="4" oct="2" pname="d"
                              stem.dir="up">
                              <artic artic="stacc" />
                           </note>
                           <chord xml:id="chord-0000000569090818" dur="4" stem.dir="down">
                              <note xml:id="note-0000002119759500" oct="3" pname="d" />
                              <note xml:id="note-0000001034759272" oct="3" pname="a" />
                              <note xml:id="note-0000002055581753" oct="4" pname="d" />
                           </chord>
                           <chord xml:id="chord-0000001216891756" dur="4" stem.dir="down">
                              <note xml:id="note-0000000661331377" oct="3" pname="d" />
                              <note xml:id="note-0000000653538663" oct="3" pname="a" />
                              <note xml:id="note-0000000473991343" oct="4" pname="d" />
                           </chord>
                        </layer>
                     </staff>
                     <pedal vgrp="200" staff="2" tstamp="1" dir="down" place="below" />
                     <pedal xml:id="pedal-0000001149759747" staff="2" tstamp="3.5" dir="up"
                        place="below" vgrp="200" />
                  </measure>
                  <measure id="measure-5-1" n="4">
                     <staff xml:id="staff-0000001671736671" n="1">
                        <layer xml:id="layer-0000000877073221" n="1">
                           <note xml:id="note-0000001710976921" dur="2" oct="5" pname="c"
                              stem.dir="up" accid.ges="s" dots="1">
                              <artic xml:id="artic-0000000968263177" artic="acc" />
                           </note>
                        </layer>
                        <layer xml:id="layer-0000001019203284" n="2">
                           <rest xml:id="rest-0000001369872910" dur="4" ploc="c" oloc="4" />
                           <chord xml:id="chord-0000001421334356" dur="4" stem.dir="down">
                              <note xml:id="note-0000001691749195" oct="4" pname="e" />
                              <note xml:id="note-0000001984845390" oct="4" pname="a" />
                           </chord>
                           <chord dur="4">
                              <note xml:id="note-0000001664025047" dur="4" oct="4" pname="g"
                                 stem.dir="down" />
                              <note xml:id="note-0000001193850999" dur="4" oct="4" pname="a"
                                 stem.dir="up" />
                           </chord>
                        </layer>
                     </staff>
                     <staff xml:id="staff-0000001009636065" n="2">
                        <layer xml:id="layer-0000000872121015" n="5">
                           <note xml:id="note-0000001572123152" dur="4" oct="2" pname="a"
                              stem.dir="up">
                              <artic xml:id="artic-0000000504272904" artic="stacc" />
                           </note>
                           <note xml:id="note-0000002089012771" dur="4" oct="3" pname="a"
                              stem.dir="down" />
                           <chord xml:id="chord-0000000978264247" dur="4" stem.dir="down">
                              <note xml:id="note-0000000078178168" oct="3" pname="a" />
                              <note xml:id="note-0000001091288870" oct="4" pname="e" />
                              <artic xml:id="artic-0000001990425175" artic="acc" />
                           </chord>
                        </layer>
                     </staff>
                     <slur xml:id="slur-0000001375859436" startid="#note-0000001710976921"
                        tstamp2="4" />
                     <pedal vgrp="200" staff="2" tstamp="1" dir="down" place="below" />
                     <pedal xml:id="pedal-0000001730404721" staff="2" tstamp="3.5" dir="up"
                        place="below" vgrp="200" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

It further ensures that slurs with mixed curve direction and tstamps in the encoding do not crash by ignoring the mixed curve direction for now.