### PR TITLE
Improve performance by optimizing glyph lookup

### DIFF
--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -65,7 +65,7 @@ public:
     /** Load all music fonts available in the resource directory */
     bool LoadAll();
     /** Set the fallback font (Leipzig or Bravura) when some glyphs are missing in the current font */
-    bool SetFallback(const std::string &fontName);
+    void SetFallbackFont(const std::string &fontName);
     /** Get the fallback font name */
     std::string GetFallbackFont() const { return m_defaultFontName; }
     /** Init the text font (bounding boxes and ASCII only) */

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -177,6 +177,9 @@ private:
      */
     GlyphNameTable m_glyphNameTable;
 
+    /** Cache of the last glyph that was looked up in loaded fonts */
+    mutable std::optional<std::pair<char32_t, const Glyph *>> m_cachedGlyph;
+
     //----------------//
     // Static members //
     //----------------//

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -68,8 +68,6 @@ public:
     void SetFallbackFont(const std::string &fontName);
     /** Get the fallback font name */
     std::string GetFallbackFont() const { return m_defaultFontName; }
-    /** Init the text font (bounding boxes and ASCII only) */
-    bool InitTextFont(const std::string &fontName, const StyleAttributes &style);
 
     /** Select a particular font */
     bool SetCurrentFont(const std::string &fontName, bool allowLoading = false);
@@ -159,6 +157,9 @@ private:
     //----------------------------------------------------------------------------
 
     bool LoadFont(const std::string &fontName, ZipFileReader *zipFile = NULL);
+
+    /** Init the text font (bounding boxes and ASCII only) */
+    bool InitTextFont(const std::string &fontName, const StyleAttributes &style);
 
     const GlyphTable &GetCurrentGlyphTable() const { return m_loadedFonts.at(m_currentFontName).GetGlyphTable(); };
     const GlyphTable &GetFallbackGlyphTable() const { return m_loadedFonts.at(m_fallbackFontName).GetGlyphTable(); };

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -67,7 +67,7 @@ public:
     /** Set the fallback font (Leipzig or Bravura) when some glyphs are missing in the current font */
     void SetFallbackFont(const std::string &fontName);
     /** Get the fallback font name */
-    std::string GetFallbackFont() const { return m_defaultFontName; }
+    std::string GetFallbackFont() const { return m_fallbackFontName; }
 
     /** Select a particular font */
     bool SetCurrentFont(const std::string &fontName, bool allowLoading = false);

--- a/include/vrv/resources.h
+++ b/include/vrv/resources.h
@@ -8,6 +8,7 @@
 #ifndef __VRV_RESOURCES_H__
 #define __VRV_RESOURCES_H__
 
+#include <optional>
 #include <unordered_map>
 
 //----------------------------------------------------------------------------

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -149,11 +149,10 @@ bool Resources::LoadAll()
     return success;
 }
 
-bool Resources::SetFallback(const std::string &fontName)
+void Resources::SetFallbackFont(const std::string &fontName)
 {
     m_cachedGlyph.reset();
     m_fallbackFontName = fontName;
-    return true;
 }
 
 bool Resources::SetCurrentFont(const std::string &fontName, bool allowLoading)

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -192,7 +192,10 @@ const Glyph *Resources::GetGlyph(const std::string &smuflName) const
 
 char32_t Resources::GetGlyphCode(const std::string &smuflName) const
 {
-    return m_glyphNameTable.contains(smuflName) ? m_glyphNameTable.at(smuflName) : 0;
+    if (auto glyphNameIter = m_glyphNameTable.find(smuflName); glyphNameIter != m_glyphNameTable.end()) {
+        return glyphNameIter->second;
+    }
+    return 0;
 }
 
 bool Resources::IsSmuflFallbackNeeded(const std::u32string &text) const

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -167,9 +167,8 @@ bool Resources::SetCurrentFont(const std::string &fontName, bool allowLoading)
         m_currentFontName = fontName;
         return true;
     }
-    else {
-        return false;
-    }
+    
+    return false;
 }
 
 const Glyph *Resources::GetGlyph(char32_t smuflCode) const
@@ -234,12 +233,7 @@ bool Resources::FontHasGlyphAvailable(const std::string &fontName, char32_t smuf
     }
 
     const GlyphTable &table = m_loadedFonts.at(fontName).GetGlyphTable();
