### PR TITLE
fix: rotation offset used in neon

### DIFF
--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -135,10 +135,10 @@ struct ClosestBB {
         Zone *zoneA = a->GetFacsimileInterface()->GetZone();
         Zone *zoneB = b->GetFacsimileInterface()->GetZone();
 
-        int distA
-            = distanceToBB(zoneA->GetUlx(), zoneA->GetUly(), zoneA->GetLrx(), zoneA->GetLry(), zoneA->GetRotate());
-        int distB
-            = distanceToBB(zoneB->GetUlx(), zoneB->GetUly(), zoneB->GetLrx(), zoneB->GetLry(), zoneB->GetRotate());
+        int distA = distanceToBB(zoneA->GetUlx(), zoneA->GetUly(), zoneA->GetLrx(), zoneA->GetLry(),
+            zoneA->HasRotate() ? zoneA->GetRotate() : 0);
+        int distB = distanceToBB(zoneB->GetUlx(), zoneB->GetUly(), zoneB->GetLrx(), zoneB->GetLry(),
+            zoneB->HasRotate() ? zoneB->GetRotate() : 0);
         return (distA < distB);
     }
 };


### PR DESCRIPTION
- Set rotate to 0 if not has rotate
- Add clef offset when using default clef

refs: https://github.com/DDMAL/Neon/issues/1254, https://github.com/DDMAL/Neon/issues/1226