### PR TITLE
Render oblique ligatures with curve shapes

### DIFF
--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -72,7 +72,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) override;
+    void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -72,7 +72,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) override;
+    void DrawBentParallelogramFilled(Point side1[4], int height) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -72,6 +72,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
+    void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/bboxdevicecontext.h
+++ b/include/vrv/bboxdevicecontext.h
@@ -72,7 +72,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[4], int height) override;
+    void DrawBentParallelogramFilled(Point side[4], int height) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -193,6 +193,7 @@ public:
     virtual void DrawQuadBezierPath(Point bezier[3]) = 0;
     virtual void DrawCubicBezierPath(Point bezier[4]) = 0;
     virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) = 0;
+    virtual void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) = 0;
     virtual void DrawCircle(int x, int y, int radius) = 0;
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -193,7 +193,7 @@ public:
     virtual void DrawQuadBezierPath(Point bezier[3]) = 0;
     virtual void DrawCubicBezierPath(Point bezier[4]) = 0;
     virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) = 0;
-    virtual void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) = 0;
+    virtual void DrawBentParallelogramFilled(Point side1[4], int height) = 0;
     virtual void DrawCircle(int x, int y, int radius) = 0;
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -193,7 +193,7 @@ public:
     virtual void DrawQuadBezierPath(Point bezier[3]) = 0;
     virtual void DrawCubicBezierPath(Point bezier[4]) = 0;
     virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) = 0;
-    virtual void DrawBentParallelogramFilled(Point side1[4], int height) = 0;
+    virtual void DrawBentParallelogramFilled(Point side[4], int height) = 0;
     virtual void DrawCircle(int x, int y, int radius) = 0;
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;

--- a/include/vrv/devicecontext.h
+++ b/include/vrv/devicecontext.h
@@ -193,7 +193,7 @@ public:
     virtual void DrawQuadBezierPath(Point bezier[3]) = 0;
     virtual void DrawCubicBezierPath(Point bezier[4]) = 0;
     virtual void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) = 0;
-    virtual void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) = 0;
+    virtual void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) = 0;
     virtual void DrawCircle(int x, int y, int radius) = 0;
     virtual void DrawEllipse(int x, int y, int width, int height) = 0;
     virtual void DrawEllipticArc(int x, int y, int width, int height, double start, double end) = 0;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -845,6 +845,7 @@ public:
 
     OptionIntMap m_durationEquivalence;
     OptionBool m_ligatureAsBracket;
+    OptionBool m_ligatureStraight;
     OptionBool m_mensuralScoreUp;
     OptionBool m_mensuralResponsiveView;
     OptionBool m_mensuralToCmn;

--- a/include/vrv/options.h
+++ b/include/vrv/options.h
@@ -75,6 +75,8 @@ enum option_FOOTER { FOOTER_none = 0, FOOTER_auto, FOOTER_encoded, FOOTER_always
 
 enum option_HEADER { HEADER_none = 0, HEADER_auto, HEADER_encoded };
 
+enum option_LIGATURE_OBL { LIGATURE_OBL_auto = 0, LIGATURE_OBL_straight, LIGATURE_OBL_curved };
+
 enum option_MULTIRESTSTYLE {
     MULTIRESTSTYLE_auto = 0,
     MULTIRESTSTYLE_default,
@@ -148,6 +150,7 @@ public:
     static const std::map<int, std::string> s_fontFallback;
     static const std::map<int, std::string> s_footer;
     static const std::map<int, std::string> s_header;
+    static const std::map<int, std::string> s_ligatureOblique;
     static const std::map<int, std::string> s_multiRestStyle;
     static const std::map<int, std::string> s_pedalStyle;
     static const std::map<int, std::string> s_systemDivider;
@@ -845,7 +848,7 @@ public:
 
     OptionIntMap m_durationEquivalence;
     OptionBool m_ligatureAsBracket;
-    OptionBool m_ligatureStraight;
+    OptionIntMap m_ligatureOblique;
     OptionBool m_mensuralScoreUp;
     OptionBool m_mensuralResponsiveView;
     OptionBool m_mensuralToCmn;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -78,6 +78,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
+    void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -78,7 +78,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) override;
+    void DrawBentParallelogramFilled(Point side1[4], int height) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -78,7 +78,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[4], int height) override;
+    void DrawBentParallelogramFilled(Point side[4], int height) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -78,7 +78,7 @@ public:
     void DrawQuadBezierPath(Point bezier[3]) override;
     void DrawCubicBezierPath(Point bezier[4]) override;
     void DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2[4]) override;
