### PR TITLE
Add support for MEI cpMark

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -655,6 +655,12 @@
 		4DACCA162990F2E600B55913 /* att.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DACCA0D2990F2E600B55913 /* att.cpp */; };
 		4DACCA172990F2E600B55913 /* attdef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DACCA0E2990F2E600B55913 /* attdef.h */; };
 		4DACCA182990F2E600B55913 /* attdef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DACCA0E2990F2E600B55913 /* attdef.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DAD09052D1EA207006095DC /* cpmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD09042D1EA207006095DC /* cpmark.cpp */; };
+		4DAD09062D1EA207006095DC /* cpmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD09042D1EA207006095DC /* cpmark.cpp */; };
+		4DAD09072D1EA207006095DC /* cpmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD09042D1EA207006095DC /* cpmark.cpp */; };
+		4DAD09082D1EA207006095DC /* cpmark.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DAD09042D1EA207006095DC /* cpmark.cpp */; };
+		4DAD090A2D1EA236006095DC /* cpmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DAD09092D1EA236006095DC /* cpmark.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4DAD090B2D1EA236006095DC /* cpmark.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DAD09092D1EA236006095DC /* cpmark.h */; };
 		4DB0B0161C44129300DBDCC3 /* timestamp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB0B0151C44129300DBDCC3 /* timestamp.cpp */; };
 		4DB0B0171C44129300DBDCC3 /* timestamp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4DB0B0151C44129300DBDCC3 /* timestamp.cpp */; };
 		4DB0B0191C4412A400DBDCC3 /* timestamp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DB0B0181C4412A400DBDCC3 /* timestamp.h */; };
@@ -1435,7 +1441,7 @@
 		BDEF9EC926725234008A3A47 /* caesura.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDEF9EC626725234008A3A47 /* caesura.cpp */; };
 		BDEF9ECA26725234008A3A47 /* caesura.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDEF9EC626725234008A3A47 /* caesura.cpp */; };
 		BDEF9ECC26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
