### PR TITLE
Update test suite ci

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -64,7 +64,7 @@ jobs:
           ls -alh ${{ env.OUTPUT_DIR }}
           sudo apt-get install wireguard
           sudo echo "${{ secrets.VPN_CONFIGURATION }}" > wg0.conf
-          python3 -m pip install diffimg jsondiff lxml xmldiff cairosvg==2.7.1
+          python3 -m pip install diffimg jsondiff lxml xmldiff cairosvg
 
       - name: Checkout the dev branch
         uses: actions/checkout@v4

--- a/doc/test-suite.py
+++ b/doc/test-suite.py
@@ -101,8 +101,6 @@ if __name__ == '__main__':
             tk.loadFile(inputFile)
             # render to SVG
             svgString = tk.renderToSVG(1)
-            svgString = svgString.replace(
-                "overflow=\"inherit\"", "overflow=\"visible\"")
             ET.ElementTree(ET.fromstring(svgString)).write(svgFile)
             svg2png(bytestring=svgString, scale=2, write_to=pngFile)
             # create time map


### PR DESCRIPTION
* removes the now obsolete change in the SVG
* uses latest CairoSVG ([after bugfix release](https://github.com/Kozea/CairoSVG/releases/tag/2.8.1))