-    void DrawBentParallelogramFilled(Point side1[3], Point side2[3]) override;
+    void DrawBentParallelogramFilled(Point side1[4], Point side2[4]) override;
     void DrawCircle(int x, int y, int radius) override;
     void DrawEllipse(int x, int y, int width, int height) override;
     void DrawEllipticArc(int x, int y, int width, int height, double start, double end) override;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -641,7 +641,7 @@ private:
     void CalcBrevisPoints(
         Note *note, Staff *staff, Point *topLeft, Point *bottomRight, int sides[4], int shape, bool isMensuralBlack);
     void CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point points[4], int sides[4], int shape,
-        bool isMensuralBlack, bool firstHalf);
+        bool isMensuralBlack, bool firstHalf, bool straight);
 
     /**
      * Internal methods for drawing a BeamSegment

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -169,7 +169,7 @@ void BBoxDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier
     this->UpdateBB(pos.x, pos.y, pos.x + width, pos.y + height);
 }
 
-void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[3], Point side2[3])
+void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[4], Point side2[4])
 {
     this->UpdateBB(side1[0].x, side1[0].y, side2[2].x, side2[2].y);
 }

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -169,6 +169,11 @@ void BBoxDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier
     this->UpdateBB(pos.x, pos.y, pos.x + width, pos.y + height);
 }
 
+void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[3], Point side2[3])
+{
+    this->UpdateBB(side1[0].x, side1[0].y, side2[2].x, side2[2].y);
+}
+
 void BBoxDeviceContext::DrawCircle(int x, int y, int radius)
 {
     this->DrawEllipse(x - radius, y - radius, 2 * radius, 2 * radius);

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -169,9 +169,9 @@ void BBoxDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier
     this->UpdateBB(pos.x, pos.y, pos.x + width, pos.y + height);
 }
 
-void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[4], int height)
+void BBoxDeviceContext::DrawBentParallelogramFilled(Point side[4], int height)
 {
-    this->UpdateBB(side1[0].x, side1[0].y, side1[3].x, side1[3].y + height);
+    this->UpdateBB(side[0].x, side[0].y, side[3].x, side[3].y + height);
 }
 
 void BBoxDeviceContext::DrawCircle(int x, int y, int radius)

--- a/src/bboxdevicecontext.cpp
+++ b/src/bboxdevicecontext.cpp
@@ -169,9 +169,9 @@ void BBoxDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier
     this->UpdateBB(pos.x, pos.y, pos.x + width, pos.y + height);
 }
 
-void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[4], Point side2[4])
+void BBoxDeviceContext::DrawBentParallelogramFilled(Point side1[4], int height)
 {
-    this->UpdateBB(side1[0].x, side1[0].y, side2[2].x, side2[2].y);
+    this->UpdateBB(side1[0].x, side1[0].y, side1[3].x, side1[3].y + height);
 }
 
 void BBoxDeviceContext::DrawCircle(int x, int y, int radius)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -44,6 +44,9 @@ const std::map<int, std::string> Option::s_footer
 const std::map<int, std::string> Option::s_header
     = { { HEADER_none, "none" }, { HEADER_auto, "auto" }, { HEADER_encoded, "encoded" } };
 
+const std::map<int, std::string> Option::s_ligatureOblique
+    = { { LIGATURE_OBL_auto, "auto" }, { LIGATURE_OBL_straight, "straight" }, { LIGATURE_OBL_curved, "curved" } };
+
 const std::map<int, std::string> Option::s_multiRestStyle = { { MULTIRESTSTYLE_auto, "auto" },
     { MULTIRESTSTYLE_default, "default" }, { MULTIRESTSTYLE_block, "block" }, { MULTIRESTSTYLE_symbols, "symbols" } };
 
@@ -1832,9 +1835,9 @@ Options::Options()
     m_ligatureAsBracket.Init(false);
     this->Register(&m_ligatureAsBracket, "ligatureAsBracket", &m_mensural);
 
-    m_ligatureStraight.SetInfo("Ligature straight", "Render oblique ligatures as straight polygons");
-    m_ligatureStraight.Init(false);
-    this->Register(&m_ligatureStraight, "ligatureStraight", &m_mensural);
+    m_ligatureOblique.SetInfo("Ligature oblique", "Ligature oblique shape");
+    m_ligatureOblique.Init(LIGATURE_OBL_auto, &Option::s_ligatureOblique);
+    this->Register(&m_ligatureOblique, "ligatureOblique", &m_mensural);
 
     m_mensuralResponsiveView.SetInfo(
         "Mensural reduced view", "Convert mensural content to a more responsive view reduced to the seleceted markup");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1832,6 +1832,10 @@ Options::Options()
     m_ligatureAsBracket.Init(false);
     this->Register(&m_ligatureAsBracket, "ligatureAsBracket", &m_mensural);
 
+    m_ligatureStraight.SetInfo("Ligature straight", "Render oblique ligatures as straight polygons");
+    m_ligatureStraight.Init(false);
+    this->Register(&m_ligatureStraight, "ligatureStraight", &m_mensural);
+
     m_mensuralResponsiveView.SetInfo(
         "Mensural reduced view", "Convert mensural content to a more responsive view reduced to the seleceted markup");
     m_mensuralResponsiveView.Init(false);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -693,14 +693,13 @@ void SvgDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
-void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[4], Point side2[4])
+void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[4], int height)
 {
     pugi::xml_node pathChild = AddChild("path");
     pathChild.append_attribute("d")
-        = StringFormat("M%d,%d Q%d,%d %d,%d L%d,%d Q%d,%d %d,%d Z", side1[0].x, side1[0].y, // M command
-            side1[1].x, side1[1].y, side1[2].x, side1[2].y, side2[2].x, side2[2].y, side2[1].x, side2[1].y, side2[0].x,
-            side2[0].y // Second Bezier
-            )
+        = StringFormat("M%d,%d C%d,%d %d,%d %d,%d L%d,%d C%d,%d %d,%d %d,%d Z", side1[0].x, side1[0].y, // M command
+            side1[1].x, side1[1].y, side1[2].x, side1[2].y, side1[3].x, side1[3].y, side1[3].x, side1[3].y + height,
+            side1[2].x, side1[2].y + height, side1[1].x, side1[1].y + height, side1[0].x, side1[0].y + height)
               .c_str();
     // pathChild.append_attribute("fill") = "currentColor";
     // pathChild.append_attribute("fill-opacity") = "1";

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -693,7 +693,7 @@ void SvgDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
-void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[3], Point side2[3])
+void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[4], Point side2[4])
 {
     pugi::xml_node pathChild = AddChild("path");
     pathChild.append_attribute("d")

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -693,6 +693,24 @@ void SvgDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
+void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[3], Point side2[3])
+{
+    pugi::xml_node pathChild = AddChild("path");
+    pathChild.append_attribute("d")
+        = StringFormat("M%d,%d Q%d,%d %d,%d L%d,%d Q%d,%d %d,%d Z", side1[0].x, side1[0].y, // M command
+            side1[1].x, side1[1].y, side1[2].x, side1[2].y, side2[2].x, side2[2].y, side2[1].x, side2[1].y, side2[0].x,
+            side2[0].y // Second Bezier
+            )
+              .c_str();
+    // pathChild.append_attribute("fill") = "currentColor";
+    // pathChild.append_attribute("fill-opacity") = "1";
+    pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
+    pathChild.append_attribute("stroke-linecap") = "round";
+    pathChild.append_attribute("stroke-linejoin") = "round";
+    // pathChild.append_attribute("stroke-opacity") = "1";
+    pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
+}
+
 void SvgDeviceContext::DrawCircle(int x, int y, int radius)
 {
     this->DrawEllipse(x - radius, y - radius, 2 * radius, 2 * radius);

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -693,20 +693,16 @@ void SvgDeviceContext::DrawCubicBezierPathFilled(Point bezier1[4], Point bezier2
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 
-void SvgDeviceContext::DrawBentParallelogramFilled(Point side1[4], int height)
+void SvgDeviceContext::DrawBentParallelogramFilled(Point side[4], int height)
 {
     pugi::xml_node pathChild = AddChild("path");
-    pathChild.append_attribute("d")
-        = StringFormat("M%d,%d C%d,%d %d,%d %d,%d L%d,%d C%d,%d %d,%d %d,%d Z", side1[0].x, side1[0].y, // M command
-            side1[1].x, side1[1].y, side1[2].x, side1[2].y, side1[3].x, side1[3].y, side1[3].x, side1[3].y + height,
-            side1[2].x, side1[2].y + height, side1[1].x, side1[1].y + height, side1[0].x, side1[0].y + height)
-              .c_str();
-    // pathChild.append_attribute("fill") = "currentColor";
-    // pathChild.append_attribute("fill-opacity") = "1";
+    pathChild.append_attribute("d") = StringFormat("M%d,%d C%d,%d %d,%d %d,%d L%d,%d C%d,%d %d,%d %d,%d Z", side[0].x,
+        side[0].y, side[1].x, side[1].y, side[2].x, side[2].y, side[3].x, side[3].y, side[3].x, side[3].y + height,
+        side[2].x, side[2].y + height, side[1].x, side[1].y + height, side[0].x, side[0].y + height)
+                                          .c_str();
     pathChild.append_attribute("stroke") = this->GetColor(m_penStack.top().GetColor()).c_str();
     pathChild.append_attribute("stroke-linecap") = "round";
     pathChild.append_attribute("stroke-linejoin") = "round";
-    // pathChild.append_attribute("stroke-opacity") = "1";
     pathChild.append_attribute("stroke-width") = m_penStack.top().GetWidth();
 }
 

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -389,7 +389,35 @@ void View::DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *lay
         this->DrawObliquePolygon(dc, bottomLeft->x, bottomLeft->y, bottomRight->x, bottomRight->y, strokeWidth);
     }
     else {
-        this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, bottomLeft->y - topLeft->y);
+
+        /*
+        Point side1[4];
+        Point side2[4];
+        side1[0] = ToDeviceContext(*topLeft);
+        side1[2] = ToDeviceContext(*topRight);
+        //
+        side2[0] = ToDeviceContext(*bottomLeft);
+        side2[2] = ToDeviceContext(*bottomRight);
+        //
+        double ratio = (obliqueEnd) ? .5 : 0;
+        int width = (side1[2].x - side1[0].x);
+        int height = (side1[2].y - side1[0].y);
+        side1[1] = side1[2];
+        side1[1].x -= width * ratio;
+        side2[1].y -= height * ratio;
+        side2[1] = side2[2];
+        side2[1].x -= width * ratio;
+        //side2[1].y -= height * ratio;
+
+        dc->DrawBentParallelogramFilled(side1, side2);
+        //}
+        // else {
+        //    this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, //bottomLeft->y -
+        //    topLeft->y);
+        //}
+        */
+        this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, bottomLeft->y -
+            topLeft->y);
     }
 
     // Do not draw a left connector with obliques
