### PR TITLE
Use Object::s_xmlIDCounter instead of std::rand for ID first letter

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -801,7 +801,7 @@ int Object::DeleteChildrenByComparison(Comparison *comparison)
 void Object::GenerateID()
 {
     // A random letter from a-z
-    char letter = 'a' + (std::rand() % 26);
+    char letter = 'a' + (s_xmlIDCounter % 26);
     m_id = letter + Object::GenerateHashID();
 }
 


### PR DESCRIPTION
This should not break the IDs and also preserved them with `--xml-id-seed`