### PR TITLE
Change Object::GetClassName() to std::string_view

### DIFF
--- a/Verovio.xcodeproj/project.pbxproj
+++ b/Verovio.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 		4D543E221B80AACF004B823C /* view_control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D543E211B80AACF004B823C /* view_control.cpp */; };
 		4D5572401CF3F32A008D06A0 /* octave.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D55723F1CF3F32A008D06A0 /* octave.cpp */; };
 		4D5572441CF57B5C008D06A0 /* pedal.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D5572431CF57B5C008D06A0 /* pedal.cpp */; };
+		4D57D0DC2D993DC800C67757 /* scoringupfunctor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B464F48E2C6D664300A778D2 /* scoringupfunctor.cpp */; };
 		4D5FA9111E16A93F00F3B919 /* boundingbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D5FA9101E16A93F00F3B919 /* boundingbox.cpp */; };
 		4D6122BC1F77E1B900FC90A0 /* rend.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D6122BB1F77E1B900FC90A0 /* rend.h */; };
 		4D6122BE1F77E1E000FC90A0 /* rend.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4D6122BD1F77E1E000FC90A0 /* rend.cpp */; };
@@ -4150,6 +4151,7 @@
 				4D1694251E3A44F300569BF4 /* timestamp.cpp in Sources */,
 				4D1694261E3A44F300569BF4 /* MidiEventList.cpp in Sources */,
 				4DA0EAC822BB779400A7EBEB /* facsimile.cpp in Sources */,
+				4D57D0DC2D993DC800C67757 /* scoringupfunctor.cpp in Sources */,
 				4D1694271E3A44F300569BF4 /* iohumdrum.cpp in Sources */,
 				4D1694281E3A44F300569BF4 /* rest.cpp in Sources */,
 				4D1694291E3A44F300569BF4 /* scoredef.cpp in Sources */,

--- a/include/vrv/abbr.h
+++ b/include/vrv/abbr.h
@@ -28,7 +28,7 @@ public:
     virtual ~Abbr();
     Object *Clone() const override { return new Abbr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "abbr"; }
+    std::string_view GetClassName() const override { return "abbr"; }
     ///@}
 
 private:

