### PR TITLE
Improvement to the facsimile support and ledger line connection to notes

### DIFF
--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -272,6 +272,11 @@ public:
     virtual void SetCustomGraphicColor(const std::string &color) {}
 
     /**
+     * Method for adding custom graphic data-* attributes
+     */
+    virtual void SetCustomGraphicAttributes(const std::string &data, const std::string &value) {}
+
+    /**
      * @name Methods for re-starting and ending a graphic for objects drawn in separate steps
      * The methods can be used to the output together, for example for a Beam
      */

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -47,6 +47,25 @@ public:
     const Zone *FindZoneByID(const std::string &zoneId) const;
     int GetMaxX() const;
     int GetMaxY() const;
+
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
+protected:
+    //
+private:
+    //
 };
 
 } // namespace vrv

--- a/include/vrv/facsimilefunctor.h
+++ b/include/vrv/facsimilefunctor.h
@@ -133,6 +133,8 @@ private:
     //
     int m_pageMarginTop;
     int m_pageMarginLeft;
+    // A flag indicating we are dealing with a neume line
+    bool m_currentNeumeLine;
 };
 
 } // namespace vrv

--- a/include/vrv/facsimilefunctor.h
+++ b/include/vrv/facsimilefunctor.h
@@ -75,6 +75,11 @@ private:
     Measure *m_currentNeumeLine;
     /** map to store the zone corresponding to a staff */
     std::map<Staff *, Zone *> m_staffZones;
+    //
+    int m_pageMarginTop;
+    int m_pageMarginLeft;
+    //
+    double m_ppuFactor;
 };
 
 //----------------------------------------------------------------------------
@@ -90,14 +95,14 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    SyncToFacsimileFunctor(Doc *doc);
+    SyncToFacsimileFunctor(Doc *doc, double ppuFactor);
     virtual ~SyncToFacsimileFunctor() = default;
     ///@}
 
     /*
      * Abstract base implementation
      */
-    bool ImplementsEndInterface() const override { return false; }
+    bool ImplementsEndInterface() const override { return true; }
 
     /*
      * Functor interface
@@ -106,6 +111,7 @@ public:
     FunctorCode VisitLayerElement(LayerElement *layerElement) override;
     FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitPage(Page *page) override;
+    FunctorCode VisitPageEnd(Page *page) override;
     FunctorCode VisitPb(Pb *pb) override;
     FunctorCode VisitSb(Sb *sb) override;
     FunctorCode VisitStaff(Staff *staff) override;
@@ -135,6 +141,8 @@ private:
     int m_pageMarginLeft;
     // A flag indicating we are dealing with a neume line
     bool m_currentNeumeLine;
+    //
+    double m_ppuFactor;
 };
 
 } // namespace vrv

--- a/include/vrv/functorinterface.h
+++ b/include/vrv/functorinterface.h
@@ -41,6 +41,7 @@ class EditorialElement;
 class Ending;
 class Expansion;
 class F;
+class Facsimile;
 class Fb;
 class Fermata;
 class Fing;
@@ -52,6 +53,7 @@ class GenericLayerElement;
 class Gliss;
 class GraceAligner;
 class GraceGrp;
+class Graphic;
 class GrpSym;
 class Hairpin;
 class HalfmRpt;
@@ -118,6 +120,7 @@ class StaffAlignment;
 class StaffDef;
 class StaffGrp;
 class Stem;
+class Surface;
 class Svg;
 class Syl;
 class Syllable;
@@ -142,6 +145,7 @@ class TupletBracket;
 class TupletNum;
 class Turn;
 class Verse;
+class Zone;
 
 //----------------------------------------------------------------------------
 // FunctorInterface
@@ -456,6 +460,20 @@ public:
     virtual FunctorCode VisitTextEnd(Text *text);
     virtual FunctorCode VisitTextElement(TextElement *textElement);
     virtual FunctorCode VisitTextElementEnd(TextElement *textElement);
+    ///@}
+
+    /**
+     * @name Visit facsimle elements
+     */
+    ///@{
+    virtual FunctorCode VisitFacsimile(Facsimile *facsimile);
+    virtual FunctorCode VisitFacsimileEnd(Facsimile *facsimile);
+    virtual FunctorCode VisitGraphic(Graphic *graphic);
+    virtual FunctorCode VisitGraphicEnd(Graphic *graphic);
+    virtual FunctorCode VisitSurface(Surface *surface);
+    virtual FunctorCode VisitSurfaceEnd(Surface *surface);
+    virtual FunctorCode VisitZone(Zone *zone);
+    virtual FunctorCode VisitZoneEnd(Zone *zone);
     ///@}
 
     /**
@@ -815,6 +833,20 @@ public:
     virtual FunctorCode VisitTextEnd(const Text *text);
     virtual FunctorCode VisitTextElement(const TextElement *textElement);
     virtual FunctorCode VisitTextElementEnd(const TextElement *textElement);
+    ///@}
+
+    /**
+     * @name Visit facsimle elements
+     */
+    ///@{
+    virtual FunctorCode VisitFacsimile(const Facsimile *facsimile);
+    virtual FunctorCode VisitFacsimileEnd(const Facsimile *facsimile);
+    virtual FunctorCode VisitGraphic(const Graphic *graphic);
+    virtual FunctorCode VisitGraphicEnd(const Graphic *graphic);
+    virtual FunctorCode VisitSurface(const Surface *surface);
+    virtual FunctorCode VisitSurfaceEnd(const Surface *surface);
+    virtual FunctorCode VisitZone(const Zone *zone);
+    virtual FunctorCode VisitZoneEnd(const Zone *zone);
     ///@}
 
     /**

--- a/include/vrv/graphic.h
+++ b/include/vrv/graphic.h
@@ -48,6 +48,20 @@ public:
     int GetDrawingHeight(int unit, int staffSize) const;
     ///@}
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
 protected:
     //
 private:

--- a/include/vrv/miscfunctor.h
+++ b/include/vrv/miscfunctor.h
@@ -25,7 +25,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    ApplyPPUFactorFunctor();
+    ApplyPPUFactorFunctor(Page *page = NULL);
     virtual ~ApplyPPUFactorFunctor() = default;
     ///@}
 
@@ -42,7 +42,9 @@ public:
     FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitPage(Page *page) override;
     FunctorCode VisitStaff(Staff *staff) override;
+    FunctorCode VisitSurface(Surface *surface) override;
     FunctorCode VisitSystem(System *system) override;
+    FunctorCode VisitZone(Zone *zone) override;
     ///@}
 
 protected:

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -45,6 +45,31 @@ public:
      */
     void AddDash(int left, int right, int extension);
 
