### PR TITLE
Simplify and split apart checks perform when building the tree

### DIFF
--- a/include/vrv/anchoredtext.h
+++ b/include/vrv/anchoredtext.h
@@ -48,7 +48,7 @@ public:
      * Add an element (text, rend. etc.) to a tempo.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/annot.h
+++ b/include/vrv/annot.h
@@ -39,7 +39,7 @@ public:
      * Add a text element to an annotation.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -37,7 +37,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
 protected:
     /** We store the level of the <app> for integrity check */

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -317,7 +317,7 @@ public:
      * Add an element (a note or a rest) to a beam.
      * Only Note or Rest elements will be actually added to the beam.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      *

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -42,7 +42,7 @@ public:
      * Add an element (a note or a chord) to a fTrem.
      * Only Note or Chord elements will be actually added to the fTrem.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Get stem mod if encoded explicitly, or determine based on duration of bTrem and underlying elements

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -38,7 +38,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
 protected:
     /** We store the level of the <choice> for integrity check */

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -74,7 +74,7 @@ public:
     /**
      * Add an element (only note supported) to a chord.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for chord

--- a/include/vrv/course.h
+++ b/include/vrv/course.h
@@ -37,7 +37,7 @@ public:
     /**
      * Add an element to a element.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/cpmark.h
+++ b/include/vrv/cpmark.h
@@ -59,7 +59,7 @@ public:
      * Add an element (text, rend. etc.) to a cpMark.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -54,7 +54,7 @@ public:
     /**
      * Add an accid to a custos.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return a SMuFL code for the custos

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -66,7 +66,7 @@ public:
      * Add an element (text, rend. etc.) to a dir.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * See FloatingObject::IsExtenderElement

--- a/include/vrv/doc.h
+++ b/include/vrv/doc.h
@@ -53,7 +53,7 @@ public:
     /**
      * Add a page to the document
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Clear the content of the document.

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -66,7 +66,7 @@ public:
      * Add an element (text, rend. etc.) to a dynam.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return true if the dynam text is only composed of f, p, r, z, etc. letters (e.g. sfz)

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -53,7 +53,7 @@ public:
      * @name Add children to an editorial element.
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     //----------//

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -47,7 +47,7 @@ public:
     /**
      * Method for adding allowed content
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -55,7 +55,7 @@ public:
      * Add an element (text, rend. etc.) to a rend.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -41,7 +41,7 @@ public:
     void Reset() override;
     std::string GetClassName() const override { return "Facsimile"; }
     ///@}
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     Zone *FindZoneByID(const std::string &zoneId);
     const Zone *FindZoneByID(const std::string &zoneId) const;

--- a/include/vrv/fb.h
+++ b/include/vrv/fb.h
@@ -38,7 +38,7 @@ public:
      * Add an element (f) to an fb.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Interface for class functor visitation

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -49,7 +49,7 @@ public:
      * Add an element (svg) to an fig.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -53,7 +53,7 @@ public:
      * Add an element (text, rend) to a fing.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Check whether the current object must be positioned closer to the staff than the other

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -51,7 +51,7 @@ public:
      * Add an element (a note or a chord) to a fTrem.
      * Only Note or Chord elements will be actually added to the fTrem.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      *

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -34,7 +34,7 @@ public:
     /**
      * Add childElement to a element.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -65,7 +65,7 @@ public:
      * Add an element (text, rend. etc.) to a harm.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Transposition related. The int tracks where we have iterated through the string.

--- a/include/vrv/horizontalaligner.h
+++ b/include/vrv/horizontalaligner.h
@@ -91,7 +91,7 @@ public:
     /**
      * Override the method of adding AlignmentReference children
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * @name Set and get the xRel value of the alignment
@@ -303,7 +303,7 @@ public:
     /**
      * Override the method of adding Alignment children
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for AlignmentReference children
@@ -437,7 +437,7 @@ public:
     /**
      * Override the method of adding AlignmentReference children
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Retrieve the alignmnet of the type at that time.
@@ -675,7 +675,7 @@ public:
     /**
      * Override the method of adding TimestampAttr children
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Look for an existing TimestampAttr at a certain time.

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -74,6 +74,11 @@ public:
      */
     bool IsSupportedChild(ClassId classId) override;
 
+    /**
+     * Additional check when adding a child.
+     */
+    bool AddChildAdditionalCheck(Object *child) override;
+
     /** Accid number getter */
     int GetAccidCount(bool fromAttribute = false) const;
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -72,7 +72,7 @@ public:
     /**
      * Add an element (a keyAccid) to a keySig.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /** Accid number getter */
     int GetAccidCount(bool fromAttribute = false) const;

--- a/include/vrv/label.h
+++ b/include/vrv/label.h
@@ -38,7 +38,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     //----------//

--- a/include/vrv/labelabbr.h
+++ b/include/vrv/labelabbr.h
@@ -38,7 +38,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     //----------//

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -59,7 +59,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/layerdef.h
+++ b/include/vrv/layerdef.h
@@ -33,7 +33,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -45,7 +45,7 @@ public:
     /**
      * Add children (notes or editorial markup)
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return the first or last note

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -40,7 +40,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -97,7 +97,7 @@ public:
     /**
      * Methods for adding allowed content
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Specific method for measures

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -100,6 +100,11 @@ public:
     bool IsSupportedChild(ClassId classId) override;
 
     /**
+     * Additional check when adding a child.
+     */
+    bool AddChildAdditionalCheck(Object *child) override;
+
+    /**
      * Specific method for measures
      */
     void AddChildBack(Object *object);

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -43,7 +43,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /** Override the method since check is required */

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -59,7 +59,7 @@ public:
      * Add an element (text, rend. etc.) to a dynam.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * @name Setter and getter of the generated flag

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -52,7 +52,7 @@ public:
     std::string GetClassName() const override { return "Nc"; }
     ///@}
 
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * @name Getter to interfaces

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -75,7 +75,7 @@ public:
      * Add an element (a note or a rest) to a syllable.
      * Only syl or neume will be added.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     int GetLigatureCount(int position);
     bool IsLastInNeume(const LayerElement *element) const;

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -115,6 +115,11 @@ public:
     void AddChild(Object *object) override;
 
     /**
+     * Additional check when adding a child.
+     */
+    bool AddChildAdditionalCheck(Object *child) override;
+
+    /**
      * Align dots shift for two notes. Should be used for unison notes to align dots positioning
      */
     void AlignDotsShift(const Note *otherNote);

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -107,7 +107,7 @@ public:
      * Add an element (a verse or an accid) to a note.
      * Only Verse and Accid elements will be actually added to the note.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for note

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -38,7 +38,7 @@ public:
     /**
      * Add an element (text) to a num.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return a pointer to the current text object.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -406,6 +406,11 @@ public:
     virtual void AddChild(Object *object);
 
     /**
+     * Additional check when adding a child.
+     */
+    virtual bool AddChildAdditionalCheck(Object *child) { return true; };
+
+    /**
      * Return the child order for a the given ClassId.
      * By default, a child is added at the end, but a class can override the method to order them.
      * The overriden method specifies a static vector with the expected order of ClassIds.

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -95,18 +95,48 @@ public:
 
     /**
      * @name Methods for checking if an object is part of a group of classId's.
+     * Used the static methods passing the object m_classId.
+     */
+    ///@{
+    bool IsControlElement() const { return Object::IsControlElement(m_classId); }
+    bool IsEditorialElement() const { return Object::IsEditorialElement(m_classId); }
+    bool IsLayerElement() const { return Object::IsLayerElement(m_classId); }
+    bool IsPageElement() const { return Object::IsPageElement(m_classId); }
+    bool IsRunningElement() const { return Object::IsRunningElement(m_classId); }
+    bool IsScoreDefElement() const { return Object::IsScoreDefElement(m_classId); }
+    bool IsSystemElement() const { return Object::IsSystemElement(m_classId); }
+    bool IsTextElement() const { return Object::IsTextElement(m_classId); }
+    ///@}
+
+    /**
+     * @name Static methods for checking if classId is part of a group of classId's.
      * For example, all LayerElement child class classId's are between LAYER_ELEMENT and LAYER_ELEMENT_max.
      * See classId enum.
      */
     ///@{
