### PR TITLE
Store clef for cautionary KeySig

### DIFF
--- a/include/vrv/clef.h
+++ b/include/vrv/clef.h
@@ -59,7 +59,7 @@ public:
     /**
      * Return the offset of the clef
      */
-    int GetClefLocOffset(data_NOTATIONTYPE notationType) const;
+    int GetClefLocOffset() const;
 
     //----------------//
     // Static methods //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -112,6 +112,7 @@ public:
      */
     ///@{
     Clef *GetDrawingClef();
+    void ResetDrawingClef();
     void SetDrawingClef(Clef *clef);
     ///@}
 

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -16,11 +16,11 @@
 #include "atts_analytical.h"
 #include "atts_shared.h"
 #include "atts_visual.h"
+#include "clef.h"
 #include "layerelement.h"
 
 namespace vrv {
 
-class Clef;
 class ScoreDefInterface;
 
 //----------------------------------------------------------------------------
@@ -174,7 +174,7 @@ private:
      * The clef used for drawing
      * Calculated from layer if not set
      */
-    Clef *m_drawingClef;
+    std::optional<Clef> m_drawingClef;
 
     //----------------//
     // Static members //

--- a/include/vrv/keysig.h
+++ b/include/vrv/keysig.h
@@ -107,6 +107,14 @@ public:
 
     int GetFifthsInt() const;
 
+    /**
+     * Set/Get the drawing clef
+     */
+    ///@{
+    Clef *GetDrawingClef();
+    void SetDrawingClef(Clef *clef);
+    ///@}
+
     //----------------//
     // Static methods //
     //----------------//
@@ -162,6 +170,16 @@ public:
     static const data_PITCHNAME s_pnameForSharps[];
 
 private:
+    /**
+     * The clef used for drawing
+     * Calculated from layer if not set
+     */
+    Clef *m_drawingClef;
+
+    //----------------//
+    // Static members //
+    //----------------//
+
     static const int octave_map[2][9][7];
 };
 

--- a/include/vrv/resetfunctor.h
+++ b/include/vrv/resetfunctor.h
@@ -56,6 +56,7 @@ public:
     FunctorCode VisitFloatingObject(FloatingObject *floatingObject) override;
     FunctorCode VisitFTrem(FTrem *fTrem) override;
     FunctorCode VisitHairpin(Hairpin *hairpin) override;
+    FunctorCode VisitKeySig(KeySig *keySig) override;
     FunctorCode VisitLayer(Layer *layer) override;
     FunctorCode VisitLayerElement(LayerElement *layerElement) override;
     FunctorCode VisitLigature(Ligature *ligature) override;

--- a/include/vrv/setscoredeffunctor.h
+++ b/include/vrv/setscoredeffunctor.h
@@ -252,7 +252,8 @@ public:
      * Functor interface
      */
     ///@{
-    FunctorCode VisitObject(Object *object) override;
+    FunctorCode VisitLayer(Layer *layer) override;
+    FunctorCode VisitStaff(Staff *staff) override;
     ///@}
 
 protected:

--- a/include/vrv/setscoredeffunctor.h
+++ b/include/vrv/setscoredeffunctor.h
@@ -336,6 +336,7 @@ public:
      */
     ///@{
     FunctorCode VisitAlignmentReference(AlignmentReference *alignmentReference) override;
+    FunctorCode VisitKeySig(KeySig *keySig) override;
     FunctorCode VisitLayer(Layer *layer) override;
     FunctorCode VisitMeasure(Measure *measure) override;
     FunctorCode VisitPage(Page *page) override;

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -79,12 +79,12 @@ void Clef::Reset()
     this->ResetVisibility();
 }
 
-int Clef::GetClefLocOffset(data_NOTATIONTYPE notationType) const
+int Clef::GetClefLocOffset() const
 {
     // Only resolve simple sameas links to avoid infinite recursion
     const Clef *sameas = dynamic_cast<const Clef *>(this->GetSameasLink());
     if (sameas && !sameas->HasSameasLink()) {
-        return sameas->GetClefLocOffset(notationType);
+        return sameas->GetClefLocOffset();
     }
 
     int offset = 0;

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -14,7 +14,6 @@
 
 //----------------------------------------------------------------------------
 
-#include "clef.h"
 #include "comparison.h"
 #include "editorial.h"
 #include "functor.h"

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -111,7 +111,7 @@ void KeySig::Reset()
     m_drawingCancelAccidType = ACCIDENTAL_WRITTEN_n;
     m_drawingCancelAccidCount = 0;
 
-    m_drawingClef = NULL;
+    m_drawingClef.reset();
 }
 
 void KeySig::FilterList(ListOfConstObjects &childList) const
