### PR TITLE
do not show tuplet ratio when numbase is missing

### DIFF
--- a/src/view_tuplet.cpp
+++ b/src/view_tuplet.cpp
@@ -182,8 +182,10 @@ void View::DrawTupletNum(DeviceContext *dc, LayerElement *element, Layer *layer,
     dc->SetFont(m_doc->GetDrawingSmuflFont(glyphSize, drawingCueSize));
     notes = IntToTupletFigures((short int)tuplet->GetNum());
     if (tuplet->GetNumFormat() == tupletVis_NUMFORMAT_ratio) {
-        notes.push_back(SMUFL_E88A_tupletColon);
-        notes += IntToTupletFigures((short int)tuplet->GetNumbase());
+        if (tuplet->HasNumbase()) {
+            notes.push_back(SMUFL_E88A_tupletColon);
+            notes += IntToTupletFigures((short int)tuplet->GetNumbase());
+        }
     }
     dc->GetSmuflTextExtent(notes, &extend);
 


### PR DESCRIPTION
This is a small fix for tuplets without given `numbase`. (In those cases Verovio would just show a 1.)
Additionally we could throw a warning or try to calculate it, but for now this should be fine.