### PR TITLE
Code refactoring for Pen and Brush classes

### DIFF
--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -76,7 +76,7 @@ public:
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
         this->SetBrush(COLOR_NONE);
-        this->SetPen(COLOR_NONE, 1, PEN_SOLID);
+        this->SetPen(1, PEN_SOLID);
     }
     DeviceContext(ClassId classId)
     {
@@ -94,7 +94,7 @@ public:
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
         this->SetBrush(COLOR_NONE);
-        this->SetPen(COLOR_NONE, 1, PEN_SOLID);
+        this->SetPen(1, PEN_SOLID);
     }
     virtual ~DeviceContext();
     ClassId GetClassId() const { return m_classId; }
@@ -146,8 +146,9 @@ public:
      */
     ///@{
     void SetBrush(int color, float opacity = 1.0);
-    void SetPen(int color, int width, PenStyle style, int dashLength = 0, int gapLength = 0,
-        LineCapStyle lineCap = LINECAP_DEFAULT, LineJoinStyle lineJoin = LINEJOIN_DEFAULT, float opacity = 1.0);
+    void SetPen(int width, PenStyle style, int dashLength = 0, int gapLength = 0,
+        LineCapStyle lineCap = LINECAP_DEFAULT, LineJoinStyle lineJoin = LINEJOIN_DEFAULT, float opacity = 1.0,
+        int color = COLOR_NONE);
     void SetFont(FontInfo *font);
     void SetPushBack() { m_pushBack = true; }
     void ResetBrush();

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -75,7 +75,7 @@ public:
         m_baseHeight = 0;
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
-        this->SetBrush(COLOR_NONE);
+        this->SetBrush(1.0);
         this->SetPen(1, PEN_SOLID);
     }
     DeviceContext(ClassId classId)
@@ -93,7 +93,7 @@ public:
         m_baseHeight = 0;
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
-        this->SetBrush(COLOR_NONE);
+        this->SetBrush(1.0);
         this->SetPen(1, PEN_SOLID);
     }
     virtual ~DeviceContext();
@@ -145,7 +145,7 @@ public:
      * Non-virtual methods cannot be overridden and manage the Pen, Brush and FontInfo stacks
      */
     ///@{
-    void SetBrush(int color, float opacity = 1.0);
+    void SetBrush(float opacity, int color = COLOR_NONE);
     void SetPen(int width, PenStyle style, int dashLength = 0, int gapLength = 0,
         LineCapStyle lineCap = LINECAP_DEFAULT, LineJoinStyle lineJoin = LINEJOIN_DEFAULT, float opacity = 1.0,
         int color = COLOR_NONE);

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -75,6 +75,8 @@ public:
         m_baseHeight = 0;
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
+        this->SetBrush(COLOR_NONE);
+        this->SetPen(COLOR_NONE, 1, PEN_SOLID);
     }
     DeviceContext(ClassId classId)
     {
@@ -91,8 +93,10 @@ public:
         m_baseHeight = 0;
         m_pushBack = false;
         m_viewBoxFactor = (double)DEFINITION_FACTOR;
+        this->SetBrush(COLOR_NONE);
+        this->SetPen(COLOR_NONE, 1, PEN_SOLID);
     }
