### PR TITLE
New: always set breaks: none for PAE

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -843,6 +843,10 @@ bool Toolkit::LoadData(const std::string &data, bool resetLogBuffer)
     // might have been ignored because of the --breaks auto option.
     // Regardless, we won't do layout if the --breaks none option was set.
     int breaks = m_options->m_breaks.GetValue();
+    if (inputFrom == PAE) {
+        // PAE loading intentionally skips cast-off/layout for faster incipit processing.
+        breaks = BREAKS_none;
+    }
 
     // When loading page-based MEI, the layout is marked as done
     // In this case, we do not cast-off the document (breaks is expected to be not set)


### PR DESCRIPTION
This provides a significant processing speedup since it skips all the castoff and layout decisions.

Benchmarking shows that this provides a 2.73x speedup in incipit parsing.

I experimented with only setting breaks: none if the user didn't explicitly set breaks in the options, but I don't think it's possible to detect between unset and `BREAKS_auto`. Suggestions on how to do this are welcome!