### PR TITLE
Use bracketSpanLog_FUNC type for bracketSpan@func

### DIFF
--- a/libmei/datatypes.yml
+++ b/libmei/datatypes.yml
@@ -187,6 +187,11 @@ defaults:
         data_STAFFREL()
 
 modules:
+    cmn:
+        att.bracketSpan.log:
+            func:
+                type: bracketSpanLog_FUNC
+
     externalsymbols:
         att.extsym:
             glyphnum:

--- a/libmei/dist/attmodule.cpp
+++ b/libmei/dist/attmodule.cpp
@@ -304,7 +304,7 @@ bool AttModule::SetCmn(Object *element, const std::string &attrType, const std::
         AttBracketSpanLog *att = dynamic_cast<AttBracketSpanLog *>(element);
         assert(att);
         if (attrType == "func") {
-            att->SetFunc(att->StrToStr(attrValue));
+            att->SetFunc(att->StrToBracketSpanLogFunc(attrValue));
             return true;
         }
     }
@@ -599,7 +599,7 @@ void AttModule::GetCmn(const Object *element, ArrayOfStrAttr *attributes)
         const AttBracketSpanLog *att = dynamic_cast<const AttBracketSpanLog *>(element);
         assert(att);
         if (att->HasFunc()) {
-            attributes->push_back({ "func", att->StrToStr(att->GetFunc()) });
+            attributes->push_back({ "func", att->BracketSpanLogFuncToStr(att->GetFunc()) });
         }
     }
     if (element->HasAttClass(ATT_CUTOUT)) {

--- a/libmei/dist/atts_cmn.cpp
+++ b/libmei/dist/atts_cmn.cpp
@@ -373,14 +373,14 @@ AttBracketSpanLog::AttBracketSpanLog() : Att()
 
 void AttBracketSpanLog::ResetBracketSpanLog()
 {
-    m_func = "";
+    m_func = bracketSpanLog_FUNC_NONE;
 }
 
 bool AttBracketSpanLog::ReadBracketSpanLog(pugi::xml_node element, bool removeAttr)
 {
     bool hasAttribute = false;
     if (element.attribute("func")) {
-        this->SetFunc(StrToStr(element.attribute("func").value()));
+        this->SetFunc(StrToBracketSpanLogFunc(element.attribute("func").value()));
         if (removeAttr) element.remove_attribute("func");
         hasAttribute = true;
     }
@@ -391,7 +391,7 @@ bool AttBracketSpanLog::WriteBracketSpanLog(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasFunc()) {
-        element.append_attribute("func") = StrToStr(this->GetFunc()).c_str();
+        element.append_attribute("func") = BracketSpanLogFuncToStr(this->GetFunc()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -399,7 +399,7 @@ bool AttBracketSpanLog::WriteBracketSpanLog(pugi::xml_node element)
 
 bool AttBracketSpanLog::HasFunc() const
 {
-    return (m_func != "");
+    return (m_func != bracketSpanLog_FUNC_NONE);
 }
 
 //----------------------------------------------------------------------------

--- a/libmei/dist/atts_cmn.h
+++ b/libmei/dist/atts_cmn.h
@@ -435,14 +435,14 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetFunc(std::string func_) { m_func = func_; }
-    std::string GetFunc() const { return m_func; }
+    void SetFunc(bracketSpanLog_FUNC func_) { m_func = func_; }
+    bracketSpanLog_FUNC GetFunc() const { return m_func; }
     bool HasFunc() const;
     ///@}
 
 private:
     /** Describes the function of the bracketed event sequence. **/
-    std::string m_func;
+    bracketSpanLog_FUNC m_func;
 };
 
 //----------------------------------------------------------------------------

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -15755,7 +15755,7 @@ void HumdrumInput::handleLigature(hum::HTp token)
     ligature->SetEndid("#" + endid);
 
     ligature->SetLform(LINEFORM_solid);
-    ligature->SetFunc("ligature");
+    ligature->SetFunc(bracketSpanLog_FUNC_ligature);
 
     addChildMeasureOrSection(ligature);
 }
@@ -15838,7 +15838,7 @@ void HumdrumInput::handleColoration(hum::HTp token)
     // data_LINEWIDTH lw;
     // lw.SetLineWidthTerm(LINEWIDTHTERM_medium);
     // coloration->SetLwidth(lw);
-    coloration->SetFunc("coloration");
+    coloration->SetFunc(bracketSpanLog_FUNC_coloration);
 
     addChildMeasureOrSection(coloration);
 }
@@ -21233,8 +21233,6 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
                 insertPhrase(bracket, phrasestart, phraseend, startmeasure, startchordsorted, endchordsorted,
                     phrasestartnoteinfo, phraseendnoteinfo, ndex, phraseindex, i, j, startpitches, endpitches,
                     indexused);
-                // bracket will not be drawn without the following line:
-                bracket->SetFunc("phrase");
             }
         }
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2009,7 +2009,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             bracketSpan->SetLform(
                 bracketSpan->AttLineRendBase::StrToLineform(bracket.attribute("line-type").as_string()));
             // bracketSpan->SetPlace(bracketSpan->AttPlacementRelStaff::StrToStaffrel(placeStr.c_str()));
-            bracketSpan->SetFunc("unclear");
+            // bracketSpan->SetFunc("unclear");
             bracketSpan->SetLstartsym(ConvertLineEndSymbol(bracket.attribute("line-end").as_string()));
             bracketSpan->SetTstamp(timeStamp);
             m_controlElements.push_back({ measureNum, bracketSpan });
@@ -2434,7 +2434,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             musicxml::OpenSpanner openBracket(voiceNumber, m_measureCounts.at(measure));
             bracketSpan->SetColor(lead.attribute("color").as_string());
             // bracketSpan->SetPlace(bracketSpan->AttPlacementRelStaff::StrToStaffrel(placeStr.c_str()));
-            bracketSpan->SetFunc("analytical");
+            // bracketSpan->SetFunc("analytical");
             bracketSpan->SetLstartsym(ConvertLineEndSymbol(lead.attribute("symbol").as_string()));
             bracketSpan->SetTstamp(timeStamp);
             bracketSpan->SetType("principal-voice");

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -448,11 +448,6 @@ void View::DrawBracketSpan(
     assert(bracketSpan->GetStart());
     assert(bracketSpan->GetEnd());
 
-    if (!bracketSpan->HasFunc()) {
-        // we cannot draw a bracketSpan that has no func
-        return;
-    }
-
     const int y = bracketSpan->GetDrawingY();
 
     if (graphic) {


### PR DESCRIPTION
Drop two string values added by MusicXML importer In order to use typed bracketSpanLog_FUNC.

If these values are really relevant, they should be added to the `@func` data type