-    virtual ~DeviceContext() {}
+    virtual ~DeviceContext();
     ClassId GetClassId() const { return m_classId; }
     bool Is(ClassId classId) const { return (m_classId == classId); }
     ///@}

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -57,26 +57,26 @@ enum LineJoinStyle : int8_t {
 class Pen {
 public:
     Pen()
-        : m_color(COLOR_NONE)
-        , m_width(0)
+        : m_width(0)
         , m_style(PEN_SOLID)
         , m_dashLength(0)
         , m_gapLength(0)
         , m_lineCap(LINECAP_DEFAULT)
         , m_lineJoin(LINEJOIN_DEFAULT)
         , m_opacity(1.0)
+        , m_color(COLOR_NONE)
     {
     }
-    Pen(int color, int width, PenStyle style, int dashLength, int gapLength, LineCapStyle lineCap,
-        LineJoinStyle lineJoin, float opacity)
-        : m_color(color)
-        , m_width(width)
+    Pen(int width, PenStyle style, int dashLength, int gapLength, LineCapStyle lineCap, LineJoinStyle lineJoin,
+        float opacity, int color)
+        : m_width(width)
         , m_style(style)
         , m_dashLength(dashLength)
         , m_gapLength(gapLength)
         , m_lineCap(lineCap)
         , m_lineJoin(lineJoin)
         , m_opacity(opacity)
+        , m_color(color)
     {
     }
 
@@ -98,12 +98,13 @@ public:
     void SetOpacity(float opacity) { m_opacity = opacity; }
 
 private:
-    int m_color, m_width;
+    int m_width;
     PenStyle m_style;
     int m_dashLength, m_gapLength;
     LineCapStyle m_lineCap;
     LineJoinStyle m_lineJoin;
     float m_opacity;
+    int m_color;
 };
 
 class Brush {

--- a/include/vrv/devicecontextbase.h
+++ b/include/vrv/devicecontextbase.h
@@ -109,8 +109,8 @@ private:
 
 class Brush {
 public:
-    Brush() : m_color(COLOR_NONE), m_opacity(1.0) {}
-    Brush(int color, float opacity) : m_color(color), m_opacity(opacity) {}
+    Brush() : m_opacity(1.0), m_color(COLOR_NONE) {}
+    Brush(float opacity, int color) : m_opacity(opacity), m_color(color) {}
 
     int GetColor() const { return m_color; }
     void SetColor(int color) { m_color = color; }
@@ -118,8 +118,8 @@ public:
     void SetOpacity(float opacity) { m_opacity = opacity; }
 
 private:
-    int m_color;
     float m_opacity;
+    int m_color;
 };
 
 // ---------------------------------------------------------------------------

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -676,11 +676,6 @@ public:
      * useful for changing the color, for example
      */
     ///@{
-    LayerElement *m_currentElement;
-    Layer *m_currentLayer;
-    Measure *m_currentMeasure;
-    Staff *m_currentStaff;
-    System *m_currentSystem;
     Page *m_currentPage;
     ///@}
 

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -37,9 +37,6 @@ BBoxDeviceContext::BBoxDeviceContext(View *view, int width, int height, unsigned
     m_drawingText = false;
     m_textAlignment = HORIZONTALALIGNMENT_left;
 
-    this->SetBrush(COLOR_NONE);
-    this->SetPen(COLOR_NONE, 1, PEN_SOLID);
-
     m_update = update;
 
     this->ResetGraphicRotation();

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -164,9 +164,9 @@ void DeviceContext::SetPen(int width, PenStyle style, int dashLength, int gapLen
     m_penStack.push(Pen(width, style, dashLength, gapLength, lineCap, lineJoin, opacity, color));
 }
 
-void DeviceContext::SetBrush(int color, float opacity)
+void DeviceContext::SetBrush(float opacity, int color)
 {
-    m_brushStack.push(Brush(color, opacity));
+    m_brushStack.push(Brush(opacity, color));
 }
 
 void DeviceContext::SetFont(FontInfo *font)

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -123,6 +123,13 @@ std::pair<double, double> BezierCurve::EstimateCurveParamForControlPoints() cons
 // DeviceContext
 //----------------------------------------------------------------------------
 
+DeviceContext::~DeviceContext()
+{
+    if (m_penStack.size() != 1) LogDebug("Pen stack should have only one pen");
+    if (m_brushStack.size() != 1) LogDebug("Brush stack should have only one brush");
+    if (!m_fontStack.empty()) LogDebug("Font stack should be empty");
+}
+
 const Resources *DeviceContext::GetResources(bool showWarning) const
 {
     if (!m_resources && showWarning) LogWarning("Requested resources unavailable.");

--- a/src/devicecontext.cpp
+++ b/src/devicecontext.cpp
@@ -141,8 +141,8 @@ void DeviceContext::SetViewBoxFactor(double ppuFactor)
     m_viewBoxFactor = double(DEFINITION_FACTOR) / ppuFactor;
 }
 
-void DeviceContext::SetPen(int color, int width, PenStyle style, int dashLength, int gapLength, LineCapStyle lineCap,
-    LineJoinStyle lineJoin, float opacity)
+void DeviceContext::SetPen(int width, PenStyle style, int dashLength, int gapLength, LineCapStyle lineCap,
+    LineJoinStyle lineJoin, float opacity, int color)
 {
     switch (style) {
         case PEN_SOLID: break;
@@ -161,7 +161,7 @@ void DeviceContext::SetPen(int color, int width, PenStyle style, int dashLength,
         default: break; // solid brush by default
     }
 
-    m_penStack.push(Pen(color, width, style, dashLength, gapLength, lineCap, lineJoin, opacity));
+    m_penStack.push(Pen(width, style, dashLength, gapLength, lineCap, lineJoin, opacity, color));
 }
 
 void DeviceContext::SetBrush(int color, float opacity)

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -38,9 +38,6 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
     m_originX = 0;
     m_originY = 0;
 
-    this->SetBrush(COLOR_NONE);
-    this->SetPen(COLOR_NONE, 1, PEN_SOLID);
-
     m_smuflGlyphs.clear();
 
     m_committed = false;

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1280,11 +1280,11 @@ void SvgDeviceContext::DrawSvgBoundingBox(Object *object, View *view)
                         p.y = object->GetSelfBottom() - y * smuflGlyphFontSize / glyph->GetUnitsPerEm();
                         p.y += (fontPoint->y * smuflGlyphFontSize / glyph->GetUnitsPerEm());
 
-                        this->SetPen(COLOR_GREEN, 10, PEN_SOLID);
+                        this->SetPen(10, PEN_SOLID, 0, 0, LINECAP_DEFAULT, LINEJOIN_DEFAULT, 1.0, COLOR_GREEN);
                         this->SetBrush(COLOR_GREEN);
                         this->DrawCircle(view->ToDeviceContextX(p.x), view->ToDeviceContextY(p.y), 5);
-                        this->SetPen(COLOR_NONE, 1, PEN_SOLID);
-                        this->SetBrush(COLOR_NONE);
+                        this->ResetBrush();
+                        this->ResetPen();
                     }
                 }
             }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1281,7 +1281,7 @@ void SvgDeviceContext::DrawSvgBoundingBox(Object *object, View *view)
                         p.y += (fontPoint->y * smuflGlyphFontSize / glyph->GetUnitsPerEm());
 
                         this->SetPen(10, PEN_SOLID, 0, 0, LINECAP_DEFAULT, LINEJOIN_DEFAULT, 1.0, COLOR_GREEN);
-                        this->SetBrush(COLOR_GREEN);
+                        this->SetBrush(1.0, COLOR_GREEN);
                         this->DrawCircle(view->ToDeviceContextX(p.x), view->ToDeviceContextY(p.y), 5);
                         this->ResetBrush();
                         this->ResetPen();

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -32,11 +32,6 @@ View::View()
     m_slurHandling = SlurHandling::Initialize;
 
     m_currentColor = COLOR_NONE;
-    m_currentElement = NULL;
-    m_currentLayer = NULL;
-    m_currentMeasure = NULL;
-    m_currentStaff = NULL;
-    m_currentSystem = NULL;
 }
 
 View::~View() {}
