### PR TITLE
GetClassName to lowerCamelCase and change ID generator to random first letter

### DIFF
--- a/include/vrv/abbr.h
+++ b/include/vrv/abbr.h
@@ -28,7 +28,7 @@ public:
     virtual ~Abbr();
     Object *Clone() const override { return new Abbr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Abbr"; }
+    std::string GetClassName() const override { return "abbr"; }
     ///@}
 
 private:

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -45,7 +45,7 @@ public:
     virtual ~Accid();
     Object *Clone() const override { return new Accid(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Accid"; }
+    std::string GetClassName() const override { return "accid"; }
     ///@}
 
     /** Override the method since it is align to the staff */

--- a/include/vrv/add.h
+++ b/include/vrv/add.h
@@ -28,7 +28,7 @@ public:
     virtual ~Add();
     Object *Clone() const override { return new Add(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Add"; }
+    std::string GetClassName() const override { return "add"; }
     ///@}
 
 private:

--- a/include/vrv/anchoredtext.h
+++ b/include/vrv/anchoredtext.h
@@ -33,7 +33,7 @@ public:
     virtual ~AnchoredText();
     Object *Clone() const override { return new AnchoredText(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "AnchoredText"; }
+    std::string GetClassName() const override { return "anchoredText"; }
     ///@}
 
     /**

--- a/include/vrv/annot.h
+++ b/include/vrv/annot.h
@@ -32,7 +32,7 @@ public:
     // This fails because of the copy contructor in ObjectListInterface (TextListInterface parent)
     // Object *Clone() const override { return new Annot(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Annot"; }
+    std::string GetClassName() const override { return "annot"; }
     ///@}
 
     /**

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -28,7 +28,7 @@ public:
     virtual ~App();
     Object *Clone() const override { return new App(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "App"; }
+    std::string GetClassName() const override { return "app"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -39,7 +39,7 @@ public:
     virtual ~Arpeg();
     Object *Clone() const override { return new Arpeg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Arpeg"; }
+    std::string GetClassName() const override { return "arpeg"; }
     ///@}
 
     /**

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -37,7 +37,7 @@ public:
     virtual ~Artic();
     Object *Clone() const override { return new Artic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Artic"; }
+    std::string GetClassName() const override { return "artic"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -43,7 +43,7 @@ public:
     virtual ~BarLine();
     Object *Clone() const override { return new BarLine(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "BarLine"; }
+    std::string GetClassName() const override { return "barLine"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -292,7 +292,7 @@ public:
     virtual ~Beam();
     Object *Clone() const override { return new Beam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Beam"; }
+    std::string GetClassName() const override { return "beam"; }
     ///@}
 
     /**

--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -44,7 +44,7 @@ public:
     virtual ~BeamSpan();
     Object *Clone() const override { return new BeamSpan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "BeamSpan"; }
+    std::string GetClassName() const override { return "beamSpan"; }
     ///@}
 
     /**

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -33,7 +33,7 @@ public:
     virtual ~BeatRpt();
     Object *Clone() const override { return new BeatRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "BeatRpt"; }
+    std::string GetClassName() const override { return "beatRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/bracketspan.h
+++ b/include/vrv/bracketspan.h
@@ -36,7 +36,7 @@ public:
     virtual ~BracketSpan();
     Object *Clone() const override { return new BracketSpan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "BracketSpan"; }
+    std::string GetClassName() const override { return "bracketSpan"; }
     ///@}
 
     /**

--- a/include/vrv/breath.h
+++ b/include/vrv/breath.h
@@ -32,7 +32,7 @@ public:
     virtual ~Breath();
     Object *Clone() const override { return new Breath(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Breath"; }
+    std::string GetClassName() const override { return "breath"; }
     ///@}
 
     /**

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -35,7 +35,7 @@ public:
     virtual ~BTrem();
     Object *Clone() const override { return new BTrem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "BTrem"; }
+    std::string GetClassName() const override { return "bTrem"; }
     ///@}
 
     /**

--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -37,7 +37,7 @@ public:
     virtual ~Caesura();
     Object *Clone() const override { return new Caesura(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Caesura"; }
+    std::string GetClassName() const override { return "caesura"; }
     ///@}
 
     /**

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -29,7 +29,7 @@ public:
     Object *Clone() const override { return new Choice(*this); }
     virtual ~Choice();
     void Reset() override;
-    std::string GetClassName() const override { return "Choice"; }
+    std::string GetClassName() const override { return "choice"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -52,7 +52,7 @@ public:
     virtual ~Chord();
     Object *Clone() const override { return new Chord(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Chord"; }
+    std::string GetClassName() const override { return "chord"; }
     ///@}
 
     /**

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -47,7 +47,7 @@ public:
     virtual ~Clef();
     Object *Clone() const override { return new Clef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Clef"; }
+    std::string GetClassName() const override { return "clef"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -117,6 +117,24 @@ protected:
 };
 
 //----------------------------------------------------------------------------
+// ChildOfClassIdComparison
+//----------------------------------------------------------------------------
+
+class ChildOfClassIdComparison : public Comparison {
+
+public:
+    ChildOfClassIdComparison(ClassId classId) { m_classId = classId; }
+
+    bool operator()(const Object *object) override
+    {
+        return (object->GetParent() && object->GetParent()->GetClassId() == m_classId);
+    }
+
+protected:
+    ClassId m_classId;
+};
+
+//----------------------------------------------------------------------------
 // PointingToComparison
 //----------------------------------------------------------------------------
 

--- a/include/vrv/controlelement.h
+++ b/include/vrv/controlelement.h
@@ -39,7 +39,6 @@ public:
     ///@{
     ControlElement();
     ControlElement(ClassId classId);
-    ControlElement(ClassId classId, const std::string &classIdStr);
     virtual ~ControlElement();
     void Reset() override;
     ///@}

--- a/include/vrv/corr.h
+++ b/include/vrv/corr.h
@@ -28,7 +28,7 @@ public:
     virtual ~Corr();
     Object *Clone() const override { return new Corr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Corr"; }
+    std::string GetClassName() const override { return "corr"; }
     ///@}
 
 private:

--- a/include/vrv/course.h
+++ b/include/vrv/course.h
@@ -31,7 +31,7 @@ public:
     virtual ~Course();
     Object *Clone() const override { return new Course(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Course"; }
+    std::string GetClassName() const override { return "course"; }
     ///@}
 
     /**

--- a/include/vrv/cpmark.h
+++ b/include/vrv/cpmark.h
@@ -34,7 +34,7 @@ public:
     virtual ~CpMark();
     Object *Clone() const override { return new CpMark(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "CpMark"; }
+    std::string GetClassName() const override { return "cpMark"; }
     ///@}
 
     /**

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -37,7 +37,7 @@ public:
     virtual ~Custos();
     Object *Clone() const override { return new Custos(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Custos"; }
+    std::string GetClassName() const override { return "custos"; }
     ///@}
 
     /**

--- a/include/vrv/damage.h
+++ b/include/vrv/damage.h
@@ -28,7 +28,7 @@ public:
     virtual ~Damage();
     Object *Clone() const override { return new Damage(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Damage"; }
+    std::string GetClassName() const override { return "damage"; }
     ///@}
 
 private:

--- a/include/vrv/del.h
+++ b/include/vrv/del.h
@@ -28,7 +28,7 @@ public:
     virtual ~Del();
     Object *Clone() const override { return new Del(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Del"; }
+    std::string GetClassName() const override { return "del"; }
     ///@}
 
 private:

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -41,7 +41,7 @@ public:
     virtual ~Dir();
     Object *Clone() const override { return new Dir(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Dir"; }
+    std::string GetClassName() const override { return "dir"; }
     ///@}
 
     /**

--- a/include/vrv/div.h
+++ b/include/vrv/div.h
@@ -31,7 +31,7 @@ public:
     Div();
     virtual ~Div();
     void Reset() override;
-    std::string GetClassName() const override { return "Div"; }
+    std::string GetClassName() const override { return "div"; }
     ///@}
 
     /**

--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -39,7 +39,7 @@ public:
     virtual ~DivLine();
     Object *Clone() const override { return new DivLine(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "DivLine"; }
+    std::string GetClassName() const override { return "civLine"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -85,7 +85,7 @@ public:
     DivLineAttr();
     virtual ~DivLineAttr();
     Object *Clone() const override { return new DivLineAttr(*this); }
-    std::string GetClassName() const override { return "DivLineAttr"; }
+    std::string GetClassName() const override { return "divLineAttr"; }
     ///@}
 
     // void SetLeft() { m_isLeft = true; }

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -30,7 +30,7 @@ public:
     virtual ~Dot();
     Object *Clone() const override { return new Dot(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Dot"; }
+    std::string GetClassName() const override { return "dot"; }
     ///@}
 
     /**

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -41,7 +41,7 @@ public:
     virtual ~Dynam();
     Object *Clone() const override { return new Dynam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Dynam"; }
+    std::string GetClassName() const override { return "dynam"; }
     ///@}
 
     /**

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -44,7 +44,6 @@ public:
     ///@{
     EditorialElement();
     EditorialElement(ClassId classId);
-    EditorialElement(ClassId classId, const std::string &classIdStr);
     virtual ~EditorialElement();
     void Reset() override;
     ///@}

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -34,7 +34,7 @@ public:
     Dots();
     virtual ~Dots();
     void Reset() override;
-    std::string GetClassName() const override { return "Dots"; }
+    std::string GetClassName() const override { return "dots"; }
     Object *Clone() const override { return new Dots(*this); }
     ///@}
 
@@ -104,7 +104,7 @@ public:
     Flag();
     virtual ~Flag();
     void Reset() override;
-    std::string GetClassName() const override { return "Flag"; }
+    std::string GetClassName() const override { return "flag"; }
     Object *Clone() const override { return new Flag(*this); }
     ///@}
 
@@ -157,7 +157,7 @@ public:
     TupletBracket();
     virtual ~TupletBracket();
     void Reset() override;
-    std::string GetClassName() const override { return "TupletBracket"; }
+    std::string GetClassName() const override { return "tupletBracket"; }
     ///@}
 
     /**
@@ -256,7 +256,7 @@ public:
     TupletNum();
     virtual ~TupletNum();
     void Reset() override;
-    std::string GetClassName() const override { return "TupletNum"; }
+    std::string GetClassName() const override { return "tupletNum"; }
     ///@}
 
     /**

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -41,7 +41,7 @@ public:
     virtual ~Ending();
     Object *Clone() const override { return new Ending(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Ending"; }
+    std::string GetClassName() const override { return "ending"; }
     ///@}
 
     /**

--- a/include/vrv/expan.h
+++ b/include/vrv/expan.h
@@ -28,7 +28,7 @@ public:
     virtual ~Expan();
     Object *Clone() const override { return new Expan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Expan"; }
+    std::string GetClassName() const override { return "expan"; }
     ///@}
 
 private:

--- a/include/vrv/expansion.h
+++ b/include/vrv/expansion.h
@@ -34,7 +34,7 @@ public:
     virtual ~Expansion();
     Object *Clone() const override { return new Expansion(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Expansion"; }
+    std::string GetClassName() const override { return "expansion"; }
     ///@}
 
     /**

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -32,7 +32,7 @@ public:
     virtual ~F();
     Object *Clone() const override { return new F(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "F"; }
+    std::string GetClassName() const override { return "f"; }
     ///@}
 
     /**

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -39,7 +39,7 @@ public:
     virtual ~Facsimile();
     Object *Clone() const override { return new Facsimile(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Facsimile"; }
+    std::string GetClassName() const override { return "facsimile"; }
     ///@}
     bool IsSupportedChild(ClassId classId) override;
 

--- a/include/vrv/fb.h
+++ b/include/vrv/fb.h
@@ -31,7 +31,7 @@ public:
     virtual ~Fb();
     Object *Clone() const override { return new Fb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Fb"; }
+    std::string GetClassName() const override { return "fb"; }
     ///@}
 
     /**

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -40,7 +40,7 @@ public:
     virtual ~Fermata();
     Object *Clone() const override { return new Fermata(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Fermata"; }
+    std::string GetClassName() const override { return "fermata"; }
     ///@}
 
     /**

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -31,7 +31,7 @@ public:
     virtual ~Fig();
     Object *Clone() const override { return new Fig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Fig"; }
+    std::string GetClassName() const override { return "fig"; }
     ///@}
 
     /**

--- a/include/vrv/findfunctor.h
+++ b/include/vrv/findfunctor.h
@@ -402,6 +402,7 @@ private:
 
 /**
  * This class finds all objects to which another object refers to.
+ * The constructor should take either elements or a listWithAttName pointer set, the other should be NULL.
  */
 class FindAllReferencedObjectsFunctor : public Functor {
 public:
@@ -409,7 +410,7 @@ public:
      * @name Constructors, destructors
      */
     ///@{
-    FindAllReferencedObjectsFunctor(SetOfObjects *elements);
+    FindAllReferencedObjectsFunctor(SetOfObjects *elements, ListOfObjectAttNamePairs *listWithAttName);
     virtual ~FindAllReferencedObjectsFunctor() = default;
     ///@}
 
@@ -434,13 +435,59 @@ protected:
     //
 private:
     //
+    void AddObject(Object *object, const std::string &attribute);
+
 public:
     //
 private:
     // The set of all matching objects
     SetOfObjects *m_elements;
+    // The list of pairs of matching objects with the attribute name
+    ListOfObjectAttNamePairs *m_listWithAttName;
     // A flag indicating if milestone references should be included as well
     bool m_milestoneReferences;
+};
+
+//----------------------------------------------------------------------------
+// FindAllReferringObjectsFunctor
+//----------------------------------------------------------------------------
+
+/**
+ * This class finds all objects referring to a specific object
+ */
+class FindAllReferringObjectsFunctor : public Functor {
+public:
+    /**
+     * @name Constructors, destructors
+     */
+    ///@{
+    FindAllReferringObjectsFunctor(const Object *object, ListOfObjectAttNamePairs *elements);
+    virtual ~FindAllReferringObjectsFunctor() = default;
+    ///@}
+
+    /*
+     * Abstract base implementation
+     */
+    bool ImplementsEndInterface() const override { return false; }
+
+    /*
+     * Functor interface
+     */
+    ///@{
+    FunctorCode VisitObject(Object *object) override;
+    ///@}
+
+protected:
+    //
+private:
+    //
+public:
+    //
+private:
+    // The object referred to
+    const Object *m_object;
+    // The set of all objects with the attribute name they are referring through
+    ListOfObjectAttNamePairs *m_elements;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -33,7 +33,7 @@ public:
     virtual ~Fing();
     Object *Clone() const override { return new Fing(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Fing"; }
+    std::string GetClassName() const override { return "fing"; }
     ///@}
 
     /**

--- a/include/vrv/floatingobject.h
+++ b/include/vrv/floatingobject.h
@@ -34,7 +34,6 @@ public:
     ///@{
     FloatingObject();
     FloatingObject(ClassId classId);
-    FloatingObject(ClassId classId, const std::string &classIdStr);
     virtual ~FloatingObject();
     void Reset() override;
     void ResetDrawing();

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -33,7 +33,7 @@ public:
     virtual ~FTrem();
     Object *Clone() const override { return new FTrem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "FTrem"; }
+    std::string GetClassName() const override { return "fTrem"; }
     ///@}
 
     /**

--- a/include/vrv/gliss.h
+++ b/include/vrv/gliss.h
@@ -36,7 +36,7 @@ public:
     virtual ~Gliss();
     Object *Clone() const override { return new Gliss(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Gliss"; }
+    std::string GetClassName() const override { return "gliss"; }
     ///@}
 
     /**

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -28,7 +28,7 @@ public:
     virtual ~GraceGrp();
     Object *Clone() const override { return new GraceGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "GraceGrp"; }
+    std::string GetClassName() const override { return "graceGrp"; }
     ///@}
 
     /**

--- a/include/vrv/graphic.h
+++ b/include/vrv/graphic.h
@@ -37,7 +37,7 @@ public:
     virtual ~Graphic();
     Object *Clone() const override { return new Graphic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Graphic"; }
+    std::string GetClassName() const override { return "graphic"; }
     ///@}
 
     /**

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -38,7 +38,7 @@ public:
     virtual ~GrpSym();
     Object *Clone() const override { return new GrpSym(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "GrpSym"; }
+    std::string GetClassName() const override { return "grpSym"; }
     ///@}
 
     /**

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -39,7 +39,7 @@ public:
     virtual ~Hairpin();
     Object *Clone() const override { return new Hairpin(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Hairpin"; }
+    std::string GetClassName() const override { return "hairpin"; }
     ///@}
 
     /**

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -34,7 +34,7 @@ public:
     virtual ~HalfmRpt();
     Object *Clone() const override { return new HalfmRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "HalfmRpt"; }
+    std::string GetClassName() const override { return "halfmRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -40,7 +40,7 @@ public:
     virtual ~Harm();
     Object *Clone() const override { return new Harm(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Harm"; }
+    std::string GetClassName() const override { return "harm"; }
     ///@}
 
     /**

--- a/include/vrv/instrdef.h
+++ b/include/vrv/instrdef.h
@@ -37,7 +37,7 @@ public:
     virtual ~InstrDef();
     Object *Clone() const override { return new InstrDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "InstrDef"; }
+    std::string GetClassName() const override { return "instrDef"; }
     ///@}
 
     //----------//

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -41,7 +41,7 @@ public:
     virtual ~KeyAccid();
     Object *Clone() const override { return new KeyAccid(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "KeyAccid"; }
+    std::string GetClassName() const override { return "keyAccid"; }
     ///@}
 
     /**

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -60,7 +60,7 @@ public:
     virtual ~KeySig();
     Object *Clone() const override { return new KeySig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "KeySig"; }
+    std::string GetClassName() const override { return "keySig"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/label.h
+++ b/include/vrv/label.h
@@ -31,7 +31,7 @@ public:
     virtual ~Label();
     Object *Clone() const override { return new Label(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Label"; }
+    std::string GetClassName() const override { return "label"; }
     ///@}
 
     /**

--- a/include/vrv/labelabbr.h
+++ b/include/vrv/labelabbr.h
@@ -31,7 +31,7 @@ public:
     virtual ~LabelAbbr();
     Object *Clone() const override { return new LabelAbbr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "LabelAbbr"; }
+    std::string GetClassName() const override { return "labelAbbr"; }
     ///@}
 
     /**

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -47,7 +47,7 @@ public:
     virtual ~Layer();
     Object *Clone() const override { return new Layer(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Layer"; }
+    std::string GetClassName() const override { return "layer"; }
     ///@}
 
     /**

--- a/include/vrv/layerdef.h
+++ b/include/vrv/layerdef.h
@@ -26,7 +26,7 @@ public:
     virtual ~LayerDef();
     Object *Clone() const override { return new LayerDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "LayerDef"; }
+    std::string GetClassName() const override { return "layerDef"; }
     ///@}
 
     /**

--- a/include/vrv/layerelement.h
+++ b/include/vrv/layerelement.h
@@ -57,7 +57,6 @@ public:
     ///@{
     LayerElement();
     LayerElement(ClassId classId);
-    LayerElement(ClassId classId, const std::string &classIdStr);
     virtual ~LayerElement();
     void Reset() override;
     ///@}

--- a/include/vrv/lb.h
+++ b/include/vrv/lb.h
@@ -31,7 +31,7 @@ public:
     virtual ~Lb();
     Object *Clone() const override { return new Lb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Lb"; }
+    std::string GetClassName() const override { return "lb"; }
     ///@}
 
     /**

--- a/include/vrv/lem.h
+++ b/include/vrv/lem.h
@@ -28,7 +28,7 @@ public:
     virtual ~Lem();
     Object *Clone() const override { return new Lem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Lem"; }
+    std::string GetClassName() const override { return "lem"; }
     ///@}
 
 private:

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -36,7 +36,7 @@ public:
     virtual ~Ligature();
     Object *Clone() const override { return new Ligature(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Ligature"; }
+    std::string GetClassName() const override { return "ligature"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -31,7 +31,7 @@ public:
     virtual ~Liquescent();
     Object *Clone() const override { return new Liquescent(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Liquescent"; }
+    std::string GetClassName() const override { return "liquescent"; }
     ///@}
 
     /**

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -30,7 +30,7 @@ public:
     virtual ~Lv();
     Object *Clone() const override { return new Lv(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Lv"; }
+    std::string GetClassName() const override { return "lv"; }
     ///@}
 
     bool CalculatePosition(

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -33,7 +33,7 @@ public:
     virtual ~Mdiv();
     Object *Clone() const override { return new Mdiv(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Mdiv"; }
+    std::string GetClassName() const override { return "mdiv"; }
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -57,7 +57,7 @@ public:
     virtual ~Measure();
     Object *Clone() const override { return new Measure(*this); };
     void Reset() override;
-    std::string GetClassName() const override { return "Measure"; }
+    std::string GetClassName() const override { return "measure"; }
     ///@}
 
     /**

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -42,7 +42,7 @@ public:
     virtual ~Mensur();
     Object *Clone() const override { return new Mensur(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Mensur"; }
+    std::string GetClassName() const override { return "mensur"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -42,7 +42,7 @@ public:
     virtual ~MeterSig();
     Object *Clone() const override { return new MeterSig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MeterSig"; }
+    std::string GetClassName() const override { return "meterSig"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -36,7 +36,7 @@ public:
     virtual ~MeterSigGrp();
     Object *Clone() const override { return new MeterSigGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MeterSigGrp"; }
+    std::string GetClassName() const override { return "meterSigGrp"; }
     ///@}
 
     /**

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -39,7 +39,7 @@ public:
     virtual ~MNum();
     Object *Clone() const override { return new MNum(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MNum"; }
+    std::string GetClassName() const override { return "mNum"; }
     ///@}
 
     /**

--- a/include/vrv/mordent.h
+++ b/include/vrv/mordent.h
@@ -40,7 +40,7 @@ public:
     virtual ~Mordent();
     Object *Clone() const override { return new Mordent(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Mordent"; }
+    std::string GetClassName() const override { return "mordent"; }
     ///@}
 
     /**

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -40,7 +40,7 @@ public:
     virtual ~MRest();
     Object *Clone() const override { return new MRest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MRest"; }
+    std::string GetClassName() const override { return "mRest"; }
     ///@}
 
     /**

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -34,7 +34,7 @@ public:
     virtual ~MRpt();
     Object *Clone() const override { return new MRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MRpt"; }
+    std::string GetClassName() const override { return "mRpt"; }
     ///@}
 
     //----------//

--- a/include/vrv/mrpt2.h
+++ b/include/vrv/mrpt2.h
@@ -34,7 +34,7 @@ public:
     virtual ~MRpt2();
     Object *Clone() const override { return new MRpt2(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MRpt2"; }
+    std::string GetClassName() const override { return "mRpt2"; }
     ///@}
 
     /**

--- a/include/vrv/mspace.h
+++ b/include/vrv/mspace.h
@@ -30,7 +30,7 @@ public:
     virtual ~MSpace();
     Object *Clone() const override { return new MSpace(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MSpace"; }
+    std::string GetClassName() const override { return "mSpace"; }
     ///@}
 
     //----------//

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -40,7 +40,7 @@ public:
     virtual ~MultiRest();
     Object *Clone() const override { return new MultiRest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MultiRest"; }
+    std::string GetClassName() const override { return "multiRest"; }
     ///@}
 
     /**

--- a/include/vrv/multirpt.h
+++ b/include/vrv/multirpt.h
@@ -33,7 +33,7 @@ public:
     virtual ~MultiRpt();
     Object *Clone() const override { return new MultiRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "MultiRpt"; }
+    std::string GetClassName() const override { return "multiRpt"; }
     ///@}
 
     /**

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -49,7 +49,7 @@ public:
     virtual ~Nc();
     Object *Clone() const override { return new Nc(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Nc"; }
+    std::string GetClassName() const override { return "nc"; }
     ///@}
 
     bool IsSupportedChild(ClassId classId) override;

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -68,7 +68,7 @@ public:
     virtual ~Neume();
     void Reset() override;
     Object *Clone() const override { return new Neume(*this); }
-    std::string GetClassName() const override { return "Neume"; }
+    std::string GetClassName() const override { return "neume"; }
     ///@}
 
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -75,7 +75,7 @@ public:
     virtual ~Note();
     Object *Clone() const override { return new Note(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Note"; }
+    std::string GetClassName() const override { return "note"; }
     ///@}
 
     /**

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -32,7 +32,7 @@ public:
     virtual ~Num();
     Object *Clone() const override { return new Num(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Num"; }
+    std::string GetClassName() const override { return "num"; }
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -65,7 +65,6 @@ public:
     ///@{
     Object();
     Object(ClassId classId);
-    Object(ClassId classId, const std::string &classIdStr);
     virtual ~Object();
     ClassId GetClassId() const final { return m_classId; }
     virtual std::string GetClassName() const { return "[MISSING]"; }
@@ -746,9 +745,9 @@ private:
     void GenerateID();
 
     /**
-     * Initialisation method taking the class id and a id prefix argument.
+     * Initialisation method taking the class id argument.
      */
-    void Init(ClassId classId, const std::string &classIdStr);
+    void Init(ClassId classId);
 
     /**
      * Helper methods for functor processing
@@ -789,7 +788,6 @@ private:
      */
     ///@{
     std::string m_id;
-    std::string m_classIdStr;
     ///@}
 
     /**

--- a/include/vrv/octave.h
+++ b/include/vrv/octave.h
@@ -39,7 +39,7 @@ public:
     virtual ~Octave();
     Object *Clone() const override { return new Octave(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Octave"; }
+    std::string GetClassName() const override { return "octave"; }
     ///@}
 
     /**

--- a/include/vrv/orig.h
+++ b/include/vrv/orig.h
@@ -28,7 +28,7 @@ public:
     virtual ~Orig();
     Object *Clone() const override { return new Orig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Orig"; }
+    std::string GetClassName() const override { return "orig"; }
     ///@}
 
 private:

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -31,7 +31,7 @@ public:
     virtual ~Oriscus();
     Object *Clone() const override { return new Oriscus(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Oriscus"; }
+    std::string GetClassName() const override { return "oriscus"; }
     ///@}
 
     /**

--- a/include/vrv/ornam.h
+++ b/include/vrv/ornam.h
@@ -39,7 +39,7 @@ public:
     virtual ~Ornam();
     Object *Clone() const override { return new Ornam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Ornam"; }
+    std::string GetClassName() const override { return "ornam"; }
     ///@}
 
     /**

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -38,7 +38,7 @@ public:
     Page();
     virtual ~Page();
     void Reset() override;
-    std::string GetClassName() const override { return "Page"; }
+    std::string GetClassName() const override { return "page"; }
     ///@}
 
     /**

--- a/include/vrv/pageelement.h
+++ b/include/vrv/pageelement.h
@@ -31,7 +31,6 @@ public:
     ///@{
     PageElement();
     PageElement(ClassId classId);
-    PageElement(ClassId classId, const std::string &classIdStr);
     virtual ~PageElement();
     void Reset() override;
     ///@}

--- a/include/vrv/pagemilestone.h
+++ b/include/vrv/pagemilestone.h
@@ -33,7 +33,7 @@ public:
     PageMilestoneEnd(Object *start);
     virtual ~PageMilestoneEnd();
     void Reset() override;
-    std::string GetClassName() const override { return "PageMilestoneEnd"; }
+    std::string GetClassName() const override { return "pageMilestoneEnd"; }
     ///@}
 
     /**

--- a/include/vrv/pages.h
+++ b/include/vrv/pages.h
@@ -35,7 +35,7 @@ public:
     Pages();
     virtual ~Pages();
     void Reset() override;
-    std::string GetClassName() const override { return "Pages"; }
+    std::string GetClassName() const override { return "pages"; }
     ///@}
 
     /**

--- a/include/vrv/pb.h
+++ b/include/vrv/pb.h
@@ -33,7 +33,7 @@ public:
     virtual ~Pb();
     Object *Clone() const override { return new Pb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Pb"; }
+    std::string GetClassName() const override { return "pb"; }
     ///@}
 
     /**

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -42,7 +42,7 @@ public:
     virtual ~Pedal();
     Object *Clone() const override { return new Pedal(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Pedal"; }
+    std::string GetClassName() const override { return "pedal"; }
     ///@}
 
     /**

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -29,7 +29,7 @@ public:
     PgFoot();
     virtual ~PgFoot();
     void Reset() override;
-    std::string GetClassName() const override { return "PgFoot"; }
+    std::string GetClassName() const override { return "pgFoot"; }
     ///@}
 
     /**

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -29,7 +29,7 @@ public:
     PgHead();
     virtual ~PgHead();
     void Reset() override;
-    std::string GetClassName() const override { return "PgHead"; }
+    std::string GetClassName() const override { return "pgHead"; }
     ///@}
 
     /**

--- a/include/vrv/phrase.h
+++ b/include/vrv/phrase.h
@@ -27,7 +27,7 @@ public:
     virtual ~Phrase();
     Object *Clone() const override { return new Phrase(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Phrase"; }
+    std::string GetClassName() const override { return "phrase"; }
     ///@}
 
     //----------//

--- a/include/vrv/pitchinflection.h
+++ b/include/vrv/pitchinflection.h
@@ -31,7 +31,7 @@ public:
     virtual ~PitchInflection();
     Object *Clone() const override { return new PitchInflection(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "PitchInflection"; }
+    std::string GetClassName() const override { return "pitchInflection"; }
     ///@}
 
     /**

--- a/include/vrv/plica.h
+++ b/include/vrv/plica.h
@@ -28,7 +28,7 @@ public:
     virtual ~Plica();
     Object *Clone() const override { return new Plica(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Plica"; }
+    std::string GetClassName() const override { return "plica"; }
 
     //----------//
     // Functors //

--- a/include/vrv/proport.h
+++ b/include/vrv/proport.h
@@ -31,7 +31,7 @@ public:
     virtual ~Proport();
     Object *Clone() const override { return new Proport(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Proport"; }
+    std::string GetClassName() const override { return "proport"; }
     ///@}
 
     int GetCumulatedNum() const;

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -31,7 +31,7 @@ public:
     virtual ~Quilisma();
     Object *Clone() const override { return new Quilisma(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Quilisma"; }
+    std::string GetClassName() const override { return "quilisma"; }
     ///@}
 
     /**

--- a/include/vrv/rdg.h
+++ b/include/vrv/rdg.h
@@ -28,7 +28,7 @@ public:
     virtual ~Rdg();
     Object *Clone() const override { return new Rdg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Rdg"; }
+    std::string GetClassName() const override { return "rdg"; }
     ///@}
 
 private:

--- a/include/vrv/ref.h
+++ b/include/vrv/ref.h
@@ -31,7 +31,7 @@ public:
     virtual ~Ref();
     Object *Clone() const override { return new Ref(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Ref"; }
+    std::string GetClassName() const override { return "ref"; }
     ///@}
 
     //----------//

--- a/include/vrv/reg.h
+++ b/include/vrv/reg.h
@@ -28,7 +28,7 @@ public:
     virtual ~Reg();
     Object *Clone() const override { return new Reg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Reg"; }
+    std::string GetClassName() const override { return "reg"; }
     ///@}
 
 private:

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -38,7 +38,7 @@ public:
     virtual ~Reh();
     Object *Clone() const override { return new Reh(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Reh"; }
+    std::string GetClassName() const override { return "reh"; }
     ///@}
 
     /**

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -41,7 +41,7 @@ public:
     virtual ~Rend();
     Object *Clone() const override { return new Rend(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Rend"; }
+    std::string GetClassName() const override { return "rend"; }
     ///@}
 
     /**

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -40,7 +40,7 @@ public:
     virtual ~RepeatMark();
     Object *Clone() const override { return new RepeatMark(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "RepeatMark"; }
+    std::string GetClassName() const override { return "repeatMark"; }
     ///@}
 
     /**

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -53,7 +53,7 @@ public:
     virtual ~Rest();
     Object *Clone() const override { return new Rest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Rest"; }
+    std::string GetClassName() const override { return "rest"; }
     ///@}
 
     /**

--- a/include/vrv/restore.h
+++ b/include/vrv/restore.h
@@ -28,7 +28,7 @@ public:
     virtual ~Restore();
     Object *Clone() const override { return new Restore(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Restore"; }
+    std::string GetClassName() const override { return "restore"; }
     ///@}
 
 private:

--- a/include/vrv/runningelement.h
+++ b/include/vrv/runningelement.h
@@ -33,8 +33,7 @@ public:
      */
     ///@{
     // RunningElement();
-    // RunningElement(ClassId classId);
-    RunningElement(ClassId classId, const std::string &classIdStr);
+    RunningElement(ClassId classId);
     virtual ~RunningElement();
     void Reset() override;
     ///@}

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -33,7 +33,7 @@ public:
     virtual ~Sb();
     Object *Clone() const override { return new Sb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Sb"; }
+    std::string GetClassName() const override { return "sb"; }
     ///@}
 
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -38,7 +38,7 @@ public:
     Score();
     virtual ~Score();
     void Reset() override;
-    std::string GetClassName() const override { return "Score"; }
+    std::string GetClassName() const override { return "score"; }
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -47,7 +47,6 @@ public:
     ///@{
     ScoreDefElement();
     ScoreDefElement(ClassId classId);
-    ScoreDefElement(ClassId classId, const std::string &classIdStr);
     virtual ~ScoreDefElement();
     void Reset() override;
     ///@}

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -144,7 +144,7 @@ public:
     virtual ~ScoreDef();
     Object *Clone() const override { return new ScoreDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "ScoreDef"; }
+    std::string GetClassName() const override { return "scoreDef"; }
     ///@}
 
     /**

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -36,7 +36,7 @@ public:
     virtual ~Section();
     Object *Clone() const override { return new Section(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Section"; }
+    std::string GetClassName() const override { return "section"; }
     ///@}
 
     /**

--- a/include/vrv/sic.h
+++ b/include/vrv/sic.h
@@ -28,7 +28,7 @@ public:
     virtual ~Sic();
     Object *Clone() const override { return new Sic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Sic"; }
+    std::string GetClassName() const override { return "sic"; }
     ///@}
 
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -67,7 +67,7 @@ public:
     virtual ~Slur();
     Object *Clone() const override { return new Slur(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Slur"; }
+    std::string GetClassName() const override { return "slur"; }
     ///@}
 
     /**

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -63,7 +63,6 @@ public:
     ///@{
     Slur();
     Slur(ClassId classId);
-    Slur(ClassId classId, const std::string &classIdStr);
     virtual ~Slur();
     Object *Clone() const override { return new Slur(*this); }
     void Reset() override;

--- a/include/vrv/space.h
+++ b/include/vrv/space.h
@@ -31,7 +31,7 @@ public:
     virtual ~Space();
     Object *Clone() const override { return new Space(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Space"; }
+    std::string GetClassName() const override { return "space"; }
     ///@}
 
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -116,7 +116,7 @@ public:
     virtual ~Staff();
     Object *Clone() const override { return new Staff(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Staff"; }
+    std::string GetClassName() const override { return "staff"; }
     ///@}
 
     /**

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -45,7 +45,7 @@ public:
     virtual ~StaffDef();
     Object *Clone() const override { return new StaffDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "StaffDef"; }
+    std::string GetClassName() const override { return "staffDef"; }
     ///@}
 
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -47,7 +47,7 @@ public:
     virtual ~StaffGrp();
     Object *Clone() const override { return new StaffGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "StaffGrp"; }
+    std::string GetClassName() const override { return "staffGrp"; }
     ///@}
 
     /**

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -35,7 +35,7 @@ public:
     virtual ~Stem();
     Object *Clone() const override { return new Stem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Stem"; }
+    std::string GetClassName() const override { return "stem"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -31,7 +31,7 @@ public:
     virtual ~Subst();
     Object *Clone() const override { return new Subst(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Subst"; }
+    std::string GetClassName() const override { return "subst"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/supplied.h
+++ b/include/vrv/supplied.h
@@ -28,7 +28,7 @@ public:
     virtual ~Supplied();
     Object *Clone() const override { return new Supplied(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Supplied"; }
+    std::string GetClassName() const override { return "supplied"; }
     ///@}
 
 private:

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -37,7 +37,7 @@ public:
     virtual ~Surface();
     Object *Clone() const override { return new Surface(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Surface"; }
+    std::string GetClassName() const override { return "surface"; }
     ///@}
     bool IsSupportedChild(ClassId classId) override;
 

--- a/include/vrv/svg.h
+++ b/include/vrv/svg.h
@@ -27,7 +27,7 @@ public:
     Svg();
     virtual ~Svg();
     void Reset() override;
-    std::string GetClassName() const override { return "Svg"; }
+    std::string GetClassName() const override { return "svg"; }
     ///@}
 
     /**

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -44,7 +44,7 @@ public:
     virtual ~Syl();
     Object *Clone() const override { return new Syl(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Syl"; }
+    std::string GetClassName() const override { return "syl"; }
     ///@}
 
     /** Override the method since it is align to the staff */

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -34,7 +34,7 @@ public:
     virtual ~Syllable();
     Object *Clone() const override { return new Syllable(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Syllable"; }
+    std::string GetClassName() const override { return "syllable"; }
     ///@}
 
     /**

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -33,7 +33,7 @@ public:
     virtual ~Symbol();
     Object *Clone() const override { return new Symbol(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Symbol"; }
+    std::string GetClassName() const override { return "symbol"; }
     ///@}
 
     /**

--- a/include/vrv/symboldef.h
+++ b/include/vrv/symboldef.h
@@ -27,7 +27,7 @@ public:
     SymbolDef();
     virtual ~SymbolDef();
     void Reset() override;
-    std::string GetClassName() const override { return "SymbolDef"; }
+    std::string GetClassName() const override { return "symbolDef"; }
     ///@}
 
     /**

--- a/include/vrv/symboltable.h
+++ b/include/vrv/symboltable.h
@@ -27,7 +27,7 @@ public:
     SymbolTable();
     virtual ~SymbolTable();
     void Reset() override;
-    std::string GetClassName() const override { return "SymbolTable"; }
+    std::string GetClassName() const override { return "symbolTable"; }
     ///@}
 
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -43,7 +43,7 @@ public:
     System();
     virtual ~System();
     void Reset() override;
-    std::string GetClassName() const override { return "System"; }
+    std::string GetClassName() const override { return "system"; }
     ///@}
 
     /**

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -31,7 +31,6 @@ public:
     ///@{
     SystemElement();
     SystemElement(ClassId classId);
-    SystemElement(ClassId classId, const std::string &classIdStr);
     virtual ~SystemElement();
     void Reset() override;
     ///@}

--- a/include/vrv/systemmilestone.h
+++ b/include/vrv/systemmilestone.h
@@ -35,7 +35,7 @@ public:
     SystemMilestoneEnd(Object *start);
     virtual ~SystemMilestoneEnd();
     void Reset() override;
-    std::string GetClassName() const override { return "SystemMilestoneEnd"; }
+    std::string GetClassName() const override { return "systemMilestoneEnd"; }
     ///@}
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -37,7 +37,7 @@ public:
     virtual ~TabDurSym();
     Object *Clone() const override { return new TabDurSym(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "TabDurSym"; }
+    std::string GetClassName() const override { return "tabDurSym"; }
     ///@}
 
     /**

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -31,7 +31,7 @@ public:
     virtual ~TabGrp();
     Object *Clone() const override { return new TabGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "TabGrp"; }
+    std::string GetClassName() const override { return "tabGrp"; }
     ///@}
 
     /**

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -41,7 +41,7 @@ public:
     virtual ~Tempo();
     Object *Clone() const override { return new Tempo(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Tempo"; }
+    std::string GetClassName() const override { return "tempo"; }
     ///@}
 
     /**

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -31,7 +31,7 @@ public:
     virtual ~Text();
     Object *Clone() const override { return new Text(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Text"; }
+    std::string GetClassName() const override { return "text"; }
     ///@}
 
     /**

--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -28,7 +28,6 @@ public:
     ///@{
     TextElement();
     TextElement(ClassId classId);
-    TextElement(ClassId classId, const std::string &classIdStr);
     virtual ~TextElement();
     void Reset() override;
     ///@}

--- a/include/vrv/textlayoutelement.h
+++ b/include/vrv/textlayoutelement.h
@@ -28,7 +28,7 @@ public:
      * Reset method resets all attribute classes
      */
     ///@{
-    TextLayoutElement(ClassId classId, const std::string &classIdStr);
+    TextLayoutElement(ClassId classId);
     virtual ~TextLayoutElement();
     void Reset() override;
     ///@}

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -37,7 +37,7 @@ public:
     virtual ~Tie();
     Object *Clone() const override { return new Tie(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Tie"; }
+    std::string GetClassName() const override { return "tie"; }
     ///@}
 
     /**

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -33,7 +33,6 @@ public:
     ///@{
     Tie();
     Tie(ClassId classId);
-    Tie(ClassId classId, const std::string &classIdStr);
     virtual ~Tie();
     Object *Clone() const override { return new Tie(*this); }
     void Reset() override;

--- a/include/vrv/timestamp.h
+++ b/include/vrv/timestamp.h
@@ -26,7 +26,7 @@ public:
     TimestampAttr();
     virtual ~TimestampAttr();
     void Reset() override;
-    std::string GetClassName() const override { return "TimestampAttr"; }
+    std::string GetClassName() const override { return "timestampAttr"; }
     ///@}
 
     /**

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -42,7 +42,7 @@ public:
     virtual ~Trill();
     Object *Clone() const override { return new Trill(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Trill"; }
+    std::string GetClassName() const override { return "trill"; }
     ///@}
 
     /**

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -31,7 +31,7 @@ public:
     virtual ~Tuning();
     Object *Clone() const override { return new Tuning(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Tuning"; }
+    std::string GetClassName() const override { return "tuning"; }
     ///@}
 
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -41,7 +41,7 @@ public:
     virtual ~Tuplet();
     Object *Clone() const override { return new Tuplet(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Tuplet"; }
+    std::string GetClassName() const override { return "tuplet"; }
     ///@}
 
     /**

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -40,7 +40,7 @@ public:
     virtual ~Turn();
     Object *Clone() const override { return new Turn(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Turn"; }
+    std::string GetClassName() const override { return "turn"; }
     ///@}
 
     /**

--- a/include/vrv/unclear.h
+++ b/include/vrv/unclear.h
@@ -28,7 +28,7 @@ public:
     virtual ~Unclear();
     Object *Clone() const override { return new Unclear(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Unclear"; }
+    std::string GetClassName() const override { return "unclear"; }
     ///@}
 
 private:

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -36,7 +36,7 @@ public:
     virtual ~Verse();
     Object *Clone() const override { return new Verse(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Verse"; }
+    std::string GetClassName() const override { return "verse"; }
     ///@}
 
     /**

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -367,6 +367,8 @@ typedef std::vector<CurveSpannedElement *> ArrayOfCurveSpannedElements;
 
 typedef std::list<std::pair<Object *, data_MEASUREBEAT>> ListOfObjectBeatPairs;
 
+typedef std::list<std::pair<Object *, std::string>> ListOfObjectAttNamePairs;
+
 typedef std::list<std::pair<TimePointInterface *, ClassId>> ListOfPointingInterClassIdPairs;
 
 typedef std::list<std::pair<TimeSpanningInterface *, ClassId>> ListOfSpanningInterClassIdPairs;

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -37,7 +37,7 @@ public:
     virtual ~Zone();
     Object *Clone() const override { return new Zone(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "Zone"; }
+    std::string GetClassName() const override { return "zone"; }
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
     int GetLogicalUly() const;

--- a/src/abbr.cpp
+++ b/src/abbr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Abbr> s_factory("abbr", ABBR);
 
-Abbr::Abbr() : EditorialElement(ABBR, "abbr-"), AttSource()
+Abbr::Abbr() : EditorialElement(ABBR), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 static const ClassRegistrar<Accid> s_factory("accid", ACCID);
 
 Accid::Accid()
-    : LayerElement(ACCID, "accid-")
+    : LayerElement(ACCID)
     , PositionInterface()
     , AttAccidental()
     , AttAccidentalGes()

--- a/src/add.cpp
+++ b/src/add.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Add> s_factory("add", ADD);
 
-Add::Add() : EditorialElement(ADD, "add-"), AttSource()
+Add::Add() : EditorialElement(ADD), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/anchoredtext.cpp
+++ b/src/anchoredtext.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<AnchoredText> s_factory("anchoredText", ANCHOREDTEXT);
 
-AnchoredText::AnchoredText() : ControlElement(ANCHOREDTEXT, "anchtxt-"), TextDirInterface()
+AnchoredText::AnchoredText() : ControlElement(ANCHOREDTEXT), TextDirInterface()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
 

--- a/src/annot.cpp
+++ b/src/annot.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Annot> s_factory("annot", ANNOT);
 
-Annot::Annot() : EditorialElement(ANNOT, "annot-"), TextListInterface(), AttPlist(), AttSource()
+Annot::Annot() : EditorialElement(ANNOT), TextListInterface(), AttPlist(), AttSource()
 {
     this->RegisterAttClass(ATT_PLIST);
     this->RegisterAttClass(ATT_SOURCE);

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -25,14 +25,14 @@ namespace vrv {
 
 static const ClassRegistrar<App> s_factory("app", APP);
 
-App::App() : EditorialElement(APP, "app-")
+App::App() : EditorialElement(APP)
 {
     m_level = EDITORIAL_UNDEFINED;
 
     this->Reset();
 }
 
-App::App(EditorialLevel level) : EditorialElement(APP, "app-")
+App::App(EditorialLevel level) : EditorialElement(APP)
 {
     m_level = level;
 

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Arpeg> s_factory("arpeg", ARPEG);
 
-Arpeg::Arpeg() : ControlElement(ARPEG, "arpeg-"), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis()
+Arpeg::Arpeg() : ControlElement(ARPEG), PlistInterface(), TimePointInterface(), AttArpegLog(), AttArpegVis()
 {
     this->RegisterInterface(PlistInterface::GetAttClasses(), PlistInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/artic.cpp
+++ b/src/artic.cpp
@@ -42,7 +42,7 @@ const std::vector<data_ARTICULATION> Artic::s_aboveStaffArtic = { ARTICULATION_d
 static const ClassRegistrar<Artic> s_factory("artic", ARTIC);
 
 Artic::Artic()
-    : LayerElement(ARTIC, "artic-")
+    : LayerElement(ARTIC)
     , AttArticulation()
     , AttArticulationGes()
     , AttColor()

--- a/src/barline.cpp
+++ b/src/barline.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 static const ClassRegistrar<BarLine> s_factory("barLine", BARLINE);
 
 BarLine::BarLine()
-    : LayerElement(BARLINE, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
+    : LayerElement(BARLINE), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BARLINELOG);
     this->RegisterAttClass(ATT_BARLINEVIS);
@@ -45,7 +45,7 @@ BarLine::BarLine()
 }
 
 BarLine::BarLine(ClassId classId)
-    : LayerElement(classId, "bline-"), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
+    : LayerElement(classId), AttBarLineLog(), AttBarLineVis(), AttColor(), AttNNumberLike(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BARLINELOG);
     this->RegisterAttClass(ATT_BARLINEVIS);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -1598,7 +1598,7 @@ void BeamSegment::RequestStaffSpace(const Doc *doc, const BeamDrawingInterface *
 
 static const ClassRegistrar<Beam> s_factory("beam", BEAM);
 
-Beam::Beam() : LayerElement(BEAM, "beam-"), BeamDrawingInterface(), AttBeamedWith(), AttBeamRend(), AttColor(), AttCue()
+Beam::Beam() : LayerElement(BEAM), BeamDrawingInterface(), AttBeamedWith(), AttBeamRend(), AttColor(), AttCue()
 {
     this->RegisterAttClass(ATT_BEAMEDWITH);
     this->RegisterAttClass(ATT_BEAMREND);

--- a/src/beamspan.cpp
+++ b/src/beamspan.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<BeamSpan> s_factory("beamSpan", BEAMSPAN);
 
 BeamSpan::BeamSpan()
-    : ControlElement(BEAMSPAN, "beamspan-")
+    : ControlElement(BEAMSPAN)
     , BeamDrawingInterface()
     , PlistInterface()
     , TimeSpanningInterface()

--- a/src/beatrpt.cpp
+++ b/src/beatrpt.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<BeatRpt> s_factory("beatRpt", BEATRPT);
 
-BeatRpt::BeatRpt() : LayerElement(BEATRPT, "beatrpt-"), AttColor(), AttBeatRptLog(), AttBeatRptVis()
+BeatRpt::BeatRpt() : LayerElement(BEATRPT), AttColor(), AttBeatRptLog(), AttBeatRptVis()
 {
     this->RegisterAttClass(ATT_BEATRPTLOG);
     this->RegisterAttClass(ATT_BEATRPTVIS);

--- a/src/bracketspan.cpp
+++ b/src/bracketspan.cpp
@@ -28,11 +28,7 @@ namespace vrv {
 static const ClassRegistrar<BracketSpan> s_factory("bracketSpan", BRACKETSPAN);
 
 BracketSpan::BracketSpan()
-    : ControlElement(BRACKETSPAN, "bspan-")
-    , TimeSpanningInterface()
-    , AttBracketSpanLog()
-    , AttLineRend()
-    , AttLineRendBase()
+    : ControlElement(BRACKETSPAN), TimeSpanningInterface(), AttBracketSpanLog(), AttLineRend(), AttLineRendBase()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_BRACKETSPANLOG);

--- a/src/breath.cpp
+++ b/src/breath.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Breath> s_factory("breath", BREATH);
 
-Breath::Breath() : ControlElement(BREATH, "breath-"), TimePointInterface(), AttPlacementRelStaff()
+Breath::Breath() : ControlElement(BREATH), TimePointInterface(), AttPlacementRelStaff()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);

--- a/src/btrem.cpp
+++ b/src/btrem.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 
 static const ClassRegistrar<BTrem> s_factory("btrem", BTREM);
 
-BTrem::BTrem() : LayerElement(BTREM, "btrem-"), AttNumbered(), AttNumberPlacement(), AttTremForm(), AttTremMeasured()
+BTrem::BTrem() : LayerElement(BTREM), AttNumbered(), AttNumberPlacement(), AttTremForm(), AttTremMeasured()
 {
     this->RegisterAttClass(ATT_NUMBERED);
     this->RegisterAttClass(ATT_NUMBERPLACEMENT);

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -27,11 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
 
 Caesura::Caesura()
-    : ControlElement(CAESURA, "caesura-")
-    , TimePointInterface()
-    , AttExtSymAuth()
-    , AttExtSymNames()
-    , AttPlacementRelStaff()
+    : ControlElement(CAESURA), TimePointInterface(), AttExtSymAuth(), AttExtSymNames(), AttPlacementRelStaff()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_EXTSYMAUTH);

--- a/src/choice.cpp
+++ b/src/choice.cpp
@@ -30,14 +30,14 @@ namespace vrv {
 
 static const ClassRegistrar<Choice> s_factory("choice", CHOICE);
 
-Choice::Choice() : EditorialElement(CHOICE, "choice-")
+Choice::Choice() : EditorialElement(CHOICE)
 {
     m_level = EDITORIAL_UNDEFINED;
 
     this->Reset();
 }
 
-Choice::Choice(EditorialLevel level) : EditorialElement(CHOICE, "choice-")
+Choice::Choice(EditorialLevel level) : EditorialElement(CHOICE)
 {
     m_level = level;
 

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -66,7 +66,7 @@ template <typename Iterator> std::set<int> CalculateDotLocations(Iterator begin,
 static const ClassRegistrar<Chord> s_factory("chord", CHORD);
 
 Chord::Chord()
-    : LayerElement(CHORD, "chord-")
+    : LayerElement(CHORD)
     , ObjectListInterface()
     , DrawingListInterface()
     , StemmedDrawingInterface()

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 static const ClassRegistrar<Clef> s_factory("clef", CLEF);
 
 Clef::Clef()
-    : LayerElement(CLEF, "clef-")
+    : LayerElement(CLEF)
     , AttClefLog()
     , AttClefShape()
     , AttColor()

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -28,12 +28,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 ControlElement::ControlElement()
-    : FloatingObject(CONTROL_ELEMENT, "ce")
-    , AltSymInterface()
-    , LinkingInterface()
-    , AttColor()
-    , AttLabelled()
-    , AttTyped()
+    : FloatingObject(CONTROL_ELEMENT), AltSymInterface(), LinkingInterface(), AttColor(), AttLabelled(), AttTyped()
 {
     this->RegisterInterface(AltSymInterface::GetAttClasses(), AltSymInterface::IsInterface());
     this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
@@ -45,19 +40,7 @@ ControlElement::ControlElement()
 }
 
 ControlElement::ControlElement(ClassId classId)
-    : FloatingObject(classId, "ce"), AltSymInterface(), LinkingInterface(), AttLabelled(), AttTyped()
-{
-    this->RegisterInterface(AltSymInterface::GetAttClasses(), AltSymInterface::IsInterface());
-    this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
-    this->RegisterAttClass(ATT_COLOR);
-    this->RegisterAttClass(ATT_LABELLED);
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-ControlElement::ControlElement(ClassId classId, const std::string &classIdStr)
-    : FloatingObject(classId, classIdStr), AltSymInterface(), LinkingInterface(), AttLabelled(), AttTyped()
+    : FloatingObject(classId), AltSymInterface(), LinkingInterface(), AttLabelled(), AttTyped()
 {
     this->RegisterInterface(AltSymInterface::GetAttClasses(), AltSymInterface::IsInterface());
     this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());

--- a/src/corr.cpp
+++ b/src/corr.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Corr> s_factory("corr", CORR);
 
-Corr::Corr() : EditorialElement(CORR, "corr-"), AttSource()
+Corr::Corr() : EditorialElement(CORR), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/course.cpp
+++ b/src/course.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Course> s_factory("course", COURSE);
 
-Course::Course() : Object(COURSE, "course-"), AttAccidental(), AttNNumberLike(), AttOctave(), AttPitch()
+Course::Course() : Object(COURSE), AttAccidental(), AttNNumberLike(), AttOctave(), AttPitch()
 {
     this->RegisterAttClass(ATT_ACCIDENTAL);
     this->RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/cpmark.cpp
+++ b/src/cpmark.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<CpMark> s_factory("cpMark", CPMARK);
 
-CpMark::CpMark() : ControlElement(CPMARK, "cpmark-"), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
+CpMark::CpMark() : ControlElement(CPMARK), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -26,12 +26,7 @@ namespace vrv {
 static const ClassRegistrar<Custos> s_factory("custos", CUSTOS);
 
 Custos::Custos()
-    : LayerElement(CUSTOS, "custos-")
-    , PitchInterface()
-    , PositionInterface()
-    , AttColor()
-    , AttExtSymAuth()
-    , AttExtSymNames()
+    : LayerElement(CUSTOS), PitchInterface(), PositionInterface(), AttColor(), AttExtSymAuth(), AttExtSymNames()
 {
     this->RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Damage> s_factory("damage", DAMAGE);
 
-Damage::Damage() : EditorialElement(DAMAGE, "damage-"), AttSource()
+Damage::Damage() : EditorialElement(DAMAGE), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/del.cpp
+++ b/src/del.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Del> s_factory("del", DEL);
 
-Del::Del() : EditorialElement(DEL, "del-"), AttSource()
+Del::Del() : EditorialElement(DEL), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/dir.cpp
+++ b/src/dir.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<Dir> s_factory("dir", DIR);
 
 Dir::Dir()
-    : ControlElement(DIR, "dir-")
+    : ControlElement(DIR)
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/div.cpp
+++ b/src/div.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Div> s_factory("div", DIV);
 
-Div::Div() : TextLayoutElement(DIV, "div-")
+Div::Div() : TextLayoutElement(DIV)
 {
     this->Reset();
 }

--- a/src/divline.cpp
+++ b/src/divline.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 DivLine::DivLine()
-    : LayerElement(DIVLINE, "dline-")
+    : LayerElement(DIVLINE)
     , AttColor()
     , AttDivLineLog()
     , AttExtSymAuth()

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -86,7 +86,7 @@ namespace vrv {
 // Doc
 //----------------------------------------------------------------------------
 
-Doc::Doc() : Object(DOC, "doc-")
+Doc::Doc() : Object(DOC)
 {
     m_options = new Options();
 

--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Dot> s_factory("dot", DOT);
 
-Dot::Dot() : LayerElement(DOT, "dot-"), PositionInterface(), AttColor(), AttDotLog()
+Dot::Dot() : LayerElement(DOT), PositionInterface(), AttColor(), AttDotLog()
 {
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     this->RegisterAttClass(ATT_COLOR);

--- a/src/dynam.cpp
+++ b/src/dynam.cpp
@@ -36,7 +36,7 @@ const std::u32string dynamSmufl[] = { U"\uE520", U"\uE521", U"\uE522", U"\uE523"
 static const ClassRegistrar<Dynam> s_factory("dynam", DYNAM);
 
 Dynam::Dynam()
-    : ControlElement(DYNAM, "dynam-")
+    : ControlElement(DYNAM)
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -34,8 +34,7 @@ namespace vrv {
 // EditorialElement
 //----------------------------------------------------------------------------
 
-EditorialElement::EditorialElement()
-    : Object(EDITORIAL_ELEMENT, "ee-"), SystemMilestoneInterface(), AttLabelled(), AttTyped()
+EditorialElement::EditorialElement() : Object(EDITORIAL_ELEMENT), SystemMilestoneInterface(), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);
@@ -44,16 +43,7 @@ EditorialElement::EditorialElement()
 }
 
 EditorialElement::EditorialElement(ClassId classId)
-    : Object(classId, "ee-"), SystemMilestoneInterface(), AttLabelled(), AttTyped()
-{
-    this->RegisterAttClass(ATT_LABELLED);
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-EditorialElement::EditorialElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), SystemMilestoneInterface(), AttLabelled(), AttTyped()
+    : Object(classId), SystemMilestoneInterface(), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);

--- a/src/elementpart.cpp
+++ b/src/elementpart.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 // Dots
 //----------------------------------------------------------------------------
 
-Dots::Dots() : LayerElement(DOTS, "dots-"), AttAugmentDots()
+Dots::Dots() : LayerElement(DOTS), AttAugmentDots()
 {
     this->RegisterAttClass(ATT_AUGMENTDOTS);
 
@@ -66,7 +66,7 @@ std::set<int> &Dots::ModifyDotLocsForStaff(const Staff *staff)
 // Flag
 //----------------------------------------------------------------------------
 
-Flag::Flag() : LayerElement(FLAG, "flag-")
+Flag::Flag() : LayerElement(FLAG)
 {
 
     this->Reset();
@@ -129,7 +129,7 @@ Point Flag::GetStemDownNW(const Doc *doc, int staffSize, bool graceSize) const
 // TupletBracket
 //----------------------------------------------------------------------------
 
-TupletBracket::TupletBracket() : LayerElement(TUPLET_BRACKET, "bracket-"), AttTupletVis()
+TupletBracket::TupletBracket() : LayerElement(TUPLET_BRACKET), AttTupletVis()
 {
     this->RegisterAttClass(ATT_TUPLETVIS);
 
@@ -206,7 +206,7 @@ int TupletBracket::GetDrawingYRight() const
 // TupletNum
 //----------------------------------------------------------------------------
 
-TupletNum::TupletNum() : LayerElement(TUPLET_NUM, "num-"), AttNumberPlacement(), AttTupletVis()
+TupletNum::TupletNum() : LayerElement(TUPLET_NUM), AttNumberPlacement(), AttTupletVis()
 {
     this->RegisterAttClass(ATT_NUMBERPLACEMENT);
     this->RegisterAttClass(ATT_TUPLETVIS);

--- a/src/ending.cpp
+++ b/src/ending.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<Ending> s_factory("ending", ENDING);
 
 Ending::Ending()
-    : SystemElement(ENDING, "ending-")
+    : SystemElement(ENDING)
     , SystemMilestoneInterface()
     , AttLabelled()
     , AttLineRend()

--- a/src/expan.cpp
+++ b/src/expan.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Expan> s_factory("expan", EXPAN);
 
-Expan::Expan() : EditorialElement(EXPAN, "expan-"), AttSource()
+Expan::Expan() : EditorialElement(EXPAN), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Expansion> s_factory("expansion", EXPANSION);
 
-Expansion::Expansion() : SystemElement(EXPANSION, "expansion-"), PlistInterface()
+Expansion::Expansion() : SystemElement(EXPANSION), PlistInterface()
 {
     this->RegisterInterface(PlistInterface::GetAttClasses(), PlistInterface::IsInterface());
 

--- a/src/f.cpp
+++ b/src/f.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<F> s_factory("f", FIGURE);
 
-F::F() : TextElement(FIGURE, "f-"), TimeSpanningInterface(), AttExtender()
+F::F() : TextElement(FIGURE), TimeSpanningInterface(), AttExtender()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_EXTENDER);

--- a/src/facsimile.cpp
+++ b/src/facsimile.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<Facsimile> s_factory("facsimile", FACSIMILE);
 
-Facsimile::Facsimile() : Object(FACSIMILE, "facsimile-"), AttTyped() {}
+Facsimile::Facsimile() : Object(FACSIMILE), AttTyped() {}
 
 Facsimile::~Facsimile() {}
 

--- a/src/fb.cpp
+++ b/src/fb.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fb> s_factory("fb", FB);
 
-Fb::Fb() : Object(FB, "fb-")
+Fb::Fb() : Object(FB)
 {
 
     this->Reset();

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Fermata> s_factory("fermata", FERMATA);
 
 Fermata::Fermata()
-    : ControlElement(FERMATA, "fermata-")
+    : ControlElement(FERMATA)
     , TimePointInterface()
     , AttExtSymAuth()
     , AttExtSymNames()

--- a/src/fig.cpp
+++ b/src/fig.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fig> s_factory("fig", FIG);
 
-Fig::Fig() : TextElement(FIG, "fig-"), AreaPosInterface()
+Fig::Fig() : TextElement(FIG), AreaPosInterface()
 {
     this->RegisterInterface(AreaPosInterface::GetAttClasses(), AreaPosInterface::IsInterface());
 

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Fing> s_factory("fing", FING);
 
-Fing::Fing() : ControlElement(FING, "fing-"), TimePointInterface(), TextDirInterface(), AttNNumberLike()
+Fing::Fing() : ControlElement(FING), TimePointInterface(), TextDirInterface(), AttNNumberLike()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -56,17 +56,12 @@ thread_local std::vector<void *> FloatingObject::s_drawingObjectIds;
 // FloatingObject
 //----------------------------------------------------------------------------
 
-FloatingObject::FloatingObject() : Object(FLOATING_OBJECT, "fe")
+FloatingObject::FloatingObject() : Object(FLOATING_OBJECT)
 {
     this->Reset();
 }
 
-FloatingObject::FloatingObject(ClassId classId) : Object(classId, "fe")
-{
-    this->Reset();
-}
-
-FloatingObject::FloatingObject(ClassId classId, const std::string &classIdStr) : Object(classId, classIdStr)
+FloatingObject::FloatingObject(ClassId classId) : Object(classId)
 {
     this->Reset();
 }

--- a/src/ftrem.cpp
+++ b/src/ftrem.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<FTrem> s_factory("fTrem", FTREM);
 
-FTrem::FTrem() : LayerElement(FTREM, "ftrem-"), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
+FTrem::FTrem() : LayerElement(FTREM), BeamDrawingInterface(), AttFTremVis(), AttTremMeasured()
 {
     this->RegisterAttClass(ATT_FTREMVIS);
     this->RegisterAttClass(ATT_TREMMEASURED);

--- a/src/genericlayerelement.cpp
+++ b/src/genericlayerelement.cpp
@@ -24,14 +24,14 @@ namespace vrv {
 
 // static const ClassRegistrar<GenericLayerElement> s_factory("generic", GENERIC_ELEMENT);
 
-GenericLayerElement::GenericLayerElement() : LayerElement(GENERIC_ELEMENT, "generic-")
+GenericLayerElement::GenericLayerElement() : LayerElement(GENERIC_ELEMENT)
 {
     LogError("Creating generic element without name");
     m_className = "[unspecified]";
     this->Reset();
 }
 
-GenericLayerElement::GenericLayerElement(const std::string &name) : LayerElement(GENERIC_ELEMENT, name + "-")
+GenericLayerElement::GenericLayerElement(const std::string &name) : LayerElement(GENERIC_ELEMENT)
 {
     m_meiName = name;
     m_className = name;

--- a/src/gliss.cpp
+++ b/src/gliss.cpp
@@ -26,8 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Gliss> s_factory("gliss", GLISS);
 
-Gliss::Gliss()
-    : ControlElement(GLISS, "gliss-"), TimeSpanningInterface(), AttLineRend(), AttLineRendBase(), AttNNumberLike()
+Gliss::Gliss() : ControlElement(GLISS), TimeSpanningInterface(), AttLineRend(), AttLineRendBase(), AttNNumberLike()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_LINEREND);

--- a/src/gracegrp.cpp
+++ b/src/gracegrp.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<GraceGrp> s_factory("graceGrp", GRACEGRP);
 
-GraceGrp::GraceGrp() : LayerElement(GRACEGRP, "gracegrp-"), AttColor(), AttGraced(), AttGraceGrpLog()
+GraceGrp::GraceGrp() : LayerElement(GRACEGRP), AttColor(), AttGraced(), AttGraceGrpLog()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_GRACED);

--- a/src/graphic.cpp
+++ b/src/graphic.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Graphic> s_factory("graphic", GRAPHIC);
 
-Graphic::Graphic() : Object(GRAPHIC, "graphic-"), AttPointing(), AttWidth(), AttHeight(), AttTyped()
+Graphic::Graphic() : Object(GRAPHIC), AttPointing(), AttWidth(), AttHeight(), AttTyped()
 {
     this->RegisterAttClass(ATT_POINTING);
     this->RegisterAttClass(ATT_WIDTH);

--- a/src/grpsym.cpp
+++ b/src/grpsym.cpp
@@ -26,8 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<GrpSym> s_factory("grpSym", GRPSYM);
 
-GrpSym::GrpSym()
-    : Object(GRPSYM, "grpsym-"), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
+GrpSym::GrpSym() : Object(GRPSYM), AttColor(), AttGrpSymLog(), AttStaffGroupingSym(), AttStartId(), AttStartEndId()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_GRPSYMLOG);

--- a/src/hairpin.cpp
+++ b/src/hairpin.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<Hairpin> s_factory("hairpin", HAIRPIN);
 
 Hairpin::Hairpin()
-    : ControlElement(HAIRPIN, "hairpin-")
+    : ControlElement(HAIRPIN)
     , TimeSpanningInterface()
     , AttHairpinLog()
     , AttHairpinVis()

--- a/src/halfmrpt.cpp
+++ b/src/halfmrpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<HalfmRpt> s_factory("halfmRpt", HALFMRPT);
 
-HalfmRpt::HalfmRpt() : LayerElement(HALFMRPT, "mrpt-")
+HalfmRpt::HalfmRpt() : LayerElement(HALFMRPT)
 {
     this->RegisterAttClass(ATT_COLOR);
 

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -33,7 +33,7 @@ namespace vrv {
 static const ClassRegistrar<Harm> s_factory("harm", HARM);
 
 Harm::Harm()
-    : ControlElement(HARM, "harm-")
+    : ControlElement(HARM)
     , TextListInterface()
     , TextDirInterface()
     , TimeSpanningInterface()

--- a/src/instrdef.cpp
+++ b/src/instrdef.cpp
@@ -25,8 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<InstrDef> s_factory("instrDef", INSTRDEF);
 
-InstrDef::InstrDef()
-    : Object(INSTRDEF, "instrdef-"), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
+InstrDef::InstrDef() : Object(INSTRDEF), AttChannelized(), AttLabelled(), AttMidiInstrument(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_CHANNELIZED);
     this->RegisterAttClass(ATT_LABELLED);

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -15470,7 +15470,7 @@ void HumdrumInput::addExplicitStemDirection(FTrem *ftrem, hum::HTp start)
     // also deal with chords later
     for (int i = 0; i < count; ++i) {
         Object *obj = ftrem->GetChild(i);
-        if (obj->GetClassName() == "Note") {
+        if (obj->GetClassName() == "note") {
             if (direction > 0) {
                 ((Note *)obj)->SetStemDir(STEMDIRECTION_up);
                 if (m_humtype && showplace) {
@@ -18115,7 +18115,7 @@ void HumdrumInput::processLinkedDirection(int index, hum::HTp token, int staffin
                 int count = tempo->GetChildCount();
                 for (int j = 0; j < count; j++) {
                     Object *obj = tempo->GetChild(j);
-                    if (obj->GetClassName() != "Rend") {
+                    if (obj->GetClassName() != "rend") {
                         continue;
                     }
                     Rend *item = (Rend *)obj;
@@ -20642,7 +20642,7 @@ void HumdrumInput::addTextElement(
         hre.replaceDestructive(data, "", "</i>", "g");
     }
 
-    if (element->GetClassName() == "Syl") {
+    if (element->GetClassName() == "syl") {
         // Approximate centering of single-letter text on noteheads.
         // currently the text is left justified to before the left edge of the notehead.
         hum::HumRegex hre;
@@ -28116,7 +28116,7 @@ template <class ELEMENT> hum::HumNum HumdrumInput::convertRhythm(ELEMENT element
                 int staffindex = staff - 1;
                 std::vector<humaux::StaffStateVariables> &ss = m_staffstates;
                 if (ss[staffindex].righthalfstem
-                    && ((element->GetClassName() == "Note") || (element->GetClassName() == "Chord"))) {
+                    && ((element->GetClassName() == "note") || (element->GetClassName() == "chord"))) {
                     m_setrightstem = true;
                 }
             } break;

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -184,7 +184,7 @@ bool MEIOutput::Export()
 {
 
     if (m_removeIds) {
-        FindAllReferencedObjectsFunctor findAllReferencedObjects(&m_referredObjects);
+        FindAllReferencedObjectsFunctor findAllReferencedObjects(&m_referredObjects, NULL);
         // When saving page-based MEI we also want to keep IDs for milestone elements
         findAllReferencedObjects.IncludeMilestoneReferences(this->IsPageBasedMEI());
         m_doc->Process(findAllReferencedObjects);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1650,9 +1650,7 @@ void MEIOutput::WritePageMilestoneEnd(pugi::xml_node currentNode, PageMilestoneE
 
     this->WritePageElement(currentNode, milestoneEnd);
     currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
-    std::string meiElementName = milestoneEnd->GetStart()->GetClassName();
-    std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
-    currentNode.append_attribute("type") = meiElementName.c_str();
+    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().c_str();
 }
 
 void MEIOutput::WriteSystem(pugi::xml_node currentNode, System *system)
@@ -1686,9 +1684,7 @@ void MEIOutput::WriteSystemMilestoneEnd(pugi::xml_node currentNode, SystemMilest
 
     this->WriteSystemElement(currentNode, milestoneEnd);
     currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
-    std::string meiElementName = milestoneEnd->GetStart()->GetClassName();
-    std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
-    currentNode.append_attribute("type") = meiElementName.c_str();
+    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().c_str();
 }
 
 void MEIOutput::WriteSection(pugi::xml_node currentNode, Section *section)
@@ -5161,10 +5157,8 @@ bool MEIInput::ReadRunningChildren(Object *parent, pugi::xml_node parentNode, Ob
         this->NormalizeAttributes(xmlElement);
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
-            std::string meiElementName = filter->GetClassName();
-            std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                meiElementName.c_str());
+                filter->GetClassName().c_str());
             continue;
         }
         // editorial
@@ -6234,10 +6228,8 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         elementName = std::string(xmlElement.name());
         // LogDebug("ReadLayerChildren: element <%s>", xmlElement.name());
         if (!this->IsAllowed(elementName, filter)) {
-            std::string meiElementName = filter->GetClassName();
-            std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                meiElementName.c_str());
+                filter->GetClassName().c_str());
             continue;
         }
         // editorial
@@ -7217,10 +7209,8 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         this->NormalizeAttributes(xmlElement);
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
-            std::string meiElementName = filter->GetClassName();
-            std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                meiElementName.c_str());
+                filter->GetClassName().c_str());
             continue;
         }
         // editorial
@@ -7280,10 +7270,8 @@ bool MEIInput::ReadSymbolDefChildren(Object *parent, pugi::xml_node parentNode, 
         this->NormalizeAttributes(xmlElement);
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
-            std::string meiElementName = filter->GetClassName();
-            std::transform(meiElementName.begin(), meiElementName.begin() + 1, meiElementName.begin(), ::tolower);
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                meiElementName.c_str());
+                filter->GetClassName().c_str());
             continue;
         }
         // content

--- a/src/keyaccid.cpp
+++ b/src/keyaccid.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<KeyAccid> s_factory("keyAccid", KEYACCID);
 
 KeyAccid::KeyAccid()
-    : LayerElement(KEYACCID, "keyaccid-")
+    : LayerElement(KEYACCID)
     , PitchInterface()
     , PositionInterface()
     , AttAccidental()

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -72,7 +72,7 @@ const int KeySig::octave_map[2][9][7] = {
 static const ClassRegistrar<KeySig> s_factory("keySig", KEYSIG);
 
 KeySig::KeySig()
-    : LayerElement(KEYSIG, "keysig-")
+    : LayerElement(KEYSIG)
     , ObjectListInterface()
     , AttAccidental()
     , AttColor()

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Label> s_factory("label", LABEL);
 
-Label::Label() : Object(LABEL, "label-"), TextListInterface()
+Label::Label() : Object(LABEL), TextListInterface()
 {
     this->Reset();
 }

--- a/src/labelabbr.cpp
+++ b/src/labelabbr.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<LabelAbbr> s_factory("labelAbbr", LABELABBR);
 
-LabelAbbr::LabelAbbr() : Object(LABELABBR, "labelAbbr-"), TextListInterface()
+LabelAbbr::LabelAbbr() : Object(LABELABBR), TextListInterface()
 {
     this->Reset();
 }

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -46,13 +46,7 @@ namespace vrv {
 static const ClassRegistrar<Layer> s_factory("layer", LAYER);
 
 Layer::Layer()
-    : Object(LAYER, "layer-")
-    , DrawingListInterface()
-    , ObjectListInterface()
-    , AttCue()
-    , AttNInteger()
-    , AttTyped()
-    , AttVisibility()
+    : Object(LAYER), DrawingListInterface(), ObjectListInterface(), AttCue(), AttNInteger(), AttTyped(), AttVisibility()
 {
     this->RegisterAttClass(ATT_CUE);
     this->RegisterAttClass(ATT_NINTEGER);

--- a/src/layerdef.cpp
+++ b/src/layerdef.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<LayerDef> s_factory("layerDef", LAYERDEF);
 
-LayerDef::LayerDef() : Object(LAYERDEF, "layerdef-"), AttLabelled(), AttNInteger(), AttTyped()
+LayerDef::LayerDef() : Object(LAYERDEF), AttLabelled(), AttNInteger(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NINTEGER);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -86,7 +86,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 LayerElement::LayerElement()
-    : Object(LAYER_ELEMENT, "le-"), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
+    : Object(LAYER_ELEMENT), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
 {
     this->RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
@@ -98,19 +98,7 @@ LayerElement::LayerElement()
 }
 
 LayerElement::LayerElement(ClassId classId)
-    : Object(classId, "le-"), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
-{
-    this->RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
-    this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());
-    this->RegisterAttClass(ATT_COORDX1);
-    this->RegisterAttClass(ATT_LABELLED);
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-LayerElement::LayerElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
+    : Object(classId), FacsimileInterface(), LinkingInterface(), AttCoordX1(), AttLabelled(), AttTyped()
 {
     this->RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());
     this->RegisterInterface(LinkingInterface::GetAttClasses(), LinkingInterface::IsInterface());

--- a/src/lb.cpp
+++ b/src/lb.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lb> s_factory("lb", LB);
 
-Lb::Lb() : TextElement(LB, "lb-")
+Lb::Lb() : TextElement(LB)
 {
     this->Reset();
 }

--- a/src/lem.cpp
+++ b/src/lem.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lem> s_factory("lem", LEM);
 
-Lem::Lem() : EditorialElement(LEM, "lem-"), AttSource()
+Lem::Lem() : EditorialElement(LEM), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/ligature.cpp
+++ b/src/ligature.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<Ligature> s_factory("ligature", LIGATURE);
 
-Ligature::Ligature() : LayerElement(LIGATURE, "ligature-"), ObjectListInterface(), AttLigatureVis()
+Ligature::Ligature() : LayerElement(LIGATURE), ObjectListInterface(), AttLigatureVis()
 {
     this->RegisterAttClass(ATT_LIGATUREVIS);
 

--- a/src/liquescent.cpp
+++ b/src/liquescent.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Liquescent
 //----------------------------------------------------------------------------
 
-Liquescent::Liquescent() : LayerElement(LIQUESCENT, "liquescent-"), PitchInterface(), PositionInterface(), AttColor()
+Liquescent::Liquescent() : LayerElement(LIQUESCENT), PitchInterface(), PositionInterface(), AttColor()
 {
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());

--- a/src/lv.cpp
+++ b/src/lv.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Lv> s_factory("lv", LV);
 
-Lv::Lv() : Tie(LV, "lv-")
+Lv::Lv() : Tie(LV)
 {
     this->Reset();
 }

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 
 static const ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
 
-Mdiv::Mdiv() : PageElement(MDIV, "mdiv-"), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
+Mdiv::Mdiv() : PageElement(MDIV), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -55,7 +55,7 @@ namespace vrv {
 static const ClassRegistrar<Measure> s_factory("measure", MEASURE);
 
 Measure::Measure(MeasureType measureMusic, int logMeasureNb)
-    : Object(MEASURE, "measure-")
+    : Object(MEASURE)
     , FacsimileInterface()
     , AttBarring()
     , AttCoordX1()

--- a/src/mensur.cpp
+++ b/src/mensur.cpp
@@ -30,7 +30,7 @@ const int Mensur::s_numBase = 2;
 static const ClassRegistrar<Mensur> s_factory("mensur", MENSUR);
 
 Mensur::Mensur()
-    : LayerElement(MENSUR, "mensur-")
+    : LayerElement(MENSUR)
     , AttColor()
     , AttCue()
     , AttDurationRatio()

--- a/src/metersig.cpp
+++ b/src/metersig.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<MeterSig> s_factory("meterSig", METERSIG);
 
 MeterSig::MeterSig()
-    : LayerElement(METERSIG, "msig-")
+    : LayerElement(METERSIG)
     , AttColor()
     , AttEnclosingChars()
     , AttExtSymNames()

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -24,8 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<MeterSigGrp> s_factory("meterSigGrp", METERSIGGRP);
 
-MeterSigGrp::MeterSigGrp()
-    : LayerElement(METERSIGGRP, "metersiggrp-"), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog()
+MeterSigGrp::MeterSigGrp() : LayerElement(METERSIGGRP), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog()
 {
     this->RegisterAttClass(ATT_BASIC);
     this->RegisterAttClass(ATT_METERSIGGRPLOG);

--- a/src/mnum.cpp
+++ b/src/mnum.cpp
@@ -26,12 +26,7 @@ namespace vrv {
 //----------------------------------------------------------------------------
 
 MNum::MNum()
-    : ControlElement(MNUM, "mnum-")
-    , TextListInterface()
-    , TextDirInterface()
-    , TimePointInterface()
-    , AttLang()
-    , AttTypography()
+    : ControlElement(MNUM), TextListInterface(), TextDirInterface(), TimePointInterface(), AttLang(), AttTypography()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/mordent.cpp
+++ b/src/mordent.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Mordent> s_factory("mordent", MORDENT);
 
 Mordent::Mordent()
-    : ControlElement(MORDENT, "mordent-")
+    : ControlElement(MORDENT)
     , TimePointInterface()
     , AttExtSymAuth()
     , AttExtSymNames()

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -29,8 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<MRest> s_factory("mRest", MREST);
 
-MRest::MRest()
-    : LayerElement(MREST, "mrest-"), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
+MRest::MRest() : LayerElement(MREST), PositionInterface(), AttColor(), AttCue(), AttFermataPresent(), AttVisibility()
 {
     this->RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());
     this->RegisterAttClass(ATT_COLOR);

--- a/src/mrpt.cpp
+++ b/src/mrpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MRpt> s_factory("mRpt", MRPT);
 
-MRpt::MRpt() : LayerElement(MRPT, "mrpt-"), AttColor(), AttNumbered(), AttNumberPlacement()
+MRpt::MRpt() : LayerElement(MRPT), AttColor(), AttNumbered(), AttNumberPlacement()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_NUMBERED);

--- a/src/mrpt2.cpp
+++ b/src/mrpt2.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MRpt2> s_factory("mRpt2", MRPT2);
 
-MRpt2::MRpt2() : LayerElement(MRPT2, "mrpt2-"), AttColor()
+MRpt2::MRpt2() : LayerElement(MRPT2), AttColor()
 {
     this->RegisterAttClass(ATT_COLOR);
 

--- a/src/mspace.cpp
+++ b/src/mspace.cpp
@@ -22,7 +22,7 @@ namespace vrv {
 
 static const ClassRegistrar<MSpace> s_factory("mSpace", MSPACE);
 
-MSpace::MSpace() : LayerElement(MSPACE, "mSpace-")
+MSpace::MSpace() : LayerElement(MSPACE)
 {
     this->Reset();
 }

--- a/src/multirest.cpp
+++ b/src/multirest.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 static const ClassRegistrar<MultiRest> s_factory("multiRest", MULTIREST);
 
 MultiRest::MultiRest()
-    : LayerElement(MULTIREST, "multirest-")
+    : LayerElement(MULTIREST)
     , PositionInterface()
     , AttColor()
     , AttMultiRestVis()

--- a/src/multirpt.cpp
+++ b/src/multirpt.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 
 static const ClassRegistrar<MultiRpt> s_factory("multiRpt", MULTIRPT);
 
-MultiRpt::MultiRpt() : LayerElement(MULTIRPT, "multirpt-"), AttNumbered()
+MultiRpt::MultiRpt() : LayerElement(MULTIRPT), AttNumbered()
 {
     this->RegisterAttClass(ATT_NUMBERED);
     this->Reset();

--- a/src/nc.cpp
+++ b/src/nc.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<Nc> s_factory("nc", NC);
 
 Nc::Nc()
-    : LayerElement(NC, "nc-")
+    : LayerElement(NC)
     , DurationInterface()
     , PitchInterface()
     , PositionInterface()

--- a/src/neume.cpp
+++ b/src/neume.cpp
@@ -44,7 +44,7 @@ const std::map<std::string, NeumeGroup> Neume::s_neumes
 
 static const ClassRegistrar<Neume> s_factory("neume", NEUME);
 
-Neume::Neume() : LayerElement(NEUME, "neume-"), ObjectListInterface(), AttColor()
+Neume::Neume() : LayerElement(NEUME), ObjectListInterface(), AttColor()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->Reset();

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -51,7 +51,7 @@ namespace vrv {
 static const ClassRegistrar<Note> s_factory("note", NOTE);
 
 Note::Note()
-    : LayerElement(NOTE, "note-")
+    : LayerElement(NOTE)
     , StemmedDrawingInterface()
     , AltSymInterface()
     , DurationInterface()

--- a/src/num.cpp
+++ b/src/num.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Num> s_factory("num", NUM);
 
-Num::Num() : TextElement(NUM, "num-")
+Num::Num() : TextElement(NUM)
 {
     this->Reset();
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -73,7 +73,7 @@ Object::Object() : BoundingBox()
     if (s_objectCounter++ == 0) {
         this->SeedID();
     }
-    this->Init(OBJECT, "m-");
+    this->Init(OBJECT);
 }
 
 Object::Object(ClassId classId) : BoundingBox()
@@ -81,15 +81,7 @@ Object::Object(ClassId classId) : BoundingBox()
     if (s_objectCounter++ == 0) {
         this->SeedID();
     }
-    this->Init(classId, "m-");
-}
-
-Object::Object(ClassId classId, const std::string &classIdStr) : BoundingBox()
-{
-    if (s_objectCounter++ == 0) {
-        this->SeedID();
-    }
-    this->Init(classId, classIdStr);
+    this->Init(classId);
 }
 
 Object *Object::Clone() const
@@ -104,7 +96,6 @@ Object::Object(const Object &object) : BoundingBox(object)
     this->ResetBoundingBox(); // It does not make sense to keep the values of the BBox
 
     m_classId = object.m_classId;
-    m_classIdStr = object.m_classIdStr;
     m_parent = NULL;
 
     // Flags
@@ -151,7 +142,6 @@ Object &Object::operator=(const Object &object)
         this->ResetBoundingBox(); // It does not make sense to keep the values of the BBox
 
         m_classId = object.m_classId;
-        m_classIdStr = object.m_classIdStr;
         m_parent = NULL;
         // Flags
         m_isAttribute = object.m_isAttribute;
@@ -189,12 +179,9 @@ Object::~Object()
     ClearChildren();
 }
 
-void Object::Init(ClassId classId, const std::string &classIdStr)
+void Object::Init(ClassId classId)
 {
-    assert(classIdStr.size());
-
     m_classId = classId;
-    m_classIdStr = classIdStr;
     m_parent = NULL;
     // Flags
     m_isAttribute = false;
@@ -813,7 +800,9 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
 
 void Object::GenerateID()
 {
-    m_id = m_classIdStr.at(0) + Object::GenerateHashID();
+    // A random letter from a-z
+    char letter = 'a' + (std::rand() % 26);
+    m_id = letter + Object::GenerateHashID();
 }
 
 void Object::ResetID()

--- a/src/octave.cpp
+++ b/src/octave.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Octave> s_factory("octave", OCTAVE);
 
 Octave::Octave()
-    : ControlElement(OCTAVE, "octave-")
+    : ControlElement(OCTAVE)
     , TimeSpanningInterface()
     , AttExtender()
     , AttLineRend()

--- a/src/orig.cpp
+++ b/src/orig.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Orig> s_factory("orig", ORIG);
 
-Orig::Orig() : EditorialElement(ORIG, "orig-"), AttSource()
+Orig::Orig() : EditorialElement(ORIG), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/oriscus.cpp
+++ b/src/oriscus.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Oriscus
 //----------------------------------------------------------------------------
 
-Oriscus::Oriscus() : LayerElement(ORISCUS, "oriscus-"), PitchInterface(), PositionInterface(), AttColor()
+Oriscus::Oriscus() : LayerElement(ORISCUS), PitchInterface(), PositionInterface(), AttColor()
 {
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());

--- a/src/ornam.cpp
+++ b/src/ornam.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<Ornam> s_factory("ornam", ORNAM);
 
 Ornam::Ornam()
-    : ControlElement(ORNAM, "ornam-"), TextListInterface(), TextDirInterface(), TimePointInterface(), AttOrnamentAccid()
+    : ControlElement(ORNAM), TextListInterface(), TextDirInterface(), TimePointInterface(), AttOrnamentAccid()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -72,7 +72,7 @@ namespace vrv {
 // Page
 //----------------------------------------------------------------------------
 
-Page::Page() : Object(PAGE, "page-")
+Page::Page() : Object(PAGE)
 {
     this->Reset();
 }

--- a/src/pageelement.cpp
+++ b/src/pageelement.cpp
@@ -22,21 +22,14 @@ namespace vrv {
 // PageElement
 //----------------------------------------------------------------------------
 
-PageElement::PageElement() : Object(PAGE_ELEMENT, "pe"), AttTyped()
+PageElement::PageElement() : Object(PAGE_ELEMENT), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 
     this->Reset();
 }
 
-PageElement::PageElement(ClassId classId) : Object(classId, "pe"), AttTyped()
-{
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-PageElement::PageElement(ClassId classId, const std::string &classIdStr) : Object(classId, classIdStr), AttTyped()
+PageElement::PageElement(ClassId classId) : Object(classId), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 

--- a/src/pagemilestone.cpp
+++ b/src/pagemilestone.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // PageMilestoneEnd
 //----------------------------------------------------------------------------
 
-PageMilestoneEnd::PageMilestoneEnd(Object *start) : PageElement(PAGE_MILESTONE_END, "page-milestone-end-")
+PageMilestoneEnd::PageMilestoneEnd(Object *start) : PageElement(PAGE_MILESTONE_END)
 {
     this->Reset();
     m_start = start;

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 // Pages
 //----------------------------------------------------------------------------
 
-Pages::Pages() : Object(PAGES, "pages-"), AttLabelled(), AttNNumberLike()
+Pages::Pages() : Object(PAGES), AttLabelled(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/pb.cpp
+++ b/src/pb.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Pb> s_factory("pb", PB);
 
-Pb::Pb() : SystemElement(PB, "pb-"), FacsimileInterface(), AttNNumberLike()
+Pb::Pb() : SystemElement(PB), FacsimileInterface(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());

--- a/src/pedal.cpp
+++ b/src/pedal.cpp
@@ -35,7 +35,7 @@ namespace vrv {
 static const ClassRegistrar<Pedal> s_factory("pedal", PEDAL);
 
 Pedal::Pedal()
-    : ControlElement(PEDAL, "pedal-")
+    : ControlElement(PEDAL)
     , TimeSpanningInterface()
     , AttExtSymAuth()
     , AttExtSymNames()

--- a/src/pgfoot.cpp
+++ b/src/pgfoot.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgFoot> s_factory("pgFoot", PGFOOT);
 
-PgFoot::PgFoot() : RunningElement(PGFOOT, "pgfoot-")
+PgFoot::PgFoot() : RunningElement(PGFOOT)
 {
     this->Reset();
 }

--- a/src/pghead.cpp
+++ b/src/pghead.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 
 static const ClassRegistrar<PgHead> s_factory("pgHead", PGHEAD);
 
-PgHead::PgHead() : RunningElement(PGHEAD, "pghead-")
+PgHead::PgHead() : RunningElement(PGHEAD)
 {
     this->Reset();
 }

--- a/src/phrase.cpp
+++ b/src/phrase.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<Phrase> s_factory("phrase", PHRASE);
 
-Phrase::Phrase() : Slur(PHRASE, "phrase-")
+Phrase::Phrase() : Slur(PHRASE)
 {
     this->Reset();
 }

--- a/src/pitchinflection.cpp
+++ b/src/pitchinflection.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<PitchInflection> s_factory("pitchInflection", PITCHINFLECTION);
 
-PitchInflection::PitchInflection() : ControlElement(PITCHINFLECTION, "pinflexion-"), TimeSpanningInterface()
+PitchInflection::PitchInflection() : ControlElement(PITCHINFLECTION), TimeSpanningInterface()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
 

--- a/src/plica.cpp
+++ b/src/plica.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Plica> s_factory("plica", PLICA);
 
-Plica::Plica() : LayerElement(PLICA, "plica-"), AttPlicaVis()
+Plica::Plica() : LayerElement(PLICA), AttPlicaVis()
 {
     this->RegisterAttClass(ATT_PLICAVIS);
 

--- a/src/proport.cpp
+++ b/src/proport.cpp
@@ -19,7 +19,7 @@ namespace vrv {
 
 static const ClassRegistrar<Proport> s_factory("proport", PROPORT);
 
-Proport::Proport() : LayerElement(PROPORT, "prop-"), AttDurationRatio()
+Proport::Proport() : LayerElement(PROPORT), AttDurationRatio()
 {
     this->RegisterAttClass(ATT_DURATIONRATIO);
 

--- a/src/quilisma.cpp
+++ b/src/quilisma.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 // Quilisma
 //----------------------------------------------------------------------------
 
-Quilisma::Quilisma() : LayerElement(QUILISMA, "quilisma-"), PitchInterface(), PositionInterface(), AttColor()
+Quilisma::Quilisma() : LayerElement(QUILISMA), PitchInterface(), PositionInterface(), AttColor()
 {
     RegisterInterface(PitchInterface::GetAttClasses(), PitchInterface::IsInterface());
     RegisterInterface(PositionInterface::GetAttClasses(), PositionInterface::IsInterface());

--- a/src/rdg.cpp
+++ b/src/rdg.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Rdg> s_factory("rdg", RDG);
 
-Rdg::Rdg() : EditorialElement(RDG, "rdg-"), AttSource()
+Rdg::Rdg() : EditorialElement(RDG), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/ref.cpp
+++ b/src/ref.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Ref> s_factory("ref", REF);
 
-Ref::Ref() : EditorialElement(REF, "ref-")
+Ref::Ref() : EditorialElement(REF)
 {
     this->Reset();
 }

--- a/src/reg.cpp
+++ b/src/reg.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Reg> s_factory("reg", REG);
 
-Reg::Reg() : EditorialElement(REG, "reg-"), AttSource()
+Reg::Reg() : EditorialElement(REG), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/reh.cpp
+++ b/src/reh.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 
 static const ClassRegistrar<Reh> s_factory("reh", REH);
 
-Reh::Reh() : ControlElement(REH, "reh-"), TextDirInterface(), TimePointInterface(), AttLang(), AttVerticalGroup()
+Reh::Reh() : ControlElement(REH), TextDirInterface(), TimePointInterface(), AttLang(), AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());

--- a/src/rend.cpp
+++ b/src/rend.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<Rend> s_factory("rend", REND);
 
 Rend::Rend()
-    : TextElement(REND, "rend-")
+    : TextElement(REND)
     , AreaPosInterface()
     , AttColor()
     , AttExtSymAuth()

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<RepeatMark> s_factory("repeatMark", REPEATMARK);
 
 RepeatMark::RepeatMark()
-    : ControlElement(REPEATMARK, "repeatMark-")
+    : ControlElement(REPEATMARK)
     , TextListInterface()
     , TextDirInterface()
     , TimePointInterface()

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -171,7 +171,7 @@ RestAccidental MeiAccidentalToRestAccidental(data_ACCIDENTAL_WRITTEN accidental)
 static const ClassRegistrar<Rest> s_factory("rest", REST);
 
 Rest::Rest()
-    : LayerElement(REST, "rest-")
+    : LayerElement(REST)
     , AltSymInterface()
     , DurationInterface()
     , PositionInterface()

--- a/src/restore.cpp
+++ b/src/restore.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Restore> s_factory("restore", RESTORE);
 
-Restore::Restore() : EditorialElement(RESTORE, "restore-"), AttSource()
+Restore::Restore() : EditorialElement(RESTORE), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/runningelement.cpp
+++ b/src/runningelement.cpp
@@ -47,8 +47,7 @@ RunningElement::RunningElement(ClassId classId) : TextLayoutElement(classId, "re
 }
 */
 
-RunningElement::RunningElement(ClassId classId, const std::string &classIdStr)
-    : TextLayoutElement(classId, classIdStr), AttFormework()
+RunningElement::RunningElement(ClassId classId) : TextLayoutElement(classId), AttFormework()
 {
     this->RegisterAttClass(ATT_FORMEWORK);
 

--- a/src/sb.cpp
+++ b/src/sb.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 
 static const ClassRegistrar<Sb> s_factory("sb", SB);
 
-Sb::Sb() : SystemElement(SB, "sb-"), FacsimileInterface(), AttNNumberLike()
+Sb::Sb() : SystemElement(SB), FacsimileInterface(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterInterface(FacsimileInterface::GetAttClasses(), FacsimileInterface::IsInterface());

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -36,7 +36,7 @@ namespace vrv {
 
 static const ClassRegistrar<Score> s_factory("score", SCORE);
 
-Score::Score() : PageElement(SCORE, "score-"), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
+Score::Score() : PageElement(SCORE), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -46,7 +46,7 @@ namespace vrv {
 // ScoreDefElement
 //----------------------------------------------------------------------------
 
-ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT, "scoredefelement-"), ScoreDefInterface(), AttTyped()
+ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT), ScoreDefInterface(), AttTyped()
 {
     this->RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
     this->RegisterAttClass(ATT_TYPED);
@@ -54,16 +54,7 @@ ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT, "scoredefelement-"
     this->Reset();
 }
 
-ScoreDefElement::ScoreDefElement(ClassId classId) : Object(classId, "scoredefelement-"), ScoreDefInterface(), AttTyped()
-{
-    this->RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-ScoreDefElement::ScoreDefElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), ScoreDefInterface(), AttTyped()
+ScoreDefElement::ScoreDefElement(ClassId classId) : Object(classId), ScoreDefInterface(), AttTyped()
 {
     this->RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
     this->RegisterAttClass(ATT_TYPED);
@@ -222,7 +213,7 @@ MeterSigGrp *ScoreDefElement::GetMeterSigGrpCopy() const
 static const ClassRegistrar<ScoreDef> s_factory("scoreDef", SCOREDEF);
 
 ScoreDef::ScoreDef()
-    : ScoreDefElement(SCOREDEF, "scoredef-")
+    : ScoreDefElement(SCOREDEF)
     , ObjectListInterface()
     , AttDistances()
     , AttEndings()

--- a/src/section.cpp
+++ b/src/section.cpp
@@ -33,7 +33,7 @@ namespace vrv {
 
 static const ClassRegistrar<Section> s_factory("section", SECTION);
 
-Section::Section() : SystemElement(SECTION, "section-"), SystemMilestoneInterface(), AttNNumberLike(), AttSectionVis()
+Section::Section() : SystemElement(SECTION), SystemMilestoneInterface(), AttNNumberLike(), AttSectionVis()
 {
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterAttClass(ATT_SECTIONVIS);

--- a/src/sic.cpp
+++ b/src/sic.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Sic> s_factory("sic", SIC);
 
-Sic::Sic() : EditorialElement(SIC, "sic-"), AttSource()
+Sic::Sic() : EditorialElement(SIC), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/slur.cpp
+++ b/src/slur.cpp
@@ -40,8 +40,7 @@ namespace vrv {
 
 static const ClassRegistrar<Slur> s_factory("slur", SLUR);
 
-Slur::Slur()
-    : ControlElement(SLUR, "slur-"), TimeSpanningInterface(), AttCurvature(), AttLayerIdent(), AttLineRendBase()
+Slur::Slur() : ControlElement(SLUR), TimeSpanningInterface(), AttCurvature(), AttLayerIdent(), AttLineRendBase()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_CURVATURE);
@@ -52,18 +51,7 @@ Slur::Slur()
 }
 
 Slur::Slur(ClassId classId)
-    : ControlElement(classId, "slur-"), TimeSpanningInterface(), AttCurvature(), AttLayerIdent(), AttLineRendBase()
-{
-    this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
-    this->RegisterAttClass(ATT_CURVATURE);
-    this->RegisterAttClass(ATT_LAYERIDENT);
-    this->RegisterAttClass(ATT_LINERENDBASE);
-
-    this->Reset();
-}
-
-Slur::Slur(ClassId classId, const std::string &classIdStr)
-    : ControlElement(classId, classIdStr), TimeSpanningInterface(), AttCurvature(), AttLayerIdent(), AttLineRendBase()
+    : ControlElement(classId), TimeSpanningInterface(), AttCurvature(), AttLayerIdent(), AttLineRendBase()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_CURVATURE);

--- a/src/space.cpp
+++ b/src/space.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Space> s_factory("space", SPACE);
 
-Space::Space() : LayerElement(SPACE, "space-"), DurationInterface()
+Space::Space() : LayerElement(SPACE), DurationInterface()
 {
     this->RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
 

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -42,8 +42,7 @@ namespace vrv {
 
 static const ClassRegistrar<Staff> s_factory("staff", STAFF);
 
-Staff::Staff(int n)
-    : Object(STAFF, "staff-"), FacsimileInterface(), AttCoordY1(), AttNInteger(), AttTyped(), AttVisibility()
+Staff::Staff(int n) : Object(STAFF), FacsimileInterface(), AttCoordY1(), AttNInteger(), AttTyped(), AttVisibility()
 {
     this->RegisterAttClass(ATT_COORDY1);
     this->RegisterAttClass(ATT_NINTEGER);

--- a/src/staffdef.cpp
+++ b/src/staffdef.cpp
@@ -32,7 +32,7 @@ namespace vrv {
 static const ClassRegistrar<StaffDef> s_factory("staffDef", STAFFDEF);
 
 StaffDef::StaffDef()
-    : ScoreDefElement(STAFFDEF, "staffdef-")
+    : ScoreDefElement(STAFFDEF)
     , AttDistances()
     , AttLabelled()
     , AttNInteger()

--- a/src/staffgrp.cpp
+++ b/src/staffgrp.cpp
@@ -30,7 +30,7 @@ namespace vrv {
 static const ClassRegistrar<StaffGrp> s_factory("staffGrp", STAFFGRP);
 
 StaffGrp::StaffGrp()
-    : Object(STAFFGRP, "staffgrp-")
+    : Object(STAFFGRP)
     , ObjectListInterface()
     , AttBarring()
     , AttBasic()

--- a/src/stem.cpp
+++ b/src/stem.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 
 static const ClassRegistrar<Note> s_factory("stem", STEM);
 
-Stem::Stem() : LayerElement(STEM, "stem-"), AttGraced(), AttStemVis(), AttVisibility()
+Stem::Stem() : LayerElement(STEM), AttGraced(), AttStemVis(), AttVisibility()
 {
     this->RegisterAttClass(ATT_GRACED);
     this->RegisterAttClass(ATT_STEMVIS);

--- a/src/subst.cpp
+++ b/src/subst.cpp
@@ -25,14 +25,14 @@ namespace vrv {
 
 static const ClassRegistrar<Subst> s_factory("subst", SUBST);
 
-Subst::Subst() : EditorialElement(SUBST, "subst-")
+Subst::Subst() : EditorialElement(SUBST)
 {
     m_level = EDITORIAL_UNDEFINED;
 
     this->Reset();
 }
 
-Subst::Subst(EditorialLevel level) : EditorialElement(SUBST, "subst-")
+Subst::Subst(EditorialLevel level) : EditorialElement(SUBST)
 {
     m_level = level;
 

--- a/src/supplied.cpp
+++ b/src/supplied.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Supplied> s_factory("supplied", SUPPLIED);
 
-Supplied::Supplied() : EditorialElement(SUPPLIED, "supplied-"), AttSource()
+Supplied::Supplied() : EditorialElement(SUPPLIED), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -28,7 +28,7 @@ namespace vrv {
 
 static const ClassRegistrar<Surface> s_factory("surface", SURFACE);
 
-Surface::Surface() : Object(SURFACE, "surface-"), AttTyped(), AttCoordinated()
+Surface::Surface() : Object(SURFACE), AttTyped(), AttCoordinated()
 {
     this->RegisterAttClass(ATT_TYPED);
     this->RegisterAttClass(ATT_COORDINATED);

--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Svg> s_factory("svg", SVG);
 
-Svg::Svg() : Object(SVG, "svg-")
+Svg::Svg() : Object(SVG)
 {
     this->Reset();
 }

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -1174,7 +1174,6 @@ void SvgDeviceContext::AppendIdAndClass(
     const std::string &gId, const std::string &baseClass, const std::string &addedClasses, GraphicID graphicID)
 {
     std::string baseClassFull = baseClass;
-    std::transform(baseClassFull.begin(), baseClassFull.begin() + 1, baseClassFull.begin(), ::tolower);
 
     if (gId.length() > 0) {
         if (m_html5) {

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -38,8 +38,7 @@ namespace vrv {
 
 static const ClassRegistrar<Syl> s_factory("syl", SYL);
 
-Syl::Syl()
-    : LayerElement(SYL, "syl-"), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
+Syl::Syl() : LayerElement(SYL), TextListInterface(), TimeSpanningInterface(), AttLang(), AttTypography(), AttSylLog()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_LANG);

--- a/src/syllable.cpp
+++ b/src/syllable.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 
 static const ClassRegistrar<Syllable> s_factory("syllable", SYLLABLE);
 
-Syllable::Syllable() : LayerElement(SYLLABLE, "syllable-"), ObjectListInterface(), AttColor(), AttSlashCount()
+Syllable::Syllable() : LayerElement(SYLLABLE), ObjectListInterface(), AttColor(), AttSlashCount()
 {
     Init();
 }

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -26,7 +26,7 @@ namespace vrv {
 
 static const ClassRegistrar<Symbol> s_factory("symbol", SYMBOL);
 
-Symbol::Symbol() : TextElement(SYMBOL, "symbol-"), AttColor(), AttExtSymAuth(), AttExtSymNames(), AttTypography()
+Symbol::Symbol() : TextElement(SYMBOL), AttColor(), AttExtSymAuth(), AttExtSymNames(), AttTypography()
 {
     this->Reset();
 

--- a/src/symboldef.cpp
+++ b/src/symboldef.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<SymbolDef> s_factory("symbolDef", SYMBOLDEF);
 
-SymbolDef::SymbolDef() : Object(SYMBOLDEF, "symdef-")
+SymbolDef::SymbolDef() : Object(SYMBOLDEF)
 {
     this->Reset();
 }

--- a/src/symboltable.cpp
+++ b/src/symboltable.cpp
@@ -24,7 +24,7 @@ namespace vrv {
 
 static const ClassRegistrar<SymbolTable> s_factory("symbolTable", SYMBOLTABLE);
 
-SymbolTable::SymbolTable() : Object(SYMBOLTABLE, "symtable-")
+SymbolTable::SymbolTable() : Object(SYMBOLTABLE)
 {
     this->Reset();
 }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -45,7 +45,7 @@ namespace vrv {
 // System
 //----------------------------------------------------------------------------
 
-System::System() : Object(SYSTEM, "system-"), DrawingListInterface(), AttTyped()
+System::System() : Object(SYSTEM), DrawingListInterface(), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 

--- a/src/systemelement.cpp
+++ b/src/systemelement.cpp
@@ -22,22 +22,14 @@ namespace vrv {
 // SystemElement
 //----------------------------------------------------------------------------
 
-SystemElement::SystemElement() : FloatingObject(SYSTEM_ELEMENT, "se"), AttTyped()
+SystemElement::SystemElement() : FloatingObject(SYSTEM_ELEMENT), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 
     this->Reset();
 }
 
-SystemElement::SystemElement(ClassId classId) : FloatingObject(classId, "se"), AttTyped()
-{
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-SystemElement::SystemElement(ClassId classId, const std::string &classIdStr)
-    : FloatingObject(classId, classIdStr), AttTyped()
+SystemElement::SystemElement(ClassId classId) : FloatingObject(classId), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 

--- a/src/systemmilestone.cpp
+++ b/src/systemmilestone.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 // SystemMilestoneEnd
 //----------------------------------------------------------------------------
 
-SystemMilestoneEnd::SystemMilestoneEnd(Object *start) : SystemElement(SYSTEM_MILESTONE_END, "system-milestone-end-")
+SystemMilestoneEnd::SystemMilestoneEnd(Object *start) : SystemElement(SYSTEM_MILESTONE_END)
 {
     this->Reset();
     m_start = start;

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -32,11 +32,7 @@ namespace vrv {
 static const ClassRegistrar<TabDurSym> s_factory("tabDurSym", TABDURSYM);
 
 TabDurSym::TabDurSym()
-    : LayerElement(TABDURSYM, "tabdursym-")
-    , StemmedDrawingInterface()
-    , AttNNumberLike()
-    , AttStringtab()
-    , AttVisualOffsetVo()
+    : LayerElement(TABDURSYM), StemmedDrawingInterface(), AttNNumberLike(), AttStringtab(), AttVisualOffsetVo()
 {
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterAttClass(ATT_STRINGTAB);

--- a/src/tabgrp.cpp
+++ b/src/tabgrp.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<TabGrp> s_factory("tabGrp", TABGRP);
 
-TabGrp::TabGrp() : LayerElement(TABGRP, "tabgrp-"), ObjectListInterface(), DurationInterface()
+TabGrp::TabGrp() : LayerElement(TABGRP), ObjectListInterface(), DurationInterface()
 {
     this->RegisterInterface(DurationInterface::GetAttClasses(), DurationInterface::IsInterface());
 

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -31,7 +31,7 @@ namespace vrv {
 static const ClassRegistrar<Tempo> s_factory("tempo", TEMPO);
 
 Tempo::Tempo()
-    : ControlElement(TEMPO, "tempo-")
+    : ControlElement(TEMPO)
     , TextDirInterface()
     , TimeSpanningInterface()
     , AttExtender()

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 // Text
 //----------------------------------------------------------------------------
 
-Text::Text() : TextElement(TEXT, "text-")
+Text::Text() : TextElement(TEXT)
 {
     this->Reset();
 }

--- a/src/textelement.cpp
+++ b/src/textelement.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // TextElement
 //----------------------------------------------------------------------------
 
-TextElement::TextElement() : Object(TEXT_ELEMENT, "te-"), AttLabelled(), AttTyped()
+TextElement::TextElement() : Object(TEXT_ELEMENT), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);
@@ -29,16 +29,7 @@ TextElement::TextElement() : Object(TEXT_ELEMENT, "te-"), AttLabelled(), AttType
     this->Reset();
 }
 
-TextElement::TextElement(ClassId classId) : Object(classId, "te-"), AttLabelled(), AttTyped()
-{
-    this->RegisterAttClass(ATT_LABELLED);
-    this->RegisterAttClass(ATT_TYPED);
-
-    this->Reset();
-}
-
-TextElement::TextElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), AttLabelled(), AttTyped()
+TextElement::TextElement(ClassId classId) : Object(classId), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);

--- a/src/textlayoutelement.cpp
+++ b/src/textlayoutelement.cpp
@@ -25,8 +25,7 @@ namespace vrv {
 // TextLayoutElement
 //----------------------------------------------------------------------------
 
-TextLayoutElement::TextLayoutElement(ClassId classId, const std::string &classIdStr)
-    : Object(classId, classIdStr), ObjectListInterface(), AttTyped()
+TextLayoutElement::TextLayoutElement(ClassId classId) : Object(classId), ObjectListInterface(), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 

--- a/src/tie.cpp
+++ b/src/tie.cpp
@@ -34,7 +34,7 @@ namespace vrv {
 
 static const ClassRegistrar<Tie> s_factory("tie", TIE);
 
-Tie::Tie() : ControlElement(TIE, "tie-"), TimeSpanningInterface(), AttCurvature(), AttLineRendBase()
+Tie::Tie() : ControlElement(TIE), TimeSpanningInterface(), AttCurvature(), AttLineRendBase()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_CURVATURE);
@@ -43,17 +43,7 @@ Tie::Tie() : ControlElement(TIE, "tie-"), TimeSpanningInterface(), AttCurvature(
     this->Reset();
 }
 
-Tie::Tie(ClassId classId) : ControlElement(classId, "tie-"), TimeSpanningInterface(), AttCurvature(), AttLineRendBase()
-{
-    this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
-    this->RegisterAttClass(ATT_CURVATURE);
-    this->RegisterAttClass(ATT_LINERENDBASE);
-
-    this->Reset();
-}
-
-Tie::Tie(ClassId classId, const std::string &classIdStr)
-    : ControlElement(classId, classIdStr), TimeSpanningInterface(), AttCurvature(), AttLineRendBase()
+Tie::Tie(ClassId classId) : ControlElement(classId), TimeSpanningInterface(), AttCurvature(), AttLineRendBase()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_CURVATURE);

--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -21,7 +21,7 @@ namespace vrv {
 // TimestampAttr
 //----------------------------------------------------------------------------
 
-TimestampAttr::TimestampAttr() : LayerElement(TIMESTAMP_ATTR, "tstp-")
+TimestampAttr::TimestampAttr() : LayerElement(TIMESTAMP_ATTR)
 {
     this->Reset();
 }

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 static const ClassRegistrar<Trill> s_factory("trill", TRILL);
 
 Trill::Trill()
-    : ControlElement(TRILL, "trill-")
+    : ControlElement(TRILL)
     , TimeSpanningInterface()
     , AttExtender()
     , AttExtSymAuth()

--- a/src/tuning.cpp
+++ b/src/tuning.cpp
@@ -27,7 +27,7 @@ namespace vrv {
 
 static const ClassRegistrar<Tuning> s_factory("tuning", TUNING);
 
-Tuning::Tuning() : Object(TUNING, "tuning-"), AttTuningLog()
+Tuning::Tuning() : Object(TUNING), AttTuningLog()
 {
     this->RegisterAttClass(ATT_TUNINGLOG);
 

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -38,12 +38,7 @@ namespace vrv {
 static const ClassRegistrar<Tuplet> s_factory("tuplet", TUPLET);
 
 Tuplet::Tuplet()
-    : LayerElement(TUPLET, "tuplet-")
-    , ObjectListInterface()
-    , AttColor()
-    , AttDurationRatio()
-    , AttNumberPlacement()
-    , AttTupletVis()
+    : LayerElement(TUPLET), ObjectListInterface(), AttColor(), AttDurationRatio(), AttNumberPlacement(), AttTupletVis()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_DURATIONRATIO);

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -29,7 +29,7 @@ namespace vrv {
 static const ClassRegistrar<Turn> s_factory("turn", TURN);
 
 Turn::Turn()
-    : ControlElement(TURN, "turn-")
+    : ControlElement(TURN)
     , TimePointInterface()
     , AttExtSymAuth()
     , AttExtSymNames()

--- a/src/unclear.cpp
+++ b/src/unclear.cpp
@@ -23,7 +23,7 @@ namespace vrv {
 
 static const ClassRegistrar<Unclear> s_factory("unclear", UNCLEAR);
 
-Unclear::Unclear() : EditorialElement(UNCLEAR, "unclear-"), AttSource()
+Unclear::Unclear() : EditorialElement(UNCLEAR), AttSource()
 {
     this->RegisterAttClass(ATT_SOURCE);
 

--- a/src/verse.cpp
+++ b/src/verse.cpp
@@ -33,7 +33,7 @@ namespace vrv {
 
 static const ClassRegistrar<Verse> s_factory("verse", VERSE);
 
-Verse::Verse() : LayerElement(VERSE, "verse-"), AttColor(), AttLang(), AttNInteger(), AttTypography()
+Verse::Verse() : LayerElement(VERSE), AttColor(), AttLang(), AttNInteger(), AttTypography()
 {
     this->RegisterAttClass(ATT_COLOR);
     this->RegisterAttClass(ATT_LANG);

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -35,7 +35,7 @@ namespace vrv {
 // SystemAligner
 //----------------------------------------------------------------------------
 
-SystemAligner::SystemAligner() : Object(SYSTEM_ALIGNER), m_system(NULL)
+SystemAligner::SystemAligner() : Object(SYSTEM_ALIGNER)
 {
     this->Reset();
 }

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -35,7 +35,7 @@ namespace vrv {
 // SystemAligner
 //----------------------------------------------------------------------------
 
-SystemAligner::SystemAligner() : Object(SYSTEM_ALIGNER), m_bottomAlignment(NULL), m_system(NULL)
+SystemAligner::SystemAligner() : Object(SYSTEM_ALIGNER), m_system(NULL)
 {
     this->Reset();
 }

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Zone> s_factory("zone", ZONE);
 
-Zone::Zone() : Object(ZONE), AttCoordinated()
+Zone::Zone() : Object(ZONE), AttTyped(), AttCoordinated()
 {
     this->RegisterAttClass(ATT_TYPED);
     this->RegisterAttClass(ATT_COORDINATED);

--- a/src/zone.cpp
+++ b/src/zone.cpp
@@ -25,7 +25,7 @@ namespace vrv {
 
 static const ClassRegistrar<Zone> s_factory("zone", ZONE);
 
-Zone::Zone() : Object(ZONE, "zone-"), AttTyped(), AttCoordinated()
+Zone::Zone() : Object(ZONE), AttCoordinated()
 {
     this->RegisterAttClass(ATT_TYPED);
     this->RegisterAttClass(ATT_COORDINATED);


### PR DESCRIPTION
The `Object::GetClassName` is used mostly for logging purposes. For classes implementing an MEI element, the value returned by the method typically matches the MEI element name, except for the initial capital letter (e.g., `Note` for `note` or `ScoreDef` for `scoreDef`).

There was and is no good reason to have an initial capital letter, except to match exactly the class name. However, there are a few places where the class name is also used to match the MEI element name (e.g., in the SVG output), and a conversion to the initial letter to lower case is needed. So it actually makes more sense to match the MEI element name (with the lower case initial), an this PR changes this.

The only place where this change might have an impact is in the Humdrum importer, so @craigsapp should have a close look at it. See for example https://github.com/rism-digital/verovio/blob/4a996c1736b4a7d6aa3e88a2b771ca02ee3d884e/src/iohumdrum.cpp#L5522C1-L5525C10

For such cases, it would actually be better to use the ClassId. So instead doing:
```cpp
ClassId classId = obj->GetClassId();
if (classId != STAFFGRP) {
    continue;
}
```

@craigsapp how do you want to proceed?