### PR TITLE
Fix interaction between dynam and cross-staff accent

### DIFF
--- a/include/vrv/calcarticfunctor.h
+++ b/include/vrv/calcarticfunctor.h
@@ -48,6 +48,8 @@ protected:
 private:
     // Calculate shift for the articulation based on its type and presence of other articulations
     int CalculateHorizontalShift(const Artic *artic, bool virtualStem) const;
+    // Include the parent beam staff in the calculation of the above and below staff
+    void IncludeBeamStaff(LayerElement *layerElement);
 
 public:
     //

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -152,8 +152,8 @@ public:
      * Calculate the staff where the slur's floating curve positioner lives
      */
     ///@{
-    Staff *CalculateExtremalStaff(const Staff *staff, int xMin, int xMax);
-    const Staff *CalculateExtremalStaff(const Staff *staff, int xMin, int xMax) const;
+    Staff *CalculatePrincipalStaff(const Staff *staff, int xMin, int xMax);
+    const Staff *CalculatePrincipalStaff(const Staff *staff, int xMin, int xMax) const;
     ///@}
 
     /**

--- a/src/adjustarticfunctor.cpp
+++ b/src/adjustarticfunctor.cpp
@@ -34,11 +34,11 @@ FunctorCode AdjustArticFunctor::VisitArtic(Artic *artic)
     int yIn, yOut, yRel;
 
     Staff *staff = artic->GetAncestorStaff(RESOLVE_CROSS_STAFF);
-    Beam *beam = vrv_cast<Beam *>(artic->GetFirstAncestor(BEAM));
+    const Beam *beam = artic->GetAncestorBeam();
     const int staffHeight = m_doc->GetDrawingDoubleUnit(staff->m_drawingStaffSize) * (staff->m_drawingLines - 1);
 
-    Stem *stem = vrv_cast<Stem *>(m_parent->FindDescendantByType(STEM));
-    Flag *flag = vrv_cast<Flag *>(m_parent->FindDescendantByType(FLAG));
+    const Stem *stem = vrv_cast<const Stem *>(m_parent->FindDescendantByType(STEM));
+    const Flag *flag = vrv_cast<const Flag *>(m_parent->FindDescendantByType(FLAG));
     // Avoid artic to be in ledger lines
     if (artic->GetDrawingPlace() == STAFFREL_above) {
         int yAboveStem = m_parent->GetDrawingTop(m_doc, staff->m_drawingStaffSize, false) - staff->GetDrawingY();

--- a/src/calcarticfunctor.cpp
+++ b/src/calcarticfunctor.cpp
@@ -134,6 +134,8 @@ FunctorCode CalcArticFunctor::VisitChord(Chord *chord)
         }
     }
 
+    this->IncludeBeamStaff(chord);
+
     return FUNCTOR_CONTINUE;
 }
 
@@ -164,6 +166,8 @@ FunctorCode CalcArticFunctor::VisitNote(Note *note)
         m_crossStaffBelow = true;
     }
 
+    this->IncludeBeamStaff(note);
+
     return FUNCTOR_CONTINUE;
 }
 
@@ -192,6 +196,18 @@ int CalcArticFunctor::CalculateHorizontalShift(const Artic *artic, bool virtualS
     }
 
     return shift;
+}
+
+void CalcArticFunctor::IncludeBeamStaff(LayerElement *layerElement)
+{
+    if (Beam *beam = layerElement->GetAncestorBeam(); beam) {
+        if (m_crossStaffAbove && (beam->m_drawingPlace == BEAMPLACE_above)) {
+            m_staffAbove = beam->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+        }
+        else if (m_crossStaffBelow && (beam->m_drawingPlace == BEAMPLACE_below)) {
+            m_staffBelow = beam->GetAncestorStaff(RESOLVE_CROSS_STAFF);
+        }
+    }
 }
 
 } // namespace vrv

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -487,27 +487,32 @@ void Slur::AddPositionerToArticulations(FloatingCurvePositioner *curve)
     }
 }
 
-Staff *Slur::CalculateExtremalStaff(const Staff *staff, int xMin, int xMax)
+Staff *Slur::CalculatePrincipalStaff(const Staff *staff, int xMin, int xMax)
 {
-    return const_cast<Staff *>(std::as_const(*this).CalculateExtremalStaff(staff, xMin, xMax));
+    return const_cast<Staff *>(std::as_const(*this).CalculatePrincipalStaff(staff, xMin, xMax));
 }
 
-const Staff *Slur::CalculateExtremalStaff(const Staff *staff, int xMin, int xMax) const
+const Staff *Slur::CalculatePrincipalStaff(const Staff *staff, int xMin, int xMax) const
 {
-    const Staff *extremalStaff = staff;
+    assert(staff);
+
+    const Staff *principalStaff = NULL;
 
     const SlurCurveDirection curveDir = this->GetDrawingCurveDir();
     const SpannedElements spanned = this->CollectSpannedElements(staff, xMin, xMax);
+    if (spanned.elements.empty()) {
+        return staff;
+    }
 
     // The floating curve positioner of cross staff slurs should live in the lower/upper staff alignment
     // corresponding to whether the slur is curved below or not
-    auto adaptStaff = [&extremalStaff, curveDir](const LayerElement *element) {
+    auto adaptStaff = [&principalStaff, curveDir](const LayerElement *element) {
         const Staff *elementStaff = element->GetAncestorStaff(RESOLVE_CROSS_STAFF);
-        const bool updateExtremal = (curveDir == SlurCurveDirection::Below)
-            ? (elementStaff->GetN() > extremalStaff->GetN())
-            : (elementStaff->GetN() < extremalStaff->GetN());
-        if (updateExtremal) {
-            extremalStaff = elementStaff;
+        const bool updatePrincipal = !principalStaff
+            || ((curveDir == SlurCurveDirection::Below) ? (elementStaff->GetN() > principalStaff->GetN())
+                                                        : (elementStaff->GetN() < principalStaff->GetN()));
+        if (updatePrincipal) {
+            principalStaff = elementStaff;
         }
     };
 
@@ -521,7 +526,8 @@ const Staff *Slur::CalculateExtremalStaff(const Staff *staff, int xMin, int xMax
         }
     });
 
-    return extremalStaff;
+    assert(principalStaff);
+    return principalStaff;
 }
 
 bool Slur::IsElementBelow(const LayerElement *element, const Staff *startStaff, const Staff *endStaff) const

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -311,7 +311,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
                 if (this->GetSlurHandling() == SlurHandling::Ignore) break;
                 Slur *slur = vrv_cast<Slur *>(element);
                 assert(slur);
-                staff = slur->CalculateExtremalStaff(staff, x1, x2);
+                staff = slur->CalculatePrincipalStaff(staff, x1, x2);
             }
 
             // Create the floating positioner

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -305,7 +305,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     bool isFirst = true;
     for (Staff *staff : staffList) {
 
-        // TimeSpanning element are not necessary floating elements (e.g., syl) - we have a bounding box only for them
+        // TimeSpanning elements are not necessary floating elements (e.g., syl) - we have a bounding box only for them
         if (element->IsControlElement()) {
             if (element->Is({ PHRASE, SLUR })) {
                 if (this->GetSlurHandling() == SlurHandling::Ignore) break;


### PR DESCRIPTION
This PR improves the example given in #3764 . With the `--justify-vertically` option, the difference is:

| Before | After |
| ------ | ----- |
| <img width="500" alt="Before" src="https://github.com/user-attachments/assets/2a842756-bc13-448d-9a4b-26f8c0b167b0"> | <img width="500" alt="After" src="https://github.com/user-attachments/assets/0a0b11d3-79a9-4424-a547-9a46aab434c6"> |

There are two improvements in this PR:
- If all the spanning elements of a slur are encoded cross staff, then the slur is also attached to this cross staff. Thus the slurs over the first beam are not flying in the air, if vertical justification is enabled.
- The cross staff handling of articulations now includes parent beams. Thus the articulations over the second beam are now properly placed.

There is another issue which should be fixed separately: Slurs attached to notes with articulations always start above/below the articulation even if it is positioned outside the staff and therefore quite far away from the notehead. I will open a separate issue for this.

Closes #3764 .