### PR TITLE
Use set for referenced objects

### DIFF
--- a/include/vrv/findfunctor.h
+++ b/include/vrv/findfunctor.h
@@ -409,7 +409,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    FindAllReferencedObjectsFunctor(ListOfObjects *elements);
+    FindAllReferencedObjectsFunctor(SetOfObjects *elements);
     virtual ~FindAllReferencedObjectsFunctor() = default;
     ///@}
 
@@ -437,8 +437,8 @@ private:
 public:
     //
 private:
-    // The array of all matching objects
-    ListOfObjects *m_elements;
+    // The set of all matching objects
+    SetOfObjects *m_elements;
     // A flag indicating if milestone references should be included as well
     bool m_milestoneReferences;
 };

--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -597,7 +597,7 @@ private:
 
     bool m_ignoreHeader;
     bool m_removeIds;
-    ListOfObjects m_referredObjects;
+    SetOfObjects m_referredObjects;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -342,6 +342,10 @@ typedef std::list<Object *> ListOfObjects;
 
 typedef std::list<const Object *> ListOfConstObjects;
 
+typedef std::set<Object *> SetOfObjects;
+
+typedef std::set<const Object *> SetOfConstObjects;
+
 typedef std::vector<Note *> ChordNoteGroup;
 
 typedef std::vector<std::tuple<Alignment *, Alignment *, int>> ArrayOfAdjustmentTuples;

--- a/src/findfunctor.cpp
+++ b/src/findfunctor.cpp
@@ -254,7 +254,7 @@ FunctorCode FindExtremeByComparisonFunctor::VisitObject(const Object *object)
 // FindAllReferencedObjectsFunctor
 //----------------------------------------------------------------------------
 
-FindAllReferencedObjectsFunctor::FindAllReferencedObjectsFunctor(ListOfObjects *elements) : Functor()
+FindAllReferencedObjectsFunctor::FindAllReferencedObjectsFunctor(SetOfObjects *elements) : Functor()
 {
     m_elements = elements;
     m_milestoneReferences = false;
@@ -265,43 +265,46 @@ FunctorCode FindAllReferencedObjectsFunctor::VisitObject(Object *object)
     if (object->HasInterface(INTERFACE_ALT_SYM)) {
         AltSymInterface *interface = object->GetAltSymInterface();
         assert(interface);
-        if (interface->GetAltSymbolDef()) m_elements->push_back(interface->GetAltSymbolDef());
+        if (interface->GetAltSymbolDef()) m_elements->insert(interface->GetAltSymbolDef());
     }
     if (object->HasInterface(INTERFACE_LINKING)) {
         LinkingInterface *interface = object->GetLinkingInterface();
         assert(interface);
-        if (interface->GetNextLink()) m_elements->push_back(interface->GetNextLink());
-        if (interface->GetSameasLink()) m_elements->push_back(interface->GetSameasLink());
+        if (interface->GetNextLink()) m_elements->insert(interface->GetNextLink());
+        if (interface->GetSameasLink()) m_elements->insert(interface->GetSameasLink());
     }
     if (object->HasInterface(INTERFACE_PLIST)) {
         PlistInterface *interface = object->GetPlistInterface();
         assert(interface);
         for (Object *object : interface->GetRefs()) {
-            m_elements->push_back(object);
+            m_elements->insert(object);
         }
     }
     if (object->HasInterface(INTERFACE_TIME_POINT) || object->HasInterface(INTERFACE_TIME_SPANNING)) {
         TimePointInterface *interface = object->GetTimePointInterface();
         assert(interface);
-        if (interface->GetStart() && !interface->GetStart()->Is(TIMESTAMP_ATTR))
-            m_elements->push_back(interface->GetStart());
+        if (interface->GetStart() && !interface->GetStart()->Is(TIMESTAMP_ATTR)) {
+            m_elements->insert(interface->GetStart());
+        }
     }
     if (object->HasInterface(INTERFACE_TIME_SPANNING)) {
         TimeSpanningInterface *interface = object->GetTimeSpanningInterface();
         assert(interface);
-        if (interface->GetEnd() && !interface->GetEnd()->Is(TIMESTAMP_ATTR)) m_elements->push_back(interface->GetEnd());
+        if (interface->GetEnd() && !interface->GetEnd()->Is(TIMESTAMP_ATTR)) {
+            m_elements->insert(interface->GetEnd());
+        }
     }
     if (object->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(object);
         assert(note);
         // The note has a stem.sameas that was resolved the a note, then that one is referenced
         if (note->HasStemSameas() && note->HasStemSameasNote()) {
-            m_elements->push_back(note->GetStemSameasNote());
+            m_elements->insert(note->GetStemSameasNote());
         }
     }
     // These will also be referred to as milestones in page-based MEI
     if (m_milestoneReferences && object->IsMilestoneElement()) {
-        m_elements->push_back(object);
+        m_elements->insert(object);
     }
 
     // continue until the end

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -188,7 +188,6 @@ bool MEIOutput::Export()
         // When saving page-based MEI we also want to keep IDs for milestone elements
         findAllReferencedObjects.IncludeMilestoneReferences(this->IsPageBasedMEI());
         m_doc->Process(findAllReferencedObjects);
-        m_referredObjects.unique();
     }
 
     try {
@@ -1459,10 +1458,8 @@ std::string MEIOutput::IDToMeiStr(Object *element)
 
 void MEIOutput::WriteXmlId(pugi::xml_node currentNode, Object *object)
 {
-    if (m_removeIds) {
-        ListOfObjects::iterator it = std::find(m_referredObjects.begin(), m_referredObjects.end(), object);
-        if (it == m_referredObjects.end()) return;
-        m_referredObjects.erase(it);
+    if (m_removeIds && !m_referredObjects.contains(object)) {
+        return;
     }
     currentNode.append_attribute("xml:id") = IDToMeiStr(object).c_str();
 }


### PR DESCRIPTION
This PR replaces the object list in the `FindAllReferencedObjectsFunctor` by a set which is better suited for value search.