+    class Dash {
+    public:
+        int m_x1;
+        int m_x2;
+        ListOfConstObjects m_events;
+
+        // Constructor
+        Dash(int x1, int x2, const Object *object)
+        {
+            m_x1 = x1;
+            m_x2 = x2;
+            m_events.push_back(object);
+        }
+
+        // Merge function to merge another Dash object into this one
+        void MergeWith(const Dash &other)
+        {
+            // Keep the first int from this Dash object, and the second int from the other
+            this->m_x1 = std::min(other.m_x1, this->m_x1);
+            this->m_x2 = std::max(other.m_x2, this->m_x2);
+            // Append the list from other to this
+            this->m_events.insert(this->m_events.end(), other.m_events.begin(), other.m_events.end());
+        }
+    };
+
 protected:
     //
 private:
@@ -53,7 +78,8 @@ public:
     /**
      * A list of dashes relative to the staff position.
      */
-    std::list<std::pair<int, int>> m_dashes;
+    // std::list<std::pair<int, int>> m_dashes;
+    std::list<Dash> m_dashes;
 
 protected:
     //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -66,7 +66,9 @@ public:
             this->m_x1 = std::min(other.m_x1, this->m_x1);
             this->m_x2 = std::max(other.m_x2, this->m_x2);
             // Append the list from other to this
-            this->m_events.insert(this->m_events.end(), other.m_events.begin(), other.m_events.end());
+            if (!other.m_events.empty()) {
+                this->m_events.insert(this->m_events.end(), other.m_events.begin(), other.m_events.end());
+            }
         }
     };
 

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -43,7 +43,7 @@ public:
      * Add a dash to the ledger line object.
      * If necessary merges overlapping dashes.
      */
