### PR TITLE
Fix prefix being added after each match

### DIFF
--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -10,6 +10,7 @@
 //----------------------------------------------------------------------------
 
 #include <cassert>
+#include <numeric>
 #include <regex>
 
 //----------------------------------------------------------------------------
@@ -610,7 +611,6 @@ void SvgDeviceContext::AppendStrokeDashArray(pugi::xml_node node, const Pen &pen
 void SvgDeviceContext::PrefixCssRules(std::string &rules)
 {
     static std::regex selectorRegex(R"(([^{}]+)\s*\{([^}]*)\})");
-    static std::regex multiSelectorRegex(R"((\b\w+\.?[\w-]+\b))");
 
     std::sregex_iterator it(rules.begin(), rules.end(), selectorRegex);
     std::sregex_iterator end;
@@ -618,19 +618,26 @@ void SvgDeviceContext::PrefixCssRules(std::string &rules)
     std::string result;
 
     while (it != end) {
-
         std::string selectors = (*it)[1].str();
         std::string properties = (*it)[2].str();
 
-        // Trim trailing spaces from selectors to prevent extra spaces before `{`
-        selectors = std::regex_replace(selectors, std::regex(R"(\s+$)"), "");
+        // Split by comma to handle multi-selectors
+        std::stringstream ss(selectors);
+        std::string selector;
+        std::vector<std::string> prefixedSelectors;
 
-        // Prepend `#docId` to each selector
-        selectors = std::regex_replace(selectors, multiSelectorRegex, "#" + m_docId + " $1");
+        while (std::getline(ss, selector, ',')) {
+            // Trim whitespace
+            selector = std::regex_replace(selector, std::regex(R"(^\s+|\s+$)"), "");
+            prefixedSelectors.push_back("#" + m_docId + " " + selector);
+        }
 
-        // Keep contents inside `{}` unchanged
-        result += selectors + " {" + properties + "}";
+        std::string finalSelector = std::accumulate(
+            std::next(prefixedSelectors.begin()), prefixedSelectors.end(),
+            prefixedSelectors[0],
+            [](std::string a, std::string b) { return a + ", " + b; });
 
+        result += finalSelector + " {" + properties + "}";
         ++it;
     }
 

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -632,8 +632,10 @@ void SvgDeviceContext::PrefixCssRules(std::string &rules)
             prefixedSelectors.push_back("#" + m_docId + " " + selector);
         }
 
+        if (prefixedSelectors.empty()) continue;
+
         std::string finalSelector = std::accumulate(std::next(prefixedSelectors.begin()), prefixedSelectors.end(),
-            prefixedSelectors[0], [](std::string a, std::string b) { return a + ", " + b; });
+            prefixedSelectors.at(0), [](std::string a, std::string b) { return a + ", " + b; });
 
         result += finalSelector + " {" + properties + "}";
         ++it;

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -632,10 +632,8 @@ void SvgDeviceContext::PrefixCssRules(std::string &rules)
             prefixedSelectors.push_back("#" + m_docId + " " + selector);
         }
 
-        std::string finalSelector = std::accumulate(
-            std::next(prefixedSelectors.begin()), prefixedSelectors.end(),
-            prefixedSelectors[0],
-            [](std::string a, std::string b) { return a + ", " + b; });
+        std::string finalSelector = std::accumulate(std::next(prefixedSelectors.begin()), prefixedSelectors.end(),
+            prefixedSelectors[0], [](std::string a, std::string b) { return a + ", " + b; });
 
         result += finalSelector + " {" + properties + "}";
         ++it;


### PR DESCRIPTION
The PR fixes an issue with the prefixing of CSS introduced in https://github.com/rism-digital/verovio/pull/3953

The problem is when successive elements are addressed within a single rule, each of them would be prefixed. 
```css
g.annot rect { fill-opacity: 0.0; }
```
was prefixed as
```css
#klq53v0 g.annot #klq53v0 rect { fill-opacity: 0.0; }
``` 
but is should now be
```css
#klq53v0 g.annot rect { fill-opacity: 0.0; }
```