@@ -624,6 +652,9 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
     assert(staff);
 
     const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+    const int noteDiff = note1->PitchDifferenceTo(note2);
+    
+    const int yAdjust = noteDiff * stemWidth / 10;
 
     Point *topLeft = &points[0];
     Point *bottomLeft = &points[1];
@@ -648,25 +679,97 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
     sides[3] = sides2[3];
 
     // With oblique it is best visually to move them up / down - more with (white) ligatures with serif
-    double adjustmentFactor = (isMensuralBlack) ? 0.5 : 1.8;
+    //double adjustmentFactor = (isMensuralBlack) ? 2.5 : 1.8;
     double slope = 0.0;
+    if (bottomRight->x != bottomLeft->x)
+        slope = (double)(bottomRight->y - bottomLeft->y) / (double)(bottomRight->x - bottomLeft->x);
+
+    int length = (bottomRight->x - bottomLeft->x) / 2;
+    slope *= 0.85;
+
+    if (firstHalf) {
+        // make sure there are some pixels of overlap
+        length += 1;
+        bottomRight->x = bottomLeft->x + length;
+        topRight->x = bottomRight->x;
+        bottomRight->y = bottomLeft->y + (int)(length * slope);
+        topRight->y = topLeft->y + (int)(length * slope);
+        //
+        topLeft->y += yAdjust;
+        bottomLeft->y += yAdjust;
+    }
+    else {
+        bottomLeft->x = bottomLeft->x + length;
+        topLeft->x = bottomLeft->x;
+        bottomLeft->y = bottomLeft->y + (int)(length * slope);
+        topLeft->y = topLeft->y + (int)(length * slope);
+        //
+        topRight->y -= yAdjust;
+        bottomRight->y -= yAdjust;
+    }
+
+}
+
+/*
+void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point points[4], int sides[4], int shape,
+    bool isMensuralBlack, bool firstHalf)
+{
+    assert(note1);
+    assert(note2);
+    assert(staff);
+
+    const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
+
+    Point *topLeft = &points[0];
+    Point *bottomLeft = &points[1];
+    Point *topRight = &points[2];
+    Point *bottomRight = &points[3];
+
+    int sides1[4];
+    CalcBrevisPoints(note1, staff, topLeft, bottomLeft, sides1, shape, isMensuralBlack);
+    // Correct the x of bottomLeft
+    bottomLeft->x = topLeft->x;
+    // Copy the left sides
+    sides[0] = sides1[0];
+    sides[1] = sides1[1];
+
+    int sides2[4];
+    // add OBLIQUE shape to make sure sides are shortened in mensural black
+    CalcBrevisPoints(note2, staff, topRight, bottomRight, sides2, LIGATURE_OBLIQUE, isMensuralBlack);
+    // Correct the x of topRight;
+    topRight->x = bottomRight->x;
+    // Copy the right sides
+    sides[2] = sides2[2];
+    sides[3] = sides2[3];
+
+    // With oblique it is best visually to move them up / down - more with (white) ligatures with serif
+    double adjustmentFactor = (isMensuralBlack) ? 2.5 : 1.8;
+    double slope = 0.0;
+    slope *= 1.6;
     if (bottomRight->x != bottomLeft->x)
         slope = (double)(bottomRight->y - bottomLeft->y) / (double)(bottomRight->x - bottomLeft->x);
     int adjustment = (int)(slope * stemWidth) * adjustmentFactor;
     topLeft->y -= adjustment;
-    bottomLeft->y -= adjustment;
-    topRight->y += adjustment;
-    bottomRight->y += adjustment;
+    // bottomLeft->y -= adjustment;
+    if (firstHalf) {
+        topRight->y -= adjustment;
+        // bottomRight->y += adjustment;
+    }
+    else {
+        // topRight->y += adjustment;
+        // bottomRight->y -= adjustment;
+    }
 
     slope = 0.0;
     // recalculate slope after adjustment
     if (bottomRight->x != bottomLeft->x)
         slope = (double)(bottomRight->y - bottomLeft->y) / (double)(bottomRight->x - bottomLeft->x);
     int length = (bottomRight->x - bottomLeft->x) / 2;
+    slope *= 1.6;
 
     if (firstHalf) {
         // make sure there are some pixels of overlap
-        length += 10;
+        // length += 10;
         bottomRight->x = bottomLeft->x + length;
         topRight->x = bottomRight->x;
         bottomRight->y = bottomLeft->y + (int)(length * slope);
@@ -679,6 +782,7 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
         topLeft->y = topLeft->y + (int)(length * slope);
     }
 }
+*/
 
 data_STEMDIRECTION View::GetMensuralStemDir(Layer *layer, Note *note, int verticalCenter)
 {

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -389,8 +389,6 @@ void View::DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *lay
         this->DrawObliquePolygon(dc, bottomLeft->x, bottomLeft->y, bottomRight->x, bottomRight->y, strokeWidth);
     }
     else {
-
-        /*
         Point side1[4];
         Point side2[4];
         side1[0] = ToDeviceContext(*topLeft);
@@ -399,25 +397,17 @@ void View::DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *lay
         side2[0] = ToDeviceContext(*bottomLeft);
         side2[2] = ToDeviceContext(*bottomRight);
         //
-        double ratio = (obliqueEnd) ? .5 : 0;
+        double ratio = (obliqueEnd) ? .5 : 0.5;
         int width = (side1[2].x - side1[0].x);
         int height = (side1[2].y - side1[0].y);
         side1[1] = side1[2];
-        side1[1].x -= width * ratio;
-        side2[1].y -= height * ratio;
+        side1[1].x -= (width * ratio);
+        side1[1].y -= (1.15 * height * ratio);
         side2[1] = side2[2];
         side2[1].x -= width * ratio;
-        //side2[1].y -= height * ratio;
+        side2[1].y -= (1.15 * height * ratio);
 
         dc->DrawBentParallelogramFilled(side1, side2);
-        //}
-        // else {
-        //    this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, //bottomLeft->y -
-        //    topLeft->y);
-        //}
-        */
-        this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, bottomLeft->y -
-            topLeft->y);
     }
 
     // Do not draw a left connector with obliques
