### PR TITLE
Fix c++ flags for Java / Android

### DIFF
--- a/bindings/android/jni/Application.mk
+++ b/bindings/android/jni/Application.mk
@@ -1,6 +1,6 @@
 # only build armeabi-v7a, if required add 'armeabi' or 'x86'
 APP_ABI := armeabi-v7a
-APP_CPPFLAGS += -fexceptions -frtti -std=c++17
+APP_CPPFLAGS += -fexceptions -frtti -std=c++20
 APP_OPTIM := release
 APP_STL := c++_shared
 APP_MODULES := verovio-android

--- a/bindings/java/build.sh
+++ b/bindings/java/build.sh
@@ -24,7 +24,7 @@ FILES="$SRCFILES \
  ../../src/json/jsonxx.cc \
  ../../src/crc/crc.cpp"
 
-CXXOPTS="-g -fpic -std=c++17 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/crc -I../../include/midi -I../../include/pugi -I../../include/zip -I../../libmei/addons -I../../libmei/dist -I/opt/local/include/ "
+CXXOPTS="-g -fpic -std=c++20 -I../../include -I../../include/vrv -I../../include/json -I../../include/hum -I../../include/crc -I../../include/midi -I../../include/pugi -I../../include/zip -I../../libmei/addons -I../../libmei/dist -I/opt/local/include/ "
 
 PATHS=""
 unamestr=$(uname)


### PR DESCRIPTION
## Summary

Closes #3874 
This PR updates the compiler flags for Java / Android bindings.

## Expected Outputs

```bash
$ mvn package

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.rism.verovio:VerovioToolkit >-------------------
[INFO] Building VerovioToolkit 4.5.0-dev
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- resources:3.3.1:resources (default-resources) @ VerovioToolkit ---
[INFO] skip non existing resourceDirectory /Users/withsang/Develop/verovio/bindings/java/src/main/resources
[INFO] 
[INFO] --- compiler:3.13.0:compile (default-compile) @ VerovioToolkit ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 11 source files with javac [debug target 1.8] to target/classes
[WARNING] bootstrap class path not set in conjunction with -source 8
[INFO] 
[INFO] --- antrun:3.1.0:run (build-native) @ VerovioToolkit ---
[INFO] Executing tasks
[INFO] Executed tasks
[INFO] 
[INFO] --- resources:3.3.1:testResources (default-testResources) @ VerovioToolkit ---
[INFO] skip non existing resourceDirectory /Users/withsang/Develop/verovio/bindings/java/src/test/resources
[INFO] 
[INFO] --- compiler:3.13.0:testCompile (default-testCompile) @ VerovioToolkit ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ VerovioToolkit ---
[INFO] No tests to run.
[INFO] 
[INFO] --- jar:3.4.1:jar (default-jar) @ VerovioToolkit ---
[INFO] Building jar: /Users/withsang/Develop/verovio/bindings/java/target/VerovioToolkit-4.5.0-dev.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:17 min
[INFO] Finished at: 2024-12-04T20:14:22+09:00
[INFO] ------------------------------------------------------------------------

$ cd example-mei                                                                             
$ javac -cp .:../target/VerovioToolkit-4.5.0-dev.jar main.java
$ java -cp ::../target/VerovioToolkit-4.5.0-dev.jar main  
```

