### PR TITLE
Use a vector instead of a map for consistent glyph ordering in SVG

### DIFF
--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -361,7 +361,7 @@ private:
         std::string m_refId;
     };
     const std::string InsertGlyphRef(const Glyph *glyph);
-    std::map<const Glyph *, GlyphRef> m_smuflGlyphs;
+    std::vector<std::pair<const Glyph *, GlyphRef>> m_smuflGlyphs;
     std::map<std::string, int> m_glyphCodeFontCounter;
 
     // pugixml data


### PR DESCRIPTION
With the change of the map key from a string to a pointer [here](https://github.com/rism-digital/verovio/commit/1ab043a261a6bdfb6eb06a0205bf5aea090d9dbe) the ordering of the `g` in the SVG `defs` is not always the same even when with `--xml-id-seed` set. It is fixed here by using a `vector` or `pair` instead of a `map`.