### PR TITLE
Fix loading custom fonts in JS and support base64 strings

### DIFF
--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -216,7 +216,6 @@ export class VerovioToolkit {
         let filesInBase64 = [];
         // Get all the files and convert them to a base64 string if necessary
         for ( const file of files ) {
-            const file = files[i];
             // The file in already passed as base64 string - nothing to do
             if (!/^https?:\/\//.test( file )) {
                 filesInBase64.push( file );

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -216,7 +216,7 @@ export class VerovioToolkit {
         let filesInBase64 = [];
         // Get all the files and convert them to a base64 string if necessary
         for ( const file of files ) {
-            // The file in already passed as base64 string - nothing to do
+            // The file is already passed as base64 string - nothing to do
             if (!/^https?:\/\//.test( file )) {
                 filesInBase64.push( file );
                 continue;

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -212,23 +212,28 @@ export class VerovioToolkit {
         if (!options.hasOwnProperty('fontAddCustom')) {
             return options;
         }
-        const filenames = options['fontAddCustom'];
+        const files = options['fontAddCustom'];
         let filesInBase64 = [];
-        // Get all the files and convert them to a base64 string
-        for (let i = 0; i < filenames.length; i++ ) {
+        // Get all the files and convert them to a base64 string if necessary
+        for ( let i = 0; i < files.length; i++ ) {
+            const file = files[i];
+            // The file in already passed as base64 string - nothing to do
+            if (!/^https?:\/\//.test( file )) {
+                filesInBase64.push( file );
+                continue;
+            }
             const request = new XMLHttpRequest();
-            request.open("GET", filenames[i], false); // `false` makes the request synchronous
+            request.open("GET", file, false); // `false` makes the request synchronous
             request.send(null);
 
             if (request.status === 200) {
                 filesInBase64.push(request.responseText);
             }
             else {
-                console.error(`${filenames[i]} could not be retrieved`);
+                console.error(`${file} could not be retrieved`);
             }
         }
         options["fontAddCustom"] = filesInBase64;
-        //console.log( options );
         return options;
     }
 }

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -215,7 +215,7 @@ export class VerovioToolkit {
         const files = options['fontAddCustom'];
         let filesInBase64 = [];
         // Get all the files and convert them to a base64 string if necessary
-        for ( let i = 0; i < files.length; i++ ) {
+        for ( const file of files ) {
             const file = files[i];
             // The file in already passed as base64 string - nothing to do
             if (!/^https?:\/\//.test( file )) {

--- a/src/resources.cpp
+++ b/src/resources.cpp
@@ -249,13 +249,17 @@ std::string Resources::GetCSSFontFor(const std::string &fontName) const
 std::string Resources::GetCustomFontname(const std::string &filename, const ZipFileReader &zipFile)
 {
 #ifdef __EMSCRIPTEN__
+    // Extracts the font name from the bounding box XML file
+    // For example, OneGlyph/OneGlpyh.xml
     for (auto &s : zipFile.GetFileList()) {
         std::filesystem::path path(s);
-        if (!path.has_parent_path() && path.has_extension() && path.extension() == ".xml") {
-            return path.stem();
+        if (!path.has_parent_path() || (path.parent_path() == path.stem())) {
+            if (path.has_extension() && (path.extension() == ".xml")) {
+                return path.stem();
+            }
         }
     }
-    LogWarning("The font name could not be extracted from the archive");
+    LogWarning("The font name could not be extracted from the archive XML file");
     return "";
 #else
     std::filesystem::path path(filename);
@@ -314,13 +318,13 @@ bool Resources::LoadFont(const std::string &fontName, ZipFileReader *zipFile)
         const std::string filename = fontName + ".xml";
         if (!zipFile->HasFile(filename)) {
             // File not found, default bounding boxes will be used
-            LogError("Failed to load font and glyph bounding boxes");
+            LogError("Failed to load the XML file containing glyph bounding boxes");
             return false;
         }
         pugi::xml_parse_result parseResult = doc.load_string(zipFile->ReadTextFile(filename).c_str());
         if (!parseResult) {
             // File not found, default bounding boxes will be used
-            LogError("Failed to load font and glyph bounding boxes");
+            LogError("Failed to parse the XML file containing glyph bounding boxes");
             return false;
         }
     }


### PR DESCRIPTION
This PR fixes an issue with the font name not being properly detected when a custom font is passed as base64 string to the JS toolkit.

It also allows for the font to be passed as base64 string directly and not has url. So in addition to be able to do
```json
{
    "font": "GoldenAge",
    "fontAddCustom": ["https://www.verovio.org/examples/fonts/custom/GoldenAge.txt"],
    "fontFallback": "Bravura"
}
```
one can pass the content of `https://www.verovio.org/examples/fonts/custom/GoldenAge.txt` as value directly. This can be useful in [server side](https://github.com/rism-digital/verovio/pull/3586) uses.