### PR TITLE
Import meter visibility

### DIFF
--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -25,7 +25,7 @@ class Measure;
  * This class represents a MEI meterSigGrp.
  * It contains meterSigGrp objects.
  */
-class MeterSigGrp : public LayerElement, public ObjectListInterface, public AttBasic, public AttMeterSigGrpLog {
+class MeterSigGrp : public LayerElement, public ObjectListInterface, public AttBasic, public AttMeterSigGrpLog, public AttVisibility {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/metersiggrp.h
+++ b/include/vrv/metersiggrp.h
@@ -25,7 +25,11 @@ class Measure;
  * This class represents a MEI meterSigGrp.
  * It contains meterSigGrp objects.
  */
-class MeterSigGrp : public LayerElement, public ObjectListInterface, public AttBasic, public AttMeterSigGrpLog, public AttVisibility {
+class MeterSigGrp : public LayerElement,
+                    public ObjectListInterface,
+                    public AttBasic,
+                    public AttMeterSigGrpLog,
+                    public AttVisibility {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1983,6 +1983,7 @@ void MEIOutput::WriteMeterSigGrp(pugi::xml_node currentNode, MeterSigGrp *meterS
     this->WriteLayerElement(currentNode, meterSigGrp);
     meterSigGrp->WriteBasic(currentNode);
     meterSigGrp->WriteMeterSigGrpLog(currentNode);
+    meterSigGrp->WriteVisibility(currentNode);
 }
 
 void MEIOutput::WriteFb(pugi::xml_node currentNode, Fb *fb)
@@ -5723,6 +5724,7 @@ bool MEIInput::ReadMeterSigGrp(Object *parent, pugi::xml_node meterSigGrp)
     this->ReadLayerElement(meterSigGrp, vrvMeterSigGrp);
     vrvMeterSigGrp->ReadBasic(meterSigGrp);
     vrvMeterSigGrp->ReadMeterSigGrpLog(meterSigGrp);
+    vrvMeterSigGrp->ReadVisibility(meterSigGrp);
 
     parent->AddChild(vrvMeterSigGrp);
     this->ReadUnsupportedAttr(meterSigGrp, vrvMeterSigGrp);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -1505,6 +1505,7 @@ short int MusicXmlInput::ReadMusicXmlPartAttributesAsStaffDef(
 
 void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *parent)
 {
+    const bool invisible = HasAttributeWithValue(time, "print-object", "no");
     if ((time.select_nodes("beats").size() > 1) || time.select_node("interchangeable")) {
         MeterSigGrp *meterSigGrp = new MeterSigGrp();
         if (time.attribute("id")) {
@@ -1516,6 +1517,9 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
         std::tie(m_meterCount, m_meterUnit) = this->GetMeterSigGrpValues(time, meterSigGrp);
         if (interchangeable) {
             std::tie(std::ignore, std::ignore) = this->GetMeterSigGrpValues(interchangeable.node(), meterSigGrp);
+        }
+        if (invisible) {
+            meterSigGrp->SetVisible(BOOLEAN_false);
         }
         parent->AddChild(meterSigGrp);
     }
@@ -1552,6 +1556,9 @@ void MusicXmlInput::ReadMusicXMLMeterSig(const pugi::xml_node &time, Object *par
             else {
                 meterSig->SetVisible(BOOLEAN_false);
             }
+        }
+        if (invisible) {
+            meterSig->SetVisible(BOOLEAN_false);
         }
         parent->AddChild(meterSig);
     }

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -24,7 +24,8 @@ namespace vrv {
 
 static const ClassRegistrar<MeterSigGrp> s_factory("meterSigGrp", METERSIGGRP);
 
-MeterSigGrp::MeterSigGrp() : LayerElement(METERSIGGRP), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog(), AttVisibility()
+MeterSigGrp::MeterSigGrp()
+    : LayerElement(METERSIGGRP), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BASIC);
     this->RegisterAttClass(ATT_METERSIGGRPLOG);

--- a/src/metersiggrp.cpp
+++ b/src/metersiggrp.cpp
@@ -24,10 +24,11 @@ namespace vrv {
 
 static const ClassRegistrar<MeterSigGrp> s_factory("meterSigGrp", METERSIGGRP);
 
-MeterSigGrp::MeterSigGrp() : LayerElement(METERSIGGRP), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog()
+MeterSigGrp::MeterSigGrp() : LayerElement(METERSIGGRP), ObjectListInterface(), AttBasic(), AttMeterSigGrpLog(), AttVisibility()
 {
     this->RegisterAttClass(ATT_BASIC);
     this->RegisterAttClass(ATT_METERSIGGRPLOG);
+    this->RegisterAttClass(ATT_VISIBILITY);
 
     this->Reset();
 }
@@ -39,6 +40,7 @@ void MeterSigGrp::Reset()
     LayerElement::Reset();
     this->ResetBasic();
     this->ResetMeterSigGrpLog();
+    this->ResetVisibility();
 }
 
 bool MeterSigGrp::IsSupportedChild(ClassId classId)


### PR DESCRIPTION
This extends the MusicXML support for invisible time signatures. 
Also it makes meterSigGrp part of AttVisibility.
