### PR TITLE
Improve the positioning of editorial accidentals

### DIFF
--- a/include/vrv/accid.h
+++ b/include/vrv/accid.h
@@ -10,12 +10,14 @@
 
 #include "atts_externalsymbols.h"
 #include "atts_gestural.h"
+#include "floatingobject.h"
 #include "layerelement.h"
 #include "positioninterface.h"
 
 namespace vrv {
 
 class AlignmentReference;
+class AccidFloatingObject;
 
 //----------------------------------------------------------------------------
 // Accid
@@ -47,6 +49,15 @@ public:
     void Reset() override;
     std::string GetClassName() const override { return "accid"; }
     ///@}
+
+    /**  Delete the floating object (editorial accidental) on reset or deletion */
+    void ClearFloatingObject();
+
+    /** Init the accid floating object for editorial accidentals */
+    void InitFloatingObject();
+
+    /** Return the floating object (NULL if not set) */
+    AccidFloatingObject *GetFloatingObject() { return m_floatingObject; }
 
     /** Override the method since it is align to the staff */
     bool IsRelativeToStaff() const override { return (this->HasLoc() || (this->HasOloc() && this->HasPloc())); }
@@ -133,6 +144,37 @@ public:
 private:
     Accid *m_drawingUnison;
     bool m_alignedWithSameLayer;
+
+    /** Floating object for rendering the editorial accidental */
+    AccidFloatingObject *m_floatingObject;
+};
+
+//----------------------------------------------------------------------------
+// AccidFloatingObject
+//----------------------------------------------------------------------------
+
+/**
+ * This class is used for editorial accidentals to be laid out as floating objects
+ */
+class AccidFloatingObject : public FloatingObject {
+public:
+    /**
+     * @name Constructors, destructors, and other standard methods
+     * No Reset() method is required.
+     */
+    ///@{
+    AccidFloatingObject();
+    virtual ~AccidFloatingObject() {}
+    std::string GetClassName() const override { return "accid"; }
+    void Reset() override;
+    ///@}
+
+private:
+    //
+public:
+    //
+private:
+    //
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -42,6 +42,7 @@ public:
      * Functor interface
      */
     ///@{
+    FunctorCode VisitAccid(Accid *accid) override;
     FunctorCode VisitDiv(Div *div) override;
     FunctorCode VisitChord(Chord *chord) override;
     FunctorCode VisitFloatingObject(FloatingObject *floatingObject) override;

--- a/include/vrv/vrvdef.h
+++ b/include/vrv/vrvdef.h
@@ -94,6 +94,7 @@ enum ClassId : uint16_t {
     FLOATING_POSITIONER,
     FLOATING_CURVE_POSITIONER,
     // Ids for ungrouped objects
+    ACCID_FLOATING,
     ALIGNMENT,
     ALIGNMENT_REFERENCE,
     CLEF_ATTR,

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -53,10 +53,15 @@ Accid::Accid()
     this->RegisterAttClass(ATT_PLACEMENTONSTAFF);
     this->RegisterAttClass(ATT_PLACEMENTRELEVENT);
 
+    m_floatingObject = NULL;
+
     this->Reset();
 }
 
-Accid::~Accid() {}
+Accid::~Accid()
+{
+    this->ClearFloatingObject();
+}
 
 void Accid::Reset()
 {
@@ -74,6 +79,23 @@ void Accid::Reset()
 
     m_drawingUnison = NULL;
     m_alignedWithSameLayer = false;
+
+    this->ClearFloatingObject();
+}
+
+void Accid::ClearFloatingObject()
+{
+    if (m_floatingObject) {
+        delete m_floatingObject;
+        m_floatingObject = NULL;
+    }
+}
+
+void Accid::InitFloatingObject()
+{
+    assert(!m_floatingObject);
+    m_floatingObject = new AccidFloatingObject();
+    m_floatingObject->SetParent(this);
 }
 
 std::u32string Accid::GetSymbolStr(data_NOTATIONTYPE notationType) const
@@ -309,6 +331,20 @@ FunctorCode Accid::AcceptEnd(Functor &functor)
 FunctorCode Accid::AcceptEnd(ConstFunctor &functor) const
 {
     return functor.VisitAccidEnd(this);
+}
+
+//----------------------------------------------------------------------------
+// AccidFloatingObject
+//----------------------------------------------------------------------------
+
+AccidFloatingObject::AccidFloatingObject() : FloatingObject(ACCID_FLOATING)
+{
+    this->Reset();
+}
+
+void AccidFloatingObject::Reset()
+{
+    FloatingObject::Reset();
 }
 
 //----------------------------------------------------------------------------

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -214,6 +214,9 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
     m_classId = OCTAVE;
     system->m_systemAligner.Process(*this);
 
+    m_classId = ACCID_FLOATING;
+    system->m_systemAligner.Process(*this);
+
     m_classId = BREATH;
     system->m_systemAligner.Process(*this);
 

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -181,6 +181,9 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
     m_classId = PHRASE;
     system->m_systemAligner.Process(*this);
 
+    m_classId = ACCID_FLOATING;
+    system->m_systemAligner.Process(*this);
+
     m_classId = MORDENT;
     system->m_systemAligner.Process(*this);
 
@@ -212,9 +215,6 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
     system->m_systemAligner.Process(*this);
 
     m_classId = OCTAVE;
-    system->m_systemAligner.Process(*this);
-
-    m_classId = ACCID_FLOATING;
     system->m_systemAligner.Process(*this);
 
     m_classId = BREATH;

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -214,7 +214,14 @@ FloatingPositioner::FloatingPositioner(FloatingObject *object, StaffAlignment *a
     m_alignment = alignment;
     m_spanningType = spanningType;
 
-    if (object->Is(ANNOTSCORE)) {
+    if (object->Is(ACCID_FLOATING)) {
+        assert(object->GetParent());
+        Accid *accid = vrv_cast<Accid *>(object->GetParent());
+        assert(accid);
+        // accid above by default;
+        m_place = (accid->GetPlace() != STAFFREL_NONE) ? accid->GetPlace() : STAFFREL_above;
+    }
+    else if (object->Is(ANNOTSCORE)) {
         m_place = STAFFREL_above;
     }
     else if (object->Is(BRACKETSPAN)) {

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -57,8 +57,22 @@ namespace vrv {
 
 PrepareDataInitializationFunctor::PrepareDataInitializationFunctor(Doc *doc) : DocFunctor(doc) {}
 
+FunctorCode PrepareDataInitializationFunctor::VisitAccid(Accid *accid)
+{
+    // Call parent one too
+    this->VisitObject(accid);
+
+    if (accid->GetFunc() == accidLog_FUNC_edit) {
+        accid->InitFloatingObject();
+    }
+    accid->Modify();
+
+    return FUNCTOR_CONTINUE;
+}
+
 FunctorCode PrepareDataInitializationFunctor::VisitDiv(Div *div)
 {
+    // Call parent one too
     this->VisitTextLayoutElement(div);
 
     if (m_doc->GetOptions()->m_breaks.GetValue() == BREAKS_none) {
@@ -70,6 +84,9 @@ FunctorCode PrepareDataInitializationFunctor::VisitDiv(Div *div)
 
 FunctorCode PrepareDataInitializationFunctor::VisitChord(Chord *chord)
 {
+    // Call parent one too
+    this->VisitObject(chord);
+
     if (chord->HasEmptyList()) {
         LogWarning("Chord '%s' has no child note - a default note is added", chord->GetID().c_str());
         Note *rescueNote = new Note();
@@ -82,6 +99,9 @@ FunctorCode PrepareDataInitializationFunctor::VisitChord(Chord *chord)
 
 FunctorCode PrepareDataInitializationFunctor::VisitFloatingObject(FloatingObject *floatingObject)
 {
+    // Call parent one too
+    this->VisitObject(floatingObject);
+
     floatingObject->ResetDrawingObjectIDs();
 
     return FUNCTOR_CONTINUE;
@@ -89,6 +109,9 @@ FunctorCode PrepareDataInitializationFunctor::VisitFloatingObject(FloatingObject
 
 FunctorCode PrepareDataInitializationFunctor::VisitKeySig(KeySig *keySig)
 {
+    // Call parent one too
+    this->VisitObject(keySig);
+
     // Clear and regenerate attribute children
     keySig->GenerateKeyAccidAttribChildren();
 
@@ -112,6 +135,9 @@ FunctorCode PrepareDataInitializationFunctor::VisitRepeatMark(RepeatMark *repeat
 
 FunctorCode PrepareDataInitializationFunctor::VisitScore(Score *score)
 {
+    // Call parent one too
+    this->VisitPageElement(score);
+
     assert(score->GetScoreDef());
 
     // Evaluate functor on scoreDef
@@ -122,6 +148,9 @@ FunctorCode PrepareDataInitializationFunctor::VisitScore(Score *score)
 
 FunctorCode PrepareDataInitializationFunctor::VisitTextLayoutElement(TextLayoutElement *textLayoutElement)
 {
+    // Call parent one too
+    this->VisitObject(textLayoutElement);
+
     textLayoutElement->ResetCells();
     textLayoutElement->ResetDrawingScaling();
 

--- a/src/resetfunctor.cpp
+++ b/src/resetfunctor.cpp
@@ -57,6 +57,7 @@ FunctorCode ResetDataFunctor::VisitAccid(Accid *accid)
     // Call parent one too
     this->VisitLayerElement(accid);
     accid->PositionInterface::InterfaceResetData(*this, accid);
+    accid->ClearFloatingObject();
 
     return FUNCTOR_CONTINUE;
 }


### PR DESCRIPTION
This PR changes the positioning of editorial accidentals placed above (or below) the staff. It prioritises the placement of slurs over editorial accidentals. Fixes #4115.

Example given in the issue before and after

<img width="233" height="125" alt="image" src="https://github.com/user-attachments/assets/cf0c6f2a-9b44-4a89-abf2-c53bbe1072dc" />

<img width="233" height="125" alt="image" src="https://github.com/user-attachments/assets/b90f724e-2fb6-4b1f-b149-e24e7a706c10" />

Example added to the test-suite before and after

<details>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/5.1/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Editorial accidentals and slurs</title>
         </titleStmt>
         <pubStmt>
            <date isodate="2025-09-09" />
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application version="5.6.0" label="2">
               <name>Verovio</name>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="n1phmrc7" dur="4" oct="5" pname="f" stem.dir="down">
                              <accid accid="s" func="edit" />
                           </note>
                           <beam>
                              <note dur="16" oct="5" pname="g" stem.dir="down" />
                              <note dur="16" oct="5" pname="b" />
                              <note dur="16" oct="5" pname="e" />
                              <note dur="16" oct="4" pname="e" />
                           </beam>
                           <beam>
                              <note dur="16" oct="4" pname="f">
                                 <accid accid="n" func="edit" />
                              </note>
                              <note dur="16" oct="4" pname="e" />
                              <note dur="16" oct="4" pname="f" stem.dir="up">
                                 <accid accid="n" func="edit" />
                              </note>
                              <note dur="16" oct="4" pname="e" stem.dir="up" />
                           </beam>
                           <note xml:id="ngmzq6m" dur="4" oct="4" pname="f" stem.dir="up">
                              <accid accid="s" func="edit" />
                           </note>
                        </layer>
                     </staff>
                     <slur startid="#n1phmrc7" endid="#ngmzq6m" curvedir="above" />
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```
</details>

<img width="294" height="332" alt="image" src="https://github.com/user-attachments/assets/c711216e-1dbe-43a4-8ed2-e74944bd0172" />
