### PR TITLE
Fix bug in Toolkit::RedoLayout. Fixes #3900

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -431,6 +431,12 @@ public:
     Object *DetachChild(int idx);
 
     /**
+     * Replace an object with a copy of the other.
+     * They must be of the same class.
+     */
+    void ReplaceWithCopyOf(Object *object);
+
+    /**
      * Return true if the object has the child Object as descendant (reference of direct).
      * Processes in depth-first.
      */

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -357,7 +357,7 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitStaffDef(StaffDef *staffDef)
         m_octDefaultForStaffN[staffDef->GetN()] = staffDef->GetOctDefault();
     }
 
-    return FUNCTOR_CONTINUE;
+    return FUNCTOR_SIBLINGS;
 }
 
 } // namespace vrv

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -572,6 +572,14 @@ Object *Object::DetachChild(int idx)
     return child;
 }
 
+void Object::ReplaceWithCopyOf(Object *object)
+{
+    Object *parent = this->GetParent();
+    *this = *object;
+    this->CloneReset();
+    this->SetParent(parent);
+}
+
 bool Object::HasDescendant(const Object *child, int deepness) const
 {
     ArrayOfObjects::const_iterator iter;

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -484,21 +484,21 @@ void ScoreDef::ResetFromDrawingValues()
         assert(staffDef);
 
         Clef *clef = vrv_cast<Clef *>(staffDef->FindDescendantByType(CLEF));
-        if (clef) *clef = *staffDef->GetCurrentClef();
+        if (clef) clef->ReplaceWithCopyOf(staffDef->GetCurrentClef());
 
         KeySig *keySig = vrv_cast<KeySig *>(staffDef->FindDescendantByType(KEYSIG));
-        if (keySig) *keySig = *staffDef->GetCurrentKeySig();
+        if (keySig) keySig->ReplaceWithCopyOf(staffDef->GetCurrentKeySig());
 
         Mensur *mensur = vrv_cast<Mensur *>(staffDef->FindDescendantByType(MENSUR));
-        if (mensur) *mensur = *staffDef->GetCurrentMensur();
+        if (mensur) mensur->ReplaceWithCopyOf(staffDef->GetCurrentMensur());
 
         MeterSigGrp *meterSigGrp = vrv_cast<MeterSigGrp *>(staffDef->FindDescendantByType(METERSIGGRP));
         MeterSig *meterSig = vrv_cast<MeterSig *>(staffDef->FindDescendantByType(METERSIG));
         if (meterSigGrp) {
-            *meterSigGrp = *staffDef->GetCurrentMeterSigGrp();
+            meterSigGrp->ReplaceWithCopyOf(staffDef->GetCurrentMeterSigGrp());
         }
         else if (meterSig) {
-            *meterSig = *staffDef->GetCurrentMeterSig();
+            meterSig->ReplaceWithCopyOf(staffDef->GetCurrentMeterSig());
         }
     }
 }


### PR DESCRIPTION
The staffDef values were loosing their parent when being replaced. Fixed with a new method added for doing it properly. Also, processing them in CalcAligmentPitchPos is not needed, so VisitStaffDef was modified accordingly.