-    if (table.find(smuflCode) != table.end()) {
-        return true;
-    }
-    else {
-        return false;
-    }
+    return (table.find(smuflCode) != table.end());
 }
 
 std::string Resources::GetCSSFontFor(const std::string &fontName) const

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -135,18 +135,18 @@ bool Resources::AddCustom(const std::vector<std::string> &extraFonts)
 
 bool Resources::LoadAll()
 {
-    bool success = true;
     std::string path = Resources::GetPath() + "/";
-    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(path)) {
-        const std::filesystem::path path = entry.path();
-        if (path.has_extension() && path.has_stem() && path.extension() == ".xml") {
-            const std::string fontName = path.stem().string();
-            if (!IsFontLoaded(fontName)) {
-                success = success && LoadFont(fontName);
+    return std::ranges::all_of(
+        std::filesystem::directory_iterator(path), [this](const std::filesystem::directory_entry &entry) {
+            const std::filesystem::path &path = entry.path();
+            if (path.has_extension() && path.has_stem() && path.extension() == ".xml") {
+                const std::string fontName = path.stem().string();
+                if (!this->IsFontLoaded(fontName) && !this->LoadFont(fontName)) {
+                    return false;
+                }
             }
-        }
-    }
-    return success;
+            return true;
+        });
 }
 
 void Resources::SetFallbackFont(const std::string &fontName)
@@ -167,7 +167,7 @@ bool Resources::SetCurrentFont(const std::string &fontName, bool allowLoading)
         m_currentFontName = fontName;
         return true;
     }
-    
+
     return false;
 }
 

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -184,7 +184,10 @@ const Glyph *Resources::GetGlyph(char32_t smuflCode) const
 
 const Glyph *Resources::GetGlyph(const std::string &smuflName) const
 {
-    return (this->GetGlyphCode(smuflName)) ? &GetCurrentGlyphTable().at(this->GetGlyphCode(smuflName)) : NULL;
+    if (const char32_t code = this->GetGlyphCode(smuflName); code) {
+        return this->GetGlyph(code);
+    }
+    return NULL;
 }
 
 char32_t Resources::GetGlyphCode(const std::string &smuflName) const

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -169,16 +169,17 @@ bool Resources::SetCurrentFont(const std::string &fontName, bool allowLoading)
 
 const Glyph *Resources::GetGlyph(char32_t smuflCode) const
 {
-    if (GetCurrentGlyphTable().contains(smuflCode)) {
-        return &GetCurrentGlyphTable().at(smuflCode);
+    const GlyphTable &currentTable = this->GetCurrentGlyphTable();
+    if (auto glyphIter = currentTable.find(smuflCode); glyphIter != currentTable.end()) {
+        return &glyphIter->second;
     }
     else if (!this->IsCurrentFontFallback()) {
         const GlyphTable &fallbackTable = this->GetFallbackGlyphTable();
-        return (fallbackTable.contains(smuflCode)) ? &fallbackTable.at(smuflCode) : NULL;
+        if (auto glyphIter = fallbackTable.find(smuflCode); glyphIter != fallbackTable.end()) {
+            return &glyphIter->second;
+        }
     }
-    else {
-        return NULL;
-    }
+    return NULL;
 }
 
 const Glyph *Resources::GetGlyph(const std::string &smuflName) const

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -98,7 +98,7 @@ bool Resources::SetFont(const std::string &fontName)
 {
     m_cachedGlyph.reset();
 
-    // and the default font provided in options, if it is not one of the previous
+    // add the default font provided in options, if it is not one of the previous
     if (!fontName.empty() && !IsFontLoaded(fontName)) {
         if (!LoadFont(fontName)) {
             LogError("%s font could not be loaded.", fontName.c_str());

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -127,7 +127,7 @@ bool Toolkit::SetResourcePath(const std::string &path)
         success = success && this->SetFont(m_options->m_font.GetValue());
     }
     if (m_options->m_fontFallback.IsSet()) {
-        success = success && resources.SetFallback(m_options->m_fontFallback.GetStrValue());
+        resources.SetFallbackFont(m_options->m_fontFallback.GetStrValue());
     }
     if (m_options->m_fontLoadAll.IsSet()) {
         success = success && resources.LoadAll();
@@ -1224,7 +1224,7 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
     }
     if (json.has<jsonxx::String>("fontFallback")) {
         Resources &resources = m_doc.GetResourcesForModification();
-        resources.SetFallback(m_options->m_fontFallback.GetStrValue());
+        resources.SetFallbackFont(m_options->m_fontFallback.GetStrValue());
     }
     if (json.has<jsonxx::Boolean>("fontLoadAll")) {
         Resources &resources = m_doc.GetResourcesForModification();


### PR DESCRIPTION
This PR improves the total runtime by optimizing the glyph lookup in resources. Some runtime data with a few pieces of different size:

| Number of pages | Runtime before in s | Runtime after in s | Improvement in % |
| ----- | ----- | ----- | ----- |
| 3 | 0.306 | 0.260 | 15 |
| 10 | 1.732 | 1.525 | 12 |
| 97 | 4.339 | 3.963 | 9 |

Note that after adding the possibility to use several fonts simultaneously, glyph lookup now involves two maps: one for loaded fonts and one for the glyph itself. Changes in this PR:
- We optimize the number of map lookups, mostly by replacing `map::contains` followed by `map::at` with a single `map::find`.
- We cache the glyph that was looked up last. This is helpful, since often the same glyph is requested several times consecutively, e.g. from calls of `GetGlyphWidth` and `GetGlyphHeight`.
- There are a few other (minor) code improvements in `Resources`.