### PR TITLE
Const overload for GetTstampStaves

### DIFF
--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -85,7 +85,7 @@ public:
     bool IsOnStaff(int n) const;
 
     /**
-     * Return a vector of staves looking at the @staff attribute or at the parent staff or the @startid
+     * Return a vector of staves looking at the @staff attribute or at the parent staff of the @startid
      */
     ///@{
     std::vector<const Staff *> GetTstampStaves(const Measure *measure, const Object *object) const;

--- a/include/vrv/timeinterface.h
+++ b/include/vrv/timeinterface.h
@@ -87,7 +87,10 @@ public:
     /**
      * Return a vector of staves looking at the @staff attribute or at the parent staff or the @startid
      */
-    std::vector<Staff *> GetTstampStaves(Measure *measure, Object *object);
+    ///@{
+    std::vector<const Staff *> GetTstampStaves(const Measure *measure, const Object *object) const;
+    std::vector<Staff *> GetTstampStaves(const Measure *measure, const Object *object);
+    ///@}
 
     /**
      * Return true if the interface owner is encoded in the measure of its start element

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -108,17 +108,26 @@ bool TimePointInterface::IsOnStaff(int n) const
     return false;
 }
 
-std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Object *object)
+std::vector<Staff *> TimePointInterface::GetTstampStaves(const Measure *measure, const Object *object)
+{
+    std::vector<const Staff *> staves = std::as_const(*this).GetTstampStaves(measure, object);
+    std::vector<Staff *> stavesCasted;
+    std::transform(staves.begin(), staves.end(), std::back_inserter(stavesCasted),
+        [](const Staff *staff) { return const_cast<Staff *>(staff); });
+    return stavesCasted;
+}
+
+std::vector<const Staff *> TimePointInterface::GetTstampStaves(const Measure *measure, const Object *object) const
 {
     assert(measure);
     assert(object);
 
-    std::vector<Staff *> staves;
+    std::vector<const Staff *> staves;
     std::vector<int> staffList;
 
     // For <f> within <harm> without @staff we try to get the @staff from the <harm> ancestor
     if (object->Is(FIGURE) && !this->HasStaff()) {
-        Harm *harm = vrv_cast<Harm *>(object->GetFirstAncestor(HARM));
+        const Harm *harm = vrv_cast<const Harm *>(object->GetFirstAncestor(HARM));
         if (harm) {
             staffList = harm->GetStaff();
         }
@@ -127,7 +136,7 @@ std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Objec
         bool isInBetween = false;
         // limit between support to some elements?
         if (object->Is({ DYNAM, DIR, HAIRPIN, TEMPO })) {
-            AttPlacementRelStaff *att = dynamic_cast<AttPlacementRelStaff *>(object);
+            const AttPlacementRelStaff *att = dynamic_cast<const AttPlacementRelStaff *>(object);
             assert(att);
             isInBetween = (att->GetPlace() == STAFFREL_between);
         }
@@ -141,18 +150,18 @@ std::vector<Staff *> TimePointInterface::GetTstampStaves(Measure *measure, Objec
         }
     }
     else if (m_start && !m_start->Is({ BARLINE, TIMESTAMP_ATTR })) {
-        Staff *staff = m_start->GetAncestorStaff();
+        const Staff *staff = m_start->GetAncestorStaff();
         staffList.push_back(staff->GetN());
     }
     else if (measure->GetChildCount(STAFF) == 1) {
         // If we have no @staff or startid but only one staff child assume it is the first one
-        Staff *staff = vrv_cast<Staff *>(measure->GetFirst(STAFF));
+        const Staff *staff = vrv_cast<const Staff *>(measure->GetFirst(STAFF));
         staffList.push_back(staff->GetN());
     }
 
     for (int staffN : staffList) {
         AttNIntegerComparison comparison(STAFF, staffN);
-        Staff *staff = vrv_cast<Staff *>(measure->FindDescendantByComparison(&comparison, 1));
+        const Staff *staff = vrv_cast<const Staff *>(measure->FindDescendantByComparison(&comparison, 1));
         if (!staff) {
             // LogDebug("Staff with @n '%d' not found in measure '%s'", *iter, measure->GetID().c_str());
             continue;


### PR DESCRIPTION
This MR adds a const overload to `TimePointInterface::GetTstampStaves`. Related to the changes in #3881 .