-    bool IsControlElement() const { return ((m_classId > CONTROL_ELEMENT) && (m_classId < CONTROL_ELEMENT_max)); }
-    bool IsEditorialElement() const { return ((m_classId > EDITORIAL_ELEMENT) && (m_classId < EDITORIAL_ELEMENT_max)); }
-    bool IsLayerElement() const { return ((m_classId > LAYER_ELEMENT) && (m_classId < LAYER_ELEMENT_max)); }
-    bool IsPageElement() const { return ((m_classId > PAGE_ELEMENT) && (m_classId < PAGE_ELEMENT_max)); }
-    bool IsRunningElement() const { return ((m_classId > RUNNING_ELEMENT) && (m_classId < RUNNING_ELEMENT_max)); }
-    bool IsScoreDefElement() const { return ((m_classId > SCOREDEF_ELEMENT) && (m_classId < SCOREDEF_ELEMENT_max)); }
-    bool IsSystemElement() const { return ((m_classId > SYSTEM_ELEMENT) && (m_classId < SYSTEM_ELEMENT_max)); }
-    bool IsTextElement() const { return ((m_classId > TEXT_ELEMENT) && (m_classId < TEXT_ELEMENT_max)); }
+    static bool IsControlElement(ClassId classId)
+    {
+        return ((classId > CONTROL_ELEMENT) && (classId < CONTROL_ELEMENT_max));
+    }
+    static bool IsEditorialElement(ClassId classId)
+    {
+        return ((classId > EDITORIAL_ELEMENT) && (classId < EDITORIAL_ELEMENT_max));
+    }
+    static bool IsLayerElement(ClassId classId) { return ((classId > LAYER_ELEMENT) && (classId < LAYER_ELEMENT_max)); }
+    static bool IsPageElement(ClassId classId) { return ((classId > PAGE_ELEMENT) && (classId < PAGE_ELEMENT_max)); }
+    static bool IsRunningElement(ClassId classId)
+    {
+        return ((classId > RUNNING_ELEMENT) && (classId < RUNNING_ELEMENT_max));
+    }
+    static bool IsScoreDefElement(ClassId classId)
+    {
+        return ((classId > SCOREDEF_ELEMENT) && (classId < SCOREDEF_ELEMENT_max));
+    }
+    static bool IsSystemElement(ClassId classId)
+    {
+        return ((classId > SYSTEM_ELEMENT) && (classId < SYSTEM_ELEMENT_max));
+    }
+    static bool IsTextElement(ClassId classId) { return ((classId > TEXT_ELEMENT) && (classId < TEXT_ELEMENT_max)); }
     ///@}
 
     /**
@@ -367,7 +397,7 @@ public:
      * Base method for checking if a child can be added.
      * The method has to be overridden.
      */
-    virtual bool IsSupportedChild(Object *object);
+    virtual bool IsSupportedChild(ClassId classId);
 
     /**
      * Base method for adding children.

--- a/include/vrv/ornam.h
+++ b/include/vrv/ornam.h
@@ -59,7 +59,7 @@ public:
      * Add an element (text, rend. etc.) to a ornam.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -45,7 +45,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/pages.h
+++ b/include/vrv/pages.h
@@ -42,7 +42,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -58,7 +58,7 @@ public:
      * Add an element (text, rend. etc.) to a reh.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -59,7 +59,7 @@ public:
      * Add an element (text, rend. etc.) to a rend.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Check if rend has an enclosing.

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -60,7 +60,7 @@ public:
      * Add an element (text, rend. etc.) to a ornam.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Get the SMuFL glyph for the repeatMark based on func or glyph.num

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -60,7 +60,7 @@ public:
      * Add an element to a rest.
      * Only Dots elements will be actually added to the rest.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for rest

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -45,7 +45,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -150,7 +150,7 @@ public:
     /**
      * Check if a object is allowed as child.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return an order for the given ClassId.

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -153,6 +153,11 @@ public:
     bool IsSupportedChild(ClassId classId) override;
 
     /**
+     * Additional check when adding a child.
+     */
+    bool AddChildAdditionalCheck(Object *child) override;
+
+    /**
      * Return an order for the given ClassId.
      */
     int GetInsertOrderFor(ClassId classId) const override;

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -42,7 +42,7 @@ public:
     /**
      * Method for adding allowed content
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     //----------//
     // Functors //

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -155,7 +155,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -159,6 +159,11 @@ public:
     ///@}
 
     /**
+     * Additional check when adding a child.
+     */
+    bool AddChildAdditionalCheck(Object *child) override;
+
+    /**
      * @name Get the X, Y, and angle of drawing position
      */
     ///@{

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -52,7 +52,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return an order for the given ClassId.

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -54,7 +54,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -44,7 +44,7 @@ public:
     /**
      * Add an element (only flag supported) to a stem.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Fill the attributes from the AttStems attribute of the parent note/chord

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -40,7 +40,7 @@ public:
     /**
      * Add children to a apparatus.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
 protected:
     /** We store the level of the <subst> for integrity check */

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -39,7 +39,7 @@ public:
     void Reset() override;
     std::string GetClassName() const override { return "Surface"; }
     ///@}
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     int GetMaxX() const;
     int GetMaxY() const;

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -70,7 +70,7 @@ public:
      * Add an element (text, rend. etc.) to a syl.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Calculate the hyphen length using the text font

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -41,7 +41,7 @@ public:
      * Add an element (a note or a rest) to a syllable.
      * Only syl or neume will be added.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /** Override the method since alignment is required */
     bool HasToBeAligned() const override { return true; }

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -39,7 +39,7 @@ public:
     /**
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Get the SMuFL glyph for the symbol based on glyph.num or glyph.name

--- a/include/vrv/symboldef.h
+++ b/include/vrv/symboldef.h
@@ -34,7 +34,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/symboltable.h
+++ b/include/vrv/symboltable.h
@@ -34,7 +34,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -50,7 +50,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -57,7 +57,7 @@ public:
     /**
      * Add an element to a element.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for note

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -45,7 +45,7 @@ public:
     /**
      * Add an element to a element.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return the top or bottom note or their Y position

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -66,7 +66,7 @@ public:
      * Add an element (text, rend. etc.) to a tempo.
      * Only supported elements will be actually added to the child list.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * @name Getter and setter for the X drawing position

--- a/include/vrv/textlayoutelement.h
+++ b/include/vrv/textlayoutelement.h
@@ -37,7 +37,7 @@ public:
      * @name Methods for adding allowed content
      */
     ///@{
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
     ///@}
 
     /**

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -37,7 +37,7 @@ public:
     /**
      * Add an element to a element.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Return the line for a note according to tablature type.

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -48,7 +48,7 @@ public:
      * Add an element (a note or a rest) to a tuplet.
      * Only Note or Rest elements will be actually added to the beam.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Overwritten method for tuplet

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -43,7 +43,7 @@ public:
      * Add an element (a syl) to a verse.
      * Only Syl elements will be actually added to the verse.
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * @name Getter and setter for the labelAbbr

--- a/include/vrv/verticalaligner.h
+++ b/include/vrv/verticalaligner.h
@@ -42,7 +42,7 @@ public:
     /**
      * Override the method of adding AlignmentReference children
      */
