### PR TITLE
Add support for editorial markup in top-level scoreDef

### DIFF
--- a/include/vrv/iomei.h
+++ b/include/vrv/iomei.h
@@ -627,6 +627,7 @@ private:
     bool ReadMdiv(Object *parent, pugi::xml_node parentNode, bool isVisible);
     bool ReadMdivChildren(Object *parent, pugi::xml_node parentNode, bool isVisible);
     bool ReadScore(Object *parent, pugi::xml_node parentNode);
+    bool ReadScoreScoreDef(Object *parent, pugi::xml_node parentNode);
     ///@}
 
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -36,6 +36,7 @@ public:
      */
     ///@{
     Score();
+    Score(bool createScoreDef);
     virtual ~Score();
     void Reset() override;
     std::string GetClassName() const override { return "score"; }
@@ -52,8 +53,10 @@ public:
      * Getter for the score/scoreDef
      */
     ///@{
-    ScoreDef *GetScoreDef() { return &m_scoreDef; }
-    const ScoreDef *GetScoreDef() const { return &m_scoreDef; }
+    void SetScoreDefSubtree(Object *subtree, ScoreDef *scoreScoreDef);
+    ScoreDef *GetScoreDef() { return m_scoreDef; }
+    const ScoreDef *GetScoreDef() const { return m_scoreDef; }
+    Object *GetScoreDefSubtree() { return m_scoreDefSubtree; }
     ///@}
 
     /**
@@ -86,7 +89,12 @@ private:
     /**
      * The score/scoreDef (first child of the score)
      */
-    ScoreDef m_scoreDef;
+    ScoreDef *m_scoreDef;
+    /**
+     * A complete subtree of the scoreDefs (including editorial markup);
+     */
+public:
+    Object *m_scoreDefSubtree;
 
 public:
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -89,7 +89,7 @@ private:
     /**
      * The score/scoreDef (first child of the score).
      * A score can have either a single scoreDef, or a subtree with editorial markup and different scoreDefs.
-     * This member hold the selected scoreDef. It is set either in the constructor, by SetScoreDefSubtree (only once)
+     * This member holds the selected scoreDef. It is set either in the constructor, or by SetScoreDefSubtree (only once).
      */
     ScoreDef *m_scoreDef;
     /**

--- a/include/vrv/score.h
+++ b/include/vrv/score.h
@@ -87,13 +87,15 @@ public:
 
 private:
     /**
-     * The score/scoreDef (first child of the score)
+     * The score/scoreDef (first child of the score).
+     * A score can have either a single scoreDef, or a subtree with editorial markup and different scoreDefs.
+     * This member hold the selected scoreDef. It is set either in the constructor, by SetScoreDefSubtree (only once)
      */
     ScoreDef *m_scoreDef;
     /**
-     * A complete subtree of the scoreDefs (including editorial markup);
+     * A complete subtree of the scoreDefs (including editorial markup).
+     * The subtree is owned by the Score object. The m_scoreDef member is expected to be part of the subtree.
      */
