### PR TITLE
Add round-trip test

### DIFF
--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -106,6 +106,7 @@ jobs:
         working-directory: ${{ github.workspace }}/${{ env.DEV_DIR }}/doc
         run: |
           python3 ./test-suite-diff.py ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.DEV_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
+          python3 ./test-suite-roundtrip.py ${{ github.workspace }}/${{env.GH_PAGES_DIR}}/_tests ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
           ls -al
 
       - name: Upload results as artefacts

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: ${{ github.workspace }}/${{ env.DEV_DIR }}/doc
         run: |
           python3 ./test-suite-diff.py ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.DEV_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
-          python3 ./test-suite-roundtrip.py ${{ github.workspace }}/${{env.GH_PAGES_DIR}}/_tests ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
+          # python3 ./test-suite-roundtrip.py ${{ github.workspace }}/${{env.GH_PAGES_DIR}}/_tests ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
           ls -al
 
       - name: Upload results as artefacts

--- a/.github/workflows/tests_build.yml
+++ b/.github/workflows/tests_build.yml
@@ -106,7 +106,7 @@ jobs:
         working-directory: ${{ github.workspace }}/${{ env.DEV_DIR }}/doc
         run: |
           python3 ./test-suite-diff.py ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.DEV_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
-          # python3 ./test-suite-roundtrip.py ${{ github.workspace }}/${{env.GH_PAGES_DIR}}/_tests ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ env.PR_DIR }}/ ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
+          # python3 ./test-suite-roundtrip.py ${{ github.workspace }}/${{env.GH_PAGES_DIR}}/_tests ${{ github.workspace }}/${{ env.OUTPUT_DIR }}/
           ls -al
 
       - name: Upload results as artefacts

--- a/doc/diffTests.sh
+++ b/doc/diffTests.sh
@@ -62,6 +62,6 @@ $PYTHON ../../doc/test-suite.py "$testdir" "$indir2" --shortlist "$shortlist"
 
 $PYTHON ../../doc/test-suite-diff.py "$indir2" "$indir1" "$outdir"
 
-$PYTHON ../../doc/test-suite-roundtrip.py "$testdir" "$indir2" "$outdir"
+$PYTHON ../../doc/test-suite-roundtrip.py "$testdir" "$outdir"
 
 open $outdir/index.html

--- a/doc/diffTests.sh
+++ b/doc/diffTests.sh
@@ -62,4 +62,6 @@ $PYTHON ../../doc/test-suite.py "$testdir" "$indir2" --shortlist "$shortlist"
 
 $PYTHON ../../doc/test-suite-diff.py "$indir2" "$indir1" "$outdir"
 
+$PYTHON ../../doc/test-suite-roundtrip.py "$testdir" "$indir2" "$outdir"
+
 open $outdir/index.html

