### PR TITLE
Generate MIDI file in test-suite

### DIFF
--- a/doc/test-suite.py
+++ b/doc/test-suite.py
@@ -108,6 +108,7 @@ if __name__ == '__main__':
             svgFile = os.path.join(path2, item1, name + '.svg')
             pngFile = os.path.join(path2, item1, name + '.png')
             timeMapFile = os.path.join(path2, item1, name + '.json')
+            midiFile = os.path.join(path2, item1, name + '.mid')
 
             # parse the MEI file
             if ext == '.mei':
@@ -129,5 +130,7 @@ if __name__ == '__main__':
             svg2png(bytestring=svgString, scale=2, write_to=pngFile)
             # create time map
             tk.renderToTimemapFile(timeMapFile)
+            # create MIDI file
+            tk.renderToMIDIFile(midiFile)
             tk.resetOptions()
             options.clear()


### PR DESCRIPTION
This PR only adds MIDI generation to `test-suite.py` to ensure that the PR at https://github.com/rism-digital/verovio/pull/4365 has MIDI files to compare in both branches.