-    bool IsSupportedChild(Object *object) override;
+    bool IsSupportedChild(ClassId classId) override;
 
     /**
      * Do not copy children for HorizontalAligner

--- a/src/anchoredtext.cpp
+++ b/src/anchoredtext.cpp
@@ -41,18 +41,19 @@ void AnchoredText::Reset()
     TextDirInterface::Reset();
 }
 
-bool AnchoredText::IsSupportedChild(Object *child)
+bool AnchoredText::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode AnchoredText::Accept(Functor &functor)

--- a/src/annot.cpp
+++ b/src/annot.cpp
@@ -41,18 +41,19 @@ void Annot::Reset()
     this->ResetSource();
 }
 
-bool Annot::IsSupportedChild(Object *child)
+bool Annot::IsSupportedChild(ClassId classId)
 {
-    if (child->IsTextElement()) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ ANNOT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(ANNOT)) {
-        assert(dynamic_cast<Annot *>(child));
+    else if (Object::IsTextElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -46,18 +46,16 @@ void App::Reset()
 
 App::~App() {}
 
-bool App::IsSupportedChild(Object *child)
+bool App::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(LEM)) {
-        assert(dynamic_cast<Lem *>(child));
-    }
-    else if (child->Is(RDG)) {
-        assert(dynamic_cast<Rdg *>(child));
+    static const std::vector<ClassId> supported{ LEM, RDG };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1631,48 +1631,20 @@ void Beam::CloneReset()
     LayerElement::CloneReset();
 }
 
-bool Beam::IsSupportedChild(Object *child)
+bool Beam::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(BEAM)) {
-        assert(dynamic_cast<Beam *>(child));
+    static const std::vector<ClassId> supported{ BEAM, BTREM, CHORD, CLEF, FTREM, GRACEGRP, NOTE, REST, SPACE, TABGRP,
+        TUPLET };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(BTREM)) {
-        assert(dynamic_cast<BTrem *>(child));
-    }
-    else if (child->Is(CHORD)) {
-        assert(dynamic_cast<Chord *>(child));
-    }
-    else if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
-    }
-    else if (child->Is(FTREM)) {
-        assert(dynamic_cast<FTrem *>(child));
-    }
-    else if (child->Is(GRACEGRP)) {
-        assert(dynamic_cast<GraceGrp *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->Is(REST)) {
-        assert(dynamic_cast<Rest *>(child));
-    }
-    else if (child->Is(SPACE)) {
-        assert(dynamic_cast<Space *>(child));
-    }
-    else if (child->Is(TABGRP)) {
-        assert(dynamic_cast<TabGrp *>(child));
-    }
-    else if (child->Is(TUPLET)) {
-        assert(dynamic_cast<Tuplet *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Beam::FilterList(ListOfConstObjects &childList) const

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -52,24 +52,19 @@ void BTrem::Reset()
     this->ResetTremMeasured();
 }
 
-bool BTrem::IsSupportedChild(Object *child)
+bool BTrem::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(CHORD)) {
-        assert(dynamic_cast<Chord *>(child));
+    static const std::vector<ClassId> supported{ CHORD, CLEF, NOTE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode BTrem::Accept(Functor &functor)

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -51,36 +51,16 @@ void Choice::Reset()
 
 Choice::~Choice() {}
 
-bool Choice::IsSupportedChild(Object *child)
+bool Choice::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(ABBR)) {
-        assert(dynamic_cast<Abbr *>(child));
-    }
-    else if (child->Is(CHOICE)) {
-        assert(dynamic_cast<Choice *>(child));
-    }
-    else if (child->Is(CORR)) {
-        assert(dynamic_cast<Corr *>(child));
-    }
-    else if (child->Is(EXPAN)) {
-        assert(dynamic_cast<Expan *>(child));
-    }
-    else if (child->Is(ORIG)) {
-        assert(dynamic_cast<Orig *>(child));
-    }
-    else if (child->Is(REG)) {
-        assert(dynamic_cast<Reg *>(child));
-    }
-    else if (child->Is(SIC)) {
-        assert(dynamic_cast<Sic *>(child));
-    }
-    else if (child->Is(UNCLEAR)) {
-        assert(dynamic_cast<Unclear *>(child));
+    static const std::vector<ClassId> supported{ ABBR, CHOICE, CORR, EXPAN, ORIG, REG, SIC, UNCLEAR };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -186,7 +186,7 @@ bool Chord::IsSupportedChild(ClassId classId)
 
 void Chord::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -169,35 +169,24 @@ void Chord::CalculateNoteGroups()
     }
 }
 
-bool Chord::IsSupportedChild(Object *child)
+bool Chord::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(ARTIC)) {
-        assert(dynamic_cast<Artic *>(child));
+    static const std::vector<ClassId> supported{ ARTIC, DOTS, NOTE, STEM, VERSE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(DOTS)) {
-        assert(dynamic_cast<Dots *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->Is(STEM)) {
-        assert(dynamic_cast<Stem *>(child));
-    }
-    else if (child->Is(VERSE)) {
-        assert(dynamic_cast<Verse *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Chord::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/course.cpp
+++ b/src/course.cpp
@@ -44,7 +44,7 @@ void Course::Reset()
     this->ResetPitch();
 }
 
-bool Course::IsSupportedChild(Object *child)
+bool Course::IsSupportedChild(ClassId classId)
 {
     // Nothing for now
     return false;

--- a/src/cpmark.cpp
+++ b/src/cpmark.cpp
@@ -46,18 +46,19 @@ void CpMark::Reset()
     TimeSpanningInterface::Reset();
 }
 
-bool CpMark::IsSupportedChild(Object *child)
+bool CpMark::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -54,15 +54,16 @@ void Custos::Reset()
     this->ResetExtSymNames();
 }
 
-bool Custos::IsSupportedChild(Object *child)
+bool Custos::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(ACCID)) {
-        assert(dynamic_cast<Accid *>(child));
+    static const std::vector<ClassId> supported{ ACCID };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 char32_t Custos::GetCustosGlyph(const data_NOTATIONTYPE notationtype) const

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -62,18 +62,19 @@ void Dir::Reset()
     this->ResetVerticalGroup();
 }
 
-bool Dir::IsSupportedChild(Object *child)
+bool Dir::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -180,18 +180,16 @@ void Doc::SetType(DocType type)
     m_type = type;
 }
 
-bool Doc::IsSupportedChild(Object *child)
+bool Doc::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(MDIV)) {
-        assert(dynamic_cast<Mdiv *>(child));
-    }
-    else if (child->Is(PAGES)) {
-        assert(dynamic_cast<Pages *>(child));
+    static const std::vector<ClassId> supported{ MDIV, PAGES };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Doc::GenerateDocumentScoreDef()

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -72,18 +72,19 @@ void Dynam::Reset()
     this->ResetVerticalGroup();
 }
 
-bool Dynam::IsSupportedChild(Object *child)
+bool Dynam::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Dynam::IsSymbolOnly() const

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -73,48 +73,31 @@ void EditorialElement::Reset()
 
 EditorialElement::~EditorialElement() {}
 
-bool EditorialElement::IsSupportedChild(Object *child)
+bool EditorialElement::IsSupportedChild(ClassId classId)
 {
-    if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    static const std::vector<ClassId> supported{ LAYER, MEASURE, SCOREDEF, STAFF, STAFFDEF, STAFFGRP };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsSystemElement()) {
-        assert(dynamic_cast<SystemElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
-    else if (child->IsControlElement()) {
-        assert(dynamic_cast<ControlElement *>(child));
+    else if (Object::IsSystemElement(classId)) {
+        return true;
     }
-    else if (child->IsLayerElement()) {
-        assert(dynamic_cast<LayerElement *>(child));
+    else if (Object::IsControlElement(classId)) {
+        return true;
     }
-    else if (child->IsTextElement()) {
-        assert(dynamic_cast<TextElement *>(child));
+    else if (Object::IsLayerElement(classId)) {
+        return true;
     }
-    else if (child->Is(LAYER)) {
-        assert(dynamic_cast<Layer *>(child));
-    }
-    else if (child->Is(MEASURE)) {
-        assert(dynamic_cast<Measure *>(child));
-    }
-    else if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
-    }
-    else if (child->Is(STAFF)) {
-        assert(dynamic_cast<Staff *>(child));
-    }
-    else if (child->Is(STAFFDEF)) {
-        assert(dynamic_cast<Staff *>(child));
-    }
-    else if (child->Is(STAFFGRP)) {
-        assert(dynamic_cast<Staff *>(child));
-    }
-    else if (child->Is(SYMBOL)) {
-        assert(dynamic_cast<Symbol *>(child));
+    else if (Object::IsTextElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -57,28 +57,23 @@ void Ending::Reset()
     this->ResetNNumberLike();
 }
 
-bool Ending::IsSupportedChild(Object *child)
+bool Ending::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(MEASURE)) {
-        assert(dynamic_cast<Measure *>(child));
+    static const std::vector<ClassId> supported{ MEASURE, SCOREDEF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
+    else if (Object::IsSystemElement(classId)) {
+        // without this we would be allowing ending within ending, which is wrong
+        return (classId != ENDING);
     }
-    else if (child->IsSystemElement()) {
-        assert(dynamic_cast<SystemElement *>(child));
-        // here we are actually allowing ending within ending, which is wrong
-        if (child->Is(ENDING)) {
-            return false;
-        }
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/f.cpp
+++ b/src/f.cpp
@@ -43,18 +43,19 @@ void F::Reset()
     this->ResetExtender();
 }
 
-bool F::IsSupportedChild(Object *child)
+bool F::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(TEXT)) {
-        assert(dynamic_cast<Text *>(child));
+    static const std::vector<ClassId> supported{ TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -33,16 +33,16 @@ Facsimile::~Facsimile() {}
 
 void Facsimile::Reset() {}
 
-bool Facsimile::IsSupportedChild(Object *object)
+bool Facsimile::IsSupportedChild(ClassId classId)
 {
-    if (object->Is(SURFACE)) {
-        assert(dynamic_cast<Surface *>(object));
+    static const std::vector<ClassId> supported{ SURFACE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
-        LogError("Unsupported child '%s' of facsimile", object->GetClassName().c_str());
         return false;
     }
-    return true;
 }
 
 Zone *Facsimile::FindZoneByID(const std::string &zoneId)

--- a/src/fb.cpp
+++ b/src/fb.cpp
@@ -39,18 +39,19 @@ void Fb::Reset()
     Object::Reset();
 }
 
-bool Fb::IsSupportedChild(Object *child)
+bool Fb::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(FIGURE)) {
-        assert(dynamic_cast<F *>(child));
+    static const std::vector<ClassId> supported{ FIGURE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode Fb::Accept(Functor &functor)

--- a/src/fig.cpp
+++ b/src/fig.cpp
@@ -40,15 +40,16 @@ void Fig::Reset()
     AreaPosInterface::Reset();
 }
 
-bool Fig::IsSupportedChild(Object *child)
+bool Fig::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(SVG)) {
-        assert(dynamic_cast<Svg *>(child));
+    static const std::vector<ClassId> supported{ SVG };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -44,15 +44,16 @@ void Fing::Reset()
     this->ResetNNumberLike();
 }
 
-bool Fing::IsSupportedChild(Object *child)
+bool Fing::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Fing::IsCloserToStaffThan(const FloatingObject *other, data_STAFFREL drawingPlace) const

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -59,7 +59,6 @@ bool FTrem::IsSupportedChild(ClassId classId)
     if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
         return true;
     }
-
     else if (Object::IsEditorialElement(classId)) {
         return true;
     }

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -52,24 +52,20 @@ void FTrem::Reset()
     this->ResetTremMeasured();
 }
 
-bool FTrem::IsSupportedChild(Object *child)
+bool FTrem::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(CHORD)) {
-        assert(dynamic_cast<Chord *>(child));
+    static const std::vector<ClassId> supported{ CHORD, CLEF, NOTE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 const ArrayOfBeamElementCoords *FTrem::GetElementCoords()

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -53,30 +53,19 @@ void GraceGrp::Reset()
     this->ResetGraceGrpLog();
 }
 
-bool GraceGrp::IsSupportedChild(Object *child)
+bool GraceGrp::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(BEAM)) {
-        assert(dynamic_cast<Beam *>(child));
+    static const std::vector<ClassId> supported{ BEAM, CHORD, NOTE, REST, SPACE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(CHORD)) {
-        assert(dynamic_cast<Chord *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->Is(REST)) {
-        assert(dynamic_cast<Rest *>(child));
-    }
-    else if (child->Is(SPACE)) {
-        assert(dynamic_cast<Space *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode GraceGrp::Accept(Functor &functor)

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -59,21 +59,19 @@ void Harm::Reset()
     this->ResetNNumberLike();
 }
 
-bool Harm::IsSupportedChild(Object *child)
+bool Harm::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ FB, LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(FB)) {
-        assert(dynamic_cast<Fb *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Harm::GetRootPitch(TransPitch &pitch, unsigned int &pos) const

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -145,9 +145,9 @@ void MeasureAligner::Reset()
     m_initialTstampDur = -1;
 }
 
-bool MeasureAligner::IsSupportedChild(Object *child)
+bool MeasureAligner::IsSupportedChild(ClassId classId)
 {
-    assert(dynamic_cast<Alignment *>(child));
+    // Nothing to check here
     return true;
 }
 
@@ -536,9 +536,9 @@ void Alignment::ClearGraceAligners()
     m_graceAligners.clear();
 }
 
-bool Alignment::IsSupportedChild(Object *child)
+bool Alignment::IsSupportedChild(ClassId classId)
 {
-    assert(dynamic_cast<AlignmentReference *>(child));
+    // Nothing to check here
     return true;
 }
 
@@ -820,9 +820,9 @@ void AlignmentReference::Reset()
     m_layerCount = 0;
 }
 
-bool AlignmentReference::IsSupportedChild(Object *child)
+bool AlignmentReference::IsSupportedChild(ClassId classId)
 {
-    assert(dynamic_cast<LayerElement *>(child));
+    // Nothing to check here
     return true;
 }
 
@@ -916,9 +916,9 @@ void TimestampAligner::Reset()
     Object::Reset();
 }
 
-bool TimestampAligner::IsSupportedChild(Object *child)
+bool TimestampAligner::IsSupportedChild(ClassId classId)
 {
-    assert(dynamic_cast<TimestampAttr *>(child));
+    // Nothing to check here
     return true;
 }
 

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -4655,7 +4655,7 @@ bool PAEInput::CheckHierarchy()
             if (token.m_object->Is({ KEYSIG, METERSIG, MENSUR })) continue;
 
             // Test is the element is supported by the current top container
-            if (!token.IsContainerEnd() && !stack.back()->m_object->IsSupportedChild(token.m_object)) {
+            if (!token.IsContainerEnd() && !stack.back()->m_object->IsSupportedChild(token.m_object->GetClassId())) {
                 LogPAE(ERR_040_HIERARCHY_INVALID, token,
                     StringFormat("%s / %s", token.GetName().c_str(), stack.back()->GetName().c_str()));
                 if (m_pedanticMode) return false;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -125,22 +125,26 @@ void KeySig::FilterList(ListOfConstObjects &childList) const
     }
 }
 
-bool KeySig::IsSupportedChild(Object *child)
+bool KeySig::IsSupportedChild(ClassId classId)
 {
+    /*
     if (this->IsAttribute() && !child->IsAttribute()) {
         LogError("Adding a non-attribute child to an attribute is not allowed");
         assert(false);
     }
-    else if (child->Is(KEYACCID)) {
-        assert(dynamic_cast<KeyAccid *>(child));
+    */
+
+    static const std::vector<ClassId> supported{ KEYACCID };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int KeySig::GetAccidCount(bool fromAttribute) const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -127,12 +127,6 @@ void KeySig::FilterList(ListOfConstObjects &childList) const
 
 bool KeySig::IsSupportedChild(ClassId classId)
 {
-    /*
-    if (this->IsAttribute() && !child->IsAttribute()) {
-        LogError("Adding a non-attribute child to an attribute is not allowed");
-        assert(false);
-    }
-    */
 
     static const std::vector<ClassId> supported{ KEYACCID };
 
@@ -145,6 +139,16 @@ bool KeySig::IsSupportedChild(ClassId classId)
     else {
         return false;
     }
+}
+
+bool KeySig::AddChildAdditionalCheck(Object *child)
+{
+
+    if (this->IsAttribute() && !child->IsAttribute()) {
+        LogError("Adding a non-attribute child to an attribute is not allowed");
+        return false;
+    }
+    return (LayerElement::AddChildAdditionalCheck(child));
 }
 
 int KeySig::GetAccidCount(bool fromAttribute) const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -127,7 +127,6 @@ void KeySig::FilterList(ListOfConstObjects &childList) const
 
 bool KeySig::IsSupportedChild(ClassId classId)
 {
-
     static const std::vector<ClassId> supported{ KEYACCID };
 
     if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
@@ -143,7 +142,6 @@ bool KeySig::IsSupportedChild(ClassId classId)
 
 bool KeySig::AddChildAdditionalCheck(Object *child)
 {
-
     if (this->IsAttribute() && !child->IsAttribute()) {
         LogError("Adding a non-attribute child to an attribute is not allowed");
         return false;

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -38,18 +38,19 @@ void Label::Reset()
     Object::Reset();
 }
 
-bool Label::IsSupportedChild(Object *child)
+bool Label::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/labelabbr.cpp
+++ b/src/labelabbr.cpp
@@ -38,18 +38,19 @@ void LabelAbbr::Reset()
     Object::Reset();
 }
 
-bool LabelAbbr::IsSupportedChild(Object *child)
+bool LabelAbbr::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -159,21 +159,17 @@ void Layer::ResetStaffDefObjects()
     }
 }
 
