### PR TITLE
Fix regression on toolkit methods retrieving time-related information and adjust json keys

### DIFF
--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -489,7 +489,7 @@ public:
         if (!MatchesType(object)) return false;
         const Measure *measure = vrv_cast<const Measure *>(object);
         assert(measure);
-        return (measure->EnclosesTime(m_time) > 0);
+        return (measure->EnclosesTime(m_time) != VRV_UNSET);
     }
 
 private:

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -305,7 +305,7 @@ public:
 
     /**
      * Check if the measure encloses the given time (in millisecond)
-     * Return the playing repeat time (1-based), 0 otherwise
+     * Return the playing repeat time (1-based), VRV_UNSET otherwise
      */
     int EnclosesTime(int time) const;
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -470,11 +470,11 @@ int Measure::EnclosesTime(int time) const
         = m_measureAligner.GetRightAlignment()->GetTime().ToDouble() * SCORE_TIME_UNIT * 60.0 / m_currentTempo * 1000.0
         + 0.5;
     std::vector<double>::const_iterator iter;
-    for (iter = m_realTimeOffsetMilliseconds.begin(); iter != m_realTimeOffsetMilliseconds.end(); ++iter) {
+    for (iter = m_realTimeOnsetMilliseconds.begin(); iter != m_realTimeOnsetMilliseconds.end(); ++iter) {
         if ((time >= *iter) && (time <= *iter + timeDuration)) return repeat;
         repeat++;
     }
-    return 0;
+    return VRV_UNSET;
 }
 
 Fraction Measure::GetScoreTimeOnset(int repeat) const

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -2125,7 +2125,7 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
         o << "qfracDuration" << scoreTimeDuration;
         o << "qfracTiedDuration" << scoreTimeTiedDuration;
         o << "tstampOn" << realTimeOnsetMilliseconds;
-        o << "tstamp" << realTimeOffsetMilliseconds;
+        o << "tstampOff" << realTimeOffsetMilliseconds;
     }
     return o.json();
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -2110,21 +2110,22 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
         assert(measure);
 
         // For now ignore repeats and access always the first
-        double offset = measure->GetRealTimeOffsetMilliseconds(1);
-        realTimeOffsetMilliseconds << offset + note->GetRealTimeOffsetMilliseconds();
-        realTimeOnsetMilliseconds << offset + note->GetRealTimeOnsetMilliseconds();
+        double mRealTimeOnsetMilliseconds = measure->GetRealTimeOnsetMilliseconds(1);
+        realTimeOnsetMilliseconds << mRealTimeOnsetMilliseconds + note->GetRealTimeOnsetMilliseconds();
+        realTimeOffsetMilliseconds << mRealTimeOnsetMilliseconds + note->GetRealTimeOffsetMilliseconds();
 
-        scoreTimeOnset << note->GetScoreTimeOnset();
-        scoreTimeOffset << note->GetScoreTimeOffset();
-        scoreTimeDuration << note->GetScoreTimeDuration();
-        scoreTimeTiedDuration << note->GetScoreTimeTiedDuration();
+        Fraction mScoreTimeOnset = measure->GetScoreTimeOnset(1);
+        scoreTimeOnset << jsonxx::Value(Timemap::ToArray(mScoreTimeOnset + note->GetScoreTimeOnset()));
+        scoreTimeOffset << jsonxx::Value(Timemap::ToArray(mScoreTimeOnset + note->GetScoreTimeOffset()));
+        scoreTimeDuration << jsonxx::Value(Timemap::ToArray(note->GetScoreTimeDuration()));
+        scoreTimeTiedDuration << jsonxx::Value(Timemap::ToArray(note->GetScoreTimeTiedDuration()));
 
-        o << "scoreTimeOnset" << scoreTimeOnset;
-        o << "scoreTimeOffset" << scoreTimeOffset;
-        o << "scoreTimeDuration" << scoreTimeDuration;
-        o << "scoreTimeTiedDuration" << scoreTimeTiedDuration;
-        o << "realTimeOnsetMilliseconds" << realTimeOnsetMilliseconds;
-        o << "realTimeOffsetMilliseconds" << realTimeOffsetMilliseconds;
+        o << "qfracOn" << scoreTimeOnset;
+        o << "qfracOff" << scoreTimeOffset;
+        o << "qfracDuration" << scoreTimeDuration;
+        o << "qfracTiedDuration" << scoreTimeTiedDuration;
+        o << "tstampOn" << realTimeOnsetMilliseconds;
+        o << "tstamp" << realTimeOffsetMilliseconds;
     }
     return o.json();
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -42,6 +42,7 @@
 #include "slur.h"
 #include "staff.h"
 #include "svgdevicecontext.h"
+#include "timemap.h"
 #include "vrv.h"
 
 //----------------------------------------------------------------------------
@@ -1920,7 +1921,7 @@ std::string Toolkit::GetElementsAtTime(int millisec)
     }
 
     int repeat = measure->EnclosesTime(millisec);
-    int measureTimeOffset = measure->GetRealTimeOffsetMilliseconds(repeat);
+    int measureTimeOffset = measure->GetRealTimeOnsetMilliseconds(repeat);
 
     // Get the pageNo from the first note (if any)
     int pageNo = -1;
@@ -2051,14 +2052,14 @@ int Toolkit::GetTimeForElement(const std::string &xmlId)
         Measure *measure = vrv_cast<Measure *>(note->GetFirstAncestor(MEASURE));
         assert(measure);
         // For now ignore repeats and access always the first
-        timeofElement = measure->GetRealTimeOffsetMilliseconds(1);
+        timeofElement = measure->GetRealTimeOnsetMilliseconds(1);
         timeofElement += note->GetRealTimeOnsetMilliseconds();
     }
     else if (element->Is(MEASURE)) {
         Measure *measure = vrv_cast<Measure *>(element);
         assert(measure);
         // For now ignore repeats and access always the first
-        timeofElement = measure->GetRealTimeOffsetMilliseconds(1);
+        timeofElement = measure->GetRealTimeOnsetMilliseconds(1);
     }
     else if (element->Is(CHORD)) {
         Chord *chord = vrv_cast<Chord *>(element);
@@ -2068,7 +2069,7 @@ int Toolkit::GetTimeForElement(const std::string &xmlId)
         Measure *measure = vrv_cast<Measure *>(note->GetFirstAncestor(MEASURE));
         assert(measure);
         // For now ignore repeats and access always the first
-        timeofElement = measure->GetRealTimeOffsetMilliseconds(1);
+        timeofElement = measure->GetRealTimeOnsetMilliseconds(1);
         timeofElement += note->GetRealTimeOnsetMilliseconds();
     }
     return timeofElement;


### PR DESCRIPTION
Fixes the #4101 regression, which is actually not on the timemap, but on the methods retrieving information about elements at a given time.

It also fixes the `Toolkit::GetTimesForElement` that apparently never worked - at least not since we use `Fraction`. In addition to the fix, the PR changes the JSON keys to be inline with the time map keys (`tstamp` and `qfrac`).

Example value returned:
```json
{
   "qfracDuration": [
      [2, 1]
   ],
   "qfracOff": [
      [47, 2]
   ],
   "qfracOn": [
      [43, 2]
   ],
   "qfracTiedDuration": [
      [0,  1]
    ],
   "tstampOff": [11750],
   "tstampOn": [10750]
}
```