### PR TITLE
Clarify option message for avoiding cue notes in MIDI playback

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1816,7 +1816,7 @@ Options::Options()
     m_midi.SetCategory(OptionsCategory::Midi);
     m_grps.push_back(&m_midi);
 
-    m_midiNoCue.SetInfo("MIDI playback of cue notes", "Skip cue notes in MIDI output");
+    m_midiNoCue.SetInfo("MIDI playback without cue notes", "Skip cue notes in MIDI output");
     m_midiNoCue.Init(false);
     this->Register(&m_midiNoCue, "midiNoCue", &m_midi);
 


### PR DESCRIPTION
The option message for avoiding/skipping cue notes in MIDI playback suggested the opposite: `"MIDI playback of cue notes" `would play them, when set to `false` (thus not ticked in mei-friend), but skip them, when `true`/ticked.

The new formulation makes this clear. 

PS: I would prefer to invert the entire option and transform the variable into `m_midiWithCue`. 