-bool Layer::IsSupportedChild(Object *child)
+bool Layer::IsSupportedChild(ClassId classId)
 {
-    if (child->IsLayerElement()) {
-        assert(dynamic_cast<LayerElement *>(child));
+    if (Object::IsLayerElement(classId)) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
-    }
-    else if (child->Is(METERSIGGRP)) {
-        assert(dynamic_cast<MeterSigGrp *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 LayerElement *Layer::GetPrevious(const LayerElement *element)

--- a/src/layerdef.cpp
+++ b/src/layerdef.cpp
@@ -45,21 +45,16 @@ void LayerDef::Reset()
     this->ResetTyped();
 }
 
-bool LayerDef::IsSupportedChild(Object *child)
+bool LayerDef::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(INSTRDEF)) {
-        assert(dynamic_cast<InstrDef *>(child));
-    }
-    else if (child->Is(LABEL)) {
-        assert(dynamic_cast<Label *>(child));
-    }
-    else if (child->Is(LABELABBR)) {
-        assert(dynamic_cast<LabelAbbr *>(child));
+    static const std::vector<ClassId> supported{ INSTRDEF, LABEL, LABELABBR };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode LayerDef::Accept(Functor &functor)

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -45,21 +45,19 @@ void Ligature::Reset()
     this->ResetLigatureVis();
 }
 
-bool Ligature::IsSupportedChild(Object *child)
+bool Ligature::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(DOT)) {
-        assert(dynamic_cast<Dot *>(child));
+    static const std::vector<ClassId> supported{ DOT, NOTE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 Note *Ligature::GetFirstNote()

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -47,18 +47,16 @@ void Mdiv::Reset()
     m_visibility = Hidden;
 }
 
-bool Mdiv::IsSupportedChild(Object *child)
+bool Mdiv::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(MDIV)) {
-        assert(dynamic_cast<Mdiv *>(child));
-    }
-    else if (child->Is(SCORE)) {
-        assert(dynamic_cast<Score *>(child));
+    static const std::vector<ClassId> supported{ MDIV, SCORE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Mdiv::MakeVisible()

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -173,17 +173,6 @@ bool Measure::IsSupportedChild(ClassId classId)
     else if (Object::IsEditorialElement(classId)) {
         return true;
     }
-    /*
-    else if (child->Is(STAFF)) {
-        Staff *staff = vrv_cast<Staff *>(child);
-        assert(staff);
-        if (staff && (staff->GetN() < 1)) {
-            // This is not 100% safe if we have a <app> and <rdg> with more than
-            // one staff as a previous child.
-            staff->SetN(this->GetChildCount());
-        }
-    }
-    */
     else {
         return false;
     }
@@ -191,7 +180,7 @@ bool Measure::IsSupportedChild(ClassId classId)
 
 void Measure::AddChildBack(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }
@@ -213,6 +202,20 @@ void Measure::AddChildBack(Object *child)
         }
     }
     Modify();
