### PR TITLE
Improve justification for last page / single pages

### DIFF
--- a/src/page.cpp
+++ b/src/page.cpp
@@ -650,13 +650,11 @@ void Page::ReduceJustifiableHeight(const Doc *doc)
     double maxRatio = doc->GetOptions()->m_justificationMaxVertical.GetValue();
     // Special handling for justification of last page
     if (pages->GetLast() == this) {
-        const Page *previousPage = vrv_cast<const Page *>(pages->GetPrevious(this, PAGE));
-        if (previousPage) {
-            const int systemCount = this->GetChildCount(SYSTEM);
-            const int previousSystemCount = previousPage->GetChildCount(SYSTEM);
-            if (systemCount < previousSystemCount) {
-                maxRatio *= (double)systemCount / (double)previousSystemCount;
-            }
+        const System *firstSystem = vrv_cast<const System *>(this->GetFirst(SYSTEM));
+        const System *lastSystem = vrv_cast<const System *>(this->GetLast(SYSTEM));
+        if (firstSystem && lastSystem) {
+            const int usedDrawingHeight = firstSystem->GetDrawingY() - lastSystem->GetDrawingY() + lastSystem->GetHeight();
+            maxRatio *= (double)usedDrawingHeight / (double)doc->m_drawingPageHeight;
         }
     }
 

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -653,7 +653,8 @@ void Page::ReduceJustifiableHeight(const Doc *doc)
         const System *firstSystem = vrv_cast<const System *>(this->GetFirst(SYSTEM));
         const System *lastSystem = vrv_cast<const System *>(this->GetLast(SYSTEM));
         if (firstSystem && lastSystem) {
-            const int usedDrawingHeight = firstSystem->GetDrawingY() - lastSystem->GetDrawingY() + lastSystem->GetHeight();
+            const int usedDrawingHeight
+                = firstSystem->GetDrawingY() - lastSystem->GetDrawingY() + lastSystem->GetHeight();
             maxRatio *= (double)usedDrawingHeight / (double)doc->m_drawingPageHeight;
         }
     }


### PR DESCRIPTION
This MR improves the justification of the last page, particularly if there is just a single page.

Instead of scaling the `--justification-max-vertical` ratio by the number of systems on the last page over the number of systems on the page before (which just works for at least two pages), we scale by the used drawing height over the page drawing height.

This further refines the changes in #3821 . Single system example with `--justify-vertically`:

| Before  | After |
| ------ | ------ |
|<img width="300" alt="before" src="https://github.com/user-attachments/assets/3ae3eb25-bf43-4a45-ac1b-eef45ad82b8c"> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/49ebdfee-8f3a-4cea-a26d-9ebe4afb14a2"> |
