### PR TITLE
Scope the CSS included in the SVG

### DIFF
--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -233,7 +233,11 @@ public:
     /**
      * Setter for an additional CSS
      */
-    void SetCss(const std::string &css) { m_css = css; }
+    void SetCss(const std::string &css)
+    {
+        m_css = css;
+        this->PrefixCssRules(m_css);
+    }
 
     /**
      *  Copies additional attributes of defined elements to the SVG, each string in the form "elementName@attribute"
@@ -306,6 +310,11 @@ private:
     void AppendStrokeLineJoin(pugi::xml_node node, const Pen &pen);
     void AppendStrokeDashArray(pugi::xml_node node, const Pen &pen);
     ///@}
+
+    /**
+     * Prefix the CSS rules with a #docId for scoping them to the SVG
+     */
+    void PrefixCssRules(std::string &rules);
 
 public:
     //

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -42,7 +42,7 @@ public:
      * @name Constructors, destructors, and other standard methods
      */
     ///@{
-    SvgDeviceContext();
+    SvgDeviceContext(const std::string &docId);
     virtual ~SvgDeviceContext();
     ///@}
 
@@ -384,6 +384,8 @@ private:
     std::string m_glyphPostfixId;
     // embedding of the smufl text font
     option_SMUFLTEXTFONT m_smuflTextFont;
+    // the document id
+    std::string m_docId;
 };
 
 } // namespace vrv

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -476,11 +476,11 @@ void SvgDeviceContext::StartPage()
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
         std::string css = "g.page-margin{font-family:Times,serif;} "
-                          //"g.page-margin{background: pink;} "
-                          //"g.bounding-box{stroke:red; stroke-width:10} "
-                          //"g.content-bounding-box{stroke:blue; stroke-width:10} "
                           "g.ending, g.fing, g.reh, g.tempo{font-weight:bold;} g.dir, g.dynam, "
                           "g.mNum{font-style:italic;} g.label{font-weight:normal;} path{stroke:currentColor}";
+        // bounding box css - for debugging
+        // css += " g.bounding-box{stroke:red; stroke-width:10} "
+        //        "g.content-bounding-box{stroke:blue; stroke-width:10}";
         this->PrefixCssRules(css);
         m_currentNode.text().set(css);
         m_currentNode = m_svgNodeStack.back();

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -33,8 +33,10 @@ namespace vrv {
 // SvgDeviceContext
 //----------------------------------------------------------------------------
 
-SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
+SvgDeviceContext::SvgDeviceContext(const std::string &docId) : DeviceContext(SVG_DEVICE_CONTEXT)
 {
+    m_docId = docId;
+
     m_originX = 0;
     m_originY = 0;
 
@@ -61,6 +63,7 @@ SvgDeviceContext::SvgDeviceContext() : DeviceContext(SVG_DEVICE_CONTEXT)
     m_svgNode.append_attribute("xmlns:xlink") = "http://www.w3.org/1999/xlink";
     m_svgNode.append_attribute("xmlns:mei") = "http://www.music-encoding.org/ns/mei";
     m_svgNode.append_attribute("overflow") = "visible";
+    m_svgNode.append_attribute("id") = m_docId;
 
     // start the stack
     m_svgNodeStack.push_back(m_svgNode);
@@ -472,19 +475,21 @@ void SvgDeviceContext::StartPage()
     if (this->UseGlobalStyling()) {
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
-        m_currentNode.text().set("g.page-margin{font-family:Times,serif;} "
-                                 //"g.page-margin{background: pink;} "
-                                 //"g.bounding-box{stroke:red; stroke-width:10} "
-                                 //"g.content-bounding-box{stroke:blue; stroke-width:10} "
-                                 "g.ending, g.fing, g.reh, g.tempo{font-weight:bold;} g.dir, g.dynam, "
-                                 "g.mNum{font-style:italic;} g.label{font-weight:normal;} path{stroke:currentColor}");
+        m_currentNode.text().set("#" + m_docId
+            + " "
+              "g.page-margin{font-family:Times,serif;} "
+              //"g.page-margin{background: pink;} "
+              //"g.bounding-box{stroke:red; stroke-width:10} "
+              //"g.content-bounding-box{stroke:blue; stroke-width:10} "
+              "g.ending, g.fing, g.reh, g.tempo{font-weight:bold;} g.dir, g.dynam, "
+              "g.mNum{font-style:italic;} g.label{font-weight:normal;} path{stroke:currentColor}");
         m_currentNode = m_svgNodeStack.back();
     }
 
     if (!m_css.empty()) {
         m_currentNode = m_currentNode.append_child("style");
         m_currentNode.append_attribute("type") = "text/css";
-        m_currentNode.text().set(m_css.c_str());
+        m_currentNode.text().set(("#" + m_docId + " " + m_css).c_str());
         m_currentNode = m_svgNodeStack.back();
     }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -61,7 +61,6 @@ SvgDeviceContext::SvgDeviceContext(const std::string &docId) : DeviceContext(SVG
     m_svgNode.append_attribute("version") = "1.1";
     m_svgNode.append_attribute("xmlns") = "http://www.w3.org/2000/svg";
     m_svgNode.append_attribute("xmlns:xlink") = "http://www.w3.org/1999/xlink";
-    m_svgNode.append_attribute("xmlns:mei") = "http://www.music-encoding.org/ns/mei";
     m_svgNode.append_attribute("overflow") = "visible";
     m_svgNode.append_attribute("id") = m_docId;
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -621,7 +621,7 @@ void SvgDeviceContext::AppendStrokeDashArray(pugi::xml_node node, const Pen &pen
 void SvgDeviceContext::PrefixCssRules(std::string &rules)
 {
     static std::regex selectorRegex(R"(([^{}]+)\s*\{([^}]*)\})");
-    static std::regex multiSelectorRegex(R"((\b\w+\.[\w-]+\b))");
+    static std::regex multiSelectorRegex(R"((\b\w+\.?[\w-]+\b))");
 
     std::sregex_iterator it(rules.begin(), rules.end(), selectorRegex);
     std::sregex_iterator end;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1684,7 +1684,7 @@ std::string Toolkit::RenderToSVG(int pageNo, bool xmlDeclaration)
     int initialPageNo = (m_doc.GetDrawingPage() == NULL) ? -1 : m_doc.GetDrawingPage()->GetIdx();
     // Create the SVG object, h & w come from the system
     // We will need to set the size of the page after having drawn it depending on the options
-    SvgDeviceContext svg;
+    SvgDeviceContext svg(m_doc.GetID());
     svg.SetResources(&m_doc.GetResources());
 
     int indent = (m_options->m_outputIndentTab.GetValue()) ? -1 : m_options->m_outputIndent.GetValue();


### PR DESCRIPTION
Limit the scope of CSS style in the SVG through `svg@id`, namely with
```xml
<svg id="de1cn3h">
```
and then
```css
#de1cn3h g.syl {
   opacity: 0.0;
}
```

Also remove `xmlns:mei` from the `svg`, which is not necessary but make the svg invalid.

No change expected