### PR TITLE
cmake: use CMAKE_CURRENT_SOURCE_DIR as working directory

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 execute_process(
     COMMAND ../tools/get_git_commit.sh
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_COMMIT
 )
 


### PR DESCRIPTION
Currently, the commit-hash is generated using a bash script that is called during the cmake step. When using verovio as a library in another project that also uses cmake (e.g. Android Studio) and includes verovio via `add_subdirectory(./verovio/cmake)` the `CMAKE_SOURCE_DIR` will still contain the parent cmake folder and `../tools/get_git_commit.sh` will fail silently not generating/updating the header file.

To avoid this behavior, the WORKING_DIRECTORY for `execute_process` is set using `CMAKE_CURRENT_SOURCE_DIR` which refers to the CMakeLists that is currently processed (see https://stackoverflow.com/a/67568372).

This change has no effect on standalone builds. `CMAKE_CURRENT_SOURCE_DIR` has the same value as `CMAKE_SOURCE_DIR` if the project is build via `cd tools && cmake ../cmake && make`.