-    void AddDash(int left, int right, int extension);
+    void AddDash(int left, int right, int extension, const Object *event);
 
     class Dash {
     public:
@@ -233,8 +233,8 @@ public:
      * If necessary creates the ledger line array.
      */
     ///@{
-    void AddLedgerLineAbove(int count, int left, int right, int extension, bool cueSize);
-    void AddLedgerLineBelow(int count, int left, int right, int extension, bool cueSize);
+    void AddLedgerLineAbove(int count, int left, int right, int extension, bool cueSize, const Object *event);
+    void AddLedgerLineBelow(int count, int left, int right, int extension, bool cueSize, const Object *event);
     ///@}
 
     /**
@@ -274,7 +274,7 @@ private:
     /**
      * Add the ledger line dashes to the legderline array.
      */
-    void AddLedgerLines(ArrayOfLedgerLines &lines, int count, int left, int right, int extension);
+    void AddLedgerLines(ArrayOfLedgerLines &lines, int count, int left, int right, int extension, const Object *event);
 
 public:
     /**

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -44,6 +44,20 @@ public:
     int GetMaxX() const;
     int GetMaxY() const;
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
 protected:
     //
 private:

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -131,7 +131,12 @@ public:
     /**
      * Method for changing the color of a custom graphic
      */
-    virtual void SetCustomGraphicColor(const std::string &color) override;
+    void SetCustomGraphicColor(const std::string &color) override;
+
+    /**
+     * Method for adding custom graphic data-* attributes
+     */
+    void SetCustomGraphicAttributes(const std::string &data, const std::string &value) override;
 
     /**
      * @name Methods for re-starting and ending a graphic for objects drawn in separate steps

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -43,6 +43,20 @@ public:
     int GetLogicalUly() const;
     int GetLogicalLry() const;
 
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
 protected:
     //
 private:

--- a/src/calcledgerlinesfunctor.cpp
+++ b/src/calcledgerlinesfunctor.cpp
@@ -82,10 +82,10 @@ void CalcLedgerLinesFunctor::CalcForLayerElement(
     }
 
     if (linesAbove > 0) {
-        staff->AddLedgerLineAbove(linesAbove, left, right, extension, drawingCueSize);
+        staff->AddLedgerLineAbove(linesAbove, left, right, extension, drawingCueSize, layerElement);
     }
     else {
-        staff->AddLedgerLineBelow(linesBelow, left, right, extension, drawingCueSize);
+        staff->AddLedgerLineBelow(linesBelow, left, right, extension, drawingCueSize, layerElement);
     }
 }
 

--- a/src/calcledgerlinesfunctor.cpp
+++ b/src/calcledgerlinesfunctor.cpp
@@ -121,15 +121,14 @@ void CalcLedgerLinesFunctor::AdjustLedgerLines(
     // For each dash on the inner line (both cue and normal) we construct an adjustment with zero delta
     // and sort them
     std::vector<Adjustment> adjustments;
-    using DashType = std::pair<int, int>;
     if (!lines.empty()) {
-        for (const DashType &dash : lines.at(0).m_dashes) {
-            adjustments.push_back({ dash.first, dash.second, false, 0 });
+        for (const LedgerLine::Dash &dash : lines.at(0).m_dashes) {
+            adjustments.push_back({ dash.m_x1, dash.m_x2, false, 0 });
         }
     }
     if (!cueLines.empty()) {
-        for (const DashType &dash : cueLines.at(0).m_dashes) {
-            adjustments.push_back({ dash.first, dash.second, true, 0 });
+        for (const LedgerLine::Dash &dash : cueLines.at(0).m_dashes) {
+            adjustments.push_back({ dash.m_x1, dash.m_x2, true, 0 });
         }
     }
 
@@ -175,13 +174,13 @@ void CalcLedgerLinesFunctor::AdjustLedgerLines(
         if (adjustment.delta > 0) {
             ArrayOfLedgerLines &linesToAdjust = adjustment.isCue ? cueLines : lines;
             for (LedgerLine &line : linesToAdjust) {
-                std::list<DashType>::iterator iterDash
-                    = std::find_if(line.m_dashes.begin(), line.m_dashes.end(), [&adjustment](const DashType &dash) {
-                          return ((dash.first >= adjustment.left) && (dash.second <= adjustment.right));
-                      });
+                std::list<LedgerLine::Dash>::iterator iterDash = std::find_if(
+                    line.m_dashes.begin(), line.m_dashes.end(), [&adjustment](const LedgerLine::Dash &dash) {
+                        return ((dash.m_x1 >= adjustment.left) && (dash.m_x2 <= adjustment.right));
+                    });
                 if (iterDash != line.m_dashes.end()) {
-                    iterDash->first += adjustment.delta;
-                    iterDash->second -= adjustment.delta;
+                    iterDash->m_x1 += adjustment.delta;
+                    iterDash->m_x2 -= adjustment.delta;
                 }
             }
         }

--- a/src/calcledgerlinesfunctor.cpp
+++ b/src/calcledgerlinesfunctor.cpp
@@ -81,11 +81,12 @@ void CalcLedgerLinesFunctor::CalcForLayerElement(
         left -= width / 2;
     }
 
+    const LayerElement *event = (m_doc->GetOptions()->m_svgHtml5.GetValue()) ? layerElement : NULL;
     if (linesAbove > 0) {
-        staff->AddLedgerLineAbove(linesAbove, left, right, extension, drawingCueSize, layerElement);
+        staff->AddLedgerLineAbove(linesAbove, left, right, extension, drawingCueSize, event);
     }
     else {
-        staff->AddLedgerLineBelow(linesBelow, left, right, extension, drawingCueSize, layerElement);
+        staff->AddLedgerLineBelow(linesBelow, left, right, extension, drawingCueSize, event);
     }
 }
 

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "comparison.h"
+#include "functor.h"
 #include "surface.h"
 #include "vrv.h"
 #include "zone.h"
@@ -78,6 +79,30 @@ int Facsimile::GetMaxY() const
         max = (surface->GetMaxY() > max) ? surface->GetMaxY() : max;
     }
     return max;
+}
+
+//----------------------------------------------------------------------------
+// Functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode Facsimile::Accept(Functor &functor)
+{
+    return functor.VisitFacsimile(this);
+}
+
+FunctorCode Facsimile::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitFacsimile(this);
+}
+
+FunctorCode Facsimile::AcceptEnd(Functor &functor)
+{
+    return functor.VisitFacsimileEnd(this);
+}
+
+FunctorCode Facsimile::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitFacsimileEnd(this);
 }
 
 } // namespace vrv

--- a/src/facsimilefunctor.cpp
+++ b/src/facsimilefunctor.cpp
@@ -36,6 +36,9 @@ SyncFromFacsimileFunctor::SyncFromFacsimileFunctor(Doc *doc) : Functor()
     m_view.SetDoc(doc);
     m_currentPage = NULL;
     m_currentSystem = NULL;
+    m_pageMarginTop = 0;
+    m_pageMarginLeft = 0;
+    m_ppuFactor = 1.0;
 }
 
 FunctorCode SyncFromFacsimileFunctor::VisitLayerElement(LayerElement *layerElement)
@@ -45,9 +48,9 @@ FunctorCode SyncFromFacsimileFunctor::VisitLayerElement(LayerElement *layerEleme
 
     Zone *zone = layerElement->GetZone();
     assert(zone);
-    layerElement->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR);
+    layerElement->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
     if (m_currentNeumeLine && layerElement->Is({ ACCID, SYL })) {
-        layerElement->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR);
+        layerElement->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR - m_pageMarginTop);
     }
 
     return FUNCTOR_CONTINUE;
@@ -62,8 +65,8 @@ FunctorCode SyncFromFacsimileFunctor::VisitMeasure(Measure *measure)
     else {
         Zone *zone = measure->GetZone();
         assert(zone);
-        measure->m_drawingFacsX1 = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR);
-        measure->m_drawingFacsX2 = m_view.ToLogicalX(zone->GetLrx() * DEFINITION_FACTOR);
+        measure->m_drawingFacsX1 = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
+        measure->m_drawingFacsX2 = m_view.ToLogicalX(zone->GetLrx() * DEFINITION_FACTOR - m_pageMarginLeft);
     }
 
     return FUNCTOR_CONTINUE;
@@ -81,7 +84,10 @@ FunctorCode SyncFromFacsimileFunctor::VisitPage(Page *page)
 FunctorCode SyncFromFacsimileFunctor::VisitPageEnd(Page *page)
 {
     // Used for adjusting staff size in neon - filled in VisitStaff
-    if (m_staffZones.empty()) return FUNCTOR_CONTINUE;
+    if (!m_staffZones.empty()) {
+        // Since we multiply all values by the DEFINITION_FACTOR, set it as PPU for neon facs
+        m_ppuFactor = DEFINITION_FACTOR;
+    }
 
     // The staff size is calculated based on the zone height and takes into acocunt the rotation
     for (auto &[staff, zone] : m_staffZones) {
@@ -93,8 +99,7 @@ FunctorCode SyncFromFacsimileFunctor::VisitPageEnd(Page *page)
         staff->SetDrawingRotation(rotate);
     }
 
-    // Since we multiply all values by the DEFINITION_FACTOR, set it as PPU
-    m_currentPage->SetPPUFactor(DEFINITION_FACTOR);
+    m_currentPage->SetPPUFactor(m_ppuFactor);
     if (m_currentPage->GetPPUFactor() != 1.0) {
         ApplyPPUFactorFunctor applyPPUFactor;
         m_currentPage->Process(applyPPUFactor);
@@ -118,12 +123,35 @@ FunctorCode SyncFromFacsimileFunctor::VisitPb(Pb *pb)
     if (surface && surface->HasLrx() && surface->HasLry()) {
         m_currentPage->m_pageHeight = surface->GetLry() * DEFINITION_FACTOR;
         m_currentPage->m_pageWidth = surface->GetLrx() * DEFINITION_FACTOR;
+        // Read the ppu factor from surface@type
+        std::string surfaceType = surface->GetType();
+        if (surfaceType.starts_with("ppu:")) {
+            std::string ppuFactorStr = surfaceType.substr(surfaceType.find(":") + 1);
+            if (vrv::IsValidDouble(ppuFactorStr)) {
+                m_ppuFactor = std::strtod(ppuFactorStr.c_str(), NULL);
+                m_ppuFactor *= DEFINITION_FACTOR / m_doc->GetOptions()->m_unit.GetValue();
+            }
+        }
+        // Read margins
+        if (zone && zone->HasUlx() && zone->HasUly() && zone->HasLrx() && zone->HasLry()) {
+            m_pageMarginTop = zone->GetUly() * DEFINITION_FACTOR;
+            m_pageMarginLeft = zone->GetUlx() * DEFINITION_FACTOR;
+            m_currentPage->m_pageMarginTop = m_pageMarginTop;
+            // Calculate the bottom margin looking at the surface lry and zone lry
+            m_currentPage->m_pageMarginBottom = m_currentPage->m_pageHeight - zone->GetLry() * DEFINITION_FACTOR;
+            m_currentPage->m_pageMarginLeft = m_pageMarginLeft;
+            // Calculate the right margin looking at the surface lrx and zone lrx
+            m_currentPage->m_pageMarginRight = m_currentPage->m_pageWidth - zone->GetLrx() * DEFINITION_FACTOR;
+            ;
+            m_doc->UpdatePageDrawingSizes();
+        }
     }
     // Fallback on zone
     else {
         m_currentPage->m_pageHeight = zone->GetLry() * DEFINITION_FACTOR;
         m_currentPage->m_pageWidth = zone->GetLrx() * DEFINITION_FACTOR;
     }
+
     // Update the page size to have to View::ToLogicalX/Y valid
     m_doc->UpdatePageDrawingSizes();
 
@@ -137,8 +165,8 @@ FunctorCode SyncFromFacsimileFunctor::VisitSb(Sb *sb)
 
     Zone *zone = sb->GetZone();
     assert(zone);
-    m_currentSystem->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR);
-    m_currentSystem->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR);
+    m_currentSystem->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
+    m_currentSystem->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR - m_pageMarginTop);
 
     return FUNCTOR_CONTINUE;
 }
@@ -147,12 +175,12 @@ FunctorCode SyncFromFacsimileFunctor::VisitStaff(Staff *staff)
 {
     Zone *zone = staff->GetZone();
     assert(zone);
-    staff->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR);
+    staff->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR - m_pageMarginTop);
 
     // neon specific code - set the position of the pseudo measure (neume line)
     if (m_currentNeumeLine) {
-        m_currentNeumeLine->m_drawingFacsX1 = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR);
-        m_currentNeumeLine->m_drawingFacsX2 = m_view.ToLogicalX(zone->GetLrx() * DEFINITION_FACTOR);
+        m_currentNeumeLine->m_drawingFacsX1 = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
+        m_currentNeumeLine->m_drawingFacsX2 = m_view.ToLogicalX(zone->GetLrx() * DEFINITION_FACTOR - m_pageMarginLeft);
         m_staffZones[staff] = zone;
 
         // The staff slope is going up. The y left position needs to be adjusted accordingly
@@ -178,9 +206,10 @@ FunctorCode SyncFromFacsimileFunctor::VisitSystem(System *system)
 // SyncToFacsimileFunctor
 //----------------------------------------------------------------------------
 
-SyncToFacsimileFunctor::SyncToFacsimileFunctor(Doc *doc) : Functor()
+SyncToFacsimileFunctor::SyncToFacsimileFunctor(Doc *doc, double ppuFactor) : Functor()
 {
     m_doc = doc;
+    m_ppuFactor = ppuFactor;
     m_view.SetDoc(doc);
     m_surface = NULL;
     m_currentPage = NULL;
@@ -218,29 +247,68 @@ FunctorCode SyncToFacsimileFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode SyncToFacsimileFunctor::VisitPage(Page *page)
 {
+    // This is required since processing Pb will create or select the Surface
+    if (!page->FindDescendantByType(PB)) {
+        LogWarning("Page without <pb> skipped when synching to facsimile");
+        return FUNCTOR_SIBLINGS;
+    }
+
     m_currentPage = page;
     m_doc->SetDrawingPage(page->GetIdx());
     page->LayOut();
-    //
-    m_surface = new Surface();
-    assert(m_doc->GetFacsimile());
-    m_doc->GetFacsimile()->AddChild(m_surface);
-    m_surface->SetLrx(m_doc->m_drawingPageWidth / DEFINITION_FACTOR);
-    m_surface->SetLry(m_doc->m_drawingPageHeight / DEFINITION_FACTOR);
-    // Because the facsimile output zone positions include the margins, we will add them to each zone
-    m_pageMarginTop = m_doc->m_drawingPageMarginTop / DEFINITION_FACTOR;
-    m_pageMarginLeft = m_doc->m_drawingPageMarginLeft / DEFINITION_FACTOR;
+    // From a previously loaded facsimile
+    if (page->GetPPUFactor() != 1.0) {
+        m_ppuFactor = page->GetPPUFactor();
+    }
+    // When generating a facsimile with a scale option
+    else {
+        page->SetPPUFactor(m_ppuFactor);
+    }
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode SyncToFacsimileFunctor::VisitPageEnd(Page *page)
+{
+    if (m_ppuFactor != 1.0) {
+        ApplyPPUFactorFunctor applyPPUFactor(m_currentPage);
+        m_surface->Process(applyPPUFactor);
+        m_surface->SetType(
+            StringFormat("ppu:%f", m_ppuFactor * m_doc->GetOptions()->m_unit.GetValue() / DEFINITION_FACTOR));
+    }
 
     return FUNCTOR_CONTINUE;
 }
 
 FunctorCode SyncToFacsimileFunctor::VisitPb(Pb *pb)
 {
-    Zone *zone = this->GetZone(pb, pb->GetClassName());
+    Zone *zone = pb->GetZone();
+    // Assume to be creating the facsimile data from scratch
+    if (!pb->GetZone()) {
+        // Also create a new surface
+        m_surface = new Surface();
+        assert(m_doc->GetFacsimile());
+        m_doc->GetFacsimile()->AddChild(m_surface);
+        zone = this->GetZone(pb, pb->GetClassName());
+    }
+    // We already have some facsimile data - retrieve the surface ancestor
+    else {
+        m_surface = vrv_cast<Surface *>(zone->GetFirstAncestor(SURFACE));
+    }
+    assert(m_surface);
+    assert(zone);
+
+    m_surface->SetLrx(m_doc->m_drawingPageWidth / DEFINITION_FACTOR);
+    m_surface->SetLry(m_doc->m_drawingPageHeight / DEFINITION_FACTOR);
+    // Because the facsimile output zone positions include the margins, we will add them to each zone
+    m_pageMarginTop = m_doc->m_drawingPageMarginTop / DEFINITION_FACTOR;
+    m_pageMarginLeft = m_doc->m_drawingPageMarginLeft / DEFINITION_FACTOR;
+
     // The Pb zone values are currently not used in SyncFromFacsimileFunctor because the
     // page sizes are synced from the parent Surface and zone positions include margins
     zone->SetUlx(m_pageMarginLeft);
     zone->SetUly(m_pageMarginTop);
+    // Use the page content size to factor in the bottom and right margins
     zone->SetLrx(m_doc->m_drawingPageContentWidth / DEFINITION_FACTOR + m_pageMarginLeft);
     zone->SetLry(m_doc->m_drawingPageContentHeight / DEFINITION_FACTOR + m_pageMarginTop);
 
@@ -273,8 +341,11 @@ FunctorCode SyncToFacsimileFunctor::VisitSystem(System *system)
 
 Zone *SyncToFacsimileFunctor::GetZone(FacsimileInterface *interface, std::string type)
 {
+    assert(m_surface);
+
     if (interface->GetZone()) {
         // Here we should probably check if the zone is a child of m_surface
+        assert(interface->GetZone()->GetParent() == m_surface);
         return interface->GetZone();
     }
     else {

--- a/src/functorinterface.cpp
+++ b/src/functorinterface.cpp
@@ -35,6 +35,7 @@
 #include "ending.h"
 #include "expansion.h"
 #include "f.h"
+#include "facsimile.h"
 #include "fb.h"
 #include "fermata.h"
 #include "fig.h"
@@ -43,6 +44,7 @@
 #include "genericlayerelement.h"
 #include "gliss.h"
 #include "gracegrp.h"
+#include "graphic.h"
 #include "grpsym.h"
 #include "hairpin.h"
 #include "halfmrpt.h"
@@ -101,6 +103,7 @@
 #include "staffdef.h"
 #include "staffgrp.h"
 #include "stem.h"
+#include "surface.h"
 #include "svg.h"
 #include "syl.h"
 #include "syllable.h"
@@ -119,6 +122,7 @@
 #include "tuplet.h"
 #include "turn.h"
 #include "verse.h"
+#include "zone.h"
 
 namespace vrv {
 
@@ -1324,6 +1328,46 @@ FunctorCode FunctorInterface::VisitTextElement(TextElement *textElement)
 FunctorCode FunctorInterface::VisitTextElementEnd(TextElement *textElement)
 {
     return this->VisitObjectEnd(textElement);
+}
+
+FunctorCode FunctorInterface::VisitFacsimile(Facsimile *facsimile)
+{
+    return this->VisitObject(facsimile);
+}
+
+FunctorCode FunctorInterface::VisitFacsimileEnd(Facsimile *facsimile)
+{
+    return this->VisitObjectEnd(facsimile);
+}
+
+FunctorCode FunctorInterface::VisitGraphic(Graphic *graphic)
+{
+    return this->VisitObject(graphic);
+}
+
+FunctorCode FunctorInterface::VisitGraphicEnd(Graphic *graphic)
+{
+    return this->VisitObjectEnd(graphic);
+}
+
+FunctorCode FunctorInterface::VisitSurface(Surface *surface)
+{
+    return this->VisitObject(surface);
+}
+
+FunctorCode FunctorInterface::VisitSurfaceEnd(Surface *surface)
+{
+    return this->VisitObjectEnd(surface);
+}
+
+FunctorCode FunctorInterface::VisitZone(Zone *zone)
+{
+    return this->VisitObject(zone);
+}
+
+FunctorCode FunctorInterface::VisitZoneEnd(Zone *zone)
+{
+    return this->VisitObjectEnd(zone);
 }
 
 FunctorCode FunctorInterface::VisitAlignment(Alignment *alignment)
@@ -2618,6 +2662,46 @@ FunctorCode ConstFunctorInterface::VisitTextElement(const TextElement *textEleme
 FunctorCode ConstFunctorInterface::VisitTextElementEnd(const TextElement *textElement)
 {
     return this->VisitObjectEnd(textElement);
+}
+
+FunctorCode ConstFunctorInterface::VisitFacsimile(const Facsimile *facsimile)
+{
+    return this->VisitObject(facsimile);
+}
+
+FunctorCode ConstFunctorInterface::VisitFacsimileEnd(const Facsimile *facsimile)
+{
+    return this->VisitObjectEnd(facsimile);
+}
+
+FunctorCode ConstFunctorInterface::VisitGraphic(const Graphic *graphic)
+{
+    return this->VisitObject(graphic);
+}
+
+FunctorCode ConstFunctorInterface::VisitGraphicEnd(const Graphic *graphic)
+{
+    return this->VisitObjectEnd(graphic);
+}
+
+FunctorCode ConstFunctorInterface::VisitSurface(const Surface *surface)
+{
+    return this->VisitObject(surface);
+}
+
+FunctorCode ConstFunctorInterface::VisitSurfaceEnd(const Surface *surface)
+{
+    return this->VisitObjectEnd(surface);
+}
+
+FunctorCode ConstFunctorInterface::VisitZone(const Zone *zone)
+{
+    return this->VisitObject(zone);
+}
+
+FunctorCode ConstFunctorInterface::VisitZoneEnd(const Zone *zone)
+{
+    return this->VisitObjectEnd(zone);
 }
 
 FunctorCode ConstFunctorInterface::VisitAlignment(const Alignment *alignment)

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "comparison.h"
+#include "functor.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -57,6 +58,30 @@ int Graphic::GetDrawingHeight(int unit, int staffSize) const
     if (this->GetHeight().GetType() == MEASUREMENTTYPE_px) return (this->GetHeight().GetPx() * staffSize / 100);
     // The staffSize is already taken into account in the unit
     return (this->GetHeight().GetVu() * unit);
+}
+
+//----------------------------------------------------------------------------
+// Functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode Graphic::Accept(Functor &functor)
+{
+    return functor.VisitGraphic(this);
+}
+
+FunctorCode Graphic::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitGraphic(this);
+}
+
+FunctorCode Graphic::AcceptEnd(Functor &functor)
+{
+    return functor.VisitGraphicEnd(this);
+}
+
+FunctorCode Graphic::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitGraphicEnd(this);
 }
 
 } // namespace vrv

--- a/src/miscfunctor.cpp
+++ b/src/miscfunctor.cpp
@@ -12,8 +12,10 @@
 #include "layer.h"
 #include "page.h"
 #include "staff.h"
+#include "surface.h"
 #include "system.h"
 #include "verse.h"
+#include "zone.h"
 
 //----------------------------------------------------------------------------
 
@@ -23,13 +25,15 @@ namespace vrv {
 // ApplyPPUFactorFunctor
 //----------------------------------------------------------------------------
 
-ApplyPPUFactorFunctor::ApplyPPUFactorFunctor() : Functor()
+ApplyPPUFactorFunctor::ApplyPPUFactorFunctor(Page *page) : Functor()
 {
-    m_page = NULL;
+    m_page = page;
 }
 
 FunctorCode ApplyPPUFactorFunctor::VisitLayerElement(LayerElement *layerElement)
 {
+    assert(m_page);
+
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     if (layerElement->m_drawingFacsX != VRV_UNSET) layerElement->m_drawingFacsX /= m_page->GetPPUFactor();
@@ -40,6 +44,8 @@ FunctorCode ApplyPPUFactorFunctor::VisitLayerElement(LayerElement *layerElement)
 
 FunctorCode ApplyPPUFactorFunctor::VisitMeasure(Measure *measure)
 {
+    assert(m_page);
+
     if (measure->m_drawingFacsX1 != VRV_UNSET) measure->m_drawingFacsX1 /= m_page->GetPPUFactor();
     if (measure->m_drawingFacsX2 != VRV_UNSET) measure->m_drawingFacsX2 /= m_page->GetPPUFactor();
 
@@ -61,17 +67,45 @@ FunctorCode ApplyPPUFactorFunctor::VisitPage(Page *page)
 
 FunctorCode ApplyPPUFactorFunctor::VisitStaff(Staff *staff)
 {
+    assert(m_page);
+
     if (staff->m_drawingFacsY != VRV_UNSET) staff->m_drawingFacsY /= m_page->GetPPUFactor();
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode ApplyPPUFactorFunctor::VisitSurface(Surface *surface)
+{
+    assert(m_page);
+
+    if (surface->HasUlx()) surface->SetUlx(surface->GetUlx() * m_page->GetPPUFactor());
+    if (surface->HasUly()) surface->SetUly(surface->GetUly() * m_page->GetPPUFactor());
+    if (surface->HasLrx()) surface->SetLrx(surface->GetLrx() * m_page->GetPPUFactor());
+    if (surface->HasLry()) surface->SetLry(surface->GetLry() * m_page->GetPPUFactor());
 
     return FUNCTOR_CONTINUE;
 }
 
 FunctorCode ApplyPPUFactorFunctor::VisitSystem(System *system)
 {
+    assert(m_page);
+
     if (system->m_drawingFacsX != VRV_UNSET) system->m_drawingFacsX /= m_page->GetPPUFactor();
     if (system->m_drawingFacsY != VRV_UNSET) system->m_drawingFacsY /= m_page->GetPPUFactor();
     system->m_systemLeftMar *= m_page->GetPPUFactor();
     system->m_systemRightMar *= m_page->GetPPUFactor();
+
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode ApplyPPUFactorFunctor::VisitZone(Zone *zone)
+{
+    assert(m_page);
+
+    if (zone->HasUlx()) zone->SetUlx(zone->GetUlx() * m_page->GetPPUFactor());
+    if (zone->HasUly()) zone->SetUly(zone->GetUly() * m_page->GetPPUFactor());
+    if (zone->HasLrx()) zone->SetLrx(zone->GetLrx() * m_page->GetPPUFactor());
+    if (zone->HasLry()) zone->SetLry(zone->GetLry() * m_page->GetPPUFactor());
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -302,23 +302,24 @@ void LedgerLine::AddDash(int left, int right, int extension)
 {
     assert(left < right);
 
-    std::list<std::pair<int, int>>::iterator iter;
+    std::list<LedgerLine::Dash>::iterator iter;
 
     // First add the dash
     for (iter = m_dashes.begin(); iter != m_dashes.end(); ++iter) {
-        if (iter->first > left) break;
+        if (iter->m_x1 > left) break;
     }
-    m_dashes.insert(iter, { left, right });
+    m_dashes.insert(iter, LedgerLine::Dash(left, right, NULL));
 
     // Merge dashes which overlap by more than 1.5 extensions
     // => Dashes belonging to the same chord overlap at least by two extensions and will get merged
     // => Overlapping dashes of adjacent notes will not get merged
-    std::list<std::pair<int, int>>::iterator previous = m_dashes.begin();
+    std::list<LedgerLine::Dash>::iterator previous = m_dashes.begin();
     iter = m_dashes.begin();
     ++iter;
     while (iter != m_dashes.end()) {
-        if (previous->second > iter->first + 1.5 * extension) {
-            previous->second = std::max(iter->second, previous->second);
+        if (previous->m_x1 > iter->m_x1 + 1.5 * extension) {
+            previous->MergeWith(*iter);
+            previous->m_x2 = std::max(iter->m_x2, previous->m_x2);
             iter = m_dashes.erase(iter);
         }
         else {

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -239,23 +239,24 @@ int Staff::CalcPitchPosYRel(const Doc *doc, int loc) const
     return (loc - staffLocOffset) * doc->GetDrawingUnit(m_drawingStaffSize);
 }
 
-void Staff::AddLedgerLineAbove(int count, int left, int right, int extension, bool cueSize)
+void Staff::AddLedgerLineAbove(int count, int left, int right, int extension, bool cueSize, const Object *event)
 {
-    this->AddLedgerLines(cueSize ? m_ledgerLinesAboveCue : m_ledgerLinesAbove, count, left, right, extension);
+    this->AddLedgerLines(cueSize ? m_ledgerLinesAboveCue : m_ledgerLinesAbove, count, left, right, extension, event);
 }
 
-void Staff::AddLedgerLineBelow(int count, int left, int right, int extension, bool cueSize)
+void Staff::AddLedgerLineBelow(int count, int left, int right, int extension, bool cueSize, const Object *event)
 {
-    this->AddLedgerLines(cueSize ? m_ledgerLinesBelowCue : m_ledgerLinesBelow, count, left, right, extension);
+    this->AddLedgerLines(cueSize ? m_ledgerLinesBelowCue : m_ledgerLinesBelow, count, left, right, extension, event);
 }
 
-void Staff::AddLedgerLines(ArrayOfLedgerLines &lines, int count, int left, int right, int extension)
+void Staff::AddLedgerLines(
+    ArrayOfLedgerLines &lines, int count, int left, int right, int extension, const Object *event)
 {
     assert(left < right);
 
     if ((int)lines.size() < count) lines.resize(count);
     for (int i = 0; i < count; ++i) {
-        lines.at(i).AddDash(left, right, extension);
+        lines.at(i).AddDash(left, right, extension, event);
     }
 }
 
@@ -298,7 +299,7 @@ int Staff::GetNearestInterStaffPosition(int y, const Doc *doc, data_STAFFREL pla
 // LedgerLine
 //----------------------------------------------------------------------------
 
-void LedgerLine::AddDash(int left, int right, int extension)
+void LedgerLine::AddDash(int left, int right, int extension, const Object *event)
 {
     assert(left < right);
 
@@ -308,7 +309,7 @@ void LedgerLine::AddDash(int left, int right, int extension)
     for (iter = m_dashes.begin(); iter != m_dashes.end(); ++iter) {
         if (iter->m_x1 > left) break;
     }
-    m_dashes.insert(iter, LedgerLine::Dash(left, right, NULL));
+    m_dashes.insert(iter, LedgerLine::Dash(left, right, event));
 
     // Merge dashes which overlap by more than 1.5 extensions
     // => Dashes belonging to the same chord overlap at least by two extensions and will get merged

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -15,6 +15,7 @@
 
 #include "comparison.h"
 #include "facsimile.h"
+#include "functor.h"
 #include "graphic.h"
 #include "vrv.h"
 #include "zone.h"
@@ -83,6 +84,30 @@ int Surface::GetMaxY() const
         max = (zone->GetLry() > max) ? zone->GetLry() : max;
     }
     return max;
+}
+
+//----------------------------------------------------------------------------
+// Functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode Surface::Accept(Functor &functor)
+{
+    return functor.VisitSurface(this);
+}
+
+FunctorCode Surface::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitSurface(this);
+}
+
+FunctorCode Surface::AcceptEnd(Functor &functor)
+{
+    return functor.VisitSurfaceEnd(this);
+}
+
+FunctorCode Surface::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitSurfaceEnd(this);
 }
 
 } // namespace vrv

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -438,6 +438,11 @@ void SvgDeviceContext::SetCustomGraphicColor(const std::string &color)
     m_currentNode.append_attribute("fill") = color.c_str();
 }
 
+void SvgDeviceContext::SetCustomGraphicAttributes(const std::string &data, const std::string &value)
+{
+    m_currentNode.append_attribute(("data-" + data).c_str()) = value.c_str();
+}
+
 void SvgDeviceContext::EndResumedGraphic(Object *object, View *view)
 {
     m_svgNodeStack.pop_back();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1746,7 +1746,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
         return;
     }
 
-    if (!m_doc->IsFacs() && !m_doc->IsNeumeLines()) {
+    if (!m_doc->IsFacs() && !m_doc->IsTranscription() && !m_doc->IsNeumeLines()) {
         syl->SetDrawingYRel(this->GetSylYRel(syl->m_drawingVerse, staff));
     }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <math.h>
+#include <ranges>
 
 //----------------------------------------------------------------------------
 
@@ -1375,10 +1376,31 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
     dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), AxSOLID);
     dc->SetBrush(m_currentColor, AxSOLID);
 
+    bool svgHtml5 = (m_doc->GetOptions()->m_svgHtml5.GetValue());
+
     for (const LedgerLine &line : lines) {
         for (const LedgerLine::Dash &dash : line.m_dashes) {
+            if (svgHtml5) {
+                // Add the custom graphic only with html5
+                dc->StartCustomGraphic("lineDash");
+                // Function to concatenate IDs from the list of Object events
+                auto concatenateIDs = [](const ListOfConstObjects &objects) {
+                    // Get a list of strings
+                    auto ids = objects | std::views::transform([](const Object *object) { return object->GetID(); });
+                    // Concatenate IDs with a space separator
+                    std::stringstream sstream;
+                    std::copy(ids.begin(), ids.end(), std::ostream_iterator<std::string>(sstream, " "));
+                    return sstream.str();
+                };
+                std::string events = concatenateIDs(dash.m_events);
+                if (!events.empty()) events.pop_back(); // Remove extra space added by the concatenation
+                dc->SetCustomGraphicAttributes("mei-id", events);
+            }
+
             dc->DrawLine(ToDeviceContextX(x + dash.m_x1), ToDeviceContextY(y), ToDeviceContextX(x + dash.m_x2),
                 ToDeviceContextY(y));
+
+            if (svgHtml5) dc->EndCustomGraphic();
         }
         y += ySpace;
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1386,15 +1386,19 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
                 // Function to concatenate IDs from the list of Object events
                 auto concatenateIDs = [](const ListOfConstObjects &objects) {
                     // Get a list of strings
-                    auto ids = objects | std::views::transform([](const Object *object) { return object->GetID(); });
-                    // Concatenate IDs with a space separator
+                    auto ids = objects
+                        | std::views::transform([](const Object *object) { return ("#" + object->GetID() + " "); });
+                    // Concatenate IDs
+                    // Once we have C++ 23 we can add the space above and do
+                    // std::ranges::to<std::string>(std::views::join(ids));
+                    // But for now use a stringstream
                     std::stringstream sstream;
-                    std::copy(ids.begin(), ids.end(), std::ostream_iterator<std::string>(sstream, " "));
+                    std::copy(ids.begin(), ids.end(), std::ostream_iterator<std::string>(sstream));
                     return sstream.str();
                 };
                 std::string events = concatenateIDs(dash.m_events);
                 if (!events.empty()) events.pop_back(); // Remove extra space added by the concatenation
-                dc->SetCustomGraphicAttributes("mei-id", events);
+                dc->SetCustomGraphicAttributes("related", events);
             }
 
             dc->DrawLine(ToDeviceContextX(x + dash.m_x1), ToDeviceContextY(y), ToDeviceContextX(x + dash.m_x2),

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1376,8 +1376,8 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
     dc->SetBrush(m_currentColor, AxSOLID);
 
     for (const LedgerLine &line : lines) {
-        for (const std::pair<int, int> &dash : line.m_dashes) {
-            dc->DrawLine(ToDeviceContextX(x + dash.first), ToDeviceContextY(y), ToDeviceContextX(x + dash.second),
+        for (const LedgerLine::Dash &dash : line.m_dashes) {
+            dc->DrawLine(ToDeviceContextX(x + dash.m_x1), ToDeviceContextY(y), ToDeviceContextX(x + dash.m_x2),
                 ToDeviceContextY(y));
         }
         y += ySpace;

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -14,6 +14,7 @@
 //----------------------------------------------------------------------------
 
 #include "comparison.h"
+#include "functor.h"
 #include "vrv.h"
 
 namespace vrv {
@@ -57,6 +58,30 @@ int Zone::GetLogicalUly() const
 int Zone::GetLogicalLry() const
 {
     return (this->GetLry());
+}
+
+//----------------------------------------------------------------------------
+// Functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode Zone::Accept(Functor &functor)
+{
+    return functor.VisitZone(this);
+}
+
+FunctorCode Zone::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitZone(this);
+}
+
+FunctorCode Zone::AcceptEnd(Functor &functor)
+{
+    return functor.VisitZoneEnd(this);
+}
+
+FunctorCode Zone::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitZoneEnd(this);
 }
 
 } // namespace vrv


### PR DESCRIPTION
The PR brings some adjustments to the facsimile support as discussed for the Beethovens Werkstatt project.

It also adds connections between ledger line dashes and corresponding notes or accidentals when the `--svg-html5` option is set. This fixes #3858.

When the `--svg-html5` option is set, each ledger line dash in the SVG is placed in a `g` element with an additional `data-mei-id` attribute carrying the id(s) of the note(s) or accidental(s) related to it.

![image](https://github.com/user-attachments/assets/122b89d5-6de5-4909-87ea-eb959137930c)

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>Pickup note spacing</title>
            </titleStmt>
            <pubStmt>
                <date isodate="2017-07-28">2017-07-28</date>
            </pubStmt>
            <seriesStmt>
                <title>Verovio test suite</title>
            </seriesStmt>
            <notesStmt>
                <annot>Verovio appropriately spaces pickup notes.</annot>
            </notesStmt>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application version="2.0.0" label="2">
                    <name>Verovio</name>
                </application>
            </appInfo>
        </encodingDesc>
    </meiHead>
    <music>
        <body>
            <mdiv>
                <score>
                    <scoreDef midi.bpm="400">
                        <staffGrp>
                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                        </staffGrp>
                    </scoreDef>
                    <section>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <accid accid="f" loc="10"></accid>
                                    <note loc="10" dur="4"></note>
                                    <accid accid="x" loc="10"></accid>
                                    <note loc="10" dur="4"></note>
                                    <accid accid="ff" loc="11"></accid>
                                    <note loc="11" dur="4"></note>
                                    <accid accid="tf" loc="12"></accid>
                                    <note loc="12" dur="4"></note>
                                </layer>
                            </staff>
                        </measure>
                        <measure>
                            <staff n="1">
                                <layer n="1">
                                    <accid accid="f" loc="-1"></accid>
                                    <note loc="-1" dur="4"></note>
                                    <accid accid="x" loc="-2"></accid>
                                    <note loc="-2" dur="4"></note>
                                    <accid accid="ff" loc="-3"></accid>
                                    <note loc="-3" dur="4"></note>
                                    <accid accid="tf" loc="-4"></accid>
                                    <note loc="-4" dur="4"></note>
                                </layer>
                            </staff>
                        </measure>
                    </section>
                </score>
            </mdiv>
        </body>
    </music>
</mei>
```
</details>

SVG of the staff element of the second measure without `--svg-html5`

```xml
<g id="s9yy8yz" class="staff">
    <path d="M4719 1423 L8793 1423" stroke="currentColor" stroke-width="13" />
    <path d="M4719 1603 L8793 1603" stroke="currentColor" stroke-width="13" />
    <path d="M4719 1783 L8793 1783" stroke="currentColor" stroke-width="13" />
    <path d="M4719 1963 L8793 1963" stroke="currentColor" stroke-width="13" />
    <path d="M4719 2143 L8793 2143" stroke="currentColor" stroke-width="13" />
    <g class="ledgerLines below">
        <path d="M5730 2323 L6003 2323" stroke="currentColor" stroke-width="22" />
        <path d="M6049 2323 L6363 2323" stroke="currentColor" stroke-width="22" />
        <path d="M6600 2323 L6967 2323" stroke="currentColor" stroke-width="22" />
        <path d="M7013 2323 L7327 2323" stroke="currentColor" stroke-width="22" />
        <path d="M7495 2323 L7999 2323" stroke="currentColor" stroke-width="22" />
        <path d="M8046 2323 L8360 2323" stroke="currentColor" stroke-width="22" />
        <path d="M7495 2503 L7999 2503" stroke="currentColor" stroke-width="22" />
        <path d="M8046 2503 L8360 2503" stroke="currentColor" stroke-width="22" />
    </g>
    <g id="l174qs6g" class="layer">
        <g id="a1xuua9r" class="accid">
            <use xlink:href="#E260-1wr3wsz" x="4899" y="2233" height="720px" width="720px" />
        </g>
        <g id="n3yctqk" class="note">
            <g class="notehead">
                <use xlink:href="#E0A4-1wr3wsz" x="5176" y="2233" height="720px" width="720px" />
            </g>
            <g id="segyzt9" class="stem">
                <path d="M5393 2205 L5393 1603" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g id="a1madmg3" class="accid">
            <use xlink:href="#E263-1wr3wsz" x="5773" y="2323" height="720px" width="720px" />
        </g>
        <g id="niamgx1" class="note">
            <g class="notehead">
                <use xlink:href="#E0A4-1wr3wsz" x="6093" y="2323" height="720px" width="720px" />
            </g>
            <g id="s1ldqugp" class="stem">
                <path d="M6310 2295 L6310 1693" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g id="a8x2zjm" class="accid">
            <use xlink:href="#E264-1wr3wsz" x="6643" y="2413" height="720px" width="720px" />
        </g>
        <g id="n18lkvm6" class="note">
            <g class="notehead">
                <use xlink:href="#E0A4-1wr3wsz" x="7057" y="2413" height="720px" width="720px" />
            </g>
            <g id="s18b48g1" class="stem">
                <path d="M7274 2385 L7274 1783" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g id="ar0dk67" class="accid">
            <use xlink:href="#E266-1wr3wsz" x="7539" y="2503" height="720px" width="720px" />
        </g>
        <g id="n1gbxadu" class="note">
            <g class="notehead">
                <use xlink:href="#E0A4-1wr3wsz" x="8090" y="2503" height="720px" width="720px" />
            </g>
            <g id="s19us33q" class="stem">
                <path d="M8307 2475 L8307 1783" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
    </g>
</g>
```

The first measure with `--svg-html5`

```xml
<g data-id="susm273" data-class="staff" class="staff">
    <path d="M0 1423 L4719 1423" stroke="currentColor" stroke-width="13" />
    <path d="M0 1603 L4719 1603" stroke="currentColor" stroke-width="13" />
    <path d="M0 1783 L4719 1783" stroke="currentColor" stroke-width="13" />
    <path d="M0 1963 L4719 1963" stroke="currentColor" stroke-width="13" />
    <path d="M0 2143 L4719 2143" stroke="currentColor" stroke-width="13" />
    <g data-id="cz06acv" data-class="clef" class="clef">
        <use xlink:href="#E050-hrnrfr" x="90" y="1963" height="720px" width="720px" />
    </g>
    <g data-id="kjntlfz" data-class="keySig" class="keySig" />
    <g data-class="ledgerLines" class="ledgerLines above">
        <g data-class="lineDash" class="lineDash" data-mei-id="abt2snm">
            <path d="M782 1243 L1012 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="nk1d95g">
            <path d="M1058 1243 L1372 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="a7wuvt3">
            <path d="M1656 1243 L1929 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="n1h1urjr">
            <path d="M1975 1243 L2289 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="a1q3fvtp">
            <path d="M2526 1243 L2893 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="n67yql6">
            <path d="M2939 1243 L3253 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="af5w3jm">
            <path d="M3421 1243 L3925 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="nm8vrvn">
            <path d="M3972 1243 L4286 1243" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="af5w3jm">
            <path d="M3421 1063 L3925 1063" stroke="currentColor" stroke-width="22" />
        </g>
        <g data-class="lineDash" class="lineDash" data-mei-id="nm8vrvn">
            <path d="M3972 1063 L4286 1063" stroke="currentColor" stroke-width="22" />
        </g>
    </g>
    <g data-id="l1idfoa9" data-class="layer" class="layer">
        <g data-id="abt2snm" data-class="accid" class="accid">
            <use xlink:href="#E260-hrnrfr" x="825" y="1243" height="720px" width="720px" />
        </g>
        <g data-id="nk1d95g" data-class="note" class="note">
            <g data-class="notehead" class="notehead">
                <use xlink:href="#E0A4-hrnrfr" x="1102" y="1243" height="720px" width="720px" />
            </g>
            <g data-id="s1009fsf" data-class="stem" class="stem">
                <path d="M1111 1271 L1111 1873" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g data-id="a7wuvt3" data-class="accid" class="accid">
            <use xlink:href="#E263-hrnrfr" x="1699" y="1243" height="720px" width="720px" />
        </g>
        <g data-id="n1h1urjr" data-class="note" class="note">
            <g data-class="notehead" class="notehead">
                <use xlink:href="#E0A4-hrnrfr" x="2019" y="1243" height="720px" width="720px" />
            </g>
            <g data-id="s1dg8eld" data-class="stem" class="stem">
                <path d="M2028 1271 L2028 1873" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g data-id="a1q3fvtp" data-class="accid" class="accid">
            <use xlink:href="#E264-hrnrfr" x="2569" y="1153" height="720px" width="720px" />
        </g>
        <g data-id="n67yql6" data-class="note" class="note">
            <g data-class="notehead" class="notehead">
                <use xlink:href="#E0A4-hrnrfr" x="2983" y="1153" height="720px" width="720px" />
            </g>
            <g data-id="shqqoqx" data-class="stem" class="stem">
                <path d="M2992 1181 L2992 1783" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
        <g data-id="af5w3jm" data-class="accid" class="accid">
            <use xlink:href="#E266-hrnrfr" x="3465" y="1063" height="720px" width="720px" />
        </g>
        <g data-id="nm8vrvn" data-class="note" class="note">
            <g data-class="notehead" class="notehead">
                <use xlink:href="#E0A4-hrnrfr" x="4016" y="1063" height="720px" width="720px" />
            </g>
            <g data-id="s1iww319" data-class="stem" class="stem">
                <path d="M4025 1091 L4025 1783" stroke="currentColor" stroke-width="18" />
            </g>
        </g>
    </g>
</g>
```