@@ -53,11 +48,6 @@ void View::SetDoc(Doc *doc)
         m_doc = doc;
         m_options = doc->GetOptions();
     }
-    m_currentElement = NULL;
-    m_currentLayer = NULL;
-    m_currentMeasure = NULL;
-    m_currentStaff = NULL;
-    m_currentSystem = NULL;
     m_currentPage = NULL;
     m_pageIdx = 0;
 }
@@ -81,12 +71,6 @@ void View::SetPage(int pageIdx, bool doLayout)
             m_currentPage->LayOut();
         }
     }
-
-    m_currentElement = NULL;
-    m_currentLayer = NULL;
-    m_currentMeasure = NULL;
-    m_currentStaff = NULL;
-    m_currentSystem = NULL;
 
     OnPageChange();
     DoRefresh();

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -469,7 +469,7 @@ void View::DrawBracketSpan(
     x1 += lineWidth / 2;
     x2 -= lineWidth / 2;
 
-    dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
+    dc->SetPen(lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
     dc->SetBrush(m_currentColor);
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
@@ -515,7 +515,7 @@ void View::DrawBracketSpan(
             const int diff = (x2 - x1) % (lineWidth * 3 + 1);
             x1 += diff / 2;
         }
-        dc->SetPen(m_currentColor, lineWidth, penStyle, 0, 0, lineCapStyle);
+        dc->SetPen(lineWidth, penStyle, 0, 0, lineCapStyle);
         dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
         dc->ResetPen();
     }
@@ -640,7 +640,7 @@ void View::DrawHairpin(
 
     const LineCapStyle cap = (style == PEN_DOT) ? LINECAP_ROUND : LINECAP_SQUARE;
 
-    dc->SetPen(m_currentColor, hairpinThickness, style, 0, 0, cap, LINEJOIN_MITER);
+    dc->SetPen(hairpinThickness, style, 0, 0, cap, LINEJOIN_MITER);
 
     if ((startY == 0) && !niente) {
         Point p[3];
@@ -787,7 +787,7 @@ void View::DrawOctave(
                 actualLineWidth = lineWidth * 3 / 2;
             }
         }
-        dc->SetPen(m_currentColor, actualLineWidth, penStyle, 0, actualGap, lineCapStyle);
+        dc->SetPen(actualLineWidth, penStyle, 0, actualGap, lineCapStyle);
         dc->SetBrush(m_currentColor);
 
         // adjust vertical ends
@@ -808,14 +808,13 @@ void View::DrawOctave(
             if (spanningType == SPANNING_END || spanningType == SPANNING_START_END) {
                 if (octave->GetLform() == LINEFORM_dotted) {
                     // make sure we have at least two dots for the dotted hook
-                    dc->SetPen(m_currentColor, lineWidth * 3 / 2, PEN_DOT, 0, std::min(gap, unit * 2 - lineWidth),
-                        LINECAP_ROUND);
+                    dc->SetPen(lineWidth * 3 / 2, PEN_DOT, 0, std::min(gap, unit * 2 - lineWidth), LINECAP_ROUND);
                     dc->DrawLine(
                         ToDeviceContextX(x2), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
                     dc->ResetPen();
                 }
                 else {
-                    dc->SetPen(m_currentColor, lineWidth, PEN_SOLID);
+                    dc->SetPen(lineWidth, PEN_SOLID);
                     // Right hook
                     Point hookRight[3];
                     hookRight[0] = { ToDeviceContextX(x2), ToDeviceContextY(y2) };
@@ -922,7 +921,7 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
         dc->StartGraphic(pitchInflection, "spanning-pinflection", "");
     }
 
-    dc->SetPen(m_currentColor, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize), PEN_SOLID);
+    dc->SetPen(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize), PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     dc->DrawQuadBezierPath(points);
@@ -2102,18 +2101,18 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
             break;
         }
         case LINEFORM_dashed:
-            dc->SetPen(m_currentColor, lineWidth, PEN_SHORT_DASH, 0, 0, LINECAP_ROUND);
+            dc->SetPen(lineWidth, PEN_SHORT_DASH, 0, 0, LINECAP_ROUND);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_dotted:
-            dc->SetPen(m_currentColor, lineWidth * 3 / 2, PEN_DOT, 0, 0, LINECAP_ROUND);
+            dc->SetPen(lineWidth * 3 / 2, PEN_DOT, 0, 0, LINECAP_ROUND);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_solid: [[fallthrough]];
         default: {
-            dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_ROUND);
+            dc->SetPen(lineWidth, PEN_SOLID, 0, 0, LINECAP_ROUND);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
@@ -3008,7 +3007,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
             default: penStyle = PEN_SOLID;
         }
 
-        dc->SetPen(m_currentColor, lineWidth, penStyle, 0, 0, capStyle);
+        dc->SetPen(lineWidth, penStyle, 0, 0, capStyle);
         dc->DrawLine(ToDeviceContextX(startX), ToDeviceContextY(y2), ToDeviceContextX(endX), ToDeviceContextY(y2));
         if ((spanningType != SPANNING_END) && (spanningType != SPANNING_MIDDLE)
             && (ending->GetLstartsym() != LINESTARTENDSYMBOL_none)) {

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -470,7 +470,6 @@ void View::DrawBracketSpan(
     x2 -= lineWidth / 2;
 
     dc->SetPen(lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
-    dc->SetBrush(m_currentColor);
 
     if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_START)) {
         if (!bracketSpan->GetStart()->Is(TIMESTAMP_ATTR)) {
@@ -521,7 +520,6 @@ void View::DrawBracketSpan(
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     if (graphic) {
         dc->EndResumedGraphic(graphic, this);
@@ -658,7 +656,7 @@ void View::DrawHairpin(
     }
     else {
         if (niente) {
-            dc->SetBrush(m_currentColor, 0.0);
+            dc->SetBrush(0.0);
             if (startY == 0) {
                 dc->DrawCircle(ToDeviceContextX(x1), ToDeviceContextY(y), unit / 2);
                 startY = unit * endY / (x2 - x1) / 2;
@@ -788,7 +786,6 @@ void View::DrawOctave(
             }
         }
         dc->SetPen(actualLineWidth, penStyle, 0, actualGap, lineCapStyle);
-        dc->SetBrush(m_currentColor);
 
         // adjust vertical ends
         y1 += (disPlace == STAFFREL_basic_above) ? -lineWidth / 2 : lineWidth / 2;
@@ -826,7 +823,6 @@ void View::DrawOctave(
             }
         }
 
-        dc->ResetBrush();
         dc->ResetPen();
     }
 
@@ -922,7 +918,6 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
     }
 
     dc->SetPen(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize), PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawQuadBezierPath(points);
     if (drawArrow) {
@@ -930,7 +925,6 @@ void View::DrawPitchInflection(DeviceContext *dc, PitchInflection *pitchInflecti
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     if (graphic) {
         dc->EndResumedGraphic(graphic, this);
@@ -1663,7 +1657,6 @@ void View::DrawControlElementText(DeviceContext *dc, ControlElement *element, Me
             params.m_y -= m_doc->GetTextXHeight(&dirTxt, false) / 2;
         }
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&dirTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x - xAdjust), ToDeviceContextY(params.m_y), alignment);
@@ -1671,7 +1664,6 @@ void View::DrawControlElementText(DeviceContext *dc, ControlElement *element, Me
         dc->EndText();
 
         dc->ResetFont();
-        dc->ResetBrush();
 
         this->DrawTextEnclosure(dc, params, staffSize);
     }
@@ -1742,7 +1734,6 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             this->DrawDynamSymbolOnly(dc, staff, dynam, dynamSymbol, alignment, params);
         }
         else {
-            dc->SetBrush(m_currentColor);
             dc->SetFont(&dynamTxt);
 
             dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -1750,7 +1741,6 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
             dc->EndText();
 
             dc->ResetFont();
-            dc->ResetBrush();
         }
         this->DrawTextEnclosure(dc, params, staffSize);
     }
@@ -1821,7 +1811,6 @@ void View::DrawFb(DeviceContext *dc, Staff *staff, Fb *fb, TextDrawingParams &pa
 
     fontDim->SetPointSize(m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize)->GetPointSize());
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(fontDim);
 
     for (Object *current : fb->GetChildren()) {
@@ -1844,7 +1833,6 @@ void View::DrawFb(DeviceContext *dc, Staff *staff, Fb *fb, TextDrawingParams &pa
     }
 
     dc->ResetFont();
-    dc->ResetBrush();
 
     dc->EndGraphic(fb, this);
 }
@@ -1973,7 +1961,6 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
 
         fingTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&fingTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -1981,7 +1968,6 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
         dc->EndText();
 
         dc->ResetFont();
-        dc->ResetBrush();
 
         this->DrawTextEnclosure(dc, params, staffSize);
     }
@@ -2171,7 +2157,6 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
 
             harmTxt.SetPointSize(params.m_pointSize);
 
-            dc->SetBrush(m_currentColor);
             dc->SetFont(&harmTxt);
 
             dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2179,7 +2164,6 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
             dc->EndText();
 
             dc->ResetFont();
-            dc->ResetBrush();
 
             this->DrawTextEnclosure(dc, params, staffSize);
         }
@@ -2467,7 +2451,6 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
 
         rehTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&rehTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2475,7 +2458,6 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         dc->EndText();
 
         dc->ResetFont();
-        dc->ResetBrush();
 
         this->DrawTextEnclosure(dc, params, staffSize);
     }
@@ -2588,7 +2570,6 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
             params.m_y -= m_doc->GetTextXHeight(&tempoTxt, false) / 2;
         }
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&tempoTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -2596,7 +2577,6 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         dc->EndText();
 
         dc->ResetFont();
-        dc->ResetBrush();
 
         this->DrawTextEnclosure(dc, params, staffSize);
     }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -500,18 +500,24 @@ void View::DrawBracketSpan(
     }
     // We have a @lform - draw a full line
     if (bracketSpan->HasLform()) {
+        PenStyle penStyle = PEN_SOLID;
+        LineCapStyle lineCapStyle = LINECAP_BUTT;
         if (bracketSpan->GetLform() == LINEFORM_dashed) {
-            dc->SetPen(m_currentColor, lineWidth, PEN_LONG_DASH, 0, 0, LINECAP_SQUARE);
+            penStyle = PEN_LONG_DASH;
+            lineCapStyle = LINECAP_SQUARE;
         }
         else if (bracketSpan->GetLform() == LINEFORM_dotted) {
+            penStyle = PEN_DOT;
+            lineCapStyle = LINECAP_ROUND;
             // Adjust start and end
-            dc->SetPen(m_currentColor, lineWidth, PEN_DOT, 0, 0, LINECAP_ROUND);
             x1 += unit + lineWidth * 2;
             x2 -= unit + lineWidth * 2;
             const int diff = (x2 - x1) % (lineWidth * 3 + 1);
             x1 += diff / 2;
         }
+        dc->SetPen(m_currentColor, lineWidth, penStyle, 0, 0, lineCapStyle);
         dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
+        dc->ResetPen();
     }
 
     dc->ResetPen();
