### PR TITLE
Remove event listener for deprecated unload event

### DIFF
--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -226,14 +226,3 @@ export class VerovioToolkit {
 
 // A pointer to the object - only one instance can be created for now
 VerovioToolkit.instances = [];
-
-
-// If the window object is defined (if we are not within a WebWorker)...
-if ((typeof window !== "undefined") && (window.addEventListener)) {
-    // Add a listener that will delete the object (if necessary) when the page is closed
-    window.addEventListener("unload", () => {
-        VerovioToolkit.instances.forEach((instance) => {
-            instance.destroy();
-        });
-    });
-}


### PR DESCRIPTION
This resolves https://github.com/rism-digital/verovio/issues/4174.