### PR TITLE
Improve render performance

### DIFF
--- a/include/vrv/adjustxposfunctor.h
+++ b/include/vrv/adjustxposfunctor.h
@@ -66,8 +66,13 @@ public:
     ///@{
     void SetIncluded(const std::vector<ClassId> &classIDs) { m_includes = classIDs; }
     void ClearIncluded() { m_includes.clear(); }
-    void SetExcluded(const std::vector<ClassId> &classIDs) { m_excludes = classIDs; }
+    void SetExcluded(const std::vector<ClassId> &classIDs)
+    {
+        m_excludes = classIDs;
+        m_hasExcludedElements = false;
+    }
     void ClearExcluded() { m_excludes.clear(); }
+    bool HasExcludedElements() const { return m_hasExcludedElements; }
     ///@}
 
     /*
@@ -119,6 +124,8 @@ private:
     std::vector<ClassId> m_includes;
     // The list of types to exclude
     std::vector<ClassId> m_excludes;
+    // Indicates whether the last pass saw an excluded element
+    bool m_hasExcludedElements;
     // Indicates whether only right bar line positions should be considered
     bool m_rightBarLinesOnly;
     // The list of tie endpoints for the current measure

--- a/include/vrv/customtuning.h
+++ b/include/vrv/customtuning.h
@@ -12,7 +12,9 @@
 
 //----------------------------------------------------------------------------
 
+#include <cassert>
 #include <map>
+#include <memory>
 
 //----------------------------------------------------------------------------
 
@@ -29,14 +31,26 @@ class CustomTuning {
 public:
     CustomTuning() {}
     CustomTuning(const std::string &tuningDef, Doc *doc, bool useMusicXmlAccidentals);
+    CustomTuning(const CustomTuning &other);
+    CustomTuning(CustomTuning &&other) noexcept = default;
+    CustomTuning &operator=(const CustomTuning &other);
+    CustomTuning &operator=(CustomTuning &&other) noexcept = default;
 
     /**
      * @name Getters and validity checkers
      */
     ///@{
-    bool IsValid() const { return m_tuning.notationMapping.count > 0; }
-    Tunings::Tuning &GetTuning() { return m_tuning; }
-    const Tunings::Tuning &GetTuning() const { return m_tuning; }
+    bool IsValid() const { return m_tuning && m_tuning->notationMapping.count > 0; }
+    Tunings::Tuning &GetTuning()
+    {
+        assert(m_tuning);
+        return *m_tuning;
+    }
+    const Tunings::Tuning &GetTuning() const
+    {
+        assert(m_tuning);
+        return *m_tuning;
+    }
     std::map<std::string, std::string> &GetNoteMap() { return m_noteMap; }
     const std::map<std::string, std::string> &GetNoteMap() const { return m_noteMap; }
     ///@}
@@ -75,7 +89,7 @@ public:
     //
 
 private:
-    Tunings::Tuning m_tuning;
+    std::unique_ptr<Tunings::Tuning> m_tuning;
     std::map<std::string, std::string> m_noteMap;
 
     //----------------//

--- a/include/vrv/customtuning.h
+++ b/include/vrv/customtuning.h
@@ -14,7 +14,6 @@
 
 #include <cassert>
 #include <map>
-#include <memory>
 
 //----------------------------------------------------------------------------
 
