### PR TITLE
 Fix more lost IDs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Support for `verse@place` for lyrics above the staff
 * Support for MIDI octave displacement without `@oct.ges` (@brdvd)
 * Option `--lyric-height-factor` to increase the spacing of the lyrics
-* Fix `symbolDef` losing `@xml:id`s with `--remove-ids` (@rettinghaus)
+* Fix `surface`, `symbolDef`, and `zone` losing `@xml:id`s with `--remove-ids` (@rettinghaus)
 
 ## [4.5.0] – 2024-12-22
 * Integration of tablature customization implementation

--- a/src/findfunctor.cpp
+++ b/src/findfunctor.cpp
@@ -14,7 +14,9 @@
 #include "object.h"
 #include "plistinterface.h"
 #include "score.h"
+#include "surface.h"
 #include "symboldef.h"
+#include "zone.h"
 
 namespace vrv {
 
@@ -272,6 +274,12 @@ FunctorCode FindAllReferencedObjectsFunctor::VisitObject(Object *object)
         assert(interface);
         if (interface->GetNextLink()) m_elements->push_back(interface->GetNextLink());
         if (interface->GetSameasLink()) m_elements->push_back(interface->GetSameasLink());
+    }
+    if (object->HasInterface(INTERFACE_FACSIMILE)) {
+        FacsimileInterface *interface = object->GetFacsimileInterface();
+        assert(interface);
+        if (interface->GetSurface()) m_elements->push_back(interface->GetSurface());
+        if (interface->GetZone()) m_elements->push_back(interface->GetZone());
     }
     if (object->HasInterface(INTERFACE_PLIST)) {
         PlistInterface *interface = object->GetPlistInterface();


### PR DESCRIPTION
Same fix as in #3924 just for `surface` and `zone`.