### PR TITLE
Implement issue #3892 Small performance increase obtainable by constructing regular expressions just once.

### DIFF
--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -8443,13 +8443,13 @@ void HumdrumInput::setInstrumentAbbreviation(ELEMENT *element, const std::string
 
     std::string name8 = name;
     // Substitute b and "-flat" for Unicode flat symbol:
-    std::regex exp1("\\b([ABDEFG])b\\b");
-    std::regex exp2("\\b([A-Ga-g])-flat\\b");
+    static const std::regex exp1("\\b([ABDEFG])b\\b");
+    static const std::regex exp2("\\b([A-Ga-g])-flat\\b");
     name8 = std::regex_replace(name8, exp1, "$1\xe2\x99\xad");
     name8 = std::regex_replace(name8, exp2, "$1\xe2\x99\xad");
     // Substitute # and "-sharp" for Unicode sharp symbol:
-    std::regex exp3("\\b([A-G])#\\b");
-    std::regex exp4("\\b([A-Ga-g])-sharp\\b");
+    static const std::regex exp3("\\b([A-G])#\\b");
+    static const std::regex exp4("\\b([A-Ga-g])-sharp\\b");
     name8 = std::regex_replace(name8, exp3, "$1\xe2\x99\xaf");
     name8 = std::regex_replace(name8, exp4, "$1\xe2\x99\xaf");
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3051,9 +3051,9 @@ void MusicXmlInput::ReadMusicXmlNote(
                     std::string textStr = childNode.text().as_string();
 
                     // convert verse numbers to labels
-                    std::regex labelSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)$");
+                    static const std::regex labelSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)$");
                     std::smatch labelSearchMatches;
-                    std::regex labelPrefixSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)[\\s\\u00A0]+");
+                    static const std::regex labelPrefixSearch("^([^[:alpha:]]*\\d[^[:alpha:]]*)[\\s\\u00A0]+");
                     std::smatch labelPrefixSearchMatches;
                     if (!textStr.empty() && std::regex_search(textStr, labelSearchMatches, labelSearch)
                         && labelSearchMatches.ready() && childNode.next_sibling("elision")) {

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -1249,7 +1249,7 @@ int PAEInput::getTupletFermata(const char *incipit, pae::Note *note, int index)
     // std::regex_constants::ECMAScript is the default syntax, so optional.
     // Previously these were extended regex syntax, but this case
     // is the same in ECMAScript syntax.
-    std::regex exp("^([^)]*[ABCDEFG-][^)]*[ABCDEFG-][^)]*)", std::regex_constants::ECMAScript);
+    static const std::regex exp("^([^)]*[ABCDEFG-][^)]*[ABCDEFG-][^)]*)", std::regex_constants::ECMAScript);
     bool is_tuplet = regex_search(incipit + i, exp);
 
     if (is_tuplet) {

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -235,20 +235,20 @@ bool AreEqual(double dFirstVal, double dSecondVal)
 bool IsValidInteger(const std::string &value)
 {
     // Accept "1" " 1 " "+1" "-1" "1." "1.0"
-    std::regex re(R"(^\s*[+-]?\d+\.?\d*\s*$)");
+    static const std::regex re(R"(^\s*[+-]?\d+\.?\d*\s*$)");
     return std::regex_match(value, re);
 }
 
 bool IsValidDouble(const std::string &value)
 {
     // Accept "1.0" " 1.0 " ".0"  "1." "+1.0" "-1.0"
-    std::regex re(R"(^\s*[+-]?(?:\d+\.?\d*|\.\d+)\s*$)");
+    static const std::regex re(R"(^\s*[+-]?(?:\d+\.?\d*|\.\d+)\s*$)");
     return std::regex_match(value, re);
 }
 
 bool IsDigits(const std::string &value)
 {
-    std::regex re(R"(^\d+$)");
+    static const std::regex re(R"(^\d+$)");
     return std::regex_match(value, re);
 }
 
@@ -432,8 +432,8 @@ std::string BaseEncodeInt(uint32_t value, uint8_t base)
 
 std::string FromCamelCase(const std::string &s)
 {
-    std::regex regExp1("(.)([A-Z][a-z]+)");
-    std::regex regExp2("([a-z0-9])([A-Z])");
+    static const std::regex regExp1("(.)([A-Z][a-z]+)");
+    static const std::regex regExp2("([a-z0-9])([A-Z])");
 
     std::string result = s;
     result = std::regex_replace(result, regExp1, "$1-$2");


### PR DESCRIPTION
Make all std::regex definitions "static const" so that they are only constructed once.