@@ -760,12 +766,15 @@ void View::DrawOctave(
         x1 += lineWidth;
         if (altSymbols) x1 += extend.m_width / 2;
 
-        dc->SetPen(m_currentColor, lineWidth, PEN_SHORT_DASH, 0, gap, LINECAP_SQUARE);
-        dc->SetBrush(m_currentColor);
+        PenStyle penStyle = PEN_SHORT_DASH;
+        LineCapStyle lineCapStyle = LINECAP_SQUARE;
+        int actualGap = gap;
+        int actualLineWidth = lineWidth;
+
         if (octave->HasLform()) {
             if (octave->GetLform() == LINEFORM_solid) {
-                dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_SQUARE);
-                dc->SetBrush(m_currentColor);
+                penStyle = PEN_SOLID;
+                actualGap = 0;
             }
             else if (octave->GetLform() == LINEFORM_dotted) {
                 if ((spanningType == SPANNING_START_END) || (spanningType == SPANNING_END)) {
@@ -773,10 +782,13 @@ void View::DrawOctave(
                     const int diff = (x2 - x1) % (gap + 1);
                     x2 += (gap - diff < diff) ? gap - diff : -diff;
                 }
-                dc->SetPen(m_currentColor, lineWidth * 3 / 2, PEN_DOT, 0, gap, LINECAP_ROUND);
-                dc->SetBrush(m_currentColor);
+                penStyle = PEN_SOLID;
+                lineCapStyle = LINECAP_ROUND;
+                actualLineWidth = lineWidth * 3 / 2;
             }
         }
+        dc->SetPen(m_currentColor, actualLineWidth, penStyle, 0, actualGap, lineCapStyle);
+        dc->SetBrush(m_currentColor);
 
         // adjust vertical ends
         y1 += (disPlace == STAFFREL_basic_above) ? -lineWidth / 2 : lineWidth / 2;
@@ -800,6 +812,7 @@ void View::DrawOctave(
                         LINECAP_ROUND);
                     dc->DrawLine(
                         ToDeviceContextX(x2), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
+                    dc->ResetPen();
                 }
                 else {
                     dc->SetPen(m_currentColor, lineWidth, PEN_SOLID);
@@ -809,9 +822,13 @@ void View::DrawOctave(
                     hookRight[1] = { ToDeviceContextX(x2), ToDeviceContextY(y1) };
                     hookRight[2] = { ToDeviceContextX(x2 - unit), ToDeviceContextY(y1) };
                     dc->DrawPolyline(3, hookRight);
+                    dc->ResetPen();
                 }
             }
         }
