### PR TITLE
add problem matcher to ci

### DIFF
--- a/.github/problem_matchers/gcc.json
+++ b/.github/problem_matchers/gcc.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "name": "gcc",
+      "owner": "gcc",
+      "source": "gcc",
+      "fileLocation": [
+        "relative"
+      ],
+      "pattern": [
+        {
+          "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Checkout main repo
         uses: actions/checkout@v4
 
+      - name: Register gcc problem matcher
+        run: echo "::add-matcher::.github/problem_matchers/gcc.json"
+
       # Installation step for Ubuntu
       - name: Configure Ubuntu with ${{ matrix.compiler }}-${{ matrix.version }}
         if: runner.os == 'Linux'


### PR DESCRIPTION
This PR adds a gcc problem matcher to the CI to show compiler warnings: 

<img width="1435" alt="grafik" src="https://github.com/user-attachments/assets/ed81e342-8397-4229-8407-7448425fd30b" />
