### PR TITLE
Add a VisibilityDrawingInterface to reduce code duplication

### DIFF
--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -435,7 +435,7 @@ public:
      */
     ///@{
     void SetVisibility(VisibilityType visibility) { m_visibility = visibility; }
-    const bool IsHidden() const { return (m_visibility == Hidden); }
+    bool IsHidden() const { return (m_visibility == Hidden); }
     ///@}
 
     //-----------------//

--- a/include/vrv/drawinginterface.h
+++ b/include/vrv/drawinginterface.h
@@ -412,6 +412,45 @@ protected:
     Stem *m_drawingStem;
 };
 
+//----------------------------------------------------------------------------
+// VisibilityDrawingInterface
+//----------------------------------------------------------------------------
+
+/**
+ * This class is an interface for MEI element that can be hidden during drawing.
+ */
+class VisibilityDrawingInterface {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     */
+    ///@{
+    VisibilityDrawingInterface();
+    virtual ~VisibilityDrawingInterface();
+    virtual void Reset();
+    ///@}
+
+    /**
+     * @name Set and get the visibility
+     */
+    ///@{
+    void SetVisibility(VisibilityType visibility) { m_visibility = visibility; }
+    const bool IsHidden() const { return (m_visibility == Hidden); }
+    ///@}
+
+    //-----------------//
+    // Pseudo functors //
+    //-----------------//
+
+private:
+    /**
+     * Holds the visibility (hidden or visible) for an element implementing the interface.
+     * By default, all editorial elements are visible. However, in an <app>, only one <rdg> is visible at the time. When
+     * loading the file, the first <rdg> (or the <lem>) is made visible.
+     */
+    VisibilityType m_visibility;
+};
+
 } // namespace vrv
 
 #endif

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -60,6 +60,20 @@ public:
     bool IsSupportedChild(ClassId classId) override;
     ///@}
 
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    VisibilityDrawingInterface *GetVisibilityDrawingInterface() override
+    {
+        return vrv_cast<VisibilityDrawingInterface *>(this);
+    }
+    const VisibilityDrawingInterface *GetVisibilityDrawingInterface() const override
+    {
+        return vrv_cast<const VisibilityDrawingInterface *>(this);
+    }
+    ///@}
+
     //----------//
     // Functors //
     //----------//

--- a/include/vrv/editorial.h
+++ b/include/vrv/editorial.h
@@ -10,6 +10,7 @@
 
 #include "atts_critapp.h"
 #include "atts_shared.h"
+#include "drawinginterface.h"
 #include "object.h"
 #include "systemmilestone.h"
 
@@ -35,7 +36,11 @@ class TextElement;
  * It is not an abstract class but should not be instantiated directly.
  * It can be both a container (in score-based MEI) and a milestone (in page-based MEI).
  */
