### PR TITLE
Avoid vector initialization in BoundingBox::IsAnyOf

### DIFF
--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -40,7 +40,7 @@ public:
     virtual ~BoundingBox() {}
     virtual ClassId GetClassId() const = 0;
     bool Is(ClassId classId) const { return (this->GetClassId() == classId); }
-    bool Is(const std::vector<ClassId> &classIds) const;
+    bool IsAnyOf(const std::vector<ClassId> &classIds) const;
     ///@}
 
     /**

--- a/include/vrv/boundingbox.h
+++ b/include/vrv/boundingbox.h
@@ -40,7 +40,10 @@ public:
     virtual ~BoundingBox() {}
     virtual ClassId GetClassId() const = 0;
     bool Is(ClassId classId) const { return (this->GetClassId() == classId); }
-    bool IsAnyOf(const std::vector<ClassId> &classIds) const;
+    template <typename Range> bool IsAnyOf(const Range &classIds) const
+    {
+        return std::find(std::begin(classIds), std::end(classIds), GetClassId()) != std::end(classIds);
+    }
     ///@}
 
     /**

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -89,7 +89,7 @@ public:
 
     bool operator()(const Object *object) override { return Result(this->MatchesType(object)); }
 
-    bool MatchesType(const Object *object) { return (object->Is(m_classIds)); }
+    bool MatchesType(const Object *object) { return (object->IsAnyOf(m_classIds)); }
 
 protected:
     std::vector<ClassId> m_classIds;

--- a/src/adjustbeamsfunctor.cpp
+++ b/src/adjustbeamsfunctor.cpp
@@ -241,7 +241,8 @@ FunctorCode AdjustBeamsFunctor::VisitLayerElement(LayerElement *layerElement)
     // ignore elements that are both on other layer and cross-staff
     if (m_isOtherLayer && layerElement->m_crossStaff) return FUNCTOR_CONTINUE;
     // ignore specific elements, since they should not be influencing beam positioning
-    if (layerElement->IsAnyOf({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf(std::array{ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM }))
+        return FUNCTOR_CONTINUE;
     // ignore elements that start before the beam
     if (layerElement->GetDrawingX() < m_x1) return FUNCTOR_CONTINUE;
     // ignore elements that have @visible attribute set to false

--- a/src/adjustbeamsfunctor.cpp
+++ b/src/adjustbeamsfunctor.cpp
@@ -241,7 +241,7 @@ FunctorCode AdjustBeamsFunctor::VisitLayerElement(LayerElement *layerElement)
     // ignore elements that are both on other layer and cross-staff
     if (m_isOtherLayer && layerElement->m_crossStaff) return FUNCTOR_CONTINUE;
     // ignore specific elements, since they should not be influencing beam positioning
-    if (layerElement->Is({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf({ BTREM, GRACEGRP, SPACE, TUPLET, TUPLET_BRACKET, TUPLET_NUM })) return FUNCTOR_CONTINUE;
     // ignore elements that start before the beam
     if (layerElement->GetDrawingX() < m_x1) return FUNCTOR_CONTINUE;
     // ignore elements that have @visible attribute set to false

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -43,7 +43,7 @@ FunctorCode AdjustDotsFunctor::VisitAlignmentEnd(Alignment *alignment)
             for (LayerElement *element : m_elements) {
                 if (dots->HorizontalSelfOverlap(element, thirdUnit)
                     && dots->VerticalSelfOverlap(element, 2 * thirdUnit)) {
-                    if (element->Is({ CHORD, NOTE })) {
+                    if (element->IsAnyOf({ CHORD, NOTE })) {
                         if (dynamic_cast<AttAugmentDots *>(element)->GetDots() < 1) continue;
                         overlapElements.emplace(dots, element);
                     }

--- a/src/adjustdotsfunctor.cpp
+++ b/src/adjustdotsfunctor.cpp
@@ -43,7 +43,7 @@ FunctorCode AdjustDotsFunctor::VisitAlignmentEnd(Alignment *alignment)
             for (LayerElement *element : m_elements) {
                 if (dots->HorizontalSelfOverlap(element, thirdUnit)
                     && dots->VerticalSelfOverlap(element, 2 * thirdUnit)) {
-                    if (element->IsAnyOf({ CHORD, NOTE })) {
+                    if (element->IsAnyOf(std::array{ CHORD, NOTE })) {
                         if (dynamic_cast<AttAugmentDots *>(element)->GetDots() < 1) continue;
                         overlapElements.emplace(dots, element);
                     }

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -90,7 +90,7 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
             bool skipAbove = false;
             bool skipBelow = false;
 
-            if (positioner->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
+            if (positioner->GetObject()->IsAnyOf(std::array{ LV, PHRASE, SLUR, TIE })) {
                 TimeSpanningInterface *interface = positioner->GetObject()->GetTimeSpanningInterface();
                 assert(interface);
                 interface->GetCrossStaffOverflows(staffAlignment, curve->GetDir(), skipAbove, skipBelow);
@@ -454,7 +454,7 @@ FunctorCode AdjustFloatingPositionersBetweenFunctor::VisitStaffAlignment(StaffAl
 
     for (FloatingPositioner *positioner : m_previousStaffAlignment->GetFloatingPositioners()) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->IsAnyOf({ CPMARK, DIR, DYNAM, HAIRPIN, TEMPO })) continue;
+        if (!positioner->GetObject()->IsAnyOf(std::array{ CPMARK, DIR, DYNAM, HAIRPIN, TEMPO })) continue;
 
         if (positioner->GetDrawingPlace() != STAFFREL_between) continue;
 

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -90,7 +90,7 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
             bool skipAbove = false;
             bool skipBelow = false;
 
-            if (positioner->GetObject()->Is({ LV, PHRASE, SLUR, TIE })) {
+            if (positioner->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
                 TimeSpanningInterface *interface = positioner->GetObject()->GetTimeSpanningInterface();
                 assert(interface);
                 interface->GetCrossStaffOverflows(staffAlignment, curve->GetDir(), skipAbove, skipBelow);
@@ -454,7 +454,7 @@ FunctorCode AdjustFloatingPositionersBetweenFunctor::VisitStaffAlignment(StaffAl
 
     for (FloatingPositioner *positioner : m_previousStaffAlignment->GetFloatingPositioners()) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->Is({ CPMARK, DIR, DYNAM, HAIRPIN, TEMPO })) continue;
+        if (!positioner->GetObject()->IsAnyOf({ CPMARK, DIR, DYNAM, HAIRPIN, TEMPO })) continue;
 
         if (positioner->GetDrawingPlace() != STAFFREL_between) continue;
 

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -102,7 +102,7 @@ FunctorCode AdjustLayersFunctor::VisitLayerElement(LayerElement *layerElement)
 
     // These are the only ones we want to keep for further collision detection
     if (layerElement->HasSelfBB()) {
-        if (layerElement->Is({ NOTE, STEM })) {
+        if (layerElement->IsAnyOf({ NOTE, STEM })) {
             m_current.push_back(layerElement);
         }
         else if (!m_ignoreDots && layerElement->Is(DOTS)) {

--- a/src/adjustlayersfunctor.cpp
+++ b/src/adjustlayersfunctor.cpp
@@ -102,7 +102,7 @@ FunctorCode AdjustLayersFunctor::VisitLayerElement(LayerElement *layerElement)
 
     // These are the only ones we want to keep for further collision detection
     if (layerElement->HasSelfBB()) {
-        if (layerElement->IsAnyOf({ NOTE, STEM })) {
+        if (layerElement->IsAnyOf(std::array{ NOTE, STEM })) {
             m_current.push_back(layerElement);
         }
         else if (!m_ignoreDots && layerElement->Is(DOTS)) {

--- a/src/adjustslursfunctor.cpp
+++ b/src/adjustslursfunctor.cpp
@@ -46,7 +46,7 @@ FunctorCode AdjustSlursFunctor::VisitStaffAlignment(StaffAlignment *staffAlignme
     ArrayOfFloatingCurvePositioners positioners;
     for (FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->Is({ PHRASE, SLUR })) continue;
+        if (!positioner->GetObject()->IsAnyOf({ PHRASE, SLUR })) continue;
         Slur *slur = vrv_cast<Slur *>(positioner->GetObject());
         assert(slur);
         m_currentSlur = slur;

--- a/src/adjustslursfunctor.cpp
+++ b/src/adjustslursfunctor.cpp
@@ -46,7 +46,7 @@ FunctorCode AdjustSlursFunctor::VisitStaffAlignment(StaffAlignment *staffAlignme
     ArrayOfFloatingCurvePositioners positioners;
     for (FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->IsAnyOf({ PHRASE, SLUR })) continue;
+        if (!positioner->GetObject()->IsAnyOf(std::array{ PHRASE, SLUR })) continue;
         Slur *slur = vrv_cast<Slur *>(positioner->GetObject());
         assert(slur);
         m_currentSlur = slur;

--- a/src/adjuststaffoverlapfunctor.cpp
+++ b/src/adjuststaffoverlapfunctor.cpp
@@ -71,7 +71,7 @@ FunctorCode AdjustStaffOverlapFunctor::VisitStaffAlignment(StaffAlignment *staff
             iter = std::find_if(iter, end, [bboxBelow, drawingUnit](BoundingBox *elem) {
                 if (bboxBelow->Is(FLOATING_POSITIONER)) {
                     FloatingPositioner *fp = vrv_cast<FloatingPositioner *>(bboxBelow);
-                    if (fp->GetObject()->Is({ DIR, DYNAM, TEMPO }) && fp->GetObject()->IsExtenderElement()) {
+                    if (fp->GetObject()->IsAnyOf({ DIR, DYNAM, TEMPO }) && fp->GetObject()->IsExtenderElement()) {
                         return bboxBelow->HorizontalContentOverlap(elem, drawingUnit * 4)
                             || bboxBelow->VerticalContentOverlap(elem);
                     }
@@ -83,7 +83,7 @@ FunctorCode AdjustStaffOverlapFunctor::VisitStaffAlignment(StaffAlignment *staff
                 int overflowBelow = m_previous->CalcOverflowBelow(bboxBelow);
                 int overflowAbove = staffAlignment->CalcOverflowAbove(*iter);
                 int minSpaceBetween = 0;
-                if ((bboxBelow->Is(ARTIC) && ((*iter)->Is({ ARTIC, NOTE })))
+                if ((bboxBelow->Is(ARTIC) && ((*iter)->IsAnyOf({ ARTIC, NOTE })))
                     || (bboxBelow->Is(NOTE) && ((*iter)->Is(ARTIC)))) {
                     minSpaceBetween = drawingUnit;
                 }

--- a/src/adjuststaffoverlapfunctor.cpp
+++ b/src/adjuststaffoverlapfunctor.cpp
@@ -71,7 +71,8 @@ FunctorCode AdjustStaffOverlapFunctor::VisitStaffAlignment(StaffAlignment *staff
             iter = std::find_if(iter, end, [bboxBelow, drawingUnit](BoundingBox *elem) {
                 if (bboxBelow->Is(FLOATING_POSITIONER)) {
                     FloatingPositioner *fp = vrv_cast<FloatingPositioner *>(bboxBelow);
-                    if (fp->GetObject()->IsAnyOf({ DIR, DYNAM, TEMPO }) && fp->GetObject()->IsExtenderElement()) {
+                    if (fp->GetObject()->IsAnyOf(std::array{ DIR, DYNAM, TEMPO })
+                        && fp->GetObject()->IsExtenderElement()) {
                         return bboxBelow->HorizontalContentOverlap(elem, drawingUnit * 4)
                             || bboxBelow->VerticalContentOverlap(elem);
                     }
@@ -83,7 +84,7 @@ FunctorCode AdjustStaffOverlapFunctor::VisitStaffAlignment(StaffAlignment *staff
                 int overflowBelow = m_previous->CalcOverflowBelow(bboxBelow);
                 int overflowAbove = staffAlignment->CalcOverflowAbove(*iter);
                 int minSpaceBetween = 0;
-                if ((bboxBelow->Is(ARTIC) && ((*iter)->IsAnyOf({ ARTIC, NOTE })))
+                if ((bboxBelow->Is(ARTIC) && ((*iter)->IsAnyOf(std::array{ ARTIC, NOTE })))
                     || (bboxBelow->Is(NOTE) && ((*iter)->Is(ARTIC)))) {
                     minSpaceBetween = drawingUnit;
                 }

--- a/src/adjusttupletsyfunctor.cpp
+++ b/src/adjusttupletsyfunctor.cpp
@@ -337,10 +337,11 @@ AdjustTupletNumOverlapFunctor::AdjustTupletNumOverlapFunctor(
 
 FunctorCode AdjustTupletNumOverlapFunctor::VisitLayerElement(const LayerElement *layerElement)
 {
-    if (!layerElement->IsAnyOf({ ACCID, ARTIC, CHORD, DOT, FLAG, NOTE, REST, STEM }) || !layerElement->HasSelfBB())
+    if (!layerElement->IsAnyOf(std::array{ ACCID, ARTIC, CHORD, DOT, FLAG, NOTE, REST, STEM })
+        || !layerElement->HasSelfBB())
         return FUNCTOR_CONTINUE;
 
-    if (layerElement->IsAnyOf({ CHORD, NOTE, REST })
+    if (layerElement->IsAnyOf(std::array{ CHORD, NOTE, REST })
         && ((layerElement->m_crossStaff || (layerElement->GetFirstAncestor(STAFF) != m_staff))
             && (layerElement->m_crossStaff != m_staff)))
         return FUNCTOR_SIBLINGS;

--- a/src/adjusttupletsyfunctor.cpp
+++ b/src/adjusttupletsyfunctor.cpp
@@ -337,10 +337,10 @@ AdjustTupletNumOverlapFunctor::AdjustTupletNumOverlapFunctor(
 
 FunctorCode AdjustTupletNumOverlapFunctor::VisitLayerElement(const LayerElement *layerElement)
 {
-    if (!layerElement->Is({ ACCID, ARTIC, CHORD, DOT, FLAG, NOTE, REST, STEM }) || !layerElement->HasSelfBB())
+    if (!layerElement->IsAnyOf({ ACCID, ARTIC, CHORD, DOT, FLAG, NOTE, REST, STEM }) || !layerElement->HasSelfBB())
         return FUNCTOR_CONTINUE;
 
-    if (layerElement->Is({ CHORD, NOTE, REST })
+    if (layerElement->IsAnyOf({ CHORD, NOTE, REST })
         && ((layerElement->m_crossStaff || (layerElement->GetFirstAncestor(STAFF) != m_staff))
             && (layerElement->m_crossStaff != m_staff)))
         return FUNCTOR_SIBLINGS;

--- a/src/adjustxoverflowfunctor.cpp
+++ b/src/adjustxoverflowfunctor.cpp
@@ -32,7 +32,7 @@ AdjustXOverflowFunctor::AdjustXOverflowFunctor(int margin) : Functor()
 
 FunctorCode AdjustXOverflowFunctor::VisitControlElement(ControlElement *controlElement)
 {
-    if (!controlElement->IsAnyOf({ CPMARK, DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
+    if (!controlElement->IsAnyOf(std::array{ CPMARK, DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/adjustxoverflowfunctor.cpp
+++ b/src/adjustxoverflowfunctor.cpp
@@ -32,7 +32,7 @@ AdjustXOverflowFunctor::AdjustXOverflowFunctor(int margin) : Functor()
 
 FunctorCode AdjustXOverflowFunctor::VisitControlElement(ControlElement *controlElement)
 {
-    if (!controlElement->Is({ CPMARK, DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
+    if (!controlElement->IsAnyOf({ CPMARK, DIR, DYNAM, ORNAM, REPEATMARK, TEMPO })) {
         return FUNCTOR_SIBLINGS;
     }
 

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -104,12 +104,12 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
     }
 
     // If we have a list of types to exclude and it is one of them, stop it
-    if (!m_excludes.empty() && layerElement->Is(m_excludes)) {
+    if (!m_excludes.empty() && layerElement->IsAnyOf(m_excludes)) {
         return FUNCTOR_CONTINUE;
     }
 
     // If we have a list of types to include and it is not one of them, stop it
-    if (!m_includes.empty() && !layerElement->Is(m_includes)) {
+    if (!m_includes.empty() && !layerElement->IsAnyOf(m_includes)) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -160,7 +160,7 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
     Alignment *nextAlignment = vrv_cast<Alignment *>(
         layerElement->GetAlignment()->GetParent()->GetNext(layerElement->GetAlignment(), ALIGNMENT));
     AlignmentType next = nextAlignment ? nextAlignment->GetType() : ALIGNMENT_DEFAULT;
-    if (layerElement->Is({ DOTS, FLAG }) && currentReference->HasMultipleLayer()
+    if (layerElement->IsAnyOf({ DOTS, FLAG }) && currentReference->HasMultipleLayer()
         && (next != ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
         const int additionalOffset = selfRight - m_upcomingMinPos;
         if (additionalOffset > m_currentAlignment.m_offset) {
@@ -402,7 +402,7 @@ std::pair<int, int> AdjustXPosFunctor::CalculateXPosOffset(LayerElement *layerEl
         if (!overlap) {
             // if last element of the tuplet is rest, make sure there is sufficient distance between it and next
             // note/chord (for ledger lines)
-            if (layerElement->Is({ NOTE, CHORD }) && !layerElement->GetFirstAncestor(TUPLET) && bboxElement->Is(REST)
+            if (layerElement->IsAnyOf({ NOTE, CHORD }) && !layerElement->GetFirstAncestor(TUPLET) && bboxElement->Is(REST)
                 && bboxElement->GetFirstAncestor(TUPLET)) {
                 Rest *rest = vrv_cast<Rest *>(bboxElement);
                 if (rest->GetDur() > DURATION_8) {

--- a/src/adjustxposfunctor.cpp
+++ b/src/adjustxposfunctor.cpp
@@ -160,7 +160,7 @@ FunctorCode AdjustXPosFunctor::VisitLayerElement(LayerElement *layerElement)
     Alignment *nextAlignment = vrv_cast<Alignment *>(
         layerElement->GetAlignment()->GetParent()->GetNext(layerElement->GetAlignment(), ALIGNMENT));
     AlignmentType next = nextAlignment ? nextAlignment->GetType() : ALIGNMENT_DEFAULT;
-    if (layerElement->IsAnyOf({ DOTS, FLAG }) && currentReference->HasMultipleLayer()
+    if (layerElement->IsAnyOf(std::array{ DOTS, FLAG }) && currentReference->HasMultipleLayer()
         && (next != ALIGNMENT_MEASURE_RIGHT_BARLINE)) {
         const int additionalOffset = selfRight - m_upcomingMinPos;
         if (additionalOffset > m_currentAlignment.m_offset) {
@@ -402,8 +402,8 @@ std::pair<int, int> AdjustXPosFunctor::CalculateXPosOffset(LayerElement *layerEl
         if (!overlap) {
             // if last element of the tuplet is rest, make sure there is sufficient distance between it and next
             // note/chord (for ledger lines)
-            if (layerElement->IsAnyOf({ NOTE, CHORD }) && !layerElement->GetFirstAncestor(TUPLET) && bboxElement->Is(REST)
-                && bboxElement->GetFirstAncestor(TUPLET)) {
+            if (layerElement->IsAnyOf(std::array{ NOTE, CHORD }) && !layerElement->GetFirstAncestor(TUPLET)
+                && bboxElement->Is(REST) && bboxElement->GetFirstAncestor(TUPLET)) {
                 Rest *rest = vrv_cast<Rest *>(bboxElement);
                 if (rest->GetDur() > DURATION_8) {
                     overlap = 1.5 * (rest->GetDur() - DURATION_8) * drawingUnit;

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -172,7 +172,7 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
     else if (tabGrpParent) {
         layerElement->SetAlignment(tabGrpParent->GetAlignment());
     }
-    else if (layerElement->IsAnyOf({ DOTS, FLAG, STEM })) {
+    else if (layerElement->IsAnyOf(std::array{ DOTS, FLAG, STEM })) {
         assert(false);
     }
     else if (ligatureParent && layerElement->Is(NOTE) && !ligatureAsBracket) {
@@ -194,7 +194,7 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         // Nothing to do
     }
     // We do not align these (container). Any other?
-    else if (layerElement->IsAnyOf({ BEAM, FTREM, TUPLET })) {
+    else if (layerElement->IsAnyOf(std::array{ BEAM, FTREM, TUPLET })) {
         Fraction duration = layerElement->GetSameAsContentAlignmentDuration(m_currentParams, true, m_notationType);
         m_time = m_time + duration;
         return FUNCTOR_CONTINUE;
@@ -268,10 +268,10 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         }
         type = ALIGNMENT_PROPORT;
     }
-    else if (layerElement->IsAnyOf({ MULTIREST, MREST, MRPT })) {
+    else if (layerElement->IsAnyOf(std::array{ MULTIREST, MREST, MRPT })) {
         type = ALIGNMENT_FULLMEASURE;
     }
-    else if (layerElement->IsAnyOf({ MRPT2, MULTIRPT })) {
+    else if (layerElement->IsAnyOf(std::array{ MRPT2, MULTIRPT })) {
         type = ALIGNMENT_FULLMEASURE2;
     }
     else if (layerElement->Is(DOT)) {

--- a/src/alignfunctor.cpp
+++ b/src/alignfunctor.cpp
@@ -172,7 +172,7 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
     else if (tabGrpParent) {
         layerElement->SetAlignment(tabGrpParent->GetAlignment());
     }
-    else if (layerElement->Is({ DOTS, FLAG, STEM })) {
+    else if (layerElement->IsAnyOf({ DOTS, FLAG, STEM })) {
         assert(false);
     }
     else if (ligatureParent && layerElement->Is(NOTE) && !ligatureAsBracket) {
@@ -194,7 +194,7 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         // Nothing to do
     }
     // We do not align these (container). Any other?
-    else if (layerElement->Is({ BEAM, FTREM, TUPLET })) {
+    else if (layerElement->IsAnyOf({ BEAM, FTREM, TUPLET })) {
         Fraction duration = layerElement->GetSameAsContentAlignmentDuration(m_currentParams, true, m_notationType);
         m_time = m_time + duration;
         return FUNCTOR_CONTINUE;
@@ -268,10 +268,10 @@ FunctorCode AlignHorizontallyFunctor::VisitLayerElement(LayerElement *layerEleme
         }
         type = ALIGNMENT_PROPORT;
     }
-    else if (layerElement->Is({ MULTIREST, MREST, MRPT })) {
+    else if (layerElement->IsAnyOf({ MULTIREST, MREST, MRPT })) {
         type = ALIGNMENT_FULLMEASURE;
     }
-    else if (layerElement->Is({ MRPT2, MULTIRPT })) {
+    else if (layerElement->IsAnyOf({ MRPT2, MULTIRPT })) {
         type = ALIGNMENT_FULLMEASURE2;
     }
     else if (layerElement->Is(DOT)) {

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -75,7 +75,7 @@ int Arpeg::GetDrawingX() const
 
 bool Arpeg::IsValidRef(const Object *ref) const
 {
-    if (!ref->Is({ CHORD, NOTE })) {
+    if (!ref->IsAnyOf({ CHORD, NOTE })) {
         LogWarning(
             "%s is not supported as @plist target for %s", ref->GetClassName().c_str(), this->GetClassName().c_str());
         return false;

--- a/src/arpeg.cpp
+++ b/src/arpeg.cpp
@@ -75,7 +75,7 @@ int Arpeg::GetDrawingX() const
 
 bool Arpeg::IsValidRef(const Object *ref) const
 {
-    if (!ref->IsAnyOf({ CHORD, NOTE })) {
+    if (!ref->IsAnyOf(std::array{ CHORD, NOTE })) {
         LogWarning(
             "%s is not supported as @plist target for %s", ref->GetClassName().c_str(), this->GetClassName().c_str());
         return false;

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -156,7 +156,7 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         // All notes and chords get their stem value stored
         LayerElement *el = coord->m_element;
-        if (!el->IsAnyOf({ CHORD, NOTE })) continue;
+        if (!el->IsAnyOf(std::array{ CHORD, NOTE })) continue;
 
         // Get the interface for the chord or note
         StemmedDrawingInterface *stemmedInterface = coord->GetStemHolderInterface();
@@ -333,8 +333,9 @@ std::pair<int, int> BeamSegment::GetMinimalStemLength(const BeamDrawingInterface
     const auto [topOffset, bottomOffset] = this->GetVerticalOffset(beamInterface);
 
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
-    const auto isNoteOrChord
-        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->IsAnyOf({ CHORD, NOTE })); };
+    const auto isNoteOrChord = [](BeamElementCoord *coord) {
+        return (coord->m_element && coord->m_element->IsAnyOf(std::array{ CHORD, NOTE }));
+    };
 
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         if (!isNoteOrChord(coord)) continue;
@@ -458,8 +459,9 @@ void BeamSegment::AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterf
     // set to store durations of relevant notes (it's ordered, so min duration is going to be first)
     std::set<data_DURATION> noteDurations;
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
-    const auto isNoteOrChord
-        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->IsAnyOf({ CHORD, NOTE })); };
+    const auto isNoteOrChord = [](BeamElementCoord *coord) {
+        return (coord->m_element && coord->m_element->IsAnyOf(std::array{ CHORD, NOTE }));
+    };
     // iterators
     using CoordIt = ArrayOfBeamElementCoords::iterator;
     using CoordReverseIt = ArrayOfBeamElementCoords::reverse_iterator;
@@ -635,7 +637,7 @@ void BeamSegment::CalcBeamInit(
         BeamElementCoord *coord = m_beamElementCoordRefs.at(i);
         coord->m_yBeam = 0;
 
-        if (coord->m_element->IsAnyOf({ CHORD, NOTE, TABGRP })) {
+        if (coord->m_element->IsAnyOf(std::array{ CHORD, NOTE, TABGRP })) {
             if (!m_firstNoteOrChord) m_firstNoteOrChord = coord;
             m_lastNoteOrChord = coord;
             m_nbNotesOrChords++;
@@ -1849,7 +1851,7 @@ void BeamElementCoord::SetDrawingStemDir(data_STEMDIRECTION stemDir, const Staff
     }
     m_centered = (segment->m_uniformStemLength % 2) || (m_element->IsGraceNote());
 
-    if (m_element->IsAnyOf({ REST, SPACE })) {
+    if (m_element->IsAnyOf(std::array{ REST, SPACE })) {
         m_x += m_element->GetDrawingRadius(doc);
         m_yBeam = m_element->GetDrawingY();
         m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
@@ -1987,9 +1989,9 @@ int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBi
 
 StemmedDrawingInterface *BeamElementCoord::GetStemHolderInterface()
 {
-    if (!m_element || !m_element->IsAnyOf({ CHORD, NOTE, TABGRP })) return NULL;
+    if (!m_element || !m_element->IsAnyOf(std::array{ CHORD, NOTE, TABGRP })) return NULL;
 
-    if (m_element->IsAnyOf({ CHORD, NOTE })) return m_element->GetStemmedDrawingInterface();
+    if (m_element->IsAnyOf(std::array{ CHORD, NOTE })) return m_element->GetStemmedDrawingInterface();
 
     TabGrp *tabGrp = vrv_cast<TabGrp *>(m_element);
     assert(tabGrp);

--- a/src/beam.cpp
+++ b/src/beam.cpp
@@ -156,7 +156,7 @@ void BeamSegment::CalcSetStemValues(const Staff *staff, const Doc *doc, const Be
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         // All notes and chords get their stem value stored
         LayerElement *el = coord->m_element;
-        if (!el->Is({ CHORD, NOTE })) continue;
+        if (!el->IsAnyOf({ CHORD, NOTE })) continue;
 
         // Get the interface for the chord or note
         StemmedDrawingInterface *stemmedInterface = coord->GetStemHolderInterface();
@@ -334,7 +334,7 @@ std::pair<int, int> BeamSegment::GetMinimalStemLength(const BeamDrawingInterface
 
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
     const auto isNoteOrChord
-        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->Is({ CHORD, NOTE })); };
+        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->IsAnyOf({ CHORD, NOTE })); };
 
     for (BeamElementCoord *coord : m_beamElementCoordRefs) {
         if (!isNoteOrChord(coord)) continue;
@@ -459,7 +459,7 @@ void BeamSegment::AdjustBeamToFrenchStyle(const BeamDrawingInterface *beamInterf
     std::set<data_DURATION> noteDurations;
     // lambda check whether coord has element set and whether that element is CHORD or NOTE
     const auto isNoteOrChord
-        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->Is({ CHORD, NOTE })); };
+        = [](BeamElementCoord *coord) { return (coord->m_element && coord->m_element->IsAnyOf({ CHORD, NOTE })); };
     // iterators
     using CoordIt = ArrayOfBeamElementCoords::iterator;
     using CoordReverseIt = ArrayOfBeamElementCoords::reverse_iterator;
@@ -635,7 +635,7 @@ void BeamSegment::CalcBeamInit(
         BeamElementCoord *coord = m_beamElementCoordRefs.at(i);
         coord->m_yBeam = 0;
 
-        if (coord->m_element->Is({ CHORD, NOTE, TABGRP })) {
+        if (coord->m_element->IsAnyOf({ CHORD, NOTE, TABGRP })) {
             if (!m_firstNoteOrChord) m_firstNoteOrChord = coord;
             m_lastNoteOrChord = coord;
             m_nbNotesOrChords++;
@@ -1849,7 +1849,7 @@ void BeamElementCoord::SetDrawingStemDir(data_STEMDIRECTION stemDir, const Staff
     }
     m_centered = (segment->m_uniformStemLength % 2) || (m_element->IsGraceNote());
 
-    if (m_element->Is({ REST, SPACE })) {
+    if (m_element->IsAnyOf({ REST, SPACE })) {
         m_x += m_element->GetDrawingRadius(doc);
         m_yBeam = m_element->GetDrawingY();
         m_yBeam += (stemLen * doc->GetDrawingUnit(staff->m_drawingStaffSize) / 2);
@@ -1987,9 +1987,9 @@ int BeamElementCoord::CalculateStemModAdjustment(int stemLength, int directionBi
 
 StemmedDrawingInterface *BeamElementCoord::GetStemHolderInterface()
 {
-    if (!m_element || !m_element->Is({ CHORD, NOTE, TABGRP })) return NULL;
+    if (!m_element || !m_element->IsAnyOf({ CHORD, NOTE, TABGRP })) return NULL;
 
-    if (m_element->Is({ CHORD, NOTE })) return m_element->GetStemmedDrawingInterface();
+    if (m_element->IsAnyOf({ CHORD, NOTE })) return m_element->GetStemmedDrawingInterface();
 
     TabGrp *tabGrp = vrv_cast<TabGrp *>(m_element);
     assert(tabGrp);

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -42,7 +42,7 @@ BoundingBox::BoundingBox()
     this->ResetBoundingBox();
 }
 
-bool BoundingBox::Is(const std::vector<ClassId> &classIds) const
+bool BoundingBox::IsAnyOf(const std::vector<ClassId> &classIds) const
 {
     return (std::find(classIds.begin(), classIds.end(), this->GetClassId()) != classIds.end());
 }
@@ -634,7 +634,7 @@ int BoundingBox::Intersects(const FloatingCurvePositioner *curve, Accessor type,
 {
     assert(curve);
     assert(curve->GetObject());
-    assert(curve->GetObject()->Is({ LV, PHRASE, SLUR, TIE }));
+    assert(curve->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE }));
 
     // for readability
     Point points[4];

--- a/src/boundingbox.cpp
+++ b/src/boundingbox.cpp
@@ -42,11 +42,6 @@ BoundingBox::BoundingBox()
     this->ResetBoundingBox();
 }
 
-bool BoundingBox::IsAnyOf(const std::vector<ClassId> &classIds) const
-{
-    return (std::find(classIds.begin(), classIds.end(), this->GetClassId()) != classIds.end());
-}
-
 void BoundingBox::UpdateContentBBoxX(int x1, int x2)
 {
     // LogDebug("CB Was: %i %i %i %i", m_contentBB_x1, m_contentBB_y1, m_contentBB_x2, m_contentBB_y2);
@@ -634,7 +629,7 @@ int BoundingBox::Intersects(const FloatingCurvePositioner *curve, Accessor type,
 {
     assert(curve);
     assert(curve->GetObject());
-    assert(curve->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE }));
+    assert(curve->GetObject()->IsAnyOf(std::array{ LV, PHRASE, SLUR, TIE }));
 
     // for readability
     Point points[4];

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -150,7 +150,7 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitLayerElement(LayerElement *layerE
         mRest->SetDrawingLoc(loc);
         mRest->SetDrawingYRel(staffY->CalcPitchPosYRel(m_doc, loc));
     }
-    else if (layerElement->IsAnyOf({ REST, SPACE })) {
+    else if (layerElement->IsAnyOf(std::array{ REST, SPACE })) {
         DurationInterface *durInterface = layerElement->GetDurationInterface();
         assert(durInterface);
         Rest *rest = NULL;

--- a/src/calcalignmentpitchposfunctor.cpp
+++ b/src/calcalignmentpitchposfunctor.cpp
@@ -150,7 +150,7 @@ FunctorCode CalcAlignmentPitchPosFunctor::VisitLayerElement(LayerElement *layerE
         mRest->SetDrawingLoc(loc);
         mRest->SetDrawingYRel(staffY->CalcPitchPosYRel(m_doc, loc));
     }
-    else if (layerElement->Is({ REST, SPACE })) {
+    else if (layerElement->IsAnyOf({ REST, SPACE })) {
         DurationInterface *durInterface = layerElement->GetDurationInterface();
         assert(durInterface);
         Rest *rest = NULL;

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -196,7 +196,7 @@ bool Chord::AddChild(Object *child)
     child->SetParent(this);
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->Is({ DOTS, STEM })) {
+    if (child->IsAnyOf({ DOTS, STEM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/chord.cpp
+++ b/src/chord.cpp
@@ -196,7 +196,7 @@ bool Chord::AddChild(Object *child)
     child->SetParent(this);
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->IsAnyOf({ DOTS, STEM })) {
+    if (child->IsAnyOf(std::array{ DOTS, STEM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -83,7 +83,7 @@ data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment() const
 data_STAFFREL ControlElement::GetLayerPlace(data_STAFFREL defaultValue) const
 {
     // Do this only for the following elements
-    if (!this->IsAnyOf({ TRILL, MORDENT, ORNAM, REPEATMARK, TURN })) return defaultValue;
+    if (!this->IsAnyOf(std::array{ TRILL, MORDENT, ORNAM, REPEATMARK, TURN })) return defaultValue;
 
     const TimePointInterface *interface = this->GetTimePointInterface();
     assert(interface);

--- a/src/controlelement.cpp
+++ b/src/controlelement.cpp
@@ -83,7 +83,7 @@ data_HORIZONTALALIGNMENT ControlElement::GetChildRendAlignment() const
 data_STAFFREL ControlElement::GetLayerPlace(data_STAFFREL defaultValue) const
 {
     // Do this only for the following elements
-    if (!this->Is({ TRILL, MORDENT, ORNAM, REPEATMARK, TURN })) return defaultValue;
+    if (!this->IsAnyOf({ TRILL, MORDENT, ORNAM, REPEATMARK, TURN })) return defaultValue;
 
     const TimePointInterface *interface = this->GetTimePointInterface();
     assert(interface);

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -481,7 +481,7 @@ FunctorCode ConvertToCmnFunctor::VisitLayerElement(LayerElement *layerElement)
         // Reset the tuplet since we expect the num / numbase to be different
         m_proportTuplet = NULL;
     }
-    else if (layerElement->Is({ ACCID, BARLINE, DOT })) {
+    else if (layerElement->IsAnyOf({ ACCID, BARLINE, DOT })) {
         // can be ignored
     }
     else {

--- a/src/convertfunctor.cpp
+++ b/src/convertfunctor.cpp
@@ -481,7 +481,7 @@ FunctorCode ConvertToCmnFunctor::VisitLayerElement(LayerElement *layerElement)
         // Reset the tuplet since we expect the num / numbase to be different
         m_proportTuplet = NULL;
     }
-    else if (layerElement->IsAnyOf({ ACCID, BARLINE, DOT })) {
+    else if (layerElement->IsAnyOf(std::array{ ACCID, BARLINE, DOT })) {
         // can be ignored
     }
     else {

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -211,7 +211,7 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
         }
 
         // Skip rests and tabGrp
-        if (current->Is({ CHORD, NOTE })) {
+        if (current->IsAnyOf({ CHORD, NOTE })) {
             // Look at the stemDir to see if we have multiple stem Dir
             if (!m_hasMultipleStemDir) {
                 // At this stage, BeamCoord::m_stem is not necessary set, so we need to look at the Note / Chord
@@ -230,7 +230,7 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
             }
         }
         // Skip rests
-        if (current->Is({ CHORD, NOTE, TABGRP })) {
+        if (current->IsAnyOf({ CHORD, NOTE, TABGRP })) {
             // keep the shortest dur in the beam
             m_shortestDur = std::max(currentDur, m_shortestDur);
         }

--- a/src/drawinginterface.cpp
+++ b/src/drawinginterface.cpp
@@ -211,7 +211,7 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
         }
 
         // Skip rests and tabGrp
-        if (current->IsAnyOf({ CHORD, NOTE })) {
+        if (current->IsAnyOf(std::array{ CHORD, NOTE })) {
             // Look at the stemDir to see if we have multiple stem Dir
             if (!m_hasMultipleStemDir) {
                 // At this stage, BeamCoord::m_stem is not necessary set, so we need to look at the Note / Chord
@@ -230,7 +230,7 @@ void BeamDrawingInterface::InitCoords(const ListOfObjects &childList, Staff *sta
             }
         }
         // Skip rests
-        if (current->IsAnyOf({ CHORD, NOTE, TABGRP })) {
+        if (current->IsAnyOf(std::array{ CHORD, NOTE, TABGRP })) {
             // keep the shortest dur in the beam
             m_shortestDur = std::max(currentDur, m_shortestDur);
         }

--- a/src/editfunctor.cpp
+++ b/src/editfunctor.cpp
@@ -29,16 +29,16 @@ SectionContextFunctor::SectionContextFunctor(Object *object) : Functor()
 FunctorCode SectionContextFunctor::VisitObject(Object *object)
 {
     // In any case do not go beyond these
-    if (object->GetParent() && object->GetParent()->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
+    if (object->GetParent() && object->GetParent()->IsAnyOf(std::array{ DIV, MEASURE, SCOREDEF })) {
         return FUNCTOR_SIBLINGS;
     }
 
-    if (object->IsAnyOf({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf(std::array{ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
         return FUNCTOR_CONTINUE;
     }
 
     bool ownChildren = false;
-    if (object->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
+    if (object->IsAnyOf(std::array{ DIV, MEASURE, SCOREDEF })) {
         ownChildren = true;
     }
 
@@ -55,10 +55,10 @@ FunctorCode SectionContextFunctor::VisitObjectEnd(Object *object)
         return FUNCTOR_CONTINUE;
     }
 
-    if (object->IsAnyOf({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf(std::array{ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
         m_current = m_current->GetParent();
     }
-    if (object->IsAnyOf({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf(std::array{ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -83,7 +83,7 @@ ScoreContextFunctor::ScoreContextFunctor(Object *object) : Functor()
 FunctorCode ScoreContextFunctor::VisitObject(Object *object)
 {
     // In any case do not go beyond these
-    if (object->GetParent() && object->GetParent()->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
+    if (object->GetParent() && object->GetParent()->IsAnyOf(std::array{ DIV, MEASURE, SCOREDEF })) {
         return FUNCTOR_SIBLINGS;
     }
     if (m_inScoreLevel == INCLUDED) {
@@ -92,7 +92,7 @@ FunctorCode ScoreContextFunctor::VisitObject(Object *object)
     }
 
     // Do not include in the tree
-    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf({ MDIV, SCORE })) {
+    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf(std::array{ MDIV, SCORE })) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -132,7 +132,7 @@ FunctorCode ScoreContextFunctor::VisitObjectEnd(Object *object)
         m_current = m_current->GetParent();
     }
     // The have not been pushed, continue
-    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf({ MDIV, SCORE })) {
+    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf(std::array{ MDIV, SCORE })) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/editfunctor.cpp
+++ b/src/editfunctor.cpp
@@ -29,16 +29,16 @@ SectionContextFunctor::SectionContextFunctor(Object *object) : Functor()
 FunctorCode SectionContextFunctor::VisitObject(Object *object)
 {
     // In any case do not go beyond these
-    if (object->GetParent() && object->GetParent()->Is({ DIV, MEASURE, SCOREDEF })) {
+    if (object->GetParent() && object->GetParent()->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
         return FUNCTOR_SIBLINGS;
     }
 
-    if (object->Is({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
         return FUNCTOR_CONTINUE;
     }
 
     bool ownChildren = false;
-    if (object->Is({ DIV, MEASURE, SCOREDEF })) {
+    if (object->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
         ownChildren = true;
     }
 
@@ -55,10 +55,10 @@ FunctorCode SectionContextFunctor::VisitObjectEnd(Object *object)
         return FUNCTOR_CONTINUE;
     }
 
-    if (object->Is({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
         m_current = m_current->GetParent();
     }
-    if (object->Is({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
+    if (object->IsAnyOf({ DOC, PAGE, PAGES, PAGE_MILESTONE_END, SYSTEM, SYSTEM_MILESTONE_END })) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -83,7 +83,7 @@ ScoreContextFunctor::ScoreContextFunctor(Object *object) : Functor()
 FunctorCode ScoreContextFunctor::VisitObject(Object *object)
 {
     // In any case do not go beyond these
-    if (object->GetParent() && object->GetParent()->Is({ DIV, MEASURE, SCOREDEF })) {
+    if (object->GetParent() && object->GetParent()->IsAnyOf({ DIV, MEASURE, SCOREDEF })) {
         return FUNCTOR_SIBLINGS;
     }
     if (m_inScoreLevel == INCLUDED) {
@@ -92,7 +92,7 @@ FunctorCode ScoreContextFunctor::VisitObject(Object *object)
     }
 
     // Do not include in the tree
-    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->Is({ MDIV, SCORE })) {
+    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf({ MDIV, SCORE })) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -132,7 +132,7 @@ FunctorCode ScoreContextFunctor::VisitObjectEnd(Object *object)
         m_current = m_current->GetParent();
     }
     // The have not been pushed, continue
-    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->Is({ MDIV, SCORE })) {
+    if ((m_inScoreLevel == NOT_IN_SCORE) && !object->IsAnyOf({ MDIV, SCORE })) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/editortoolkit_shared.cpp
+++ b/src/editortoolkit_shared.cpp
@@ -1022,7 +1022,9 @@ void EditorToolkitShared::ContextForObject(const Object *object, jsonxx::Object 
     }
     // Remove children that are added as element parts (never exist in EditorTreeObject)
     children.erase(std::remove_if(children.begin(), children.end(),
-                       [](const Object *item) { return item->IsAnyOf({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET }); }),
+                       [](const Object *item) {
+                           return item->IsAnyOf(std::array{ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET });
+                       }),
         children.end());
 
     if (children.size() > 0) {
@@ -1053,7 +1055,7 @@ void EditorToolkitShared::ContextForObjects(const ArrayOfConstObjects &objects, 
             if (mNum->IsGenerated()) continue;
         }
         if (object->IsAttribute()) continue;
-        if (object->IsAnyOf({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET })) continue;
+        if (object->IsAnyOf(std::array{ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET })) continue;
 
         jsonxx::Object element;
         this->ContextForObject(object, element);

--- a/src/editortoolkit_shared.cpp
+++ b/src/editortoolkit_shared.cpp
@@ -606,7 +606,7 @@ bool EditorToolkitShared::Navigate(std::string &elementId, const int &direction)
 
         if (!result || (layerElement->GetAlignment() == result->GetAlignment())) continue;
 
-        if (result->Is(classIds)) break;
+        if (result->IsAnyOf(classIds)) break;
     }
 
     if (!result) {
@@ -1022,7 +1022,7 @@ void EditorToolkitShared::ContextForObject(const Object *object, jsonxx::Object 
     }
     // Remove children that are added as element parts (never exist in EditorTreeObject)
     children.erase(std::remove_if(children.begin(), children.end(),
-                       [](const Object *item) { return item->Is({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET }); }),
+                       [](const Object *item) { return item->IsAnyOf({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET }); }),
         children.end());
 
     if (children.size() > 0) {
@@ -1053,7 +1053,7 @@ void EditorToolkitShared::ContextForObjects(const ArrayOfConstObjects &objects, 
             if (mNum->IsGenerated()) continue;
         }
         if (object->IsAttribute()) continue;
-        if (object->Is({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET })) continue;
+        if (object->IsAnyOf({ DOTS, FLAG, STEM, TUPLET_NUM, TUPLET_BRACKET })) continue;
 
         jsonxx::Object element;
         this->ContextForObject(object, element);

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -103,7 +103,7 @@ Object *ExpansionMap::Expand(Expansion *expansion, xsdAnyURI_List &existingList,
 
     // find and add all relevant (and new) expansion sibling ids to deletionList
     for (Object *siblings : parent->GetChildren()) {
-        if (siblings->Is({ SECTION, ENDING, LEM, RDG })
+        if (siblings->IsAnyOf({ SECTION, ENDING, LEM, RDG })
             && std::count(deletionList.begin(), deletionList.end(), siblings->GetID()) == 0) {
             deletionList.push_back(siblings->GetID());
         }
@@ -174,7 +174,7 @@ Object *ExpansionMap::Expand(Expansion *expansion, xsdAnyURI_List &existingList,
                     if (prevIdx < childCount - 1) {
                         Object *nextElement = prevSect->GetParent()->GetChild(prevIdx + 1);
                         assert(nextElement);
-                        if (nextElement->Is({ SECTION, ENDING, LEM, RDG }) && nextElement != currSect) {
+                        if (nextElement->IsAnyOf({ SECTION, ENDING, LEM, RDG }) && nextElement != currSect) {
                             moveCurrentElement = true;
                         }
                     }

--- a/src/expansionmap.cpp
+++ b/src/expansionmap.cpp
@@ -103,7 +103,7 @@ Object *ExpansionMap::Expand(Expansion *expansion, xsdAnyURI_List &existingList,
 
     // find and add all relevant (and new) expansion sibling ids to deletionList
     for (Object *siblings : parent->GetChildren()) {
-        if (siblings->IsAnyOf({ SECTION, ENDING, LEM, RDG })
+        if (siblings->IsAnyOf(std::array{ SECTION, ENDING, LEM, RDG })
             && std::count(deletionList.begin(), deletionList.end(), siblings->GetID()) == 0) {
             deletionList.push_back(siblings->GetID());
         }
@@ -174,7 +174,7 @@ Object *ExpansionMap::Expand(Expansion *expansion, xsdAnyURI_List &existingList,
                     if (prevIdx < childCount - 1) {
                         Object *nextElement = prevSect->GetParent()->GetChild(prevIdx + 1);
                         assert(nextElement);
-                        if (nextElement->IsAnyOf({ SECTION, ENDING, LEM, RDG }) && nextElement != currSect) {
+                        if (nextElement->IsAnyOf(std::array{ SECTION, ENDING, LEM, RDG }) && nextElement != currSect) {
                             moveCurrentElement = true;
                         }
                     }

--- a/src/facsimilefunctor.cpp
+++ b/src/facsimilefunctor.cpp
@@ -43,13 +43,14 @@ SyncFromFacsimileFunctor::SyncFromFacsimileFunctor(Doc *doc) : Functor()
 
 FunctorCode SyncFromFacsimileFunctor::VisitLayerElement(LayerElement *layerElement)
 {
-    if (!layerElement->IsAnyOf({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DIVLINE, DOT, LIQUESCENT, NC, NOTE, REST, SYL }))
+    if (!layerElement->IsAnyOf(
+            std::array{ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DIVLINE, DOT, LIQUESCENT, NC, NOTE, REST, SYL }))
         return FUNCTOR_CONTINUE;
 
     Zone *zone = layerElement->GetZone();
     assert(zone);
     layerElement->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
-    if (m_currentNeumeLine && layerElement->IsAnyOf({ ACCID, SYL })) {
+    if (m_currentNeumeLine && layerElement->IsAnyOf(std::array{ ACCID, SYL })) {
         layerElement->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR - m_pageMarginTop);
     }
 
@@ -221,12 +222,13 @@ SyncToFacsimileFunctor::SyncToFacsimileFunctor(Doc *doc, double ppuFactor) : Fun
 
 FunctorCode SyncToFacsimileFunctor::VisitLayerElement(LayerElement *layerElement)
 {
-    if (!layerElement->IsAnyOf({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DOT, DIVLINE, LIQUESCENT, NC, NOTE, REST, SYL }))
+    if (!layerElement->IsAnyOf(
+            std::array{ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DOT, DIVLINE, LIQUESCENT, NC, NOTE, REST, SYL }))
         return FUNCTOR_CONTINUE;
 
     Zone *zone = this->GetZone(layerElement, layerElement->GetClassName());
     zone->SetUlx(m_view.ToDeviceContextX(layerElement->GetDrawingX()) / DEFINITION_FACTOR + m_pageMarginLeft);
-    if (m_currentNeumeLine && layerElement->IsAnyOf({ ACCID, SYL })) {
+    if (m_currentNeumeLine && layerElement->IsAnyOf(std::array{ ACCID, SYL })) {
         zone->SetUly(m_view.ToDeviceContextY(layerElement->GetDrawingY()) / DEFINITION_FACTOR + m_pageMarginTop);
     }
 

--- a/src/facsimilefunctor.cpp
+++ b/src/facsimilefunctor.cpp
@@ -43,13 +43,13 @@ SyncFromFacsimileFunctor::SyncFromFacsimileFunctor(Doc *doc) : Functor()
 
 FunctorCode SyncFromFacsimileFunctor::VisitLayerElement(LayerElement *layerElement)
 {
-    if (!layerElement->Is({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DIVLINE, DOT, LIQUESCENT, NC, NOTE, REST, SYL }))
+    if (!layerElement->IsAnyOf({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DIVLINE, DOT, LIQUESCENT, NC, NOTE, REST, SYL }))
         return FUNCTOR_CONTINUE;
 
     Zone *zone = layerElement->GetZone();
     assert(zone);
     layerElement->m_drawingFacsX = m_view.ToLogicalX(zone->GetUlx() * DEFINITION_FACTOR - m_pageMarginLeft);
-    if (m_currentNeumeLine && layerElement->Is({ ACCID, SYL })) {
+    if (m_currentNeumeLine && layerElement->IsAnyOf({ ACCID, SYL })) {
         layerElement->m_drawingFacsY = m_view.ToLogicalY(zone->GetUly() * DEFINITION_FACTOR - m_pageMarginTop);
     }
 
@@ -221,12 +221,12 @@ SyncToFacsimileFunctor::SyncToFacsimileFunctor(Doc *doc, double ppuFactor) : Fun
 
 FunctorCode SyncToFacsimileFunctor::VisitLayerElement(LayerElement *layerElement)
 {
-    if (!layerElement->Is({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DOT, DIVLINE, LIQUESCENT, NC, NOTE, REST, SYL }))
+    if (!layerElement->IsAnyOf({ ACCID, BARLINE, CHORD, CLEF, CUSTOS, DOT, DIVLINE, LIQUESCENT, NC, NOTE, REST, SYL }))
         return FUNCTOR_CONTINUE;
 
     Zone *zone = this->GetZone(layerElement, layerElement->GetClassName());
     zone->SetUlx(m_view.ToDeviceContextX(layerElement->GetDrawingX()) / DEFINITION_FACTOR + m_pageMarginLeft);
-    if (m_currentNeumeLine && layerElement->Is({ ACCID, SYL })) {
+    if (m_currentNeumeLine && layerElement->IsAnyOf({ ACCID, SYL })) {
         zone->SetUly(m_view.ToDeviceContextY(layerElement->GetDrawingY()) / DEFINITION_FACTOR + m_pageMarginTop);
     }
 

--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -120,7 +120,7 @@ FunctorCode LayerElementsInTimeSpanFunctor::VisitLayerElement(const LayerElement
         return FUNCTOR_CONTINUE;
     }
 
-    if (!layerElement->GetDurationInterface() || layerElement->Is({ MSPACE, SPACE })) return FUNCTOR_CONTINUE;
+    if (!layerElement->GetDurationInterface() || layerElement->IsAnyOf({ MSPACE, SPACE })) return FUNCTOR_CONTINUE;
 
     Fraction duration = !layerElement->GetFirstAncestor(CHORD)
         ? layerElement->GetAlignmentDuration(m_meterParams)
@@ -176,7 +176,7 @@ FunctorCode FindSpannedLayerElementsFunctor::VisitLayerElement(const LayerElemen
 {
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
-    if (!layerElement->Is(m_classIds)) {
+    if (!layerElement->IsAnyOf(m_classIds)) {
         return FUNCTOR_CONTINUE;
     }
 
@@ -267,7 +267,7 @@ FunctorCode GetRelativeLayerElementFunctor::VisitLayerElement(const LayerElement
         }
     }
 
-    if (layerElement->Is({ NOTE, CHORD, FTREM })) {
+    if (layerElement->IsAnyOf({ NOTE, CHORD, FTREM })) {
         m_relativeElement = layerElement;
         return FUNCTOR_STOP;
     }

--- a/src/findlayerelementsfunctor.cpp
+++ b/src/findlayerelementsfunctor.cpp
@@ -120,7 +120,8 @@ FunctorCode LayerElementsInTimeSpanFunctor::VisitLayerElement(const LayerElement
         return FUNCTOR_CONTINUE;
     }
 
-    if (!layerElement->GetDurationInterface() || layerElement->IsAnyOf({ MSPACE, SPACE })) return FUNCTOR_CONTINUE;
+    if (!layerElement->GetDurationInterface() || layerElement->IsAnyOf(std::array{ MSPACE, SPACE }))
+        return FUNCTOR_CONTINUE;
 
     Fraction duration = !layerElement->GetFirstAncestor(CHORD)
         ? layerElement->GetAlignmentDuration(m_meterParams)
@@ -267,7 +268,7 @@ FunctorCode GetRelativeLayerElementFunctor::VisitLayerElement(const LayerElement
         }
     }
 
-    if (layerElement->IsAnyOf({ NOTE, CHORD, FTREM })) {
+    if (layerElement->IsAnyOf(std::array{ NOTE, CHORD, FTREM })) {
         m_relativeElement = layerElement;
         return FUNCTOR_STOP;
     }

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -502,7 +502,7 @@ void FloatingPositioner::CalcDrawingYRel(
                 assert(turn);
                 yRel += turn->GetTurnHeight(doc, staffSize) / 2;
             }
-            else if (!m_object->Is({ CPMARK, DIR, HAIRPIN })) {
+            else if (!m_object->IsAnyOf({ CPMARK, DIR, HAIRPIN })) {
                 yRel += (this->GetContentY2() - this->GetContentY1()) / 2;
             }
             this->SetDrawingYRel(yRel);
@@ -528,7 +528,7 @@ void FloatingPositioner::CalcDrawingYRel(
 
         if (!hasRefinedContentBoundary) {
             // Employ special collision detection for beams and slurs/ties
-            if (curve && curve->m_object->Is({ LV, PHRASE, SLUR, TIE })) {
+            if (curve && curve->m_object->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
                 const int shift = this->Intersects(curve, CONTENT, margin);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
@@ -574,7 +574,7 @@ void FloatingPositioner::CalcDrawingYRel(
 
 void FloatingPositioner::AdjustExtenders()
 {
-    const bool isExtender = m_object->Is({ DIR, DYNAM, TEMPO }) && m_object->IsExtenderElement();
+    const bool isExtender = m_object->IsAnyOf({ DIR, DYNAM, TEMPO }) && m_object->IsExtenderElement();
     if (!isExtender) return;
 
     m_object->SetMaxDrawingYRel(this->GetDrawingYRel(), m_place);
@@ -737,7 +737,7 @@ void FloatingCurvePositioner::MoveBackVertical(int distance)
 int FloatingCurvePositioner::CalcMinMaxY(const Point points[4]) const
 {
     assert(this->GetObject());
-    assert(this->GetObject()->Is({ LV, PHRASE, SLUR, TIE }));
+    assert(this->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE }));
     assert(m_dir != curvature_CURVEDIR_NONE);
 
     if (m_cachedMinMaxY != VRV_UNSET) return m_cachedMinMaxY;
@@ -833,7 +833,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxTopY = boundingBox->GetTopBy(type);
-        if (this->GetObject()->Is({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
+        if (this->GetObject()->IsAnyOf({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxTopY = boundingBox->GetCutOutTop(*resources);
@@ -870,7 +870,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxBottomY = boundingBox->GetBottomBy(type);
-        if (this->GetObject()->Is({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
+        if (this->GetObject()->IsAnyOf({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxBottomY = boundingBox->GetCutOutBottom(*resources);

--- a/src/floatingobject.cpp
+++ b/src/floatingobject.cpp
@@ -502,7 +502,7 @@ void FloatingPositioner::CalcDrawingYRel(
                 assert(turn);
                 yRel += turn->GetTurnHeight(doc, staffSize) / 2;
             }
-            else if (!m_object->IsAnyOf({ CPMARK, DIR, HAIRPIN })) {
+            else if (!m_object->IsAnyOf(std::array{ CPMARK, DIR, HAIRPIN })) {
                 yRel += (this->GetContentY2() - this->GetContentY1()) / 2;
             }
             this->SetDrawingYRel(yRel);
@@ -528,7 +528,7 @@ void FloatingPositioner::CalcDrawingYRel(
 
         if (!hasRefinedContentBoundary) {
             // Employ special collision detection for beams and slurs/ties
-            if (curve && curve->m_object->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
+            if (curve && curve->m_object->IsAnyOf(std::array{ LV, PHRASE, SLUR, TIE })) {
                 const int shift = this->Intersects(curve, CONTENT, margin);
                 if (shift != 0) {
                     this->SetDrawingYRel(this->GetDrawingYRel() - shift);
@@ -574,7 +574,7 @@ void FloatingPositioner::CalcDrawingYRel(
 
 void FloatingPositioner::AdjustExtenders()
 {
-    const bool isExtender = m_object->IsAnyOf({ DIR, DYNAM, TEMPO }) && m_object->IsExtenderElement();
+    const bool isExtender = m_object->IsAnyOf(std::array{ DIR, DYNAM, TEMPO }) && m_object->IsExtenderElement();
     if (!isExtender) return;
 
     m_object->SetMaxDrawingYRel(this->GetDrawingYRel(), m_place);
@@ -737,7 +737,7 @@ void FloatingCurvePositioner::MoveBackVertical(int distance)
 int FloatingCurvePositioner::CalcMinMaxY(const Point points[4]) const
 {
     assert(this->GetObject());
-    assert(this->GetObject()->IsAnyOf({ LV, PHRASE, SLUR, TIE }));
+    assert(this->GetObject()->IsAnyOf(std::array{ LV, PHRASE, SLUR, TIE }));
     assert(m_dir != curvature_CURVEDIR_NONE);
 
     if (m_cachedMinMaxY != VRV_UNSET) return m_cachedMinMaxY;
@@ -833,7 +833,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxTopY = boundingBox->GetTopBy(type);
-        if (this->GetObject()->IsAnyOf({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
+        if (this->GetObject()->IsAnyOf(std::array{ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxTopY = boundingBox->GetCutOutTop(*resources);
@@ -870,7 +870,7 @@ std::pair<int, int> FloatingCurvePositioner::CalcDirectionalLeftRightAdjustment(
 
         // For selected types use the cut out boundary
         int boxBottomY = boundingBox->GetBottomBy(type);
-        if (this->GetObject()->IsAnyOf({ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
+        if (this->GetObject()->IsAnyOf(std::array{ PHRASE, SLUR }) && boundingBox->Is(ACCID)) {
             const Resources *resources = vrv_cast<const Object *>(boundingBox)->GetDocResources();
             if (resources) {
                 boxBottomY = boundingBox->GetCutOutBottom(*resources);

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -377,7 +377,7 @@ Alignment *GraceAligner::GetAlignmentAtTime(const Fraction &time, AlignmentType 
 void GraceAligner::StackGraceElement(LayerElement *element)
 {
     // Nespresso: What else?
-    assert(element->IsAnyOf({ NOTE, CHORD }));
+    assert(element->IsAnyOf(std::array{ NOTE, CHORD }));
 
     if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);
@@ -646,7 +646,7 @@ bool Alignment::AddLayerElementRef(LayerElement *element)
             }
             // staffN and layerN remain unused for barLine attributes and timestamps
             else {
-                assert(element->IsAnyOf({ BARLINE, TIMESTAMP_ATTR }));
+                assert(element->IsAnyOf(std::array{ BARLINE, TIMESTAMP_ATTR }));
             }
         }
     }

--- a/src/horizontalaligner.cpp
+++ b/src/horizontalaligner.cpp
@@ -377,7 +377,7 @@ Alignment *GraceAligner::GetAlignmentAtTime(const Fraction &time, AlignmentType 
 void GraceAligner::StackGraceElement(LayerElement *element)
 {
     // Nespresso: What else?
-    assert(element->Is({ NOTE, CHORD }));
+    assert(element->IsAnyOf({ NOTE, CHORD }));
 
     if (element->Is(NOTE)) {
         Note *note = vrv_cast<Note *>(element);
@@ -646,7 +646,7 @@ bool Alignment::AddLayerElementRef(LayerElement *element)
             }
             // staffN and layerN remain unused for barLine attributes and timestamps
             else {
-                assert(element->Is({ BARLINE, TIMESTAMP_ATTR }));
+                assert(element->IsAnyOf({ BARLINE, TIMESTAMP_ATTR }));
             }
         }
     }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1037,7 +1037,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
 {
     if (this->IsScoreBasedMEI()) {
         // In score-based MEI, page, pages and system are not written.
-        if (object->Is({ PAGE, PAGES, SYSTEM })) {
+        if (object->IsAnyOf({ PAGE, PAGES, SYSTEM })) {
             return true;
         }
 
@@ -1046,7 +1046,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
             m_boundaries.push(object->GetMilestoneEnd());
             return true;
         }
-        if (object->Is({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
+        if (object->IsAnyOf({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
             assert(!m_boundaries.empty() && (m_boundaries.top() == object));
             m_boundaries.pop();
             // For system milestone ends that point to editorial markup, we need to make sure
@@ -1064,7 +1064,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
     }
     else {
         // In page-based MEI, pb and sb are not written unless when serializing
-        if (object->Is({ PB, SB }) && !this->IsSerializing()) {
+        if (object->IsAnyOf({ PB, SB }) && !this->IsSerializing()) {
             return true;
         }
     }
@@ -1158,17 +1158,17 @@ bool MEIOutput::IsTreeObject(Object *object) const
     if (this->IsPageBasedMEI()) return !object->IsAttribute();
 
     // These are not tree objects in score-based MEI
-    if (object->Is({ PAGES, PAGE, SYSTEM })) return false;
+    if (object->IsAnyOf({ PAGES, PAGE, SYSTEM })) return false;
 
     if (this->GetBasic()) {
         // Always elements for accid, artic, fermata and tie in MEI Basic
-        if (object->Is({ ACCID, ARTIC, FERMATA, TIE })) return true;
+        if (object->IsAnyOf({ ACCID, ARTIC, FERMATA, TIE })) return true;
 
         // Always attibutes for grpSym and keyAccid in MEI Basic
-        if (object->Is({ GRPSYM, KEYACCID })) return false;
+        if (object->IsAnyOf({ GRPSYM, KEYACCID })) return false;
 
         // Always attributes for clef, keySig and meterSig in MEI Basic within a scoreDef
-        if (object->Is({ CLEF, KEYSIG, METERSIG }) && object->GetFirstAncestor(SCOREDEF)) return false;
+        if (object->IsAnyOf({ CLEF, KEYSIG, METERSIG }) && object->GetFirstAncestor(SCOREDEF)) return false;
     }
 
     return !object->IsAttribute();
@@ -1329,7 +1329,7 @@ bool MEIOutput::ProcessScoreBasedFilter(Object *object)
         }
     }
 
-    if (this->IsTreeObject(object) && !object->Is({ SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
+    if (this->IsTreeObject(object) && !object->IsAnyOf({ SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
         m_objectStack.push_back(object);
     }
 
@@ -3759,7 +3759,7 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         }
     }
     // filter for dir or tempo
-    else if (filterParent->Is({ DIR, ORNAM, REPEATMARK, TEMPO })) {
+    else if (filterParent->IsAnyOf({ DIR, ORNAM, REPEATMARK, TEMPO })) {
         if (element == "") {
             return true;
         }

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1037,7 +1037,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
 {
     if (this->IsScoreBasedMEI()) {
         // In score-based MEI, page, pages and system are not written.
-        if (object->IsAnyOf({ PAGE, PAGES, SYSTEM })) {
+        if (object->IsAnyOf(std::array{ PAGE, PAGES, SYSTEM })) {
             return true;
         }
 
@@ -1046,7 +1046,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
             m_boundaries.push(object->GetMilestoneEnd());
             return true;
         }
-        if (object->IsAnyOf({ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
+        if (object->IsAnyOf(std::array{ PAGE_MILESTONE_END, SYSTEM_MILESTONE_END })) {
             assert(!m_boundaries.empty() && (m_boundaries.top() == object));
             m_boundaries.pop();
             // For system milestone ends that point to editorial markup, we need to make sure
@@ -1064,7 +1064,7 @@ bool MEIOutput::WriteObjectEnd(Object *object)
     }
     else {
         // In page-based MEI, pb and sb are not written unless when serializing
-        if (object->IsAnyOf({ PB, SB }) && !this->IsSerializing()) {
+        if (object->IsAnyOf(std::array{ PB, SB }) && !this->IsSerializing()) {
             return true;
         }
     }
@@ -1158,17 +1158,17 @@ bool MEIOutput::IsTreeObject(Object *object) const
     if (this->IsPageBasedMEI()) return !object->IsAttribute();
 
     // These are not tree objects in score-based MEI
-    if (object->IsAnyOf({ PAGES, PAGE, SYSTEM })) return false;
+    if (object->IsAnyOf(std::array{ PAGES, PAGE, SYSTEM })) return false;
 
     if (this->GetBasic()) {
         // Always elements for accid, artic, fermata and tie in MEI Basic
-        if (object->IsAnyOf({ ACCID, ARTIC, FERMATA, TIE })) return true;
+        if (object->IsAnyOf(std::array{ ACCID, ARTIC, FERMATA, TIE })) return true;
 
         // Always attibutes for grpSym and keyAccid in MEI Basic
-        if (object->IsAnyOf({ GRPSYM, KEYACCID })) return false;
+        if (object->IsAnyOf(std::array{ GRPSYM, KEYACCID })) return false;
 
         // Always attributes for clef, keySig and meterSig in MEI Basic within a scoreDef
-        if (object->IsAnyOf({ CLEF, KEYSIG, METERSIG }) && object->GetFirstAncestor(SCOREDEF)) return false;
+        if (object->IsAnyOf(std::array{ CLEF, KEYSIG, METERSIG }) && object->GetFirstAncestor(SCOREDEF)) return false;
     }
 
     return !object->IsAttribute();
@@ -1329,7 +1329,7 @@ bool MEIOutput::ProcessScoreBasedFilter(Object *object)
         }
     }
 
-    if (this->IsTreeObject(object) && !object->IsAnyOf({ SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
+    if (this->IsTreeObject(object) && !object->IsAnyOf(std::array{ SYSTEM_MILESTONE_END, PAGE_MILESTONE_END })) {
         m_objectStack.push_back(object);
     }
 
@@ -3759,7 +3759,7 @@ bool MEIInput::IsAllowed(std::string element, Object *filterParent)
         }
     }
     // filter for dir or tempo
-    else if (filterParent->IsAnyOf({ DIR, ORNAM, REPEATMARK, TEMPO })) {
+    else if (filterParent->IsAnyOf(std::array{ DIR, ORNAM, REPEATMARK, TEMPO })) {
         if (element == "") {
             return true;
         }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -329,7 +329,7 @@ void MusicXmlInput::InsertClefIntoObject(
     }
     else {
         Object *parent = layerElement->GetParent();
-        if (parent->Is({ CHORD, FTREM, TABGRP })) {
+        if (parent->IsAnyOf({ CHORD, FTREM, TABGRP })) {
             this->InsertClefIntoObject(parent->GetParent(), clef, parent, insertAfter);
         }
         else {
@@ -454,7 +454,7 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
     if (!element->GetParent()) return;
 
     m_layerEndTimes[layer] = m_durTotal + duration;
-    if (!element->Is({ BEAM, TUPLET })) {
+    if (!element->IsAnyOf({ BEAM, TUPLET })) {
         m_layerTimes[layer].emplace(m_durTotal + duration, element);
     }
 }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -329,7 +329,7 @@ void MusicXmlInput::InsertClefIntoObject(
     }
     else {
         Object *parent = layerElement->GetParent();
-        if (parent->IsAnyOf({ CHORD, FTREM, TABGRP })) {
+        if (parent->IsAnyOf(std::array{ CHORD, FTREM, TABGRP })) {
             this->InsertClefIntoObject(parent->GetParent(), clef, parent, insertAfter);
         }
         else {
@@ -454,7 +454,7 @@ void MusicXmlInput::AddLayerElement(Layer *layer, LayerElement *element, int dur
     if (!element->GetParent()) return;
 
     m_layerEndTimes[layer] = m_durTotal + duration;
-    if (!element->IsAnyOf({ BEAM, TUPLET })) {
+    if (!element->IsAnyOf(std::array{ BEAM, TUPLET })) {
         m_layerTimes[layer].emplace(m_durTotal + duration, element);
     }
 }

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -3083,7 +3083,7 @@ bool PAEInput::Parse()
             scoreDefChange = NULL;
         }
         // Place the keySig, mensur or meterSig to the scoreDefChange - create it if necessary
-        else if (token.m_object->Is({ KEYSIG, MENSUR, METERSIG })) {
+        else if (token.m_object->IsAnyOf({ KEYSIG, MENSUR, METERSIG })) {
             if (!scoreDefChange) {
                 scoreDefChange = new ScoreDef();
                 section->InsertBefore(currentMeasure, scoreDefChange);
@@ -3102,7 +3102,7 @@ bool PAEInput::Parse()
                 scoreDefChange->AddChild(token.m_object);
                 // For the meterSig and mensur, we can have them as attribute. KeySig not because of the enclose
                 // attributes
-                if (token.m_object->Is({ MENSUR, METERSIG })) {
+                if (token.m_object->IsAnyOf({ MENSUR, METERSIG })) {
                     token.m_object->IsAttribute(true);
                     if (token.m_object->Is(METERSIG)) {
                         currentMeterSig = vrv_cast<MeterSig *>(token.m_object);
@@ -3146,7 +3146,7 @@ bool PAEInput::Parse()
             layerElementContainers.back()->AddChild(element);
 
             // Add to the stack the layer element that are containers
-            if (element->Is({ BEAM, CHORD, GRACEGRP, LIGATURE, TUPLET })) {
+            if (element->IsAnyOf({ BEAM, CHORD, GRACEGRP, LIGATURE, TUPLET })) {
                 layerElementContainers.push_back(element);
             }
         }
@@ -3768,7 +3768,7 @@ bool PAEInput::ConvertFermata()
         else if (fermataToken) {
             // We have an open fermata sign but have not reached a fermata target
             if (!fermataTarget) {
-                if (token.m_object && token.m_object->Is({ MREST, NOTE, REST })) {
+                if (token.m_object && token.m_object->IsAnyOf({ MREST, NOTE, REST })) {
                     fermataTarget = token.m_object;
                     continue;
                 }
@@ -4650,7 +4650,7 @@ bool PAEInput::CheckHierarchy()
             if (!token.m_object->IsLayerElement()) continue;
 
             // These will be added to a scoreDef
-            if (token.m_object->Is({ KEYSIG, METERSIG, MENSUR })) continue;
+            if (token.m_object->IsAnyOf({ KEYSIG, METERSIG, MENSUR })) continue;
 
             // Test is the element is supported by the current top container
             if (!token.IsContainerEnd() && !stack.back()->m_object->IsSupportedChild(token.m_object->GetClassId())) {
@@ -4665,7 +4665,7 @@ bool PAEInput::CheckHierarchy()
             }
 
             // Add to the stack the layer element that are containers
-            if (token.m_object->Is({ BEAM, CHORD, GRACEGRP, TUPLET })) {
+            if (token.m_object->IsAnyOf({ BEAM, CHORD, GRACEGRP, TUPLET })) {
                 // Begining of a container - simply push it to the stack
                 if (token.m_char != pae::CONTAINER_END) {
                     stack.push_back(&token);

--- a/src/iopae.cpp
+++ b/src/iopae.cpp
@@ -3083,7 +3083,7 @@ bool PAEInput::Parse()
             scoreDefChange = NULL;
         }
         // Place the keySig, mensur or meterSig to the scoreDefChange - create it if necessary
-        else if (token.m_object->IsAnyOf({ KEYSIG, MENSUR, METERSIG })) {
+        else if (token.m_object->IsAnyOf(std::array{ KEYSIG, MENSUR, METERSIG })) {
             if (!scoreDefChange) {
                 scoreDefChange = new ScoreDef();
                 section->InsertBefore(currentMeasure, scoreDefChange);
@@ -3102,7 +3102,7 @@ bool PAEInput::Parse()
                 scoreDefChange->AddChild(token.m_object);
                 // For the meterSig and mensur, we can have them as attribute. KeySig not because of the enclose
                 // attributes
-                if (token.m_object->IsAnyOf({ MENSUR, METERSIG })) {
+                if (token.m_object->IsAnyOf(std::array{ MENSUR, METERSIG })) {
                     token.m_object->IsAttribute(true);
                     if (token.m_object->Is(METERSIG)) {
                         currentMeterSig = vrv_cast<MeterSig *>(token.m_object);
@@ -3146,7 +3146,7 @@ bool PAEInput::Parse()
             layerElementContainers.back()->AddChild(element);
 
             // Add to the stack the layer element that are containers
-            if (element->IsAnyOf({ BEAM, CHORD, GRACEGRP, LIGATURE, TUPLET })) {
+            if (element->IsAnyOf(std::array{ BEAM, CHORD, GRACEGRP, LIGATURE, TUPLET })) {
                 layerElementContainers.push_back(element);
             }
         }
@@ -3768,7 +3768,7 @@ bool PAEInput::ConvertFermata()
         else if (fermataToken) {
             // We have an open fermata sign but have not reached a fermata target
             if (!fermataTarget) {
-                if (token.m_object && token.m_object->IsAnyOf({ MREST, NOTE, REST })) {
+                if (token.m_object && token.m_object->IsAnyOf(std::array{ MREST, NOTE, REST })) {
                     fermataTarget = token.m_object;
                     continue;
                 }
@@ -4650,7 +4650,7 @@ bool PAEInput::CheckHierarchy()
             if (!token.m_object->IsLayerElement()) continue;
 
             // These will be added to a scoreDef
-            if (token.m_object->IsAnyOf({ KEYSIG, METERSIG, MENSUR })) continue;
+            if (token.m_object->IsAnyOf(std::array{ KEYSIG, METERSIG, MENSUR })) continue;
 
             // Test is the element is supported by the current top container
             if (!token.IsContainerEnd() && !stack.back()->m_object->IsSupportedChild(token.m_object->GetClassId())) {
@@ -4665,7 +4665,7 @@ bool PAEInput::CheckHierarchy()
             }
 
             // Add to the stack the layer element that are containers
-            if (token.m_object->IsAnyOf({ BEAM, CHORD, GRACEGRP, TUPLET })) {
+            if (token.m_object->IsAnyOf(std::array{ BEAM, CHORD, GRACEGRP, TUPLET })) {
                 // Begining of a container - simply push it to the stack
                 if (token.m_char != pae::CONTAINER_END) {
                     stack.push_back(&token);

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -216,7 +216,7 @@ FTrem *LayerElement::GetAncestorFTrem()
 
 const FTrem *LayerElement::GetAncestorFTrem() const
 {
-    if (!this->Is({ CHORD, NOTE })) return NULL;
+    if (!this->IsAnyOf({ CHORD, NOTE })) return NULL;
     return vrv_cast<const FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
 }
 
@@ -227,7 +227,7 @@ Beam *LayerElement::GetAncestorBeam()
 
 const Beam *LayerElement::GetAncestorBeam() const
 {
-    if (!this->Is({ CHORD, NOTE, REST, TABGRP, TABDURSYM, STEM })) return NULL;
+    if (!this->IsAnyOf({ CHORD, NOTE, REST, TABGRP, TABDURSYM, STEM })) return NULL;
     const Beam *beamParent = vrv_cast<const Beam *>(this->GetFirstAncestor(BEAM));
     if (this->Is(REST)) return beamParent;
 
@@ -263,7 +263,7 @@ int LayerElement::GetOriginalLayerN() const
 
 void LayerElement::SetIsInBeamSpan(bool isInBeamSpan)
 {
-    if (!this->Is({ CHORD, NOTE, REST })) return;
+    if (!this->IsAnyOf({ CHORD, NOTE, REST })) return;
     m_isInBeamspan = isInBeamSpan;
 }
 
@@ -334,7 +334,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
     this->GetChordOverflow(above, below, staff->GetN());
 
     // Stems cross-staff beam need special treatment but only if the beam itself is not cross-staff
-    if (this->Is({ ARTIC, STEM })) {
+    if (this->IsAnyOf({ ARTIC, STEM })) {
         if (this->GetFirstAncestor(BEAM)) {
             Beam *beam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
             if (!beam->m_crossStaff) beam->GetBeamChildOverflow(above, below);
@@ -345,7 +345,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
         }
     }
     // Beams in cross-staff situation need special treatment
-    else if (this->Is({ BEAM, FTREM }) && !m_crossStaff) {
+    else if (this->IsAnyOf({ BEAM, FTREM }) && !m_crossStaff) {
         BeamDrawingInterface *interface = this->GetBeamDrawingInterface();
         assert(interface);
         interface->GetBeamOverflow(above, below);
@@ -356,7 +356,7 @@ void LayerElement::GetChordOverflow(StaffAlignment *&above, StaffAlignment *&bel
 {
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
     // Dots, flags and stems with cross-staff chords need special treatment
-    if (this->Is({ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
+    if (this->IsAnyOf({ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
         Staff *staffAbove = NULL;
         Staff *staffBelow = NULL;
         chord->GetCrossStaffExtremes(staffAbove, staffBelow);
@@ -452,7 +452,7 @@ int LayerElement::GetDrawingY() const
 int LayerElement::GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type) const
 {
     // It would not crash otherwise but there is not reason to call it
-    assert(this->Is({ NOTE, CHORD }));
+    assert(this->IsAnyOf({ NOTE, CHORD }));
 
     ClassIdComparison isArtic(ARTIC);
     ListOfConstObjects artics;
@@ -522,7 +522,7 @@ void LayerElement::CenterDrawingX()
 
 int LayerElement::GetDrawingTop(const Doc *doc, int staffSize, bool withArtic, ArticType type) const
 {
-    if (this->Is({ NOTE, CHORD }) && withArtic) {
+    if (this->IsAnyOf({ NOTE, CHORD }) && withArtic) {
         int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_above, type);
         if (articY != VRV_UNSET) return articY;
     }
@@ -560,7 +560,7 @@ int LayerElement::GetDrawingTop(const Doc *doc, int staffSize, bool withArtic, A
 
 int LayerElement::GetDrawingBottom(const Doc *doc, int staffSize, bool withArtic, ArticType type) const
 {
-    if (this->Is({ NOTE, CHORD }) && withArtic) {
+    if (this->IsAnyOf({ NOTE, CHORD }) && withArtic) {
         int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_below, type);
         if (articY != -VRV_UNSET) return articY;
     }
@@ -600,7 +600,7 @@ int LayerElement::GetDrawingRadius(const Doc *doc, bool isInLigature) const
 {
     assert(doc);
 
-    if (!this->Is({ CHORD, NC, NOTE, REST })) return 0;
+    if (!this->IsAnyOf({ CHORD, NC, NOTE, REST })) return 0;
 
     char32_t code = 0;
     data_DURATION dur = DURATION_4;
@@ -636,7 +636,7 @@ int LayerElement::GetDrawingRadius(const Doc *doc, bool isInLigature) const
             code = SMUFL_E0A4_noteheadBlack;
         }
     }
-    else if (this->Is({ REST, NC })) {
+    else if (this->IsAnyOf({ REST, NC })) {
         code = SMUFL_E0A4_noteheadBlack;
     }
 
@@ -749,7 +749,7 @@ Fraction LayerElement::GetAlignmentDuration(
     }
     // We align all full measure element to the current time signature, even the ones that last longer than one measure
     // If metcon is false, then the duration will remain 0 because it cannot be determined
-    else if (params.metcon && this->Is({ HALFMRPT, MREST, MULTIREST, MRPT, MRPT2, MULTIRPT })) {
+    else if (params.metcon && this->IsAnyOf({ HALFMRPT, MREST, MULTIREST, MRPT, MRPT2, MULTIRPT })) {
         data_DURATION meterUnit = DURATION_4;
         int meterCount = 4;
         if (params.meterSig && params.meterSig->HasUnit()) meterUnit = params.meterSig->GetUnitAsDur();
@@ -783,7 +783,7 @@ Fraction LayerElement::GetAlignmentDuration(bool notGraceOnly, data_NOTATIONTYPE
 Fraction LayerElement::GetSameAsContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
-    if (!this->HasSameasLink() || !this->GetSameasLink()->Is({ BEAM, FTREM, TUPLET })) {
+    if (!this->HasSameasLink() || !this->GetSameasLink()->IsAnyOf({ BEAM, FTREM, TUPLET })) {
         return Fraction(0);
     }
 
@@ -796,7 +796,7 @@ Fraction LayerElement::GetSameAsContentAlignmentDuration(
 Fraction LayerElement::GetContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
-    if (!this->Is({ BEAM, FTREM, TUPLET })) {
+    if (!this->IsAnyOf({ BEAM, FTREM, TUPLET })) {
         return Fraction(0);
     }
 
@@ -908,7 +908,7 @@ std::vector<int> LayerElement::GetElementsInUnison(
 
 MapOfDotLocs LayerElement::CalcOptimalDotLocations()
 {
-    if (!this->Is({ NOTE, CHORD })) {
+    if (!this->IsAnyOf({ NOTE, CHORD })) {
         return {};
     }
 
@@ -1086,7 +1086,7 @@ int LayerElement::AdjustOverlappingLayers(const Doc *doc, const std::vector<Laye
         if (stemSameas) return 0;
     }
 
-    if (this->Is({ ACCID, DOTS, STEM })) {
+    if (this->IsAnyOf({ ACCID, DOTS, STEM })) {
         LayerElement *parent
             = vrv_cast<LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
         assert(parent);
@@ -1212,7 +1212,7 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
             Dots *dot = vrv_cast<Dots *>(this);
             if (dot->IsAdjusted() || !HorizontalSelfOverlap(otherElements.at(i), horizontalMargin)) continue;
 
-            if (otherElements.at(i)->Is({ NOTE, STEM })) {
+            if (otherElements.at(i)->IsAnyOf({ NOTE, STEM })) {
                 shift -= otherElements.at(i)->HorizontalLeftOverlap(this, doc, shift + horizontalMargin / 2, 0);
             }
             else {

--- a/src/layerelement.cpp
+++ b/src/layerelement.cpp
@@ -216,7 +216,7 @@ FTrem *LayerElement::GetAncestorFTrem()
 
 const FTrem *LayerElement::GetAncestorFTrem() const
 {
-    if (!this->IsAnyOf({ CHORD, NOTE })) return NULL;
+    if (!this->IsAnyOf(std::array{ CHORD, NOTE })) return NULL;
     return vrv_cast<const FTrem *>(this->GetFirstAncestor(FTREM, MAX_FTREM_DEPTH));
 }
 
@@ -227,7 +227,7 @@ Beam *LayerElement::GetAncestorBeam()
 
 const Beam *LayerElement::GetAncestorBeam() const
 {
-    if (!this->IsAnyOf({ CHORD, NOTE, REST, TABGRP, TABDURSYM, STEM })) return NULL;
+    if (!this->IsAnyOf(std::array{ CHORD, NOTE, REST, TABGRP, TABDURSYM, STEM })) return NULL;
     const Beam *beamParent = vrv_cast<const Beam *>(this->GetFirstAncestor(BEAM));
     if (this->Is(REST)) return beamParent;
 
@@ -263,7 +263,7 @@ int LayerElement::GetOriginalLayerN() const
 
 void LayerElement::SetIsInBeamSpan(bool isInBeamSpan)
 {
-    if (!this->IsAnyOf({ CHORD, NOTE, REST })) return;
+    if (!this->IsAnyOf(std::array{ CHORD, NOTE, REST })) return;
     m_isInBeamspan = isInBeamSpan;
 }
 
@@ -334,7 +334,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
     this->GetChordOverflow(above, below, staff->GetN());
 
     // Stems cross-staff beam need special treatment but only if the beam itself is not cross-staff
-    if (this->IsAnyOf({ ARTIC, STEM })) {
+    if (this->IsAnyOf(std::array{ ARTIC, STEM })) {
         if (this->GetFirstAncestor(BEAM)) {
             Beam *beam = vrv_cast<Beam *>(this->GetFirstAncestor(BEAM));
             if (!beam->m_crossStaff) beam->GetBeamChildOverflow(above, below);
@@ -345,7 +345,7 @@ void LayerElement::GetOverflowStaffAlignments(StaffAlignment *&above, StaffAlign
         }
     }
     // Beams in cross-staff situation need special treatment
-    else if (this->IsAnyOf({ BEAM, FTREM }) && !m_crossStaff) {
+    else if (this->IsAnyOf(std::array{ BEAM, FTREM }) && !m_crossStaff) {
         BeamDrawingInterface *interface = this->GetBeamDrawingInterface();
         assert(interface);
         interface->GetBeamOverflow(above, below);
@@ -356,7 +356,7 @@ void LayerElement::GetChordOverflow(StaffAlignment *&above, StaffAlignment *&bel
 {
     Chord *chord = vrv_cast<Chord *>(this->GetFirstAncestor(CHORD));
     // Dots, flags and stems with cross-staff chords need special treatment
-    if (this->IsAnyOf({ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
+    if (this->IsAnyOf(std::array{ DOTS, FLAG, STEM }) && chord && chord->HasCrossStaff()) {
         Staff *staffAbove = NULL;
         Staff *staffBelow = NULL;
         chord->GetCrossStaffExtremes(staffAbove, staffBelow);
@@ -452,7 +452,7 @@ int LayerElement::GetDrawingY() const
 int LayerElement::GetDrawingArticulationTopOrBottom(data_STAFFREL place, ArticType type) const
 {
     // It would not crash otherwise but there is not reason to call it
-    assert(this->IsAnyOf({ NOTE, CHORD }));
+    assert(this->IsAnyOf(std::array{ NOTE, CHORD }));
 
     ClassIdComparison isArtic(ARTIC);
     ListOfConstObjects artics;
@@ -522,7 +522,7 @@ void LayerElement::CenterDrawingX()
 
 int LayerElement::GetDrawingTop(const Doc *doc, int staffSize, bool withArtic, ArticType type) const
 {
-    if (this->IsAnyOf({ NOTE, CHORD }) && withArtic) {
+    if (this->IsAnyOf(std::array{ NOTE, CHORD }) && withArtic) {
         int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_above, type);
         if (articY != VRV_UNSET) return articY;
     }
@@ -560,7 +560,7 @@ int LayerElement::GetDrawingTop(const Doc *doc, int staffSize, bool withArtic, A
 
 int LayerElement::GetDrawingBottom(const Doc *doc, int staffSize, bool withArtic, ArticType type) const
 {
-    if (this->IsAnyOf({ NOTE, CHORD }) && withArtic) {
+    if (this->IsAnyOf(std::array{ NOTE, CHORD }) && withArtic) {
         int articY = this->GetDrawingArticulationTopOrBottom(STAFFREL_below, type);
         if (articY != -VRV_UNSET) return articY;
     }
@@ -600,7 +600,7 @@ int LayerElement::GetDrawingRadius(const Doc *doc, bool isInLigature) const
 {
     assert(doc);
 
-    if (!this->IsAnyOf({ CHORD, NC, NOTE, REST })) return 0;
+    if (!this->IsAnyOf(std::array{ CHORD, NC, NOTE, REST })) return 0;
 
     char32_t code = 0;
     data_DURATION dur = DURATION_4;
@@ -636,7 +636,7 @@ int LayerElement::GetDrawingRadius(const Doc *doc, bool isInLigature) const
             code = SMUFL_E0A4_noteheadBlack;
         }
     }
-    else if (this->IsAnyOf({ REST, NC })) {
+    else if (this->IsAnyOf(std::array{ REST, NC })) {
         code = SMUFL_E0A4_noteheadBlack;
     }
 
@@ -749,7 +749,7 @@ Fraction LayerElement::GetAlignmentDuration(
     }
     // We align all full measure element to the current time signature, even the ones that last longer than one measure
     // If metcon is false, then the duration will remain 0 because it cannot be determined
-    else if (params.metcon && this->IsAnyOf({ HALFMRPT, MREST, MULTIREST, MRPT, MRPT2, MULTIRPT })) {
+    else if (params.metcon && this->IsAnyOf(std::array{ HALFMRPT, MREST, MULTIREST, MRPT, MRPT2, MULTIRPT })) {
         data_DURATION meterUnit = DURATION_4;
         int meterCount = 4;
         if (params.meterSig && params.meterSig->HasUnit()) meterUnit = params.meterSig->GetUnitAsDur();
@@ -783,7 +783,7 @@ Fraction LayerElement::GetAlignmentDuration(bool notGraceOnly, data_NOTATIONTYPE
 Fraction LayerElement::GetSameAsContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
-    if (!this->HasSameasLink() || !this->GetSameasLink()->IsAnyOf({ BEAM, FTREM, TUPLET })) {
+    if (!this->HasSameasLink() || !this->GetSameasLink()->IsAnyOf(std::array{ BEAM, FTREM, TUPLET })) {
         return Fraction(0);
     }
 
@@ -796,7 +796,7 @@ Fraction LayerElement::GetSameAsContentAlignmentDuration(
 Fraction LayerElement::GetContentAlignmentDuration(
     const AlignMeterParams &params, bool notGraceOnly, data_NOTATIONTYPE notationType) const
 {
-    if (!this->IsAnyOf({ BEAM, FTREM, TUPLET })) {
+    if (!this->IsAnyOf(std::array{ BEAM, FTREM, TUPLET })) {
         return Fraction(0);
     }
 
@@ -908,7 +908,7 @@ std::vector<int> LayerElement::GetElementsInUnison(
 
 MapOfDotLocs LayerElement::CalcOptimalDotLocations()
 {
-    if (!this->IsAnyOf({ NOTE, CHORD })) {
+    if (!this->IsAnyOf(std::array{ NOTE, CHORD })) {
         return {};
     }
 
@@ -1086,7 +1086,7 @@ int LayerElement::AdjustOverlappingLayers(const Doc *doc, const std::vector<Laye
         if (stemSameas) return 0;
     }
 
-    if (this->IsAnyOf({ ACCID, DOTS, STEM })) {
+    if (this->IsAnyOf(std::array{ ACCID, DOTS, STEM })) {
         LayerElement *parent
             = vrv_cast<LayerElement *>(this->GetFirstAncestorInRange(LAYER_ELEMENT, LAYER_ELEMENT_max));
         assert(parent);
@@ -1212,7 +1212,7 @@ std::pair<int, bool> LayerElement::CalcElementHorizontalOverlap(const Doc *doc,
             Dots *dot = vrv_cast<Dots *>(this);
             if (dot->IsAdjusted() || !HorizontalSelfOverlap(otherElements.at(i), horizontalMargin)) continue;
 
-            if (otherElements.at(i)->IsAnyOf({ NOTE, STEM })) {
+            if (otherElements.at(i)->IsAnyOf(std::array{ NOTE, STEM })) {
                 shift -= otherElements.at(i)->HorizontalLeftOverlap(this, doc, shift + horizontalMargin / 2, 0);
             }
             else {

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -112,7 +112,7 @@ FunctorCode LinkingInterface::InterfacePrepareStaffCurrentTimeSpanning(
     PrepareStaffCurrentTimeSpanningFunctor &functor, Object *object)
 {
     // Only dir and dynam can be spanning with @next (extender)
-    if (!object->IsAnyOf({ DIR, DYNAM })) {
+    if (!object->IsAnyOf(std::array{ DIR, DYNAM })) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/linkinginterface.cpp
+++ b/src/linkinginterface.cpp
@@ -112,7 +112,7 @@ FunctorCode LinkingInterface::InterfacePrepareStaffCurrentTimeSpanning(
     PrepareStaffCurrentTimeSpanningFunctor &functor, Object *object)
 {
     // Only dir and dynam can be spanning with @next (extender)
-    if (!object->Is({ DIR, DYNAM })) {
+    if (!object->IsAnyOf({ DIR, DYNAM })) {
         return FUNCTOR_CONTINUE;
     }
 

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -166,7 +166,7 @@ FunctorCode InitOnsetOffsetFunctor::VisitLayerElement(LayerElement *layerElement
         m_currentScoreTime = m_currentScoreTime + incrementScoreTime;
         m_currentRealTimeSeconds += incrementScoreTime.ToDouble() * 60.0 / m_currentTempo;
     }
-    else if (layerElement->Is({ BEAM, LIGATURE, FTREM, TUPLET }) && layerElement->HasSameasLink()) {
+    else if (layerElement->IsAnyOf({ BEAM, LIGATURE, FTREM, TUPLET }) && layerElement->HasSameasLink()) {
         incrementScoreTime
             = layerElement->GetSameAsContentAlignmentDuration(m_meterParams, true, m_notationType) * SCORE_TIME_UNIT;
         m_currentScoreTime = m_currentScoreTime + incrementScoreTime;
@@ -1219,7 +1219,7 @@ void GenerateTimemapFunctor::AddTimemapEntry(const Object *object)
 {
     assert(object);
 
-    if (object->Is({ NOTE, REST })) {
+    if (object->IsAnyOf({ NOTE, REST })) {
         const DurationInterface *interface = object->GetDurationInterface();
         assert(interface);
 
@@ -1275,7 +1275,7 @@ void GenerateTimemapFunctor::AddTimemapEntry(const Object *object)
         // Add the measureOn
         startEntry.measureOn = measure->GetID();
     }
-    else if (object->Is({ MREST, MULTIREST })) {
+    else if (object->IsAnyOf({ MREST, MULTIREST })) {
         // Get the ancestor measure
         const Measure *measure = vrv_cast<const Measure *>(object->GetFirstAncestor(MEASURE));
         assert(measure);

--- a/src/midifunctor.cpp
+++ b/src/midifunctor.cpp
@@ -166,7 +166,7 @@ FunctorCode InitOnsetOffsetFunctor::VisitLayerElement(LayerElement *layerElement
         m_currentScoreTime = m_currentScoreTime + incrementScoreTime;
         m_currentRealTimeSeconds += incrementScoreTime.ToDouble() * 60.0 / m_currentTempo;
     }
-    else if (layerElement->IsAnyOf({ BEAM, LIGATURE, FTREM, TUPLET }) && layerElement->HasSameasLink()) {
+    else if (layerElement->IsAnyOf(std::array{ BEAM, LIGATURE, FTREM, TUPLET }) && layerElement->HasSameasLink()) {
         incrementScoreTime
             = layerElement->GetSameAsContentAlignmentDuration(m_meterParams, true, m_notationType) * SCORE_TIME_UNIT;
         m_currentScoreTime = m_currentScoreTime + incrementScoreTime;
@@ -1219,7 +1219,7 @@ void GenerateTimemapFunctor::AddTimemapEntry(const Object *object)
 {
     assert(object);
 
-    if (object->IsAnyOf({ NOTE, REST })) {
+    if (object->IsAnyOf(std::array{ NOTE, REST })) {
         const DurationInterface *interface = object->GetDurationInterface();
         assert(interface);
 
@@ -1275,7 +1275,7 @@ void GenerateTimemapFunctor::AddTimemapEntry(const Object *object)
         // Add the measureOn
         startEntry.measureOn = measure->GetID();
     }
-    else if (object->IsAnyOf({ MREST, MULTIREST })) {
+    else if (object->IsAnyOf(std::array{ MREST, MULTIREST })) {
         // Get the ancestor measure
         const Measure *measure = vrv_cast<const Measure *>(object->GetFirstAncestor(MEASURE));
         assert(measure);

--- a/src/miscfunctor.cpp
+++ b/src/miscfunctor.cpp
@@ -126,7 +126,7 @@ FunctorCode GetAlignmentLeftRightFunctor::VisitObject(const Object *object)
 
     if (!object->HasSelfBB() || object->HasEmptyBB()) return FUNCTOR_CONTINUE;
 
-    if (object->Is(m_excludeClasses)) return FUNCTOR_CONTINUE;
+    if (object->IsAnyOf(m_excludeClasses)) return FUNCTOR_CONTINUE;
 
     m_minLeft = std::min(m_minLeft, object->GetSelfLeft());
     m_maxRight = std::max(m_maxRight, object->GetSelfRight());

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -106,7 +106,7 @@ int MRest::GetOptimalLayerLocation(const Layer *layer, int defaultLocation) cons
     // find all locations for other layer
     std::vector<int> locations;
     for (const Object *element : collidingElementsList) {
-        if (element->IsAnyOf({ CHORD, NOTE })) {
+        if (element->IsAnyOf(std::array{ CHORD, NOTE })) {
             const LayerElement *layerElement = vrv_cast<const LayerElement *>(element);
             int loc = PitchInterface::CalcLoc(layerElement, layer, layerElement, isTopLayer);
             locations.push_back(loc);

--- a/src/mrest.cpp
+++ b/src/mrest.cpp
@@ -106,7 +106,7 @@ int MRest::GetOptimalLayerLocation(const Layer *layer, int defaultLocation) cons
     // find all locations for other layer
     std::vector<int> locations;
     for (const Object *element : collidingElementsList) {
-        if (element->Is({ CHORD, NOTE })) {
+        if (element->IsAnyOf({ CHORD, NOTE })) {
             const LayerElement *layerElement = vrv_cast<const LayerElement *>(element);
             int loc = PitchInterface::CalcLoc(layerElement, layer, layerElement, isTopLayer);
             locations.push_back(loc);

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -162,7 +162,7 @@ bool Note::AddChild(Object *child)
 
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->Is({ DOTS, STEM })) {
+    if (child->IsAnyOf({ DOTS, STEM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -162,7 +162,7 @@ bool Note::AddChild(Object *child)
 
     // Stem are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->IsAnyOf({ DOTS, STEM })) {
+    if (child->IsAnyOf(std::array{ DOTS, STEM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1205,7 +1205,7 @@ FunctorCode Object::AcceptEnd(ConstFunctor &functor) const
 bool Object::SkipChildren(bool visibleOnly) const
 {
     if (visibleOnly) {
-        if (this->IsEditorialElement() || this->Is({ MDIV, STAFF }) || this->IsSystemElement()) {
+        if (this->IsEditorialElement() || this->IsAnyOf({ MDIV, STAFF }) || this->IsSystemElement()) {
             const VisibilityDrawingInterface *interface = this->GetVisibilityDrawingInterface();
             assert(interface);
             if (interface->IsHidden()) {
@@ -1612,7 +1612,7 @@ void TextListInterface::FilterList(ListOfConstObjects &childList) const
 {
     ListOfConstObjects::iterator iter = childList.begin();
     while (iter != childList.end()) {
-        if (!(*iter)->Is({ LB, TEXT })) {
+        if (!(*iter)->IsAnyOf({ LB, TEXT })) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc. but keep Lb)
             iter = childList.erase(iter);
             continue;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1205,7 +1205,7 @@ FunctorCode Object::AcceptEnd(ConstFunctor &functor) const
 bool Object::SkipChildren(bool visibleOnly) const
 {
     if (visibleOnly) {
-        if (this->IsEditorialElement() || this->IsAnyOf({ MDIV, STAFF }) || this->IsSystemElement()) {
+        if (this->IsEditorialElement() || this->IsAnyOf(std::array{ MDIV, STAFF }) || this->IsSystemElement()) {
             const VisibilityDrawingInterface *interface = this->GetVisibilityDrawingInterface();
             assert(interface);
             if (interface->IsHidden()) {
@@ -1612,7 +1612,7 @@ void TextListInterface::FilterList(ListOfConstObjects &childList) const
 {
     ListOfConstObjects::iterator iter = childList.begin();
     while (iter != childList.end()) {
-        if (!(*iter)->IsAnyOf({ LB, TEXT })) {
+        if (!(*iter)->IsAnyOf(std::array{ LB, TEXT })) {
             // remove anything that is not an LayerElement (e.g. Verse, Syl, etc. but keep Lb)
             iter = childList.erase(iter);
             continue;

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -219,7 +219,7 @@ FunctorCode PrepareCueSizeFunctor::VisitLayerElement(LayerElement *layerElement)
             if (note) accid->SetDrawingCueSize(note->GetDrawingCueSize());
         }
     }
-    else if (layerElement->IsAnyOf({ ARTIC, DOTS, FLAG, STEM })) {
+    else if (layerElement->IsAnyOf(std::array{ ARTIC, DOTS, FLAG, STEM })) {
         Note *note = vrv_cast<Note *>(layerElement->GetFirstAncestor(NOTE, MAX_NOTE_DEPTH));
         if (note)
             layerElement->SetDrawingCueSize(note->GetDrawingCueSize());
@@ -333,7 +333,7 @@ FunctorCode PrepareCrossStaffFunctor::VisitLayerElementEnd(LayerElement *layerEl
             m_currentCrossLayer = NULL;
         }
     }
-    else if (layerElement->IsAnyOf({ BEAM, BTREM, FTREM, TUPLET })) {
+    else if (layerElement->IsAnyOf(std::array{ BEAM, BTREM, FTREM, TUPLET })) {
         // For other elements (e.g., beams, tuplets) check if all their child duration elements are cross-staff
         // If yes, make them cross-staff themselves.
         ListOfObjects durations;
@@ -541,7 +541,8 @@ FunctorCode PreparePlistFunctor::VisitObject(Object *object)
         }
     }
     else {
-        if (!object->IsLayerElement() && !object->IsAnyOf({ ENDING, EXPANSION, SECTION })) return FUNCTOR_CONTINUE;
+        if (!object->IsLayerElement() && !object->IsAnyOf(std::array{ ENDING, EXPANSION, SECTION }))
+            return FUNCTOR_CONTINUE;
 
         const std::string &id = object->GetID();
         for (auto it = m_plistObjectIDPairs.begin(); it != m_plistObjectIDPairs.end();) {
@@ -656,7 +657,7 @@ FunctorCode PrepareTimePointingFunctor::VisitLayerElement(LayerElement *layerEle
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     // Do not look for tstamp pointing to these
-    if (layerElement->IsAnyOf({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf(std::array{ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
 
     ListOfPointingInterClassIdPairs::iterator iter = m_timePointingInterfaces.begin();
     while (iter != m_timePointingInterfaces.end()) {
@@ -722,7 +723,7 @@ FunctorCode PrepareTimeSpanningFunctor::VisitLayerElement(LayerElement *layerEle
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     // Do not look for tstamp pointing to these
-    if (layerElement->IsAnyOf({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf(std::array{ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
 
     ListOfSpanningInterOwnerPairs::iterator iter = m_timeSpanningInterfaces.begin();
     while (iter != m_timeSpanningInterfaces.end()) {
@@ -1010,7 +1011,7 @@ FunctorCode PreparePointersByLayerFunctor::VisitLayerElement(LayerElement *layer
         // Do not attach a note when a barline is passed
         m_currentElement = NULL;
     }
-    else if (layerElement->IsAnyOf({ NOTE, REST })) {
+    else if (layerElement->IsAnyOf(std::array{ NOTE, REST })) {
         m_currentElement = layerElement;
     }
 

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -219,7 +219,7 @@ FunctorCode PrepareCueSizeFunctor::VisitLayerElement(LayerElement *layerElement)
             if (note) accid->SetDrawingCueSize(note->GetDrawingCueSize());
         }
     }
-    else if (layerElement->Is({ ARTIC, DOTS, FLAG, STEM })) {
+    else if (layerElement->IsAnyOf({ ARTIC, DOTS, FLAG, STEM })) {
         Note *note = vrv_cast<Note *>(layerElement->GetFirstAncestor(NOTE, MAX_NOTE_DEPTH));
         if (note)
             layerElement->SetDrawingCueSize(note->GetDrawingCueSize());
@@ -333,7 +333,7 @@ FunctorCode PrepareCrossStaffFunctor::VisitLayerElementEnd(LayerElement *layerEl
             m_currentCrossLayer = NULL;
         }
     }
-    else if (layerElement->Is({ BEAM, BTREM, FTREM, TUPLET })) {
+    else if (layerElement->IsAnyOf({ BEAM, BTREM, FTREM, TUPLET })) {
         // For other elements (e.g., beams, tuplets) check if all their child duration elements are cross-staff
         // If yes, make them cross-staff themselves.
         ListOfObjects durations;
@@ -541,7 +541,7 @@ FunctorCode PreparePlistFunctor::VisitObject(Object *object)
         }
     }
     else {
-        if (!object->IsLayerElement() && !object->Is({ ENDING, EXPANSION, SECTION })) return FUNCTOR_CONTINUE;
+        if (!object->IsLayerElement() && !object->IsAnyOf({ ENDING, EXPANSION, SECTION })) return FUNCTOR_CONTINUE;
 
         const std::string &id = object->GetID();
         for (auto it = m_plistObjectIDPairs.begin(); it != m_plistObjectIDPairs.end();) {
@@ -656,7 +656,7 @@ FunctorCode PrepareTimePointingFunctor::VisitLayerElement(LayerElement *layerEle
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     // Do not look for tstamp pointing to these
-    if (layerElement->Is({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
 
     ListOfPointingInterClassIdPairs::iterator iter = m_timePointingInterfaces.begin();
     while (iter != m_timePointingInterfaces.end()) {
@@ -722,7 +722,7 @@ FunctorCode PrepareTimeSpanningFunctor::VisitLayerElement(LayerElement *layerEle
     if (layerElement->IsScoreDefElement()) return FUNCTOR_SIBLINGS;
 
     // Do not look for tstamp pointing to these
-    if (layerElement->Is({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
+    if (layerElement->IsAnyOf({ ARTIC, BEAM, FLAG, TUPLET, STEM, VERSE })) return FUNCTOR_CONTINUE;
 
     ListOfSpanningInterOwnerPairs::iterator iter = m_timeSpanningInterfaces.begin();
     while (iter != m_timeSpanningInterfaces.end()) {
@@ -1010,7 +1010,7 @@ FunctorCode PreparePointersByLayerFunctor::VisitLayerElement(LayerElement *layer
         // Do not attach a note when a barline is passed
         m_currentElement = NULL;
     }
-    else if (layerElement->Is({ NOTE, REST })) {
+    else if (layerElement->IsAnyOf({ NOTE, REST })) {
         m_currentElement = layerElement;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -542,7 +542,7 @@ int Rest::GetFirstRelativeElementLocation(
     (*layerIter)->Process(getRelativeLayerElement);
 
     const Object *lastLayerElement = getRelativeLayerElement.GetRelativeElement();
-    if (lastLayerElement && lastLayerElement->IsAnyOf({ NOTE, CHORD, FTREM })) {
+    if (lastLayerElement && lastLayerElement->IsAnyOf(std::array{ NOTE, CHORD, FTREM })) {
         return this->GetElementLocation(lastLayerElement, vrv_cast<const Layer *>(*layerIter), !isTopLayer).first;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -542,7 +542,7 @@ int Rest::GetFirstRelativeElementLocation(
     (*layerIter)->Process(getRelativeLayerElement);
 
     const Object *lastLayerElement = getRelativeLayerElement.GetRelativeElement();
-    if (lastLayerElement && lastLayerElement->Is({ NOTE, CHORD, FTREM })) {
+    if (lastLayerElement && lastLayerElement->IsAnyOf({ NOTE, CHORD, FTREM })) {
         return this->GetElementLocation(lastLayerElement, vrv_cast<const Layer *>(*layerIter), !isTopLayer).first;
     }
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -341,7 +341,7 @@ void System::AddToDrawingListIfNecessary(Object *object)
 
     if (!object->HasInterface(INTERFACE_TIME_SPANNING)) return;
 
-    if (object->Is({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
+    if (object->IsAnyOf({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
             SLUR, SYL, TIE })) {
         this->AddToDrawingList(object);
     }

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -341,8 +341,8 @@ void System::AddToDrawingListIfNecessary(Object *object)
 
     if (!object->HasInterface(INTERFACE_TIME_SPANNING)) return;
 
-    if (object->IsAnyOf({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
-            SLUR, SYL, TIE })) {
+    if (object->IsAnyOf(std::array{ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE,
+            PITCHINFLECTION, SLUR, SYL, TIE })) {
         this->AddToDrawingList(object);
     }
     else if (object->Is(DIR)) {

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -145,7 +145,7 @@ std::vector<const Staff *> TimePointInterface::GetTstampStaves(const Measure *me
     else if (this->HasStaff()) {
         bool isInBetween = false;
         // limit between support to some elements?
-        if (object->Is({ DYNAM, DIR, HAIRPIN, TEMPO })) {
+        if (object->IsAnyOf({ DYNAM, DIR, HAIRPIN, TEMPO })) {
             const AttPlacementRelStaff *att = dynamic_cast<const AttPlacementRelStaff *>(object);
             assert(att);
             isInBetween = (att->GetPlace() == STAFFREL_between);
@@ -159,7 +159,7 @@ std::vector<const Staff *> TimePointInterface::GetTstampStaves(const Measure *me
             staffList = this->GetStaff();
         }
     }
-    else if (m_start && !m_start->Is({ BARLINE, TIMESTAMP_ATTR })) {
+    else if (m_start && !m_start->IsAnyOf({ BARLINE, TIMESTAMP_ATTR })) {
         const Staff *staff = m_start->GetAncestorStaff();
         staffList.push_back(staff->GetN());
     }

--- a/src/timeinterface.cpp
+++ b/src/timeinterface.cpp
@@ -145,7 +145,7 @@ std::vector<const Staff *> TimePointInterface::GetTstampStaves(const Measure *me
     else if (this->HasStaff()) {
         bool isInBetween = false;
         // limit between support to some elements?
-        if (object->IsAnyOf({ DYNAM, DIR, HAIRPIN, TEMPO })) {
+        if (object->IsAnyOf(std::array{ DYNAM, DIR, HAIRPIN, TEMPO })) {
             const AttPlacementRelStaff *att = dynamic_cast<const AttPlacementRelStaff *>(object);
             assert(att);
             isInBetween = (att->GetPlace() == STAFFREL_between);
@@ -159,7 +159,7 @@ std::vector<const Staff *> TimePointInterface::GetTstampStaves(const Measure *me
             staffList = this->GetStaff();
         }
     }
-    else if (m_start && !m_start->IsAnyOf({ BARLINE, TIMESTAMP_ATTR })) {
+    else if (m_start && !m_start->IsAnyOf(std::array{ BARLINE, TIMESTAMP_ATTR })) {
         const Staff *staff = m_start->GetAncestorStaff();
         staffList.push_back(staff->GetN());
     }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1471,7 +1471,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
                 const std::string correspId = ExtractIDFragment(link->GetCorresp());
                 Object *origin = m_doc.FindDescendantByID(correspId);
                 // if no original element was found, try searching through scoredef in score (only for certain elements)
-                if (!origin && element->IsAnyOf({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
+                if (!origin && element->IsAnyOf(std::array{ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
                     Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
                     if (page && page->m_score && page->m_score->GetScoreDef()) {
                         origin = page->m_score->GetScoreDef()->FindDescendantByID(correspId);
@@ -1962,7 +1962,7 @@ std::string Toolkit::GetElementsAtTime(int millisec)
             Chord *chord = note->IsChordTone();
             if (chord) chords.push_back(chord);
         }
-        else if (object->IsAnyOf({ MREST, MULTIREST, REST })) {
+        else if (object->IsAnyOf(std::array{ MREST, MULTIREST, REST })) {
             restArray << object->GetID();
         }
     }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1471,7 +1471,7 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
                 const std::string correspId = ExtractIDFragment(link->GetCorresp());
                 Object *origin = m_doc.FindDescendantByID(correspId);
                 // if no original element was found, try searching through scoredef in score (only for certain elements)
-                if (!origin && element->Is({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
+                if (!origin && element->IsAnyOf({ CLEF, GRPSYM, KEYSIG, MENSUR, METERSIG, METERSIGGRP })) {
                     Page *page = vrv_cast<Page *>(m_doc.FindDescendantByType(PAGE));
                     if (page && page->m_score && page->m_score->GetScoreDef()) {
                         origin = page->m_score->GetScoreDef()->FindDescendantByID(correspId);
@@ -1962,7 +1962,7 @@ std::string Toolkit::GetElementsAtTime(int millisec)
             Chord *chord = note->IsChordTone();
             if (chord) chords.push_back(chord);
         }
-        else if (object->Is({ MREST, MULTIREST, REST })) {
+        else if (object->IsAnyOf({ MREST, MULTIREST, REST })) {
             restArray << object->GetID();
         }
     }

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -94,7 +94,7 @@ bool Tuplet::AddChild(Object *child)
 
     // Num and bracket are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->Is({ TUPLET_BRACKET, TUPLET_NUM })) {
+    if (child->IsAnyOf({ TUPLET_BRACKET, TUPLET_NUM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/tuplet.cpp
+++ b/src/tuplet.cpp
@@ -94,7 +94,7 @@ bool Tuplet::AddChild(Object *child)
 
     // Num and bracket are always added by PrepareLayerElementParts (for now) and we want them to be in the front
     // for the drawing order in the SVG output
-    if (child->IsAnyOf({ TUPLET_BRACKET, TUPLET_NUM })) {
+    if (child->IsAnyOf(std::array{ TUPLET_BRACKET, TUPLET_NUM })) {
         children.insert(children.begin(), child);
     }
     else {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -743,7 +743,7 @@ void StaffAlignment::SetCurrentFloatingPositioner(
 {
     FloatingPositioner *positioner = this->GetCorrespFloatingPositioner(object);
     if (positioner == NULL) {
-        if (object->Is({ LV, PHRASE, SLUR, TIE })) {
+        if (object->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
             positioner = new FloatingCurvePositioner(object, this, spanningType);
             m_floatingPositioners.push_back(positioner);
         }
@@ -801,7 +801,7 @@ void StaffAlignment::FindAllIntersectionPoints(
 {
     for (const auto positioner : m_floatingPositioners) {
         assert(positioner->GetObject());
-        if (!positioner->GetObject()->Is(classIds)) {
+        if (!positioner->GetObject()->IsAnyOf(classIds)) {
             continue;
         }
         if (positioner->HorizontalContentOverlap(&boundingBox, margin / 2)) {

--- a/src/verticalaligner.cpp
+++ b/src/verticalaligner.cpp
@@ -743,7 +743,7 @@ void StaffAlignment::SetCurrentFloatingPositioner(
 {
     FloatingPositioner *positioner = this->GetCorrespFloatingPositioner(object);
     if (positioner == NULL) {
-        if (object->IsAnyOf({ LV, PHRASE, SLUR, TIE })) {
+        if (object->IsAnyOf(std::array{ LV, PHRASE, SLUR, TIE })) {
             positioner = new FloatingCurvePositioner(object, this, spanningType);
             m_floatingPositioners.push_back(positioner);
         }

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -79,8 +79,8 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
     this->StartOffset(dc, element, 100);
 
     // For dir, dynam, fermata, and harm, we do not consider the @tstamp2 for rendering
-    if (element->IsAnyOf({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
-            SLUR, TIE })) {
+    if (element->IsAnyOf(std::array{ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE,
+            PITCHINFLECTION, SLUR, TIE })) {
         // create placeholder
         dc->StartGraphic(element, "", element->GetID());
         dc->EndGraphic(element, this);
@@ -190,7 +190,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
         BBoxDeviceContext *bBoxDC = vrv_cast<BBoxDeviceContext *>(dc);
         assert(bBoxDC);
         if (!bBoxDC->UpdateVerticalValues()) {
-            if (element->IsAnyOf({ ANNOTSCORE, BRACKETSPAN, HAIRPIN, OCTAVE, PITCHINFLECTION })) return;
+            if (element->IsAnyOf(std::array{ ANNOTSCORE, BRACKETSPAN, HAIRPIN, OCTAVE, PITCHINFLECTION })) return;
         }
     }
 
@@ -326,7 +326,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
 
         // TimeSpanning elements are not necessary floating elements (e.g., syl) - we have a bounding box only for them
         if (element->IsControlElement()) {
-            if (element->IsAnyOf({ PHRASE, SLUR })) {
+            if (element->IsAnyOf(std::array{ PHRASE, SLUR })) {
                 if (this->GetSlurHandling() == SlurHandling::Ignore) break;
                 Slur *slur = vrv_cast<Slur *>(element);
                 assert(slur);
@@ -446,7 +446,7 @@ bool View::HasValidTimeSpanningOrder(DeviceContext *dc, Object *element, LayerEl
                 }
             }
         }
-        else if (element->IsAnyOf({ OCTAVE, SYL })) {
+        else if (element->IsAnyOf(std::array{ OCTAVE, SYL })) {
             return true;
         }
         // To avoid showing the same warning multiple times, display a warning only during actual drawing

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -79,7 +79,7 @@ void View::DrawControlElement(DeviceContext *dc, ControlElement *element, Measur
     this->StartOffset(dc, element, 100);
 
     // For dir, dynam, fermata, and harm, we do not consider the @tstamp2 for rendering
-    if (element->Is({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
+    if (element->IsAnyOf({ ANNOTSCORE, BEAMSPAN, BRACKETSPAN, FIGURE, GLISS, HAIRPIN, LV, OCTAVE, PHRASE, PITCHINFLECTION,
             SLUR, TIE })) {
         // create placeholder
         dc->StartGraphic(element, "", element->GetID());
@@ -190,7 +190,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
         BBoxDeviceContext *bBoxDC = vrv_cast<BBoxDeviceContext *>(dc);
         assert(bBoxDC);
         if (!bBoxDC->UpdateVerticalValues()) {
-            if (element->Is({ ANNOTSCORE, BRACKETSPAN, HAIRPIN, OCTAVE, PITCHINFLECTION })) return;
+            if (element->IsAnyOf({ ANNOTSCORE, BRACKETSPAN, HAIRPIN, OCTAVE, PITCHINFLECTION })) return;
         }
     }
 
@@ -326,7 +326,7 @@ void View::DrawTimeSpanningElement(DeviceContext *dc, Object *element, System *s
 
         // TimeSpanning elements are not necessary floating elements (e.g., syl) - we have a bounding box only for them
         if (element->IsControlElement()) {
-            if (element->Is({ PHRASE, SLUR })) {
+            if (element->IsAnyOf({ PHRASE, SLUR })) {
                 if (this->GetSlurHandling() == SlurHandling::Ignore) break;
                 Slur *slur = vrv_cast<Slur *>(element);
                 assert(slur);
@@ -446,7 +446,7 @@ bool View::HasValidTimeSpanningOrder(DeviceContext *dc, Object *element, LayerEl
                 }
             }
         }
-        else if (element->Is({ OCTAVE, SYL })) {
+        else if (element->IsAnyOf({ OCTAVE, SYL })) {
             return true;
         }
         // To avoid showing the same warning multiple times, display a warning only during actual drawing

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -489,7 +489,7 @@ void View::DrawLabels(
 {
     assert(dc);
     assert(scoreDef);
-    assert(object->Is({ LAYERDEF, STAFFDEF, STAFFGRP }));
+    assert(object->IsAnyOf({ LAYERDEF, STAFFDEF, STAFFGRP }));
 
     Label *label = vrv_cast<Label *>(object->FindDescendantByType(LABEL, 1));
     LabelAbbr *labelAbbr = vrv_cast<LabelAbbr *>(object->FindDescendantByType(LABELABBR, 1));
@@ -1811,7 +1811,7 @@ void View::DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, St
             // cast to EditorialElement check in DrawLayerEditorialElement
             this->DrawLayerEditorialElement(dc, dynamic_cast<EditorialElement *>(current), layer, staff, measure);
         }
-        else if (!current->Is({ LABEL, LABELABBR })) {
+        else if (!current->IsAnyOf({ LABEL, LABELABBR })) {
             assert(false);
         }
     }

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -489,7 +489,7 @@ void View::DrawLabels(
 {
     assert(dc);
     assert(scoreDef);
-    assert(object->IsAnyOf({ LAYERDEF, STAFFDEF, STAFFGRP }));
+    assert(object->IsAnyOf(std::array{ LAYERDEF, STAFFDEF, STAFFGRP }));
 
     Label *label = vrv_cast<Label *>(object->FindDescendantByType(LABEL, 1));
     LabelAbbr *labelAbbr = vrv_cast<LabelAbbr *>(object->FindDescendantByType(LABELABBR, 1));
@@ -1811,7 +1811,7 @@ void View::DrawLayerChildren(DeviceContext *dc, Object *parent, Layer *layer, St
             // cast to EditorialElement check in DrawLayerEditorialElement
             this->DrawLayerEditorialElement(dc, dynamic_cast<EditorialElement *>(current), layer, staff, measure);
         }
-        else if (!current->IsAnyOf({ LABEL, LABELABBR })) {
+        else if (!current->IsAnyOf(std::array{ LABEL, LABELABBR })) {
             assert(false);
         }
     }


### PR DESCRIPTION
Follow up of the optimisation potential brought by #4342.

Following a ChatGPT suggestion, the `BoundinBox::Is(const std::vector &)` (now IsAnyOf) has been modified to use `std::array`.

There is a small change needed in the call so `IsAnyOf({CHORD, NOTE, REST})` is now `IsAnyOf(std::array{CHORD, NOTE, REST})`.

I haven't ran a proper evaluation, but a quick test shows a processing time reduced from 2.20s to 1.80s. 

@sonovice could you evaluate against your test set?