### PR TITLE
treat virtual units like doubles

### DIFF
--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -44,7 +44,9 @@ std::string Att::IntToStr(int data) const
 
 std::string Att::VUToStr(data_VU data) const
 {
-    return StringFormat("%fvu", data);
+    std::stringstream sstream;
+    sstream << round(data * 10000.0) / 10000.0 << "vu";
+    return sstream.str();
 }
 
 // Basic converters for reading
@@ -416,7 +418,7 @@ std::string Att::MeasurementsignedToStr(data_MEASUREMENTSIGNED data) const
         value = StringFormat("%dpx", data.GetPx() / DEFINITION_FACTOR);
     }
     else if (data.GetType() == MEASUREMENTTYPE_vu) {
-        value = StringFormat("%.4fvu", data.GetVu());
+        value = VUToStr(data.GetVu());
     }
 
     return value;


### PR DESCRIPTION
This PR brings the writing of virtual unit in liune with doubles, changing this

`<multiRest loc="2" block="true" num="4" width="6.0000vu" />`

into this

`<multiRest loc="2" block="true" num="4" width="6vu" />`