### PR TITLE
Fix lost IDs on symbolDef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support for `verse@place` for lyrics above the staff
 * Support for MIDI octave displacement without `@oct.ges` (@brdvd)
 * Option `--lyric-height-factor` to increase the spacing of the lyrics
-* Fix `symbolDef` losing `@xml:id`s (@rettinghaus)
+* Fix `symbolDef` losing `@xml:id`s with `--remove-ids` (@rettinghaus)
 
 ## [4.5.0] – 2024-12-22
 * Integration of tablature customization implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for `verse@place` for lyrics above the staff
 * Support for MIDI octave displacement without `@oct.ges` (@brdvd)
 * Option `--lyric-height-factor` to increase the spacing of the lyrics
+* Fix `symbolDef` losing `@xml:id`s (@rettinghaus)
 
 ## [4.5.0] – 2024-12-22
 * Integration of tablature customization implementation

--- a/src/findfunctor.cpp
+++ b/src/findfunctor.cpp
@@ -14,6 +14,7 @@
 #include "object.h"
 #include "plistinterface.h"
 #include "score.h"
+#include "symboldef.h"
 
 namespace vrv {
 
@@ -261,6 +262,11 @@ FindAllReferencedObjectsFunctor::FindAllReferencedObjectsFunctor(ListOfObjects *
 
 FunctorCode FindAllReferencedObjectsFunctor::VisitObject(Object *object)
 {
+    if (object->HasInterface(INTERFACE_ALT_SYM)) {
+        AltSymInterface *interface = object->GetAltSymInterface();
+        assert(interface);
+        if (interface->GetAltSymbolDef()) m_elements->push_back(interface->GetAltSymbolDef());
+    }
     if (object->HasInterface(INTERFACE_LINKING)) {
         LinkingInterface *interface = object->GetLinkingInterface();
         assert(interface);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -8676,6 +8676,7 @@ bool MEIInput::ReadGraphic(Object *parent, pugi::xml_node graphic)
     vrvGraphic->ReadHeight(graphic);
     vrvGraphic->ReadTyped(graphic);
     parent->AddChild(vrvGraphic);
+    this->ReadUnsupportedAttr(graphic, vrvGraphic);
     return true;
 }
 


### PR DESCRIPTION
This PR fixes a problem with losing the `@xml:id` on `symbolDef` elements when outputting MEI using the `--remove-ids` option. The functor simply ignored the `AltSymInterface`.

It also fixes lost attributes on `graphic` (e.g., `@ulx`) that are not supported yet.
