### PR TITLE
set metcon for pickup measures

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1719,6 +1719,13 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
         }
     }
 
+    // set metcon to false for pickup measures
+    int endDuration = m_ppq;
+    for (const int &num : m_meterCount) endDuration *= num;
+    if (m_durTotal != endDuration) {
+        measure->SetMetcon(BOOLEAN_false);
+    }
+
     this->MatchTies(true);
     if (!m_tieStack.empty()) this->MatchTies(false);
     for (auto openTie : m_tieStack) {


### PR DESCRIPTION
The rendering still shows a small gap, but the timemap seems to fine with this.

![Bildschirmfoto 2025-07-07 um 15 23 04](https://github.com/user-attachments/assets/78cd5d91-3a23-4660-8681-c405fb5e6ca8)

closes #1568