### PR TITLE
Fixed: include git_commit.h if it is available

### DIFF
--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -27,15 +27,13 @@
 
 //----------------------------------------------------------------------------
 
-// Windows has no Bourne shell (sh), therefore no "git_commit.h" is created.
-#ifndef _WIN32
+// Use the generated git commit header when it is available.
 #ifdef COCOAPODS
 #define GIT_COMMIT "[cocoapods]"
 #elif defined(SWIFT_PACKAGE)
 #define GIT_COMMIT "[swift-package]"
-#else
+#elif __has_include("git_commit.h")
 #include "git_commit.h"
-#endif
 #else
 #define GIT_COMMIT "[undefined]"
 #endif


### PR DESCRIPTION
This fix removes the specific WIN32 guard against including git_commit.h.

Now, if the git_commit.h file exists it will be included, even if it's on WIN32. Otherwise, it will fall back to setting the GIT_COMMIT to "[undefined]"

AI was used to suggest the fix, but it was manually verified.