### PR TITLE
Update and fixes for ABC

### DIFF
--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -161,12 +161,12 @@ void ABCInput::ParseABC(std::istream &infile)
             this->ReadMusicCode(abcLine, section);
         }
     }
+    this->FlushControlElements(score, section);
 
     if (section && score && !section->GetParent()) {
         score->AddChild(section);
     }
 
-    m_controlElements.clear();
     m_composer.clear();
     m_info.clear();
     m_title.clear();

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -833,6 +833,7 @@ void ABCInput::ParseReferenceNumber(const std::string &referenceNumberString)
 void ABCInput::PrintInformationFields(Score *score)
 {
     PgHead *pgHead = new PgHead();
+    pgHead->SetFunc(PGFUNC_first);
     for (const auto &it : m_title) {
         Rend *titleRend = new Rend();
         titleRend->SetHalign(HORIZONTALALIGNMENT_center);

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -369,7 +369,7 @@ void ABCInput::AddChordSymbol(LayerElement *element)
         m_harmStack.clear();
     }
 
-    m_dynam.clear();
+    m_harmStack.clear();
 }
 
 void ABCInput::AddDynamic(LayerElement *element)


### PR DESCRIPTION
This PR fixes the title generation of ABC input files by handling the recently added `pgHead@func`.

Fixes missing control events in files not ending with a new line.
 