--- a/doc/test-suite-roundtrip.py
+++ b/doc/test-suite-roundtrip.py
@@ -1,0 +1,136 @@
+# This script it expected to be run from ./bindings/python
+import argparse
+import json
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+import lxml.etree as etree
+from xmldiff.main import diff_trees as xmldiff
+
+# Add path for toolkit built in-place
+sys.path.append('.')
+import verovio
+
+ns = {'mei': 'http://www.music-encoding.org/ns/mei'}
+
+ET.register_namespace('', 'http://www.music-encoding.org/ns/mei')
+
+# Optional list for processing only listed test files
+# Files must be listed in a file passed with --shortlist, one by line
+# Ex. 'accid/accid-001.mei'
+shortlist = []
+
+testOptions = {
+    'breaks': 'auto',
+    'removeIds': True
+}
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('test_suite_dir')
+    parser.add_argument('input_dir2')
+    parser.add_argument('output_dir')
+    parser.add_argument('--shortlist', nargs='?', default='')
+    args = parser.parse_args()
+
+    # version of the toolkit
+    tk = verovio.toolkit(False)
+    print(f'Verovio {tk.getVersion()}')
+
+    tk.setResourcePath('../../data')
+
+    # look if we have a shortlist file and read it
+    if len(args.shortlist) > 0:
+        print(args.shortlist)
+        with open(args.shortlist) as f:
+            for line in f:
+                shortlist.append(line.strip('\n'))
+                print('File {} added to the shortlist'.format(line))
+
+    totalChanges = 0
+    log = []
+
+    path1 = args.test_suite_dir.replace(r"\ ", " ")
+    path2 = args.output_dir.replace(r"\ ", " ")
+    path_out = args.output_dir
+    dir1 = sorted(os.listdir(path1))
+    for item1 in dir1:
+        if not (os.path.isdir(os.path.join(path1, item1))):
+            continue
+
+        # create the output directory if necessary
+        if not (os.path.isdir(os.path.join(path2, item1))):
+            os.mkdir(os.path.join(path2, item1))
+
+        dir2 = sorted(os.listdir(os.path.join(path1, item1)))
+        for item2 in dir2:
+            # skip directories
+            if not (os.path.isfile(os.path.join(path1, item1, item2))):
+                continue
+            # skip hidden files
+            if item2.startswith('.'):
+                continue
+
+            if shortlist and not (os.path.join(item1, item2) in shortlist):
+                continue
+
+            # reset the options
+            options = testOptions.copy()
+
+            # filenames (input MEI/XML and output SVG)
+            inputFile = os.path.join(path1, item1, item2)
+            options.update({"xmlIdChecksum": True})
+            print(f'Evaluating {item2}')
+            name, ext = os.path.splitext(item2)
+            meiFile = os.path.join(path2, item1, name + '.mei')
+
+            # parse the MEI file
+            if ext != '.mei':
+                continue
+
+            tree = ET.parse(inputFile)
+            root = tree.getroot()
+
+            toskip = root.find(
+                './/mei:appInfo/mei:application[@type]', namespaces=ns)
+            if toskip is not None and toskip.attrib['type'] == 'skip-round-trip':
+                print(f'Skipping {item2}')
+                continue
+
+            # try to get the extMeta tag and load the options if existing
+            meta = root.findtext(
+                './/mei:meiHead/mei:extMeta', namespaces=ns)
+            if meta is not None and meta != '':
+                print(meta)
+                metaOptions = json.loads(meta)
+                options |= metaOptions
+
+            tk.setOptions(options)
+            tk.loadFile(inputFile)
+            # round-trip to MEI
+            meiString = tk.getMEI({})
+            #print(meiString)
+            ET.ElementTree(ET.fromstring(meiString)).write(meiFile)
+            options.clear()
+
+            tree1 = etree.parse(inputFile)
+            root1 = tree1.getroot()
+
+
+            root2 = etree.fromstring(meiString.encode('utf-8'))
+
+            diff = xmldiff(root1, root2)
+            if (len(diff) > 0):
+                log.append("****** {}: {} ******".format(item2, len(diff)))
+                totalChanges += 1
+                print(f'::warning round-trip on {item2} produced a different MEI ({len(diff)} nodes)')
+
+    text1 = '{} round-trip change(s) detected'.format(totalChanges)
+
+    if (totalChanges > 0):
+        logFileOut = os.path.join(path_out, 'log.md')
+        with open(logFileOut, 'a') as f:
+            f.write("\n\n%s\n" % text1)
+            for item in log:
+                f.write("%s\n" % item)

--- a/doc/test-suite-roundtrip.py
+++ b/doc/test-suite-roundtrip.py
@@ -81,7 +81,6 @@ if __name__ == '__main__':
             # filenames (input MEI/XML and output SVG)
             inputFile = os.path.join(path1, item1, item2)
             options.update({"xmlIdChecksum": True})
-            print(f'Evaluating {item2}')
             name, ext = os.path.splitext(item2)
             meiFile = os.path.join(path2, item1, name + '.mei')
 
@@ -97,6 +96,8 @@ if __name__ == '__main__':
             if toskip is not None and toskip.attrib['type'] == 'skip-round-trip':
                 print(f'Skipping {item2}')
                 continue
+
+            print(f'Evaluating {item2}')
 
             # try to get the extMeta tag and load the options if existing
             meta = root.findtext(

--- a/doc/test-suite-roundtrip.py
+++ b/doc/test-suite-roundtrip.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     tk = verovio.toolkit(False)
     print(f'Verovio {tk.getVersion()}')
 
-    tk.setResourcePath('../data')
+    tk.setResourcePath('../../data')
 
     # look if we have a shortlist file and read it
     if len(args.shortlist) > 0:


### PR DESCRIPTION
This PR adds a round-trip evaluation and the test suite units. It loads the MEI and exports it and performs and XML diff.

Test suite examples that are expected to modify the MEI when loaded are flagged with a `./appInfo@type"skip-round-trip"` and are ignored from the evaluation. 

For now, test suite examples failing the round-trip are added to the `log.md`. Eventually, we could make the action fail.