### PR TITLE
Preserve ID in annot even with `--remove-ids`

### DIFF
--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1497,7 +1497,7 @@ std::string MEIOutput::IDToMeiStr(Object *element)
 void MEIOutput::WriteXmlId(pugi::xml_node currentNode, Object *object)
 {
     // Keep IDs for annot elements
-    if (m_removeIds && !object->Is({ANNOT, ANNOTSCORE}) && !m_referredObjects.contains(object)) {
+    if (m_removeIds && !object->Is({ ANNOT, ANNOTSCORE }) && !m_referredObjects.contains(object)) {
         return;
     }
     currentNode.append_attribute("xml:id") = IDToMeiStr(object).c_str();

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1496,7 +1496,8 @@ std::string MEIOutput::IDToMeiStr(Object *element)
 
 void MEIOutput::WriteXmlId(pugi::xml_node currentNode, Object *object)
 {
-    if (m_removeIds && !m_referredObjects.contains(object)) {
+    // Keep IDs for annot elements
+    if (m_removeIds && !object->Is({ANNOT, ANNOTSCORE}) && !m_referredObjects.contains(object)) {
         return;
     }
     currentNode.append_attribute("xml:id") = IDToMeiStr(object).c_str();


### PR DESCRIPTION
Tiny PR that preserves `annot@xml:id` even with the `--remove-ids` option is enabled since these IDs are quite likely to be referenced from the outside. No change expected - at least from my point of view. Pinging @DILewis 