### PR TITLE
Prefer map::contains in codebase (C++20)

### DIFF
--- a/src/adjustaccidxfunctor.cpp
+++ b/src/adjustaccidxfunctor.cpp
@@ -59,7 +59,7 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
     // Align the octaves
     for (Accid *accid : accids) {
         // Skip any accid that was already adjusted
-        if (m_adjustedAccids.count(accid) > 0) continue;
+        if (m_adjustedAccids.contains(accid)) continue;
         // Skip accid not descendant of a note (e.g., mensural)
         if (!accid->GetFirstAncestor(NOTE)) continue;
 
@@ -102,7 +102,7 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
     // Zig-zag processing
     for (int i = 0, j = count - 1; i < middle; ++i, --j) {
         // top one - but skip if already adjusted (i.e. octaves)
-        if (m_adjustedAccids.count(accids.at(i)) == 0) {
+        if (!m_adjustedAccids.contains(accids.at(i))) {
             this->AdjustAccidWithSpace(accids.at(i), alignmentReference, staffSize);
         }
 
@@ -110,7 +110,7 @@ FunctorCode AdjustAccidXFunctor::VisitAlignmentReference(AlignmentReference *ali
         if (i == j) break;
 
         // bottom one - but skip if already adjusted
-        if (m_adjustedAccids.count(accids.at(j)) == 0) {
+        if (!m_adjustedAccids.contains(accids.at(j))) {
             this->AdjustAccidWithSpace(accids.at(j), alignmentReference, staffSize);
         }
     }

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -45,7 +45,7 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitLayerElement(LayerElement *layerE
     if (pitchInterface) {
         pitchInterface->SetOctDefault(m_octDefault);
         // Check if there is a octave default for the staff - ignore cross-staff for this and use staffY
-        if (m_octDefaultForStaffN.count(staffY->GetN()) > 0) {
+        if (m_octDefaultForStaffN.contains(staffY->GetN())) {
             pitchInterface->SetOctDefault(m_octDefaultForStaffN.at(staffY->GetN()));
         }
     }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -225,7 +225,7 @@ bool ExpansionMap::AddExpandedIDToExpansionMap(const std::string &origXmlId, std
 
 std::vector<std::string> ExpansionMap::GetExpansionIDsForElement(const std::string &xmlId)
 {
-    if (m_map.count(xmlId)) {
+    if (m_map.contains(xmlId)) {
         return m_map.at(xmlId);
     }
     else {

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -675,7 +675,7 @@ void Alignment::GetLeftRight(int staffN, int &minLeft, int &maxRight, const std:
 
 GraceAligner *Alignment::GetGraceAligner(int id)
 {
-    if (m_graceAligners.count(id) == 0) {
+    if (!m_graceAligners.contains(id)) {
         m_graceAligners[id] = new GraceAligner();
     }
     return m_graceAligners[id];

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -325,7 +325,7 @@ int ABCInput::ParseTuplet(const std::string &musicCode, int index)
     // List of tuplets with default base of 3
     const std::unordered_set<int> threeBase = { 2, 4, 8, 9 };
     if (!tupletNumbase) {
-        tupletNumbase = threeBase.count(tupletNum) ? 3 : 2;
+        tupletNumbase = threeBase.contains(tupletNum) ? 3 : 2;
     }
     // Get number of elements supposed to be in the tuplet _:_:9
     // Ignore this for the time being

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1270,7 +1270,7 @@ bool MEIOutput::ProcessScoreBasedFilterEnd(Object *object)
 void MEIOutput::PruneAttributes(pugi::xml_node node)
 {
     if (node.text()) return;
-    if (!MEIBasic::map.count(node.name())) {
+    if (!MEIBasic::map.contains(node.name())) {
         LogWarning("Element '%s' is not supported but will be preserved", node.name());
         return;
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -422,7 +422,7 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
     assert(element);
 
     int currTime = 0;
-    if (m_layerEndTimes.count(layer) > 0) currTime = m_layerEndTimes.at(layer);
+    if (m_layerEndTimes.contains(layer)) currTime = m_layerEndTimes.at(layer);
     if ((layer->GetChildren().size() == 0 && m_durTotal > 0) || currTime < m_durTotal) {
         FillSpace(layer, m_durTotal - currTime);
     }

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -4572,14 +4572,14 @@ bool PAEInput::ConvertAccidGes()
             std::string noteID = note->GetID();
             if (!accid) {
                 // Tied note with a previous note with an accidental
-                if (ties.count(noteID)) {
+                if (ties.contains(noteID)) {
                     Accid *tieAccid = new Accid();
                     note->AddChild(tieAccid);
                     tieAccid->SetAccidGes(Att::AccidentalWrittenToGestural(ties[noteID]));
                     ties.erase(noteID);
                 }
                 // Nothing in front of the note, but something in the list - make it an accid.ges
-                else if ((currentAccids.count(octavedPitch) != 0)) {
+                else if (currentAccids.contains(octavedPitch)) {
                     Accid *gesAccid = new Accid();
                     note->AddChild(gesAccid);
                     data_ACCIDENTAL_WRITTEN accidWritten = currentAccids.at(octavedPitch);
@@ -4590,7 +4590,7 @@ bool PAEInput::ConvertAccidGes()
                 data_ACCIDENTAL_WRITTEN noteAccid = accid->GetAccid();
                 // Natural in front of the note, remove it from the current list
                 if (noteAccid == ACCIDENTAL_WRITTEN_n) {
-                    if (currentAccids.count(octavedPitch) != 0) {
+                    if (currentAccids.contains(octavedPitch)) {
                         currentAccids[octavedPitch] = ACCIDENTAL_WRITTEN_n;
                     }
                 }

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -132,7 +132,7 @@ NeumeGroup Neume::GetNeumeGroup() const
         previous = current;
     }
 
-    if (s_neumes.count(key) > 0) {
+    if (s_neumes.contains(key)) {
         return s_neumes.at(key);
     }
     else {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1612,7 +1612,7 @@ ClassId ObjectFactory::GetClassId(std::string name)
 void ObjectFactory::GetClassIds(const std::vector<std::string> &classStrings, std::vector<ClassId> &classIds)
 {
     for (const std::string &str : classStrings) {
-        if (s_classIdsRegistry.count(str) > 0) {
+        if (s_classIdsRegistry.contains(str)) {
             classIds.push_back(s_classIdsRegistry.at(str));
         }
         else {

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -461,7 +461,7 @@ void PrepareLinkingFunctor::ResolveStemSameas(Note *note)
     // Second pass we resolve links
     else {
         const std::string id = note->GetID();
-        if (m_stemSameasIDPairs.count(id)) {
+        if (m_stemSameasIDPairs.contains(id)) {
             Note *noteStemSameas = m_stemSameasIDPairs.at(id);
             // Instanciate the bi-directional references and mark the roles as unset
             note->SetStemSameasNote(noteStemSameas);
@@ -542,7 +542,7 @@ FunctorCode PrepareDurationFunctor::VisitLayerElement(LayerElement *layerElement
         // Check if there is a duration default for the staff
         if (!m_durDefaultForStaffN.empty()) {
             Staff *staff = layerElement->GetAncestorStaff(RESOLVE_CROSS_STAFF);
-            if (m_durDefaultForStaffN.count(staff->GetN()) > 0) {
+            if (m_durDefaultForStaffN.contains(staff->GetN())) {
                 durInterface->SetDurDefault(m_durDefaultForStaffN.at(staff->GetN()));
             }
         }
@@ -1435,7 +1435,7 @@ FunctorCode PrepareDelayedTurnsFunctor::VisitLayerElement(LayerElement *layerEle
         this->ResetCurrent();
     }
 
-    if (m_delayedTurns.count(layerElement)) {
+    if (m_delayedTurns.contains(layerElement)) {
         m_previousElement = layerElement;
         m_currentTurn = m_delayedTurns.at(layerElement);
         if (layerElement->Is(CHORD)) {

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -260,7 +260,7 @@ void Resources::SelectTextFont(data_FONTWEIGHT fontWeight, data_FONTSTYLE fontSt
     }
 
     m_currentStyle = { fontWeight, fontStyle };
-    if (m_textFont.count(m_currentStyle) == 0) {
+    if (!m_textFont.contains(m_currentStyle)) {
         LogWarning("Text font for style (%d, %d) is not loaded. Use default", fontWeight, fontStyle);
         m_currentStyle = k_defaultStyle;
     }
@@ -268,11 +268,11 @@ void Resources::SelectTextFont(data_FONTWEIGHT fontWeight, data_FONTSTYLE fontSt
 
 const Glyph *Resources::GetTextGlyph(char32_t code) const
 {
-    const StyleAttributes style = (m_textFont.count(m_currentStyle) != 0) ? m_currentStyle : k_defaultStyle;
-    if (m_textFont.count(style) == 0) return NULL;
+    const StyleAttributes style = m_textFont.contains(m_currentStyle) ? m_currentStyle : k_defaultStyle;
+    if (!m_textFont.contains(style)) return NULL;
 
     const GlyphTable &currentTable = m_textFont.at(style);
-    if (currentTable.count(code) == 0) {
+    if (!currentTable.contains(code)) {
         return NULL;
     }
 
@@ -414,7 +414,7 @@ bool Resources::InitTextFont(const std::string &fontName, const StyleAttributes 
     }
     const int unitsPerEm = root.attribute("units-per-em").as_int();
     pugi::xml_node current;
-    if (m_textFont.count(style) == 0) {
+    if (!m_textFont.contains(style)) {
         m_textFont[style] = {};
     }
     GlyphTable &currentTable = m_textFont.at(style);
@@ -433,7 +433,7 @@ bool Resources::InitTextFont(const std::string &fontName, const StyleAttributes 
             glyph.SetBoundingBox(x, y, width, height);
 
             if (current.attribute("h-a-x")) glyph.SetHorizAdvX(current.attribute("h-a-x").as_float());
-            if (currentTable.count(code) > 0) {
+            if (currentTable.contains(code)) {
                 LogDebug("Redefining %d with %s", code, fontName.c_str());
             }
             currentTable[code] = glyph;

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -380,9 +380,9 @@ void Slur::AddSpannedElements(
                                  TimeSpanningInterface *interface = positioner->GetObject()->GetTimeSpanningInterface();
                                  assert(interface);
                                  const bool startsInCollisionLayer
-                                     = (spanned.layersN.count(interface->GetStart()->GetOriginalLayerN()) > 0);
+                                     = spanned.layersN.contains(interface->GetStart()->GetOriginalLayerN());
                                  const bool endsInCollisionLayer
-                                     = (spanned.layersN.count(interface->GetEnd()->GetOriginalLayerN()) > 0);
+                                     = spanned.layersN.contains(interface->GetEnd()->GetOriginalLayerN());
                                  return (!startsInCollisionLayer && !endsInCollisionLayer);
                              }),
         tiePositioners.end());

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -109,7 +109,7 @@ FunctorCode TransposeFunctor::VisitNote(Note *note)
     m_transposer->Transpose(pitch);
 
     const int staffN = note->GetAncestorStaff(RESOLVE_CROSS_STAFF)->GetN();
-    const bool hasKeySig = ((m_keySigForStaffN.count(staffN) > 0) || (m_keySigForStaffN.count(-1) > 0));
+    const bool hasKeySig = m_keySigForStaffN.contains(staffN) || m_keySigForStaffN.contains(-1);
     note->UpdateFromTransPitch(pitch, hasKeySig);
 
     return FUNCTOR_SIBLINGS;
@@ -329,7 +329,7 @@ FunctorCode TransposeToSoundingPitchFunctor::VisitScoreDef(ScoreDef *scoreDef)
 
 FunctorCode TransposeToSoundingPitchFunctor::VisitScoreDefEnd(ScoreDef *scoreDef)
 {
-    const bool hasScoreDefKeySig = (m_keySigForStaffN.count(-1) > 0);
+    const bool hasScoreDefKeySig = m_keySigForStaffN.contains(-1);
     if (hasScoreDefKeySig) {
         bool showWarning = false;
         // Check if some staves are untransposed
@@ -389,7 +389,7 @@ FunctorCode TransposeToSoundingPitchFunctor::VisitStaffDef(StaffDef *staffDef)
 void TransposeToSoundingPitchFunctor::UpdateTranspositionFromStaffN(const AttNInteger *staffN)
 {
     int transposeInterval = 0;
-    if (staffN->HasN() && (m_transposeIntervalForStaffN.count(staffN->GetN()) > 0)) {
+    if (staffN->HasN() && m_transposeIntervalForStaffN.contains(staffN->GetN())) {
         transposeInterval = m_transposeIntervalForStaffN.at(staffN->GetN());
     }
     m_transposer->SetTransposition(transposeInterval);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -665,7 +665,7 @@ bool StaffAlignment::IsInBracketGroup(bool isFirst) const
             });
 
             const int currentN = this->m_staff->GetN();
-            if (staffNs.count(currentN)) {
+            if (staffNs.contains(currentN)) {
                 if ((isFirst && (*staffNs.begin() == currentN)) || (!isFirst && (*staffNs.rbegin() == currentN)))
                     return true;
             }


### PR DESCRIPTION
This PR replaces occurrences of `std::map::count` by `std::map::contains` in order to check the existence of an element. 