### PR TITLE
glyph generation: pass command line arguments to python-script

### DIFF
--- a/fonts/generate_all.sh
+++ b/fonts/generate_all.sh
@@ -10,23 +10,23 @@ $PYTHON generate.py smufl
 
 echo "Generating Bravura files ..."
 $PYTHON generate.py extract Bravura
-$PYTHON generate.py css Bravura
+$PYTHON generate.py css Bravura $@
 
 echo "Generating Leipzig files ..."
 $PYTHON generate.py check Leipzig
 $PYTHON generate.py extract Leipzig
-$PYTHON generate.py css Leipzig
+$PYTHON generate.py css Leipzig $@
 
 echo "Generating Gootville files ..."
 $PYTHON generate.py extract Gootville
-$PYTHON generate.py css Gootville
+$PYTHON generate.py css Gootville $@
 
 echo "Generating Petaluma files ..."
 $PYTHON generate.py extract Petaluma
-$PYTHON generate.py css Petaluma
+$PYTHON generate.py css Petaluma $@
 
 echo "Generating Leland files ..."
 $PYTHON generate.py extract Leland
-$PYTHON generate.py css Leland
+$PYTHON generate.py css Leland $@
 
 echo "Done!"


### PR DESCRIPTION
When using a custom FontForge binary (e.g. latest [AppImage](https://fontforge.org/en-US/downloads/gnulinux-dl/)) the specific location needs to be provided to `generate.py` via the `--fontforge <path-to-fontforge-binary>` command line argument. When using `generate_all.sh`, all command line arguments are now passed on to the python scripts.

Example: `./generate_all.sh --fontforge /mnt/linux-data/henry/Apps/FontForge-2023-01-01-a1dad3e-x86_64.AppImage`