-public:
     Object *m_scoreDefSubtree;
 
 public:

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -536,6 +536,7 @@ enum FunctorCode { FUNCTOR_CONTINUE = 0, FUNCTOR_SIBLINGS, FUNCTOR_STOP };
 // the maximum is 255 (unsigned char)
 enum EditorialLevel {
     EDITORIAL_UNDEFINED = 0,
+    EDITORIAL_SCORE,
     EDITORIAL_TOPLEVEL,
     EDITORIAL_SCOREDEF,
     EDITORIAL_STAFFGRP,

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -125,6 +125,8 @@ FunctorCode AdjustDotsFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode AdjustDotsFunctor::VisitScore(Score *score)
 {
+    assert(score->GetScoreDef());
+
     m_staffNs = score->GetScoreDef()->GetStaffNs();
 
     return FUNCTOR_CONTINUE;

--- a/src/adjustgracexposfunctor.cpp
+++ b/src/adjustgracexposfunctor.cpp
@@ -230,6 +230,8 @@ FunctorCode AdjustGraceXPosFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode AdjustGraceXPosFunctor::VisitScore(Score *score)
 {
+    assert(score->GetScoreDef());
+
     m_staffNs = score->GetScoreDef()->GetStaffNs();
 
     return FUNCTOR_CONTINUE;

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -148,6 +148,8 @@ FunctorCode AdjustLayersFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode AdjustLayersFunctor::VisitScore(Score *score)
 {
+    assert(score->GetScoreDef());
+
     m_staffNs = score->GetScoreDef()->GetStaffNs();
 
     return FUNCTOR_CONTINUE;

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -307,6 +307,8 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
 
 FunctorCode AdjustXPosFunctor::VisitScore(Score *score)
 {
+    assert(score->GetScoreDef());
+
     m_staffNs = score->GetScoreDef()->GetStaffNs();
 
     return FUNCTOR_CONTINUE;

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -612,7 +612,7 @@ FunctorCode ConvertToCmnFunctor::VisitMeasure(Measure *measure)
 FunctorCode ConvertToCmnFunctor::VisitMeasureEnd(Measure *measure)
 {
     // This is the first measure in the system - we need to update the scoreDef
-    if (m_score) {
+    if (m_score && m_score->GetScoreDef()) {
         for (Object *child : m_score->GetScoreDef()->GetList()) {
             StaffDef *staffDef = vrv_cast<StaffDef *>(child);
             assert(staffDef);

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -230,6 +230,7 @@ void Doc::GenerateFooter()
 {
     for (Score *score : this->GetVisibleScores()) {
         ScoreDef *scoreDef = score->GetScoreDef();
+        assert(scoreDef);
         if (scoreDef->FindDescendantByType(PGFOOT)) continue;
 
         PgFoot *pgFoot = new PgFoot();
@@ -253,6 +254,7 @@ void Doc::GenerateHeader()
 {
     for (Score *score : this->GetVisibleScores()) {
         ScoreDef *scoreDef = score->GetScoreDef();
+        assert(scoreDef);
         if (scoreDef->FindDescendantByType(PGHEAD)) continue;
 
         PgHead *pgHead = new PgHead();
@@ -384,6 +386,7 @@ void Doc::CalculateTimemap()
 
     // Set tempo
     ScoreDef *scoreDef = this->GetFirstVisibleScore()->GetScoreDef();
+    assert(scoreDef);
     if (scoreDef->HasMidiBpm()) {
         tempo = scoreDef->GetMidiBpm();
     }
@@ -431,6 +434,7 @@ void Doc::ExportMIDI(smf::MidiFile *midiFile)
 
     // set MIDI tempo
     ScoreDef *scoreDef = this->GetFirstVisibleScore()->GetScoreDef();
+    assert(scoreDef);
     if (scoreDef->HasMidiBpm()) {
         tempo = scoreDef->GetMidiBpm();
         tempoEventTicks.insert(0);
@@ -916,6 +920,7 @@ void Doc::PrepareData()
 
     for (Score *score : this->GetVisibleScores()) {
         ScoreDefSetGrpSymFunctor scoreDefSetGrpSym;
+        assert(score->GetScoreDef());
         score->GetScoreDef()->Process(scoreDefSetGrpSym);
     }
 
@@ -1270,6 +1275,7 @@ void Doc::ReactivateSelection(bool resetAligners)
     System *system = vrv_cast<System *>(selectionPage->FindDescendantByType(SYSTEM));
     // Add a selection scoreDef based on the current drawing system scoreDef
     Score *selectionScore = new Score();
+    selectionScore->AddChild(new ScoreDef());
     selectionScore->GetScoreDef()->ReplaceWithCopyOf(system->GetDrawingScoreDef());
     selectionScore->SetLabel("[selectionScore]");
     // Use the drawing values as actual scoreDef

--- a/src/findfunctor.cpp
+++ b/src/findfunctor.cpp
@@ -445,6 +445,8 @@ FunctorCode FindElementInLayerStaffDefFunctor::VisitLayer(const Layer *layer)
 
 FunctorCode FindElementInLayerStaffDefFunctor::VisitScore(const Score *score)
 {
+    assert(score->GetScoreDef());
+
     if (score->GetScoreDef()->GetID() == m_id) {
         m_element = score->GetScoreDef();
     }

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -870,6 +870,7 @@ void ABCInput::PrintInformationFields(Score *score)
         originRend->AddChild(origin);
         pgHead->AddChild(originRend);
     }
+    assert(score->GetScoreDef());
     score->GetScoreDef()->AddChild(pgHead);
 }
 
@@ -1021,6 +1022,7 @@ void ABCInput::InitScoreAndSection(Score *&score, Section *&section)
     staffGrp->AddChild(staffDef);
     // create page head
     this->PrintInformationFields(score);
+    assert(score->GetScoreDef());
     score->GetScoreDef()->AddChild(staffGrp);
     if (m_key) {
         score->GetScoreDef()->AddChild(m_key);
@@ -1039,6 +1041,7 @@ void ABCInput::InitScoreAndSection(Score *&score, Section *&section)
     if (m_durDefault == DURATION_NONE) {
         CalcUnitNoteLength();
     }
+    assert(score->GetScoreDef());
     score->GetScoreDef()->SetDurDefault(m_durDefault);
     m_durDefault = DURATION_NONE;
 

--- a/src/iocmme.cpp
+++ b/src/iocmme.cpp
@@ -153,6 +153,7 @@ bool CmmeInput::Import(const std::string &cmme)
             staffDef->AddChild(mensur);
         }
 
+        assert(m_score->GetScoreDef());
         m_score->GetScoreDef()->AddChild(staffGrp);
 
         m_doc->ConvertToPageBasedDoc();

--- a/src/iohumdrum.cpp
+++ b/src/iohumdrum.cpp
@@ -1005,6 +1005,7 @@ void HumdrumInput::addDefaultTempoDist(double distance)
 {
     data_MEASUREMENTSIGNED something;
     something.SetVu(distance);
+    assert(m_score->GetScoreDef());
     m_score->GetScoreDef()->SetTempoDist(something);
 }
 

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4492,7 +4492,9 @@ bool MEIInput::ReadScoreScoreDef(Object *parent, pugi::xml_node parentNode)
     // This might be problematic with comments - ideally we should loop and skip them, but then also skip the right
     // number of nodes in ReadScore
     pugi::xml_node firstChild = parentNode.first_child();
-    if (!firstChild) return false;
+    // We return true because we can have empty editorial markup parent, even though that will fail if that element is
+    // selected
+    if (!firstChild) return true;
 
     if (this->IsEditorialElementName(firstChild.name())) {
         success = this->ReadEditorialElement(parent, firstChild, EDITORIAL_SCORE);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4438,7 +4438,9 @@ bool MEIInput::ReadScore(Object *parent, pugi::xml_node score)
     // Detach the first child
     Object *subtree = tmpScore.DetachChild(0);
     // This will find the one selected by xpath queries since the subtree is filtered by visibility
-    ScoreDef *scoreScoreDef = (subtree) ? vrv_cast<ScoreDef *>(subtree->FindDescendantByType(SCOREDEF)) : NULL;
+    ScoreDef *scoreScoreDef = (!subtree || subtree->Is(SCOREDEF))
+        ? vrv_cast<ScoreDef *>(subtree)
+        : vrv_cast<ScoreDef *>(subtree->FindDescendantByType(SCOREDEF));
     if (!scoreScoreDef) {
         LogError("No top-level scoreDef could be read as child or direct descendant of score.");
         return false;

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -888,15 +888,18 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
             }
         }
         if (head) {
+            assert(score->GetScoreDef());
             score->GetScoreDef()->AddChild(head);
         }
         if (foot) {
+            assert(score->GetScoreDef());
             score->GetScoreDef()->AddChild(foot);
         }
     }
 
     std::vector<StaffGrp *> m_staffGrpStack;
     StaffGrp *staffGrp = new StaffGrp();
+    assert(score->GetScoreDef());
     score->GetScoreDef()->AddChild(staffGrp);
     m_staffGrpStack.push_back(staffGrp);
 
@@ -904,7 +907,10 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
     m_octDis.push_back(0);
 
     pugi::xpath_node scoreMidiBpm = root.select_node("/score-partwise/part[1]/measure[1]/sound[@tempo][1]");
-    if (scoreMidiBpm) score->GetScoreDef()->SetMidiBpm(scoreMidiBpm.node().attribute("tempo").as_double());
+    if (scoreMidiBpm) {
+        assert(score->GetScoreDef());
+        score->GetScoreDef()->SetMidiBpm(scoreMidiBpm.node().attribute("tempo").as_double());
+    }
 
     pugi::xpath_node_set partListChildren = root.select_nodes("/score-partwise/part-list/*");
     for (pugi::xpath_node_set::const_iterator it = partListChildren.begin(); it != partListChildren.end(); ++it) {

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -145,6 +145,7 @@ RunningElement *Page::GetHeader()
 const RunningElement *Page::GetHeader() const
 {
     assert(m_score);
+    assert(m_score->GetScoreDef());
 
     const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_header.GetValue() == HEADER_none)) {
@@ -171,6 +172,7 @@ RunningElement *Page::GetFooter()
 const RunningElement *Page::GetFooter() const
 {
     assert(m_scoreEnd);
+    assert(m_scoreEnd->GetScoreDef());
 
     const Doc *doc = vrv_cast<const Doc *>(this->GetFirstAncestor(DOC));
     if (!doc || (doc->GetOptions()->m_footer.GetValue() == FOOTER_none)) {

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -112,6 +112,8 @@ FunctorCode PrepareDataInitializationFunctor::VisitRepeatMark(RepeatMark *repeat
 
 FunctorCode PrepareDataInitializationFunctor::VisitScore(Score *score)
 {
+    assert(score->GetScoreDef());
+
     // Evaluate functor on scoreDef
     score->GetScoreDef()->Process(*this);
 
@@ -354,6 +356,7 @@ FunctorCode PrepareAltSymFunctor::VisitObject(Object *object)
     if (object->Is(SCORE)) {
         Score *score = vrv_cast<Score *>(object);
         assert(score);
+        assert(score->GetScoreDef());
         m_symbolTable = vrv_cast<SymbolTable *>(score->GetScoreDef()->FindDescendantByType(SYMBOLTABLE));
     }
 
@@ -1396,6 +1399,7 @@ FunctorCode PrepareRptFunctor::VisitStaff(Staff *staff)
 
     // This is happening only for the first staff element of the staff @n
     ScoreDef *scoreDef = m_doc->GetCorrespondingScore(staff)->GetScoreDef();
+    assert(scoreDef);
     if (StaffDef *staffDef = scoreDef->GetStaffDef(staff->GetN())) {
         const bool hideNumber = (staffDef->GetMultiNumber() == BOOLEAN_false)
             || ((staffDef->GetMultiNumber() != BOOLEAN_true) && (scoreDef->GetMultiNumber() == BOOLEAN_false));

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -95,6 +95,7 @@ bool Score::IsSupportedChild(ClassId classId)
 void Score::SetScoreDefSubtree(Object *substree, ScoreDef *scoreScoreDef)
 {
     assert(!m_scoreDef);
+    assert(!m_scoreDefSubtree);
 
     m_scoreDefSubtree = substree;
     m_scoreDef = scoreScoreDef;

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -36,15 +36,33 @@ namespace vrv {
 
 static const ClassRegistrar<Score> s_factory("score", SCORE);
 
-Score::Score() : PageElement(SCORE), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
+Score::Score() : Score(true) {}
+
+Score::Score(bool createScoreDef) : PageElement(SCORE), PageMilestoneInterface(), AttLabelled(), AttNNumberLike()
 {
     this->RegisterAttClass(ATT_LABELLED);
     this->RegisterAttClass(ATT_NNUMBERLIKE);
 
+    if (createScoreDef) {
+        m_scoreDef = new ScoreDef();
+        m_scoreDefSubtree = m_scoreDef;
+    }
+    else {
+        m_scoreDef = NULL;
+        m_scoreDefSubtree = NULL;
+    }
+
     this->Reset();
 }
 
-Score::~Score() {}
+Score::~Score()
+{
+    if (m_scoreDefSubtree) {
+        delete m_scoreDefSubtree;
+        m_scoreDefSubtree = NULL;
+        m_scoreDef = NULL;
+    }
+}
 
 void Score::Reset()
 {
@@ -52,8 +70,6 @@ void Score::Reset()
     PageMilestoneInterface::Reset();
     this->ResetLabelled();
     this->ResetNNumberLike();
-
-    m_scoreDef.Reset();
 
     m_drawingPgHeadHeight = 0;
     m_drawingPgFootHeight = 0;
@@ -74,6 +90,14 @@ bool Score::IsSupportedChild(ClassId classId)
     else {
         return false;
     }
+}
+
+void Score::SetScoreDefSubtree(Object *substree, ScoreDef *scoreScoreDef)
+{
+    assert(!m_scoreDef);
+
+    m_scoreDefSubtree = substree;
+    m_scoreDef = scoreScoreDef;
 }
 
 void Score::CalcRunningElementHeight(Doc *doc)
@@ -118,12 +142,14 @@ void Score::CalcRunningElementHeight(Doc *doc)
 
 bool Score::ScoreDefNeedsOptimization(int optionCondense) const
 {
+    assert(m_scoreDef);
+
     if (optionCondense == CONDENSE_none) return false;
     // optimize scores only if encoded
-    bool optimize = (m_scoreDef.HasOptimize() && m_scoreDef.GetOptimize() == BOOLEAN_true);
+    bool optimize = (m_scoreDef->HasOptimize() && m_scoreDef->GetOptimize() == BOOLEAN_true);
     // if nothing specified, do not if there is only one grpSym
-    if ((optionCondense == CONDENSE_auto) && !m_scoreDef.HasOptimize()) {
-        ListOfConstObjects symbols = m_scoreDef.FindAllDescendantsByType(GRPSYM);
+    if ((optionCondense == CONDENSE_auto) && !m_scoreDef->HasOptimize()) {
+        ListOfObjects symbols = m_scoreDef->FindAllDescendantsByType(GRPSYM);
         optimize = (symbols.size() > 1);
     }
 

--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -223,6 +223,7 @@ FunctorCode ScoreDefSetCurrentFunctor::VisitPage(Page *page)
     // However, page->m_score has already been set by ScoreDefSetCurrentPageFunctor
     // This must be the first page or a new score is starting on this page
     assert(page->m_score);
+    assert(page->m_score->GetScoreDef());
     if (!m_currentScore || (m_currentScore != page->m_score)) {
         m_upcomingScoreDef = *page->m_score->GetScoreDef();
         m_upcomingScoreDef.Process(*this);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1440,7 +1440,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
                 // if no original element was found, try searching through scoredef in score (only for certain elements)
                 if (!origin && element->Is({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
                     Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
-                    if (page && page->m_score) {
+                    if (page && page->m_score && page->m_score->GetScoreDef()) {
                         origin = page->m_score->GetScoreDef()->FindDescendantByID(correspId);
                     }
                 }

--- a/src/transposefunctor.cpp
+++ b/src/transposefunctor.cpp
@@ -176,6 +176,7 @@ FunctorCode TransposeFunctor::VisitRest(Rest *rest)
 FunctorCode TransposeFunctor::VisitScore(Score *score)
 {
     ScoreDef *scoreDef = score->GetScoreDef();
+    assert(scoreDef);
 
     if (m_transposer->IsValidIntervalName(m_transposition)) {
         m_transposer->SetTransposition(m_transposition);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1846,10 +1846,14 @@ void View::DrawSystemEditorialElement(DeviceContext *dc, EditorialElement *eleme
         return;
     }
     if (element->Is(APP)) {
-        assert(dynamic_cast<App *>(element) && (dynamic_cast<App *>(element)->GetLevel() == EDITORIAL_TOPLEVEL));
+        assert(dynamic_cast<App *>(element));
+        EditorialLevel level = dynamic_cast<App *>(element)->GetLevel();
+        if ((level != EDITORIAL_SCORE) || (level != EDITORIAL_TOPLEVEL)) return;
     }
     else if (element->Is(CHOICE)) {
-        assert(dynamic_cast<Choice *>(element) && (dynamic_cast<Choice *>(element)->GetLevel() == EDITORIAL_TOPLEVEL));
+        assert(dynamic_cast<Choice *>(element));
+        EditorialLevel level = dynamic_cast<Choice *>(element)->GetLevel();
+        if ((level != EDITORIAL_SCORE) || (level != EDITORIAL_TOPLEVEL)) return;
     }
     std::string elementStart;
     if (element->IsMilestoneElement()) elementStart = "systemElementStart";


### PR DESCRIPTION
Currently, Verovio expects a top level `scoreDef` as a first child of `score`:
```xml
<mdiv>
   <score>
      <scoreDef/>
      <section/>
   </score>
</mdiv>
```

This top-level `scoreDef` cannot be surrounded by editorial markup. This PR adds support for it, which means we can now have:
```xml
<mdiv>
   <score>
      <app>
         <lem>
            <scoreDef/>
         </lem>
         <rdg>
            <scoreDef/>
         </rdg>
      </app>
      <section/>
   </score>
</mdiv>
```

Rendered with `--app-x-path-query="./rdg"`

<img width="781" alt="image" src="https://github.com/user-attachments/assets/3cee5d5b-5020-4655-b795-9dedce9e3687" />


<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Top-level scoreDef in editorial markup</title>
         </titleStmt>
         <pubStmt>
            <date>2025-05-05</date>
         </pubStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="5.3">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv xml:id="aoqsi69" n="7">
            <score xml:id="mjft1g2">
               <app>
                  <lem>
                     <scoreDef xml:id="u168fb37" keysig="3s" meter.count="2" meter.unit="4">
                        <staffGrp xml:id="e13jbbey" bar.thru="false">
                           <staffGrp xml:id="wzodm98" bar.thru="true" symbol="bracket">
                              <staffDef xml:id="c1d0qcvg" n="1" lines="5" clef.shape="G" clef.line="2">
                                 <label xml:id="c82fpt">Flauto</label>
                                 <labelAbbr xml:id="s1bb0tuc">Fl</labelAbbr>
                              </staffDef>
                              <staffDef xml:id="qgj8qwy" n="2" lines="5" clef.shape="G" clef.line="2">
                                 <label xml:id="awtw03u">Oboe I, II</label>
                                 <labelAbbr xml:id="tjwwkjn">Ob</labelAbbr>
                              </staffDef>
                              <staffDef xml:id="s1dict13" n="3" lines="5" clef.shape="F" clef.line="4">
                                 <label xml:id="bqqgytg">Fagotto I, II</label>
                                 <labelAbbr xml:id="m4oqxce">Fag</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffGrp xml:id="b23h8om" symbol="bracket">
                              <staffDef xml:id="y1n0fw13" n="4" lines="5" trans.diat="-2" trans.semi="-3" clef.shape="G" clef.line="2" keysig="0">
                                 <label xml:id="mo3qcsy">Corno I, II<lb xml:id="h1wb3e2s" />in La</label>
                                 <labelAbbr xml:id="t1p91bt0">Cor (La)</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffGrp xml:id="ppw8dyc" bar.thru="true" symbol="bracket">
                              <staffGrp xml:id="z9jzia9" symbol="brace">
                                 <staffDef xml:id="stn72u" n="5" lines="5" clef.shape="G" clef.line="2">
                                    <label xml:id="d98porn">Violino I</label>
                                    <labelAbbr xml:id="o2rcrlx">Vl I</labelAbbr>
                                 </staffDef>
                                 <staffDef xml:id="n1s4ffnc" n="6" lines="5" clef.shape="G" clef.line="2">
                                    <label xml:id="ma56g6u">Violino II</label>
                                    <labelAbbr xml:id="y147azdb">Vl II</labelAbbr>
                                 </staffDef>
                              </staffGrp>
                              <staffDef xml:id="fshell2" n="7" lines="5" clef.shape="C" clef.line="3">
                                 <label xml:id="b1ahluu1">Viola I, II</label>
                                 <labelAbbr xml:id="erbcoh7">Va</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffDef xml:id="pivwb27" n="8" lines="5" clef.shape="G" clef.line="2">
                              <label xml:id="j4bj489">ZERLINA</label>
                              <labelAbbr xml:id="yb8g0u0">Z</labelAbbr>
                           </staffDef>
                           <staffDef xml:id="f16zdwlv" n="9" lines="5" clef.shape="F" clef.line="4">
                              <label xml:id="i1e7ub62">DON GIOVANNI</label>
                              <labelAbbr xml:id="qt9ronl">D G</labelAbbr>
                           </staffDef>
                           <staffGrp xml:id="l1ufntge" symbol="bracket">
                              <staffDef xml:id="nxq6cll" n="10" lines="5" clef.shape="F" clef.line="4">
                                 <label xml:id="k1onwf8y">Violoncello<lb xml:id="d1bp6nfw" />e Basso</label>
                                 <labelAbbr xml:id="nxlbg6w">Vc e Bs</labelAbbr>
                              </staffDef>
                           </staffGrp>
                        </staffGrp>
                     </scoreDef>
                  </lem>
                  <rdg>
                     <scoreDef xml:id="u168fb37" keysig="3s" meter.count="2" meter.unit="4">
                        <staffGrp xml:id="e13jbbey" bar.thru="false">
                           <staffGrp xml:id="ppw8dyc" bar.thru="true" symbol="bracket">
                              <staffGrp xml:id="z9jzia9" symbol="brace">
                                 <staffDef xml:id="stn72u" n="5" lines="5" clef.shape="G" clef.line="2">
                                    <label xml:id="d98porn">Violino I</label>
                                    <labelAbbr xml:id="o2rcrlx">Vl I</labelAbbr>
                                 </staffDef>
                                 <staffDef xml:id="n1s4ffnc" n="6" lines="5" clef.shape="G" clef.line="2">
                                    <label xml:id="ma56g6u">Violino II</label>
                                    <labelAbbr xml:id="y147azdb">Vl II</labelAbbr>
                                 </staffDef>
                              </staffGrp>
                              <staffDef xml:id="fshell2" n="7" lines="5" clef.shape="C" clef.line="3">
                                 <label xml:id="b1ahluu1">Viola I, II</label>
                                 <labelAbbr xml:id="erbcoh7">Va</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffGrp xml:id="wzodm98" bar.thru="true" symbol="bracket">
                              <staffDef xml:id="c1d0qcvg" n="1" lines="5" clef.shape="G" clef.line="2">
                                 <label xml:id="c82fpt">Flauto</label>
                                 <labelAbbr xml:id="s1bb0tuc">Fl</labelAbbr>
                              </staffDef>
                              <staffDef xml:id="qgj8qwy" n="2" lines="5" clef.shape="G" clef.line="2">
                                 <label xml:id="awtw03u">Oboe I, II</label>
                                 <labelAbbr xml:id="tjwwkjn">Ob</labelAbbr>
                              </staffDef>
                              <staffDef xml:id="s1dict13" n="3" lines="5" clef.shape="F" clef.line="4">
                                 <label xml:id="bqqgytg">Fagotto I, II</label>
                                 <labelAbbr xml:id="m4oqxce">Fag</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffGrp xml:id="b23h8om" symbol="bracket">
                              <staffDef xml:id="y1n0fw13" n="4" lines="5" trans.diat="-2" trans.semi="-3" clef.shape="G" clef.line="2" keysig="0">
                                 <label xml:id="mo3qcsy">Corno I, II<lb xml:id="h1wb3e2s" />in La</label>
                                 <labelAbbr xml:id="t1p91bt0">Cor (La)</labelAbbr>
                              </staffDef>
                           </staffGrp>
                           <staffDef xml:id="pivwb27" n="8" lines="5" clef.shape="G" clef.line="2">
                              <label xml:id="j4bj489">ZERLINA</label>
                              <labelAbbr xml:id="yb8g0u0">Z</labelAbbr>
                           </staffDef>
                           <staffDef xml:id="f16zdwlv" n="9" lines="5" clef.shape="F" clef.line="4">
                              <label xml:id="i1e7ub62">DON GIOVANNI</label>
                              <labelAbbr xml:id="qt9ronl">D G</labelAbbr>
                           </staffDef>
                           <staffGrp xml:id="l1ufntge" symbol="bracket">
                              <staffDef xml:id="nxq6cll" n="10" lines="5" clef.shape="F" clef.line="4">
                                 <label xml:id="k1onwf8y">Violoncello<lb xml:id="d1bp6nfw" />e Basso</label>
                                 <labelAbbr xml:id="nxlbg6w">Vc e Bs</labelAbbr>
                              </staffDef>
                           </staffGrp>
                        </staffGrp>
                     </scoreDef>
                  </rdg>
               </app>
               <section xml:id="g1hwlyfa">
                  <section xml:id="zpk7z6m">
                     <pb xml:id="g1vmyhcz" />
                     <measure xml:id="ec0c02x" n="1">
                        <tempo xml:id="s12l1c7g" type="tempo" place="above" part="%all" staff="1" tstamp="1" midi.bpm="55" n="1">Andante</tempo>
                        <tempo xml:id="q1gxitk" type="heading" place="above" part="%all" staff="1" tstamp="0.5">
                           <rend xml:id="c1905d68" halign="center" fontsize="x-large" fontweight="normal">No. 7 Duettino</rend>
                        </tempo>
                        <staff xml:id="u17jmr1w" n="1">
                           <layer xml:id="e11huxwv" n="1">
                              <mRest xml:id="znr4k48" />
                           </layer>
                        </staff>
                        <staff xml:id="y1m8zn17" n="2">
                           <layer xml:id="psdt8x1" n="1">
                              <mRest xml:id="n10jcx5a" />
                           </layer>
                           <layer xml:id="ba7j3uy" n="2" />
                        </staff>
                        <staff xml:id="juiaea7" n="3">
                           <layer xml:id="oxzwqqc" n="1">
                              <mRest xml:id="r3i55up" />
                           </layer>
                           <layer xml:id="h12zs17z" n="2" />
                        </staff>
                        <staff xml:id="n1rmtrje" n="4">
                           <layer xml:id="zjeoxmv" n="1">
                              <mRest xml:id="kke0vy6" />
                           </layer>
                           <layer xml:id="n1sctd0l" n="2" />
                        </staff>
                        <staff xml:id="v41nhpl" n="5">
                           <layer xml:id="qwlajgs" n="1">
                              <rest xml:id="y1pgsif9" dur="8" />
                              <note xml:id="note_1656" dur="8" oct="4" pname="a" />
                              <rest xml:id="j1jp5f3v" dur="8" />
                              <note xml:id="v82tfll" dur="8" oct="4" pname="a" />
                           </layer>
                        </staff>
                        <staff xml:id="e14q1aig" n="6">
                           <layer xml:id="t1w3vevx" n="1">
                              <rest xml:id="v12wj9cg" dur="8" />
                              <note xml:id="note_1698" dur="8" oct="4" pname="c">
                                 <accid xml:id="x1053kmm" accid.ges="s" />
                              </note>
                              <rest xml:id="ijaxy2q" dur="8" />
                              <note xml:id="s18z7271" dur="8" oct="4" pname="c">
                                 <accid xml:id="z85g2or" accid.ges="s" />
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="nznfzok" n="7">
                           <layer xml:id="jc8wdp9" n="1">
                              <rest xml:id="qxvimeh" dur="8" />
                              <note xml:id="note_1740" dur="8" oct="4" pname="e" />
                              <rest xml:id="rrvbxh6" dur="8" />
                              <note xml:id="d1gv1amb" dur="8" oct="4" pname="e" />
                           </layer>
                        </staff>
                        <staff xml:id="spvbxwl" n="8">
                           <layer xml:id="o1yz9fdu" n="1">
                              <mRest xml:id="v16qode7" />
                           </layer>
                        </staff>
                        <staff xml:id="m16e8mly" n="9">
                           <layer xml:id="c1b9tw60" n="1">
                              <note xml:id="note_1800" dur="8" oct="3" pname="a">
                                 <verse xml:id="l1rpc8a2">
                                    <syl xml:id="ita496l">Là</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_1827" dur="16" oct="3" pname="a">
                                 <verse xml:id="c1ymreae">
                                    <syl xml:id="hbicarv">ci</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_1854" dur="16" oct="3" pname="b">
                                 <verse xml:id="f7t36q5">
                                    <syl xml:id="da4bnz4" con="d" wordpos="i">da</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_1881" dur="8" oct="4" pname="c">
                                 <accid xml:id="d1f9wq1" accid.ges="s" />
                                 <verse xml:id="n1cyeyp3">
                                    <syl xml:id="g18kllgp" wordpos="t">rem</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_1908" dur="8" oct="3" pname="a">
                                 <verse xml:id="qdjxg5p">
                                    <syl xml:id="l9n3x7f">la</syl>
                                 </verse>
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="i14onpgt" n="10">
                           <layer xml:id="olwctc6" n="1">
                              <note xml:id="note_1956" dur="8" oct="2" pname="a" />
                              <rest xml:id="s17r2sbn" dur="8" />
                              <note xml:id="sklwdg" dur="8" oct="2" pname="a" />
                              <rest xml:id="l17jlnp0" dur="8" />
                           </layer>
                           <layer xml:id="i1tqn102" n="2" />
                        </staff>
                        <dynam xml:id="v9btm6t" staff="5" startid="#note_1656">p</dynam>
                        <dynam xml:id="o2mj26n" staff="6" startid="#note_1698">p</dynam>
                        <dynam xml:id="q1tkjxkp" staff="7" startid="#note_1740" layer="1">p</dynam>
                        <dynam xml:id="rh31vrx" staff="10" startid="#note_1956" layer="1 2">p</dynam>
                     </measure>
                     <measure xml:id="r5xpaue" n="2">
                        <staff xml:id="a4ez1j9" n="1">
                           <layer xml:id="xfmd4j" n="1">
                              <mRest xml:id="l18et2sh" />
                           </layer>
                        </staff>
                        <staff xml:id="x1lorvfs" n="2">
                           <layer xml:id="n1wjncss" n="1">
                              <mRest xml:id="d1u86xew" />
                           </layer>
                           <layer xml:id="vwj58e8" n="2" />
                        </staff>
                        <staff xml:id="e56ze40" n="3">
                           <layer xml:id="k114aunr" n="1">
                              <mRest xml:id="ujdvior" />
                           </layer>
                           <layer xml:id="m1lbogsu" n="2" />
                        </staff>
                        <staff xml:id="e9kef4i" n="4">
                           <layer xml:id="n11fu5of" n="1">
                              <mRest xml:id="o12rtncy" />
                           </layer>
                           <layer xml:id="v14b93oq" n="2" />
                        </staff>
                        <staff xml:id="d11u8k3z" n="5">
                           <layer xml:id="v1vwdyp" n="1">
                              <rest xml:id="lhrd5pz" dur="8" />
                              <note xml:id="c1rqcbn5" dur="8" oct="4" pname="b" />
                              <rest xml:id="nwmfg7o" dur="8" />
                              <note xml:id="ndhioz2" dur="8" oct="4" pname="a" />
                           </layer>
                        </staff>
                        <staff xml:id="w1vn47bf" n="6">
                           <layer xml:id="r1kz42q6" n="1">
                              <rest xml:id="fcy59xo" dur="8" />
                              <note xml:id="m32l04c" dur="8" oct="4" pname="f">
                                 <accid xml:id="yfdh2og" accid.ges="s" />
                              </note>
                              <rest xml:id="qjakmhx" dur="8" />
                              <note xml:id="yg37udu" dur="8" oct="4" pname="f">
                                 <accid xml:id="t1al30pf" accid.ges="s" />
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="l1nb62c3" n="7">
                           <layer xml:id="wkg2d2a" n="1">
                              <rest xml:id="eccwrwf" dur="8" />
                              <note xml:id="u1sve6dq" dur="8" oct="4" pname="d" />
                              <rest xml:id="mb06m4d" dur="8" />
                              <note xml:id="n10ahdpa" dur="8" oct="3" pname="b" />
                           </layer>
                        </staff>
                        <staff xml:id="x16z2swc" n="8">
                           <layer xml:id="t1k68kr4" n="1">
                              <mRest xml:id="mop993u" />
                           </layer>
                        </staff>
                        <staff xml:id="jzqft21" n="9">
                           <layer xml:id="d13mhw1v" n="1">
                              <note xml:id="note_2292" dur="8" oct="3" pname="f">
                                 <accid xml:id="o1huv7ug" accid.ges="s" />
                                 <verse xml:id="h2tl8w5">
                                    <syl xml:id="v1lra14t" con="d" wordpos="i">ma</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_2319" dots="1" dur="4" oct="3" pname="b">
                                 <verse xml:id="anyoh2x">
                                    <syl xml:id="v1b3yb8" wordpos="t">no,</syl>
                                 </verse>
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="oodpwfc" n="10">
                           <layer xml:id="avn23fz" n="1">
                              <note xml:id="n1ksyeqi" dur="8" oct="3" pname="d" />
                              <rest xml:id="a72br06" dur="8" />
                              <note xml:id="p14vagd9" dur="8" oct="3" pname="d">
                                 <accid xml:id="e2lpm6k" accid="s" />
                              </note>
                              <rest xml:id="q12soi0" dur="8" />
                           </layer>
                           <layer xml:id="urbgpnr" n="2" />
                        </staff>
                     </measure>
                     <measure xml:id="mc2e38p" n="3">
                        <staff xml:id="i6ie1om" n="1">
                           <layer xml:id="fqycxek" n="1">
                              <mRest xml:id="mh4hyvb" />
                           </layer>
                        </staff>
                        <staff xml:id="t1pkmxhl" n="2">
                           <layer xml:id="k13rs43l" n="1">
                              <mRest xml:id="z1o7o13m" />
                           </layer>
                           <layer xml:id="r855ag" n="2" />
                        </staff>
                        <staff xml:id="javnt97" n="3">
                           <layer xml:id="ifnxpbz" n="1">
                              <mRest xml:id="jjxbu3k" />
                           </layer>
                           <layer xml:id="n1h9nhab" n="2" />
                        </staff>
                        <staff xml:id="yx2e5iz" n="4">
                           <layer xml:id="h1eiswrh" n="1">
                              <mRest xml:id="a1grnb6y" />
                           </layer>
                           <layer xml:id="i1s3hncn" n="2" />
                        </staff>
                        <staff xml:id="alla1sy" n="5">
                           <layer xml:id="i1956xao" n="1">
                              <rest xml:id="q1usr1ts" dur="8" />
                              <note xml:id="kd6qbcb" dur="8" oct="4" pname="g">
                                 <accid xml:id="z17pgesv" accid.ges="s" />
                              </note>
                              <rest xml:id="tfbwy6p" dur="8" />
                              <note xml:id="vj1wbz8" dur="8" oct="4" pname="f">
                                 <accid xml:id="n1gsuziy" accid.ges="s" />
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="k12ct6rx" n="6">
                           <layer xml:id="s7dpojb" n="1">
                              <rest xml:id="j1yv9rff" dur="8" />
                              <note xml:id="e1y61bsk" dur="8" oct="4" pname="e" />
                              <rest xml:id="mk92rdx" dur="8" />
                              <note xml:id="d5g8y4a" dur="8" oct="4" pname="d">
                                 <accid xml:id="pr53rn5" accid="s" />
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="q1itv918" n="7">
                           <layer xml:id="w12mu2tn" n="1">
                              <rest xml:id="y1ihwfv2" dur="8" />
                              <note xml:id="m1xd8ah" dur="8" oct="3" pname="b" />
                              <rest xml:id="c15on24b" dur="8" />
                              <note xml:id="hgk04xh" dur="8" oct="3" pname="a" />
                           </layer>
                        </staff>
                        <staff xml:id="w1uaepqx" n="8">
                           <layer xml:id="qte8iez" n="1">
                              <mRest xml:id="ffvkmz9" />
                           </layer>
                        </staff>
                        <staff xml:id="k146wte7" n="9">
                           <layer xml:id="rj3cwlc" n="1">
                              <note xml:id="note_2664" dur="8" oct="3" pname="g">
                                 <accid xml:id="e11ydlzz" accid.ges="s" />
                                 <verse xml:id="yixhv1k">
                                    <syl xml:id="v1w1r9q1">là</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_2691" dur="16" oct="3" pname="g">
                                 <accid xml:id="b1ut7bzm" accid.ges="s" />
                                 <verse xml:id="w71jc3c">
                                    <syl xml:id="q1iuwyps">mi</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_2718" dur="16" oct="3" pname="g">
                                 <accid xml:id="an60b9w" accid.ges="s" />
                                 <verse xml:id="re19588">
                                    <syl xml:id="g1v5lexf" con="d" wordpos="i">di</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_2745" dur="8" oct="3" pname="a">
                                 <verse xml:id="p1j419jh">
                                    <syl xml:id="o1x7m9c2" wordpos="t">rai</syl>
                                 </verse>
                              </note>
                              <note xml:id="note_2772" dur="8" oct="3" pname="b">
                                 <verse xml:id="erqel9v">
                                    <syl xml:id="l1b5nlj4">di</syl>
                                 </verse>
                              </note>
                           </layer>
                        </staff>
                        <staff xml:id="li81gdq" n="10">
                           <layer xml:id="b1b41ken" n="1">
                              <note xml:id="a1evnohv" dur="8" oct="3" pname="e" />
                              <rest xml:id="b1i53k8" dur="8" />
                              <note xml:id="jlteqnp" dur="8" oct="2" pname="b" />
                              <rest xml:id="z18bi7ed" dur="8" />
                           </layer>
                           <layer xml:id="v1l16zx8" n="2" />
                        </staff>
                     </measure>
                  </section>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>
   