+
+        dc->ResetBrush();
+        dc->ResetPen();
     }
 
     if (graphic) {
@@ -2086,20 +2103,17 @@ void View::DrawGliss(DeviceContext *dc, Gliss *gliss, int x1, int x2, Staff *sta
         }
         case LINEFORM_dashed:
             dc->SetPen(m_currentColor, lineWidth, PEN_SHORT_DASH, 0, 0, LINECAP_ROUND);
-            dc->SetBrush(m_currentColor);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_dotted:
             dc->SetPen(m_currentColor, lineWidth * 3 / 2, PEN_DOT, 0, 0, LINECAP_ROUND);
-            dc->SetBrush(m_currentColor);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;
         case LINEFORM_solid: [[fallthrough]];
         default: {
             dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_ROUND);
-            dc->SetBrush(m_currentColor);
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
             dc->ResetPen();
             break;

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1748,8 +1748,6 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     dc->StartGraphic(syl, "", syl->GetID());
     dc->DeactivateGraphicY();
 
-    dc->SetBrush(m_currentColor);
-
     FontInfo currentFont = *m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize);
     if (syl->HasFontweight()) {
         currentFont.SetWeight(syl->GetFontweight());
@@ -1806,7 +1804,6 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     dc->EndText();
 
     dc->ResetFont();
-    dc->ResetBrush();
 
     if (syl->GetStart() && syl->GetEnd()) {
         System *currentSystem = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
@@ -1863,7 +1860,6 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         params.m_y = staff->GetDrawingY() + this->GetSylYRel(std::max(1, verse->GetN()), staff, verse->GetPlace());
         params.m_pointSize = labelTxt.GetPointSize();
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&labelTxt);
 
         dc->StartGraphic(graphic, "", graphic->GetID());
@@ -1875,7 +1871,6 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         dc->EndGraphic(graphic, this);
 
         dc->ResetFont();
-        dc->ResetBrush();
     }
 
     dc->StartGraphic(verse, "", verse->GetID());
@@ -1896,7 +1891,6 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     assert(staff);
 
     dc->SetPen(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 1.2, PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     int positionShift = m_doc->GetCueSize(m_doc->GetDrawingUnit(staff->m_drawingStaffSize));
     int positionShiftX1 = positionShift;
@@ -1933,7 +1927,6 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 }
 
 void View::DrawDotsPart(DeviceContext *dc, int x, int y, unsigned char dots, const Staff *staff, bool dimin)

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1895,7 +1895,7 @@ void View::DrawAcciaccaturaSlash(DeviceContext *dc, Stem *stem, Staff *staff)
     assert(stem);
     assert(staff);
 
-    dc->SetPen(m_currentColor, m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 1.2, PEN_SOLID);
+    dc->SetPen(m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize) * 1.2, PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     int positionShift = m_doc->GetCueSize(m_doc->GetDrawingUnit(staff->m_drawingStaffSize));

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -77,15 +77,6 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
         return;
     }
 
-    int previousColor = m_currentColor;
-
-    if (element == m_currentElement) {
-        m_currentColor = COLOR_RED;
-    }
-    else {
-        m_currentColor = COLOR_NONE;
-    }
-
     if (element->Is(ACCID)) {
         this->DrawAccid(dc, element, layer, staff, measure);
     }
