### PR TITLE
fix ledger lines on mRest

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1164,7 +1164,7 @@ void View::DrawMRest(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
     this->DrawSmuflCode(dc, x, y, rest, staffSize, drawingCueSize);
 
     // single legder line for whole rest glyphs
-    if ((measure->m_measureAligner.GetMaxTime() < Fraction(DURATION_1))
+    if (!isDouble
         && (y > staff->GetDrawingY()
             || y < staff->GetDrawingY() - (staff->m_drawingLines - 1) * m_doc->GetDrawingDoubleUnit(staffSize))) {
         const int width = m_doc->GetGlyphWidth(rest, staffSize, drawingCueSize);


### PR DESCRIPTION
This fixes the ledger lines on mRests. 
It was already implemented (and working) but the switch to `Fraction` seems to have broken it.

closes #3980
