### PR TITLE
Split Fraction constructors

### DIFF
--- a/include/vrv/fraction.h
+++ b/include/vrv/fraction.h
@@ -20,7 +20,8 @@ class Fraction {
 
 public:
     // Constructors - make them explicit to avoid type conversion
-    explicit Fraction(int num = 0, int denom = 1);
+    explicit Fraction(int num = 0) : m_numerator(num), m_denominator(1) {}
+    explicit Fraction(int num, int denom);
     explicit Fraction(data_DURATION duration);
 
     // Enable implicit conversion constructor for `int`

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -965,8 +965,8 @@ void ConvertToCmnFunctor::SplitDurationIntoCmn(
     const int semiBrevisDots = (prolatioMajor) ? 1 : 0;
     const int brevisDots = (tempusPerfectum) ? 1 : 0;
 
-    const Fraction semiBrevis = Fraction(1, 1) * abs(mensur->GetProlatio()) / 2;
-    const Fraction brevis = Fraction(1, 1) * abs(mensur->GetTempus());
+    const Fraction semiBrevis = Fraction(1) * abs(mensur->GetProlatio()) / 2;
+    const Fraction brevis = Fraction(1) * abs(mensur->GetTempus());
 
     // First see if we are expecting a breve and if the duration is long enough
     if (elementDur == DURATION_breve) {

--- a/src/durationinterface.cpp
+++ b/src/durationinterface.cpp
@@ -100,7 +100,7 @@ Fraction DurationInterface::GetInterfaceAlignmentMensuralDuration(
 
     if (!currentMensur) {
         LogWarning("No current mensur for calculating duration");
-        return Fraction(1, 1);
+        return Fraction(1);
     }
 
     if (this->HasNum() || this->HasNumbase()) {

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -29,7 +29,7 @@ Fraction::Fraction(int num, int denom)
         denom = 1;
     }
     m_denominator = denom;
-    Reduce();
+    this->Reduce();
 }
 
 Fraction::Fraction(data_DURATION duration)
@@ -39,7 +39,7 @@ Fraction::Fraction(data_DURATION duration)
     int den = pow(2, (duration + 1));
     m_numerator = 8;
     m_denominator = den;
-    Reduce();
+    this->Reduce();
 }
 
 Fraction Fraction::operator+(const Fraction &other) const

--- a/src/fraction.cpp
+++ b/src/fraction.cpp
@@ -122,7 +122,7 @@ void Fraction::Reduce()
         m_numerator = -m_numerator;
         m_denominator = -m_denominator;
     }
-    int gcdVal = std::gcd(abs(m_numerator), abs(m_denominator));
+    const int gcdVal = std::gcd(m_numerator, m_denominator);
     if (gcdVal != 1) {
         m_numerator /= gcdVal;
         m_denominator /= gcdVal;

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -516,15 +516,15 @@ void Alignment::Reset()
     Object::Reset();
 
     m_xRel = 0;
-    m_time = Fraction(0, 1);
+    m_time = Fraction(0);
     m_type = ALIGNMENT_DEFAULT;
 
-    ClearGraceAligners();
+    this->ClearGraceAligners();
 }
 
 Alignment::~Alignment()
 {
-    ClearGraceAligners();
+    this->ClearGraceAligners();
 }
 
 void Alignment::ClearGraceAligners()

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -675,7 +675,7 @@ Fraction LayerElement::GetAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
     if (this->IsGraceNote() && notGraceOnly) {
-        return Fraction(0, 1);
+        return Fraction(0);
     }
 
     // Mensural chords are aligned looking at the duration of the notes
@@ -777,7 +777,7 @@ Fraction LayerElement::GetAlignmentDuration(
         return (syllable->GetLast() == this) ? NEUME_MEDIUM_SPACE : NEUME_SMALL_SPACE;
     }
     else {
-        return Fraction(0, 1);
+        return Fraction(0);
     }
 }
 
@@ -791,7 +791,7 @@ Fraction LayerElement::GetSameAsContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
     if (!this->HasSameasLink() || !this->GetSameasLink()->Is({ BEAM, FTREM, TUPLET })) {
-        return Fraction(0, 1);
+        return Fraction(0);
     }
 
     const LayerElement *sameas = vrv_cast<const LayerElement *>(this->GetSameasLink());
@@ -804,7 +804,7 @@ Fraction LayerElement::GetContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
     if (!this->Is({ BEAM, FTREM, TUPLET })) {
-        return Fraction(0, 1);
+        return Fraction(0);
     }
 
     Fraction duration;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1166,7 +1166,7 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
 
     const bool drawingCueSize = mRest->GetDrawingCueSize();
     int x = mRest->GetDrawingX();
-    const bool isDouble = (measure->m_measureAligner.GetMaxTime() >= Fraction(2, 1));
+    const bool isDouble = (measure->m_measureAligner.GetMaxTime() >= Fraction(2));
     int y = isDouble ? element->GetDrawingY() - m_doc->GetDrawingDoubleUnit(staffSize) : element->GetDrawingY();
     char32_t rest = isDouble ? SMUFL_E4E2_restDoubleWhole : SMUFL_E4E3_restWhole;
 


### PR DESCRIPTION
This PR adds a simplified `Fraction(int)` constructor setting the denominator to 1. In this case we don't have to reduce the fraction and don't need to check for zero denominator.