### PR TITLE
Preserve MusicXML lyric extender stops

### DIFF
--- a/include/vrv/syl.h
+++ b/include/vrv/syl.h
@@ -89,6 +89,11 @@ public:
     int GetDrawingWidth() const;
     int GetDrawingHeight() const;
 
+    /**
+     * Return true when the syl has no textual content.
+     */
+    bool IsEmpty() const;
+
     //----------------//
     // Static methods //
     //----------------//

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3333,7 +3333,17 @@ void MusicXmlInput::ReadMusicXmlNote(
 
         // verse / syl
         for (pugi::xml_node lyric : node.children("lyric")) {
-            if (!lyric.child("text")) continue; // Dorico exports non-valid MusicXML
+            pugi::xml_node extendStop;
+            bool hasStartingExtend = false;
+            for (pugi::xml_node extend : lyric.children("extend")) {
+                if (HasAttributeWithValue(extend, "type", "stop")) {
+                    extendStop = extend;
+                }
+                else {
+                    hasStartingExtend = true;
+                }
+            }
+            if (!lyric.child("text") && !extendStop) continue; // Dorico exports non-valid MusicXML
             short int lyricNumber = lyric.attribute("number").as_int();
             lyricNumber = (lyricNumber < 1) ? 1 : lyricNumber;
             Verse *verse = new Verse();
@@ -3341,6 +3351,11 @@ void MusicXmlInput::ReadMusicXmlNote(
             // verse->SetPlace(verse->AttPlacementRelStaff::StrToStaffrelBasic(lyric.attribute("placement").as_string()));
             verse->SetLabel(lyric.attribute("name").as_string());
             verse->SetN(lyricNumber);
+            // MusicXML represents melisma endpoints as textless <lyric><extend type="stop"/></lyric>.
+            // Keep this as a schema-valid empty syl anchor so lyric preparation can close the previous extender here.
+            if (extendStop) {
+                verse->AddChild(new Syl());
+            }
             std::string syllabic = "single";
             for (pugi::xml_node childNode : lyric.children()) {
                 if (!strcmp(childNode.name(), "syllabic")) syllabic = GetContent(childNode);
@@ -3408,7 +3423,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     if (childNode.next_sibling("elision")) {
                         syl->SetCon(sylLog_CON_b);
                     }
-                    else if (lyric.child("extend")) {
+                    else if (hasStartingExtend) {
                         syl->SetCon(sylLog_CON_u);
                     }
 

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -1038,6 +1038,9 @@ FunctorCode GenerateMIDIFunctor::VisitStaffDef(const StaffDef *staffDef)
 
 FunctorCode GenerateMIDIFunctor::VisitSyl(const Syl *syl)
 {
+    const std::string sylText = UTF32to8(syl->GetText());
+    if (sylText.empty()) return FUNCTOR_CONTINUE;
+
     const Note *note = NULL;
     if (syl->GetFirstAncestor(CHORD)) {
         const Chord *parentChord = vrv_cast<const Chord *>(syl->GetFirstAncestor(CHORD));
@@ -1049,7 +1052,6 @@ FunctorCode GenerateMIDIFunctor::VisitSyl(const Syl *syl)
     if (!note) return FUNCTOR_CONTINUE;
 
     const double startTime = m_totalTime + note->GetScoreTimeOnset().ToDouble();
-    const std::string sylText = UTF32to8(syl->GetText());
 
     m_midiFile->addLyric(m_midiTrack, startTime * m_midiFile->getTPQ(), sylText);
 

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -1038,8 +1038,7 @@ FunctorCode GenerateMIDIFunctor::VisitStaffDef(const StaffDef *staffDef)
 
 FunctorCode GenerateMIDIFunctor::VisitSyl(const Syl *syl)
 {
-    const std::string sylText = UTF32to8(syl->GetText());
-    if (sylText.empty()) return FUNCTOR_CONTINUE;
+    if (syl->IsEmpty()) return FUNCTOR_CONTINUE;
 
     const Note *note = NULL;
     if (syl->GetFirstAncestor(CHORD)) {
@@ -1052,6 +1051,7 @@ FunctorCode GenerateMIDIFunctor::VisitSyl(const Syl *syl)
     if (!note) return FUNCTOR_CONTINUE;
 
     const double startTime = m_totalTime + note->GetScoreTimeOnset().ToDouble();
+    const std::string sylText = UTF32to8(syl->GetText());
 
     m_midiFile->addLyric(m_midiTrack, startTime * m_midiFile->getTPQ(), sylText);
 

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -1089,24 +1089,33 @@ FunctorCode PrepareLyricsFunctor::VisitSyl(Syl *syl)
     if (!syl->GetStart()) {
         syl->SetStart(vrv_cast<LayerElement *>(syl->GetFirstAncestor(CHORD, MAX_CHORD_DEPTH)));
     }
+    const bool isEmptySyl = syl->IsEmpty();
 
     // At this stage currentSyl is actually the previous one that is ending here
     if (m_currentSyl) {
         // The previous syl was an initial or median -> The note we just parsed is the end
         if ((m_currentSyl->GetWordpos() == sylLog_WORDPOS_i) || (m_currentSyl->GetWordpos() == sylLog_WORDPOS_m)) {
-            m_currentSyl->SetEnd(m_lastNoteOrChord);
-            m_currentSyl->m_nextWordSyl = syl;
+            if (!isEmptySyl) {
+                m_currentSyl->SetEnd(m_lastNoteOrChord);
+                m_currentSyl->m_nextWordSyl = syl;
+            }
         }
-        // The previous syl was a underscore -> the previous but one was the end
+        // The previous syl was an underscore -> the explicit empty endpoint or the previous but one was the end.
         else if (m_currentSyl->GetCon() == sylLog_CON_u) {
-            if (m_currentSyl->GetStart() == m_penultimateNoteOrChord) {
+            LayerElement *end = isEmptySyl ? syl->GetStart() : m_penultimateNoteOrChord;
+            if (end && (m_currentSyl->GetStart() == end)) {
                 LogWarning("Syllable with underline extender under one single note '%s'",
                     m_currentSyl->GetStart()->GetID().c_str());
             }
-            else {
-                m_currentSyl->SetEnd(m_penultimateNoteOrChord);
+            else if (end) {
+                m_currentSyl->SetEnd(end);
             }
         }
+    }
+
+    if (isEmptySyl) {
+        m_currentSyl = NULL;
+        return FUNCTOR_CONTINUE;
     }
 
     // Now decide what to do with the starting syl and check if it has a forward connector

--- a/src/syl.cpp
+++ b/src/syl.cpp
@@ -147,6 +147,11 @@ int Syl::GetDrawingHeight() const
     return 0;
 }
 
+bool Syl::IsEmpty() const
+{
+    return this->GetText().empty();
+}
+
 void Syl::AdjustToLyricSize(const Doc *doc, int &value)
 {
     const OptionDbl &lyricSize = doc->GetOptions()->m_lyricSize;


### PR DESCRIPTION
## Summary

Fix MusicXML lyric extender stops that are encoded as textless lyrics containing `<extend type="stop"/>`.

MusicXML allows a melisma or lyric extender to end on a note without repeating lyric text. In that case, the stop is represented by a `<lyric>` element that contains only the `<extend type="stop"/>` child. Verovio previously skipped lyrics without `<text>`, which meant those stop markers were discarded during MusicXML import. The MEI output then had no anchor at the intended stop note, so the extender could continue until the next textual lyric.

Correct (Sibelius):
<img width="890" height="159" alt="image" src="https://github.com/user-attachments/assets/bfceb64b-ef90-4069-9ae2-1a8ec785e632" />

Verovio (using exported MusicXML):
<img width="943" height="151" alt="image" src="https://github.com/user-attachments/assets/1d05ee68-d47d-4c82-a3ac-8a4654208253" />


## Changes

- Preserve stop-only MusicXML lyric entries as empty MEI `<syl/>` anchors.
- Treat those empty syllables as explicit endpoints when preparing lyric extenders.
- Avoid treating `<extend type="stop"/>` as a new underline extender start.
- Skip empty syllable anchors during MIDI lyric export so they do not produce empty lyric events.


