### PR TITLE
Fix MusicXML grace[@slash] to honor value, not just presence

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3260,7 +3260,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                 element = chord;
                 if (cue) chord->SetCue(BOOLEAN_true);
                 if (grace) {
-                    if (grace.attribute("slash")) {
+                    if (grace.attribute("slash").as_bool()) {
                         chord->SetGrace(GRACE_unacc);
                         chord->SetStemMod(STEMMODIFIER_1slash);
                     }
@@ -3293,7 +3293,7 @@ void MusicXmlInput::ReadMusicXmlNote(
 
         // single grace note
         if (grace) {
-            if (grace.attribute("slash")) {
+            if (grace.attribute("slash").as_bool()) {
                 note->SetGrace(GRACE_unacc);
                 note->SetStemMod(STEMMODIFIER_1slash);
             }


### PR DESCRIPTION
Fixes #4346.

## Summary

The MusicXML importer was treating `<grace slash="no"/>` identically to `<grace slash="yes"/>` because the conditional checked only for attribute presence, not its value. Both produced MEI with `grace="unacc"` + `stem.mod="1slash"`, drawing an unintended stem-slash on long appoggiaturas.

Switching to `as_bool()` uses pugixml's standard truthy parsing ("1" / "true" / "yes" — case-insensitive) so the boolean MusicXML attribute is honored.

## Behavior

| MusicXML | Before | After |
|---|---|---|
| `<grace slash="yes"/>` | `grace="unacc"` + `stem.mod="1slash"` (slashed) | unchanged |
| `<grace slash="no"/>` | `grace="unacc"` + `stem.mod="1slash"` (slashed — bug) | `grace="acc"` (no slash) |
| `<grace/>` (attr absent) | `grace="acc"` (no slash) | unchanged (MusicXML default = "no") |

## Scope

Two call sites in `src/iomusxml.cpp` share the same logic — chord grace notes and single grace notes. Both updated.

## Reproduction

See the MusicXML snippet in #4346. With `verovio` 6.1.0 the first two `<grace>` elements produce byte-identical MEI; after this change, only the `slash="yes"` case carries `stem.mod="1slash"`.

## Notes

- Contribution is well under 20 lines (2 lines changed); CLA exempt per the project guidelines.
- No test fixtures in `doc/tests/` cover MusicXML grace notes directly (the grace fixtures there are PAE-format). Happy to add a regression fixture if a maintainer points me at the right location and format.