+}
+
+bool Measure::AddChildAdditionalCheck(Object *child)
+{
+    if (child->Is(STAFF)) {
+        Staff *staff = vrv_cast<Staff *>(child);
+        assert(staff);
+        if (staff && (staff->GetN() < 1)) {
+            // This is not 100% safe if we have a <app> and <rdg> with more than
+            // one staff as a previous child.
+            staff->SetN(this->GetChildCount());
+        }
+    }
+    return (Object::AddChildAdditionalCheck(child));
 }
 
 int Measure::GetDrawingX() const

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -160,14 +160,20 @@ void Measure::Reset()
     m_currentTempo = MIDI_TEMPO;
 }
 
-bool Measure::IsSupportedChild(Object *child)
+bool Measure::IsSupportedChild(ClassId classId)
 {
-    if (child->IsControlElement()) {
-        assert(dynamic_cast<ControlElement *>(child));
+    static const std::vector<ClassId> supported{ STAFF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsControlElement(classId)) {
+        return true;
     }
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
+    }
+    /*
     else if (child->Is(STAFF)) {
         Staff *staff = vrv_cast<Staff *>(child);
         assert(staff);
@@ -177,15 +183,15 @@ bool Measure::IsSupportedChild(Object *child)
             staff->SetN(this->GetChildCount());
         }
     }
+    */
     else {
         return false;
     }
-    return true;
 }
 
 void Measure::AddChildBack(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -42,15 +42,16 @@ void MeterSigGrp::Reset()
     this->ResetMeterSigGrpLog();
 }
 
-bool MeterSigGrp::IsSupportedChild(Object *child)
+bool MeterSigGrp::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(METERSIG)) {
-        assert(dynamic_cast<MeterSig *>(child));
+    static const std::vector<ClassId> supported{ METERSIG };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void MeterSigGrp::FilterList(ListOfConstObjects &childList) const

--- a/src/mnum.cpp
+++ b/src/mnum.cpp
@@ -54,18 +54,19 @@ void MNum::Reset()
     m_isGenerated = false;
 }
 
-bool MNum::IsSupportedChild(Object *child)
+bool MNum::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -96,21 +96,16 @@ FunctorCode Nc::AcceptEnd(ConstFunctor &functor) const
     return functor.VisitNcEnd(this);
 }
 
-bool Nc::IsSupportedChild(Object *child)
+bool Nc::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(LIQUESCENT)) {
-        assert(dynamic_cast<Liquescent *>(child));
-    }
-    else if (child->Is(ORISCUS)) {
-        assert(dynamic_cast<Oriscus *>(child));
-    }
-    else if (child->Is(QUILISMA)) {
-        assert(dynamic_cast<Quilisma *>(child));
+    static const std::vector<ClassId> supported{ LIQUESCENT, ORISCUS, QUILISMA };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 } // namespace vrv

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -58,15 +58,16 @@ void Neume::Reset()
     this->ResetColor();
 }
 
-bool Neume::IsSupportedChild(Object *child)
+bool Neume::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(NC)) {
-        assert(dynamic_cast<Nc *>(child));
+    static const std::vector<ClassId> supported{ NC };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Neume::GetPosition(const LayerElement *element) const

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -131,9 +131,10 @@ void Note::Reset()
     m_stemSameasRole = SAMEAS_NONE;
 }
 
