### PR TITLE
Improve generation of `git_commit.h` to also work in submodules

### DIFF
--- a/tools/get_git_commit.sh
+++ b/tools/get_git_commit.sh
@@ -5,19 +5,20 @@ cd ..
 output="./include/vrv/git_commit.h"
 COMMIT=""
 
-if [ ! -d "./.git" ]; then
-     echo "This is not a git directory and the git commit sha will remain undefined"
-else
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     SHA=$(git describe  --exclude '*' --abbrev=7 --always --dirty)
     if [ -z "$SHA" ]; then
         echo "Undefined git commit version"
     else
         COMMIT="-$SHA"
     fi
+else
+    echo "This is not a git directory and the git commit sha will remain undefined"
 fi
 
 echo "////////////////////////////////////////////////////////" > $output
 echo "/// Git commit version file generated at compilation ///" >> $output
+echo "/// Timestamp: $(date +"%Y-%m-%dT%H:%M:%S%:z")             ///" >> $output
 echo "////////////////////////////////////////////////////////" >> $output
 echo "" >> $output
 echo "#define GIT_COMMIT \"$COMMIT\"" >> $output

--- a/tools/get_git_commit.sh
+++ b/tools/get_git_commit.sh
@@ -18,7 +18,7 @@ fi
 
 echo "////////////////////////////////////////////////////////" > $output
 echo "/// Git commit version file generated at compilation ///" >> $output
-echo "/// Timestamp: $(date +"%Y-%m-%dT%H:%M:%S%:z")             ///" >> $output
+echo "/// Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")                  ///" >> $output
 echo "////////////////////////////////////////////////////////" >> $output
 echo "" >> $output
 echo "#define GIT_COMMIT \"$COMMIT\"" >> $output


### PR DESCRIPTION
The current method (check for `.git` folder) in `tools/get_git_commit.sh` fails when verovio is added as a submodule to another repository. The bash script was refactored to use git [rev-parse](https://linux.die.net/man/1/git-rev-parse) to check if it's inside a git structure. Furthermore, a timestamp was added as a comment in the header-file to allow to verify that the file is up-to-date.