### PR TITLE
Fix handling of -p and -a options regarding MEI output

### DIFF
--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -363,7 +363,7 @@ int main(int argc, char **argv)
 
     if (outformat == "svg") {
         const int from = page ? *page : 1;
-        const int to = (page && !all_pages) ? *page : toolkit.GetPageCount();
+        const int to = all_pages ? toolkit.GetPageCount() : from;
 
         for (int p = from; p <= to; ++p) {
             std::string cur_outfile = outfile;

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -348,14 +348,14 @@ int main(int argc, char **argv)
         }
     }
 
-    if (toolkit.GetOutputTo() != vrv::HUMDRUM) {
+    if (page && (toolkit.GetOutputTo() != vrv::HUMDRUM)) {
         // Check the page range
-        if (page > toolkit.GetPageCount()) {
-            std::cerr << "The page requested (" << page << ") is not in the page range (max is "
+        if (*page > toolkit.GetPageCount()) {
+            std::cerr << "The page requested (" << *page << ") is not in the page range (max is "
                       << toolkit.GetPageCount() << ")." << std::endl;
             exit(1);
         }
-        if (page < 1) {
+        if (*page < 1) {
             std::cerr << "The page number has to be greater than 0." << std::endl;
             exit(1);
         }
@@ -570,7 +570,7 @@ int main(int argc, char **argv)
         outfile += ".mei";
         const std::string params = page
             ? vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'pageNo': %d, 'removeIds': %s, 'generateFacs': %s}",
-                  scoreBased, basic, page, removeIds, generateFacs)
+                  scoreBased, basic, *page, removeIds, generateFacs)
             : vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'removeIds': %s, 'generateFacs': %s}", scoreBased,
                   basic, removeIds, generateFacs);
         if (std_output) {

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -86,9 +86,9 @@ int main(int argc, char **argv)
     std::string outformat = "svg";
     bool std_output = false;
 
-    int all_pages = 0;
-    int page = 1;
-    int show_version = 0;
+    bool all_pages = false;
+    std::optional<int> page;
+    bool show_version = false;
 
     // Create the toolkit instance without loading the font because
     // the resource path might be specified in the parameters
@@ -202,7 +202,7 @@ int main(int argc, char **argv)
                 }
                 break;
 
-            case 'a': all_pages = 1; break;
+            case 'a': all_pages = true; break;
 
             case 'f':
                 if (!toolkit.SetInputFrom(std::string(optarg))) {
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
                 }
                 break;
 
-            case 'v': show_version = 1; break;
+            case 'v': show_version = true; break;
 
             case 'x':
                 if (!options->m_xmlIdSeed.SetValue(optarg)) {
@@ -361,17 +361,13 @@ int main(int argc, char **argv)
         }
     }
 
-    int from = page;
-    int to = page + 1;
-    if (all_pages) {
-        to = toolkit.GetPageCount() + 1;
-    }
-
     if (outformat == "svg") {
-        int p;
-        for (p = from; p < to; ++p) {
+        const int from = page ? *page : 1;
+        const int to = (page && !all_pages) ? *page : toolkit.GetPageCount();
+
+        for (int p = from; p <= to; ++p) {
             std::string cur_outfile = outfile;
-            if (all_pages) {
+            if (from < to) {
                 cur_outfile += vrv::StringFormat("_%03d", p);
             }
             cur_outfile += ".svg";
@@ -572,35 +568,20 @@ int main(int argc, char **argv)
         const char *removeIds = (options->m_removeIds.GetValue()) ? "true" : "false";
         const char *generateFacs = (outformat == "mei-facs") ? "true" : "false";
         outfile += ".mei";
-        if (all_pages) {
-            std::string params
-                = vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'removeIds': %s, 'generateFacs': %s}", scoreBased,
-                    basic, removeIds, generateFacs);
-            if (std_output) {
-                std::string output;
-                std::cout << toolkit.GetMEI(params);
-            }
-            else if (!toolkit.SaveFile(outfile, params)) {
-                exit(1);
-            }
-            else {
-                std::cerr << "Output written to " << outfile << "." << std::endl;
-            }
+        const std::string params = page
+            ? vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'pageNo': %d, 'removeIds': %s, 'generateFacs': %s}",
+                  scoreBased, basic, page, removeIds, generateFacs)
+            : vrv::StringFormat("{'scoreBased': %s, 'basic': %s, 'removeIds': %s, 'generateFacs': %s}", scoreBased,
+                  basic, removeIds, generateFacs);
+        if (std_output) {
+            std::cout << toolkit.GetMEI(params);
+        }
+        else if (!toolkit.SaveFile(outfile, params)) {
+            std::cerr << "Unable to write MEI to " << outfile << "." << std::endl;
+            exit(1);
         }
         else {
-            std::string params = vrv::StringFormat(
-                "{'scoreBased': %s, 'basic': %s, 'pageNo': %d, 'removeIds': %s, 'generateFacs': %s}", scoreBased, basic,
-                page, removeIds, generateFacs);
-            if (std_output) {
-                std::cout << toolkit.GetMEI(params);
-            }
-            else if (!toolkit.SaveFile(outfile, params)) {
-                std::cerr << "Unable to write MEI to " << outfile << "." << std::endl;
-                exit(1);
-            }
-            else {
-                std::cerr << "Output written to " << outfile << "." << std::endl;
-            }
+            std::cerr << "Output written to " << outfile << "." << std::endl;
         }
     }
 


### PR DESCRIPTION
This PR applies the `-a` option only for rendering. It keeps the behavior for rendering as before:
- By default, the first page is rendered.
- If `-p` is provided, then only the given page is rendered.
- If `-a` is provided, then all pages are rendered.
- If `-p` and `-a` are provided, then the range from the given page until the end is rendered.

The behavior for MEI output is changed. The option `-a` is ignored here. Instead:
- By default, all pages are written.
- If `-p` is provided, then only the given page is written. This corresponds to setting a page filter and does not work in certain cases, e.g. mensural music.

Closes #3938 .