-bool Note::IsSupportedChild(Object *child)
+bool Note::IsSupportedChild(ClassId classId)
 {
     // additional verification for accid and artic - this will not be raised with editorial markup, though
+    /*
     if (child->Is(ACCID)) {
         IsAttributeComparison isAttributeComparison(ACCID);
         if (this->FindDescendantByComparison(&isAttributeComparison))
@@ -144,40 +145,24 @@ bool Note::IsSupportedChild(Object *child)
         if (this->FindDescendantByComparison(&isAttributeComparison))
             LogWarning("Having both @artic and <artic> child will cause problems");
     }
+    */
 
-    if (child->Is(ACCID)) {
-        assert(dynamic_cast<Accid *>(child));
+    static const std::vector<ClassId> supported{ ACCID, ARTIC, DOTS, PLICA, STEM, SYL, VERSE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(ARTIC)) {
-        assert(dynamic_cast<Artic *>(child));
-    }
-    else if (child->Is(DOTS)) {
-        assert(dynamic_cast<Dots *>(child));
-    }
-    else if (child->Is(PLICA)) {
-        assert(dynamic_cast<Plica *>(child));
-    }
-    else if (child->Is(STEM)) {
-        assert(dynamic_cast<Stem *>(child));
-    }
-    else if (child->Is(SYL)) {
-        assert(dynamic_cast<Syl *>(child));
-    }
-    else if (child->Is(VERSE)) {
-        assert(dynamic_cast<Verse *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Note::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -133,20 +133,6 @@ void Note::Reset()
 
 bool Note::IsSupportedChild(ClassId classId)
 {
-    // additional verification for accid and artic - this will not be raised with editorial markup, though
-    /*
-    if (child->Is(ACCID)) {
-        IsAttributeComparison isAttributeComparison(ACCID);
-        if (this->FindDescendantByComparison(&isAttributeComparison))
-            LogWarning("Having both @accid or @accid.ges and <accid> child will cause problems");
-    }
-    else if (child->Is(ARTIC)) {
-        IsAttributeComparison isAttributeComparison(ARTIC);
-        if (this->FindDescendantByComparison(&isAttributeComparison))
-            LogWarning("Having both @artic and <artic> child will cause problems");
-    }
-    */
-
     static const std::vector<ClassId> supported{ ACCID, ARTIC, DOTS, PLICA, STEM, SYL, VERSE };
 
     if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
@@ -162,7 +148,7 @@ bool Note::IsSupportedChild(ClassId classId)
 
 void Note::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }
@@ -180,6 +166,23 @@ void Note::AddChild(Object *child)
         children.push_back(child);
     }
     Modify();
+}
+
+bool Note::AddChildAdditionalCheck(Object *child)
+{
+    // Additional verification for accid and artic - this will not be raised with editorial markup, though
+    // Left as a warning for now.
+    if (child->Is(ACCID)) {
+        IsAttributeComparison isAttributeComparison(ACCID);
+        if (this->FindDescendantByComparison(&isAttributeComparison))
+            LogWarning("Having both @accid or @accid.ges and <accid> child will cause problems");
+    }
+    else if (child->Is(ARTIC)) {
+        IsAttributeComparison isAttributeComparison(ARTIC);
+        if (this->FindDescendantByComparison(&isAttributeComparison))
+            LogWarning("Having both @artic and <artic> child will cause problems");
+    }
+    return (LayerElement::AddChildAdditionalCheck(child));
 }
 
 void Note::AlignDotsShift(const Note *otherNote)

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -38,15 +38,16 @@ void Num::Reset()
     m_currentText.SetText(U"");
 }
 
-bool Num::IsSupportedChild(Object *child)
+bool Num::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(TEXT)) {
-        assert(dynamic_cast<Text *>(child));
+    static const std::vector<ClassId> supported{ TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 FunctorCode Num::Accept(Functor &functor)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -832,12 +832,9 @@ bool Object::IsSupportedChild(ClassId classId)
 
 void Object::AddChild(Object *child)
 {
-    if (!((child->GetClassName() == "Staff") && (this->GetClassName() == "Section"))) {
-        // temporarily allowing staff in section for issue https://github.com/MeasuringPolyphony/mp_editor/issues/62
-        if (!this->IsSupportedChild(child->GetClassId())) {
-            LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
-            return;
-        }
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
+        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        return;
     }
 
     if (!this->IsReferenceObject()) {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -822,11 +822,10 @@ void Object::SetParent(Object *parent)
     m_parent = parent;
 }
 
-bool Object::IsSupportedChild(Object *child)
+bool Object::IsSupportedChild(ClassId classId)
 {
     // This should never happen because the method should be overridden
-    LogDebug(
-        "Method for adding %s to %s should be overridden", child->GetClassName().c_str(), this->GetClassName().c_str());
+    LogDebug("Method for adding %d to %s should be overridden", classId, this->GetClassName().c_str());
     // assert(false);
     return false;
 }
@@ -835,7 +834,7 @@ void Object::AddChild(Object *child)
 {
     if (!((child->GetClassName() == "Staff") && (this->GetClassName() == "Section"))) {
         // temporarily allowing staff in section for issue https://github.com/MeasuringPolyphony/mp_editor/issues/62
-        if (!this->IsSupportedChild(child)) {
+        if (!this->IsSupportedChild(child->GetClassId())) {
             LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
             return;
         }

--- a/src/ornam.cpp
+++ b/src/ornam.cpp
@@ -49,18 +49,19 @@ void Ornam::Reset()
     this->ResetOrnamentAccid();
 }
 
-bool Ornam::IsSupportedChild(Object *child)
+bool Ornam::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -102,18 +102,19 @@ void Page::Reset()
     m_justificationSum = 0.;
 }
 
-bool Page::IsSupportedChild(Object *child)
+bool Page::IsSupportedChild(ClassId classId)
 {
-    if (child->IsPageElement()) {
-        assert(dynamic_cast<PageElement *>(child));
+    static const std::vector<ClassId> supported{ SYSTEM };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(SYSTEM)) {
-        assert(dynamic_cast<System *>(child));
+    else if (Object::IsPageElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Page::IsFirstOfSelection() const

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -44,18 +44,16 @@ void Pages::Reset()
     this->ResetNNumberLike();
 }
 
-bool Pages::IsSupportedChild(Object *child)
+bool Pages::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(PAGE)) {
-        assert(dynamic_cast<Page *>(child));
-    }
-    else if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
+    static const std::vector<ClassId> supported{ PAGE, SCOREDEF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Pages::ConvertFrom(Score *score)

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -49,18 +49,19 @@ void Reh::Reset()
     this->ResetVerticalGroup();
 }
 
-bool Reh::IsSupportedChild(Object *child)
+bool Reh::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/rend.cpp
+++ b/src/rend.cpp
@@ -67,30 +67,19 @@ void Rend::Reset()
     this->ResetWhitespace();
 }
 
-bool Rend::IsSupportedChild(Object *child)
+bool Rend::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(LB)) {
-        assert(dynamic_cast<Lb *>(child));
+    static const std::vector<ClassId> supported{ LB, NUM, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(NUM)) {
-        assert(dynamic_cast<Num *>(child));
-    }
-    else if (child->Is(REND)) {
-        assert(dynamic_cast<Rend *>(child));
-    }
-    else if (child->Is(SYMBOL)) {
-        assert(dynamic_cast<Symbol *>(child));
-    }
-    else if (child->Is(TEXT)) {
-        assert(dynamic_cast<Text *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 bool Rend::HasEnclosure() const

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -59,18 +59,19 @@ void RepeatMark::Reset()
     this->ResetRepeatMarkLog();
 }
 
-bool RepeatMark::IsSupportedChild(Object *child)
+bool RepeatMark::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 char32_t RepeatMark::GetMarkGlyph() const

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -224,7 +224,7 @@ bool Rest::IsSupportedChild(ClassId classId)
 
 void Rest::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -207,23 +207,24 @@ void Rest::Reset()
     this->ResetRestVisMensural();
 }
 
-bool Rest::IsSupportedChild(Object *child)
+bool Rest::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(DOTS)) {
-        assert(dynamic_cast<Dots *>(child));
+    static const std::vector<ClassId> supported{ DOTS };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Rest::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -60,30 +60,19 @@ void Score::Reset()
     m_drawingPgFoot2Height = 0;
 }
 
-bool Score::IsSupportedChild(Object *child)
+bool Score::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
+    static const std::vector<ClassId> supported{ ENDING, PB, SCOREDEF, SB, SECTION };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(SB)) {
-        assert(dynamic_cast<Sb *>(child));
-    }
-    else if (child->Is(SECTION)) {
-        assert(dynamic_cast<Section *>(child));
-    }
-    else if (child->Is(ENDING)) {
-        assert(dynamic_cast<Ending *>(child));
-    }
-    else if (child->Is(PB)) {
-        assert(dynamic_cast<Pb *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Score::CalcRunningElementHeight(Doc *doc)

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -256,41 +256,20 @@ void ScoreDef::Reset()
     m_setAsDrawing = false;
 }
 
-bool ScoreDef::IsSupportedChild(Object *child)
+bool ScoreDef::IsSupportedChild(ClassId classId)
 {
-    // Clef is actually not allowed as child of scoreDef in MEI
-    if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
+    static const std::vector<ClassId> supported{ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP, STAFFGRP,
+        SYMBOLTABLE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(GRPSYM)) {
-        assert(dynamic_cast<GrpSym *>(child));
-    }
-    else if (child->Is(KEYSIG)) {
-        assert(dynamic_cast<KeySig *>(child));
-    }
-    else if (child->Is(STAFFGRP)) {
-        assert(dynamic_cast<StaffGrp *>(child));
-    }
-    // Mensur is actually not allowed as child of scoreDef in MEI
-    else if (child->Is(MENSUR)) {
-        assert(dynamic_cast<Mensur *>(child));
-    }
-    else if (child->Is(METERSIG)) {
-        assert(dynamic_cast<MeterSig *>(child));
-    }
-    else if (child->Is(METERSIGGRP)) {
-        assert(dynamic_cast<MeterSigGrp *>(child));
-    }
-    else if (child->IsRunningElement()) {
-        assert(dynamic_cast<RunningElement *>(child));
-    }
-    else if (child->Is(SYMBOLTABLE)) {
-        assert(dynamic_cast<SymbolTable *>(child));
+    else if (Object::IsRunningElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int ScoreDef::GetInsertOrderFor(ClassId classId) const

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -272,6 +272,19 @@ bool ScoreDef::IsSupportedChild(ClassId classId)
     }
 }
 
+bool ScoreDef::AddChildAdditionalCheck(Object *child)
+{
+    // Clef and mensur are actually not allowed as child of scoreDef in MEI.
+    // Left as a warning for now.
+    if (child->Is(CLEF) && !child->IsAttribute()) {
+        LogWarning("Having <clef> as child of <scoreDef> is not valid MEI");
+    }
+    else if (child->Is(MENSUR) && !child->IsAttribute()) {
+        LogWarning("Having <clef> as child of <scoreDef> is not valid MEI");
+    }
+    return (ScoreDefElement::AddChildAdditionalCheck(child));
+}
+
 int ScoreDef::GetInsertOrderFor(ClassId classId) const
 {
 

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -51,27 +51,22 @@ void Section::Reset()
     this->ResetSectionVis();
 }
 
-bool Section::IsSupportedChild(Object *child)
+bool Section::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(MEASURE)) {
-        assert(dynamic_cast<Measure *>(child));
+    static const std::vector<ClassId> supported{ DIV, MEASURE, SCOREDEF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
+    else if (Object::IsSystemElement(classId)) {
+        return true;
     }
-    else if (child->IsSystemElement()) {
-        assert(dynamic_cast<SystemElement *>(child));
-    }
-    else if (child->Is(DIV)) {
-        assert(dynamic_cast<Div *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -108,8 +108,14 @@ void Staff::ClearLedgerLines()
     m_ledgerLinesBelowCue.clear();
 }
 
-bool Staff::IsSupportedChild(Object *child)
+bool Staff::IsSupportedChild(ClassId classId)
 {
+    static const std::vector<ClassId> supported{ LAYER };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
+    }
+    /*
     if (child->Is(LAYER)) {
         Layer *layer = vrv_cast<Layer *>(child);
         assert(layer);
@@ -119,13 +125,13 @@ bool Staff::IsSupportedChild(Object *child)
             layer->SetN(this->GetChildCount(LAYER) + 1);
         }
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    */
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Staff::GetDrawingX() const

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -115,7 +115,16 @@ bool Staff::IsSupportedChild(ClassId classId)
     if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
         return true;
     }
-    /*
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+bool Staff::AddChildAdditionalCheck(Object *child)
+{
     if (child->Is(LAYER)) {
         Layer *layer = vrv_cast<Layer *>(child);
         assert(layer);
@@ -125,13 +134,7 @@ bool Staff::IsSupportedChild(ClassId classId)
             layer->SetN(this->GetChildCount(LAYER) + 1);
         }
     }
-    */
-    else if (Object::IsEditorialElement(classId)) {
-        return true;
-    }
-    else {
-        return false;
-    }
+    return (Object::AddChildAdditionalCheck(child));
 }
 
 int Staff::GetDrawingX() const

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -78,42 +78,17 @@ void StaffDef::Reset()
     m_drawingVisibility = OPTIMIZATION_NONE;
 }
 
-bool StaffDef::IsSupportedChild(Object *child)
+bool StaffDef::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
-    }
-    else if (child->Is(INSTRDEF)) {
-        assert(dynamic_cast<InstrDef *>(child));
-    }
-    else if (child->Is(KEYSIG)) {
-        assert(dynamic_cast<KeySig *>(child));
-    }
-    else if (child->Is(LABEL)) {
-        assert(dynamic_cast<Label *>(child));
-    }
-    else if (child->Is(LABELABBR)) {
-        assert(dynamic_cast<LabelAbbr *>(child));
-    }
-    else if (child->Is(LAYERDEF)) {
-        assert(dynamic_cast<LayerDef *>(child));
-    }
-    else if (child->Is(MENSUR)) {
-        assert(dynamic_cast<Mensur *>(child));
-    }
-    else if (child->Is(METERSIG)) {
-        assert(dynamic_cast<MeterSig *>(child));
-    }
-    else if (child->Is(METERSIGGRP)) {
-        assert(dynamic_cast<MeterSigGrp *>(child));
-    }
-    else if (child->Is(TUNING)) {
-        assert(dynamic_cast<Tuning *>(child));
+    static const std::vector<ClassId> supported{ CLEF, INSTRDEF, KEYSIG, LABEL, LABELABBR, LAYERDEF, MENSUR, METERSIG,
+        METERSIGGRP, TUNING };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int StaffDef::GetInsertOrderFor(ClassId classId) const

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -68,33 +68,19 @@ void StaffGrp::Reset()
     m_groupSymbol = NULL;
 }
 
-bool StaffGrp::IsSupportedChild(Object *child)
+bool StaffGrp::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(GRPSYM)) {
-        assert(dynamic_cast<GrpSym *>(child));
+    static const std::vector<ClassId> supported{ GRPSYM, INSTRDEF, LABEL, LABELABBR, STAFFDEF, STAFFGRP };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(INSTRDEF)) {
-        assert(dynamic_cast<InstrDef *>(child));
-    }
-    else if (child->Is(LABEL)) {
-        assert(dynamic_cast<Label *>(child));
-    }
-    else if (child->Is(LABELABBR)) {
-        assert(dynamic_cast<LabelAbbr *>(child));
-    }
-    else if (child->Is(STAFFDEF)) {
-        assert(dynamic_cast<StaffDef *>(child));
-    }
-    else if (child->Is(STAFFGRP)) {
-        assert(dynamic_cast<StaffGrp *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int StaffGrp::GetInsertOrderFor(ClassId classId) const

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -57,15 +57,16 @@ void Stem::Reset()
     m_stemModRelY = 0;
 }
 
-bool Stem::IsSupportedChild(Object *child)
+bool Stem::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(FLAG)) {
-        assert(dynamic_cast<Flag *>(child));
+    static const std::vector<ClassId> supported{ FLAG };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Stem::FillAttributes(const AttStems &attSource)

--- a/src/subst.cpp
+++ b/src/subst.cpp
@@ -46,21 +46,16 @@ void Subst::Reset()
 
 Subst::~Subst() {}
 
-bool Subst::IsSupportedChild(Object *child)
+bool Subst::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(ADD)) {
-        assert(dynamic_cast<Add *>(child));
-    }
-    else if (child->Is(DEL)) {
-        assert(dynamic_cast<Del *>(child));
-    }
-    else if (child->Is(SUBST)) {
-        assert(dynamic_cast<Subst *>(child));
+    static const std::vector<ClassId> supported{ ADD, DEL, SUBST };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 //----------------------------------------------------------------------------

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -45,19 +45,16 @@ void Surface::Reset()
     this->ResetCoordinatedUl();
 }
 
-bool Surface::IsSupportedChild(Object *object)
+bool Surface::IsSupportedChild(ClassId classId)
 {
-    if (object->Is(GRAPHIC)) {
-        assert(dynamic_cast<Graphic *>(object));
-    }
-    else if (object->Is(ZONE)) {
-        assert(dynamic_cast<Zone *>(object));
+    static const std::vector<ClassId> supported{ GRAPHIC, ZONE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
-        LogError("Unsupported child '%s' of surface", object->GetClassName().c_str());
         return false;
     }
-    return true;
 }
 
 int Surface::GetMaxX() const

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -64,21 +64,19 @@ void Syl::Reset()
     m_nextWordSyl = NULL;
 }
 
-bool Syl::IsSupportedChild(Object *child)
+bool Syl::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ REND, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ REND, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
-    }
-    else if (child->Is(REND)) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Syl::CalcHyphenLength(Doc *doc, int staffSize)

