### PR TITLE
Add #define to drop editor code

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,6 +18,7 @@ option(NO_MUSICXML_SUPPORT      "Disable MusicXML support"                     O
 option(NO_MXL_SUPPORT           "Disable compressed MusicXML support"          OFF)
 option(NO_HUMDRUM_SUPPORT       "Disable Humdrum support"                      OFF)
 option(MUSICXML_DEFAULT_HUMDRUM "Enable MusicXML to Humdrum by default"        OFF)
+option(NO_EDIT_SUPPORT          "Disable editor code"                          OFF)
 option(NO_RUNTIME               "Disable runtime clock support"                ON)
 option(BUILD_AS_LIBRARY         "Build Verovio as library"                     OFF)
 option(BUILD_AS_ANDROID_LIBRARY "Build Verovio as library for Android"         OFF)
@@ -147,6 +148,10 @@ else()
     if (MUSICXML_DEFAULT_HUMDRUM)
         add_definitions(-DMUSICXML_DEFAULT_HUMDRUM)
     endif()
+endif()
+
+if(NO_EDIT_SUPPORT)
+    add_definitions(-DNO_EDIT_SUPPORT)
 endif()
 
 if(NO_RUNTIME)

--- a/include/vrv/editortoolkit_cmn.h
+++ b/include/vrv/editortoolkit_cmn.h
@@ -37,6 +37,7 @@ public:
     std::string EditInfo() override;
 
 protected:
+#ifndef NO_EDIT_SUPPORT
     /**
      * Parse JSON instructions for experimental editor functions.
      */
@@ -71,6 +72,7 @@ public:
     //
 protected:
     std::string m_chainedId;
+#endif /* NO_EDIT_SUPPORT */
 };
 } // namespace vrv
 

--- a/src/editortoolkit_cmn.cpp
+++ b/src/editortoolkit_cmn.cpp
@@ -44,6 +44,7 @@ std::string EditorToolkitCMN::EditInfo()
 
 bool EditorToolkitCMN::ParseEditorAction(const std::string &json_editorAction, bool commitOnly)
 {
+#ifndef NO_EDIT_SUPPORT
     jsonxx::Object json;
 
     // Read JSON actions
@@ -131,8 +132,13 @@ bool EditorToolkitCMN::ParseEditorAction(const std::string &json_editorAction, b
         LogWarning("Unknown action type '%s'.", action.c_str());
     }
     return false;
+#else /* NO_EDIT_SUPPORT */
+    LogError("Editor functions are not supported in this build.");
+    return false;
+#endif /* NO_EDIT_SUPPORT */
 }
 
+#ifndef NO_EDIT_SUPPORT
 bool EditorToolkitCMN::ParseDeleteAction(jsonxx::Object param, std::string &elementId)
 {
     if (!param.has<jsonxx::String>("elementId")) return false;
@@ -637,5 +643,6 @@ bool EditorToolkitCMN::DeleteNote(Note *note)
         return true;
     }
 }
+#endif /* NO_EDIT_SUPPORT */
 
 } // namespace vrv


### PR DESCRIPTION
For now the code remains included in all builds by default since the definition is OFF. We might change this in the future if the editor code grows. @mei-friend: do you use the `Toolkit::Edit` function at all?