### PR TITLE
Avoid generating empty accid

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3154,12 +3154,14 @@ void MusicXmlInput::ReadMusicXmlNote(
             // or update the carried-over accidentals with current accidental value.
             if (note->HasPname()) {
                 ListOfObjects accids = note->FindAllDescendantsByType(ACCID);
-                if (!accids.size()) {
+                if (accids.empty()) {
                     try {
                         for (const auto &current : m_currentAccids.at(note->GetPname())) {
+                            // Avoid adding empty accidentals
+                            if (current.m_accid == ACCIDENTAL_WRITTEN_NONE && current.m_glyphName.empty()) continue;
+
                             Accid *accid = new Accid();
                             note->AddChild(accid);
-                            accid->IsAttribute(false);
 
                             // to make sure the new *gestural* accidental conforms to the carried-over *written*
                             // accidental, we translate the latter to a SMuFL glyph and set the gestural accidental to
@@ -3170,7 +3172,8 @@ void MusicXmlInput::ReadMusicXmlNote(
                                 accid->SetGlyphName(current.m_glyphName);
                                 accid->SetGlyphAuth(current.m_glyphAuth);
                             }
-                            else if (current.m_accid != ACCIDENTAL_WRITTEN_NONE) {
+                            // We have a current.m_accid
+                            else {
                                 char32_t glyph = Accid::GetAccidGlyph(current.m_accid);
                                 accid->SetGlyphName(CustomTuning::GetGlyphName(glyph, m_doc));
                                 accid->SetGlyphAuth("smufl");


### PR DESCRIPTION
Fixes #4340 and replaces #4341

<details>
<summary>Input 1</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="4.0">
  <part-list>
    <score-part id="P1">
      <part-name print-object="no">Oboe</part-name>
      <part-abbreviation print-object="no">Ob.</part-abbreviation>
      <score-instrument id="P1-I1">
        <instrument-name>Oboe</instrument-name>
        <instrument-sound>wind.reed.oboe</instrument-sound>
      </score-instrument>
      <midi-device id="P1-I1" port="1"></midi-device>
      <midi-instrument id="P1-I1">
        <midi-channel>1</midi-channel>
        <midi-program>69</midi-program>
        <volume>78.7402</volume>
        <pan>0</pan>
      </midi-instrument>
    </score-part>
  </part-list>
  <part id="P1">
    <measure number="1">
      <attributes>
        <divisions>1</divisions>
        <key>
          <fifths>0</fifths>
        </key>
        <time>
          <beats>4</beats>
          <beat-type>4</beat-type>
        </time>
        <clef>
          <sign>G</sign>
          <line>2</line>
        </clef>
      </attributes>
      <note>
        <pitch>
          <step>C</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>D</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>E</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>F</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
    </measure>
    <measure number="2">
      <note>
        <pitch>
          <step>G</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>A</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>B</step>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <note>
        <pitch>
          <step>C</step>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
    </measure>
    <measure number="3">
      <attributes>
        <key>
          <fifths>7</fifths>
        </key>
      </attributes>
      <note>
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>D</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>E</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>F</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
    </measure>
    <measure number="4">
      <note>
        <pitch>
          <step>G</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>A</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>B</step>
          <alter>1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <note>
        <pitch>
          <step>C</step>
          <alter>1</alter>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <barline location="right">
        <bar-style>light-light</bar-style>
      </barline>
    </measure>
    <measure number="5">
      <attributes>
        <key>
          <fifths>-7</fifths>
        </key>
      </attributes>
      <note>
        <pitch>
          <step>C</step>
          <alter>-1</alter>
          <octave>5</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <note>
        <pitch>
          <step>B</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>down</stem>
      </note>
      <note>
        <pitch>
          <step>A</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>G</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
    </measure>
    <measure number="6">
      <note>
        <pitch>
          <step>F</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>E</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>D</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <note>
        <pitch>
          <step>C</step>
          <alter>-1</alter>
          <octave>4</octave>
        </pitch>
        <duration>1</duration>
        <voice>1</voice>
        <type>quarter</type>
        <stem>up</stem>
      </note>
      <barline location="right">
        <bar-style>light-heavy</bar-style>
      </barline>
    </measure>
  </part>
</score-partwise>
```
</details>

<details>
<summary>Output 1</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="6.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title />
            <respStmt />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2026-06-09T08:34:10" version="6.3.0-dev-7e02fe4">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="1">
                        <instrDef midi.channel="0" midi.instrnum="68" midi.volume="78%" />
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <expansion plist="#l191w1tz" />
                  <section xml:id="l191w1tz">
                     <measure n="1">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up" />
                              <note dur.ppq="1" dur="4" oct="4" pname="d" stem.dir="up" />
                              <note dur.ppq="1" dur="4" oct="4" pname="e" stem.dir="up" />
                              <note dur.ppq="1" dur="4" oct="4" pname="f" stem.dir="up" />
                           </layer>
                        </staff>
                     </measure>
                     <measure n="2">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="4" pname="g" stem.dir="up" />
                              <note dur.ppq="1" dur="4" oct="4" pname="a" stem.dir="up" />
                              <note dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="down" />
                              <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down" />
                           </layer>
                        </staff>
                     </measure>
                     <scoreDef>
                        <keySig sig="7s" />
                     </scoreDef>
                     <measure n="3">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="d" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="e" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="f" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                           </layer>
                        </staff>
                     </measure>
                     <measure right="dbl" n="4">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="4" pname="g" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="a" stem.dir="up">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="down">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                 <accid accid.ges="s" glyph.auth="smufl" glyph.name="accidentalSharp" />
                              </note>
                           </layer>
                        </staff>
                     </measure>
                     <scoreDef>
                        <keySig sig="7f" />
                     </scoreDef>
                     <measure n="5">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="5" pname="c" stem.dir="down">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="b" stem.dir="down">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="a" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="g" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                           </layer>
                        </staff>
                     </measure>
                     <measure right="end" n="6">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="1" dur="4" oct="4" pname="f" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="e" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="d" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                              <note dur.ppq="1" dur="4" oct="4" pname="c" stem.dir="up">
                                 <accid accid.ges="f" glyph.auth="smufl" glyph.name="accidentalFlat" />
                              </note>
                           </layer>
                        </staff>
                     </measure>
                  </section>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

<details>
<summary>Input 2</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
<score-partwise version="4.0">
 <work>
  <work-title>GitHub PR #4341</work-title>
 </work>
 <part-list>
  <score-part id="P1">
   <part-name>Piano</part-name>
   <part-abbreviation>Pno.</part-abbreviation>
   <score-instrument id="P1-I1">
    <instrument-name>Piano</instrument-name>
    <instrument-sound>keyboard.piano</instrument-sound>
   </score-instrument>
   <midi-device id="P1-I1" port="1"></midi-device>
   <midi-instrument id="P1-I1">
    <midi-channel>1</midi-channel>
    <midi-program>1</midi-program>
    <volume>78.7402</volume>
    <pan>0</pan>
   </midi-instrument>
  </score-part>
 </part-list>
 <part id="P1">
  <measure number="1" width="520.62">
   <attributes>
    <divisions>1</divisions>
    <key>
     <fifths>0</fifths>
    </key>
    <time>
     <beats>4</beats>
     <beat-type>4</beat-type>
    </time>
    <clef>
     <sign>G</sign>
     <line>2</line>
    </clef>
   </attributes>
   <note>
    <pitch>
     <step>E</step>
     <alter>0.5</alter>
     <octave>4</octave>
    </pitch>
    <duration>2</duration>
    <voice>1</voice>
    <type>quarter</type>
    <accidental>quarter-sharp</accidental>
    <stem>up</stem>
   </note>
   <note default-x="241.67" default-y="-40">
    <pitch>
     <step>E</step>
     <alter>0.5</alter>
     <octave>4</octave>
    </pitch>
    <duration>2</duration>
    <voice>1</voice>
    <type>quarter</type>
    <stem>up</stem>
   </note>
 </part>
</score-partwise>
```
</details>

<details>
<summary>Output 2</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="6.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>GitHub PR #4341</title>
            <respStmt />
         </titleStmt>
         <pubStmt />
      </fileDesc>
      <encodingDesc>
         <appInfo>
            <application isodate="2026-06-09T08:33:33" version="6.3.0-dev-7e02fe4">
               <name>Verovio</name>
               <p>Transcoded from MusicXML</p>
            </application>
         </appInfo>
      </encodingDesc>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef>
                  <staffGrp>
                     <staffDef n="1" lines="5" ppq="1">
                        <label>Piano</label>
                        <labelAbbr>Pno.</labelAbbr>
                        <instrDef midi.channel="0" midi.instrnum="0" midi.volume="78%" />
                        <clef shape="G" line="2" />
                        <keySig sig="0" />
                        <meterSig count="4" unit="4" />
                     </staffDef>
                  </staffGrp>
               </scoreDef>
               <section>
                  <expansion plist="#xpb5cjm" />
                  <section xml:id="xpb5cjm">
                     <measure n="1">
                        <staff n="1">
                           <layer n="1">
                              <note dur.ppq="2" dur="4" oct="4" pname="e" stem.dir="up">
                                 <accid accid="1qs" accid.ges="su" />
                              </note>
                              <note dur.ppq="2" dur="4" oct="4" pname="e" stem.dir="up">
                                 <accid accid.ges="su" glyph.auth="smufl" glyph.name="accidentalQuarterToneSharpStein" />
                              </note>
                           </layer>
                        </staff>
                     </measure>
                  </section>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>

```
</details>