### PR TITLE
[MusicXML] fix accid import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3165,7 +3165,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                             // the MEI equivalent of the written accidental. The custom tuning will always choose
                             // the SMuFL glyph over the gestural or written accidentals.
                             accid->SetAccidGes(Att::AccidentalWrittenToGestural(current.m_accid));
-                            if (accid->HasAccid()) {
+                            if (!current.m_glyphName.empty()) {
                                 accid->IsAttribute(false);
                                 if (!current.m_glyphName.empty()) {
                                     accid->SetGlyphName(current.m_glyphName);

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3158,23 +3158,26 @@ void MusicXmlInput::ReadMusicXmlNote(
                     try {
                         for (const auto &current : m_currentAccids.at(note->GetPname())) {
                             Accid *accid = new Accid();
-                            note->AddChild(accid);
-                            accid->IsAttribute(false);
+                            accid->IsAttribute(true);
 
                             // to make sure the new *gestural* accidental conforms to the carried-over *written*
                             // accidental, we translate the latter to a SMuFL glyph and set the gestural accidental to
                             // the MEI equivalent of the written accidental. The custom tuning will always choose
                             // the SMuFL glyph over the gestural or written accidentals.
                             accid->SetAccidGes(Att::AccidentalWrittenToGestural(current.m_accid));
-                            if (!current.m_glyphName.empty()) {
-                                accid->SetGlyphName(current.m_glyphName);
-                                accid->SetGlyphAuth(current.m_glyphAuth);
+                            if (accid->HasAccid()) {
+                                accid->IsAttribute(false);
+                                if (!current.m_glyphName.empty()) {
+                                    accid->SetGlyphName(current.m_glyphName);
+                                    accid->SetGlyphAuth(current.m_glyphAuth);
+                                }
+                                else if (current.m_accid != ACCIDENTAL_WRITTEN_NONE) {
+                                    char32_t glyph = Accid::GetAccidGlyph(current.m_accid);
+                                    accid->SetGlyphName(CustomTuning::GetGlyphName(glyph, m_doc));
+                                    accid->SetGlyphAuth("smufl");
+                                }
                             }
-                            else if (current.m_accid != ACCIDENTAL_WRITTEN_NONE) {
-                                char32_t glyph = Accid::GetAccidGlyph(current.m_accid);
-                                accid->SetGlyphName(CustomTuning::GetGlyphName(glyph, m_doc));
-                                accid->SetGlyphAuth("smufl");
-                            }
+                            note->AddChild(accid);
                         }
                     }
                     catch (std::out_of_range &e) {


### PR DESCRIPTION
With Release 6.2.1 the errors on import are gone, but the problem of empty accid elements or useless/unneeded glyph.* attributes remained. This PR provides a fix for a cleaner conversion to MEI.