### PR TITLE
Add /bigobj option

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -29,6 +29,7 @@ endif()
 
 # Sets the compile-time value for the RESOURCE_DIR macro in the source code.
 add_compile_definitions(RESOURCE_DIR="${CMAKE_INSTALL_PREFIX}/share/verovio")
+add_compile_options(/bigobj)
 
 include_directories(
     ../include

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 
 # Sets the compile-time value for the RESOURCE_DIR macro in the source code.
 add_compile_definitions(RESOURCE_DIR="${CMAKE_INSTALL_PREFIX}/share/verovio")
-add_compile_options(/bigobj)
 
 include_directories(
     ../include
@@ -45,6 +44,7 @@ include_directories(
 )
 
 if(MSVC)
+    add_compile_options(/bigobj)
     add_definitions(/W2)
     add_definitions(/wd4244)          # suppress warning of possible loss of precision
     add_definitions(-DNO_PAE_SUPPORT) # regex is working differently under Windows so PAE is not supported (yet)


### PR DESCRIPTION
Without this option, [fatal error C1128](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128) prevents compilation due to the object file format size limit, at least while building Verovio as a Windows shared library using MSVC via x64 Native Tools Command Prompt for VS 2022: 
![library](https://github.com/user-attachments/assets/16c95082-a420-44db-825b-40c3007c9cf1)
Adding this option seems to have fixed the library, although I haven't actually tested the DLL yet.