@@ -256,12 +256,18 @@ int KeySig::GetFifthsInt() const
 
 Clef *KeySig::GetDrawingClef()
 {
-    return m_drawingClef;
+    return m_drawingClef.has_value() ? &m_drawingClef.value() : NULL;
 }
 
 void KeySig::SetDrawingClef(Clef *clef)
 {
-    m_drawingClef = clef;
+    if (clef) {
+        m_drawingClef = *clef;
+        m_drawingClef->CloneReset();
+    }
+    else {
+        m_drawingClef.reset();
+    }
 }
 
 data_KEYSIGNATURE KeySig::ConvertToSig() const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -110,6 +110,8 @@ void KeySig::Reset()
     m_skipCancellation = false;
     m_drawingCancelAccidType = ACCIDENTAL_WRITTEN_n;
     m_drawingCancelAccidCount = 0;
+
+    m_drawingClef = NULL;
 }
 
 void KeySig::FilterList(ListOfConstObjects &childList) const
@@ -250,6 +252,16 @@ int KeySig::GetFifthsInt() const
         return this->GetSig().first;
     }
     return 0;
+}
+
+Clef *KeySig::GetDrawingClef()
+{
+    return m_drawingClef;
+}
+
+void KeySig::SetDrawingClef(Clef *clef)
+{
+    m_drawingClef = clef;
 }
 
 data_KEYSIGNATURE KeySig::ConvertToSig() const

--- a/src/keysig.cpp
+++ b/src/keysig.cpp
@@ -110,7 +110,7 @@ void KeySig::Reset()
     m_drawingCancelAccidType = ACCIDENTAL_WRITTEN_n;
     m_drawingCancelAccidCount = 0;
 
-    m_drawingClef.reset();
+    this->ResetDrawingClef();
 }
 
 void KeySig::FilterList(ListOfConstObjects &childList) const
@@ -256,6 +256,11 @@ int KeySig::GetFifthsInt() const
 Clef *KeySig::GetDrawingClef()
 {
     return m_drawingClef.has_value() ? &m_drawingClef.value() : NULL;
+}
+
+void KeySig::ResetDrawingClef()
+{
+    m_drawingClef.reset();
 }
 
 void KeySig::SetDrawingClef(Clef *clef)

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -278,9 +278,7 @@ int Layer::GetClefLocOffset(const LayerElement *test) const
 {
     const Clef *clef = this->GetClef(test);
     if (!clef) return 0;
-    const Staff *staff = vrv_cast<const Staff *>(this->GetFirstAncestor(STAFF));
-    assert(staff);
-    return clef->GetClefLocOffset(staff->m_drawingNotationType);
+    return clef->GetClefLocOffset();
 }
 
 int Layer::GetCrossStaffClefLocOffset(const LayerElement *element, int currentOffset) const
@@ -290,11 +288,10 @@ int Layer::GetCrossStaffClefLocOffset(const LayerElement *element, int currentOf
         if (!element->Is(CLEF)) {
             const Clef *clef = vrv_cast<const Clef *>(GetListFirstBackward(element, CLEF));
             if (clef && clef->m_crossStaff) {
-                return clef->GetClefLocOffset(element->m_crossStaff->m_drawingNotationType);
+                return clef->GetClefLocOffset();
             }
         }
     }
-
     return currentOffset;
 }
 

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -594,6 +594,7 @@ void Layer::SetDrawingCautionValues(StaffDef *currentStaffDef)
     // special case - see above
     if (currentStaffDef->DrawKeySig()) {
         m_cautionStaffDefKeySig = new KeySig(*currentStaffDef->GetCurrentKeySig());
+        m_cautionStaffDefKeySig->SetDrawingClef(currentStaffDef->GetCurrentClef());
         m_cautionStaffDefKeySig->SetParent(this);
     }
     if (currentStaffDef->DrawMensur()) {

--- a/src/resetfunctor.cpp
+++ b/src/resetfunctor.cpp
@@ -247,6 +247,15 @@ FunctorCode ResetDataFunctor::VisitHairpin(Hairpin *hairpin)
     return FUNCTOR_CONTINUE;
 }
 