--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -45,7 +45,7 @@ public:
     virtual ~Accid();
     Object *Clone() const override { return new Accid(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "accid"; }
+    std::string_view GetClassName() const override { return "accid"; }
     ///@}
 
     /** Override the method since it is align to the staff */

--- a/include/vrv/add.h
+++ b/include/vrv/add.h
@@ -28,7 +28,7 @@ public:
     virtual ~Add();
     Object *Clone() const override { return new Add(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "add"; }
+    std::string_view GetClassName() const override { return "add"; }
     ///@}
 
 private:

--- a/include/vrv/anchoredtext.h
+++ b/include/vrv/anchoredtext.h
@@ -33,7 +33,7 @@ public:
     virtual ~AnchoredText();
     Object *Clone() const override { return new AnchoredText(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "anchoredText"; }
+    std::string_view GetClassName() const override { return "anchoredText"; }
     ///@}
 
     /**

--- a/include/vrv/annot.h
+++ b/include/vrv/annot.h
@@ -32,7 +32,7 @@ public:
     // This fails because of the copy contructor in ObjectListInterface (TextListInterface parent)
     // Object *Clone() const override { return new Annot(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "annot"; }
+    std::string_view GetClassName() const override { return "annot"; }
     ///@}
 
     /**

--- a/include/vrv/app.h
+++ b/include/vrv/app.h
@@ -28,7 +28,7 @@ public:
     virtual ~App();
     Object *Clone() const override { return new App(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "app"; }
+    std::string_view GetClassName() const override { return "app"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/arpeg.h
+++ b/include/vrv/arpeg.h
@@ -39,7 +39,7 @@ public:
     virtual ~Arpeg();
     Object *Clone() const override { return new Arpeg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "arpeg"; }
+    std::string_view GetClassName() const override { return "arpeg"; }
     ///@}
 
     /**

--- a/include/vrv/artic.h
+++ b/include/vrv/artic.h
@@ -37,7 +37,7 @@ public:
     virtual ~Artic();
     Object *Clone() const override { return new Artic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "artic"; }
+    std::string_view GetClassName() const override { return "artic"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/barline.h
+++ b/include/vrv/barline.h
@@ -43,7 +43,7 @@ public:
     virtual ~BarLine();
     Object *Clone() const override { return new BarLine(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "barLine"; }
+    std::string_view GetClassName() const override { return "barLine"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/beam.h
+++ b/include/vrv/beam.h
@@ -292,7 +292,7 @@ public:
     virtual ~Beam();
     Object *Clone() const override { return new Beam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "beam"; }
+    std::string_view GetClassName() const override { return "beam"; }
     ///@}
 
     /**

--- a/include/vrv/beamspan.h
+++ b/include/vrv/beamspan.h
@@ -44,7 +44,7 @@ public:
     virtual ~BeamSpan();
     Object *Clone() const override { return new BeamSpan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "beamSpan"; }
+    std::string_view GetClassName() const override { return "beamSpan"; }
     ///@}
 
     /**

--- a/include/vrv/beatrpt.h
+++ b/include/vrv/beatrpt.h
@@ -33,7 +33,7 @@ public:
     virtual ~BeatRpt();
     Object *Clone() const override { return new BeatRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "beatRpt"; }
+    std::string_view GetClassName() const override { return "beatRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/bracketspan.h
+++ b/include/vrv/bracketspan.h
@@ -36,7 +36,7 @@ public:
     virtual ~BracketSpan();
     Object *Clone() const override { return new BracketSpan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "bracketSpan"; }
+    std::string_view GetClassName() const override { return "bracketSpan"; }
     ///@}
 
     /**

--- a/include/vrv/breath.h
+++ b/include/vrv/breath.h
@@ -32,7 +32,7 @@ public:
     virtual ~Breath();
     Object *Clone() const override { return new Breath(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "breath"; }
+    std::string_view GetClassName() const override { return "breath"; }
     ///@}
 
     /**

--- a/include/vrv/btrem.h
+++ b/include/vrv/btrem.h
@@ -35,7 +35,7 @@ public:
     virtual ~BTrem();
     Object *Clone() const override { return new BTrem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "bTrem"; }
+    std::string_view GetClassName() const override { return "bTrem"; }
     ///@}
 
     /**

--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -37,7 +37,7 @@ public:
     virtual ~Caesura();
     Object *Clone() const override { return new Caesura(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "caesura"; }
+    std::string_view GetClassName() const override { return "caesura"; }
     ///@}
 
     /**

--- a/include/vrv/choice.h
+++ b/include/vrv/choice.h
@@ -29,7 +29,7 @@ public:
     Object *Clone() const override { return new Choice(*this); }
     virtual ~Choice();
     void Reset() override;
-    std::string GetClassName() const override { return "choice"; }
+    std::string_view GetClassName() const override { return "choice"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/chord.h
+++ b/include/vrv/chord.h
@@ -52,7 +52,7 @@ public:
     virtual ~Chord();
     Object *Clone() const override { return new Chord(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "chord"; }
+    std::string_view GetClassName() const override { return "chord"; }
     ///@}
 
     /**

--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -47,7 +47,7 @@ public:
     virtual ~Clef();
     Object *Clone() const override { return new Clef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "clef"; }
+    std::string_view GetClassName() const override { return "clef"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/corr.h
+++ b/include/vrv/corr.h
@@ -28,7 +28,7 @@ public:
     virtual ~Corr();
     Object *Clone() const override { return new Corr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "corr"; }
+    std::string_view GetClassName() const override { return "corr"; }
     ///@}
 
 private:

--- a/include/vrv/course.h
+++ b/include/vrv/course.h
@@ -31,7 +31,7 @@ public:
     virtual ~Course();
     Object *Clone() const override { return new Course(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "course"; }
+    std::string_view GetClassName() const override { return "course"; }
     ///@}
 
     /**

--- a/include/vrv/cpmark.h
+++ b/include/vrv/cpmark.h
@@ -34,7 +34,7 @@ public:
     virtual ~CpMark();
     Object *Clone() const override { return new CpMark(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "cpMark"; }
+    std::string_view GetClassName() const override { return "cpMark"; }
     ///@}
 
     /**

--- a/include/vrv/custos.h
+++ b/include/vrv/custos.h
@@ -37,7 +37,7 @@ public:
     virtual ~Custos();
     Object *Clone() const override { return new Custos(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "custos"; }
+    std::string_view GetClassName() const override { return "custos"; }
     ///@}
 
     /**

--- a/include/vrv/damage.h
+++ b/include/vrv/damage.h
@@ -28,7 +28,7 @@ public:
     virtual ~Damage();
     Object *Clone() const override { return new Damage(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "damage"; }
+    std::string_view GetClassName() const override { return "damage"; }
     ///@}
 
 private:

--- a/include/vrv/del.h
+++ b/include/vrv/del.h
@@ -28,7 +28,7 @@ public:
     virtual ~Del();
     Object *Clone() const override { return new Del(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "del"; }
+    std::string_view GetClassName() const override { return "del"; }
     ///@}
 
 private:

--- a/include/vrv/dir.h
+++ b/include/vrv/dir.h
@@ -41,7 +41,7 @@ public:
     virtual ~Dir();
     Object *Clone() const override { return new Dir(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "dir"; }
+    std::string_view GetClassName() const override { return "dir"; }
     ///@}
 
     /**

--- a/include/vrv/div.h
+++ b/include/vrv/div.h
@@ -31,7 +31,7 @@ public:
     Div();
     virtual ~Div();
     void Reset() override;
-    std::string GetClassName() const override { return "div"; }
+    std::string_view GetClassName() const override { return "div"; }
     ///@}
 
     /**

--- a/include/vrv/divline.h
+++ b/include/vrv/divline.h
@@ -39,7 +39,7 @@ public:
     virtual ~DivLine();
     Object *Clone() const override { return new DivLine(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "divLine"; }
+    std::string_view GetClassName() const override { return "divLine"; }
     ///@}
 
     /** Override the method since alignment is required */
@@ -85,7 +85,7 @@ public:
     DivLineAttr();
     virtual ~DivLineAttr();
     Object *Clone() const override { return new DivLineAttr(*this); }
-    std::string GetClassName() const override { return "divLineAttr"; }
+    std::string_view GetClassName() const override { return "divLineAttr"; }
     ///@}
 
     // void SetLeft() { m_isLeft = true; }

--- a/include/vrv/dot.h
+++ b/include/vrv/dot.h
@@ -30,7 +30,7 @@ public:
     virtual ~Dot();
     Object *Clone() const override { return new Dot(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "dot"; }
+    std::string_view GetClassName() const override { return "dot"; }
     ///@}
 
     /**

--- a/include/vrv/dynam.h
+++ b/include/vrv/dynam.h
@@ -41,7 +41,7 @@ public:
     virtual ~Dynam();
     Object *Clone() const override { return new Dynam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "dynam"; }
+    std::string_view GetClassName() const override { return "dynam"; }
     ///@}
 
     /**

--- a/include/vrv/elementpart.h
+++ b/include/vrv/elementpart.h
@@ -34,7 +34,7 @@ public:
     Dots();
     virtual ~Dots();
     void Reset() override;
-    std::string GetClassName() const override { return "dots"; }
+    std::string_view GetClassName() const override { return "dots"; }
     Object *Clone() const override { return new Dots(*this); }
     ///@}
 
@@ -104,7 +104,7 @@ public:
     Flag();
     virtual ~Flag();
     void Reset() override;
-    std::string GetClassName() const override { return "flag"; }
+    std::string_view GetClassName() const override { return "flag"; }
     Object *Clone() const override { return new Flag(*this); }
     ///@}
 
@@ -157,7 +157,7 @@ public:
     TupletBracket();
     virtual ~TupletBracket();
     void Reset() override;
-    std::string GetClassName() const override { return "tupletBracket"; }
+    std::string_view GetClassName() const override { return "tupletBracket"; }
     ///@}
 
     /**
@@ -256,7 +256,7 @@ public:
     TupletNum();
     virtual ~TupletNum();
     void Reset() override;
-    std::string GetClassName() const override { return "tupletNum"; }
+    std::string_view GetClassName() const override { return "tupletNum"; }
     ///@}
 
     /**

--- a/include/vrv/ending.h
+++ b/include/vrv/ending.h
@@ -41,7 +41,7 @@ public:
     virtual ~Ending();
     Object *Clone() const override { return new Ending(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "ending"; }
+    std::string_view GetClassName() const override { return "ending"; }
     ///@}
 
     /**

--- a/include/vrv/expan.h
+++ b/include/vrv/expan.h
@@ -28,7 +28,7 @@ public:
     virtual ~Expan();
     Object *Clone() const override { return new Expan(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "expan"; }
+    std::string_view GetClassName() const override { return "expan"; }
     ///@}
 
 private:

--- a/include/vrv/expansion.h
+++ b/include/vrv/expansion.h
@@ -34,7 +34,7 @@ public:
     virtual ~Expansion();
     Object *Clone() const override { return new Expansion(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "expansion"; }
+    std::string_view GetClassName() const override { return "expansion"; }
     ///@}
 
     /**

--- a/include/vrv/f.h
+++ b/include/vrv/f.h
@@ -32,7 +32,7 @@ public:
     virtual ~F();
     Object *Clone() const override { return new F(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "f"; }
+    std::string_view GetClassName() const override { return "f"; }
     ///@}
 
     /**

--- a/include/vrv/facsimile.h
+++ b/include/vrv/facsimile.h
@@ -39,7 +39,7 @@ public:
     virtual ~Facsimile();
     Object *Clone() const override { return new Facsimile(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "facsimile"; }
+    std::string_view GetClassName() const override { return "facsimile"; }
     ///@}
     bool IsSupportedChild(ClassId classId) override;
 

--- a/include/vrv/fb.h
+++ b/include/vrv/fb.h
@@ -31,7 +31,7 @@ public:
     virtual ~Fb();
     Object *Clone() const override { return new Fb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "fb"; }
+    std::string_view GetClassName() const override { return "fb"; }
     ///@}
 
     /**

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -40,7 +40,7 @@ public:
     virtual ~Fermata();
     Object *Clone() const override { return new Fermata(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "fermata"; }
+    std::string_view GetClassName() const override { return "fermata"; }
     ///@}
 
     /**

--- a/include/vrv/fig.h
+++ b/include/vrv/fig.h
@@ -31,7 +31,7 @@ public:
     virtual ~Fig();
     Object *Clone() const override { return new Fig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "fig"; }
+    std::string_view GetClassName() const override { return "fig"; }
     ///@}
 
     /**

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -33,7 +33,7 @@ public:
     virtual ~Fing();
     Object *Clone() const override { return new Fing(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "fing"; }
+    std::string_view GetClassName() const override { return "fing"; }
     ///@}
 
     /**

--- a/include/vrv/ftrem.h
+++ b/include/vrv/ftrem.h
@@ -33,7 +33,7 @@ public:
     virtual ~FTrem();
     Object *Clone() const override { return new FTrem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "fTrem"; }
+    std::string_view GetClassName() const override { return "fTrem"; }
     ///@}
 
     /**

--- a/include/vrv/genericlayerelement.h
+++ b/include/vrv/genericlayerelement.h
@@ -31,7 +31,7 @@ public:
     virtual ~GenericLayerElement();
     Object *Clone() const override { return new GenericLayerElement(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return m_className; }
+    std::string_view GetClassName() const override { return m_className; }
     ///@}
 
     /**

--- a/include/vrv/gliss.h
+++ b/include/vrv/gliss.h
@@ -36,7 +36,7 @@ public:
     virtual ~Gliss();
     Object *Clone() const override { return new Gliss(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "gliss"; }
+    std::string_view GetClassName() const override { return "gliss"; }
     ///@}
 
     /**

--- a/include/vrv/gracegrp.h
+++ b/include/vrv/gracegrp.h
@@ -28,7 +28,7 @@ public:
     virtual ~GraceGrp();
     Object *Clone() const override { return new GraceGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "graceGrp"; }
+    std::string_view GetClassName() const override { return "graceGrp"; }
     ///@}
 
     /**

--- a/include/vrv/graphic.h
+++ b/include/vrv/graphic.h
@@ -37,7 +37,7 @@ public:
     virtual ~Graphic();
     Object *Clone() const override { return new Graphic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "graphic"; }
+    std::string_view GetClassName() const override { return "graphic"; }
     ///@}
 
     /**

--- a/include/vrv/grpsym.h
+++ b/include/vrv/grpsym.h
@@ -38,7 +38,7 @@ public:
     virtual ~GrpSym();
     Object *Clone() const override { return new GrpSym(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "grpSym"; }
+    std::string_view GetClassName() const override { return "grpSym"; }
     ///@}
 
     /**

--- a/include/vrv/hairpin.h
+++ b/include/vrv/hairpin.h
@@ -39,7 +39,7 @@ public:
     virtual ~Hairpin();
     Object *Clone() const override { return new Hairpin(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "hairpin"; }
+    std::string_view GetClassName() const override { return "hairpin"; }
     ///@}
 
     /**

--- a/include/vrv/halfmrpt.h
+++ b/include/vrv/halfmrpt.h
@@ -34,7 +34,7 @@ public:
     virtual ~HalfmRpt();
     Object *Clone() const override { return new HalfmRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "halfmRpt"; }
+    std::string_view GetClassName() const override { return "halfmRpt"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -40,7 +40,7 @@ public:
     virtual ~Harm();
     Object *Clone() const override { return new Harm(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "harm"; }
+    std::string_view GetClassName() const override { return "harm"; }
     ///@}
 
     /**

--- a/include/vrv/instrdef.h
+++ b/include/vrv/instrdef.h
@@ -37,7 +37,7 @@ public:
     virtual ~InstrDef();
     Object *Clone() const override { return new InstrDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "instrDef"; }
+    std::string_view GetClassName() const override { return "instrDef"; }
     ///@}
 
     //----------//

--- a/include/vrv/keyaccid.h
+++ b/include/vrv/keyaccid.h
@@ -41,7 +41,7 @@ public:
     virtual ~KeyAccid();
     Object *Clone() const override { return new KeyAccid(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "keyAccid"; }
+    std::string_view GetClassName() const override { return "keyAccid"; }
     ///@}
 
     /**

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -60,7 +60,7 @@ public:
     virtual ~KeySig();
     Object *Clone() const override { return new KeySig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "keySig"; }
+    std::string_view GetClassName() const override { return "keySig"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/label.h
+++ b/include/vrv/label.h
@@ -31,7 +31,7 @@ public:
     virtual ~Label();
     Object *Clone() const override { return new Label(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "label"; }
+    std::string_view GetClassName() const override { return "label"; }
     ///@}
 
     /**

--- a/include/vrv/labelabbr.h
+++ b/include/vrv/labelabbr.h
@@ -31,7 +31,7 @@ public:
     virtual ~LabelAbbr();
     Object *Clone() const override { return new LabelAbbr(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "labelAbbr"; }
+    std::string_view GetClassName() const override { return "labelAbbr"; }
     ///@}
 
     /**

--- a/include/vrv/layer.h
+++ b/include/vrv/layer.h
@@ -47,7 +47,7 @@ public:
     virtual ~Layer();
     Object *Clone() const override { return new Layer(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "layer"; }
+    std::string_view GetClassName() const override { return "layer"; }
     ///@}
 
     /**

--- a/include/vrv/layerdef.h
+++ b/include/vrv/layerdef.h
@@ -26,7 +26,7 @@ public:
     virtual ~LayerDef();
     Object *Clone() const override { return new LayerDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "layerDef"; }
+    std::string_view GetClassName() const override { return "layerDef"; }
     ///@}
 
     /**

--- a/include/vrv/lb.h
+++ b/include/vrv/lb.h
@@ -31,7 +31,7 @@ public:
     virtual ~Lb();
     Object *Clone() const override { return new Lb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "lb"; }
+    std::string_view GetClassName() const override { return "lb"; }
     ///@}
 
     /**

--- a/include/vrv/lem.h
+++ b/include/vrv/lem.h
@@ -28,7 +28,7 @@ public:
     virtual ~Lem();
     Object *Clone() const override { return new Lem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "lem"; }
+    std::string_view GetClassName() const override { return "lem"; }
     ///@}
 
 private:

--- a/include/vrv/ligature.h
+++ b/include/vrv/ligature.h
@@ -36,7 +36,7 @@ public:
     virtual ~Ligature();
     Object *Clone() const override { return new Ligature(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "ligature"; }
+    std::string_view GetClassName() const override { return "ligature"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/liquescent.h
+++ b/include/vrv/liquescent.h
@@ -31,7 +31,7 @@ public:
     virtual ~Liquescent();
     Object *Clone() const override { return new Liquescent(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "liquescent"; }
+    std::string_view GetClassName() const override { return "liquescent"; }
     ///@}
 
     /**

--- a/include/vrv/lv.h
+++ b/include/vrv/lv.h
@@ -30,7 +30,7 @@ public:
     virtual ~Lv();
     Object *Clone() const override { return new Lv(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "lv"; }
+    std::string_view GetClassName() const override { return "lv"; }
     ///@}
 
     bool CalculatePosition(

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -33,7 +33,7 @@ public:
     virtual ~Mdiv();
     Object *Clone() const override { return new Mdiv(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mdiv"; }
+    std::string_view GetClassName() const override { return "mdiv"; }
     ///@}
 
     /**

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -57,7 +57,7 @@ public:
     virtual ~Measure();
     Object *Clone() const override { return new Measure(*this); };
     void Reset() override;
-    std::string GetClassName() const override { return "measure"; }
+    std::string_view GetClassName() const override { return "measure"; }
     ///@}
 
     /**

--- a/include/vrv/mensur.h
+++ b/include/vrv/mensur.h
@@ -42,7 +42,7 @@ public:
     virtual ~Mensur();
     Object *Clone() const override { return new Mensur(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mensur"; }
+    std::string_view GetClassName() const override { return "mensur"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersig.h
+++ b/include/vrv/metersig.h
@@ -42,7 +42,7 @@ public:
     virtual ~MeterSig();
     Object *Clone() const override { return new MeterSig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "meterSig"; }
+    std::string_view GetClassName() const override { return "meterSig"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -36,7 +36,7 @@ public:
     virtual ~MeterSigGrp();
     Object *Clone() const override { return new MeterSigGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "meterSigGrp"; }
+    std::string_view GetClassName() const override { return "meterSigGrp"; }
     ///@}
 
     /**

--- a/include/vrv/mnum.h
+++ b/include/vrv/mnum.h
@@ -39,7 +39,7 @@ public:
     virtual ~MNum();
     Object *Clone() const override { return new MNum(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mNum"; }
+    std::string_view GetClassName() const override { return "mNum"; }
     ///@}
 
     /**

--- a/include/vrv/mordent.h
+++ b/include/vrv/mordent.h
@@ -40,7 +40,7 @@ public:
     virtual ~Mordent();
     Object *Clone() const override { return new Mordent(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mordent"; }
+    std::string_view GetClassName() const override { return "mordent"; }
     ///@}
 
     /**

--- a/include/vrv/mrest.h
+++ b/include/vrv/mrest.h
@@ -40,7 +40,7 @@ public:
     virtual ~MRest();
     Object *Clone() const override { return new MRest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mRest"; }
+    std::string_view GetClassName() const override { return "mRest"; }
     ///@}
 
     /**

--- a/include/vrv/mrpt.h
+++ b/include/vrv/mrpt.h
@@ -34,7 +34,7 @@ public:
     virtual ~MRpt();
     Object *Clone() const override { return new MRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mRpt"; }
+    std::string_view GetClassName() const override { return "mRpt"; }
     ///@}
 
     //----------//

--- a/include/vrv/mrpt2.h
+++ b/include/vrv/mrpt2.h
@@ -34,7 +34,7 @@ public:
     virtual ~MRpt2();
     Object *Clone() const override { return new MRpt2(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mRpt2"; }
+    std::string_view GetClassName() const override { return "mRpt2"; }
     ///@}
 
     /**

--- a/include/vrv/mspace.h
+++ b/include/vrv/mspace.h
@@ -30,7 +30,7 @@ public:
     virtual ~MSpace();
     Object *Clone() const override { return new MSpace(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "mSpace"; }
+    std::string_view GetClassName() const override { return "mSpace"; }
     ///@}
 
     //----------//

--- a/include/vrv/multirest.h
+++ b/include/vrv/multirest.h
@@ -40,7 +40,7 @@ public:
     virtual ~MultiRest();
     Object *Clone() const override { return new MultiRest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "multiRest"; }
+    std::string_view GetClassName() const override { return "multiRest"; }
     ///@}
 
     /**

--- a/include/vrv/multirpt.h
+++ b/include/vrv/multirpt.h
@@ -33,7 +33,7 @@ public:
     virtual ~MultiRpt();
     Object *Clone() const override { return new MultiRpt(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "multiRpt"; }
+    std::string_view GetClassName() const override { return "multiRpt"; }
     ///@}
 
     /**

--- a/include/vrv/nc.h
+++ b/include/vrv/nc.h
@@ -49,7 +49,7 @@ public:
     virtual ~Nc();
     Object *Clone() const override { return new Nc(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "nc"; }
+    std::string_view GetClassName() const override { return "nc"; }
     ///@}
 
     bool IsSupportedChild(ClassId classId) override;

--- a/include/vrv/neume.h
+++ b/include/vrv/neume.h
@@ -68,7 +68,7 @@ public:
     virtual ~Neume();
     void Reset() override;
     Object *Clone() const override { return new Neume(*this); }
-    std::string GetClassName() const override { return "neume"; }
+    std::string_view GetClassName() const override { return "neume"; }
     ///@}
 
     /**

--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -75,7 +75,7 @@ public:
     virtual ~Note();
     Object *Clone() const override { return new Note(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "note"; }
+    std::string_view GetClassName() const override { return "note"; }
     ///@}
 
     /**

--- a/include/vrv/num.h
+++ b/include/vrv/num.h
@@ -32,7 +32,7 @@ public:
     virtual ~Num();
     Object *Clone() const override { return new Num(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "num"; }
+    std::string_view GetClassName() const override { return "num"; }
     ///@}
 
     /**

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -67,7 +67,7 @@ public:
     Object(ClassId classId);
     virtual ~Object();
     ClassId GetClassId() const final { return m_classId; }
-    virtual std::string GetClassName() const { return "[MISSING]"; }
+    virtual std::string_view GetClassName() const { return "[MISSING]"; }
     ///@}
 
     /**
@@ -718,7 +718,7 @@ public:
      */
     ///@{
     void LogDebugTree(int maxDepth = UNLIMITED_DEPTH, int level = 0);
-    virtual std::string LogDebugTreeMsg() { return this->GetClassName(); }
+    virtual std::string LogDebugTreeMsg() { return std::string(this->GetClassName()); }
     ///@}
 
     //----------------//

--- a/include/vrv/octave.h
+++ b/include/vrv/octave.h
@@ -39,7 +39,7 @@ public:
     virtual ~Octave();
     Object *Clone() const override { return new Octave(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "octave"; }
+    std::string_view GetClassName() const override { return "octave"; }
     ///@}
 
     /**

--- a/include/vrv/orig.h
+++ b/include/vrv/orig.h
@@ -28,7 +28,7 @@ public:
     virtual ~Orig();
     Object *Clone() const override { return new Orig(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "orig"; }
+    std::string_view GetClassName() const override { return "orig"; }
     ///@}
 
 private:

--- a/include/vrv/oriscus.h
+++ b/include/vrv/oriscus.h
@@ -31,7 +31,7 @@ public:
     virtual ~Oriscus();
     Object *Clone() const override { return new Oriscus(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "oriscus"; }
+    std::string_view GetClassName() const override { return "oriscus"; }
     ///@}
 
     /**

--- a/include/vrv/ornam.h
+++ b/include/vrv/ornam.h
@@ -39,7 +39,7 @@ public:
     virtual ~Ornam();
     Object *Clone() const override { return new Ornam(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "ornam"; }
+    std::string_view GetClassName() const override { return "ornam"; }
     ///@}
 
     /**

--- a/include/vrv/page.h
+++ b/include/vrv/page.h
@@ -38,7 +38,7 @@ public:
     Page();
     virtual ~Page();
     void Reset() override;
-    std::string GetClassName() const override { return "page"; }
+    std::string_view GetClassName() const override { return "page"; }
     ///@}
 
     /**

--- a/include/vrv/pagemilestone.h
+++ b/include/vrv/pagemilestone.h
@@ -33,7 +33,7 @@ public:
     PageMilestoneEnd(Object *start);
     virtual ~PageMilestoneEnd();
     void Reset() override;
-    std::string GetClassName() const override { return "pageMilestoneEnd"; }
+    std::string_view GetClassName() const override { return "pageMilestoneEnd"; }
     ///@}
 
     /**

--- a/include/vrv/pages.h
+++ b/include/vrv/pages.h
@@ -35,7 +35,7 @@ public:
     Pages();
     virtual ~Pages();
     void Reset() override;
-    std::string GetClassName() const override { return "pages"; }
+    std::string_view GetClassName() const override { return "pages"; }
     ///@}
 
     /**

--- a/include/vrv/pb.h
+++ b/include/vrv/pb.h
@@ -33,7 +33,7 @@ public:
     virtual ~Pb();
     Object *Clone() const override { return new Pb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "pb"; }
+    std::string_view GetClassName() const override { return "pb"; }
     ///@}
 
     /**

--- a/include/vrv/pedal.h
+++ b/include/vrv/pedal.h
@@ -42,7 +42,7 @@ public:
     virtual ~Pedal();
     Object *Clone() const override { return new Pedal(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "pedal"; }
+    std::string_view GetClassName() const override { return "pedal"; }
     ///@}
 
     /**

--- a/include/vrv/pgfoot.h
+++ b/include/vrv/pgfoot.h
@@ -29,7 +29,7 @@ public:
     PgFoot();
     virtual ~PgFoot();
     void Reset() override;
-    std::string GetClassName() const override { return "pgFoot"; }
+    std::string_view GetClassName() const override { return "pgFoot"; }
     ///@}
 
     /**

--- a/include/vrv/pghead.h
+++ b/include/vrv/pghead.h
@@ -29,7 +29,7 @@ public:
     PgHead();
     virtual ~PgHead();
     void Reset() override;
-    std::string GetClassName() const override { return "pgHead"; }
+    std::string_view GetClassName() const override { return "pgHead"; }
     ///@}
 
     /**

--- a/include/vrv/phrase.h
+++ b/include/vrv/phrase.h
@@ -27,7 +27,7 @@ public:
     virtual ~Phrase();
     Object *Clone() const override { return new Phrase(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "phrase"; }
+    std::string_view GetClassName() const override { return "phrase"; }
     ///@}
 
     //----------//

--- a/include/vrv/pitchinflection.h
+++ b/include/vrv/pitchinflection.h
@@ -31,7 +31,7 @@ public:
     virtual ~PitchInflection();
     Object *Clone() const override { return new PitchInflection(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "pitchInflection"; }
+    std::string_view GetClassName() const override { return "pitchInflection"; }
     ///@}
 
     /**

--- a/include/vrv/plica.h
+++ b/include/vrv/plica.h
@@ -28,7 +28,7 @@ public:
     virtual ~Plica();
     Object *Clone() const override { return new Plica(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "plica"; }
+    std::string_view GetClassName() const override { return "plica"; }
 
     //----------//
     // Functors //

--- a/include/vrv/proport.h
+++ b/include/vrv/proport.h
@@ -31,7 +31,7 @@ public:
     virtual ~Proport();
     Object *Clone() const override { return new Proport(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "proport"; }
+    std::string_view GetClassName() const override { return "proport"; }
     ///@}
 
     int GetCumulatedNum() const;

--- a/include/vrv/quilisma.h
+++ b/include/vrv/quilisma.h
@@ -31,7 +31,7 @@ public:
     virtual ~Quilisma();
     Object *Clone() const override { return new Quilisma(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "quilisma"; }
+    std::string_view GetClassName() const override { return "quilisma"; }
     ///@}
 
     /**

--- a/include/vrv/rdg.h
+++ b/include/vrv/rdg.h
@@ -28,7 +28,7 @@ public:
     virtual ~Rdg();
     Object *Clone() const override { return new Rdg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "rdg"; }
+    std::string_view GetClassName() const override { return "rdg"; }
     ///@}
 
 private:

--- a/include/vrv/ref.h
+++ b/include/vrv/ref.h
@@ -31,7 +31,7 @@ public:
     virtual ~Ref();
     Object *Clone() const override { return new Ref(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "ref"; }
+    std::string_view GetClassName() const override { return "ref"; }
     ///@}
 
     //----------//

--- a/include/vrv/reg.h
+++ b/include/vrv/reg.h
@@ -28,7 +28,7 @@ public:
     virtual ~Reg();
     Object *Clone() const override { return new Reg(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "reg"; }
+    std::string_view GetClassName() const override { return "reg"; }
     ///@}
 
 private:

--- a/include/vrv/reh.h
+++ b/include/vrv/reh.h
@@ -38,7 +38,7 @@ public:
     virtual ~Reh();
     Object *Clone() const override { return new Reh(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "reh"; }
+    std::string_view GetClassName() const override { return "reh"; }
     ///@}
 
     /**

--- a/include/vrv/rend.h
+++ b/include/vrv/rend.h
@@ -41,7 +41,7 @@ public:
     virtual ~Rend();
     Object *Clone() const override { return new Rend(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "rend"; }
+    std::string_view GetClassName() const override { return "rend"; }
     ///@}
 
     /**

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -40,7 +40,7 @@ public:
     virtual ~RepeatMark();
     Object *Clone() const override { return new RepeatMark(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "repeatMark"; }
+    std::string_view GetClassName() const override { return "repeatMark"; }
     ///@}
 
     /**

--- a/include/vrv/rest.h
+++ b/include/vrv/rest.h
@@ -53,7 +53,7 @@ public:
     virtual ~Rest();
     Object *Clone() const override { return new Rest(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "rest"; }
+    std::string_view GetClassName() const override { return "rest"; }
     ///@}
 
     /**

--- a/include/vrv/restore.h
+++ b/include/vrv/restore.h
@@ -28,7 +28,7 @@ public:
     virtual ~Restore();
     Object *Clone() const override { return new Restore(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "restore"; }
+    std::string_view GetClassName() const override { return "restore"; }
     ///@}
 
 private:

--- a/include/vrv/sb.h
+++ b/include/vrv/sb.h
@@ -33,7 +33,7 @@ public:
     virtual ~Sb();
     Object *Clone() const override { return new Sb(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "sb"; }
+    std::string_view GetClassName() const override { return "sb"; }
     ///@}
 
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -38,7 +38,7 @@ public:
     Score();
     virtual ~Score();
     void Reset() override;
-    std::string GetClassName() const override { return "score"; }
+    std::string_view GetClassName() const override { return "score"; }
     ///@}
 
     /**

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -143,7 +143,7 @@ public:
     virtual ~ScoreDef();
     Object *Clone() const override { return new ScoreDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "scoreDef"; }
+    std::string_view GetClassName() const override { return "scoreDef"; }
     ///@}
 
     /**

--- a/include/vrv/section.h
+++ b/include/vrv/section.h
@@ -36,7 +36,7 @@ public:
     virtual ~Section();
     Object *Clone() const override { return new Section(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "section"; }
+    std::string_view GetClassName() const override { return "section"; }
     ///@}
 
     /**

--- a/include/vrv/sic.h
+++ b/include/vrv/sic.h
@@ -28,7 +28,7 @@ public:
     virtual ~Sic();
     Object *Clone() const override { return new Sic(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "sic"; }
+    std::string_view GetClassName() const override { return "sic"; }
     ///@}
 
 private:

--- a/include/vrv/slur.h
+++ b/include/vrv/slur.h
@@ -66,7 +66,7 @@ public:
     virtual ~Slur();
     Object *Clone() const override { return new Slur(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "slur"; }
+    std::string_view GetClassName() const override { return "slur"; }
     ///@}
 
     /**

--- a/include/vrv/space.h
+++ b/include/vrv/space.h
@@ -31,7 +31,7 @@ public:
     virtual ~Space();
     Object *Clone() const override { return new Space(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "space"; }
+    std::string_view GetClassName() const override { return "space"; }
     ///@}
 
     /**

--- a/include/vrv/staff.h
+++ b/include/vrv/staff.h
@@ -116,7 +116,7 @@ public:
     virtual ~Staff();
     Object *Clone() const override { return new Staff(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "staff"; }
+    std::string_view GetClassName() const override { return "staff"; }
     ///@}
 
     /**

--- a/include/vrv/staffdef.h
+++ b/include/vrv/staffdef.h
@@ -45,7 +45,7 @@ public:
     virtual ~StaffDef();
     Object *Clone() const override { return new StaffDef(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "staffDef"; }
+    std::string_view GetClassName() const override { return "staffDef"; }
     ///@}
 
     /**

--- a/include/vrv/staffgrp.h
+++ b/include/vrv/staffgrp.h
@@ -47,7 +47,7 @@ public:
     virtual ~StaffGrp();
     Object *Clone() const override { return new StaffGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "staffGrp"; }
+    std::string_view GetClassName() const override { return "staffGrp"; }
     ///@}
 
     /**

--- a/include/vrv/stem.h
+++ b/include/vrv/stem.h
@@ -35,7 +35,7 @@ public:
     virtual ~Stem();
     Object *Clone() const override { return new Stem(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "stem"; }
+    std::string_view GetClassName() const override { return "stem"; }
     ///@}
 
     /** Override the method since alignment is required */

--- a/include/vrv/subst.h
+++ b/include/vrv/subst.h
@@ -31,7 +31,7 @@ public:
     virtual ~Subst();
     Object *Clone() const override { return new Subst(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "subst"; }
+    std::string_view GetClassName() const override { return "subst"; }
     ///@}
 
     /** Getter for level **/

--- a/include/vrv/supplied.h
+++ b/include/vrv/supplied.h
@@ -28,7 +28,7 @@ public:
     virtual ~Supplied();
     Object *Clone() const override { return new Supplied(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "supplied"; }
+    std::string_view GetClassName() const override { return "supplied"; }
     ///@}
 
 private:

--- a/include/vrv/surface.h
+++ b/include/vrv/surface.h
@@ -37,7 +37,7 @@ public:
     virtual ~Surface();
     Object *Clone() const override { return new Surface(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "surface"; }
+    std::string_view GetClassName() const override { return "surface"; }
     ///@}
     bool IsSupportedChild(ClassId classId) override;
 

--- a/include/vrv/svg.h
+++ b/include/vrv/svg.h
@@ -27,7 +27,7 @@ public:
     Svg();
     virtual ~Svg();
     void Reset() override;
-    std::string GetClassName() const override { return "svg"; }
+    std::string_view GetClassName() const override { return "svg"; }
     ///@}
 
     /**

--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -44,7 +44,7 @@ public:
     virtual ~Syl();
     Object *Clone() const override { return new Syl(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "syl"; }
+    std::string_view GetClassName() const override { return "syl"; }
     ///@}
 
     /** Override the method since it is align to the staff */

--- a/include/vrv/syllable.h
+++ b/include/vrv/syllable.h
@@ -34,7 +34,7 @@ public:
     virtual ~Syllable();
     Object *Clone() const override { return new Syllable(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "syllable"; }
+    std::string_view GetClassName() const override { return "syllable"; }
     ///@}
 
     /**

--- a/include/vrv/symbol.h
+++ b/include/vrv/symbol.h
@@ -33,7 +33,7 @@ public:
     virtual ~Symbol();
     Object *Clone() const override { return new Symbol(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "symbol"; }
+    std::string_view GetClassName() const override { return "symbol"; }
     ///@}
 
     /**

--- a/include/vrv/symboldef.h
+++ b/include/vrv/symboldef.h
@@ -27,7 +27,7 @@ public:
     SymbolDef();
     virtual ~SymbolDef();
     void Reset() override;
-    std::string GetClassName() const override { return "symbolDef"; }
+    std::string_view GetClassName() const override { return "symbolDef"; }
     ///@}
 
     /**

--- a/include/vrv/symboltable.h
+++ b/include/vrv/symboltable.h
@@ -27,7 +27,7 @@ public:
     SymbolTable();
     virtual ~SymbolTable();
     void Reset() override;
-    std::string GetClassName() const override { return "symbolTable"; }
+    std::string_view GetClassName() const override { return "symbolTable"; }
     ///@}
 
     /**

--- a/include/vrv/system.h
+++ b/include/vrv/system.h
@@ -43,7 +43,7 @@ public:
     System();
     virtual ~System();
     void Reset() override;
-    std::string GetClassName() const override { return "system"; }
+    std::string_view GetClassName() const override { return "system"; }
     ///@}
 
     /**

--- a/include/vrv/systemmilestone.h
+++ b/include/vrv/systemmilestone.h
@@ -35,7 +35,7 @@ public:
     SystemMilestoneEnd(Object *start);
     virtual ~SystemMilestoneEnd();
     void Reset() override;
-    std::string GetClassName() const override { return "systemMilestoneEnd"; }
+    std::string_view GetClassName() const override { return "systemMilestoneEnd"; }
     ///@}
 
     void SetMeasure(Measure *measure) { m_drawingMeasure = measure; }

--- a/include/vrv/tabdursym.h
+++ b/include/vrv/tabdursym.h
@@ -37,7 +37,7 @@ public:
     virtual ~TabDurSym();
     Object *Clone() const override { return new TabDurSym(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tabDurSym"; }
+    std::string_view GetClassName() const override { return "tabDurSym"; }
     ///@}
 
     /**

--- a/include/vrv/tabgrp.h
+++ b/include/vrv/tabgrp.h
@@ -31,7 +31,7 @@ public:
     virtual ~TabGrp();
     Object *Clone() const override { return new TabGrp(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tabGrp"; }
+    std::string_view GetClassName() const override { return "tabGrp"; }
     ///@}
 
     /**

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -41,7 +41,7 @@ public:
     virtual ~Tempo();
     Object *Clone() const override { return new Tempo(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tempo"; }
+    std::string_view GetClassName() const override { return "tempo"; }
     ///@}
 
     /**

--- a/include/vrv/text.h
+++ b/include/vrv/text.h
@@ -31,7 +31,7 @@ public:
     virtual ~Text();
     Object *Clone() const override { return new Text(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "text"; }
+    std::string_view GetClassName() const override { return "text"; }
     ///@}
 
     /**

--- a/include/vrv/tie.h
+++ b/include/vrv/tie.h
@@ -36,7 +36,7 @@ public:
     virtual ~Tie();
     Object *Clone() const override { return new Tie(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tie"; }
+    std::string_view GetClassName() const override { return "tie"; }
     ///@}
 
     /**

--- a/include/vrv/timestamp.h
+++ b/include/vrv/timestamp.h
@@ -26,7 +26,7 @@ public:
     TimestampAttr();
     virtual ~TimestampAttr();
     void Reset() override;
-    std::string GetClassName() const override { return "timestampAttr"; }
+    std::string_view GetClassName() const override { return "timestampAttr"; }
     ///@}
 
     /**

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -42,7 +42,7 @@ public:
     virtual ~Trill();
     Object *Clone() const override { return new Trill(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "trill"; }
+    std::string_view GetClassName() const override { return "trill"; }
     ///@}
 
     /**

--- a/include/vrv/tuning.h
+++ b/include/vrv/tuning.h
@@ -31,7 +31,7 @@ public:
     virtual ~Tuning();
     Object *Clone() const override { return new Tuning(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tuning"; }
+    std::string_view GetClassName() const override { return "tuning"; }
     ///@}
 
     /**

--- a/include/vrv/tuplet.h
+++ b/include/vrv/tuplet.h
@@ -41,7 +41,7 @@ public:
     virtual ~Tuplet();
     Object *Clone() const override { return new Tuplet(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "tuplet"; }
+    std::string_view GetClassName() const override { return "tuplet"; }
     ///@}
 
     /**

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -40,7 +40,7 @@ public:
     virtual ~Turn();
     Object *Clone() const override { return new Turn(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "turn"; }
+    std::string_view GetClassName() const override { return "turn"; }
     ///@}
 
     /**

--- a/include/vrv/unclear.h
+++ b/include/vrv/unclear.h
@@ -28,7 +28,7 @@ public:
     virtual ~Unclear();
     Object *Clone() const override { return new Unclear(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "unclear"; }
+    std::string_view GetClassName() const override { return "unclear"; }
     ///@}
 
 private:

--- a/include/vrv/verse.h
+++ b/include/vrv/verse.h
@@ -36,7 +36,7 @@ public:
     virtual ~Verse();
     Object *Clone() const override { return new Verse(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "verse"; }
+    std::string_view GetClassName() const override { return "verse"; }
     ///@}
 
     /**

--- a/include/vrv/zone.h
+++ b/include/vrv/zone.h
@@ -37,7 +37,7 @@ public:
     virtual ~Zone();
     Object *Clone() const override { return new Zone(*this); }
     void Reset() override;
-    std::string GetClassName() const override { return "zone"; }
+    std::string_view GetClassName() const override { return "zone"; }
     ///@}
     void ShiftByXY(int xDiff, int yDiff);
     int GetLogicalUly() const;

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -160,7 +160,7 @@ FunctorCode AdjustGraceXPosFunctor::VisitLayerElement(LayerElement *layerElement
 
     if (m_graceCumulatedXShift == VRV_UNSET) m_graceCumulatedXShift = 0;
 
-    // LogDebug("********* Aligning %s", layerElement->GetClassName().c_str());
+    // LogDebug("********* Aligning %s", layerElement->GetClassName().data());
 
     // With non grace alignment we do not need to do this
     layerElement->ResetCachedDrawingX();

--- a/src/adjustharmgrpsspacingfunctor.cpp
+++ b/src/adjustharmgrpsspacingfunctor.cpp
@@ -65,7 +65,7 @@ FunctorCode AdjustHarmGrpsSpacingFunctor::VisitHarm(Harm *harm)
     FloatingPositioner *harmPositioner = NULL;
     // Something is probably not right if nothing found - maybe no @staff
     if (positioners.empty()) {
-        LogDebug("Something was wrong when searching positioners for %s '%s'", harm->GetClassName().c_str(),
+        LogDebug("Something was wrong when searching positioners for %s '%s'", harm->GetClassName().data(),
             harm->GetID().c_str());
         return FUNCTOR_SIBLINGS;
     }

--- a/src/adjustxoverflowfunctor.cpp
+++ b/src/adjustxoverflowfunctor.cpp
@@ -49,7 +49,7 @@ FunctorCode AdjustXOverflowFunctor::VisitControlElement(ControlElement *controlE
 
     // Something is probably not right if nothing found - maybe no @staff
     if (positioners.empty()) {
-        LogDebug("Something was wrong when searching positioners for %s '%s'", controlElement->GetClassName().c_str(),
+        LogDebug("Something was wrong when searching positioners for %s '%s'", controlElement->GetClassName().data(),
             controlElement->GetID().c_str());
         return FUNCTOR_SIBLINGS;
     }

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -371,7 +371,7 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         }
     }
 
-    // LogDebug("Element %f %s", m_time, layerElement->GetClassName().c_str());
+    // LogDebug("Element %f %s", m_time, layerElement->GetClassName().data());
 
     if (!layerElement->Is(TIMESTAMP_ATTR)) {
         // increase the time position, but only when not a timestamp (it would actually do nothing)

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -77,7 +77,7 @@ bool Arpeg::IsValidRef(const Object *ref) const
 {
     if (!ref->Is({ CHORD, NOTE })) {
         LogWarning(
-            "%s is not supported as @plist target for %s", ref->GetClassName().c_str(), this->GetClassName().c_str());
+            "%s is not supported as @plist target for %s", ref->GetClassName().data(), this->GetClassName().data());
         return false;
     }
     return true;

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -63,7 +63,7 @@ void BoundingBox::UpdateContentBBoxX(int x1, int x2)
     if (m_contentBB_x2 < maxX) m_contentBB_x2 = maxX;
 
     // LogDebug("CB Is:  %i %i %i %i %s", m_contentBB_x1,m_contentBB_y1, m_contentBB_x2, m_contentBB_y2,
-    // this->GetClassName().c_str());
+    // this->GetClassName().data());
 }
 
 void BoundingBox::UpdateContentBBoxY(int y1, int y2)
@@ -82,7 +82,7 @@ void BoundingBox::UpdateContentBBoxY(int y1, int y2)
     if (m_contentBB_y2 < max_y) m_contentBB_y2 = max_y;
 
     // LogDebug("CB Is:  %i %i %i %i %s", m_contentBB_x1,m_contentBB_y1, m_contentBB_x2, m_contentBB_y2,
-    // this->GetClassName().c_str());
+    // this->GetClassName().data());
 }
 
 void BoundingBox::UpdateSelfBBoxX(int x1, int x2)

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -187,7 +187,7 @@ bool Chord::IsSupportedChild(ClassId classId)
 void Chord::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -485,7 +485,7 @@ FunctorCode ConvertToCmnFunctor::VisitLayerElement(LayerElement *layerElement)
         // can be ignored
     }
     else {
-        LogDebug(layerElement->GetClassName().c_str());
+        LogDebug(layerElement->GetClassName().data());
     }
 
     return FUNCTOR_SIBLINGS;

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -276,11 +276,11 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     }
     // Check if it is a LayerElement
     if (!dynamic_cast<LayerElement *>(start)) {
-        LogInfo("Element '%s' is not supported as start element", start->GetClassName().c_str());
+        LogInfo("Element '%s' is not supported as start element", start->GetClassName().data());
         return false;
     }
     if (!dynamic_cast<LayerElement *>(end)) {
-        LogInfo("Element '%s' is not supported as end element", start->GetClassName().c_str());
+        LogInfo("Element '%s' is not supported as end element", start->GetClassName().data());
         return false;
     }
 
@@ -330,7 +330,7 @@ bool EditorToolkitCMN::Insert(std::string &elementType, std::string const &start
     }
     // Check if it is a LayerElement
     if (!dynamic_cast<LayerElement *>(start)) {
-        LogInfo("Element '%s' is not supported as start element", start->GetClassName().c_str());
+        LogInfo("Element '%s' is not supported as start element", start->GetClassName().data());
         return false;
     }
 

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -1319,17 +1319,18 @@ bool EditorToolkitNeume::InsertToSyllable(std::string elementId)
     }
     if (!(element->Is(DIVLINE) || element->Is(ACCID) || element->Is(CLEF))) {
         LogError("Element is of type %s, but only Divlines and Accids can be inserted into syllables.",
-            element->GetClassName().c_str());
+            element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
         m_editInfo.import("message",
-            "Element is of type " + element->GetClassName()
+            "Element is of type " + std::string(element->GetClassName())
                 + ", but only DivLines, Accids, and Clefs can be inserted into syllables.");
         return false;
     }
     if (!parent->Is(LAYER)) {
-        LogError("The selected %s is not a child of layer.", element->GetClassName().c_str());
+        LogError("The selected %s is not a child of layer.", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "The selected " + element->GetClassName() + "is not a child of layer.");
+        m_editInfo.import(
+            "message", "The selected " + std::string(element->GetClassName()) + "is not a child of layer.");
         return false;
     }
 
@@ -1341,9 +1342,10 @@ bool EditorToolkitNeume::InsertToSyllable(std::string elementId)
         uly = element->GetFacsimileInterface()->GetZone()->GetUly();
     }
     else {
-        LogError("Selected '%s' without facsimile", element->GetClassName().c_str());
+        LogError("Selected '%s' without facsimile", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Selected '" + element->GetClassName() + "' without facsimile is unsupported.");
+        m_editInfo.import(
+            "message", "Selected '" + std::string(element->GetClassName()) + "' without facsimile is unsupported.");
         return false;
     }
 
@@ -1356,10 +1358,10 @@ bool EditorToolkitNeume::InsertToSyllable(std::string elementId)
     staff->FindAllDescendantsByComparison(&neumes, &ac);
 
     if (neumes.empty()) {
-        LogError("A syllable must exist in the staff to insert a '%s' into.", element->GetClassName().c_str());
+        LogError("A syllable must exist in the staff to insert a '%s' into.", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import(
-            "message", "A syllable must exist in the staff to insert a '" + element->GetClassName() + "' into.");
+        m_editInfo.import("message",
+            "A syllable must exist in the staff to insert a '" + std::string(element->GetClassName()) + "' into.");
         return false;
     }
 
@@ -1469,17 +1471,18 @@ bool EditorToolkitNeume::MoveOutsideSyllable(std::string elementId)
     }
     if (!(element->Is(DIVLINE) || element->Is(ACCID) || element->Is(CLEF))) {
         LogError("Element is of type %s, but only Divlines, Accids, and Clefs can be moved out of syllables.",
-            element->GetClassName().c_str());
+            element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
         m_editInfo.import("message",
-            "Element is of type " + element->GetClassName()
+            "Element is of type " + std::string(element->GetClassName())
                 + ", but only DivLines and Accids can be inserted into syllables.");
         return false;
     }
     if (!parent->Is(SYLLABLE)) {
-        LogError("The selected %s is not a child of syllable.", element->GetClassName().c_str());
+        LogError("The selected %s is not a child of syllable.", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "The selected " + element->GetClassName() + "is not a child of syllable.");
+        m_editInfo.import(
+            "message", "The selected " + std::string(element->GetClassName()) + "is not a child of syllable.");
         return false;
     }
 
@@ -1673,10 +1676,11 @@ bool EditorToolkitNeume::MatchHeight(std::string elementId)
         return false;
     }
     if (!element->Is(SYL)) {
-        LogError("Element is of type %s, but only <syl> element can match height.", element->GetClassName().c_str());
+        LogError("Element is of type %s, but only <syl> element can match height.", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import(
-            "message", "Element is of type " + element->GetClassName() + ", but only <syl> element can match height.");
+        m_editInfo.import("message",
+            "Element is of type " + std::string(element->GetClassName())
+                + ", but only <syl> element can match height.");
         return false;
     }
 
@@ -1690,9 +1694,10 @@ bool EditorToolkitNeume::MatchHeight(std::string elementId)
         height = element->GetFacsimileInterface()->GetZone()->GetLry() - uly;
     }
     else {
-        LogError("Selected '%s' without facsimile", element->GetClassName().c_str());
+        LogError("Selected '%s' without facsimile", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Selected '" + element->GetClassName() + "' without facsimile is unsupported.");
+        m_editInfo.import(
+            "message", "Selected '" + std::string(element->GetClassName()) + "' without facsimile is unsupported.");
         return false;
     }
 
@@ -1992,9 +1997,10 @@ bool EditorToolkitNeume::SetText(std::string elementId, const std::string &text)
         }
     }
     else {
-        LogError("Element type '%s' is unsupported for SetText", element->GetClassName().c_str());
+        LogError("Element type '%s' is unsupported for SetText", element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Element type '" + element->GetClassName() + "' is unsupported for SetText.");
+        m_editInfo.import(
+            "message", "Element type '" + std::string(element->GetClassName()) + "' is unsupported for SetText.");
         return false;
     }
 
@@ -2595,9 +2601,9 @@ bool EditorToolkitNeume::Resize(std::string elementId, int ulx, int uly, int lrx
         if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
     }
     else {
-        LogError("Element of type '%s' is unsupported.", obj->GetClassName().c_str());
+        LogError("Element of type '%s' is unsupported.", obj->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Element of type '" + obj->GetClassName() + "' is unsupported.");
+        m_editInfo.import("message", "Element of type '" + std::string(obj->GetClassName()) + "' is unsupported.");
         return false;
     }
 
@@ -2656,12 +2662,12 @@ bool EditorToolkitNeume::Group(std::string groupType, std::vector<std::string> e
             return false;
         }
         if (el->GetClassId() != elementClass) {
-            LogError("Element %s was of class %s. Expected class %s", el->GetID().c_str(), el->GetClassName().c_str(),
+            LogError("Element %s was of class %s. Expected class %s", el->GetID().c_str(), el->GetClassName().data(),
                 groupType.c_str());
             m_editInfo.import("status", "FAILURE");
             m_editInfo.import("message",
-                "Element " + el->GetID() + " was of class " + el->GetClassName() + " but expected class " + groupType
-                    + ".");
+                "Element " + el->GetID() + " was of class " + std::string(el->GetClassName()) + " but expected class "
+                    + groupType + ".");
             return false;
         }
 
@@ -3592,10 +3598,10 @@ bool EditorToolkitNeume::ChangeStaff(std::string elementId)
     if (!(element->Is(SYLLABLE) || element->Is(CUSTOS) || element->Is(CLEF) || element->Is(DIVLINE)
             || element->Is(ACCID))) {
         LogError("Element is of type %s, but only Syllables, Custos, Clefs, Divlines, and Accids can change staves.",
-            element->GetClassName().c_str());
+            element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
         m_editInfo.import("message",
-            "Element is of type " + element->GetClassName()
+            "Element is of type " + std::string(element->GetClassName())
                 + ", but only Syllables, Custos, Clefs, DivLines, and Accids can change staves.");
         return false;
     }
@@ -3796,10 +3802,10 @@ bool EditorToolkitNeume::ChangeStaffTo(std::string elementId, std::string staffI
 
     if (!(element->Is(CLEF) || element->Is(DIVLINE) || element->Is(ACCID))) {
         LogError("Element is of type %s, but only Clefs, Divlines, and Accids can change to a specified staff.",
-            element->GetClassName().c_str());
+            element->GetClassName().data());
         m_editInfo.import("status", "FAILURE");
         m_editInfo.import("message",
-            "Element is of type " + element->GetClassName()
+            "Element is of type " + std::string(element->GetClassName())
                 + ", but only Clefs, Divlines, and Accids can change to a specified staff.");
         return false;
     }
@@ -4248,7 +4254,7 @@ bool EditorToolkitNeume::AdjustPitchAfterDrag(Object *obj, int y)
     if (!obj->Is(NC) && !obj->Is(CUSTOS)) {
         LogError("AdjustPitchAfterDrag should only be called on custos or ncs."
                  "It has been called on %s, whose id is %s",
-            obj->GetClassName().c_str(), obj->GetID().c_str());
+            obj->GetClassName().data(), obj->GetID().c_str());
         return false;
     }
     PitchInterface *pi = obj->GetPitchInterface();
@@ -4266,7 +4272,7 @@ bool EditorToolkitNeume::AdjustPitchFromPosition(Object *obj)
 {
     if (!obj->Is(CUSTOS) && !obj->Is(SYLLABLE) && !obj->Is(NEUME)) {
         LogError("AdjustPitchFromPosition should only be called on custos or syllables/neumes. Called on %s, ID: %s",
-            obj->GetClassName().c_str(), obj->GetID().c_str());
+            obj->GetClassName().data(), obj->GetID().c_str());
         return false;
     }
 

--- a/src/facsimilefunctor.cpp
+++ b/src/facsimilefunctor.cpp
@@ -224,7 +224,7 @@ FunctorCode SyncToFacsimileFunctor::VisitLayerElement(LayerElement *layerElement
     if (!layerElement->Is({ ACCID, BARLINE, CLEF, CUSTOS, DOT, DIVLINE, LIQUESCENT, NC, NOTE, REST, SYL }))
         return FUNCTOR_CONTINUE;
 
-    Zone *zone = this->GetZone(layerElement, layerElement->GetClassName());
+    Zone *zone = this->GetZone(layerElement, std::string(layerElement->GetClassName()));
     zone->SetUlx(m_view.ToDeviceContextX(layerElement->GetDrawingX()) / DEFINITION_FACTOR + m_pageMarginLeft);
     if (m_currentNeumeLine && layerElement->Is({ ACCID, SYL })) {
         zone->SetUly(m_view.ToDeviceContextY(layerElement->GetDrawingY()) / DEFINITION_FACTOR + m_pageMarginTop);
@@ -235,7 +235,7 @@ FunctorCode SyncToFacsimileFunctor::VisitLayerElement(LayerElement *layerElement
 
 FunctorCode SyncToFacsimileFunctor::VisitMeasure(Measure *measure)
 {
-    Zone *zone = this->GetZone(measure, measure->GetClassName());
+    Zone *zone = this->GetZone(measure, std::string(measure->GetClassName()));
     zone->SetUlx(m_view.ToDeviceContextX(measure->GetDrawingX()) / DEFINITION_FACTOR + m_pageMarginLeft);
     zone->SetLrx(
         m_view.ToDeviceContextX(measure->GetDrawingX() + measure->GetWidth()) / DEFINITION_FACTOR + m_pageMarginLeft);
@@ -289,7 +289,7 @@ FunctorCode SyncToFacsimileFunctor::VisitPb(Pb *pb)
         m_surface = new Surface();
         assert(m_doc->GetFacsimile());
         m_doc->GetFacsimile()->AddChild(m_surface);
-        zone = this->GetZone(pb, pb->GetClassName());
+        zone = this->GetZone(pb, std::string(pb->GetClassName()));
     }
     // We already have some facsimile data - retrieve the surface ancestor
     else {
@@ -317,7 +317,7 @@ FunctorCode SyncToFacsimileFunctor::VisitPb(Pb *pb)
 
 FunctorCode SyncToFacsimileFunctor::VisitSb(Sb *sb)
 {
-    Zone *zone = this->GetZone(sb, sb->GetClassName());
+    Zone *zone = this->GetZone(sb, std::string(sb->GetClassName()));
     zone->SetUlx(m_view.ToDeviceContextX(m_currentSystem->GetDrawingX()) / DEFINITION_FACTOR + m_pageMarginLeft);
     zone->SetUly(m_view.ToDeviceContextY(m_currentSystem->GetDrawingY()) / DEFINITION_FACTOR + m_pageMarginTop);
 
@@ -326,7 +326,7 @@ FunctorCode SyncToFacsimileFunctor::VisitSb(Sb *sb)
 
 FunctorCode SyncToFacsimileFunctor::VisitStaff(Staff *staff)
 {
-    Zone *zone = this->GetZone(staff, staff->GetClassName());
+    Zone *zone = this->GetZone(staff, std::string(staff->GetClassName()));
     zone->SetUly(m_view.ToDeviceContextY(staff->GetDrawingY()) / DEFINITION_FACTOR + m_pageMarginTop);
 
     return FUNCTOR_CONTINUE;

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -981,7 +981,7 @@ void ABCInput::FlushControlElements(Score *score, Section *section)
         }
         if (!layer) {
             LogWarning("ABC import: Element '%s' could not be assigned to layer '%s'",
-                iter.second->GetClassName().c_str(), iter.first.c_str());
+                iter.second->GetClassName().data(), iter.first.c_str());
             delete iter.second;
             iter.second = NULL;
             continue;

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -2940,7 +2940,7 @@ void HumdrumInput::createDigitalSource(pugi::xml_node sourceDesc)
     pugi::xml_node bibl = source.append_child("bibl");
     bibl.append_copy(m_simpleTitle);
     for (pugi::xml_node_iterator childIt = m_simpleComposersDoc.begin(); childIt != m_simpleComposersDoc.end();
-        ++childIt) {
+         ++childIt) {
         bibl.append_copy(*childIt);
     }
 
@@ -3692,7 +3692,7 @@ void HumdrumInput::createPrintedSource(pugi::xml_node sourceDesc)
 
     bibl.append_copy(m_simpleTitle);
     for (pugi::xml_node_iterator childIt = m_simpleComposersDoc.begin(); childIt != m_simpleComposersDoc.end();
-        ++childIt) {
+         ++childIt) {
         bibl.append_copy(*childIt);
     }
 
@@ -31214,7 +31214,7 @@ std::string HumdrumInput::getLocationId(Object *object, hum::HTp token, int subt
 {
     int line = token->getLineIndex() + 1;
     int field = token->getFieldIndex() + 1;
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     id += "-L" + to_string(line);
     id += "F" + to_string(field);
@@ -31242,7 +31242,7 @@ std::string HumdrumInput::getLocationId(Object *object, int lineindex, int field
     int line = lineindex + 1;
     int field = fieldindex + 1;
     int subtoken = subtokenindex + 1;
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     if (line > 0) {
         id += "-L" + to_string(line);
@@ -31283,7 +31283,7 @@ void HumdrumInput::setLocationIdNSuffix(Object *object, hum::HTp token, int numb
 {
     int line = token->getLineIndex() + 1;
     int field = token->getFieldIndex() + 1;
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     id += "-L" + to_string(line);
     id += "F" + to_string(field);
@@ -31370,7 +31370,7 @@ void HumdrumInput::setBeamLocationId(Object *object, const std::vector<humaux::H
     int startline = starttoken->getLineNumber();
     int startfield = starttoken->getFieldNumber();
 
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     id += "-L" + to_string(startline);
     id += "F" + to_string(startfield);
@@ -31409,7 +31409,7 @@ void HumdrumInput::setTupletLocationId(Object *object, const std::vector<humaux:
     int startline = starttoken->getLineNumber();
     int startfield = starttoken->getFieldNumber();
 
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
     id += "-L" + to_string(startline);
     id += "F" + to_string(startfield);
@@ -31457,7 +31457,7 @@ void HumdrumInput::setTieLocationId(Object *object, hum::HTp tiestart, int sinde
         endfield = tieend->getFieldNumber();
     }
 
-    std::string id = object->GetClassName();
+    std::string id(object->GetClassName());
     std::transform(id.begin(), id.end(), id.begin(), ::tolower);
 
     id += "-L" + to_string(startline);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -932,7 +932,7 @@ bool MEIOutput::WriteObjectInternal(Object *object, bool useCustomScoreDef)
 
     else {
         // Missing output method for the class
-        LogError("Output method missing for '%s'", object->GetClassName().c_str());
+        LogError("Output method missing for '%s'", object->GetClassName().data());
         assert(false); // let's make it stop because this should not happen
     }
 
@@ -1650,7 +1650,7 @@ void MEIOutput::WritePageMilestoneEnd(pugi::xml_node currentNode, PageMilestoneE
 
     this->WritePageElement(currentNode, milestoneEnd);
     currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
-    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().c_str();
+    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().data();
 }
 
 void MEIOutput::WriteSystem(pugi::xml_node currentNode, System *system)
@@ -1684,7 +1684,7 @@ void MEIOutput::WriteSystemMilestoneEnd(pugi::xml_node currentNode, SystemMilest
 
     this->WriteSystemElement(currentNode, milestoneEnd);
     currentNode.append_attribute("startid") = ("#" + IDToMeiStr(milestoneEnd->GetStart())).c_str();
-    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().c_str();
+    currentNode.append_attribute("type") = milestoneEnd->GetStart()->GetClassName().data();
 }
 
 void MEIOutput::WriteSection(pugi::xml_node currentNode, Section *section)
@@ -2917,7 +2917,7 @@ void MEIOutput::WriteFacsimile(pugi::xml_node currentNode, Facsimile *facsimile)
             this->WriteSurface(childNode, dynamic_cast<Surface *>(child));
         }
         else {
-            LogWarning("Unable to write child '%s' of facsimile", child->GetClassName().c_str());
+            LogWarning("Unable to write child '%s' of facsimile", child->GetClassName().data());
         }
     }
 }
@@ -2950,7 +2950,7 @@ void MEIOutput::WriteSurface(pugi::xml_node currentNode, Surface *surface)
             this->WriteZone(childNode, dynamic_cast<Zone *>(child));
         }
         else {
-            LogWarning("Unable to write child '%s' of surface", child->GetClassName().c_str());
+            LogWarning("Unable to write child '%s' of surface", child->GetClassName().data());
         }
     }
 }
@@ -3181,7 +3181,7 @@ void MEIOutput::WriteUnsupportedAttr(pugi::xml_node element, Object *object)
 {
     for (const auto &pair : object->m_unsupported) {
         if (element.attribute(pair.first.c_str())) {
-            LogDebug("Attribute '%s' for '%s' is not supported", pair.first.c_str(), object->GetClassName().c_str());
+            LogDebug("Attribute '%s' for '%s' is not supported", pair.first.c_str(), object->GetClassName().data());
         }
         else {
             element.append_attribute(pair.first.c_str()) = pair.second.c_str();
@@ -3907,7 +3907,7 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         }
     }
     else {
-        LogDebug("Unknown filter for '%s'", filterParent->GetClassName().c_str());
+        LogDebug("Unknown filter for '%s'", filterParent->GetClassName().data());
         return true;
     }
 }
@@ -5158,7 +5158,7 @@ bool MEIInput::ReadRunningChildren(Object *parent, pugi::xml_node parentNode, Ob
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                filter->GetClassName().c_str());
+                filter->GetClassName().data());
             continue;
         }
         // editorial
@@ -6229,7 +6229,7 @@ bool MEIInput::ReadLayerChildren(Object *parent, pugi::xml_node parentNode, Obje
         // LogDebug("ReadLayerChildren: element <%s>", xmlElement.name());
         if (!this->IsAllowed(elementName, filter)) {
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                filter->GetClassName().c_str());
+                filter->GetClassName().data());
             continue;
         }
         // editorial
@@ -7210,7 +7210,7 @@ bool MEIInput::ReadTextChildren(Object *parent, pugi::xml_node parentNode, Objec
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                filter->GetClassName().c_str());
+                filter->GetClassName().data());
             continue;
         }
         // editorial
@@ -7271,7 +7271,7 @@ bool MEIInput::ReadSymbolDefChildren(Object *parent, pugi::xml_node parentNode, 
         elementName = std::string(xmlElement.name());
         if (filter && !this->IsAllowed(elementName, filter)) {
             LogWarning("Element <%s> within <%s> is not supported and will be ignored ", xmlElement.name(),
-                filter->GetClassName().c_str());
+                filter->GetClassName().data());
             continue;
         }
         // content

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1100,7 +1100,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
         }
         if (!measure) {
             LogWarning("MusicXML import: Element '%s' could not be added to measure %s",
-                iter.second->GetClassName().c_str(), iter.first.c_str());
+                iter.second->GetClassName().data(), iter.first.c_str());
             delete iter.second;
             continue;
         }

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2469,7 +2469,7 @@ namespace pae {
     std::string Token::GetName()
     {
         if (!m_object) return "?";
-        std::string name = m_object->GetClassName();
+        std::string name(m_object->GetClassName());
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
         return name;
     }
@@ -2498,7 +2498,7 @@ void PAEInput::ClearTokenObjects()
     // Normally, they should be none because they are passed to the doc.
     for (pae::Token &token : m_pae) {
         if (!token.m_object || token.IsContainerEnd()) continue;
-        LogDebug("Delete token %s", token.m_object->GetClassName().c_str());
+        LogDebug("Delete token %s", token.m_object->GetClassName().data());
         delete token.m_object;
         token.m_object = NULL;
     }
@@ -2589,7 +2589,7 @@ void PAEInput::LogDebugTokens(bool vertical)
         for (pae::Token &token : m_pae) {
             char c1 = (token.m_char) ? token.m_char : ' ';
             char c2 = (token.m_inputChar) ? token.m_inputChar : ' ';
-            std::string className = (token.m_object) ? token.m_object->GetClassName() : "";
+            std::string className = (token.m_object) ? std::string(token.m_object->GetClassName()) : "";
             if (token.m_isError) className += " <";
             LogDebug(" %c | %c | %s", c1, c2, className.c_str());
         }
@@ -2612,7 +2612,7 @@ void PAEInput::LogDebugTokens(bool vertical)
         }
         row.clear();
         for (pae::Token &token : m_pae) {
-            std::string className = (token.m_object) ? token.m_object->GetClassName() : " ";
+            std::string className = (token.m_object) ? std::string(token.m_object->GetClassName()) : " ";
             row.push_back(className.at(0));
         }
         LogDebug(row.c_str());
@@ -4779,7 +4779,7 @@ void PAEInput::RemoveContainerToken(Object *object)
         if (token.m_object == object) {
             if (!token.IsContainerEnd()) {
                 // Make sure we delete it only once - even though it should never be there more than once
-                LogDebug("Deleting %s", object->GetClassName().c_str());
+                LogDebug("Deleting %s", object->GetClassName().data());
                 if (!deleted) delete token.m_object;
                 deleted = true;
             }

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -181,7 +181,7 @@ bool Measure::IsSupportedChild(ClassId classId)
 void Measure::AddChildBack(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -149,7 +149,7 @@ bool Note::IsSupportedChild(ClassId classId)
 void Note::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -819,7 +819,7 @@ void Object::SetParent(Object *parent)
 bool Object::IsSupportedChild(ClassId classId)
 {
     // This should never happen because the method should be overridden
-    LogDebug("Method for adding %d to %s should be overridden", classId, this->GetClassName().c_str());
+    LogDebug("Method for adding %d to %s should be overridden", classId, this->GetClassName().data());
     // assert(false);
     return false;
 }
@@ -827,7 +827,7 @@ bool Object::IsSupportedChild(ClassId classId)
 void Object::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -440,8 +440,8 @@ FunctorCode PrepareLinkingFunctor::VisitObject(Object *object)
             // Issue a warning if classes of object and sameas do not match
             Object *owner = dynamic_cast<Object *>(j->second);
             if (owner && (owner->GetClassId() != object->GetClassId())) {
-                LogWarning("%s with @xml:id %s has @sameas to an element of class %s.", owner->GetClassName().c_str(),
-                    owner->GetID().c_str(), object->GetClassName().c_str());
+                LogWarning("%s with @xml:id %s has @sameas to an element of class %s.", owner->GetClassName().data(),
+                    owner->GetID().c_str(), object->GetClassName().data());
             }
         }
         m_sameasIDPairs.erase(r2.first, r2.second);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -225,7 +225,7 @@ bool Rest::IsSupportedChild(ClassId classId)
 void Rest::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -255,7 +255,7 @@ void SvgDeviceContext::StartGraphic(
         m_currentNode = m_currentNode.append_child("g");
     }
     m_svgNodeStack.push_back(m_currentNode);
-    AppendIdAndClass(gId, object->GetClassName(), gClassFull, graphicID);
+    AppendIdAndClass(gId, std::string(object->GetClassName()), gClassFull, graphicID);
     AppendAdditionalAttributes(object);
 
     // this sets staffDef styles for lyrics
@@ -350,7 +350,7 @@ void SvgDeviceContext::StartTextGraphic(Object *object, const std::string &gClas
 {
     m_currentNode = AddChild("tspan");
     m_svgNodeStack.push_back(m_currentNode);
-    AppendIdAndClass(gId, object->GetClassName(), gClass);
+    AppendIdAndClass(gId, std::string(object->GetClassName()), gClass);
     AppendAdditionalAttributes(object);
 
     if (object->HasAttClass(ATT_COLOR)) {

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -202,7 +202,7 @@ bool Syl::CreateDefaultZone(Doc *doc)
             zone->SetLry(lry + offsetLry);
         }
         else {
-            LogWarning("Failed to create zone for %s of type %s", this->GetID().c_str(), this->GetClassName().c_str());
+            LogWarning("Failed to create zone for %s of type %s", this->GetID().c_str(), this->GetClassName().data());
             delete zone;
             return false;
         }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -185,7 +185,7 @@ bool System::SetCurrentFloatingPositioner(
     if (m_systemAligner.GetChildCount() == 1) return false;
     StaffAlignment *alignment = m_systemAligner.GetStaffAlignmentForStaffN(staffN);
     if (!alignment) {
-        LogError("Staff @n='%d' for rendering control event %s %s not found", staffN, object->GetClassName().c_str(),
+        LogError("Staff @n='%d' for rendering control event %s %s not found", staffN, object->GetClassName().data(),
             object->GetID().c_str());
         return false;
     }

--- a/src/tabdursym.cpp
+++ b/src/tabdursym.cpp
@@ -67,7 +67,7 @@ bool TabDurSym::IsSupportedChild(ClassId classId)
 void TabDurSym::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -179,7 +179,7 @@ bool TimePointInterface::VerifyMeasure(const Object *owner) const
     assert(owner);
     if (m_start && (owner->GetFirstAncestor(MEASURE) != this->GetStartMeasure())) {
         LogWarning("%s '%s' is not encoded in the measure of its start '%s'. This may cause improper rendering.",
-            owner->GetClassName().c_str(), owner->GetID().c_str(), m_start->GetID().c_str());
+            owner->GetClassName().data(), owner->GetID().c_str(), m_start->GetID().c_str());
         return false;
     }
     return true;
@@ -366,7 +366,7 @@ FunctorCode TimePointInterface::InterfacePrepareTimestamps(PrepareTimestampsFunc
     if (this->HasStart()) {
         if (this->HasTstamp())
             LogWarning("%s with @xml:id %s has both a @startid and an @tstamp; @tstamp is ignored",
-                object->GetClassName().c_str(), object->GetID().c_str());
+                object->GetClassName().data(), object->GetID().c_str());
         return FUNCTOR_CONTINUE;
     }
     else if (!this->HasTstamp()) {
@@ -408,10 +408,10 @@ FunctorCode TimeSpanningInterface::InterfacePrepareTimestamps(PrepareTimestampsF
     if (this->HasEndid()) {
         if (this->HasTstamp2())
             LogWarning("%s with @xml:id %s has both a @endid and an @tstamp2; @tstamp2 is ignored",
-                object->GetClassName().c_str(), object->GetID().c_str());
+                object->GetClassName().data(), object->GetID().c_str());
         if ((this->GetStartid() == this->GetEndid()) && !object->Is(OCTAVE)) {
             LogWarning("%s with @xml:id %s will not get rendered as it has identical values in @startid and @endid",
-                object->GetClassName().c_str(), object->GetID().c_str());
+                object->GetClassName().data(), object->GetID().c_str());
         }
         return TimePointInterface::InterfacePrepareTimestamps(functor, object);
     }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -84,7 +84,7 @@ bool Tuplet::IsSupportedChild(ClassId classId)
 void Tuplet::AddChild(Object *child)
 {
     if (!this->IsSupportedChild(child->GetClassId()) || !this->AddChildAdditionalCheck(child)) {
-        LogError("Adding '%s' to a '%s'", child->GetClassName().c_str(), this->GetClassName().c_str());
+        LogError("Adding '%s' to a '%s'", child->GetClassName().data(), this->GetClassName().data());
         return;
     }
 

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -435,8 +435,7 @@ bool View::HasValidTimeSpanningOrder(DeviceContext *dc, Object *element, LayerEl
         // To avoid showing the same warning multiple times, display a warning only during actual drawing
         if (!dc->Is(BBOX_DEVICE_CONTEXT) && (m_currentPage == vrv_cast<Page *>(start->GetFirstAncestor(PAGE)))) {
             LogWarning("%s '%s' is ignored, since start '%s' does not occur temporally before end '%s'.",
-                element->GetClassName().c_str(), element->GetID().c_str(), start->GetID().c_str(),
-                end->GetID().c_str());
+                element->GetClassName().data(), element->GetID().c_str(), start->GetID().c_str(), end->GetID().c_str());
         }
         return false;
     }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -221,7 +221,7 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     }
     else {
         // This should never happen
-        LogError("Element '%s' cannot be drawn", element->GetClassName().c_str());
+        LogError("Element '%s' cannot be drawn", element->GetClassName().data());
     }
 }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1725,7 +1725,7 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
             this->DrawMeasureEditorialElement(dc, dynamic_cast<EditorialElement *>(current), measure, system);
         }
         else {
-            LogDebug("Current is %s", current->GetClassName().c_str());
+            LogDebug("Current is %s", current->GetClassName().data());
             assert(false);
         }
     }


### PR DESCRIPTION
This PR optimises the `Object::GetClassName` with the use of `std::string_view`. No change in behaviour expected.

Also fixes a missing file in the xcode project.