### PR TITLE
Migrate macos runners

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -23,14 +23,14 @@ jobs:
       fail-fast: false
       # Build the wheels for Linux, Windows and macOS
       matrix:
-        os: [macos-13, macos-15, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
+        os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         architecture: [x86, x64, arm64]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             architecture: x64
             platform_id: macosx_x86_64
-          - os: macos-15
+          - os: macos-latest
             architecture: arm64
             platform_id: macosx_arm64
           - os: windows-latest
@@ -46,13 +46,13 @@ jobs:
             architecture: arm64
             platform_id: manylinux_aarch64
         exclude:
-          - os: macos-13
+          - os: macos-15-intel
             architecture: x86
-          - os: macos-13
+          - os: macos-15-intel
             architecture: arm64
-          - os: macos-15
+          - os: macos-latest
             architecture: x86
-          - os: macos-15
+          - os: macos-latest
             architecture: x64
           - os: ubuntu-latest
             architecture: x86


### PR DESCRIPTION
As the macOS 13 runner image will be retired, the workflow has been adjusted to use `macos-latest` and `macos-15-intel`.