### PR TITLE
Specify bracketSpan in Verovio customisation

### DIFF
--- a/libmei/datatypes.yml
+++ b/libmei/datatypes.yml
@@ -187,11 +187,6 @@ defaults:
         data_STAFFREL()
 
 modules:
-    cmn:
-        att.bracketSpan.log:
-            func:
-                type: bracketSpanLog_FUNC
-
     externalsymbols:
         att.extsym:
             glyphnum:

--- a/libmei/dist/attconverter.cpp
+++ b/libmei/dist/attconverter.cpp
@@ -3994,6 +3994,8 @@ std::string AttConverterBase::BracketSpanLogFuncToStr(bracketSpanLog_FUNC data) 
         case bracketSpanLog_FUNC_coloration: value = "coloration"; break;
         case bracketSpanLog_FUNC_cross_rhythm: value = "cross-rhythm"; break;
         case bracketSpanLog_FUNC_ligature: value = "ligature"; break;
+        case bracketSpanLog_FUNC_analytical: value = "analytical"; break;
+        case bracketSpanLog_FUNC_uspecified: value = "uspecified"; break;
         default:
             LogWarning("Unknown value '%d' for att.bracketSpan.log@func", data);
             value = "";
@@ -4007,6 +4009,8 @@ bracketSpanLog_FUNC AttConverterBase::StrToBracketSpanLogFunc(const std::string 
     if (value == "coloration") return bracketSpanLog_FUNC_coloration;
     if (value == "cross-rhythm") return bracketSpanLog_FUNC_cross_rhythm;
     if (value == "ligature") return bracketSpanLog_FUNC_ligature;
+    if (value == "analytical") return bracketSpanLog_FUNC_analytical;
+    if (value == "uspecified") return bracketSpanLog_FUNC_uspecified;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for att.bracketSpan.log@func", value.c_str());
     return bracketSpanLog_FUNC_NONE;

--- a/libmei/dist/attconverter.cpp
+++ b/libmei/dist/attconverter.cpp
@@ -3995,6 +3995,7 @@ std::string AttConverterBase::BracketSpanLogFuncToStr(bracketSpanLog_FUNC data) 
         case bracketSpanLog_FUNC_cross_rhythm: value = "cross-rhythm"; break;
         case bracketSpanLog_FUNC_ligature: value = "ligature"; break;
         case bracketSpanLog_FUNC_analytical: value = "analytical"; break;
+        case bracketSpanLog_FUNC_phrase: value = "phrase"; break;
         case bracketSpanLog_FUNC_uspecified: value = "uspecified"; break;
         default:
             LogWarning("Unknown value '%d' for att.bracketSpan.log@func", data);
@@ -4010,6 +4011,7 @@ bracketSpanLog_FUNC AttConverterBase::StrToBracketSpanLogFunc(const std::string 
     if (value == "cross-rhythm") return bracketSpanLog_FUNC_cross_rhythm;
     if (value == "ligature") return bracketSpanLog_FUNC_ligature;
     if (value == "analytical") return bracketSpanLog_FUNC_analytical;
+    if (value == "phrase") return bracketSpanLog_FUNC_phrase;
     if (value == "uspecified") return bracketSpanLog_FUNC_uspecified;
     if (logWarning && !value.empty())
         LogWarning("Unsupported value '%s' for att.bracketSpan.log@func", value.c_str());

--- a/libmei/dist/atttypes.h
+++ b/libmei/dist/atttypes.h
@@ -1873,6 +1873,7 @@ enum bracketSpanLog_FUNC : int8_t {
     bracketSpanLog_FUNC_cross_rhythm,
     bracketSpanLog_FUNC_ligature,
     bracketSpanLog_FUNC_analytical,
+    bracketSpanLog_FUNC_phrase,
     bracketSpanLog_FUNC_uspecified,
     bracketSpanLog_FUNC_MAX
 };

--- a/libmei/dist/atttypes.h
+++ b/libmei/dist/atttypes.h
@@ -1872,6 +1872,8 @@ enum bracketSpanLog_FUNC : int8_t {
     bracketSpanLog_FUNC_coloration,
     bracketSpanLog_FUNC_cross_rhythm,
     bracketSpanLog_FUNC_ligature,
+    bracketSpanLog_FUNC_analytical,
+    bracketSpanLog_FUNC_uspecified,
     bracketSpanLog_FUNC_MAX
 };
 

--- a/libmei/mei/mei-verovio.xml
+++ b/libmei/mei/mei-verovio.xml
@@ -125,6 +125,34 @@
 					</attList>
 				</classSpec>
 
+				<classSpec ident="att.bracketSpan.log" module="MEI.cmn" type="atts" mode="change">
+					<attList>
+						<attDef ident="func" usage="req" mode="change">
+							<datatype>
+								<rng:data type="NMTOKENS"/>
+							</datatype>
+							<valList type="closed" mode="replace">
+								<valItem ident="coloration">
+									<desc xml:lang="en">Represents coloration in the mensural notation source material.</desc>
+								</valItem>
+								<valItem ident="cross-rhythm">
+									<desc xml:lang="en">Marks a sequence which does not match the current meter.</desc>
+								</valItem>
+								<valItem ident="ligature">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem>
+								<!-- Verovio specific values -->
+								<valItem ident="analytical">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem>
+								<valItem ident="uspecified">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem>
+							</valList>
+						</attDef>
+					</attList>
+				</classSpec>
+
 				<!-- ****************************************************************** -->
 				<!-- Page-based MEI -->
 				<!-- ****************************************************************** -->
@@ -522,8 +550,8 @@
 				<moduleSpec ident="MEI.frettab" mode="add">
 					<desc/>
 				</moduleSpec>
-				<dataSpec ident="data.COURSENUMBER" module="MEI.frettab" mode="add">
-					<desc xml:lang="en">In string tablature, the number of the course to be played, i.e., [1-9]+.</desc>
+				<dataSpec ident="data.COURSENUMBER" module="MEI.stringtab" mode="add">
+					<desc xml:lang="en">In string tablature, the number of the course to be played.</desc>
 					<content>
 						<rng:data type="positiveInteger"/>
 					</content>

--- a/libmei/mei/mei-verovio.xml
+++ b/libmei/mei/mei-verovio.xml
@@ -143,10 +143,13 @@
 								</valItem>
 								<!-- Verovio specific values -->
 								<valItem ident="analytical">
-									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+									<desc xml:lang="en">Highlights a grouping of some sort.</desc>
+								</valItem>
+								<valItem ident="phrase">
+									<desc xml:lang="en">Marks a phrase.</desc>
 								</valItem>
 								<valItem ident="uspecified">
-									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+									<desc xml:lang="en">Unspecified bracket.</desc>
 								</valItem>
 							</valList>
 						</attDef>

--- a/libmei/mei/mei-verovio.xml
+++ b/libmei/mei/mei-verovio.xml
@@ -54,7 +54,7 @@
 			<divGen type="toc"/>
 		</front>
 		<body>
-			<schemaSpec ident="mei" start="mei meiHead meiCorpus music" ns="http://www.music-encoding.org/ns/mei">
+			<schemaSpec ident="mei-verovio" start="mei meiHead meiCorpus music" ns="http://www.music-encoding.org/ns/mei">
 				<moduleRef key="MEI"/>
 				<moduleRef key="MEI.analytical"/>
 				<moduleRef key="MEI.cmn"/>

--- a/libmei/mei/mei-verovio.xml
+++ b/libmei/mei/mei-verovio.xml
@@ -570,7 +570,7 @@
 								<desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
 							</valItem>
 							<valItem ident="guitar.open.G">
-								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
+								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D3 G3 B3 D4.</desc>
 							</valItem>
 							<valItem ident="guitar.open.A">
 								<desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>

--- a/libmei/mei/mei-verovio_compiled.odd
+++ b/libmei/mei/mei-verovio_compiled.odd
@@ -4199,9 +4199,11 @@
 								</valItem><valItem ident="ligature">
 									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
 								</valItem><valItem ident="analytical">
-									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+									<desc xml:lang="en">Highlights a grouping of some sort.</desc>
+								</valItem><valItem ident="phrase">
+									<desc xml:lang="en">Marks a phrase.</desc>
 								</valItem><valItem ident="uspecified">
-									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+									<desc xml:lang="en">Unspecified bracket.</desc>
 								</valItem></valList></attDef></attList></classSpec><classSpec rend="add" ident="att.breath.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">

--- a/libmei/mei/mei-verovio_compiled.odd
+++ b/libmei/mei/mei-verovio_compiled.odd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:base="file:/Users/rettinghaus/git/verovio/libmei/mei/mei-verovio.xml"><?TEIVERSION Version 5.0?>
+<?xml version="1.0" encoding="utf-8"?><TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:base="file:/Users/klaus/git/verovio/libmei/mei/mei-verovio.xml"><?TEIVERSION Version 5.0?>
 	<teiHeader>
 		<fileDesc>
 			<titleStmt>
@@ -50,7 +50,7 @@
 			<divGen type="toc"/>
 		</front>
 		<body>
-			<schemaSpec ident="mei" start="mei meiHead meiCorpus music" ns="http://www.music-encoding.org/ns/mei" source="/Users/rettinghaus/git/music-encoding/build/mei-source_canonicalized.xml"><macroSpec rend="add" ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
+			<schemaSpec ident="mei-verovio" start="mei meiHead meiCorpus music" ns="http://www.music-encoding.org/ns/mei" source="/Users/klaus/git/music-encoding/build/mei-source_canonicalized.xml"><macroSpec rend="add" ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Written accidental values.</desc>
     <content xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <alternate minOccurs="1" maxOccurs="1"><macroRef key="data.ACCIDENTAL.WRITTEN.basic"/><macroRef key="data.ACCIDENTAL.WRITTEN.extended"/><macroRef key="data.ACCIDENTAL.aeu"/><macroRef key="data.ACCIDENTAL.persian"/></alternate>
@@ -4190,35 +4190,19 @@
       <memberOf key="att.startEndId"/>
       <memberOf key="att.timestamp2.log"/>
     </classes>
-  </classSpec><classSpec rend="add" ident="att.bracketSpan.log" module="MEI.cmn" type="atts">
-    <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
-    <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <memberOf key="att.controlEvent"/>
-      <memberOf key="att.duration.additive"/>
-      <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.log"/>
-    </classes>
-    <attList xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
-      <attDef ident="func" usage="req">
-        <gloss versionDate="2022-10-18" xml:lang="en">function</gloss>
-        <desc xml:lang="en">Describes the function of the bracketed event sequence.</desc>
-        <datatype>
-          <rng:data type="NMTOKENS"/>
-        </datatype>
-        <valList type="semi">
-          <valItem ident="coloration">
-            <desc xml:lang="en">Represents coloration in the mensural notation source material.</desc>
-          </valItem>
-          <valItem ident="cross-rhythm">
-            <desc xml:lang="en">Marks a sequence which does not match the current meter.</desc>
-          </valItem>
-          <valItem ident="ligature">
-            <desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
-          </valItem>
-        </valList>
-      </attDef>
-    </attList>
-  </classSpec><classSpec rend="add" ident="att.breath.log" module="MEI.cmn" type="atts">
+  </classSpec><classSpec rend="add" ident="att.bracketSpan.log" module="MEI.cmn" type="atts"><desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc><classes><memberOf key="att.controlEvent"/><memberOf key="att.duration.additive"/><memberOf key="att.startEndId"/><memberOf key="att.timestamp2.log"/></classes><attList><attDef ident="func" usage="req"><gloss xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" versionDate="2022-10-18" xml:lang="en">function</gloss><desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Describes the function of the bracketed event sequence.</desc><datatype>
+								<rng:data type="NMTOKENS"/>
+							</datatype><valList type="closed"><valItem ident="coloration">
+									<desc xml:lang="en">Represents coloration in the mensural notation source material.</desc>
+								</valItem><valItem ident="cross-rhythm">
+									<desc xml:lang="en">Marks a sequence which does not match the current meter.</desc>
+								</valItem><valItem ident="ligature">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem><valItem ident="analytical">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem><valItem ident="uspecified">
+									<desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
+								</valItem></valList></attDef></attList></classSpec><classSpec rend="add" ident="att.breath.log" module="MEI.cmn" type="atts">
     <desc xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">Logical domain attributes.</desc>
     <classes xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude">
       <memberOf key="att.alignment"/>
@@ -20435,8 +20419,8 @@
 					</attList>
 				</classSpec><moduleSpec ident="MEI.frettab" mode="add">
 					<desc/>
-				</moduleSpec><dataSpec rend="add" ident="data.COURSENUMBER" module="MEI.frettab" mode="add">
-					<desc xml:lang="en">In string tablature, the number of the course to be played, i.e., [1-9]+.</desc>
+				</moduleSpec><dataSpec rend="add" ident="data.COURSENUMBER" module="MEI.stringtab" mode="add">
+					<desc xml:lang="en">In string tablature, the number of the course to be played.</desc>
 					<content>
 						<rng:data type="positiveInteger"/>
 					</content>
@@ -20498,7 +20482,7 @@
 						<memberOf key="att.course.log"/>
 					</classes></elementSpec><elementSpec rend="add" ident="foo" module="MEI.frettab" mode="add"><gloss>foo information</gloss><desc xml:lang="en">Dummy element for enforcing that the att classes are used.</desc><classes>
 						<memberOf key="att.note.ges.tab"/>
-					</classes></elementSpec><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.analytical"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.cmn"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.cmnOrnaments"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.corpus"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.critapp"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.drama"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.edittrans"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.externalsymbols"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.facsimile"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.figtable"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.fingering"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.frbr"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.gestural"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.harmony"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.header"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.lyrics"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.mensural"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.midi"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.namesdates"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.neumes"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.performance"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.ptrref"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.shared"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.text"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.usersymbols"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.visual"/></schemaSpec>
+					</classes></elementSpec><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.analytical"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.cmn"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.cmnOrnaments"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.corpus"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.critapp"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.drama"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.edittrans"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.externalsymbols"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.facsimile"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.figtable"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.fingering"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.frbr"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.gestural"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.harmony"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.header"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.lyrics"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.mensural"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.midi"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.namesdates"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.neumes"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.performance"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.ptrref"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.shared"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.text"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.usersymbols"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.visual"/><moduleSpec xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" n="" ident="MEI.stringtab"/></schemaSpec>
 		</body>
 	</text>
 </TEI>

--- a/libmei/mei/mei-verovio_compiled.odd
+++ b/libmei/mei/mei-verovio_compiled.odd
@@ -20438,7 +20438,7 @@
 								<desc xml:lang="en">Open D tuning for guitars. D2 A2 D3 F3s A3 D4.</desc>
 							</valItem>
 							<valItem ident="guitar.open.G">
-								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D2 G2 B3 D4.</desc>
+								<desc xml:lang="en">Open G tuning for guitars. D2 G2 D3 G3 B3 D4.</desc>
 							</valItem>
 							<valItem ident="guitar.open.A">
 								<desc xml:lang="en">Open A tuning for guitars. E2 A2 E3 A3 C4s E4.</desc>

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -21245,6 +21245,7 @@ void HumdrumInput::processPhrases(hum::HTp phraseend)
                 insertPhrase(bracket, phrasestart, phraseend, startmeasure, startchordsorted, endchordsorted,
                     phrasestartnoteinfo, phraseendnoteinfo, ndex, phraseindex, i, j, startpitches, endpitches,
                     indexused);
+                bracket->SetFunc(bracketSpanLog_FUNC_phrase);
             }
         }
     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -2008,7 +2008,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             bracketSpan->SetLform(
                 bracketSpan->AttLineRendBase::StrToLineform(bracket.attribute("line-type").as_string()));
             // bracketSpan->SetPlace(bracketSpan->AttPlacementRelStaff::StrToStaffrel(placeStr.c_str()));
