### PR TITLE
Adjust m_drawingStaffSize for German tablature.  Correct rounding. Fix issue  #4331

### DIFF
--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -331,7 +331,10 @@ FunctorCode ScoreDefSetCurrentFunctor::VisitStaff(Staff *staff)
     if (m_currentStaffDef->HasScale()) {
         staff->m_drawingStaffSize = m_currentStaffDef->GetScale();
     }
-    if (staff->IsTablature()) {
+    if (staff->IsTabLuteGerman()) {
+        staff->m_drawingStaffSize *= GERMAN_TAB_STAFF_RATIO;
+    }
+    else if (staff->IsTablature()) {
         staff->m_drawingStaffSize *= TABLATURE_STAFF_RATIO;
     }
     if (MeterSigGrp *metersiggrp = m_currentStaffDef->GetCurrentMeterSigGrp();

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -10,6 +10,7 @@
 //----------------------------------------------------------------------------
 
 #include <cassert>
+#include <cmath>
 #include <iterator>
 #include <vector>
 
@@ -234,9 +235,9 @@ void Staff::AdjustDrawingStaffSize()
 
 int Staff::GetDrawingStaffNotationSize() const
 {
-    if (this->IsTabLuteGerman()) return m_drawingStaffSize / GERMAN_TAB_STAFF_RATIO;
+    if (this->IsTabLuteGerman()) return std::round(m_drawingStaffSize / GERMAN_TAB_STAFF_RATIO);
 
-    return (this->IsTablature()) ? m_drawingStaffSize / TABLATURE_STAFF_RATIO : m_drawingStaffSize;
+    return (this->IsTablature()) ? std::round(m_drawingStaffSize / TABLATURE_STAFF_RATIO) : m_drawingStaffSize;
 }
 
 bool Staff::DrawingIsVisible() const


### PR DESCRIPTION
Adjust m_drawingStaffSize for German tablature.  Correct rounding. Fix  issue #4331.  Bar line width now 27 in svg.

Also, the lack of rounding in staff.cpp was causing a 1 pixel error.