### PR TITLE
Use inline

### DIFF
--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -668,7 +668,7 @@ data_PERCENT_LIMITED_SIGNED Att::StrToPercentLimitedSigned(const std::string &va
 {
     static const std::regex test("(+|-)?[0-9]+(\\.?[0-9]*)?%");
     if (!std::regex_match(value, test)) {
-        if (logWarning) LogWarning("Unsupported data.PERCENT.LIMITED.SIGNEd '%s'", value.c_str());
+        if (logWarning) LogWarning("Unsupported data.PERCENT.LIMITED.SIGNED '%s'", value.c_str());
         return 0;
     }
     return atof(value.substr(0, value.find("%")).c_str());

--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -644,11 +644,6 @@ data_PERCENT Att::StrToPercent(const std::string &value, bool logWarning) const
     return atof(value.substr(0, value.find("%")).c_str());
 }
 
-std::string Att::PercentLimitedToStr(data_PERCENT_LIMITED data) const
-{
-    return DblToStr(data) + "%";
-}
-
 data_PERCENT_LIMITED Att::StrToPercentLimited(const std::string &value, bool logWarning) const
 {
     static const std::regex test("[0-9]+(\\.?[0-9]*)?%");
@@ -657,11 +652,6 @@ data_PERCENT_LIMITED Att::StrToPercentLimited(const std::string &value, bool log
         return 0;
     }
     return atof(value.substr(0, value.find("%")).c_str());
-}
-
-std::string Att::PercentLimitedSignedToStr(data_PERCENT_LIMITED_SIGNED data) const
-{
-    return DblToStr(data) + "%";
 }
 
 data_PERCENT_LIMITED_SIGNED Att::StrToPercentLimitedSigned(const std::string &value, bool logWarning) const

--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -90,8 +90,11 @@ public:
     std::string MeasurementsignedToStr(data_MEASUREMENTSIGNED data) const;
     data_MEASUREMENTSIGNED StrToMeasurementsigned(const std::string &value, bool logWarning = true) const;
 
-    std::string MeasurementunsignedToStr(data_MEASUREMENTUNSIGNED data) const { return MeasurementsignedToStr(data); }
-    data_MEASUREMENTUNSIGNED StrToMeasurementunsigned(const std::string &value, bool logWarning = true) const
+    inline std::string MeasurementunsignedToStr(data_MEASUREMENTUNSIGNED data) const
+    {
+        return MeasurementsignedToStr(data);
+    }
+    inline data_MEASUREMENTUNSIGNED StrToMeasurementunsigned(const std::string &value, bool logWarning = true) const
     {
         return StrToMeasurementsigned(value, logWarning);
     }

--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -132,10 +132,10 @@ public:
     std::string PercentToStr(data_PERCENT data) const;
     data_PERCENT StrToPercent(const std::string &value, bool logWarning = true) const;
 
-    std::string PercentLimitedToStr(data_PERCENT_LIMITED_SIGNED data) const;
+    inline std::string PercentLimitedToStr(data_PERCENT_LIMITED_SIGNED data) const { return PercentToStr(data); }
     data_PERCENT_LIMITED StrToPercentLimited(const std::string &value, bool logWarning = true) const;
 
-    std::string PercentLimitedSignedToStr(data_PERCENT_LIMITED data) const;
+    inline std::string PercentLimitedSignedToStr(data_PERCENT_LIMITED data) const { return PercentToStr(data); }
     data_PERCENT_LIMITED_SIGNED StrToPercentLimitedSigned(const std::string &value, bool logWarning = true) const;
 
     std::string PitchnameToStr(data_PITCHNAME data) const;


### PR DESCRIPTION
This PR combines the `PercentToStr` method for other percentage values, and marks several forwards as `inline` to reduce function calls.