### PR TITLE
fix: add `AddSyl` editor action

### DIFF
--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -39,6 +39,7 @@ public:
      * Experimental editor functions.
      */
     ///@{
+    bool AddSyl(std::string elementId, std::string sylText);
     bool Chain(jsonxx::Array actions);
     bool DisplaceClefOctave(std::string elementId, std::string direction);
     bool Drag(std::string elementId, int x, int y, bool topLevel = true);
@@ -71,6 +72,7 @@ protected:
      * Parse JSON instructions for experimental editor functions.
      */
     ///@{
+    bool ParseAddSylAction(jsonxx::Object param, std::string *elementId, std::string *sylText);
     bool ParseDisplaceClefAction(jsonxx::Object param, std::string *elementId, std::string *direction);
     bool ParseDragAction(jsonxx::Object param, std::string *elementId, int *x, int *y);
     bool ParseInsertAction(jsonxx::Object param, std::string *elementType, std::string *startId, std::string *endId);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -887,13 +887,6 @@ void Doc::PrepareData()
     PrepareLayerElementPartsFunctor prepareLayerElementParts;
     this->Process(prepareLayerElementParts);
 
-    /************ Add default syl for syllables (if applicable) ************/
-    ListOfObjects syllables = this->FindAllDescendantsByType(SYLLABLE);
-    for (Object *object : syllables) {
-        Syllable *syllable = dynamic_cast<Syllable *>(object);
-        syllable->MarkupAddSyl();
-    }
-
     /************ Resolve @facs ************/
     if (this->IsFacs()) {
         // Associate zones with elements


### PR DESCRIPTION
- Add <syl> element with text
- Skip adding default syl for syllables for Neon

refs: https://github.com/DDMAL/Neon/issues/1265