### PR TITLE
fix: multi-measure rests with staff changes in MusicXML import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Change key names for `GetTimesForElement` to be inline with the timemap keys
 * Fix order of the SVG `defs/g` to be always the same across runs
 * Fix title and control event bugs in ABC import (@rettinghaus)
+* Fix bug with multi-measure rests in MusicXML import (@rettinghaus)
 * Fix values returned by `GetTimesForElement`
 
 ## [5.3.2] – 2025-05-28

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1678,7 +1678,6 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
             Layer *layer = SelectLayer(1, measure);
             this->AddLayerElement(layer, multiRest);
             m_multiRests[index] = index + multiRestLength - 1;
-            break;
         }
         else if (isMRestInOtherSystem) {
             if ((multiRestStaffNumber > 1) && !IsElement(child, "backup")) continue;


### PR DESCRIPTION
After detection of a multi-measure rests we ignored other definitions in the first measure (including system breaks etc.).

closes #4114