--- a/src/syllable.cpp
+++ b/src/syllable.cpp
@@ -44,27 +44,22 @@ void Syllable::Init()
     this->Reset();
 }
 
-bool Syllable::IsSupportedChild(Object *child)
+bool Syllable::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(SYL)) {
-        assert(dynamic_cast<Syl *>(child));
-    }
-    else if (child->Is(NEUME)) {
-        assert(dynamic_cast<Neume *>(child));
-    }
-    else if (child->Is(DIVLINE)) {
-        assert(dynamic_cast<DivLine *>(child));
-    }
-    else if (child->Is(ACCID)) {
-        assert(dynamic_cast<Accid *>(child));
-    }
-    else if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
+    static const std::vector<ClassId> supported{
+        ACCID,
+        CLEF,
+        DIVLINE,
+        NEUME,
+        SYL,
+    };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 Syllable::~Syllable() {}

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -48,7 +48,7 @@ void Symbol::Reset()
     this->ResetTypography();
 }
 
-bool Symbol::IsSupportedChild(Object *child)
+bool Symbol::IsSupportedChild(ClassId classId)
 {
     return false;
 }

--- a/src/symboldef.cpp
+++ b/src/symboldef.cpp
@@ -41,21 +41,16 @@ void SymbolDef::Reset()
     m_originalParent = NULL;
 }
 
