### PR TITLE
fix: correcting svg color formatting

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -246,7 +246,7 @@ public:
     ///@}
 
     /**
-     * @name Gettersto improve code readability
+     * @name Getters to improve code readability
      */
     ///@{
     bool IsScoreBasedMEI() const { return m_scoreBasedMEI; }

--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -299,7 +299,7 @@ private:
 
     void WriteLine(std::string);
 
-    std::string GetColor(int color);
+    std::string GetColor(int color) const;
 
     pugi::xml_node AddChild(std::string name);
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1215,12 +1215,8 @@ void SvgDeviceContext::AppendAdditionalAttributes(Object *object)
     }
 }
 
-std::string SvgDeviceContext::GetColor(int color)
+std::string SvgDeviceContext::GetColor(int color) const
 {
-    std::ostringstream ss;
-    ss << "#";
-    ss << std::hex;
-
     switch (color) {
         case (COLOR_NONE): return "currentColor";
         case (COLOR_BLACK): return "#000000";
@@ -1231,12 +1227,7 @@ std::string SvgDeviceContext::GetColor(int color)
         case (COLOR_CYAN): return "#00FFFF";
         case (COLOR_LIGHT_GREY): return "#777777";
         default:
-            int blue = (color & 255);
-            int green = (color >> 8) & 255;
-            int red = (color >> 16) & 255;
-            ss << red << green << blue;
-            // std::strin = wxDecToHex(char(red)) + wxDecToHex(char(green)) + wxDecToHex(char(blue)) ;  // ax3
-            return ss.str();
+            return StringFormat("#%X", color);
     }
 }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1226,7 +1226,7 @@ std::string SvgDeviceContext::GetColor(int color) const
         case (COLOR_BLUE): return "#0000FF";
         case (COLOR_CYAN): return "#00FFFF";
         case (COLOR_LIGHT_GREY): return "#777777";
-        default: return StringFormat("#%X", color);
+        default: return StringFormat("#%06X", color);
     }
 }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1226,8 +1226,7 @@ std::string SvgDeviceContext::GetColor(int color) const
         case (COLOR_BLUE): return "#0000FF";
         case (COLOR_CYAN): return "#00FFFF";
         case (COLOR_LIGHT_GREY): return "#777777";
-        default:
-            return StringFormat("#%X", color);
+        default: return StringFormat("#%X", color);
     }
 }
 


### PR DESCRIPTION
This fixes the SvgDeviceContext::GetColor method by avoiding stringstream. Problem was, that `blue` values were formatted as single character for respective values, resulting in an invalid color value.