+FunctorCode ResetDataFunctor::VisitKeySig(KeySig *keySig)
+{
+    this->VisitLayerElement(keySig);
+
+    keySig->ResetDrawingClef();
+
+    return FUNCTOR_CONTINUE;
+}
+
 FunctorCode ResetDataFunctor::VisitLayer(Layer *layer)
 {
     // Call parent one too

--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -489,26 +489,16 @@ SetCautionaryScoreDefFunctor::SetCautionaryScoreDefFunctor(ScoreDef *currentScor
     m_currentStaffDef = NULL;
 }
 
-FunctorCode SetCautionaryScoreDefFunctor::VisitObject(Object *object)
+FunctorCode SetCautionaryScoreDefFunctor::VisitLayer(Layer *layer)
+{
+    layer->SetDrawingCautionValues(m_currentStaffDef);
+    return FUNCTOR_SIBLINGS;
+}
+
+FunctorCode SetCautionaryScoreDefFunctor::VisitStaff(Staff *staff)
 {
     assert(m_currentScoreDef);
-
-    // starting a new staff
-    if (object->Is(STAFF)) {
-        Staff *staff = vrv_cast<Staff *>(object);
-        assert(staff);
-        m_currentStaffDef = m_currentScoreDef->GetStaffDef(staff->GetN());
-        return FUNCTOR_CONTINUE;
-    }
-
-    // starting a new layer
-    if (object->Is(LAYER)) {
-        Layer *layer = vrv_cast<Layer *>(object);
-        assert(layer);
-        layer->SetDrawingCautionValues(m_currentStaffDef);
-        return FUNCTOR_SIBLINGS;
-    }
-
+    m_currentStaffDef = m_currentScoreDef->GetStaffDef(staff->GetN());
     return FUNCTOR_CONTINUE;
 }
 

--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -595,6 +595,13 @@ FunctorCode ScoreDefUnsetCurrentFunctor::VisitAlignmentReference(AlignmentRefere
     return FUNCTOR_SIBLINGS;
 }
 
+FunctorCode ScoreDefUnsetCurrentFunctor::VisitKeySig(KeySig *keySig)
+{
+    keySig->ResetDrawingClef();
+
+    return FUNCTOR_CONTINUE;
+}
+
 FunctorCode ScoreDefUnsetCurrentFunctor::VisitLayer(Layer *layer)
 {
     layer->ResetStaffDefObjects();

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -950,11 +950,13 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     KeySig *keySig = vrv_cast<KeySig *>(element);
     assert(keySig);
 
-    Clef *clef = layer->GetClef(element);
+    Clef *drawingClef = keySig->GetDrawingClef();
+    Clef *clef = drawingClef ? drawingClef : layer->GetClef(element);
     if (!clef) {
         keySig->SetEmptyBB();
         return;
     }
+    const int clefLocOffset = clef->GetClefLocOffset();
 
     // hidden key signature
     if (keySig->GetVisible() == BOOLEAN_false) {
@@ -981,8 +983,6 @@ void View::DrawKeySig(DeviceContext *dc, LayerElement *element, Layer *layer, St
     int x = element->GetDrawingX();
     // HARDCODED
     const int step = m_doc->GetDrawingUnit(staff->m_drawingStaffSize) * TEMP_KEYSIG_STEP;
-
-    int clefLocOffset = layer->GetClefLocOffset(element);
 
     dc->StartGraphic(element, "", element->GetID());
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1507,8 +1507,7 @@ int View::CalculatePitchCode(Layer *layer, int y_n, int x_pos, int *octave)
 
     Clef *clef = layer->GetClef(pelement);
     if (clef) {
-        yb += (clef->GetClefLocOffset(parentStaff->m_drawingNotationType))
-            * m_doc->GetDrawingUnit(staffSize); // UT1 reel
+        yb += (clef->GetClefLocOffset()) * m_doc->GetDrawingUnit(staffSize); // UT1 reel
     }
     yb -= 4 * m_doc->GetDrawingOctaveSize(staffSize); // UT, note la plus grave
 


### PR DESCRIPTION
This PR introduces an optional `m_drawingClef` member for KeySig which is used to store the correct clef for cautionary KeySigs. Closes #4036 .

<img width="841" alt="Improved" src="https://github.com/user-attachments/assets/e712b11f-2e0e-427a-ba95-d91d78bcfc49" />

**Implementation remarks**
The optional drawing clef is stored as a deep copy, since the source clef for cautionary ScoreDefs is a short-lived object and does not survive until the drawing code. There are several ways on how to store this:
- As `plain pointer`. This has the disadvantage that we need manual memory management, e.g. calling delete on the old drawing clef when setting and in the KeySig destructor.
- As `unique pointer`. No manual memory management needed, but this kills the implicit copy constructor. So we would need to reimplement copy construction/assignment in KeySig.
- As `optional`. No manual memory management and an implicit copy constructor. The disadvantage here is that it requires full type definition, so we need to include `clef.h` in `keysig.h`.

I went with the last option, but we can switch to any other, if we prefer at some point.