-bool SymbolDef::IsSupportedChild(Object *child)
+bool SymbolDef::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(GRAPHIC)) {
-        assert(dynamic_cast<Graphic *>(child));
-    }
-    else if (child->Is(SVG)) {
-        assert(dynamic_cast<Svg *>(child));
-    }
-    else if (child->Is(SYMBOL)) {
-        assert(dynamic_cast<Symbol *>(child));
+    static const std::vector<ClassId> supported{ GRAPHIC, SVG, SYMBOL };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int SymbolDef::GetSymbolWidth(Doc *doc, int staffSize, bool dimin) const

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -36,15 +36,16 @@ void SymbolTable::Reset()
     Object::Reset();
 }
 
-bool SymbolTable::IsSupportedChild(Object *child)
+bool SymbolTable::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(SYMBOLDEF)) {
-        assert(dynamic_cast<SymbolDef *>(child));
+    static const std::vector<ClassId> supported{ SYMBOLDEF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 } // namespace vrv

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -86,27 +86,22 @@ void System::Reset()
     m_drawingIsOptimized = false;
 }
 
-bool System::IsSupportedChild(Object *child)
+bool System::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(MEASURE)) {
-        assert(dynamic_cast<Measure *>(child));
+    static const std::vector<ClassId> supported{ DIV, MEASURE, SCOREDEF };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(SCOREDEF)) {
-        assert(dynamic_cast<ScoreDef *>(child));
+    else if (Object::IsSystemElement(classId)) {
+        return true;
     }
-    else if (child->IsSystemElement()) {
-        assert(dynamic_cast<SystemElement *>(child));
-    }
-    else if (child->Is(DIV)) {
-        assert(dynamic_cast<Div *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int System::GetDrawingX() const

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -56,20 +56,21 @@ void TabDurSym::Reset()
     this->ResetVisualOffsetVo();
 }
 
-bool TabDurSym::IsSupportedChild(Object *child)
+bool TabDurSym::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(STEM)) {
-        assert(dynamic_cast<Stem *>(child));
+    static const std::vector<ClassId> supported{ STEM };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void TabDurSym::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -70,7 +70,7 @@ bool TabDurSym::IsSupportedChild(ClassId classId)
 
 void TabDurSym::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -42,24 +42,19 @@ void TabGrp::Reset()
     DurationInterface::Reset();
 }
 
-bool TabGrp::IsSupportedChild(Object *child)
+bool TabGrp::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
+    static const std::vector<ClassId> supported{ NOTE, REST, TABDURSYM };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(REST)) {
-        assert(dynamic_cast<Rest *>(child));
-    }
-    else if (child->Is(TABDURSYM)) {
-        assert(dynamic_cast<TabDurSym *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void TabGrp::FilterList(ListOfConstObjects &childList) const

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -62,18 +62,19 @@ void Tempo::Reset()
     this->ResetMmTempo();
 }
 
-bool Tempo::IsSupportedChild(Object *child)
+bool Tempo::IsSupportedChild(ClassId classId)
 {
-    if (child->Is({ LB, REND, SYMBOL, TEXT })) {
-        assert(dynamic_cast<TextElement *>(child));
+    static const std::vector<ClassId> supported{ LB, REND, SYMBOL, TEXT };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Tempo::GetDrawingXRelativeToStaff(int staffN) const

--- a/src/textlayoutelement.cpp
+++ b/src/textlayoutelement.cpp
@@ -41,18 +41,17 @@ void TextLayoutElement::Reset()
     this->ResetTyped();
 }
 
-bool TextLayoutElement::IsSupportedChild(Object *child)
+bool TextLayoutElement::IsSupportedChild(ClassId classId)
 {
-    if (child->IsTextElement()) {
-        assert(dynamic_cast<TextElement *>(child));
+    if (Object::IsTextElement(classId)) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void TextLayoutElement::FilterList(ListOfConstObjects &childList) const

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -42,18 +42,19 @@ void Tuning::Reset()
     this->ResetTuningLog();
 }
 
-bool Tuning::IsSupportedChild(Object *child)
+bool Tuning::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(COURSE)) {
-        assert(dynamic_cast<Course *>(child));
+    static const std::vector<ClassId> supported{ COURSE };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Tuning::CalcPitchPos(int course, data_NOTATIONTYPE notationType, int lines, int listSize, int index, int loc,

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -70,56 +70,25 @@ void Tuplet::Reset()
     m_numAlignedBeam = NULL;
 }
 
-bool Tuplet::IsSupportedChild(Object *child)
+bool Tuplet::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(BEAM)) {
-        assert(dynamic_cast<Beam *>(child));
+    static const std::vector<ClassId> supported{ BEAM, TUPLET_BRACKET, BTREM, CHORD, CLEF, FTREM, NOTE, TUPLET_NUM,
+        REST, SPACE, TABGRP, TUPLET };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(TUPLET_BRACKET)) {
-        assert(dynamic_cast<TupletBracket *>(child));
-    }
-    else if (child->Is(BTREM)) {
-        assert(dynamic_cast<BTrem *>(child));
-    }
-    else if (child->Is(CHORD)) {
-        assert(dynamic_cast<Chord *>(child));
-    }
-    else if (child->Is(CLEF)) {
-        assert(dynamic_cast<Clef *>(child));
-    }
-    else if (child->Is(FTREM)) {
-        assert(dynamic_cast<FTrem *>(child));
-    }
-    else if (child->Is(NOTE)) {
-        assert(dynamic_cast<Note *>(child));
-    }
-    else if (child->Is(TUPLET_NUM)) {
-        assert(dynamic_cast<TupletNum *>(child));
-    }
-    else if (child->Is(REST)) {
-        assert(dynamic_cast<Rest *>(child));
-    }
-    else if (child->Is(SPACE)) {
-        assert(dynamic_cast<Space *>(child));
-    }
-    else if (child->Is(TABGRP)) {
-        assert(dynamic_cast<TabGrp *>(child));
-    }
-    else if (child->Is(TUPLET)) {
-        assert(dynamic_cast<Tuplet *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 void Tuplet::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child)) {
+    if (!this->IsSupportedChild(child->GetClassId())) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -88,7 +88,7 @@ bool Tuplet::IsSupportedChild(ClassId classId)
 
 void Tuplet::AddChild(Object *child)
 {
-    if (!this->IsSupportedChild(child->GetClassId())) {
+    if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
         LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
         return;
     }

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -58,24 +58,19 @@ void Verse::Reset()
     m_drawingLabelAbbr = NULL;
 }
 
-bool Verse::IsSupportedChild(Object *child)
+bool Verse::IsSupportedChild(ClassId classId)
 {
-    if (child->Is(LABEL)) {
-        assert(dynamic_cast<Label *>(child));
+    static const std::vector<ClassId> supported{ LABEL, LABELABBR, SYL };
+
+    if (std::find(supported.begin(), supported.end(), classId) != supported.end()) {
+        return true;
     }
-    else if (child->Is(LABELABBR)) {
-        assert(dynamic_cast<LabelAbbr *>(child));
-    }
-    else if (child->Is(SYL)) {
-        assert(dynamic_cast<Syl *>(child));
-    }
-    else if (child->IsEditorialElement()) {
-        assert(dynamic_cast<EditorialElement *>(child));
+    else if (Object::IsEditorialElement(classId)) {
+        return true;
     }
     else {
         return false;
     }
-    return true;
 }
 
 int Verse::AdjustPosition(int &overlap, int freeSpace, const Doc *doc)

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -54,9 +54,9 @@ void SystemAligner::Reset()
     this->AddChild(m_bottomAlignment);
 }
 
-bool SystemAligner::IsSupportedChild(Object *child)
+bool SystemAligner::IsSupportedChild(ClassId classId)
 {
-    assert(dynamic_cast<StaffAlignment *>(child));
+    // Nothing to check here
     return true;
 }
 


### PR DESCRIPTION
The PR is an internal refactoring with no change expected. 

It checks if a child is allowed for an element based on the ClassId, and removes unnecessary `dynamic_cast` asserts. This is done through a refactoring of `Object::IsSupportedChild` method.

Some additional checks performed before in some overridden version of the methods are now in a new `Object::AddChildAdditionalCheck`

The PR also removes an old temporary fix for https://github.com/MeasuringPolyphony/mp_editor/issues/62.