### PR TITLE
Fix regression on musicxml tie resovling

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -103,14 +103,14 @@ namespace musicxml {
     };
 
     struct OpenArpeggio {
-        OpenArpeggio(const int &arpegN, const int &timeStamp)
+        OpenArpeggio(const int &arpegN, const Fraction &timeStamp)
         {
             m_arpegN = arpegN;
             m_timeStamp = timeStamp;
         }
 
         int m_arpegN;
-        int m_timeStamp;
+        Fraction m_timeStamp;
     };
 
     struct EndingInfo {

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1753,18 +1753,18 @@ void MusicXmlInput::MatchTies(bool matchLayers)
     // match open ties with close ties
     std::vector<musicxml::OpenTie>::iterator iter = m_tieStack.begin();
     while (iter != m_tieStack.end()) {
-        double lastScoreTimeOnset = 9999; // __DBL_MAX__;
+        Fraction lastScoreTimeOnset(9999); // __DBL_MAX__;
         bool tieMatched = false;
         std::vector<musicxml::CloseTie>::iterator jter;
         for (jter = m_tieStopStack.begin(); jter != m_tieStopStack.end(); ++jter) {
             // match tie stop with pitch/oct identity, with start note earlier than end note,
             // and with earliest end note.
             if ((iter->m_note->IsEnharmonicWith(jter->m_note))
-                && (iter->m_note->GetRealTimeOnsetMilliseconds() < jter->m_note->GetRealTimeOnsetMilliseconds())
-                && (jter->m_note->GetRealTimeOnsetMilliseconds() < lastScoreTimeOnset)
+                && (iter->m_note->GetScoreTimeOnset() < jter->m_note->GetScoreTimeOnset())
+                && (jter->m_note->GetScoreTimeOnset() < lastScoreTimeOnset)
                 && (!matchLayers || (iter->m_layerNum == jter->m_layerNum))) {
                 iter->m_tie->SetEndid("#" + jter->m_note->GetID());
-                lastScoreTimeOnset = jter->m_note->GetRealTimeOnsetMilliseconds();
+                lastScoreTimeOnset = jter->m_note->GetScoreTimeOnset();
                 tieMatched = true;
                 break;
             }
@@ -2663,7 +2663,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     Note *note = NULL;
 
     bool nextIsChord = false;
-    double onset = m_durTotal; // keep note onsets for later
+    Fraction onset = m_durTotal; // keep note onsets for later
 
     // for measure repeats add a single <mRpt> and return
     if (m_mRpt) {
@@ -2828,7 +2828,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         if (!noteID.empty()) {
             note->SetID(noteID);
         }
-        note->SetRealTimeOnsetSeconds(onset); // remember the MIDI onset within that measure
+        note->SetScoreTimeOnset(onset); // remember the MIDI onset within that measure
         // set @staff attribute, if existing and different from parent staff number
         if (noteStaffNum > 0 && noteStaffNum + staffOffset != staff->GetN())
             note->SetStaff(


### PR DESCRIPTION
Fixes #4018 

Thanks @mhirasuna for isolating the commit that caused the regression. That was very helpful!

![image](https://github.com/user-attachments/assets/a54b1daf-7c60-460a-a92c-78c2bf7a4235)


<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead xml:id="mm7exji">
      <fileDesc xml:id="f1mly54b">
         <titleStmt xml:id="t19qvs7c">
            <title>Untitled score</title>
            <respStmt>
               <persName role="composer">Composer / arranger</persName>
            </respStmt>
         </titleStmt>
         <pubStmt xml:id="p2bwzjd">
            <date isodate="2025-04-02" type="encoding-date">2025-04-02</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc xml:id="eg7vcy3">
         <appInfo xml:id="affbgpt">
            <application xml:id="aj2r7k9" isodate="2025-04-03T11:58:06" version="5.2.0-dev-2463708">
               <name xml:id="n13w8y7h">Verovio</name>
               <p xml:id="p1wufdv8">Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="q9pocp6">
            <score xml:id="y1mhtw26">
               <scoreDef xml:id="u1ohrbnj">
                  <pgHead xml:id="k7iek2x">
                     <rend xml:id="fcrf87e" halign="center" valign="top">Test Case</rend>
                     <rend xml:id="xrisq7x" halign="center" valign="top">Tied chord crossing measures</rend>
                  </pgHead>
                  <staffGrp xml:id="q16ukdzr">
                     <staffDef xml:id="P1" n="1" lines="5" ppq="1">
                        <label xml:id="vkjlqte">Flute</label>
                        <labelAbbr xml:id="rmfp4mb">Fl.</labelAbbr>
                        <instrDef xml:id="y7ogrh7" midi.channel="0" midi.instrnum="73" midi.volume="78%" />
                        <clef xml:id="yl2me54" shape="G" line="2" />
                        <keySig xml:id="g11l2u49" sig="0" />
                        <meterSig xml:id="fygzv0m" count="2" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section xml:id="qgfqx6o">
                  <measure xml:id="v5cwl04" n="1">
                     <staff xml:id="h1jyevhe" n="1">
                        <layer xml:id="l1ghaw64" n="1">
                           <chord xml:id="ds7m7fm" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="q1tu5hyu" oct="4" pname="f" />
                              <note xml:id="r1tp9o1d" oct="4" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                     <tie xml:id="q1nbh3y1" startid="#q1tu5hyu" endid="#e1nc2yrd" />
                     <tie xml:id="rb0q8nu" startid="#r1tp9o1d" endid="#lsb6fc6" />
                  </measure>
                  <measure xml:id="c1avjg6x" right="end" n="2">
                     <staff xml:id="q1o9lgxf" n="1">
                        <layer xml:id="q1ibrmre" n="1">
                           <chord xml:id="k48d84w" dur.ppq="2" dur="2" stem.dir="up">
                              <note xml:id="e1nc2yrd" oct="4" pname="f" />
                              <note xml:id="lsb6fc6" oct="4" pname="a" />
                           </chord>
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```
</details>