### PR TITLE
Build Java toolkit in CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -484,6 +484,7 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
+          cache-dependency-path: ${{ github.workspace }}/bindings/java/pom.xml
 
       - name: Create TEMP_DIR
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -466,6 +466,7 @@ jobs:
           echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
           echo "IS_DRY_RUN = ${IS_DRY_RUN}"
 
+
   ##################################
   # Build the JJava toolkit        #
   ##################################
@@ -476,6 +477,14 @@ jobs:
     steps:
       - name: Checkout main repo
         uses: actions/checkout@v4.2.2
+
+      - name: Restore cache
+        id: restore_cache
+        uses: actions/setup-java@v4.7.1
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
 
       - name: Create TEMP_DIR
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -468,7 +468,7 @@ jobs:
 
 
   ##################################
-  # Build the JJava toolkit        #
+  # Build the Java toolkit         #
   ##################################
   build_java:
     name: Build Java toolkit

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -479,7 +479,6 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Restore cache
-        id: restore_cache
         uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
@@ -501,7 +500,7 @@ jobs:
       - name: Upload java build artifact (${{ matrix.toolkit.target }})
         uses: actions/upload-artifact@v4.4.3
         with:
-          name: java-build-articfat
+          name: java-build-${{ github.run_id }}
           path: ${{ github.workspace }}/${{ env.TEMP_DIR }}
       
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -313,6 +313,25 @@ jobs:
           name: ${{ env.TOOLKIT_BUILD }}-${{ github.run_id }}
           path: ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ matrix.toolkit.filepath }}
 
+  ##################################
+  # Build the JJava toolkit        #
+  ##################################
+  build_java:
+    name: Build Java toolkit
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Build Java
+        working-directory: ${{ github.workspace }}/bindings/java
+        run: mvn package
+
+      - name: Build Java
+        working-directory: ${{ github.workspace }}/bindings/java
+        run: mvn package
+
 
   ############################
   # Copy the font CSS files  #

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Register gcc problem matcher
         run: echo "::add-matcher::.github/problem_matchers/gcc.json"
@@ -271,7 +271,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Create TEMP_DIR
         working-directory: ${{ github.workspace }}
@@ -323,7 +323,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Create TEMP_DIR
         working-directory: ${{ github.workspace }}
@@ -385,7 +385,7 @@ jobs:
 
     steps:
       - name: Checkout GH_PAGES_REPO into GH_PAGES_DIR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           # repository to check out
           repository: ${{ env.GH_PAGES_REPO }}
@@ -475,7 +475,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Create TEMP_DIR
         working-directory: ${{ github.workspace }}
@@ -510,7 +510,7 @@ jobs:
 
     steps:
       - name: Checkout main repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Install doxygen
         run: |
@@ -547,7 +547,7 @@ jobs:
 
     steps:
       - name: Checkout DOXYGEN_REPO into DOXYGEN_DIR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           # repository to check out
           repository: ${{ env.DOXYGEN_REPO }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -313,25 +313,6 @@ jobs:
           name: ${{ env.TOOLKIT_BUILD }}-${{ github.run_id }}
           path: ${{ github.workspace }}/${{ env.TEMP_DIR }}/${{ matrix.toolkit.filepath }}
 
-  ##################################
-  # Build the JJava toolkit        #
-  ##################################
-  build_java:
-    name: Build Java toolkit
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout main repo
-        uses: actions/checkout@v4
-
-      - name: Build Java
-        working-directory: ${{ github.workspace }}/bindings/java
-        run: mvn package
-
-      - name: Build Java
-        working-directory: ${{ github.workspace }}/bindings/java
-        run: mvn package
-
 
   ############################
   # Copy the font CSS files  #
@@ -484,6 +465,39 @@ jobs:
 
           echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
           echo "IS_DRY_RUN = ${IS_DRY_RUN}"
+
+  ##################################
+  # Build the JJava toolkit        #
+  ##################################
+  build_java:
+    name: Build Java toolkit
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+
+      - name: Create TEMP_DIR
+        working-directory: ${{ github.workspace }}
+        run: mkdir -p $TEMP_DIR/
+
+      - name: Build Java
+        working-directory: ${{ github.workspace }}/bindings/java
+        run: mvn package
+
+      - working-directory: ${{ github.workspace }}/bindings/java
+        run: mvn package
+
+      - name: Copy build into TEMP_DIR
+        working-directory: ${{ github.workspace }}/bindings/java
+        run: cp target/*.jar $GITHUB_WORKSPACE/$TEMP_DIR/
+
+      - name: Upload java build artifact (${{ matrix.toolkit.target }})
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: java-build-articfat
+          path: ${{ github.workspace }}/${{ env.TEMP_DIR }}
+      
 
   ###################################
   # Build the doxygen documentation #

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -492,10 +492,7 @@ jobs:
 
       - name: Build Java
         working-directory: ${{ github.workspace }}/bindings/java
-        run: mvn package
-
-      - working-directory: ${{ github.workspace }}/bindings/java
-        run: mvn package
+        run: mvn package && mvn package
 
       - name: Copy build into TEMP_DIR
         working-directory: ${{ github.workspace }}/bindings/java

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -370,8 +370,8 @@ jobs:
           echo "DISABLE_DEPLOY_STEPS = ${DISABLE_DEPLOY_STEPS}"
           echo "IS_DRY_RUN = ${IS_DRY_RUN}"
 
-          echo "::set-output name=disable::${DISABLE_DEPLOY_STEPS}"
-          echo "::set-output name=dry-run::${IS_DRY_RUN}"
+          echo "name=disable=${DISABLE_DEPLOY_STEPS}" >> $GITHUB_OUTPUT
+          echo "name=dry-run=${IS_DRY_RUN}" >> $GITHUB_OUTPUT
 
   #########################################
   # Deploy the toolkit builds to gh-pages #

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -12,34 +13,31 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source> 
+    <maven.compiler.release>9</maven.compiler.release>
   </properties>
-   
-  
+
   <build>
     <plugins>
-       <plugin>
-         <artifactId>maven-antrun-plugin</artifactId>
-         <executions>
-           <execution>
-             <id>build-native</id>
-             <phase>process-classes</phase>
-             <goals>
-               <goal>run</goal>
-             </goals>
-             <configuration>
-               <target>
-                 <property name="native.classpath" refid="maven.compile.classpath" />
-                 <echo file="${project.build.directory}/compile-classpath" message="${native.classpath}" />
-                 <exec dir="." executable="./build.sh" failonerror="true"/>
-               </target>
-             </configuration>
-           </execution>
-         </executions>
-       </plugin>
-     </plugins>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build-native</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <property name="native.classpath" refid="maven.compile.classpath" />
+                <echo file="${project.build.directory}/compile-classpath" message="${native.classpath}" />
+                <exec dir="." executable="./build.sh" failonerror="true" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
-  
-</project>
 
+</project>

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -3,9 +3,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.rism.verovio</groupId>
+  <groupId>digital.rism.verovio</groupId>
   <artifactId>VerovioToolkit</artifactId>
-  <version>5.4.0-dev</version>
+  <version>5.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>VerovioToolkit</name>


### PR DESCRIPTION
This PR updates the `pom.xml` following maven naming conventions and sets up a CI step to build the Java toolkit and uploads the artifact.

First part of #3876

NB: We should think about pushing the artifacts to Maven Central.
