### PR TITLE
Reset Doc Id when resetting the Doc

### DIFF
--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -107,6 +107,7 @@ Doc::~Doc()
 void Doc::Reset()
 {
     Object::Reset();
+    this->ResetID();
 
     this->ClearSelectionPages();
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -71,7 +71,7 @@ SvgDeviceContext::SvgDeviceContext(const std::string &docId) : DeviceContext(SVG
 
     m_outdata.clear();
 
-    m_glyphPostfixId = Object::GenerateHashID();
+    m_glyphPostfixId = m_docId;
 }
 
 SvgDeviceContext::~SvgDeviceContext() {}


### PR DESCRIPTION
Forces and new Doc ID to be generated when a new document is loaded into the Toolkit. This should have no impact, but please comment if you think this can affect your use case scenarios and needs specific testing.

@ahankinson I'll push it to test-pypi for testing.