-class EditorialElement : public Object, public SystemMilestoneInterface, public AttLabelled, public AttTyped {
+class EditorialElement : public Object,
+                         public VisibilityDrawingInterface,
+                         public SystemMilestoneInterface,
+                         public AttLabelled,
+                         public AttTyped {
 public:
     /**
      * @name Constructors, destructors, reset and class name methods
@@ -72,13 +77,7 @@ public:
 private:
     //
 public:
-    /**
-     * Holds the visibility (hidden or visible) for an editorial element.
-     * By default, all editorial elements are visible. However, in an <app>, only one <rdg> is visible at the time. When
-     * loading the file, the first <rdg> (or the <lem>) is made visible.
-     */
-    VisibilityType m_visibility;
-
+    //
 private:
 };
 

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -49,6 +49,20 @@ public:
     ///@}
 
     /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    VisibilityDrawingInterface *GetVisibilityDrawingInterface() override
+    {
+        return vrv_cast<VisibilityDrawingInterface *>(this);
+    }
+    const VisibilityDrawingInterface *GetVisibilityDrawingInterface() const override
+    {
+        return vrv_cast<const VisibilityDrawingInterface *>(this);
+    }
+    ///@}
+
+    /**
      * Make the mdiv and its parent (recursively) visible
      */
     void MakeVisible();

--- a/include/vrv/mdiv.h
+++ b/include/vrv/mdiv.h
@@ -9,6 +9,7 @@
 #define __VRV_MDIV_H__
 
 #include "atts_shared.h"
+#include "drawinginterface.h"
 #include "pageelement.h"
 #include "pagemilestone.h"
 
@@ -21,7 +22,11 @@ namespace vrv {
 /**
  * This class represent a <mdiv> in page-based MEI.
  */
-class Mdiv : public PageElement, public PageMilestoneInterface, public AttLabelled, public AttNNumberLike {
+class Mdiv : public PageElement,
+             public VisibilityDrawingInterface,
+             public PageMilestoneInterface,
+             public AttLabelled,
+             public AttNNumberLike {
 
 public:
     /**
@@ -65,13 +70,7 @@ public:
 private:
     //
 public:
-    /**
-     * Holds the visibility (hidden or visible) for an mdiv element.
-     * By default, a mdiv elements is hidden, and one <mdiv> branchn has to be made visible.
-     * See Mdiv::MakeVisible();
-     */
-    VisibilityType m_visibility;
-
+    //
 private:
     //
 };

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -89,7 +89,7 @@ public:
      * Wrapper for checking if an element has a milestone start interface and also if is set as a milestone element
      */
     ///@{
-    bool IsMilestoneElement();
+    bool IsMilestoneElement() const;
     Object *GetMilestoneEnd();
     ///@}
 

--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -43,6 +43,7 @@ class StemmedDrawingInterface;
 class TextDirInterface;
 class TimePointInterface;
 class TimeSpanningInterface;
+class VisibilityDrawingInterface;
 class Zone;
 
 #define UNLIMITED_DEPTH -10000
@@ -186,6 +187,8 @@ public:
     virtual const TimePointInterface *GetTimePointInterface() const { return NULL; }
     virtual TimeSpanningInterface *GetTimeSpanningInterface() { return NULL; }
     virtual const TimeSpanningInterface *GetTimeSpanningInterface() const { return NULL; }
+    virtual VisibilityDrawingInterface *GetVisibilityDrawingInterface() { return NULL; }
+    virtual const VisibilityDrawingInterface *GetVisibilityDrawingInterface() const { return NULL; }
     ///@}
 
     /**

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -10,6 +10,7 @@
 
 #include "atts_shared.h"
 #include "devicecontextbase.h"
+#include "drawinginterface.h"
 #include "floatingobject.h"
 
 namespace vrv {
@@ -22,7 +23,7 @@ namespace vrv {
  * This class represents elements appearing within a measure.
  * It is not an abstract class but should not be instanciated directly.
  */
-class SystemElement : public FloatingObject, public AttTyped {
+class SystemElement : public FloatingObject, public VisibilityDrawingInterface, public AttTyped {
 public:
     /**
      * @name Constructors, destructors, reset methods
@@ -52,12 +53,7 @@ public:
 private:
     //
 public:
-    /**
-     * Holds the visibility (hidden or visible) for an system element.
-     * By default, a system element is visible. It can be hidden when expansion are processed.
-     */
-    VisibilityType m_visibility;
-
+    //
 private:
     //
 };

--- a/include/vrv/systemelement.h
+++ b/include/vrv/systemelement.h
@@ -36,6 +36,20 @@ public:
     void Reset() override;
     ///@}
 
+    /**
+     * @name Getter to interfaces
+     */
+    ///@{
+    VisibilityDrawingInterface *GetVisibilityDrawingInterface() override
+    {
+        return vrv_cast<VisibilityDrawingInterface *>(this);
+    }
+    const VisibilityDrawingInterface *GetVisibilityDrawingInterface() const override
+    {
+        return vrv_cast<const VisibilityDrawingInterface *>(this);
+    }
+    ///@}
+
     //----------//
     // Functors //
     //----------//

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -63,7 +63,7 @@ FunctorCode ConvertToPageBasedFunctor::VisitEditorialElement(EditorialElement *e
 
 FunctorCode ConvertToPageBasedFunctor::VisitEditorialElementEnd(EditorialElement *editorialElement)
 {
-    if (editorialElement->m_visibility == Visible) {
+    if (!editorialElement->IsHidden()) {
         editorialElement->ConvertToPageBasedMilestone(editorialElement, m_currentSystem);
     }
 
@@ -103,7 +103,7 @@ FunctorCode ConvertToPageBasedFunctor::VisitMdiv(Mdiv *mdiv)
 
 FunctorCode ConvertToPageBasedFunctor::VisitMdivEnd(Mdiv *mdiv)
 {
-    if (mdiv->m_visibility == Visible) {
+    if (!mdiv->IsHidden()) {
         mdiv->ConvertToPageBasedMilestone(mdiv, m_page);
     }
 

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -782,4 +782,20 @@ FunctorCode StemmedDrawingInterface::InterfaceResetData(ResetDataFunctor &functo
     return FUNCTOR_CONTINUE;
 }
 
+//----------------------------------------------------------------------------
+// VisibilityDrawingInterface
+//----------------------------------------------------------------------------
+
+VisibilityDrawingInterface::VisibilityDrawingInterface()
+{
+    this->Reset();
+}
+
+VisibilityDrawingInterface::~VisibilityDrawingInterface() {}
+
+void VisibilityDrawingInterface::Reset()
+{
+    m_visibility = Visible;
+}
+
 } // namespace vrv

--- a/src/editorial.cpp
+++ b/src/editorial.cpp
@@ -34,7 +34,8 @@ namespace vrv {
 // EditorialElement
 //----------------------------------------------------------------------------
 
-EditorialElement::EditorialElement() : Object(EDITORIAL_ELEMENT), SystemMilestoneInterface(), AttLabelled(), AttTyped()
+EditorialElement::EditorialElement()
+    : Object(EDITORIAL_ELEMENT), VisibilityDrawingInterface(), SystemMilestoneInterface(), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);
@@ -43,7 +44,7 @@ EditorialElement::EditorialElement() : Object(EDITORIAL_ELEMENT), SystemMileston
 }
 
 EditorialElement::EditorialElement(ClassId classId)
-    : Object(classId), SystemMilestoneInterface(), AttLabelled(), AttTyped()
+    : Object(classId), VisibilityDrawingInterface(), SystemMilestoneInterface(), AttLabelled(), AttTyped()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_TYPED);
@@ -54,11 +55,10 @@ EditorialElement::EditorialElement(ClassId classId)
 void EditorialElement::Reset()
 {
     Object::Reset();
+    VisibilityDrawingInterface::Reset();
     SystemMilestoneInterface::Reset();
     this->ResetLabelled();
     this->ResetTyped();
-
-    m_visibility = Visible;
 }
 
 EditorialElement::~EditorialElement() {}

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -809,7 +809,7 @@ void ABCInput::parseReferenceNumber(const std::string &referenceNumberString)
 {
     // The X: field is also used to indicate the start of the tune
     m_mdiv = new Mdiv();
-    m_mdiv->m_visibility = Visible;
+    m_mdiv->SetVisibility(Visible);
     if (!referenceNumberString.empty()) {
         const int mdivNum = atoi(referenceNumberString.c_str());
         if (mdivNum < 1) {

--- a/src/iocmme.cpp
+++ b/src/iocmme.cpp
@@ -102,7 +102,7 @@ bool CmmeInput::Import(const std::string &cmme)
 
         // The mDiv
         Mdiv *mdiv = new Mdiv();
-        mdiv->m_visibility = Visible;
+        mdiv->SetVisibility(Visible);
         m_doc->AddChild(mdiv);
         // The score
         m_score = new Score();
@@ -356,7 +356,7 @@ void CmmeInput::CreateLemOrRdg(pugi::xml_node lemOrRdgNode, bool isFirst)
     else {
         lemOrRdg = new Rdg();
     }
-    lemOrRdg->m_visibility = (isFirst) ? Visible : Hidden;
+    lemOrRdg->SetVisibility((isFirst) ? Visible : Hidden);
 
     if (lemOrRdg->Is(RDG)) {
         std::string label;

--- a/src/iodarms.cpp
+++ b/src/iodarms.cpp
@@ -463,7 +463,7 @@ bool DarmsInput::Import(const std::string &data_str)
     m_doc->SetType(Raw);
     // The mDiv
     Mdiv *mdiv = new Mdiv();
-    mdiv->m_visibility = Visible;
+    mdiv->SetVisibility(Visible);
     m_doc->AddChild(mdiv);
     // The score
     Score *score = new Score();

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -7738,7 +7738,7 @@ bool MEIInput::ReadAppChildren(Object *parent, pugi::xml_node parentNode, Editor
         if (selectedLemOrRdg == current) {
             EditorialElement *last = dynamic_cast<EditorialElement *>(parent->GetLast());
             if (last) {
-                last->m_visibility = Visible;
+                last->SetVisibility(Visible);
                 hasXPathSelected = true;
             }
         }
@@ -7748,7 +7748,7 @@ bool MEIInput::ReadAppChildren(Object *parent, pugi::xml_node parentNode, Editor
     if (!hasXPathSelected) {
         EditorialElement *first = dynamic_cast<EditorialElement *>(parent->GetFirst());
         if (first) {
-            first->m_visibility = Visible;
+            first->SetVisibility(Visible);
         }
         else {
             LogWarning("Could not make one <rdg> or <lem> visible");
@@ -7830,11 +7830,11 @@ bool MEIInput::ReadChoiceChildren(Object *parent, pugi::xml_node parentNode, Edi
         EditorialElement *last = dynamic_cast<EditorialElement *>(parent->GetLast());
         if (success && last) {
             if (selectedChild == current) {
-                last->m_visibility = Visible;
+                last->SetVisibility(Visible);
                 hasXPathSelected = true;
             }
             else {
-                last->m_visibility = Hidden;
+                last->SetVisibility(Hidden);
             }
         }
     }
@@ -7843,7 +7843,7 @@ bool MEIInput::ReadChoiceChildren(Object *parent, pugi::xml_node parentNode, Edi
     if (!hasXPathSelected) {
         EditorialElement *first = dynamic_cast<EditorialElement *>(parent->GetFirst());
         if (first) {
-            first->m_visibility = Visible;
+            first->SetVisibility(Visible);
         }
         else {
             LogWarning("Could not make one child of <choice> visible");
@@ -7906,7 +7906,7 @@ bool MEIInput::ReadLem(Object *parent, pugi::xml_node lem, EditorialLevel level,
 
     Lem *vrvLem = new Lem();
     // By default make them all hidden. MEIInput::ReadAppChildren will make one visible.
-    vrvLem->m_visibility = Hidden;
+    vrvLem->SetVisibility(Hidden);
     this->ReadEditorialElement(lem, vrvLem);
 
     vrvLem->ReadSource(lem);
@@ -7934,7 +7934,7 @@ bool MEIInput::ReadRdg(Object *parent, pugi::xml_node rdg, EditorialLevel level,
 
     Rdg *vrvRdg = new Rdg();
     // By default make them all hidden. MEIInput::ReadAppChildren will make one visible.
-    vrvRdg->m_visibility = Hidden;
+    vrvRdg->SetVisibility(Hidden);
     this->ReadEditorialElement(rdg, vrvRdg);
 
     vrvRdg->ReadSource(rdg);
@@ -8045,11 +8045,11 @@ bool MEIInput::ReadSubstChildren(Object *parent, pugi::xml_node parentNode, Edit
         EditorialElement *last = dynamic_cast<EditorialElement *>(parent->GetLast());
         if (success && last) {
             if (selectedChild == current) {
-                last->m_visibility = Visible;
+                last->SetVisibility(Visible);
                 hasXPathSelected = true;
             }
             else {
-                last->m_visibility = Hidden;
+                last->SetVisibility(Hidden);
             }
         }
     }
@@ -8058,7 +8058,7 @@ bool MEIInput::ReadSubstChildren(Object *parent, pugi::xml_node parentNode, Edit
     if (!hasXPathSelected) {
         EditorialElement *first = dynamic_cast<EditorialElement *>(parent->GetFirst());
         if (first) {
-            first->m_visibility = Visible;
+            first->SetVisibility(Visible);
         }
         else {
             LogWarning("Could not make one child of <subst> visible");

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -832,7 +832,7 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
 
     // the mdiv
     Mdiv *mdiv = new Mdiv();
-    mdiv->m_visibility = Visible;
+    mdiv->SetVisibility(Visible);
     m_doc->AddChild(mdiv);
     // the score
     Score *score = new Score();

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -2998,7 +2998,7 @@ bool PAEInput::Parse()
     if (m_isMensural) m_doc->m_notationType = NOTATIONTYPE_mensural;
     // The mdiv
     Mdiv *mdiv = new Mdiv();
-    mdiv->m_visibility = Visible;
+    mdiv->SetVisibility(Visible);
     m_doc->AddChild(mdiv);
     // The score
     Score *score = new Score();

--- a/src/iovolpiano.cpp
+++ b/src/iovolpiano.cpp
@@ -50,7 +50,7 @@ bool VolpianoInput::Import(const std::string &volpiano)
     m_doc->SetType(Raw);
     // The mDiv
     Mdiv *mdiv = new Mdiv();
-    mdiv->m_visibility = Visible;
+    mdiv->SetVisibility(Visible);
     m_doc->AddChild(mdiv);
     // The score
     Score *score = new Score();

--- a/src/mdiv.cpp
+++ b/src/mdiv.cpp
@@ -28,7 +28,8 @@ namespace vrv {
 
 static const ClassRegistrar<Mdiv> s_factory("mdiv", MDIV);
 
-Mdiv::Mdiv() : PageElement(MDIV), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
+Mdiv::Mdiv()
+    : PageElement(MDIV), VisibilityDrawingInterface(), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);
@@ -41,10 +42,12 @@ Mdiv::~Mdiv() {}
 void Mdiv::Reset()
 {
     Object::Reset();
+    VisibilityDrawingInterface::Reset();
+    PageMilestoneInterface::Reset();
     this->ResetLabelled();
     this->ResetNNumberLike();
 
-    m_visibility = Hidden;
+    this->SetVisibility(Hidden);
 }
 
 bool Mdiv::IsSupportedChild(ClassId classId)
@@ -61,7 +64,7 @@ bool Mdiv::IsSupportedChild(ClassId classId)
 
 void Mdiv::MakeVisible()
 {
-    m_visibility = Visible;
+    this->SetVisibility(Visible);
     if (this->GetParent() && this->GetParent()->Is(MDIV)) {
         Mdiv *parent = vrv_cast<Mdiv *>(this->GetParent());
         assert(parent);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1173,7 +1173,7 @@ bool Object::SkipChildren(bool visibleOnly) const
 {
     if (visibleOnly) {
         if (this->IsEditorialElement() || this->Is(MDIV) || this->IsSystemElement()) {
-            const VisibilityDrawingInterface *interface = vrv_cast<const VisibilityDrawingInterface *>(this);
+            const VisibilityDrawingInterface *interface = this->GetVisibilityDrawingInterface();
             assert(interface);
             if (interface->IsHidden()) {
                 return true;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -236,7 +236,7 @@ void Object::RegisterInterface(std::vector<AttClassId> *attClasses, InterfaceId 
     m_interfaces.push_back(interfaceId);
 }
 
-bool Object::IsMilestoneElement()
+bool Object::IsMilestoneElement() const
 {
     if (this->IsEditorialElement() || this->Is(ENDING) || this->Is(SECTION)) {
         SystemMilestoneInterface *interface = dynamic_cast<SystemMilestoneInterface *>(this);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1172,24 +1172,10 @@ FunctorCode Object::AcceptEnd(ConstFunctor &functor) const
 bool Object::SkipChildren(bool visibleOnly) const
 {
     if (visibleOnly) {
-        if (this->IsEditorialElement()) {
-            const EditorialElement *editorialElement = vrv_cast<const EditorialElement *>(this);
-            assert(editorialElement);
-            if (editorialElement->m_visibility == Hidden) {
-                return true;
-            }
-        }
-        else if (this->Is(MDIV)) {
-            const Mdiv *mdiv = vrv_cast<const Mdiv *>(this);
-            assert(mdiv);
-            if (mdiv->m_visibility == Hidden) {
-                return true;
-            }
-        }
-        else if (this->IsSystemElement()) {
-            const SystemElement *systemElement = vrv_cast<const SystemElement *>(this);
-            assert(systemElement);
-            if (systemElement->m_visibility == Hidden) {
+        if (this->IsEditorialElement() || this->Is(MDIV) || this->IsSystemElement()) {
+            const VisibilityDrawingInterface *interface = vrv_cast<const VisibilityDrawingInterface *>(this);
+            assert(interface);
+            if (interface->IsHidden()) {
                 return true;
             }
         }

--- a/src/savefunctor.cpp
+++ b/src/savefunctor.cpp
@@ -44,7 +44,7 @@ FunctorCode SaveFunctor::VisitDotsEnd(Dots *dots)
 FunctorCode SaveFunctor::VisitEditorialElement(EditorialElement *editorialElement)
 {
     // When writing MEI basic, only visible elements within editorial markup are saved
-    if (m_basic && (editorialElement->m_visibility == Hidden)) {
+    if (m_basic && (editorialElement->IsHidden())) {
         return FUNCTOR_SIBLINGS;
     }
     else {
@@ -55,7 +55,7 @@ FunctorCode SaveFunctor::VisitEditorialElement(EditorialElement *editorialElemen
 FunctorCode SaveFunctor::VisitEditorialElementEnd(EditorialElement *editorialElement)
 {
     // Same as above
-    if (m_basic && (editorialElement->m_visibility == Hidden)) {
+    if (m_basic && (editorialElement->IsHidden())) {
         return FUNCTOR_SIBLINGS;
     }
     else {
@@ -78,7 +78,7 @@ FunctorCode SaveFunctor::VisitMdiv(Mdiv *mdiv)
 {
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(m_output);
 
-    if (meiOutput && (mdiv->m_visibility == Hidden)) {
+    if (meiOutput && (mdiv->IsHidden())) {
         // Do not output hidden mdivs in page-based MEI or when saving score-based MEI with filter
         if (!meiOutput->GetScoreBasedMEI() || meiOutput->HasFilter()) return FUNCTOR_SIBLINGS;
     }
@@ -89,7 +89,7 @@ FunctorCode SaveFunctor::VisitMdivEnd(Mdiv *mdiv)
 {
     MEIOutput *meiOutput = dynamic_cast<MEIOutput *>(m_output);
 
-    if (meiOutput && (mdiv->m_visibility == Hidden)) {
+    if (meiOutput && (mdiv->IsHidden())) {
         // Do not output hidden mdivs in page-based MEI or when saving score-based MEI with filter
         if (!meiOutput->GetScoreBasedMEI() || meiOutput->HasFilter()) return FUNCTOR_SIBLINGS;
     }

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -49,6 +49,7 @@ Score::~Score() {}
 void Score::Reset()
 {
     Object::Reset();
+    PageMilestoneInterface::Reset();
     this->ResetLabelled();
     this->ResetNNumberLike();
 

--- a/src/systemelement.cpp
+++ b/src/systemelement.cpp
@@ -22,14 +22,14 @@ namespace vrv {
 // SystemElement
 //----------------------------------------------------------------------------
 
-SystemElement::SystemElement() : FloatingObject(SYSTEM_ELEMENT), AttTyped()
+SystemElement::SystemElement() : FloatingObject(SYSTEM_ELEMENT), VisibilityDrawingInterface(), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 
     this->Reset();
 }
 
-SystemElement::SystemElement(ClassId classId) : FloatingObject(classId), AttTyped()
+SystemElement::SystemElement(ClassId classId) : FloatingObject(classId), VisibilityDrawingInterface(), AttTyped()
 {
     this->RegisterAttClass(ATT_TYPED);
 
@@ -41,9 +41,8 @@ SystemElement::~SystemElement() {}
 void SystemElement::Reset()
 {
     FloatingObject::Reset();
+    VisibilityDrawingInterface::Reset();
     this->ResetTyped();
-
-    m_visibility = Visible;
 }
 
 //----------------------------------------------------------------------------

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1886,7 +1886,7 @@ void View::DrawMeasureEditorialElement(DeviceContext *dc, EditorialElement *elem
     }
 
     dc->StartGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawMeasureChildren(dc, element, measure, system);
     }
     dc->EndGraphic(element, this);
@@ -1907,7 +1907,7 @@ void View::DrawStaffEditorialElement(DeviceContext *dc, EditorialElement *elemen
     }
 
     dc->StartGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawStaffChildren(dc, element, staff, measure);
     }
     dc->EndGraphic(element, this);
@@ -1929,7 +1929,7 @@ void View::DrawLayerEditorialElement(
     }
 
     dc->StartGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawLayerChildren(dc, element, layer, staff, measure);
     }
     dc->EndGraphic(element, this);
@@ -1950,7 +1950,7 @@ void View::DrawTextEditorialElement(DeviceContext *dc, EditorialElement *element
     }
 
     dc->StartTextGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawTextChildren(dc, element, params);
     }
     dc->EndTextGraphic(element, this);
@@ -1971,7 +1971,7 @@ void View::DrawFbEditorialElement(DeviceContext *dc, EditorialElement *element, 
     }
 
     dc->StartTextGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawFbChildren(dc, element, params);
     }
     dc->EndTextGraphic(element, this);
@@ -1992,7 +1992,7 @@ void View::DrawRunningEditorialElement(DeviceContext *dc, EditorialElement *elem
     }
 
     dc->StartGraphic(element, "", element->GetID());
-    if (element->m_visibility == Visible) {
+    if (!element->IsHidden()) {
         this->DrawRunningChildren(dc, element, params);
     }
     dc->EndGraphic(element, this);


### PR DESCRIPTION
Code refactoring for reducing code duplication for elements (e.g., editorial markup or mDiv) implementing a visible/hidden feature during drawing. No change expected.