-		BDEF9ECD26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; };
+		BDEF9ECD26725248008A3A47 /* caesura.h in Headers */ = {isa = PBXBuildFile; fileRef = BDEF9ECB26725248008A3A47 /* caesura.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E708AA6229D2B96A001F937A /* adjustfloatingpositionerfunctor.h in Headers */ = {isa = PBXBuildFile; fileRef = E708AA6129D2B965001F937A /* adjustfloatingpositionerfunctor.h */; };
 		E708AA6329D2B96B001F937A /* adjustfloatingpositionerfunctor.h in Headers */ = {isa = PBXBuildFile; fileRef = E708AA6129D2B965001F937A /* adjustfloatingpositionerfunctor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E708AA6529D2B985001F937A /* adjustfloatingpositionerfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E708AA6429D2B985001F937A /* adjustfloatingpositionerfunctor.cpp */; };
@@ -2026,6 +2032,8 @@
 		4DACCA0C2990F2E600B55913 /* attalternates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = attalternates.h; path = libmei/addons/attalternates.h; sourceTree = "<group>"; };
 		4DACCA0D2990F2E600B55913 /* att.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = att.cpp; path = libmei/addons/att.cpp; sourceTree = "<group>"; };
 		4DACCA0E2990F2E600B55913 /* attdef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = attdef.h; path = libmei/addons/attdef.h; sourceTree = "<group>"; };
+		4DAD09042D1EA207006095DC /* cpmark.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cpmark.cpp; path = src/cpmark.cpp; sourceTree = "<group>"; };
+		4DAD09092D1EA236006095DC /* cpmark.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = cpmark.h; path = include/vrv/cpmark.h; sourceTree = "<group>"; };
 		4DB0B0151C44129300DBDCC3 /* timestamp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = timestamp.cpp; path = src/timestamp.cpp; sourceTree = "<group>"; };
 		4DB0B0181C4412A400DBDCC3 /* timestamp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = timestamp.h; path = include/vrv/timestamp.h; sourceTree = "<group>"; };
 		4DB3072D1AC9ED1800EE0982 /* space.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = space.h; path = include/vrv/space.h; sourceTree = "<group>"; };
@@ -2742,6 +2750,8 @@
 				4DE644F31EDBE9F8002FBE6C /* breath.h */,
 				BDEF9EC626725234008A3A47 /* caesura.cpp */,
 				BDEF9ECB26725248008A3A47 /* caesura.h */,
+				4DAD09042D1EA207006095DC /* cpmark.cpp */,
+				4DAD09092D1EA236006095DC /* cpmark.h */,
 				4DB351111C8040B1002DD057 /* dir.cpp */,
 				4DB3510E1C80409E002DD057 /* dir.h */,
 				4DDBBB591C7AE45900054AFF /* dynam.cpp */,
@@ -3480,6 +3490,7 @@
 				4D1BE7821C69434C0086DC0E /* MidiFile.h in Headers */,
 				4DACC9B62990F29A00B55913 /* atts_edittrans.h in Headers */,
 				4DEC4DD221C8295700D1D273 /* supplied.h in Headers */,
+				4DAD090B2D1EA236006095DC /* cpmark.h in Headers */,
 				4D3C3F11294B89C9009993E6 /* ornam.h in Headers */,
 				4DD7C0FF27A55CFD00B9C017 /* timemap.h in Headers */,
 				E79320642991452100D80975 /* calcstemfunctor.h in Headers */,
@@ -3707,6 +3718,7 @@
 				BB4C4B8622A932DF001F6AF0 /* lb.h in Headers */,
 				E77C197E28CD317B00F5BADA /* calcdotsfunctor.h in Headers */,
 				BD0562302518CD12004057EB /* beamspan.h in Headers */,
+				4DAD090A2D1EA236006095DC /* cpmark.h in Headers */,
 				E7E9C11B29B0EF9700CFCE2F /* adjusttempofunctor.h in Headers */,
 				BB4C4AFE22A932BC001F6AF0 /* subst.h in Headers */,
 				BB4C4AFC22A932BC001F6AF0 /* sic.h in Headers */,
@@ -4080,6 +4092,7 @@
 				E78F204B29D98D2B00CD5910 /* adjustxrelfortranscriptionfunctor.cpp in Sources */,
 				BD0562372518CD20004057EB /* beamspan.cpp in Sources */,
 				4D1694181E3A44F300569BF4 /* text.cpp in Sources */,
+				4DAD09052D1EA207006095DC /* cpmark.cpp in Sources */,
 				E7265E7329DC701000D11F41 /* castofffunctor.cpp in Sources */,
 				E7D48C7529D21F2B0031D89D /* adjustyposfunctor.cpp in Sources */,
 				E77C198228CD31AC00F5BADA /* calcdotsfunctor.cpp in Sources */,
@@ -4392,6 +4405,7 @@
 				E7770F8629D0DA1800A9BECF /* adjustslursfunctor.cpp in Sources */,
 				E7F39C6129A62B3E0055DBE0 /* adjustclefchangesfunctor.cpp in Sources */,
 				8F086EF8188539540037FD8E /* note.cpp in Sources */,
+				4DAD09082D1EA207006095DC /* cpmark.cpp in Sources */,
 				409B3DD91F2D1C2A0098A265 /* ftrem.cpp in Sources */,
 				4D5FA9111E16A93F00F3B919 /* boundingbox.cpp in Sources */,
 				8F086EF9188539540037FD8E /* object.cpp in Sources */,
@@ -4663,6 +4677,7 @@
 				E78F204C29D98D2C00CD5910 /* adjustxrelfortranscriptionfunctor.cpp in Sources */,
 				4DDBBCC61C2EBAE7001AB50A /* view_text.cpp in Sources */,
 				8F3DD34618854B2E0051330C /* layerelement.cpp in Sources */,
+				4DAD09072D1EA207006095DC /* cpmark.cpp in Sources */,
 				BD6E5C3E290007CA0039B0F1 /* graphic.cpp in Sources */,
 				E7265E7129DC700800D11F41 /* castofffunctor.cpp in Sources */,
 				E7D48C7629D21F2C0031D89D /* adjustyposfunctor.cpp in Sources */,
@@ -4955,6 +4970,7 @@
 				E78F204D29D98D2D00CD5910 /* adjustxrelfortranscriptionfunctor.cpp in Sources */,
 				E77C198128CD318B00F5BADA /* calcdotsfunctor.cpp in Sources */,
 				BD87768627CE8A1A005B97EA /* layerdef.cpp in Sources */,
+				4DAD09062D1EA207006095DC /* cpmark.cpp in Sources */,
 				BB4C4AF722A932BC001F6AF0 /* reg.cpp in Sources */,
 				E7265E7229DC700800D11F41 /* castofffunctor.cpp in Sources */,
 				E7D48C7729D21F2D0031D89D /* adjustyposfunctor.cpp in Sources */,

--- a/bindings/iOS/all.h
+++ b/bindings/iOS/all.h
@@ -69,6 +69,7 @@
 #import <VerovioFramework/convertfunctor.h>
 #import <VerovioFramework/corr.h>
 #import <VerovioFramework/course.h>
+#import <VerovioFramework/cpmark.h>
 #import <VerovioFramework/crc.h>
 #import <VerovioFramework/custos.h>
 #import <VerovioFramework/damage.h>

--- a/include/vrv/cpmark.h
+++ b/include/vrv/cpmark.h
@@ -1,0 +1,90 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        cpmark.h
+// Author:      Laurent Pugin
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __VRV_CPMARK_H__
+#define __VRV_CPMARK_H__
+
+#include "controlelement.h"
+#include "textdirinterface.h"
+#include "timeinterface.h"
+
+namespace vrv {
+
+class TextElement;
+
+//----------------------------------------------------------------------------
+// CpMark (copy/colla parte mark)
+//----------------------------------------------------------------------------
+
+/**
+ * This class models the MEI <cpMark> element.
+ */
+class CpMark : public ControlElement, public TextListInterface, public TextDirInterface, public TimeSpanningInterface {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * Reset method reset all attribute classes
+     */
+    ///@{
+    CpMark();
+    virtual ~CpMark();
+    Object *Clone() const override { return new CpMark(*this); }
+    void Reset() override;
+    std::string GetClassName() const override { return "CpMark"; }
+    ///@}
+
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    TextDirInterface *GetTextDirInterface() override { return vrv_cast<TextDirInterface *>(this); }
+    const TextDirInterface *GetTextDirInterface() const override { return vrv_cast<const TextDirInterface *>(this); }
+    TimePointInterface *GetTimePointInterface() override { return vrv_cast<TimePointInterface *>(this); }
+    const TimePointInterface *GetTimePointInterface() const override
+    {
+        return vrv_cast<const TimePointInterface *>(this);
+    }
+    TimeSpanningInterface *GetTimeSpanningInterface() override { return vrv_cast<TimeSpanningInterface *>(this); }
+    const TimeSpanningInterface *GetTimeSpanningInterface() const override
+    {
+        return vrv_cast<const TimeSpanningInterface *>(this);
+    }
+    ///@}
+
+    /**
+     * Add an element (text, rend. etc.) to a cpMark.
+     * Only supported elements will be actually added to the child list.
+     */
+    bool IsSupportedChild(Object *object) override;
+
+    //----------//
+    // Functors //
+    //----------//
+
+    /**
+     * Interface for class functor visitation
+     */
+    ///@{
+    FunctorCode Accept(Functor &functor) override;
+    FunctorCode Accept(ConstFunctor &functor) const override;
+    FunctorCode AcceptEnd(Functor &functor) override;
+    FunctorCode AcceptEnd(ConstFunctor &functor) const override;
+    ///@}
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    //
+};
+
+} // namespace vrv
+
+#endif

--- a/include/vrv/functorinterface.h
+++ b/include/vrv/functorinterface.h
@@ -30,6 +30,7 @@ class Chord;
 class Clef;
 class ControlElement;
 class Course;
+class CpMark;
 class Custos;
 class Dir;
 class Div;
@@ -292,6 +293,8 @@ public:
     virtual FunctorCode VisitCaesuraEnd(Caesura *caesura);
     virtual FunctorCode VisitControlElement(ControlElement *controlElement);
     virtual FunctorCode VisitControlElementEnd(ControlElement *controlElement);
+    virtual FunctorCode VisitCpMark(CpMark *cpMark);
+    virtual FunctorCode VisitCpMarkEnd(CpMark *cpMark);
     virtual FunctorCode VisitDir(Dir *dir);
     virtual FunctorCode VisitDirEnd(Dir *dir);
     virtual FunctorCode VisitDynam(Dynam *dynam);
@@ -665,6 +668,8 @@ public:
     virtual FunctorCode VisitCaesuraEnd(const Caesura *caesura);
     virtual FunctorCode VisitControlElement(const ControlElement *controlElement);
     virtual FunctorCode VisitControlElementEnd(const ControlElement *controlElement);
+    virtual FunctorCode VisitCpMark(const CpMark *cpMark);
+    virtual FunctorCode VisitCpMarkEnd(const CpMark *cpMark);
     virtual FunctorCode VisitDir(const Dir *dir);
     virtual FunctorCode VisitDirEnd(const Dir *dir);
     virtual FunctorCode VisitDynam(const Dynam *dynam);

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -46,6 +46,7 @@ class Clef;
 class ControlElement;
 class Corr;
 class Course;
+class CpMark;
 class Custos;
 class Damage;
 class Del;
@@ -437,6 +438,7 @@ private:
     void WriteBracketSpan(pugi::xml_node currentNode, BracketSpan *bracketSpan);
     void WriteBreath(pugi::xml_node currentNode, Breath *breath);
     void WriteCaesura(pugi::xml_node currentNode, Caesura *caesura);
+    void WriteCpMark(pugi::xml_node currentNode, CpMark *cpMark);
     void WriteDir(pugi::xml_node currentNode, Dir *dir);
     void WriteDynam(pugi::xml_node currentNode, Dynam *dynam);
     void WriteFermata(pugi::xml_node currentNode, Fermata *fermata);
@@ -753,6 +755,7 @@ private:
     bool ReadBracketSpan(Object *parent, pugi::xml_node bracketSpan);
     bool ReadBreath(Object *parent, pugi::xml_node breath);
     bool ReadCaesura(Object *parent, pugi::xml_node caesura);
+    bool ReadCpMark(Object *parent, pugi::xml_node cpMark);
     bool ReadDir(Object *parent, pugi::xml_node dir);
     bool ReadDynam(Object *parent, pugi::xml_node dynam);
     bool ReadFermata(Object *parent, pugi::xml_node fermata);

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -181,6 +181,7 @@ enum ClassId : uint16_t {
     BRACKETSPAN,
     BREATH,
     CAESURA,
+    CPMARK,
     DIR,
     DYNAM,
     FERMATA,

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -115,6 +115,7 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
 
         // Handle within placement (ignore collisions for certain classes)
         if (place == STAFFREL_within) {
+            if (m_classId == CPMARK) continue;
             if (m_classId == DIR) continue;
             if (m_classId == HAIRPIN) continue;
         }
@@ -213,6 +214,9 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
     system->m_systemAligner.Process(adjustFloatingPositionerGrps);
     adjustFloatingPositionerGrps.SetPlace(STAFFREL_below);
     system->m_systemAligner.Process(adjustFloatingPositionerGrps);
+
+    m_classId = CPMARK;
+    system->m_systemAligner.Process(*this);
 
     m_classId = REPEATMARK;
     system->m_systemAligner.Process(*this);
@@ -430,7 +434,7 @@ FunctorCode AdjustFloatingPositionersBetweenFunctor::VisitStaffAlignment(StaffAl
 
     for (FloatingPositioner *positioner : m_previousStaffAlignment->GetFloatingPositioners()) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->Is({ DIR, DYNAM, HAIRPIN, TEMPO })) continue;
+        if (!positioner->GetObject()->Is({ CPMARK, DIR, DYNAM, HAIRPIN, TEMPO })) continue;
 
         if (positioner->GetDrawingPlace() != STAFFREL_between) continue;
 

--- a/src/adjustxoverflowfunctor.cpp
+++ b/src/adjustxoverflowfunctor.cpp
@@ -32,7 +32,7 @@ AdjustXOverflowFunctor::AdjustXOverflowFunctor(int margin) : Functor()
 
 FunctorCode AdjustXOverflowFunctor::VisitControlElement(ControlElement *controlElement)
 {
-    if (!controlElement->Is({ DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
+    if (!controlElement->Is({ CPMARK, DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/cpmark.cpp
+++ b/src/cpmark.cpp
@@ -1,0 +1,87 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        cpmark.cpp
+// Author:      Laurent Pugin
+// Created:     2024
+// Copyright (c) Authors and others. All rights reserved.
+/////////////////////////////////////////////////////////////////////////////
+
+#include "cpmark.h"
+
+//----------------------------------------------------------------------------
+
+#include <cassert>
+
+//----------------------------------------------------------------------------
+
+#include "comparison.h"
+#include "editorial.h"
+#include "functor.h"
+#include "symbol.h"
+#include "text.h"
+#include "verticalaligner.h"
+#include "vrv.h"
+
+namespace vrv {
+
+//----------------------------------------------------------------------------
+// CpMark
+//----------------------------------------------------------------------------
+
+static const ClassRegistrar<CpMark> s_factory("cpMark", CPMARK);
+
+CpMark::CpMark() : ControlElement(DIR, "cpmark-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
+{
+    this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
+    this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+
+    this->Reset();
+}
+
+CpMark::~CpMark() {}
+
+void CpMark::Reset()
+{
+    ControlElement::Reset();
+    TextDirInterface::Reset();
+    TimeSpanningInterface::Reset();
+}
+
+bool CpMark::IsSupportedChild(Object *child)
+{
+    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
+        assert(dynamic_cast<TextElement *>(child));
+    }
+    else if (child->IsEditorialElement()) {
+        assert(dynamic_cast<EditorialElement *>(child));
+    }
+    else {
+        return false;
+    }
+    return true;
+}
+
+//----------------------------------------------------------------------------
+// CpMark functor methods
+//----------------------------------------------------------------------------
+
+FunctorCode CpMark::Accept(Functor &functor)
+{
+    return functor.VisitCpMark(this);
+}
+
+FunctorCode CpMark::Accept(ConstFunctor &functor) const
+{
+    return functor.VisitCpMark(this);
+}
+
+FunctorCode CpMark::AcceptEnd(Functor &functor)
+{
+    return functor.VisitCpMarkEnd(this);
+}
+
+FunctorCode CpMark::AcceptEnd(ConstFunctor &functor) const
+{
+    return functor.VisitCpMarkEnd(this);
+}
+
+} // namespace vrv

--- a/src/cpmark.cpp
+++ b/src/cpmark.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<CpMark> s_factory("cpMark", CPMARK);
 
-CpMark::CpMark() : ControlElement(DIR, "cpmark-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
+CpMark::CpMark() : ControlElement(CPMARK, "cpmark-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -19,6 +19,7 @@
 #include "bracketspan.h"
 #include "breath.h"
 #include "caesura.h"
+#include "cpmark.h"
 #include "dir.h"
 #include "doc.h"
 #include "dynam.h"
@@ -232,6 +233,12 @@ FloatingPositioner::FloatingPositioner(FloatingObject *object, StaffAlignment *a
         assert(caesura);
         // caesura within by default
         m_place = (caesura->GetPlace() != STAFFREL_NONE) ? caesura->GetPlace() : STAFFREL_within;
+    }
+    else if (object->Is(CPMARK)) {
+        CpMark *cpMark = vrv_cast<CpMark *>(object);
+        assert(cpMark);
+        // cpMark above by default
+        m_place = (cpMark->GetPlace() != STAFFREL_NONE) ? cpMark->GetPlace() : STAFFREL_above;
     }
     else if (object->Is(DIR)) {
         Dir *dir = vrv_cast<Dir *>(object);
@@ -490,7 +497,7 @@ void FloatingPositioner::CalcDrawingYRel(
                 assert(turn);
                 yRel += turn->GetTurnHeight(doc, staffSize) / 2;
             }
-            else if (!m_object->Is({ DIR, HAIRPIN })) {
+            else if (!m_object->Is({ CPMARK, DIR, HAIRPIN })) {
                 yRel += (this->GetContentY2() - this->GetContentY1()) / 2;
             }
             this->SetDrawingYRel(yRel);

--- a/src/functorinterface.cpp
+++ b/src/functorinterface.cpp
@@ -24,6 +24,7 @@
 #include "chord.h"
 #include "clef.h"
 #include "course.h"
+#include "cpmark.h"
 #include "custos.h"
 #include "dir.h"
 #include "div.h"
@@ -548,6 +549,16 @@ FunctorCode FunctorInterface::VisitControlElement(ControlElement *controlElement
 FunctorCode FunctorInterface::VisitControlElementEnd(ControlElement *controlElement)
 {
     return this->VisitFloatingObjectEnd(controlElement);
+}
+
+FunctorCode FunctorInterface::VisitCpMark(CpMark *cpMark)
+{
+    return this->VisitControlElement(cpMark);
+}
+
+FunctorCode FunctorInterface::VisitCpMarkEnd(CpMark *cpMark)
+{
+    return this->VisitControlElementEnd(cpMark);
 }
 
 FunctorCode FunctorInterface::VisitDir(Dir *dir)
@@ -1882,6 +1893,16 @@ FunctorCode ConstFunctorInterface::VisitControlElement(const ControlElement *con
 FunctorCode ConstFunctorInterface::VisitControlElementEnd(const ControlElement *controlElement)
 {
     return this->VisitFloatingObjectEnd(controlElement);
+}
+
+FunctorCode ConstFunctorInterface::VisitCpMark(const CpMark *cpMark)
+{
+    return this->VisitControlElement(cpMark);
+}
+
+FunctorCode ConstFunctorInterface::VisitCpMarkEnd(const CpMark *cpMark)
+{
+    return this->VisitControlElementEnd(cpMark);
 }
 
 FunctorCode ConstFunctorInterface::VisitDir(const Dir *dir)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -36,6 +36,7 @@
 #include "comparison.h"
 #include "corr.h"
 #include "course.h"
+#include "cpmark.h"
 #include "custos.h"
 #include "damage.h"
 #include "del.h"
@@ -491,6 +492,10 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
     else if (object->Is(CAESURA)) {
         m_currentNode = m_currentNode.append_child("caesura");
         this->WriteCaesura(m_currentNode, vrv_cast<Caesura *>(object));
+    }
+    else if (object->Is(CPMARK)) {
+        m_currentNode = m_currentNode.append_child("cpMark");
+        this->WriteCpMark(m_currentNode, vrv_cast<CpMark *>(object));
     }
     else if (object->Is(DIR)) {
         m_currentNode = m_currentNode.append_child("dir");
@@ -2016,6 +2021,15 @@ void MEIOutput::WriteCaesura(pugi::xml_node currentNode, Caesura *caesura)
     caesura->WriteExtSymAuth(currentNode);
     caesura->WriteExtSymNames(currentNode);
     caesura->WritePlacementRelStaff(currentNode);
+}
+
+void MEIOutput::WriteCpMark(pugi::xml_node currentNode, CpMark *cpMark)
+{
+    assert(cpMark);
+
+    this->WriteControlElement(currentNode, cpMark);
+    this->WriteTextDirInterface(currentNode, cpMark);
+    this->WriteTimeSpanningInterface(currentNode, cpMark);
 }
 
 void MEIOutput::WriteDir(pugi::xml_node currentNode, Dir *dir)
@@ -5491,6 +5505,9 @@ bool MEIInput::ReadMeasureChildren(Object *parent, pugi::xml_node parentNode)
         else if (currentName == "caesura") {
             success = this->ReadCaesura(parent, current);
         }
+        else if (currentName == "cpMark") {
+            success = this->ReadCpMark(parent, current);
+        }
         else if (currentName == "dir") {
             success = this->ReadDir(parent, current);
         }
@@ -5710,6 +5727,19 @@ bool MEIInput::ReadCaesura(Object *parent, pugi::xml_node caesura)
     parent->AddChild(vrvCaesura);
     this->ReadUnsupportedAttr(caesura, vrvCaesura);
     return true;
+}
+
+bool MEIInput::ReadCpMark(Object *parent, pugi::xml_node cpMark)
+{
+    CpMark *vrvCpMark = new CpMark();
+    this->ReadControlElement(cpMark, vrvCpMark);
+
+    this->ReadTextDirInterface(cpMark, vrvCpMark);
+    this->ReadTimeSpanningInterface(cpMark, vrvCpMark);
+
+    parent->AddChild(vrvCpMark);
+    this->ReadUnsupportedAttr(cpMark, vrvCpMark);
+    return this->ReadTextChildren(vrvCpMark, cpMark, vrvCpMark);
 }
 
 bool MEIInput::ReadDir(Object *parent, pugi::xml_node dir)

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -22,6 +22,7 @@
 #include "caesura.h"
 #include "clef.h"
 #include "comparison.h"
+#include "cpmark.h"
 #include "devicecontext.h"
 #include "dir.h"
 #include "doc.h"
@@ -96,6 +97,11 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
         Caesura *caesura = vrv_cast<Caesura *>(element);
         assert(caesura);
         this->DrawCaesura(dc, caesura, measure, system);
+    }
+    else if (element->Is(CPMARK)) {
+        CpMark *cpMark = vrv_cast<CpMark *>(element);
+        assert(cpMark);
+        this->DrawControlElementText(dc, cpMark, measure, system);
     }
     else if (element->Is(DIR)) {
         Dir *dir = vrv_cast<Dir *>(element);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -924,7 +924,7 @@ void View::DrawBarLine(DeviceContext *dc, int yTop, int yBottom, BarLine *barLin
             lines.UpdateContentBBoxX(minX, maxX);
             lines.UpdateContentBBoxY(yTop, yBottom);
             const int margin = unit / 2;
-            system->m_systemAligner.FindAllIntersectionPoints(line, lines, { DIR, DYNAM, TEMPO }, margin);
+            system->m_systemAligner.FindAllIntersectionPoints(line, lines, { CPMARK, DIR, DYNAM, TEMPO }, margin);
         }
     }
 

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -500,7 +500,8 @@ void View::DrawText(DeviceContext *dc, Text *text, TextDrawingParams &params)
     }
 
     // special case where we want to replace some unicode music points to SMuFL
-    if (text->GetFirstAncestor(DIR) || text->GetFirstAncestor(ORNAM) || text->GetFirstAncestor(REPEATMARK)) {
+    if (text->GetFirstAncestor(CPMARK) || text->GetFirstAncestor(DIR) || text->GetFirstAncestor(ORNAM)
+        || text->GetFirstAncestor(REPEATMARK)) {
         this->DrawDirString(dc, text->GetText(), params);
     }
     else if (text->GetFirstAncestor(DYNAM)) {


### PR DESCRIPTION
Visual rendering for _colla parte_ encoded with `cpMark`. By default, placed above the staff.

Test suite unit added https://github.com/rism-digital/verovio.org/blob/gh-pages/_tests/cpmark/cpmark-001.mei

<img width="478" alt="image" src="https://github.com/user-attachments/assets/ddd59255-4265-4e21-aa2e-997a87281cb4" />

Closes #3870 