@@ -232,8 +223,6 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
         // This should never happen
         LogError("Element '%s' cannot be drawn", element->GetClassName().c_str());
     }
-
-    m_currentColor = previousColor;
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -29,12 +29,10 @@ void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width
     assert(dc);
 
     dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x1), ToDeviceContextY(y2));
 
     dc->ResetPen();
-    dc->ResetBrush();
     return;
 }
 
@@ -43,12 +41,10 @@ void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int wid
     assert(dc);
 
     dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
 
     dc->ResetPen();
-    dc->ResetBrush();
     return;
 }
 
@@ -57,12 +53,10 @@ void View::DrawObliqueLine(DeviceContext *dc, int x1, int x2, int y1, int y2, in
     assert(dc);
 
     dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
 
     dc->ResetPen();
-    dc->ResetBrush();
     return;
 }
 
@@ -93,7 +87,7 @@ void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y
     std::swap(y1, y2);
 
     dc->SetPen(lineThickness, PEN_SOLID);
-    dc->SetBrush(m_currentColor, 0.0);
+    dc->SetBrush(0.0);
 
     int width = x2 - x1;
     int height = y1 - y2;
@@ -112,7 +106,7 @@ void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int
 
     const int penWidth = lineThickness;
     dc->SetPen(penWidth, PEN_SOLID);
-    dc->SetBrush(m_currentColor, 0.0);
+    dc->SetBrush(0.0);
 
     dc->DrawRoundedRectangle(
         ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
@@ -140,13 +134,11 @@ void View::DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2,
     std::swap(y1, y2);
 
     dc->SetPen(0, PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawRoundedRectangle(
         ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2 - x1), ToDeviceContextX(y1 - y2), radius);
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     return;
 }
@@ -158,7 +150,6 @@ void View::DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2,
     Point p[4];
 
     dc->SetPen(0, PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     height = ToDeviceContextX(height);
     p[0].x = ToDeviceContextX(x1);
@@ -173,7 +164,6 @@ void View::DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2,
     dc->DrawPolygon(4, p);
 
     dc->ResetPen();
-    dc->ResetBrush();
 }
 
 /* Draw an empty ("void") diamond with its top lefthand point at (x1, y1). */
@@ -184,10 +174,10 @@ void View::DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width,
 
     dc->SetPen(linewidth, PEN_SOLID);
     if (fill) {
-        dc->SetBrush(m_currentColor);
+        dc->SetBrush(1.0);
     }
     else {
-        dc->SetBrush(m_currentColor, 0.0);
+        dc->SetBrush(0.0);
     }
 
     int dHeight = ToDeviceContextX(height);
@@ -213,12 +203,10 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
     if (dimin) r *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
     dc->SetPen(0, PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(y), r);
 
     dc->ResetPen();
-    dc->ResetBrush();
 }
 
 void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line, int barlineWidth, int interval)
