### PR TITLE
fix: call `LayOutTranscription()` after set liquescent

### DIFF
--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -2044,6 +2044,8 @@ bool EditorToolkitNeume::SetLiquescent(std::string elementId, std::string curve)
         }
     }
 
+    m_doc->GetDrawingPage()->LayOutTranscription(true);
+
     m_editInfo.import("status", "OK");
     m_editInfo.import("message", "");
     return true;


### PR DESCRIPTION
refs: https://github.com/DDMAL/Neon/issues/1236#issuecomment-2585960585