@@ -31,10 +30,11 @@ class CustomTuning {
 public:
     CustomTuning() {}
     CustomTuning(const std::string &tuningDef, Doc *doc, bool useMusicXmlAccidentals);
+    ~CustomTuning();
     CustomTuning(const CustomTuning &other);
-    CustomTuning(CustomTuning &&other) noexcept = default;
+    CustomTuning(CustomTuning &&other) noexcept;
     CustomTuning &operator=(const CustomTuning &other);
-    CustomTuning &operator=(CustomTuning &&other) noexcept = default;
+    CustomTuning &operator=(CustomTuning &&other) noexcept;
 
     /**
      * @name Getters and validity checkers
@@ -89,7 +89,7 @@ public:
     //
 
 private:
-    std::unique_ptr<Tunings::Tuning> m_tuning;
+    Tunings::Tuning *m_tuning = NULL;
     std::map<std::string, std::string> m_noteMap;
 
     //----------------//

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -102,7 +102,7 @@ FunctorCode AdjustLayersFunctor::VisitLayerElement(LayerElement *layerElement)
 
     // These are the only ones we want to keep for further collision detection
     if (layerElement->HasSelfBB()) {
-        if (layerElement->Is({ NOTE, STEM })) {
+        if (layerElement->Is(NOTE) || layerElement->Is(STEM)) {
             m_current.push_back(layerElement);
         }
         else if (!m_ignoreDots && layerElement->Is(DOTS)) {

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -30,6 +30,7 @@ AdjustXPosFunctor::AdjustXPosFunctor(Doc *doc) : DocFunctor(doc)
     m_cumulatedXShift = 0;
     m_staffN = 0;
     m_staffSize = 100;
+    m_hasExcludedElements = false;
     m_rightBarLinesOnly = false;
     m_measure = NULL;
 }
@@ -94,6 +95,12 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
 {
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
+    // Track excluded elements while we are already traversing the page so the caller can avoid a separate scan.
+    if (!m_excludes.empty() && layerElement->Is(m_excludes)) {
+        m_hasExcludedElements = true;
+        return FUNCTOR_CONTINUE;
+    }
+
     // we should have processed aligned before
     assert(layerElement->GetAlignment());
 
@@ -101,11 +108,6 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
         // if nothing to do with this type of element
         // this happens for example with Artic where only ArticPart children are aligned
         return FUNCTOR_SIBLINGS;
-    }
-
-    // If we have a list of types to exclude and it is one of them, stop it
-    if (!m_excludes.empty() && layerElement->Is(m_excludes)) {
-        return FUNCTOR_CONTINUE;
     }
 
     // If we have a list of types to include and it is not one of them, stop it
@@ -160,7 +162,7 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
     Alignment *nextAlignment = vrv_cast<Alignment *>(
         layerElement->GetAlignment()->GetParent()->GetNext(layerElement->GetAlignment(), ALIGNMENT));
     AlignmentType next = nextAlignment ? nextAlignment->GetType() : ALIGNMENT_DEFAULT;
-    if (layerElement->Is({ DOTS, FLAG }) && currentReference->HasMultipleLayer()
+    if ((layerElement->Is(DOTS) || layerElement->Is(FLAG)) && currentReference->HasMultipleLayer()
         && (next != ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
         const int additionalOffset = selfRight - m_upcomingMinPos;
         if (additionalOffset > m_currentAlignment.m_offset) {
@@ -221,6 +223,8 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
     Filters filters;
     Filters *previousFilters = this->SetFilters(&filters);
 
+    m_measureTieEndpoints = measure->GetInternalTieEndpoints();
+
     for (auto staffN : m_staffNs) {
         m_minPos = 0;
         m_upcomingMinPos = VRV_UNSET;
@@ -248,7 +252,6 @@ FunctorCode AdjustXPosFunctor::VisitMeasure(Measure *measure)
         filters.SetType(Filters::Type::AnyOf);
         filters = { &matchStaff, &matchCrossStaff };
 
-        m_measureTieEndpoints = measure->GetInternalTieEndpoints();
         measure->m_measureAligner.Process(*this);
     }
 
@@ -402,8 +405,8 @@ std::pair<int, int> AdjustXPosFunctor::CalculateXPosOffset(LayerElement *layerEl
         if (!overlap) {
             // if last element of the tuplet is rest, make sure there is sufficient distance between it and next
             // note/chord (for ledger lines)
-            if (layerElement->Is({ NOTE, CHORD }) && !layerElement->GetFirstAncestor(TUPLET) && bboxElement->Is(REST)
-                && bboxElement->GetFirstAncestor(TUPLET)) {
+            if ((layerElement->Is(NOTE) || layerElement->Is(CHORD)) && !layerElement->GetFirstAncestor(TUPLET)
+                && bboxElement->Is(REST) && bboxElement->GetFirstAncestor(TUPLET)) {
                 Rest *rest = vrv_cast<Rest *>(bboxElement);
                 if (rest->GetDur() > DURATION_8) {
                     overlap = 1.5 * (rest->GetDur() - DURATION_8) * drawingUnit;

--- a/src/customtuning.cpp
+++ b/src/customtuning.cpp
@@ -30,13 +30,35 @@ std::map<char32_t, std::string> CustomTuning::s_glyphCodes;
 // CustomTuning
 //----------------------------------------------------------------------------
 
+CustomTuning::CustomTuning(const CustomTuning &other) : m_noteMap(other.m_noteMap)
+{
+    if (other.m_tuning) {
+        m_tuning = std::make_unique<Tunings::Tuning>(*other.m_tuning);
+    }
+}
+
+CustomTuning &CustomTuning::operator=(const CustomTuning &other)
+{
+    if (this == &other) return *this;
+
+    m_noteMap = other.m_noteMap;
+    if (other.m_tuning) {
+        m_tuning = std::make_unique<Tunings::Tuning>(*other.m_tuning);
+    }
+    else {
+        m_tuning.reset();
+    }
+
+    return *this;
+}
+
 CustomTuning::CustomTuning(const std::string &tuningDef, Doc *doc, bool useMusicXmlAccidentals)
 {
     assert(doc);
 
     // Parse the tuning and create the mappings
     try {
-        m_tuning = Tunings::Tuning(Tunings::parseASCLData(tuningDef));
+        m_tuning = std::make_unique<Tunings::Tuning>(Tunings::parseASCLData(tuningDef));
         CreateGlyphMapping(doc);
         CreateNoteMapping(useMusicXmlAccidentals);
     }
@@ -82,7 +104,8 @@ void CustomTuning::CreateGlyphMapping(Doc *doc)
 void CustomTuning::CreateNoteMapping(bool useMusicXmlAccidentals)
 {
     m_noteMap.clear();
-    for (const auto &note : m_tuning.notationMapping.names) {
+    assert(m_tuning);
+    for (const auto &note : m_tuning->notationMapping.names) {
         std::smatch note_names;
         std::regex note_name_regex("(?:^|\\/)([A-G])([^\\/\\s]*)");
         std::string::const_iterator search_start(note.cbegin());
@@ -212,10 +235,10 @@ int CustomTuning::GetMIDIPitch(const Note *note, const int shift, const int octa
         // FIXME! Special case: when we encounter a B pitch that's in scale degree 0, increment its oct by 1
         // otherwise, it would be in the lower octave
         const auto it = std::find(
-            m_tuning.notationMapping.names.begin(), m_tuning.notationMapping.names.end(), m_noteMap.at(noteName));
-        int scalePosition = (it - m_tuning.notationMapping.names.begin() + 1) % m_tuning.notationMapping.count;
+            m_tuning->notationMapping.names.begin(), m_tuning->notationMapping.names.end(), m_noteMap.at(noteName));
+        int scalePosition = (it - m_tuning->notationMapping.names.begin() + 1) % m_tuning->notationMapping.count;
         if (pname == PITCHNAME_b && scalePosition == 0) oct++;
-        return m_tuning.midiNoteForNoteName(m_noteMap.at(noteName), oct);
+        return m_tuning->midiNoteForNoteName(m_noteMap.at(noteName), oct);
     }
     catch (Tunings::TuningError &e) {
         LogError("Custom tuning: Error mapping note to tuning: %s", e.what());

--- a/src/customtuning.cpp
+++ b/src/customtuning.cpp
@@ -17,6 +17,10 @@
 
 #include "jsonxx.h"
 
+//----------------------------------------------------------------------------
+
+#include <utility>
+
 namespace vrv {
 
 //----------------------------------------------------------------------------
@@ -33,21 +37,41 @@ std::map<char32_t, std::string> CustomTuning::s_glyphCodes;
 CustomTuning::CustomTuning(const CustomTuning &other) : m_noteMap(other.m_noteMap)
 {
     if (other.m_tuning) {
-        m_tuning = std::make_unique<Tunings::Tuning>(*other.m_tuning);
+        m_tuning = new Tunings::Tuning(*other.m_tuning);
     }
+}
+
+CustomTuning::CustomTuning(CustomTuning &&other) noexcept
+    : m_tuning(other.m_tuning), m_noteMap(std::move(other.m_noteMap))
+{
+    other.m_tuning = NULL;
+}
+
+CustomTuning::~CustomTuning()
+{
+    delete m_tuning;
 }
 
 CustomTuning &CustomTuning::operator=(const CustomTuning &other)
 {
     if (this == &other) return *this;
 
+    Tunings::Tuning *tuning = other.m_tuning ? new Tunings::Tuning(*other.m_tuning) : NULL;
+    delete m_tuning;
+    m_tuning = tuning;
     m_noteMap = other.m_noteMap;
-    if (other.m_tuning) {
-        m_tuning = std::make_unique<Tunings::Tuning>(*other.m_tuning);
-    }
-    else {
-        m_tuning.reset();
-    }
+
+    return *this;
+}
+
+CustomTuning &CustomTuning::operator=(CustomTuning &&other) noexcept
+{
+    if (this == &other) return *this;
+
+    delete m_tuning;
+    m_tuning = other.m_tuning;
+    m_noteMap = std::move(other.m_noteMap);
+    other.m_tuning = NULL;
 
     return *this;
 }
@@ -58,12 +82,19 @@ CustomTuning::CustomTuning(const std::string &tuningDef, Doc *doc, bool useMusic
 
     // Parse the tuning and create the mappings
     try {
-        m_tuning = std::make_unique<Tunings::Tuning>(Tunings::parseASCLData(tuningDef));
+        m_tuning = new Tunings::Tuning(Tunings::parseASCLData(tuningDef));
         CreateGlyphMapping(doc);
         CreateNoteMapping(useMusicXmlAccidentals);
     }
     catch (Tunings::TuningError &e) {
+        delete m_tuning;
+        m_tuning = NULL;
         LogError("Custom tuning: Invalid tuning definition: %s", e.what());
+    }
+    catch (...) {
+        delete m_tuning;
+        m_tuning = NULL;
+        throw;
     }
 }
 

--- a/src/doc.cpp
+++ b/src/doc.cpp
@@ -242,7 +242,7 @@ void Doc::GenerateFooter()
     for (Score *score : this->GetVisibleScores()) {
         ScoreDef *scoreDef = score->GetScoreDef();
         assert(scoreDef);
-        if (scoreDef->FindDescendantByType(PGFOOT)) continue;
+        if (scoreDef->GetFirst(PGFOOT)) continue;
 
         PgFoot *pgFoot = new PgFoot();
         pgFoot->SetFunc(PGFUNC_first);
@@ -266,7 +266,7 @@ void Doc::GenerateHeader()
     for (Score *score : this->GetVisibleScores()) {
         ScoreDef *scoreDef = score->GetScoreDef();
         assert(scoreDef);
-        if (scoreDef->FindDescendantByType(PGHEAD)) continue;
+        if (scoreDef->GetFirst(PGHEAD)) continue;
 
         PgHead *pgHead = new PgHead();
         pgHead->SetFunc(PGFUNC_first);
@@ -303,15 +303,16 @@ bool Doc::GenerateMeasureNumbers()
     for (Object *object : measures) {
         Measure *measure = vrv_cast<Measure *>(object);
         // First remove previously generated elements
-        ListOfObjects mNums = measure->FindAllDescendantsByType(MNUM);
-        for (Object *child : mNums) {
+        for (int i = measure->GetChildCount() - 1; i >= 0; --i) {
+            Object *child = measure->GetChild(i);
+            if (!child->Is(MNUM)) continue;
             MNum *mNum = vrv_cast<MNum *>(child);
             assert(mNum);
             if (mNum->IsGenerated()) {
                 measure->DeleteChild(mNum);
             }
         }
-        if (measure->HasN() && !measure->FindDescendantByType(MNUM)) {
+        if (measure->HasN() && !measure->GetFirst(MNUM)) {
             MNum *mnum = new MNum;
             Text *text = new Text;
             text->SetText(UTF8to32(measure->GetN()));

--- a/src/page.cpp
+++ b/src/page.cpp
@@ -450,10 +450,12 @@ void Page::LayOutHorizontally()
     this->Process(adjustXPos);
 
     // Adjust tabRhythm separately
-    adjustXPos.ClearExcluded();
-    adjustXPos.SetIncluded({ BARLINE, KEYSIG, METERSIG, TABDURSYM });
-    adjustXPos.SetRightBarLinesOnly(true);
-    this->Process(adjustXPos);
+    if (adjustXPos.HasExcludedElements()) {
+        adjustXPos.ClearExcluded();
+        adjustXPos.SetIncluded({ BARLINE, KEYSIG, METERSIG, TABDURSYM });
+        adjustXPos.SetRightBarLinesOnly(true);
+        this->Process(adjustXPos);
+    }
 
     // Adjust the X shift of the Alignment looking at the bounding boxes
     // Look at each LayerElement and change the m_xShift if the bounding box is overlapping

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -15,6 +15,7 @@
 
 #include "doc.h"
 #include "functor.h"
+#include "measure.h"
 #include "page.h"
 #include "score.h"
 #include "staff.h"
@@ -22,6 +23,32 @@
 #include "vrv.h"
 
 namespace vrv {
+
+namespace {
+
+    const Measure *GetPageBoundaryMeasure(Page *page, bool last)
+    {
+        const ArrayOfObjects &children = page->GetChildren();
+        if (!last) {
+            for (Object *child : children) {
+                if (!child->Is(SYSTEM)) continue;
+                if (const Measure *measure = vrv_cast<const Measure *>(child->GetFirst(MEASURE)); measure)
+                    return measure;
+            }
+        }
+        else {
+            for (auto iter = children.rbegin(); iter != children.rend(); ++iter) {
+                Object *child = *iter;
+                if (!child->Is(SYSTEM)) continue;
+                if (const Measure *measure = vrv_cast<const Measure *>(child->GetLast(MEASURE)); measure)
+                    return measure;
+            }
+        }
+
+        return NULL;
+    }
+
+} // namespace
 
 //----------------------------------------------------------------------------
 // Pages
@@ -125,11 +152,10 @@ void PageRange::SetAsFocus(Page *page)
 
     m_focusPage = page;
 
-    const Object *firstMeasure = page->FindDescendantByType(MEASURE);
+    const Object *firstMeasure = GetPageBoundaryMeasure(page, false);
     if (firstMeasure) EvaluateSpanningElementsIn(firstMeasure);
 
-    const Measure *lastMeasure
-        = vrv_cast<const Measure *>(page->FindDescendantByType(MEASURE, UNLIMITED_DEPTH, BACKWARD));
+    const Measure *lastMeasure = GetPageBoundaryMeasure(page, true);
     if (lastMeasure) {
         this->EvaluateSpanningElementsIn(lastMeasure);
         ListOfConstObjects timeSpanningObjects;

--- a/src/pages.cpp
+++ b/src/pages.cpp
@@ -15,7 +15,6 @@
 
 #include "doc.h"
 #include "functor.h"
-#include "measure.h"
 #include "page.h"
 #include "score.h"
 #include "staff.h"
@@ -23,32 +22,6 @@
 #include "vrv.h"
 
 namespace vrv {
-
-namespace {
-
-    const Measure *GetPageBoundaryMeasure(Page *page, bool last)
-    {
-        const ArrayOfObjects &children = page->GetChildren();
-        if (!last) {
-            for (Object *child : children) {
-                if (!child->Is(SYSTEM)) continue;
-                if (const Measure *measure = vrv_cast<const Measure *>(child->GetFirst(MEASURE)); measure)
-                    return measure;
-            }
-        }
-        else {
-            for (auto iter = children.rbegin(); iter != children.rend(); ++iter) {
-                Object *child = *iter;
-                if (!child->Is(SYSTEM)) continue;
-                if (const Measure *measure = vrv_cast<const Measure *>(child->GetLast(MEASURE)); measure)
-                    return measure;
-            }
-        }
-
-        return NULL;
-    }
-
-} // namespace
 
 //----------------------------------------------------------------------------
 // Pages
@@ -152,10 +125,11 @@ void PageRange::SetAsFocus(Page *page)
 
     m_focusPage = page;
 
-    const Object *firstMeasure = GetPageBoundaryMeasure(page, false);
+    const Object *firstMeasure = page->FindDescendantByType(MEASURE);
     if (firstMeasure) EvaluateSpanningElementsIn(firstMeasure);
 
-    const Measure *lastMeasure = GetPageBoundaryMeasure(page, true);
+    const Measure *lastMeasure
+        = vrv_cast<const Measure *>(page->FindDescendantByType(MEASURE, UNLIMITED_DEPTH, BACKWARD));
     if (lastMeasure) {
         this->EvaluateSpanningElementsIn(lastMeasure);
         ListOfConstObjects timeSpanningObjects;

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -65,6 +65,41 @@
 
 namespace vrv {
 
+namespace {
+
+    bool IsPostponedTimeSpanningControlElement(ClassId classId)
+    {
+        switch (classId) {
+            case ANNOTSCORE:
+            case BEAMSPAN:
+            case BRACKETSPAN:
+            case FIGURE:
+            case GLISS:
+            case HAIRPIN:
+            case LV:
+            case OCTAVE:
+            case PHRASE:
+            case PITCHINFLECTION:
+            case SLUR:
+            case TIE: return true;
+            default: return false;
+        }
+    }
+
+    bool SkipsHorizontalOnlyBBox(ClassId classId)
+    {
+        switch (classId) {
+            case ANNOTSCORE:
+            case BRACKETSPAN:
+            case HAIRPIN:
+            case OCTAVE:
+            case PITCHINFLECTION: return true;
+            default: return false;
+        }
+    }
+
+} // namespace
+
 //----------------------------------------------------------------------------
 // View - FloatingObject - ControlElement
 //----------------------------------------------------------------------------
@@ -79,8 +114,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
     this->StartOffset(dc, element, 100);
 
     // For dir, dynam, fermata, and harm, we do not consider the @tstamp2 for rendering
-    if (element->Is({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
-            SLUR, TIE })) {
+    if (IsPostponedTimeSpanningControlElement(element->GetClassId())) {
         // create placeholder
         dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
@@ -186,11 +220,13 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     assert(element);
     assert(system);
 
+    const ClassId classId = element->GetClassId();
+
     if (dc->Is(BBOX_DEVICE_CONTEXT)) {
         BBoxDeviceContext *bBoxDC = vrv_cast<BBoxDeviceContext *>(dc);
         assert(bBoxDC);
         if (!bBoxDC->UpdateVerticalValues()) {
-            if (element->Is({ ANNOTSCORE, BRACKETSPAN, HAIRPIN, OCTAVE, PITCHINFLECTION })) return;
+            if (SkipsHorizontalOnlyBBox(classId)) return;
         }
     }
 
@@ -198,11 +234,11 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     assert(interface);
 
     // The start is given by the TimePointInterface
-    LayerElement *start = dynamic_cast<LayerElement *>(interface->GetStart());
+    LayerElement *start = interface->GetStart();
     // The end is given either by the TimeSpanningInterface (end) or by the LinkingInterface (next)
     LayerElement *end = NULL;
     if (interface->GetEnd()) {
-        end = dynamic_cast<LayerElement *>(interface->GetEnd());
+        end = interface->GetEnd();
     }
     else if (element->HasInterface(INTERFACE_LINKING)) {
         LinkingInterface *linkingInterface = element->GetLinkingInterface();
@@ -242,7 +278,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     // Only the first parent is the same, this means that the element is "open" at the end of the system
     else if (system == parentSystem1) {
         // We need the last measure of the system for x2 - we also use it for getting the staves later
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
+        measure = vrv_cast<Measure *>(system->GetLast(MEASURE));
         if (!measure) return;
         drawingX1 = start->GetDrawingX();
         objectX = start;
@@ -253,7 +289,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     // We are in the system of the last note - draw the element from the beginning of the system
     else if (system == parentSystem2) {
         // We need the first measure of the system for x1 - we also use it for getting the staves later
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, FORWARD));
+        measure = vrv_cast<Measure *>(system->GetFirst(MEASURE));
         if (!measure) return;
         // We need the position of the first default in the first measure for x1
         drawingX1 = measure->GetDrawingX() + measure->GetLeftBarLineXRel();
@@ -265,13 +301,13 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
     // throughout the system => recheck that the systems are in correct order
     else if (Object::IsPreOrdered(parentSystem1, system) && Object::IsPreOrdered(system, parentSystem2)) {
         // We need the first measure of the system for x1 - we also use it for getting the staves later
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, FORWARD));
+        measure = vrv_cast<Measure *>(system->GetFirst(MEASURE));
         if (!measure) return;
         // We need the position of the first default in the first measure for x1
         drawingX1 = measure->GetDrawingX() + measure->GetLeftBarLineXRel();
         objectX = measure->GetLeftBarLine();
         // We need the last measure of the system for x2
-        Measure *last = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
+        Measure *last = vrv_cast<Measure *>(system->GetLast(MEASURE));
         if (!last) return;
         drawingX2 = last->GetDrawingX() + last->GetRightBarLineXRel();
         spanningType = SPANNING_MIDDLE;
@@ -326,7 +362,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
 
         // TimeSpanning elements are not necessary floating elements (e.g., syl) - we have a bounding box only for them
         if (element->IsControlElement()) {
-            if (element->Is({ PHRASE, SLUR })) {
+            if ((classId == PHRASE) || (classId == SLUR)) {
                 if (this->GetSlurHandling() == SlurHandling::Ignore) break;
                 Slur *slur = vrv_cast<Slur *>(element);
                 assert(slur);
@@ -335,98 +371,78 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
 
             // Create the floating positioner
             if (!system->SetCurrentFloatingPositioner(
-                    staff->GetN(), dynamic_cast<ControlElement *>(element), objectX, staff, spanningType)) {
+                    staff->GetN(), vrv_cast<ControlElement *>(element), objectX, staff, spanningType)) {
                 continue;
             }
         }
 
-        if (element->Is(ANNOTSCORE)) {
-            // cast to AnnotScore check in DrawAnnotScore
-            this->DrawAnnotScore(dc, dynamic_cast<AnnotScore *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(DIR)) {
-            // cast to Dir check in DrawControlElementConnector
-            this->DrawControlElementConnector(dc, dynamic_cast<Dir *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(DYNAM)) {
-            // cast to Dynam check in DrawControlElementConnector
-            this->DrawControlElementConnector(dc, dynamic_cast<Dynam *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(FIGURE)) {
-            // cast to F check in DrawFConnector
-            this->DrawFConnector(dc, dynamic_cast<F *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(BEAMSPAN)) {
-            // cast to BeamSpan check in DrawBeamSpan
-            this->DrawBeamSpan(dc, vrv_cast<BeamSpan *>(element), system, graphic);
-        }
-        else if (element->Is(BRACKETSPAN)) {
-            // cast to BracketSpan check in DrawBracketSpan
-            this->DrawBracketSpan(dc, dynamic_cast<BracketSpan *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(GLISS)) {
-            // For gliss we limit support to one value in @staff
-            if (!isFirst) continue;
-            // cast to Gliss check in DrawGliss
-            this->DrawGliss(dc, dynamic_cast<Gliss *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(HAIRPIN)) {
-            // cast to Hairpin check in DrawHairpin
-            this->DrawHairpin(dc, dynamic_cast<Hairpin *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(LV)) {
-            // For ties we limit support to one value in @staff
-            if (!isFirst) continue;
-            // cast to Tie check in DrawTie
-            this->DrawTie(dc, dynamic_cast<Tie *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(PHRASE)) {
-            // Check if slurs should be ignored
-            if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
-            // For phrases (slurs) we limit support to one value in @staff
-            if (!isFirst) continue;
-            // cast to Slur check in DrawSlur
-            this->DrawSlur(dc, dynamic_cast<Slur *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(OCTAVE)) {
-            // cast to Slur check in DrawOctave
-            this->DrawOctave(dc, dynamic_cast<Octave *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(PEDAL)) {
-            this->DrawPedalLine(dc, dynamic_cast<Pedal *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(PITCHINFLECTION)) {
-            // cast to PitchInflection check in DrawPitchInflection
-            this->DrawPitchInflection(
-                dc, dynamic_cast<PitchInflection *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(SLUR)) {
-            // Check if slurs should be ignored
-            if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
-            // For slurs we limit support to one value in @staff
-            if (!isFirst) continue;
-            // cast to Slur check in DrawSlur
-            this->DrawSlur(dc, dynamic_cast<Slur *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(SYL)) {
-            // prolong to the end of the notehead
-            x2 += endRadius;
-            // cast to Syl check in DrawSylConnector
-            this->DrawSylConnector(dc, dynamic_cast<Syl *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(TEMPO)) {
-            // cast to Tempo check in DrawControlElementConnector
-            this->DrawControlElementConnector(dc, dynamic_cast<Tempo *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(TIE)) {
-            // For ties we limit support to one value in @staff
-            if (!isFirst) continue;
-            // cast to Slur check in DrawTie
-            this->DrawTie(dc, dynamic_cast<Tie *>(element), x1, x2, staff, spanningType, graphic);
-        }
-        else if (element->Is(TRILL)) {
-            // cast to Trill check in DrawTrill
-            this->DrawTrillExtension(dc, dynamic_cast<Trill *>(element), x1, x2, staff, spanningType, graphic);
+        switch (classId) {
+            case ANNOTSCORE:
+                this->DrawAnnotScore(dc, vrv_cast<AnnotScore *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case DIR:
+                this->DrawControlElementConnector(dc, vrv_cast<Dir *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case DYNAM:
+                this->DrawControlElementConnector(dc, vrv_cast<Dynam *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case FIGURE: this->DrawFConnector(dc, vrv_cast<F *>(element), x1, x2, staff, spanningType, graphic); break;
+            case BEAMSPAN: this->DrawBeamSpan(dc, vrv_cast<BeamSpan *>(element), system, graphic); break;
+            case BRACKETSPAN:
+                this->DrawBracketSpan(dc, vrv_cast<BracketSpan *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case GLISS:
+                // For gliss we limit support to one value in @staff
+                if (!isFirst) continue;
+                this->DrawGliss(dc, vrv_cast<Gliss *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case HAIRPIN:
+                this->DrawHairpin(dc, vrv_cast<Hairpin *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case LV:
+                // For ties we limit support to one value in @staff
+                if (!isFirst) continue;
+                this->DrawTie(dc, vrv_cast<Tie *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case PHRASE:
+                // Check if slurs should be ignored
+                if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
+                // For phrases (slurs) we limit support to one value in @staff
+                if (!isFirst) continue;
+                this->DrawSlur(dc, vrv_cast<Slur *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case OCTAVE: this->DrawOctave(dc, vrv_cast<Octave *>(element), x1, x2, staff, spanningType, graphic); break;
+            case PEDAL:
+                this->DrawPedalLine(dc, vrv_cast<Pedal *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case PITCHINFLECTION:
+                this->DrawPitchInflection(
+                    dc, vrv_cast<PitchInflection *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case SLUR:
+                // Check if slurs should be ignored
+                if (this->GetSlurHandling() == SlurHandling::Ignore) continue;
+                // For slurs we limit support to one value in @staff
+                if (!isFirst) continue;
+                this->DrawSlur(dc, vrv_cast<Slur *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case SYL:
+                // prolong to the end of the notehead
+                x2 += endRadius;
+                this->DrawSylConnector(dc, vrv_cast<Syl *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case TEMPO:
+                this->DrawControlElementConnector(dc, vrv_cast<Tempo *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case TIE:
+                // For ties we limit support to one value in @staff
+                if (!isFirst) continue;
+                this->DrawTie(dc, vrv_cast<Tie *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            case TRILL:
+                this->DrawTrillExtension(dc, vrv_cast<Trill *>(element), x1, x2, staff, spanningType, graphic);
+                break;
+            default: break;
         }
         isFirst = false;
     }
@@ -1425,7 +1441,7 @@ void View::DrawSylConnector(
             assert(measure);
             System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
             assert(system);
-            if (measure == vrv_cast<Measure *>(system->FindDescendantByType(MEASURE))) {
+            if (measure == system->GetFirst(MEASURE)) {
                 return;
             }
         }
@@ -3095,7 +3111,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     // Only the first parent is the same, this means that the ending is "open" at the end of the system
     else if (system == parentSystem1) {
         // We need the last measure of the system for x2 - we also use it for getting the staves later
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
+        measure = vrv_cast<Measure *>(system->GetLast(MEASURE));
         if (!measure) return;
         x1 = ending->GetMeasure()->GetDrawingX();
         objectX = measure;
@@ -3108,7 +3124,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     // We are in the system where the ending ends - draw it from the beginning of the system
     else if (system == parentSystem2) {
         // We need the last measure of the system for x2
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, FORWARD));
+        measure = vrv_cast<Measure *>(system->GetFirst(MEASURE));
         if (!measure) return;
         x1 = measure->GetDrawingX() + measure->GetLeftBarLineXRel();
         objectX = measure->GetLeftBarLine();
@@ -3120,13 +3136,13 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
     // throughout the system
     else {
         // We need the first measure of the system for x1 - we also use it for getting the staves later
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, FORWARD));
+        measure = vrv_cast<Measure *>(system->GetFirst(MEASURE));
         if (!measure) return;
         x1 = measure->GetDrawingX() + measure->GetLeftBarLineXRel();
         objectX = measure->GetLeftBarLine();
         endingMeasure = measure;
         // We need the last measure of the system for x2
-        measure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
+        measure = vrv_cast<Measure *>(system->GetLast(MEASURE));
         if (!measure) return;
         x2 = measure->GetDrawingX() + measure->GetRightBarLineXRel();
         spanningType = SPANNING_MIDDLE;
@@ -3215,7 +3231,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
         const int rightBarLineWidth = endingMeasure->CalculateRightBarLineWidth(m_doc, staffSize);
         int endX = x2;
         if ((spanningType == SPANNING_START) || (spanningType == SPANNING_MIDDLE)
-            || (endingMeasure == system->FindDescendantByType(MEASURE, 1, BACKWARD))) {
+            || (endingMeasure == system->GetLast(MEASURE))) {
             // Right align the ending in the last measure of the system
             endX += rightBarLineWidth - lineWidth / 2 - staffLineWidth;
         }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -79,7 +79,10 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
 
     this->StartOffset(dc, element, staff->m_drawingStaffSize);
 
-    if (element->Is(ACCID)) {
+    if (element->Is(NOTE) || element->Is(CHORD) || element->Is(REST)) {
+        this->DrawDurationElement(dc, element, layer, staff, measure);
+    }
+    else if (element->Is(ACCID)) {
         this->DrawAccid(dc, element, layer, staff, measure);
     }
     else if (element->Is(ARTIC)) {
@@ -96,9 +99,6 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     }
     else if (element->Is(BTREM)) {
         this->DrawBTrem(dc, element, layer, staff, measure);
-    }
-    else if (element->Is(CHORD)) {
-        this->DrawDurationElement(dc, element, layer, staff, measure);
     }
     else if (element->Is(CLEF)) {
         this->DrawClef(dc, element, layer, staff, measure);
@@ -169,9 +169,6 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     else if (element->Is(NC)) {
         this->DrawNc(dc, element, layer, staff, measure);
     }
-    else if (element->Is(NOTE)) {
-        this->DrawDurationElement(dc, element, layer, staff, measure);
-    }
     else if (element->Is(NEUME)) {
         this->DrawNeume(dc, element, layer, staff, measure);
     }
@@ -189,9 +186,6 @@ void View::DrawLayerElement(DeviceContext *dc, LayerElement *element, Layer *lay
     }
     else if (element->Is(STROPHICUS)) {
         this->DrawStrophicus(dc, element, layer, staff, measure);
-    }
-    else if (element->Is(REST)) {
-        this->DrawDurationElement(dc, element, layer, staff, measure);
     }
     else if (element->Is(SPACE)) {
         this->DrawSpace(dc, element, layer, staff, measure);
@@ -891,20 +885,23 @@ void View::DrawDurationElement(DeviceContext *dc, LayerElement *element, Layer *
     assert(staff);
     assert(measure);
 
-    if (dynamic_cast<Chord *>(element)) {
-        dc->StartGraphic(element, "", element->GetID());
-        this->DrawChord(dc, element, layer, staff, measure);
-        dc->EndGraphic(element, this);
-    }
-    else if (dynamic_cast<Note *>(element)) {
-        dc->StartGraphic(element, "", element->GetID());
-        this->DrawNote(dc, element, layer, staff, measure);
-        dc->EndGraphic(element, this);
-    }
-    else if (dynamic_cast<Rest *>(element)) {
-        dc->StartGraphic(element, "", element->GetID());
-        this->DrawRest(dc, element, layer, staff, measure);
-        dc->EndGraphic(element, this);
+    switch (element->GetClassId()) {
+        case CHORD:
+            dc->StartGraphic(element, "", element->GetID());
+            this->DrawChord(dc, element, layer, staff, measure);
+            dc->EndGraphic(element, this);
+            break;
+        case NOTE:
+            dc->StartGraphic(element, "", element->GetID());
+            this->DrawNote(dc, element, layer, staff, measure);
+            dc->EndGraphic(element, this);
+            break;
+        case REST:
+            dc->StartGraphic(element, "", element->GetID());
+            this->DrawRest(dc, element, layer, staff, measure);
+            dc->EndGraphic(element, this);
+            break;
+        default: assert(false); break;
     }
 }
 

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -9,9 +9,11 @@
 
 //----------------------------------------------------------------------------
 
+#include <array>
 #include <cassert>
 #include <math.h>
 #include <sstream>
+#include <vector>
 
 //----------------------------------------------------------------------------
 
@@ -58,6 +60,99 @@
 
 namespace vrv {
 
+namespace {
+
+    constexpr std::array<ClassId, 20> SYSTEM_DRAWING_LIST_ORDER = { SYL, ANNOTSCORE, BEAMSPAN, BRACKETSPAN, DYNAM, DIR,
+        GLISS, HAIRPIN, TRILL, FIGURE, LV, PHRASE, OCTAVE, ORNAM, PEDAL, PITCHINFLECTION, TEMPO, TIE, SLUR, ENDING };
+
+    int GetSystemDrawingListIndex(ClassId classId)
+    {
+        switch (classId) {
+            case SYL: return 0;
+            case ANNOTSCORE: return 1;
+            case BEAMSPAN: return 2;
+            case BRACKETSPAN: return 3;
+            case DYNAM: return 4;
+            case DIR: return 5;
+            case GLISS: return 6;
+            case HAIRPIN: return 7;
+            case TRILL: return 8;
+            case FIGURE: return 9;
+            case LV: return 10;
+            case PHRASE: return 11;
+            case OCTAVE: return 12;
+            case ORNAM: return 13;
+            case PEDAL: return 14;
+            case PITCHINFLECTION: return 15;
+            case TEMPO: return 16;
+            case TIE: return 17;
+            case SLUR: return 18;
+            case ENDING: return 19;
+            default: return -1;
+        }
+    }
+
+    MRest *FindMRestInStaff(Staff *staff)
+    {
+        for (Object *staffChild : staff->GetChildren()) {
+            if (staffChild->Is(LAYER)) {
+                for (Object *layerChild : staffChild->GetChildren()) {
+                    if (layerChild->Is(MREST)) return vrv_cast<MRest *>(layerChild);
+                    if (layerChild->IsEditorialElement()) {
+                        MRest *mrest = vrv_cast<MRest *>(layerChild->FindDescendantByType(MREST));
+                        if (mrest) return mrest;
+                    }
+                }
+            }
+            else if (staffChild->IsEditorialElement()) {
+                MRest *mrest = vrv_cast<MRest *>(staffChild->FindDescendantByType(MREST));
+                if (mrest) return mrest;
+            }
+        }
+
+        return NULL;
+    }
+
+    Object *FindDirectOrEditorialDescendant(Object *parent, ClassId classId)
+    {
+        for (Object *child : parent->GetChildren()) {
+            if (child->Is(classId)) return child;
+            if (child->IsEditorialElement()) {
+                Object *descendant = child->FindDescendantByType(classId);
+                if (descendant) return descendant;
+            }
+        }
+
+        return NULL;
+    }
+
+    void CalcBeamSpanSegmentsForSystem(Doc *doc, Object *parent, System *system)
+    {
+        for (Object *current : parent->GetChildren()) {
+            if (current->Is(BEAMSPAN)) {
+                BeamSpan *beamSpan = vrv_cast<BeamSpan *>(current);
+                BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
+                if (segment) {
+                    segment->CalcBeam(
+                        segment->GetLayer(), segment->GetStaff(), doc, beamSpan, beamSpan->m_drawingPlace);
+                }
+            }
+            else if (current->IsEditorialElement()) {
+                ListOfObjects objects = current->FindAllDescendantsByType(BEAMSPAN, false);
+                for (Object *element : objects) {
+                    BeamSpan *beamSpan = vrv_cast<BeamSpan *>(element);
+                    BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
+                    if (segment) {
+                        segment->CalcBeam(
+                            segment->GetLayer(), segment->GetStaff(), doc, beamSpan, beamSpan->m_drawingPlace);
+                    }
+                }
+            }
+        }
+    }
+
+} // namespace
+
 //----------------------------------------------------------------------------
 // View - Page
 //----------------------------------------------------------------------------
@@ -97,10 +192,10 @@ void View::DrawCurrentPage(DeviceContext *dc, bool background)
     for (Object *child : m_currentPage->GetChildren()) {
         if (child->IsPageElement()) {
             // cast to PageElement check in DrawSystemEditorial element
-            this->DrawPageElement(dc, dynamic_cast<PageElement *>(child));
+            this->DrawPageElement(dc, vrv_cast<PageElement *>(child));
         }
         else if (child->Is(SYSTEM)) {
-            System *system = dynamic_cast<System *>(child);
+            System *system = vrv_cast<System *>(child);
             this->DrawSystem(dc, system);
         }
         else {
@@ -195,7 +290,7 @@ void View::DrawSystem(DeviceContext *dc, System *system)
 
     dc->StartGraphic(system, "", system->GetID());
 
-    Measure *firstMeasure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1));
+    Measure *firstMeasure = vrv_cast<Measure *>(system->GetFirst(MEASURE));
 
     this->DrawSystemDivider(dc, system, firstMeasure);
 
@@ -208,26 +303,28 @@ void View::DrawSystem(DeviceContext *dc, System *system)
 
     this->DrawSystemChildren(dc, system, system);
 
-    this->DrawSystemList(dc, system, SYL);
-    this->DrawSystemList(dc, system, ANNOTSCORE);
-    this->DrawSystemList(dc, system, BEAMSPAN);
-    this->DrawSystemList(dc, system, BRACKETSPAN);
-    this->DrawSystemList(dc, system, DYNAM);
-    this->DrawSystemList(dc, system, DIR);
-    this->DrawSystemList(dc, system, GLISS);
-    this->DrawSystemList(dc, system, HAIRPIN);
-    this->DrawSystemList(dc, system, TRILL);
-    this->DrawSystemList(dc, system, FIGURE);
-    this->DrawSystemList(dc, system, LV);
-    this->DrawSystemList(dc, system, PHRASE);
-    this->DrawSystemList(dc, system, OCTAVE);
-    this->DrawSystemList(dc, system, ORNAM);
-    this->DrawSystemList(dc, system, PEDAL);
-    this->DrawSystemList(dc, system, PITCHINFLECTION);
-    this->DrawSystemList(dc, system, TEMPO);
-    this->DrawSystemList(dc, system, TIE);
-    this->DrawSystemList(dc, system, SLUR);
-    this->DrawSystemList(dc, system, ENDING);
+    {
+        std::array<ArrayOfObjects, SYSTEM_DRAWING_LIST_ORDER.size()> drawingListsByClass;
+        for (Object *object : *system->GetDrawingList()) {
+            const int index = GetSystemDrawingListIndex(object->GetClassId());
+            if (index >= 0) drawingListsByClass[index].push_back(object);
+        }
+
+        for (size_t i = 0; i < SYSTEM_DRAWING_LIST_ORDER.size(); ++i) {
+            const ClassId classId = SYSTEM_DRAWING_LIST_ORDER[i];
+            for (Object *object : drawingListsByClass[i]) {
+                if (classId == ENDING) {
+                    // cast to Ending check in DrawEnding
+                    this->DrawEnding(dc, vrv_cast<Ending *>(object), system);
+                }
+                else {
+                    this->StartOffset(dc, object, 100);
+                    this->DrawTimeSpanningElement(dc, object, system);
+                    this->EndOffset(dc, object);
+                }
+            }
+        }
+    }
 
     dc->EndGraphic(system, this);
 }
@@ -249,7 +346,7 @@ void View::DrawSystemList(DeviceContext *dc, System *system, const ClassId class
         }
         if (object->Is(classId) && (classId == ENDING)) {
             // cast to Ending check in DrawEnding
-            this->DrawEnding(dc, dynamic_cast<Ending *>(object), system);
+            this->DrawEnding(dc, vrv_cast<Ending *>(object), system);
         }
     }
 }
@@ -262,7 +359,7 @@ void View::DrawScoreDef(DeviceContext *dc, ScoreDef *scoreDef, Measure *measure,
     // we need at least one measure to be able to draw the groups - we need access to the staff elements,
     assert(measure);
 
-    StaffGrp *staffGrp = vrv_cast<StaffGrp *>(scoreDef->FindDescendantByType(STAFFGRP));
+    StaffGrp *staffGrp = vrv_cast<StaffGrp *>(scoreDef->GetFirst(STAFFGRP));
     if (!staffGrp) {
         return;
     }
@@ -1002,21 +1099,18 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
     }
 
     if (m_drawingScoreDef.GetMnumVisible() != BOOLEAN_false) {
-        MNum *mnum = vrv_cast<MNum *>(measure->FindDescendantByType(MNUM));
-        Reh *reh = vrv_cast<Reh *>(measure->FindDescendantByType(REH));
+        MNum *mnum = vrv_cast<MNum *>(measure->GetFirst(MNUM));
+        Reh *reh = vrv_cast<Reh *>(FindDirectOrEditorialDescendant(measure, REH));
         const bool hasRehearsal = reh
             && ((reh->HasTstamp() && (reh->GetTstamp() == 0.0))
                 || (reh->GetStart()->Is(BARLINE)
                     && vrv_cast<BarLine *>(reh->GetStart())->GetPosition() == BarLinePosition::Left));
         if (mnum && !hasRehearsal) {
-            // this should be an option
-            Measure *systemStart = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE));
-
             // Draw non-generated measure numbers
             // If mnumInterval is 0, draw system starting measure numbers > 1,
             // otherwise, draw every (mnumInterval)th measure number.
             int mnumInterval = m_options->m_mnumInterval.GetValue();
-            if ((mnumInterval == 0 && measure == systemStart && measure->GetN() != "0" && measure->GetN() != "1")
+            if ((mnumInterval == 0 && measure->IsFirstInSystem() && measure->GetN() != "0" && measure->GetN() != "1")
                 || !mnum->IsGenerated()
                 || (mnumInterval >= 1 && (std::atoi(measure->GetN().c_str()) % mnumInterval == 0))) {
                 int symbolOffset = m_doc->GetDrawingUnit(100);
@@ -1037,8 +1131,6 @@ void View::DrawMeasure(DeviceContext *dc, Measure *measure, System *system)
 
     // Draw the barlines only with measured music
     if (measure->IsMeasuredMusic()) {
-        System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
-        assert(system);
         if ((measure->GetDrawingLeftBarLine() != BARRENDITION_NONE) || measure->HasInvisibleStaffBarlines()) {
             this->DrawScoreDef(dc, system->GetDrawingScoreDef(), measure, measure->GetLeftBarLine()->GetDrawingX(),
                 measure->GetLeftBarLine());
@@ -1281,7 +1373,7 @@ void View::DrawStaff(DeviceContext *dc, Staff *staff, Measure *measure, System *
         staff->SetFromFacsimile(m_doc);
     }
 
-    MRest *mrest = vrv_cast<MRest *>(staff->FindDescendantByType(MREST));
+    MRest *mrest = FindMRestInStaff(staff);
     if (!mrest || mrest->GetCutout() != cutout_CUTOUT_cutout) {
         this->DrawStaffLines(dc, staff, staffDef, measure, system);
     }
@@ -1464,7 +1556,7 @@ void View::DrawStaffDef(DeviceContext *dc, Staff *staff, Measure *measure)
     assert(measure);
 
     // StaffDef information is always in the first layer
-    Layer *layer = vrv_cast<Layer *>(staff->FindDescendantByType(LAYER));
+    Layer *layer = vrv_cast<Layer *>(FindDirectOrEditorialDescendant(staff, LAYER));
     if (!layer || !layer->HasStaffDef()) return;
 
     // StaffDef staffDef;
@@ -1497,7 +1589,7 @@ void View::DrawStaffDefCautionary(DeviceContext *dc, Staff *staff, Measure *meas
     assert(measure);
 
     // StaffDef cautionary information is always in the first layer
-    Layer *layer = vrv_cast<Layer *>(staff->FindDescendantByType(LAYER));
+    Layer *layer = vrv_cast<Layer *>(FindDirectOrEditorialDescendant(staff, LAYER));
     if (!layer || !layer->HasCautionStaffDef()) return;
 
     // StaffDef staffDef;
@@ -1606,10 +1698,10 @@ void View::DrawLayerList(DeviceContext *dc, Layer *layer, Staff *staff, Measure 
 
     for (Object *object : *drawingList) {
         if (object->Is(classId) && (classId == TUPLET_BRACKET)) {
-            this->DrawTupletBracket(dc, dynamic_cast<LayerElement *>(object), layer, staff, measure);
+            this->DrawTupletBracket(dc, vrv_cast<LayerElement *>(object), layer, staff, measure);
         }
         if (object->Is(classId) && (classId == TUPLET_NUM)) {
-            this->DrawTupletNum(dc, dynamic_cast<LayerElement *>(object), layer, staff, measure);
+            this->DrawTupletNum(dc, vrv_cast<LayerElement *>(object), layer, staff, measure);
         }
     }
 }
@@ -1630,7 +1722,7 @@ void View::DrawSystemDivider(DeviceContext *dc, System *system, Measure *firstMe
     if (currentPage) {
         Object *previousSystem = currentPage->GetPrevious(system);
         if (previousSystem) {
-            Measure *previousSystemMeasure = vrv_cast<Measure *>(previousSystem->FindDescendantByType(MEASURE, 1));
+            Measure *previousSystemMeasure = vrv_cast<Measure *>(previousSystem->GetFirst(MEASURE));
             if (previousSystemMeasure) {
                 Staff *bottomStaff = previousSystemMeasure->GetBottomVisibleStaff();
                 // set Y position to that of lowest (bottom) staff, substact space taken by staff lines and
@@ -1667,7 +1759,7 @@ void View::DrawSystemDivider(DeviceContext *dc, System *system, Measure *firstMe
         if (m_options->m_systemDivider.GetValue() == SYSTEMDIVIDER_left_right) {
             // Right divider is not taken into account in the layout calculation and can collision with the music
             // content
-            Measure *lastMeasure = vrv_cast<Measure *>(system->FindDescendantByType(MEASURE, 1, BACKWARD));
+            Measure *lastMeasure = vrv_cast<Measure *>(system->GetLast(MEASURE));
             assert(lastMeasure);
             int x4 = lastMeasure->GetDrawingX() + lastMeasure->GetRightBarLineRight();
             int x3 = x4 - m_doc->GetDrawingUnit(100) * 6;
@@ -1718,15 +1810,15 @@ void View::DrawSystemChildren(DeviceContext *dc, Object *parent, System *system)
         }
         else if (current->IsSystemElement()) {
             // cast to SystemElement check in DrawSystemEditorial element
-            this->DrawSystemElement(dc, dynamic_cast<SystemElement *>(current), system);
+            this->DrawSystemElement(dc, vrv_cast<SystemElement *>(current), system);
         }
         else if (current->Is(DIV)) {
             // cast to Div check in DrawDiv element
-            this->DrawDiv(dc, dynamic_cast<Div *>(current), system);
+            this->DrawDiv(dc, vrv_cast<Div *>(current), system);
         }
         else if (current->IsEditorialElement()) {
             // cast to EditorialElement check in DrawSystemEditorial element
-            this->DrawSystemEditorialElement(dc, dynamic_cast<EditorialElement *>(current), system);
+            this->DrawSystemEditorialElement(dc, vrv_cast<EditorialElement *>(current), system);
         }
         else {
             assert(false);
@@ -1741,14 +1833,7 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
     assert(measure);
     assert(system);
 
-    ListOfObjects objects = parent->FindAllDescendantsByType(BEAMSPAN, false);
-    for (Object *element : objects) {
-        BeamSpan *beamSpan = vrv_cast<BeamSpan *>(element);
-        BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
-        if (segment) {
-            segment->CalcBeam(segment->GetLayer(), segment->GetStaff(), m_doc, beamSpan, beamSpan->m_drawingPlace);
-        }
-    }
+    CalcBeamSpanSegmentsForSystem(m_doc, parent, system);
 
     for (Object *current : parent->GetChildren()) {
         if (current->Is(OSSIA)) {
@@ -1760,11 +1845,11 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
         }
         else if (current->IsControlElement()) {
             // cast to ControlElement check in DrawControlElement
-            this->DrawControlElement(dc, dynamic_cast<ControlElement *>(current), measure, system);
+            this->DrawControlElement(dc, vrv_cast<ControlElement *>(current), measure, system);
         }
         else if (current->IsEditorialElement()) {
             // cast to EditorialElement check in DrawMeasureEditorialElement
-            this->DrawMeasureEditorialElement(dc, dynamic_cast<EditorialElement *>(current), measure, system);
+            this->DrawMeasureEditorialElement(dc, vrv_cast<EditorialElement *>(current), measure, system);
         }
         else {
             LogDebug("Current is %s", current->GetClassName().c_str());
@@ -1787,7 +1872,7 @@ void View::DrawStaffChildren(DeviceContext *dc, Object *parent, Staff *staff, Me
         }
         else if (current->IsEditorialElement()) {
             // cast to EditorialElement check in DrawStaffEditorialElement
-            this->DrawStaffEditorialElement(dc, dynamic_cast<EditorialElement *>(current), staff, measure);
+            this->DrawStaffEditorialElement(dc, vrv_cast<EditorialElement *>(current), staff, measure);
         }
         else {
             assert(false);
@@ -1805,11 +1890,11 @@ void View::DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, St
 
     for (Object *current : parent->GetChildren()) {
         if (current->IsLayerElement()) {
-            this->DrawLayerElement(dc, dynamic_cast<LayerElement *>(current), layer, staff, measure);
+            this->DrawLayerElement(dc, vrv_cast<LayerElement *>(current), layer, staff, measure);
         }
         else if (current->IsEditorialElement()) {
             // cast to EditorialElement check in DrawLayerEditorialElement
-            this->DrawLayerEditorialElement(dc, dynamic_cast<EditorialElement *>(current), layer, staff, measure);
+            this->DrawLayerEditorialElement(dc, vrv_cast<EditorialElement *>(current), layer, staff, measure);
         }
         else if (!current->Is({ LABEL, LABELABBR })) {
             assert(false);


### PR DESCRIPTION
This improves rendering performance by reducing repeated work in layout and drawing hot paths.

The changes are split into small commits so they can be reviewed independently. No output changes expected.

Benchmark corpus: 22 full scores from the Verovio `gh-pages` examples, mixing MEI and MusicXML, rendering all pages to SVG with a Release CLI:

```sh
verovio -r data --log-level error -f mei-or-musicxml -x 1 -t svg -a -o /tmp/out input
```

| Optimization | Commit | Real | Incremental | Total speedup | Instructions | Instruction reduction | Max RSS |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Baseline `develop` | `86c6476f` | 10.91 s | - | - | 163.62 B | - | 381.0 MiB |
| Lazy custom tuning | `773d48a6` | 9.50 s | 12.9% | 12.9% | 139.77 B | 14.6% | 369.8 MiB |
| Trim horizontal passes | `4bdb8edb` | 8.89 s | 6.4% | 18.5% | 126.66 B | 22.6% | 355.4 MiB |
| Simplify generated measure numbers | `85e08de2` | 8.80 s | 1.0% | 19.3% | 126.36 B | 22.8% | 365.6 MiB |
| Find page boundaries directly | `d4e8e263` | 8.73 s | 0.8% | 20.0% | 126.31 B | 22.8% | 373.5 MiB |
| Reduce draw dispatch overhead | `e36440bb` | 8.28 s | 5.1% | 24.1% | 118.08 B | 27.8% | 368.3 MiB |
| Reduce repeated page drawing traversals | `140ab7b3` | 7.95 s | 4.0% | 27.1% | 113.74 B | 30.5% | 348.7 MiB |

Final result on this corpus: 10.91 s -> 7.95 s, a 27.1% wall-time reduction. Retired instructions are down 30.5%. Peak RSS did not increase in this run.

Validation:

* Full-piece benchmark corpus: 412 baseline SVGs vs 412 final SVGs, normalized mismatches 0
* Verovio `_tests` + `musicxmlTestSuite`: 763 baseline SVGs vs 763 final SVGs, normalized mismatches 0
* Only normalization was the version-specific text inside the SVG `<desc>` element
* `ctest` was run against the final CMake build, but this build exposes no tests

The benchmarked full-score set was:

* `editor/brahms.mei`
* `examples/downloads/Ahle_Jesu_meines_Herzens_Freud.mei`
* `examples/downloads/Bach_Chorale_bwv.363.mei`
* `examples/downloads/Beethoven_op.18.mei`
* `examples/downloads/Beethoven_op.18_1.mei`
* `examples/downloads/Brahms_StringQuartet_Op51_No1.mei`
* `examples/downloads/Chopin_Etude_op.10_no.9.mei`
* `examples/downloads/Guami_Canzona_24.mei`
* `examples/downloads/Hummel_Concerto_for_trumpet.mei`
* `examples/downloads/Krebs_Trio_Eb_2.mei`
* `examples/downloads/Marenzio_Sesto_a_5_01.mei`
* `examples/downloads/Schubert_Lindenbaum.mei`
* `examples/musicxml/Bach_Brandburg_Concerto_BWV.1050_M1.xml`
* `examples/musicxml/Bach_Invention_No_1_BVW.772.xml`
* `examples/musicxml/Bach_Nun_komm_der_Heiden_Heiland_BWV.659.xml`
* `examples/musicxml/Chopin_Etude_Op.10_No.12.xml`
* `examples/musicxml/Costeley_Je_vois_de_glissantes_eaux.xml`
* `examples/musicxml/Haydn_String_Quartet_in_C_Major_Op.74_No.1_M2.xml`
* `examples/musicxml/Schubert_An_die_Sonne_D.439.xml`
* `examples/musicxml/Schubert_Staendchen_D.923.xml`
* `examples/musicxml/Vivaldi_Concerto_No.4_in_F_Minor_Winter.xml`
* `examples/musicxml/Waldteufel_Op.138_Les_Patineurs.xml`
