### PR TITLE
Extend support for decorations in abc

### DIFF
--- a/include/vrv/ioabc.h
+++ b/include/vrv/ioabc.h
@@ -86,6 +86,7 @@ private:
     void AddDynamic(LayerElement *element);
     void AddFermata(LayerElement *element);
     void AddOrnaments(LayerElement *element);
+    void AddRepeatMark(LayerElement *element);
 
     // additional functions
     void PrintInformationFields(Score *score);
@@ -156,6 +157,7 @@ private:
     std::vector<std::string> m_dynam;
     std::string m_ornam;
     data_STAFFREL m_fermata = STAFFREL_NONE;
+    repeatMarkLog_FUNC m_repeatMark = repeatMarkLog_FUNC_NONE;
     /*
      * The stack of control elements to be added at the end of each measure
      */

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -507,14 +507,12 @@ void ABCInput::ParseDecoration(const std::string &decorationString)
     else if (!strcmp(decorationString.c_str(), "invertedturn")) {
         m_ornam.push_back('s');
     }
-    else if (!strcmp(decorationString.c_str(), ">")) {
+    else if (!strcmp(decorationString.c_str(), ">") || !strcmp(decorationString.c_str(), "accent")
+        || !strcmp(decorationString.c_str(), "emphasis")) {
         m_artic.push_back(ARTICULATION_acc);
     }
-    else if (!strcmp(decorationString.c_str(), "accent")) {
-        m_artic.push_back(ARTICULATION_acc);
-    }
-    else if (!strcmp(decorationString.c_str(), "emphasis")) {
-        m_artic.push_back(ARTICULATION_acc);
+    else if (!strcmp(decorationString.c_str(), "^") || !strcmp(decorationString.c_str(), "marcato")) {
+        m_artic.push_back(ARTICULATION_marc);
     }
     else if (!strcmp(decorationString.c_str(), "fermata") || !strcmp(decorationString.c_str(), "H")) {
         m_fermata = STAFFREL_above;
@@ -525,14 +523,17 @@ void ABCInput::ParseDecoration(const std::string &decorationString)
     else if (!strcmp(decorationString.c_str(), "tenuto")) {
         m_artic.push_back(ARTICULATION_ten);
     }
-    else if (!strcmp(decorationString.c_str(), "+")) {
-        m_artic.push_back(ARTICULATION_stop);
-    }
-    else if (!strcmp(decorationString.c_str(), "plus")) {
+    else if (!strcmp(decorationString.c_str(), "+") || !strcmp(decorationString.c_str(), "plus")) {
         m_artic.push_back(ARTICULATION_stop);
     }
     else if (!strcmp(decorationString.c_str(), "snap")) {
         m_artic.push_back(ARTICULATION_snap);
+    }
+    else if (!strcmp(decorationString.c_str(), "slide")) {
+        m_artic.push_back(ARTICULATION_scoop);
+    }
+    else if (!strcmp(decorationString.c_str(), "wedge")) {
+        m_artic.push_back(ARTICULATION_stacciss);
     }
     else if (!strcmp(decorationString.c_str(), "upbow") || !strcmp(decorationString.c_str(), "u")) {
         m_artic.push_back(ARTICULATION_upbow);

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -1078,11 +1078,8 @@ void ABCInput::ParseLyrics()
         else if (abcLine.at(found) == '-') {
             if (abcLine.at(found - 1) == '\\') {
                 counter = 0;
-                sylType = sylLog_CON_d;
             }
-            else {
-                sylType = sylLog_CON_d;
-            }
+            sylType = sylLog_CON_d;
         }
         else if (abcLine.at(found) == '*') {
             // skip one note

--- a/src/ioabc.cpp
+++ b/src/ioabc.cpp
@@ -503,6 +503,9 @@ void ABCInput::ParseDecoration(const std::string &decorationString)
     if (!strcmp(decorationString.c_str(), ".")) {
         m_artic.push_back(ARTICULATION_stacc);
     }
+    else if (!strcmp(decorationString.c_str(), "~") || !strcmp(decorationString.c_str(), "roll")) {
+        m_ornam.push_back('S');
+    }
     else if (!strcmp(decorationString.c_str(), "trill") || !strcmp(decorationString.c_str(), "T")) {
         m_ornam.push_back('T');
     }


### PR DESCRIPTION
This PR adds support for some further decorations previously missing in ABC import: 

- `coda`, `segno`, `D.S.`, and `D.C.`
- marcato and staccatissimo
- Irish roll (handled as turn, because there is no matching SMuFL glyph)