@@ -230,7 +218,6 @@ void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line,
     int drawingPosition = top - interval / 2;
 
     dc->SetPen(0, PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     while (drawingPosition > bottom) {
         dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(drawingPosition), radius);
@@ -238,7 +225,6 @@ void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line,
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 }
 
 void View::DrawSquareBracket(DeviceContext *dc, bool leftBracket, int x, int y, int height, int width,
@@ -296,13 +282,11 @@ void View::DrawSmuflCode(DeviceContext *dc, int x, int y, char32_t code, int sta
     std::u32string str;
     str.push_back(code);
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     dc->DrawMusicText(str, ToDeviceContextX(x), ToDeviceContextY(y), setBBGlyph);
 
     dc->ResetFont();
-    dc->ResetBrush();
 
     return;
 }
@@ -323,7 +307,6 @@ void View::DrawSmuflLine(
     // We add half a fill length for an average shorter / longer line result
     const int count = (length + fillWidth / 2 - startWidth - endWidth) / fillWidth;
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     std::u32string str;
@@ -343,7 +326,6 @@ void View::DrawSmuflLine(
     dc->DrawMusicText(str, ToDeviceContextX(orig.x), ToDeviceContextY(orig.y), false);
 
     dc->ResetFont();
-    dc->ResetBrush();
 }
 
 void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::u32string s, data_HORIZONTALALIGNMENT alignment,
@@ -353,7 +335,6 @@ void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::u32string s, da
 
     int xDC = ToDeviceContextX(x);
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(m_doc->GetDrawingSmuflFont(staffSize, dimin));
 
     if (alignment == HORIZONTALALIGNMENT_center) {
@@ -370,7 +351,6 @@ void View::DrawSmuflString(DeviceContext *dc, int x, int y, std::u32string s, da
     dc->DrawMusicText(s, xDC, ToDeviceContextY(y), setBBGlyph);
 
     dc->ResetFont();
-    dc->ResetBrush();
 }
 
 void View::DrawThickBezierCurve(

--- a/src/view_graph.cpp
+++ b/src/view_graph.cpp
@@ -28,7 +28,7 @@ void View::DrawVerticalLine(DeviceContext *dc, int y1, int y2, int x1, int width
 {
     assert(dc);
 
-    dc->SetPen(m_currentColor, std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
+    dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
     dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x1), ToDeviceContextY(y2));
@@ -42,7 +42,7 @@ void View::DrawHorizontalLine(DeviceContext *dc, int x1, int x2, int y1, int wid
 {
     assert(dc);
 
-    dc->SetPen(m_currentColor, std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
+    dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
     dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y1));
@@ -56,7 +56,7 @@ void View::DrawObliqueLine(DeviceContext *dc, int x1, int x2, int y1, int y2, in
 {
     assert(dc);
 
-    dc->SetPen(m_currentColor, std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
+    dc->SetPen(std::max(1, ToDeviceContextX(width)), PEN_SOLID, dashLength, gapLength);
     dc->SetBrush(m_currentColor);
 
     dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y1), ToDeviceContextX(x2), ToDeviceContextY(y2));
@@ -92,7 +92,7 @@ void View::DrawNotFilledEllipse(DeviceContext *dc, int x1, int y1, int x2, int y
 
     std::swap(y1, y2);
 
-    dc->SetPen(m_currentColor, lineThickness, PEN_SOLID);
+    dc->SetPen(lineThickness, PEN_SOLID);
     dc->SetBrush(m_currentColor, 0.0);
 
     int width = x2 - x1;
@@ -111,7 +111,7 @@ void View::DrawNotFilledRectangle(DeviceContext *dc, int x1, int y1, int x2, int
     std::swap(y1, y2);
 
     const int penWidth = lineThickness;
-    dc->SetPen(m_currentColor, penWidth, PEN_SOLID);
+    dc->SetPen(penWidth, PEN_SOLID);
     dc->SetBrush(m_currentColor, 0.0);
 
     dc->DrawRoundedRectangle(
@@ -139,7 +139,7 @@ void View::DrawFilledRoundedRectangle(DeviceContext *dc, int x1, int y1, int x2,
 
     std::swap(y1, y2);
 
-    dc->SetPen(m_currentColor, 0, PEN_SOLID);
+    dc->SetPen(0, PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     dc->DrawRoundedRectangle(
@@ -157,7 +157,7 @@ void View::DrawObliquePolygon(DeviceContext *dc, int x1, int y1, int x2, int y2,
 {
     Point p[4];
 
-    dc->SetPen(m_currentColor, 0, PEN_SOLID);
+    dc->SetPen(0, PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     height = ToDeviceContextX(height);
@@ -182,7 +182,7 @@ void View::DrawDiamond(DeviceContext *dc, int x1, int y1, int height, int width,
 {
     Point p[4];
 
-    dc->SetPen(m_currentColor, linewidth, PEN_SOLID);
+    dc->SetPen(linewidth, PEN_SOLID);
     if (fill) {
         dc->SetBrush(m_currentColor);
     }
@@ -212,7 +212,7 @@ void View::DrawDot(DeviceContext *dc, int x, int y, int staffSize, bool dimin)
     int r = std::max(ToDeviceContextX(m_doc->GetDrawingDoubleUnit(staffSize) / 5), 2);
     if (dimin) r *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
-    dc->SetPen(m_currentColor, 0, PEN_SOLID);
+    dc->SetPen(0, PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     dc->DrawCircle(ToDeviceContextX(x), ToDeviceContextY(y), r);
@@ -229,7 +229,7 @@ void View::DrawVerticalDots(DeviceContext *dc, int x, const SegmentedLine &line,
     const int radius = std::max(barlineWidth, 2);
     int drawingPosition = top - interval / 2;
 
-    dc->SetPen(m_currentColor, 0, PEN_SOLID);
+    dc->SetPen(0, PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     while (drawingPosition > bottom) {
@@ -395,12 +395,12 @@ void View::DrawThickBezierCurve(
     // Actually draw it
     if (penStyle == PEN_SOLID) {
         // Solid Thick Bezier Curves are made of two beziers, filled in.
-        dc->SetPen(m_currentColor, std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
+        dc->SetPen(std::max(1, m_doc->GetDrawingStemWidth(staffSize) / 2), penStyle);
         dc->DrawCubicBezierPathFilled(bez1, bez2);
     }
     else {
         // Dashed or Dotted Thick Bezier Curves have a uniform line width.
-        dc->SetPen(m_currentColor, thickness, penStyle);
+        dc->SetPen(thickness, penStyle);
         dc->DrawCubicBezierPath(bez1);
     }
     dc->ResetPen();

--- a/src/view_neume.cpp
+++ b/src/view_neume.cpp
@@ -132,7 +132,7 @@ void View::DrawNeume(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
             x1 += lineWidth / 2;
             x2 += 2 * last->GetDrawingRadius(m_doc) - lineWidth / 2;
 
-            dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
+            dc->SetPen(lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
 
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y), ToDeviceContextX(x2), ToDeviceContextY(y));
             dc->DrawLine(ToDeviceContextX(x1), ToDeviceContextY(y + lineWidth / 2), ToDeviceContextX(x1),

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -694,7 +694,7 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     bez2[2] = points[2];
     bez2[3] = points[3];
 
-    dc->SetPen(m_currentColor, std::max(1, penWidth), PEN_SOLID);
+    dc->SetPen(std::max(1, penWidth), PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     dc->DrawCubicBezierPathFilled(bez1, bez2);
@@ -1312,7 +1312,7 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, M
     }
 
     const int lineWidth = m_doc->GetDrawingStaffLineWidth(staff->m_drawingStaffSize);
-    dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), PEN_SOLID);
+    dc->SetPen(ToDeviceContextX(lineWidth), PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     // If German lute tablature the default is @lines.visible="false", but setting @lines.visible="true"
@@ -1396,7 +1396,7 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
         = m_doc->GetOptions()->m_ledgerLineThickness.GetValue() * m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     if (cueSize) lineWidth *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
-    dc->SetPen(m_currentColor, ToDeviceContextX(lineWidth), PEN_SOLID);
+    dc->SetPen(ToDeviceContextX(lineWidth), PEN_SOLID);
     dc->SetBrush(m_currentColor);
 
     bool svgHtml5 = (m_doc->GetOptions()->m_svgHtml5.GetValue());

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -570,7 +570,6 @@ void View::DrawLabels(
     params.m_y = y;
     params.m_pointSize = labelTxt.GetPointSize();
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(&labelTxt);
 
     dc->StartGraphic(graphic, "", graphic->GetID());
@@ -599,7 +598,6 @@ void View::DrawLabels(
     }
 
     dc->ResetFont();
-    dc->ResetBrush();
 }
 
 void View::DrawBracket(DeviceContext *dc, int x, int y1, int y2, int staffSize)
@@ -695,7 +693,6 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     bez2[3] = points[3];
 
     dc->SetPen(std::max(1, penWidth), PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     dc->DrawCubicBezierPathFilled(bez1, bez2);
 
@@ -721,7 +718,6 @@ void View::DrawBrace(DeviceContext *dc, int x, int y1, int y2, int staffSize)
     dc->DrawCubicBezierPathFilled(bez1, bez2);
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     return;
 }
@@ -1214,7 +1210,6 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *sys
             mnumTxt.SetPointSize(m_doc->GetDrawingLyricFont(80)->GetPointSize());
         }
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&mnumTxt);
 
         dc->StartText(ToDeviceContextX(params.m_x), ToDeviceContextY(params.m_y), alignment);
@@ -1222,7 +1217,6 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *sys
         dc->EndText();
 
         dc->ResetFont();
-        dc->ResetBrush();
 
         this->DrawTextEnclosure(dc, params, staff->m_drawingStaffSize);
 
@@ -1313,7 +1307,6 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, M
 
     const int lineWidth = m_doc->GetDrawingStaffLineWidth(staff->m_drawingStaffSize);
     dc->SetPen(ToDeviceContextX(lineWidth), PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     // If German lute tablature the default is @lines.visible="false", but setting @lines.visible="true"
     // will draw the staff lines.
@@ -1364,7 +1357,6 @@ void View::DrawStaffLines(DeviceContext *dc, Staff *staff, StaffDef *staffDef, M
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     return;
 }
@@ -1397,7 +1389,6 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
     if (cueSize) lineWidth *= m_doc->GetOptions()->m_graceFactor.GetValue();
 
     dc->SetPen(ToDeviceContextX(lineWidth), PEN_SOLID);
-    dc->SetBrush(m_currentColor);
 
     bool svgHtml5 = (m_doc->GetOptions()->m_svgHtml5.GetValue());
 
@@ -1432,7 +1423,6 @@ void View::DrawLedgerLines(DeviceContext *dc, Staff *staff, const ArrayOfLedgerL
     }
 
     dc->ResetPen();
-    dc->ResetBrush();
 
     dc->EndCustomGraphic();
 }

--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -169,7 +169,7 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
                 = x - (fret.size() == 1 ? widthFront * 7 / 10 : widthFront * 12 / 10); // extend on the left hand side
             const int x2 = x + extend.m_width - widthBack * 1 / 10; // trim right hand overhang on last character
 
-            dc->SetPen(m_currentColor, lineThickness, PEN_SOLID);
+            dc->SetPen(lineThickness, PEN_SOLID);
             dc->SetBrush(m_currentColor);
 
             // overlines

--- a/src/view_tab.cpp
+++ b/src/view_tab.cpp
@@ -123,7 +123,6 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
         params.m_pointSize = m_doc->GetDrawingLyricFont(glyphSize)->GetPointSize() * 4 / 5;
         fretTxt.SetPointSize(params.m_pointSize);
 
-        dc->SetBrush(m_currentColor);
         dc->SetFont(&fretTxt);
 
         params.m_y -= (m_doc->GetTextGlyphHeight(L'0', &fretTxt, drawingCueSize) / 2);
@@ -170,7 +169,6 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
             const int x2 = x + extend.m_width - widthBack * 1 / 10; // trim right hand overhang on last character
 
             dc->SetPen(lineThickness, PEN_SOLID);
-            dc->SetBrush(m_currentColor);
 
             // overlines
             int y1 = y + extend.m_ascent + lineThickness;
@@ -197,7 +195,6 @@ void View::DrawTabNote(DeviceContext *dc, LayerElement *element, Layer *layer, S
             }
 
             dc->ResetPen();
-            dc->ResetBrush();
         }
         dc->ResetFont();
     }

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -680,13 +680,11 @@ void View::DrawTextLayoutElement(DeviceContext *dc, TextLayoutElement *textLayou
 
     textElementFont.SetPointSize(params.m_pointSize);
 
-    dc->SetBrush(m_currentColor);
     dc->SetFont(&textElementFont);
 
     this->DrawRunningChildren(dc, textLayoutElement, params);
 
     dc->ResetFont();
-    dc->ResetBrush();
 
     dc->EndGraphic(textLayoutElement, this);
 }

--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -107,7 +107,7 @@ void View::DrawTupletBracket(DeviceContext *dc, LayerElement *element, Layer *la
     const int yRight = tupletBracket->GetDrawingYRight();
     int bracketHeight = (tuplet->GetDrawingBracketPos() == STAFFREL_basic_above) ? -1 : 1;
 
-    dc->SetPen(m_currentColor, lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
+    dc->SetPen(lineWidth, PEN_SOLID, 0, 0, LINECAP_BUTT, LINEJOIN_MITER);
 
     // Draw a bracket with a gap
     if (tupletBracket->GetAlignedNum() && tupletBracket->GetAlignedNum()->HasSelfBB()) {


### PR DESCRIPTION
* Have a default Pen and Brush in DeviceContext classes
* Set the color to default (SVG defaultColor)
* Remove the need to have a Brush when default opacity is used
* Cleanup pen and brush stacks for some elements (gliss, bracketSpan, octave)

No change expected