@@ -653,7 +643,7 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
 
     const int stemWidth = m_doc->GetDrawingStemWidth(staff->m_drawingStaffSize);
     const int noteDiff = note1->PitchDifferenceTo(note2);
-    
+
     const int yAdjust = noteDiff * stemWidth / 10;
 
     Point *topLeft = &points[0];
@@ -679,7 +669,7 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
     sides[3] = sides2[3];
 
     // With oblique it is best visually to move them up / down - more with (white) ligatures with serif
-    //double adjustmentFactor = (isMensuralBlack) ? 2.5 : 1.8;
+    // double adjustmentFactor = (isMensuralBlack) ? 2.5 : 1.8;
     double slope = 0.0;
     if (bottomRight->x != bottomLeft->x)
         slope = (double)(bottomRight->y - bottomLeft->y) / (double)(bottomRight->x - bottomLeft->x);
@@ -707,7 +697,6 @@ void View::CalcObliquePoints(Note *note1, Note *note2, Staff *staff, Point point
         topRight->y -= yAdjust;
         bottomRight->y -= yAdjust;
     }
-
 }
 
 /*

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -383,31 +383,33 @@ void View::DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *lay
         }
     }
 
+    Point side1[4];
+    int thickness = topLeft->y - bottomLeft->y;
+    side1[0] = ToDeviceContext(*topLeft);
+    side1[3] = ToDeviceContext(*topRight);
+    //
+    int width = (side1[3].x - side1[0].x);
+    int height = (side1[3].y - side1[0].y);
+    side1[1] = side1[3];
+    side1[1].x -= (width * 0.75);
+    side1[1].y -= (height * 0.75) + (height * 0.05);
+    side1[2] = side1[3];
+    side1[2].x -= (width * 0.25);
+    side1[2].y -= (height * 0.25) + (height * 0.05);
+
     if (!fillNotehead) {
         // double the bases of rectangles
-        this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, -strokeWidth);
-        this->DrawObliquePolygon(dc, bottomLeft->x, bottomLeft->y, bottomRight->x, bottomRight->y, strokeWidth);
+        dc->DrawBentParallelogramFilled(side1, strokeWidth);
+        for (Point &point : side1) {
+            point.y += thickness - strokeWidth;
+        }
+        dc->DrawBentParallelogramFilled(side1, strokeWidth);
+
+        // this->DrawObliquePolygon(dc, topLeft->x, topLeft->y, topRight->x, topRight->y, -strokeWidth);
+        // this->DrawObliquePolygon(dc, bottomLeft->x, bottomLeft->y, bottomRight->x, bottomRight->y, strokeWidth);
     }
     else {
-        Point side1[4];
-        Point side2[4];
-        side1[0] = ToDeviceContext(*topLeft);
-        side1[2] = ToDeviceContext(*topRight);
-        //
-        side2[0] = ToDeviceContext(*bottomLeft);
-        side2[2] = ToDeviceContext(*bottomRight);
-        //
-        double ratio = (obliqueEnd) ? .5 : 0.5;
-        int width = (side1[2].x - side1[0].x);
-        int height = (side1[2].y - side1[0].y);
-        side1[1] = side1[2];
-        side1[1].x -= (width * ratio);
-        side1[1].y -= (1.15 * height * ratio);
-        side2[1] = side2[2];
-        side2[1].x -= width * ratio;
-        side2[1].y -= (1.15 * height * ratio);
-
-        dc->DrawBentParallelogramFilled(side1, side2);
+        dc->DrawBentParallelogramFilled(side1, thickness);
     }
 
     // Do not draw a left connector with obliques

--- a/src/view_mensural.cpp
+++ b/src/view_mensural.cpp
@@ -405,11 +405,11 @@ void View::DrawLigatureNote(DeviceContext *dc, LayerElement *element, Layer *lay
         const int width = (curvedSide[3].x - curvedSide[0].x);
         const int height = (curvedSide[3].y - curvedSide[0].y);
         curvedSide[1] = curvedSide[3];
-        curvedSide[1].x -= (width * 0.75);
-        curvedSide[1].y -= (height * 0.75) + (height * 0.05);
+        curvedSide[1].x -= (width * 0.7);
+        curvedSide[1].y -= (height * 0.7) + (height * 0.07);
         curvedSide[2] = curvedSide[3];
-        curvedSide[2].x -= (width * 0.25);
-        curvedSide[2].y -= (height * 0.25) + (height * 0.05);
+        curvedSide[2].x -= (width * 0.3);
+        curvedSide[2].y -= (height * 0.3) + (height * 0.07);
 
         if (!fillNotehead) {
             dc->DrawBentParallelogramFilled(curvedSide, strokeWidth);


### PR DESCRIPTION
The PR render oblique ligatures with curved shapes. 

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Ligatures (second to octave)</title>
            <respStmt>
               <persName role="encoder">Laurent Pugin</persName>
            </respStmt>
         </titleStmt>
         <pubStmt>
            <date isodate="2025-02-21"/>
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot />
         </notesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="5.1.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
      <extMeta><![CDATA[ { "evenNoteSpacing": true }]]></extMeta>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" notationtype="mensural.black" lines="5" clef.shape="C" clef.line="1" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <staff n="1">
                     <layer n="1">
                        <ligature>
                           <note dur="brevis" oct="4" pname="e" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <ligature>
                           <note dur="brevis" oct="4" pname="f" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <ligature>
                           <note dur="brevis" oct="4" pname="g" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <ligature>
                           <note dur="brevis" oct="4" pname="a" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <ligature>
                           <note dur="brevis" oct="4" pname="b" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <ligature>
                           <note dur="brevis" oct="5" pname="c" />
                           <note dur="brevis" oct="4" pname="c" />
                        </ligature>
                        <!-- c.o.p. -->
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="4" pname="d" />
                        </ligature>
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="4" pname="e" />
                        </ligature>
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="4" pname="f" />
                        </ligature>
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="4" pname="g" />
                        </ligature>
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="4" pname="b" />
                        </ligature>
                        <ligature form="obliqua">
                           <note dur="semibrevis" oct="4" pname="c" />
                           <note dur="semibrevis" oct="5" pname="c" />
                        </ligature>
                     </layer>
                  </staff>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<img width="802" alt="image" src="https://github.com/user-attachments/assets/8cd3ac36-0d70-4adb-9a4e-11d8e005e366" />

Straight polygons can still be obtained with `--ligature-straight`