### PR TITLE
Adjust noteOff timings

### DIFF
--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -741,7 +741,7 @@ FunctorCode GenerateMIDIFunctor::VisitLayerEnd(const Layer *layer)
     // stop all previously held notes
     for (auto &held : m_heldNotes) {
         if (held.m_pitch > 0) {
-            m_midiFile->addNoteOff(m_midiTrack, held.m_stopTime * m_midiFile->getTPQ(), m_midiChannel, held.m_pitch);
+            m_midiFile->addNoteOff(m_midiTrack, held.m_stopTime * m_midiFile->getTPQ() - 1, m_midiChannel, held.m_pitch);
         }
     }
 
@@ -828,7 +828,7 @@ FunctorCode GenerateMIDIFunctor::VisitNote(const Note *note)
             const double stopTime = startTime + midiNote.duration;
 
             m_midiFile->addNoteOn(m_midiTrack, startTime * tpq, channel, midiNote.pitch, velocity);
-            m_midiFile->addNoteOff(m_midiTrack, stopTime * tpq, channel, midiNote.pitch);
+            m_midiFile->addNoteOff(m_midiTrack, stopTime * tpq - 1, channel, midiNote.pitch);
 
             startTime = stopTime;
         }
@@ -854,7 +854,7 @@ FunctorCode GenerateMIDIFunctor::VisitNote(const Note *note)
             // or if the new pitch is already sounding, on any course
             for (auto &held : m_heldNotes) {
                 if ((held.m_pitch > 0) && ((held.m_stopTime <= startTime) || (held.m_pitch == pitch))) {
-                    m_midiFile->addNoteOff(m_midiTrack, held.m_stopTime * tpq, channel, held.m_pitch);
+                    m_midiFile->addNoteOff(m_midiTrack, held.m_stopTime * tpq - 1, channel, held.m_pitch);
                     held.m_pitch = 0;
                     held.m_stopTime = 0;
                 }
@@ -876,7 +876,7 @@ FunctorCode GenerateMIDIFunctor::VisitNote(const Note *note)
                 = m_totalTime + note->GetScoreTimeOffset().ToDouble() + note->GetScoreTimeTiedDuration().ToDouble();
 
             m_midiFile->addNoteOn(m_midiTrack, startTime * tpq, channel, pitch, velocity);
-            m_midiFile->addNoteOff(m_midiTrack, stopTime * tpq, channel, pitch);
+            m_midiFile->addNoteOff(m_midiTrack, stopTime * tpq - 1, channel, pitch);
         }
     }
 


### PR DESCRIPTION
This PR fixes #4150 by reducing the noteOff onset by 1 MIDI tick. This helps MIDI players to correctly sort the events, removing the ambiguity of dealing with simultaneous noteOn / noteOff events for the same note.
