### PR TITLE
add dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    labels:
+      - 'github_actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,13 @@
 version: 2
 updates:
   # Maintain dependencies for GitHub Actions
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'monthly'
+      interval: "monthly"
     labels:
-      - 'github_actions'
+      - "github_actions"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
I noticed that the GitHub Actions are quite outdated, so I propose to add a dependabot config.