-            // bracketSpan->SetFunc("unclear");
+            bracketSpan->SetFunc(bracketSpanLog_FUNC_uspecified);
             bracketSpan->SetLstartsym(ConvertLineEndSymbol(bracket.attribute("line-end").as_string()));
             bracketSpan->SetTstamp(timeStamp);
             m_controlElements.push_back({ measureNum, bracketSpan });
@@ -2433,7 +2433,7 @@ void MusicXmlInput::ReadMusicXmlDirection(
             musicxml::OpenSpanner openBracket(voiceNumber, m_measureCounts.at(measure));
             bracketSpan->SetColor(lead.attribute("color").as_string());
             // bracketSpan->SetPlace(bracketSpan->AttPlacementRelStaff::StrToStaffrel(placeStr.c_str()));
-            // bracketSpan->SetFunc("analytical");
+            bracketSpan->SetFunc(bracketSpanLog_FUNC_analytical);
             bracketSpan->SetLstartsym(ConvertLineEndSymbol(lead.attribute("symbol").as_string()));
             bracketSpan->SetTstamp(timeStamp);
             bracketSpan->SetType("principal-voice");


### PR DESCRIPTION
This replaces the semi-open value list in `att.bracketSpan.log` with a closed one adding two Verovio specific values.
Closes #3851