### PR TITLE
Add pitch position query API for rendered layouts

### DIFF
--- a/emscripten/exports.txt
+++ b/emscripten/exports.txt
@@ -23,6 +23,7 @@ _vrvToolkit_getPageCount
 _vrvToolkit_getPageWithElement
 _vrvToolkit_getTimeForElement
 _vrvToolkit_getTimesForElement
+_vrvToolkit_getPitchPosition
 _vrvToolkit_getVersion
 _vrvToolkit_loadData
 _vrvToolkit_loadZipDataBase64

--- a/emscripten/npm/src/emscripten-proxy.js
+++ b/emscripten/npm/src/emscripten-proxy.js
@@ -78,7 +78,7 @@ function getToolkitFunction(VerovioModule, method) {
     // char *getTimesForElement(Toolkit *ic, const char *xmlId)
     mapping.getTimesForElement = VerovioModule.cwrap("vrvToolkit_getTimesForElement", "string", ["number", "string"]);
 
-    // char *getPitchPosition(Toolkit *ic, double scoreTime, int midiPitch, int staff)
+    // char *getPitchPosition(Toolkit *ic, double scoreTime, double midiPitch, int staff)
     mapping.getPitchPosition = VerovioModule.cwrap("vrvToolkit_getPitchPosition", "string", ["number", "number", "number", "number"]);
 
     // char *getMIDIValuesForElement(Toolkit *ic, const char *xmlId)

--- a/emscripten/npm/src/emscripten-proxy.js
+++ b/emscripten/npm/src/emscripten-proxy.js
@@ -78,6 +78,9 @@ function getToolkitFunction(VerovioModule, method) {
     // char *getTimesForElement(Toolkit *ic, const char *xmlId)
     mapping.getTimesForElement = VerovioModule.cwrap("vrvToolkit_getTimesForElement", "string", ["number", "string"]);
 
+    // char *getPitchPosition(Toolkit *ic, double scoreTime, int midiPitch, int staff)
+    mapping.getPitchPosition = VerovioModule.cwrap("vrvToolkit_getPitchPosition", "string", ["number", "number", "number", "number"]);
+
     // char *getMIDIValuesForElement(Toolkit *ic, const char *xmlId)
     mapping.getMIDIValuesForElement = VerovioModule.cwrap("vrvToolkit_getMIDIValuesForElement", "string", ["number", "string"]);
 

--- a/emscripten/npm/src/verovio-toolkit.js
+++ b/emscripten/npm/src/verovio-toolkit.js
@@ -112,6 +112,10 @@ export class VerovioToolkit {
         return JSON.parse(this.proxy.getTimesForElement(this.ptr, xmlId));
     }
 
+    getPitchPosition(scoreTime, midiPitch, staff = 1) {
+        return JSON.parse(this.proxy.getPitchPosition(this.ptr, scoreTime, midiPitch, staff));
+    }
+
     getVersion() {
         return this.proxy.getVersion(this.ptr);
     }

--- a/emscripten/npm/test/get-pitch-position-xml.mjs
+++ b/emscripten/npm/test/get-pitch-position-xml.mjs
@@ -61,32 +61,6 @@ const findNoteheadTranslate = (chunk) => {
   };
 };
 
-const parseStaffLineBounds = (measureChunk) => {
-  if (!measureChunk) return null;
-  const matches = [
-    ...measureChunk.matchAll(/M([\d.]+)\s+([\d.]+)\s+L([\d.]+)\s+([\d.]+)/g),
-  ];
-  if (!matches.length) return null;
-  const points = matches.flatMap((match) => [
-    {
-      x: Number.parseFloat(match[1]),
-      y: Number.parseFloat(match[2]),
-    },
-    {
-      x: Number.parseFloat(match[3]),
-      y: Number.parseFloat(match[4]),
-    },
-  ]);
-  const xs = points.map((p) => p.x);
-  const ys = points.map((p) => p.y);
-  return {
-    minX: Math.min(...xs),
-    maxX: Math.max(...xs),
-    minY: Math.min(...ys),
-    maxY: Math.max(...ys),
-  };
-};
-
 const main = async () => {
   const xml = readFile(TEST_XML_URL);
   const module = await createVerovioModule();
@@ -147,10 +121,6 @@ const main = async () => {
   const contentHeight = viewBoxHeight !== null ? viewBoxHeight - marginY : null;
   const pitchAbs = { x: pitchPosition.x, y: pitchPosition.y };
 
-  const measureId = pitchPosition.measureId;
-  const measureChunk = measureId ? findSnippet(svg, measureId, 6000) : null;
-  const staffBounds = parseStaffLineBounds(measureChunk);
-
   console.log('Timemap notes (first 8):');
   console.log(
     noteEntries.slice(0, 8).map((entry) => ({
@@ -182,14 +152,6 @@ const main = async () => {
       dy: Math.round(pitchAbs.y - noteAbs.y),
     });
     console.log('');
-  }
-  if (staffBounds) {
-    console.log('Staff line bounds (measure):');
-    console.log(staffBounds);
-    console.log('Pitch inside staff bounds:', {
-      x: pitchAbs.x >= staffBounds.minX && pitchAbs.x <= staffBounds.maxX,
-      y: pitchAbs.y >= staffBounds.minY && pitchAbs.y <= staffBounds.maxY,
-    });
   }
 };
 

--- a/emscripten/npm/test/get-pitch-position-xml.mjs
+++ b/emscripten/npm/test/get-pitch-position-xml.mjs
@@ -1,0 +1,199 @@
+// Debug harness to compare getPitchPosition against SVG coordinates for a MusicXML file.
+// Usage: node emscripten/npm/test/get-pitch-position-xml.mjs
+// Optional env:
+//   NOTE_INDEX=0            (which timemap note to inspect)
+//   NOTE_ID=abcd123         (override note id)
+//   WRITE_SVG=1             (write test.svg next to this script)
+
+import fs from 'fs';
+import createVerovioModule from '../dist/verovio-module.mjs';
+import { VerovioToolkit } from '../dist/verovio.mjs';
+
+const TEST_XML_URL = new URL('./test.xml', import.meta.url);
+const NOTE_INDEX = Number.parseInt(process.env.NOTE_INDEX ?? '0', 10);
+const NOTE_ID_OVERRIDE = process.env.NOTE_ID ?? null;
+const WRITE_SVG = process.env.WRITE_SVG === '1';
+
+const readFile = (url) => fs.readFileSync(url, 'utf8');
+
+const parseDefinitionScale = (svg) => {
+  const viewBoxMatch = svg.match(
+    /<svg class="definition-scale"[^>]*viewBox="[^"]+ [^"]+ ([^"]+)"/,
+  );
+  const marginMatch = svg.match(
+    /<g class="page-margin"[^>]*transform="translate\((-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\)"/,
+  );
+  const viewBoxHeight = viewBoxMatch
+    ? Number.parseFloat(viewBoxMatch[1])
+    : null;
+  const marginX = marginMatch ? Number.parseFloat(marginMatch[1]) : 0;
+  const marginY = marginMatch ? Number.parseFloat(marginMatch[2]) : 0;
+  return { viewBoxHeight, marginX, marginY };
+};
+
+const findSnippet = (svg, id, size = 4000) => {
+  const idx = svg.indexOf(`id="${id}"`);
+  if (idx === -1) return null;
+  return svg.slice(Math.max(0, idx - 200), idx + size);
+};
+
+const findFirstTranslate = (chunk) => {
+  if (!chunk) return null;
+  const match = chunk.match(
+    /translate\((-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\)/,
+  );
+  if (!match) return null;
+  return {
+    x: Number.parseFloat(match[1]),
+    y: Number.parseFloat(match[2]),
+  };
+};
+
+const findNoteheadTranslate = (chunk) => {
+  if (!chunk) return null;
+  const match = chunk.match(
+    /class="notehead"[\s\S]*?translate\((-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\)/,
+  );
+  if (!match) return null;
+  return {
+    x: Number.parseFloat(match[1]),
+    y: Number.parseFloat(match[2]),
+  };
+};
+
+const parseStaffLineBounds = (measureChunk) => {
+  if (!measureChunk) return null;
+  const matches = [
+    ...measureChunk.matchAll(/M([\d.]+)\s+([\d.]+)\s+L([\d.]+)\s+([\d.]+)/g),
+  ];
+  if (!matches.length) return null;
+  const points = matches.flatMap((match) => [
+    {
+      x: Number.parseFloat(match[1]),
+      y: Number.parseFloat(match[2]),
+    },
+    {
+      x: Number.parseFloat(match[3]),
+      y: Number.parseFloat(match[4]),
+    },
+  ]);
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  return {
+    minX: Math.min(...xs),
+    maxX: Math.max(...xs),
+    minY: Math.min(...ys),
+    maxY: Math.max(...ys),
+  };
+};
+
+const main = async () => {
+  const xml = readFile(TEST_XML_URL);
+  const module = await createVerovioModule();
+  const tk = new VerovioToolkit(module);
+
+  tk.setOptions({
+    adjustPageHeight: false,
+    adjustPageWidth: false,
+    pageHeight: 1871,
+    pageWidth: 1323,
+    scale: 40,
+    svgViewBox: true,
+    svgBoundingBoxes: true,
+    xmlIdSeed: 1,
+  });
+
+  tk.loadData(xml);
+  const svg = tk.renderToSVG(1);
+  const timemap = tk.renderToTimemap({ includeMeasures: true, includeRests: true });
+
+  if (WRITE_SVG) {
+    fs.writeFileSync(new URL('./test.svg', import.meta.url), svg);
+  }
+
+  const noteEntries = timemap.filter((entry) => Array.isArray(entry.on) && entry.on.length);
+  if (!noteEntries.length) {
+    throw new Error('No note entries found in timemap.');
+  }
+
+  const selectedEntry =
+    NOTE_ID_OVERRIDE
+      ? noteEntries.find((entry) => entry.on.includes(NOTE_ID_OVERRIDE))
+      : noteEntries[Math.min(Math.max(NOTE_INDEX, 0), noteEntries.length - 1)];
+
+  if (!selectedEntry) {
+    throw new Error('Unable to select a note entry from timemap.');
+  }
+
+  const noteId = NOTE_ID_OVERRIDE ?? selectedEntry.on[0];
+  const qstamp = selectedEntry.qstamp;
+  const midiValues = tk.getMIDIValuesForElement(noteId);
+  const midi = midiValues?.pitch ?? null;
+
+  if (midi === null) {
+    throw new Error(`Unable to resolve MIDI pitch for note ${noteId}.`);
+  }
+
+  const pitchPosition = tk.getPitchPosition(qstamp, midi, 1);
+  const { viewBoxHeight, marginX, marginY } = parseDefinitionScale(svg);
+
+  const noteChunk = findSnippet(svg, noteId, 2500);
+  const noteTranslate =
+    findNoteheadTranslate(noteChunk) ?? findFirstTranslate(noteChunk);
+  const noteAbs = noteTranslate
+    ? { x: marginX + noteTranslate.x, y: marginY + noteTranslate.y }
+    : null;
+
+  const contentHeight = viewBoxHeight !== null ? viewBoxHeight - marginY : null;
+  const pitchAbs = { x: pitchPosition.x, y: pitchPosition.y };
+
+  const measureId = pitchPosition.measureId;
+  const measureChunk = measureId ? findSnippet(svg, measureId, 6000) : null;
+  const staffBounds = parseStaffLineBounds(measureChunk);
+
+  console.log('Timemap notes (first 8):');
+  console.log(
+    noteEntries.slice(0, 8).map((entry) => ({
+      qstamp: entry.qstamp,
+      noteId: entry.on[0],
+      midi: tk.getMIDIValuesForElement(entry.on[0])?.pitch,
+    })),
+  );
+  console.log('');
+  console.log('Selected note:');
+  console.log({ noteId, qstamp, midi });
+  console.log('');
+  console.log('Pitch position:');
+  console.log(pitchPosition);
+  console.log('');
+  console.log('SVG context:');
+  console.log({ viewBoxHeight, marginX, marginY, contentHeight });
+  console.log('');
+  console.log('Notehead translate (absolute):');
+  console.log(noteAbs);
+  console.log('');
+  console.log('Pitch position (svg coords):');
+  console.log(pitchAbs);
+  console.log('');
+  if (noteAbs) {
+    console.log('Delta (pitchAbs - noteAbs):');
+    console.log({
+      dx: Math.round(pitchAbs.x - noteAbs.x),
+      dy: Math.round(pitchAbs.y - noteAbs.y),
+    });
+    console.log('');
+  }
+  if (staffBounds) {
+    console.log('Staff line bounds (measure):');
+    console.log(staffBounds);
+    console.log('Pitch inside staff bounds:', {
+      x: pitchAbs.x >= staffBounds.minX && pitchAbs.x <= staffBounds.maxX,
+      y: pitchAbs.y >= staffBounds.minY && pitchAbs.y <= staffBounds.maxY,
+    });
+  }
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/emscripten/npm/test/get-pitch-position.mjs
+++ b/emscripten/npm/test/get-pitch-position.mjs
@@ -57,10 +57,17 @@ const main = async () => {
   const result = tk.getPitchPosition(0, 60, 1);
   console.log('GetPitchPosition(0, 60, 1) ->', result);
 
+  const resultFractional = tk.getPitchPosition(0, 60.5, 1);
+  console.log('GetPitchPosition(0, 60.5, 1) ->', resultFractional);
+
   assertEqual(result.measureId, 'm1', 'measureId');
   assertEqual(result.page, 1, 'page');
   assertEqual(result.system, 1, 'system');
   assertEqual(result.staff, 1, 'staff');
+
+  if (resultFractional.y === result.y) {
+    throw new Error('expected fractional MIDI pitch to adjust y position');
+  }
 };
 
 main().catch((err) => {

--- a/emscripten/npm/test/get-pitch-position.mjs
+++ b/emscripten/npm/test/get-pitch-position.mjs
@@ -1,0 +1,69 @@
+// Quick harness to exercise GetPitchPosition in the Verovio toolkit.
+// Usage: run after building the npm package (./buildNpmPackage) from the repo root:
+//   node emscripten/npm/test/get-pitch-position.mjs
+// It loads a tiny MEI with a single measure and asserts the returned measure/page/system.
+
+import createVerovioModule from '../dist/verovio-module.mjs';
+import { VerovioToolkit } from '../dist/verovio.mjs';
+
+const MEI = `<?xml version="1.0" encoding="UTF-8"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.count="4" meter.unit="4" key.sig="0">
+            <staffGrp>
+              <staffDef n="1" clef.shape="G" clef.line="2"/>
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure xml:id="m1">
+              <staff n="1">
+                <layer>
+                  <note xml:id="n1" pname="c" oct="4" dur="4"/>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
+</mei>`;
+
+const assertEqual = (actual, expected, msg) => {
+  if (actual !== expected) {
+    throw new Error(`${msg}: expected ${expected}, got ${actual}`);
+  }
+};
+
+const main = async () => {
+  const module = await createVerovioModule();
+  const tk = new VerovioToolkit(module);
+  tk.setOptions({
+    adjustPageHeight: false,
+    adjustPageWidth: false,
+    pageHeight: 1500,
+    pageWidth: 1000,
+    scale: 50,
+  });
+
+  tk.loadData(MEI);
+  // Force layout so drawing coords are available
+  tk.renderToSVG(1);
+  tk.renderToTimemap();
+
+  const result = tk.getPitchPosition(0, 60, 1);
+  console.log('GetPitchPosition(0, 60, 1) ->', result);
+
+  assertEqual(result.measureId, 'm1', 'measureId');
+  assertEqual(result.page, 1, 'page');
+  assertEqual(result.system, 1, 'system');
+  assertEqual(result.staff, 1, 'staff');
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/emscripten/npm/test/get-pitch-position.mjs
+++ b/emscripten/npm/test/get-pitch-position.mjs
@@ -1,7 +1,7 @@
 // Quick harness to exercise GetPitchPosition in the Verovio toolkit.
 // Usage: run after building the npm package (./buildNpmPackage) from the repo root:
 //   node emscripten/npm/test/get-pitch-position.mjs
-// It loads a tiny MEI with a single measure and asserts the returned measure/page/system.
+// It loads a tiny MEI with a single measure and checks the returned coordinates.
 
 import createVerovioModule from '../dist/verovio-module.mjs';
 import { VerovioToolkit } from '../dist/verovio.mjs';
@@ -38,6 +38,11 @@ const assertEqual = (actual, expected, msg) => {
   }
 };
 
+const assertResultShape = (result) => {
+  const keys = Object.keys(result).sort().join(',');
+  assertEqual(keys, 'page,system,x,y', 'result keys');
+};
+
 const main = async () => {
   const module = await createVerovioModule();
   const tk = new VerovioToolkit(module);
@@ -60,10 +65,14 @@ const main = async () => {
   const resultFractional = tk.getPitchPosition(0, 60.5, 1);
   console.log('GetPitchPosition(0, 60.5, 1) ->', resultFractional);
 
-  assertEqual(result.measureId, 'm1', 'measureId');
+  assertResultShape(result);
+  assertResultShape(resultFractional);
   assertEqual(result.page, 1, 'page');
   assertEqual(result.system, 1, 'system');
-  assertEqual(result.staff, 1, 'staff');
+
+  if (!Number.isFinite(result.x) || !Number.isFinite(result.y)) {
+    throw new Error('expected finite x and y coordinates');
+  }
 
   if (resultFractional.y === result.y) {
     throw new Error('expected fractional MIDI pitch to adjust y position');

--- a/emscripten/npm/test/test.xml
+++ b/emscripten/npm/test/test.xml
@@ -1,0 +1,1813 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/3.1/partwise.dtd">
+<score-partwise version="3.1">
+  <movement-title>Love Me Tender</movement-title>
+  <identification>
+    <creator type="composer">Elvis Presley</creator>
+    <rights>www.antescofo.com</rights>
+    <encoding>
+      <software>Finale v27.4 for Mac</software>
+      <encoding-date>2024-09-17</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="stem" type="yes"/>
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>6.35</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1871</page-height>
+      <page-width>1323</page-width>
+      <page-margins type="both">
+        <left-margin>94</left-margin>
+        <right-margin>94</right-margin>
+        <top-margin>94</top-margin>
+        <bottom-margin>94</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>0</left-margin>
+        <right-margin>0</right-margin>
+      </system-margins>
+      <system-distance>104</system-distance>
+      <top-system-distance>59</top-system-distance>
+    </system-layout>
+    <appearance>
+      <line-width type="stem">0.7487</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="staff">0.7487</line-width>
+      <line-width type="light barline">0.7487</line-width>
+      <line-width type="heavy barline">5</line-width>
+      <line-width type="leger">0.7487</line-width>
+      <line-width type="ending">0.7487</line-width>
+      <line-width type="wedge">0.7487</line-width>
+      <line-width type="enclosure">0.7487</line-width>
+      <line-width type="tuplet bracket">0.7487</line-width>
+      <note-size type="grace">60</note-size>
+      <note-size type="cue">60</note-size>
+      <distance type="hyphen">120</distance>
+      <distance type="beam">7.5</distance>
+    </appearance>
+    <music-font font-family="Maestro,engraved" font-size="18"/>
+    <word-font font-family="Times New Roman" font-size="9"/>
+    <lyric-font font-family="Finale Lyrics" font-size="9.75"/>
+  </defaults>
+  <credit page="1">
+    <credit-type>rights</credit-type>
+    <credit-words default-x="661" default-y="63" font-size="12" font-style="italic" justify="center" valign="bottom">www.antescofo.com</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-type>title</credit-type>
+    <credit-words default-x="661" default-y="1823" font-size="24" font-weight="bold" justify="center" valign="top">Love Me Tender</credit-words>
+  </credit>
+  <credit page="1">
+    <credit-type>composer</credit-type>
+    <credit-words default-x="1226" default-y="1729" font-size="14" font-weight="bold" justify="right" valign="top">Elvis Presley</credit-words>
+  </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Violin</part-name>
+      <part-abbreviation>Vn.</part-abbreviation>
+      <group>score</group>
+      <score-instrument id="P1-I1">
+        <instrument-name>SmartMusic SoftSynth</instrument-name>
+        <instrument-sound>strings.violin</instrument-sound>
+        <solo/>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-bank>15489</midi-bank>
+        <midi-program>41</midi-program>
+        <volume>80</volume>
+        <pan>1</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1" width="245">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>67</left-margin>
+            <right-margin>0</right-margin>
+          </system-margins>
+          <top-system-distance>146</top-system-distance>
+        </system-layout>
+        <measure-numbering>system</measure-numbering>
+      </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>2</fifths>
+          <mode>major</mode>
+        </key>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <sound/>
+      <direction directive="yes" placement="above">
+        <direction-type>
+          <words default-y="35" font-size="12" font-weight="bold">Tenderly</words>
+        </direction-type>
+        <sound tempo="70"/>
+      </direction>
+      <note default-x="168">
+        <rest/>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="2" width="221">
+      <direction placement="below">
+        <direction-type>
+          <dynamics default-x="22" default-y="-68" halign="center">
+            <mp/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="69"/>
+      </direction>
+      <note default-x="13">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="13">up</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="0" default-y="37" placement="above"/>
+            <fingering default-x="2" default-y="18" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="65">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="117">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="169">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="3" width="202">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="65">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-57.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="117">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="4" width="222">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="65">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="118">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-57.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="169">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="5" width="178">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="125">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="6" width="361">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>86</system-distance>
+        </system-layout>
+      </print>
+      <note default-x="89">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="13">up</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="0" default-y="37" placement="above"/>
+            <fingering default-x="2" default-y="18" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="157">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="225">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="293">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="7" width="260">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-58">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="150">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="8" width="285">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="149">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-58">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="217">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="9" width="228">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="159">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="10" width="342">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>92</system-distance>
+        </system-layout>
+      </print>
+      <direction placement="below">
+        <direction-type>
+          <words default-x="90" default-y="-64" font-style="italic">cresc.</words>
+        </direction-type>
+      </direction>
+      <note default-x="90">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+            <down-bow default-x="-1" default-y="29" placement="above"/>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="159">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+      <note default-x="229">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="11" width="288">
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+      <note default-x="89">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+      <note default-x="165">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="12" width="283">
+      <direction placement="below">
+        <direction-type>
+          <wedge default-y="-70" type="crescendo"/>
+        </direction-type>
+      </direction>
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="81">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="148">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="215">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <direction>
+        <direction-type>
+          <wedge relative-x="-5" spread="15" type="stop"/>
+        </direction-type>
+      </direction>
+    </measure>
+    <!--=======================================================-->
+    <measure number="13" width="222">
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="156">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="14" width="345">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>92</system-distance>
+        </system-layout>
+      </print>
+      <direction placement="below">
+        <direction-type>
+          <dynamics default-x="94" default-y="-64" halign="center">
+            <mf/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="83"/>
+      </direction>
+      <note default-x="90">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="-1" default-y="29" placement="above"/>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="153">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+      </note>
+      <note default-x="217">
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-33">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="15" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="281">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="15" width="272">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="85">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-58">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="156">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="16" width="285">
+      <direction placement="below">
+        <direction-type>
+          <wedge default-y="-69" spread="15" type="diminuendo"/>
+        </direction-type>
+      </direction>
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="149">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="217">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="17" width="232">
+      <note default-x="13">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <direction>
+        <direction-type>
+          <wedge type="stop"/>
+        </direction-type>
+      </direction>
+      <note default-x="162">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="18" width="360">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>98</system-distance>
+        </system-layout>
+      </print>
+      <direction placement="above">
+        <direction-type>
+          <rehearsal default-x="41" default-y="33" font-size="10.5" font-weight="bold">A</rehearsal>
+        </direction-type>
+      </direction>
+      <direction placement="below">
+        <direction-type>
+          <dynamics default-x="93" default-y="-64" halign="center">
+            <p/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="54"/>
+      </direction>
+      <note default-x="89">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="13">up</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="0" default-y="37" placement="above"/>
+            <fingering default-x="2" default-y="18" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="157">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="225">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="292">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="19" width="260">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-57.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="150">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="20" width="285">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="149">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-57.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="217">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="21" width="228">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="160">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="22" width="361">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>92</system-distance>
+        </system-layout>
+      </print>
+      <note default-x="89">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="13">up</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="0" default-y="37" placement="above"/>
+            <fingering default-x="2" default-y="18" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="157">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="225">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="293">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="23" width="260">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-58">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="150">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="24" width="285">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="82">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="149">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-58">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="217">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-53">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="25" width="228">
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="159">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="26" width="342">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>92</system-distance>
+        </system-layout>
+      </print>
+      <direction placement="below">
+        <direction-type>
+          <words default-x="89" default-y="-64" font-style="italic">cresc.</words>
+        </direction-type>
+      </direction>
+      <note default-x="89">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+            <down-bow default-x="0" default-y="29" placement="above"/>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="159">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+      </note>
+      <note default-x="228">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-38">down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="27" width="266">
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+      </note>
+      <note default-x="83">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+      </note>
+      <note default-x="153">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-38">down</stem>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="28" width="292">
+      <direction placement="below">
+        <direction-type>
+          <wedge default-y="-70" type="crescendo"/>
+        </direction-type>
+      </direction>
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="83">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="153">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-48">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="222">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-43">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <direction>
+        <direction-type>
+          <wedge relative-x="-5" spread="15" type="stop"/>
+        </direction-type>
+      </direction>
+    </measure>
+    <!--=======================================================-->
+    <measure number="29" width="234">
+      <note default-x="14">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <dot/>
+        <stem default-y="-38">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="164">
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="30" width="333">
+      <print new-system="yes">
+        <system-layout>
+          <system-distance>92</system-distance>
+        </system-layout>
+      </print>
+      <direction placement="below">
+        <direction-type>
+          <dynamics default-x="94" default-y="-66" halign="center">
+            <mf/>
+          </dynamics>
+        </direction-type>
+        <sound dynamics="83"/>
+      </direction>
+      <note default-x="90">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <down-bow default-x="-1" default-y="29" placement="above"/>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="151">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+      </note>
+      <note default-x="211">
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-32.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="15" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="272">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="31" width="234">
+      <note default-x="14">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="74">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-57.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="135">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">4</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="32" width="257">
+      <direction placement="below">
+        <direction-type>
+          <wedge default-y="-70" spread="15" type="diminuendo"/>
+        </direction-type>
+      </direction>
+      <note default-x="14">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-47.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="75">
+        <pitch>
+          <step>C</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-52.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="1" default-y="3" placement="above">2</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="135">
+        <pitch>
+          <step>F</step>
+          <alter>1</alter>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-37.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="10" placement="above">1</fingering>
+          </technical>
+        </notations>
+      </note>
+      <note default-x="196">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem default-y="-42.5">down</stem>
+        <notations>
+          <technical>
+            <fingering default-x="2" default-y="5" placement="above">0</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="33" width="173">
+      <note default-x="13">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <technical>
+            <fingering default-x="4" default-y="3" placement="above">3</fingering>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+    <!--=======================================================-->
+    <measure number="34" width="137">
+      <note default-x="13">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>8</duration>
+        <voice>1</voice>
+        <type>whole</type>
+      </note>
+      <direction>
+        <direction-type>
+          <wedge type="stop"/>
+        </direction-type>
+      </direction>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/include/vrv/comparison.h
+++ b/include/vrv/comparison.h
@@ -497,6 +497,32 @@ private:
 };
 
 //----------------------------------------------------------------------------
+// MeasureScoreTimeComparison
+//----------------------------------------------------------------------------
+
+/**
+ * This class evaluates if the object is a measure enclosing the given score time
+ */
+class MeasureScoreTimeComparison : public ClassIdComparison {
+
+public:
+    MeasureScoreTimeComparison(const Fraction &time) : ClassIdComparison(MEASURE) { m_time = time; }
+
+    void SetTime(const Fraction &time) { m_time = time; }
+
+    bool operator()(const Object *object) override
+    {
+        if (!MatchesType(object)) return false;
+        const Measure *measure = vrv_cast<const Measure *>(object);
+        assert(measure);
+        return (measure->EnclosesScoreTime(m_time) != VRV_UNSET);
+    }
+
+private:
+    Fraction m_time;
+};
+
+//----------------------------------------------------------------------------
 // NoteOrRestOnsetOffsetComparison
 //----------------------------------------------------------------------------
 

--- a/include/vrv/measure.h
+++ b/include/vrv/measure.h
@@ -319,6 +319,11 @@ public:
      * Return the playing repeat time (1-based), VRV_UNSET otherwise
      */
     int EnclosesTime(int time) const;
+    /**
+     * Check if the measure encloses the given score time (in quarter-note units)
+     * Return the playing repeat time (1-based), VRV_UNSET otherwise
+     */
+    int EnclosesScoreTime(const Fraction &time) const;
 
     /**
      * Read-only access to onset and offset.
@@ -328,6 +333,10 @@ public:
     double GetRealTimeOnsetMilliseconds(int repeat = VRV_UNSET) const;
     Fraction GetScoreTimeOffset(int repeat = VRV_UNSET) const;
     double GetRealTimeOffsetMilliseconds(int repeat = VRV_UNSET) const;
+    /**
+     * Return the X relative to the measure for a score-time position.
+     */
+    int GetXAtScoreTime(const Fraction &time, bool &interpolated) const;
     ///@}
 
     /**

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -612,6 +612,15 @@ public:
      * @return A stringified JSON object with the values
      */
     std::string GetTimesForElement(const std::string &xmlId);
+    /**
+     * Return the graphical coordinates of a pitch at a given score position and staff.
+     *
+     * @param scoreTime The score time (in quarter notes from start of the score)
+     * @param midiPitch MIDI pitch number
+     * @param staffN The staff number (1-based)
+     * @return A stringified JSON object with x / y coordinates and context information
+     */
+    std::string GetPitchPosition(double scoreTime, int midiPitch, int staffN);
 
     ///@}
 

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -618,7 +618,7 @@ public:
      * @param scoreTime The score time (in quarter notes from start of the score)
      * @param midiPitch MIDI pitch number (fractional values allowed)
      * @param staffN The staff number (1-based)
-     * @return A stringified JSON object with x / y coordinates and context information
+     * @return A stringified JSON object with x / y coordinates and page / system numbers
      */
     std::string GetPitchPosition(double scoreTime, double midiPitch, int staffN);
 

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -616,11 +616,11 @@ public:
      * Return the graphical coordinates of a pitch at a given score position and staff.
      *
      * @param scoreTime The score time (in quarter notes from start of the score)
-     * @param midiPitch MIDI pitch number
+     * @param midiPitch MIDI pitch number (fractional values allowed)
      * @param staffN The staff number (1-based)
      * @return A stringified JSON object with x / y coordinates and context information
      */
-    std::string GetPitchPosition(double scoreTime, int midiPitch, int staffN);
+    std::string GetPitchPosition(double scoreTime, double midiPitch, int staffN);
 
     ///@}
 

--- a/src/measure.cpp
+++ b/src/measure.cpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 #include <cassert>
-#include <math.h>
+#include <cmath>
 
 //----------------------------------------------------------------------------
 
@@ -372,6 +372,38 @@ int Measure::GetInnerCenterX() const
     return (this->GetDrawingX() + this->GetLeftBarLineRight() + this->GetInnerWidth() / 2);
 }
 
+int Measure::GetXAtScoreTime(const Fraction &time, bool &interpolated) const
+{
+    interpolated = false;
+
+    const Alignment *previous = NULL;
+    const Alignment *next = NULL;
+
+    for (const Object *child = m_measureAligner.GetFirst(); child; child = m_measureAligner.GetNext()) {
+        const Alignment *alignment = vrv_cast<const Alignment *>(child);
+        if (!alignment) continue;
+
+        if ((alignment->GetTime() <= time) || ApproximatelyEqual(alignment->GetTime().ToDouble(), time.ToDouble())) {
+            previous = alignment;
+            continue;
+        }
+        next = alignment;
+        break;
+    }
+
+    if (!previous && next) previous = next;
+    if (!previous) return 0;
+    if (!next || (next->GetTime() == previous->GetTime())) return previous->GetXRel();
+
+    const double deltaTime = (next->GetTime() - previous->GetTime()).ToDouble();
+    if (deltaTime == 0.0) return previous->GetXRel();
+
+    interpolated = true;
+    const double t = (time - previous->GetTime()).ToDouble() / deltaTime;
+    const int deltaX = next->GetXRel() - previous->GetXRel();
+    return previous->GetXRel() + static_cast<int>(std::round(deltaX * t));
+}
+
 int Measure::GetDrawingOverflow()
 {
     AdjustXOverflowFunctor adjustXOverflow(0);
@@ -525,6 +557,18 @@ int Measure::EnclosesTime(int time) const
     std::vector<double>::const_iterator iter;
     for (iter = m_realTimeOnsetMilliseconds.begin(); iter != m_realTimeOnsetMilliseconds.end(); ++iter) {
         if ((time >= *iter) && (time <= *iter + timeDuration)) return repeat;
+        repeat++;
+    }
+    return VRV_UNSET;
+}
+
+int Measure::EnclosesScoreTime(const Fraction &time) const
+{
+    int repeat = 1;
+    for (size_t i = 0; i < m_scoreTimeOnset.size(); ++i) {
+        const Fraction onset = m_scoreTimeOnset.at(i);
+        const Fraction offset = (i < m_scoreTimeOffset.size()) ? m_scoreTimeOffset.at(i) : onset;
+        if ((time >= onset) && (time <= offset)) return repeat;
         repeat++;
     }
     return VRV_UNSET;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -2497,7 +2497,6 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
     int clefOffset = 0;
     const KeySig *keySig = NULL;
     if (layer) {
-        clefOffset = layer->GetClefLocOffset(NULL);
         keySig = layer->GetCurrentKeySig();
     }
 
@@ -2532,6 +2531,10 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
             anchorNote = note;
             anchorPitchDistance = distance;
         }
+    }
+
+    if (layer) {
+        clefOffset = layer->GetClefLocOffset(anchorNote);
     }
 
     const bool preferSharps = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_s));

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -11,8 +11,8 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <climits>
+#include <cmath>
 #include <locale>
 #include <regex>
 
@@ -34,8 +34,8 @@
 #include "iomusxml.h"
 #include "iopae.h"
 #include "iovolpiano.h"
-#include "layer.h"
 #include "keysig.h"
+#include "layer.h"
 #include "measure.h"
 #include "nc.h"
 #include "neume.h"
@@ -44,11 +44,11 @@
 #include "page.h"
 #include "pitchinterface.h"
 #include "runtimeclock.h"
-#include "staff.h"
-#include "system.h"
 #include "score.h"
 #include "slur.h"
+#include "staff.h"
 #include "svgdevicecontext.h"
+#include "system.h"
 #include "timemap.h"
 #include "vrv.h"
 
@@ -66,134 +66,168 @@ const char *ZIP_SIGNATURE = "\x50\x4B\x03\x04";
 
 namespace {
 
-struct PitchSpell {
-    data_PITCHNAME pname;
-    int accid;
-    int oct;
-};
+    struct PitchSpell {
+        data_PITCHNAME pname;
+        int accid;
+        int oct;
+    };
 
-PitchSpell MidiToPitchSpell(int midiPitch)
-{
-    PitchSpell spell{ PITCHNAME_c, 0, 4 };
+    PitchSpell MidiToPitchSpell(int midiPitch)
+    {
+        PitchSpell spell{ PITCHNAME_c, 0, 4 };
 
-    const int pclass = ((midiPitch % 12) + 12) % 12;
-    spell.oct = midiPitch / 12 - 1;
+        const int pclass = ((midiPitch % 12) + 12) % 12;
+        spell.oct = midiPitch / 12 - 1;
 
-    switch (pclass) {
-        case 0: spell.pname = PITCHNAME_c; spell.accid = 0; break;
-        case 1: spell.pname = PITCHNAME_c; spell.accid = 1; break;
-        case 2: spell.pname = PITCHNAME_d; spell.accid = 0; break;
-        case 3: spell.pname = PITCHNAME_e; spell.accid = -1; break;
-        case 4: spell.pname = PITCHNAME_e; spell.accid = 0; break;
-        case 5: spell.pname = PITCHNAME_f; spell.accid = 0; break;
-        case 6: spell.pname = PITCHNAME_f; spell.accid = 1; break;
-        case 7: spell.pname = PITCHNAME_g; spell.accid = 0; break;
-        case 8: spell.pname = PITCHNAME_a; spell.accid = -1; break;
-        case 9: spell.pname = PITCHNAME_a; spell.accid = 0; break;
-        case 10: spell.pname = PITCHNAME_b; spell.accid = -1; break;
-        case 11: spell.pname = PITCHNAME_b; spell.accid = 0; break;
-        default: break;
+        switch (pclass) {
+            case 0:
+                spell.pname = PITCHNAME_c;
+                spell.accid = 0;
+                break;
+            case 1:
+                spell.pname = PITCHNAME_c;
+                spell.accid = 1;
+                break;
+            case 2:
+                spell.pname = PITCHNAME_d;
+                spell.accid = 0;
+                break;
+            case 3:
+                spell.pname = PITCHNAME_e;
+                spell.accid = -1;
+                break;
+            case 4:
+                spell.pname = PITCHNAME_e;
+                spell.accid = 0;
+                break;
+            case 5:
+                spell.pname = PITCHNAME_f;
+                spell.accid = 0;
+                break;
+            case 6:
+                spell.pname = PITCHNAME_f;
+                spell.accid = 1;
+                break;
+            case 7:
+                spell.pname = PITCHNAME_g;
+                spell.accid = 0;
+                break;
+            case 8:
+                spell.pname = PITCHNAME_a;
+                spell.accid = -1;
+                break;
+            case 9:
+                spell.pname = PITCHNAME_a;
+                spell.accid = 0;
+                break;
+            case 10:
+                spell.pname = PITCHNAME_b;
+                spell.accid = -1;
+                break;
+            case 11:
+                spell.pname = PITCHNAME_b;
+                spell.accid = 0;
+                break;
+            default: break;
+        }
+
+        return spell;
     }
 
-    return spell;
-}
-
-Fraction ScoreTimeFromDouble(double scoreTime)
-{
-    const int denom = 1000;
-    return Fraction(static_cast<int>(std::round(scoreTime * denom)), denom);
-}
-
-int AccidWrittenToSemitone(data_ACCIDENTAL_WRITTEN accid)
-{
-    switch (accid) {
-        case ACCIDENTAL_WRITTEN_ff: return -2;
-        case ACCIDENTAL_WRITTEN_f: return -1;
-        case ACCIDENTAL_WRITTEN_n: return 0;
-        case ACCIDENTAL_WRITTEN_s: return 1;
-        case ACCIDENTAL_WRITTEN_ss: return 2;
-        default: return 0;
+    Fraction ScoreTimeFromDouble(double scoreTime)
+    {
+        const int denom = 1000;
+        return Fraction(static_cast<int>(std::round(scoreTime * denom)), denom);
     }
-}
 
-data_ACCIDENTAL_WRITTEN SemitoneToAccidWritten(int value)
-{
-    if (value <= -2) return ACCIDENTAL_WRITTEN_ff;
-    if (value == -1) return ACCIDENTAL_WRITTEN_f;
-    if (value == 0) return ACCIDENTAL_WRITTEN_n;
-    if (value == 1) return ACCIDENTAL_WRITTEN_s;
-    if (value >= 2) return ACCIDENTAL_WRITTEN_ss;
-    return ACCIDENTAL_WRITTEN_n;
-}
-
-struct SpelledPitch {
-    data_PITCHNAME pname;
-    int accidSemitone;
-    int oct;
-};
-
-SpelledPitch ChooseContextualSpell(
-    int midiPitch, const MapOfOctavedPitchAccid &contextAccids, bool preferSharps, bool preferFlats)
-{
-    const int targetPc = ((midiPitch % 12) + 12) % 12;
-    SpelledPitch best{ PITCHNAME_c, 0, midiPitch / 12 - 1 };
-    int bestCost = INT_MAX;
-
-    const data_PITCHNAME pnames[] = { PITCHNAME_c, PITCHNAME_d, PITCHNAME_e, PITCHNAME_f, PITCHNAME_g, PITCHNAME_a,
-        PITCHNAME_b };
-
-    for (data_PITCHNAME pname : pnames) {
-        const int basePc = Note::PnameToPclass(pname);
-        int accid = targetPc - basePc;
-        while (accid > 6) accid -= 12;
-        while (accid < -6) accid += 12;
-        const int naturalPc = basePc + accid;
-        const int oct = (midiPitch - naturalPc) / 12 - 1;
-        if ((oct < 0) || (oct > 9)) continue;
-
-        const int idx = pname + oct * 7;
-        int expected = 0;
-        auto found = contextAccids.find(idx);
-        if (found != contextAccids.end()) expected = AccidWrittenToSemitone(found->second);
-
-        int cost = std::abs(accid - expected) * 10 + std::abs(accid);
-        if (preferSharps && accid < 0) cost += 5;
-        if (preferFlats && accid > 0) cost += 5;
-
-        if (cost < bestCost) {
-            bestCost = cost;
-            best = { pname, accid, oct };
+    int AccidWrittenToSemitone(data_ACCIDENTAL_WRITTEN accid)
+    {
+        switch (accid) {
+            case ACCIDENTAL_WRITTEN_ff: return -2;
+            case ACCIDENTAL_WRITTEN_f: return -1;
+            case ACCIDENTAL_WRITTEN_n: return 0;
+            case ACCIDENTAL_WRITTEN_s: return 1;
+            case ACCIDENTAL_WRITTEN_ss: return 2;
+            default: return 0;
         }
     }
 
-    return best;
-}
-
-int ContextualAccidSemitone(
-    const MapOfOctavedPitchAccid &contextAccids, data_PITCHNAME pname, int oct)
-{
-    const int idx = pname + oct * 7;
-    auto found = contextAccids.find(idx);
-    if (found == contextAccids.end()) return 0;
-    return AccidWrittenToSemitone(found->second);
-}
-
-int MidiPitchFromSpelled(data_PITCHNAME pname, int oct, int accidSemitone)
-{
-    const int basePc = Note::PnameToPclass(pname);
-    int pc = basePc + accidSemitone;
-    int octShift = 0;
-    if (pc >= 12) {
-        pc -= 12;
-        octShift = 1;
+    data_ACCIDENTAL_WRITTEN SemitoneToAccidWritten(int value)
+    {
+        if (value <= -2) return ACCIDENTAL_WRITTEN_ff;
+        if (value == -1) return ACCIDENTAL_WRITTEN_f;
+        if (value == 0) return ACCIDENTAL_WRITTEN_n;
+        if (value == 1) return ACCIDENTAL_WRITTEN_s;
+        if (value >= 2) return ACCIDENTAL_WRITTEN_ss;
+        return ACCIDENTAL_WRITTEN_n;
     }
-    else if (pc < 0) {
-        pc += 12;
-        octShift = -1;
-    }
-    return (oct + 1 + octShift) * 12 + pc;
-}
 
+    struct SpelledPitch {
+        data_PITCHNAME pname;
+        int accidSemitone;
+        int oct;
+    };
+
+    SpelledPitch ChooseContextualSpell(
+        int midiPitch, const MapOfOctavedPitchAccid &contextAccids, bool preferSharps, bool preferFlats)
+    {
+        const int targetPc = ((midiPitch % 12) + 12) % 12;
+        SpelledPitch best{ PITCHNAME_c, 0, midiPitch / 12 - 1 };
+        int bestCost = INT_MAX;
+
+        const data_PITCHNAME pnames[]
+            = { PITCHNAME_c, PITCHNAME_d, PITCHNAME_e, PITCHNAME_f, PITCHNAME_g, PITCHNAME_a, PITCHNAME_b };
+
+        for (data_PITCHNAME pname : pnames) {
+            const int basePc = Note::PnameToPclass(pname);
+            int accid = targetPc - basePc;
+            while (accid > 6) accid -= 12;
+            while (accid < -6) accid += 12;
+            const int naturalPc = basePc + accid;
+            const int oct = (midiPitch - naturalPc) / 12 - 1;
+            if ((oct < 0) || (oct > 9)) continue;
+
+            const int idx = pname + oct * 7;
+            int expected = 0;
+            auto found = contextAccids.find(idx);
+            if (found != contextAccids.end()) expected = AccidWrittenToSemitone(found->second);
+
+            int cost = std::abs(accid - expected) * 10 + std::abs(accid);
+            if (preferSharps && accid < 0) cost += 5;
+            if (preferFlats && accid > 0) cost += 5;
+
+            if (cost < bestCost) {
+                bestCost = cost;
+                best = { pname, accid, oct };
+            }
+        }
+
+        return best;
+    }
+
+    int ContextualAccidSemitone(const MapOfOctavedPitchAccid &contextAccids, data_PITCHNAME pname, int oct)
+    {
+        const int idx = pname + oct * 7;
+        auto found = contextAccids.find(idx);
+        if (found == contextAccids.end()) return 0;
+        return AccidWrittenToSemitone(found->second);
+    }
+
+    int MidiPitchFromSpelled(data_PITCHNAME pname, int oct, int accidSemitone)
+    {
+        const int basePc = Note::PnameToPclass(pname);
+        int pc = basePc + accidSemitone;
+        int octShift = 0;
+        if (pc >= 12) {
+            pc -= 12;
+            octShift = 1;
+        }
+        else if (pc < 0) {
+            pc += 12;
+            octShift = -1;
+        }
+        return (oct + 1 + octShift) * 12 + pc;
+    }
 
 } // namespace
 
@@ -2436,9 +2470,8 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
     const int yRelBase = staff->CalcPitchPosYRel(&m_doc, loc);
     double yRel = static_cast<double>(yRelBase);
     if (midiFraction > 0.0) {
-        const data_PITCHNAME stepPname = (spelled.pname == PITCHNAME_b)
-            ? PITCHNAME_c
-            : static_cast<data_PITCHNAME>(spelled.pname + 1);
+        const data_PITCHNAME stepPname
+            = (spelled.pname == PITCHNAME_b) ? PITCHNAME_c : static_cast<data_PITCHNAME>(spelled.pname + 1);
         const int stepOct = spelled.oct + (spelled.pname == PITCHNAME_b ? 1 : 0);
         const int stepLoc = PitchInterface::CalcLoc(stepPname, stepOct, clefOffset);
         const int yRelStep = staff->CalcPitchPosYRel(&m_doc, stepLoc);

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -9,6 +9,7 @@
 
 //----------------------------------------------------------------------------
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <climits>
@@ -166,6 +167,31 @@ SpelledPitch ChooseContextualSpell(
     }
 
     return best;
+}
+
+int ContextualAccidSemitone(
+    const MapOfOctavedPitchAccid &contextAccids, data_PITCHNAME pname, int oct)
+{
+    const int idx = pname + oct * 7;
+    auto found = contextAccids.find(idx);
+    if (found == contextAccids.end()) return 0;
+    return AccidWrittenToSemitone(found->second);
+}
+
+int MidiPitchFromSpelled(data_PITCHNAME pname, int oct, int accidSemitone)
+{
+    const int basePc = Note::PnameToPclass(pname);
+    int pc = basePc + accidSemitone;
+    int octShift = 0;
+    if (pc >= 12) {
+        pc -= 12;
+        octShift = 1;
+    }
+    else if (pc < 0) {
+        pc += 12;
+        octShift = -1;
+    }
+    return (oct + 1 + octShift) * 12 + pc;
 }
 
 
@@ -2266,7 +2292,7 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
     return o.json();
 }
 
-std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staffN)
+std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int staffN)
 {
     this->ResetLogBuffer();
 
@@ -2276,6 +2302,15 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
         LogWarning("Invalid staff number '%d'", staffN);
         return o.json();
     }
+    if (!std::isfinite(midiPitch)) {
+        LogWarning("Invalid MIDI pitch '%f'", midiPitch);
+        return o.json();
+    }
+
+    const int midiPitchInt = static_cast<int>(std::floor(midiPitch));
+    double midiFraction = midiPitch - midiPitchInt;
+    if (midiFraction < 0.0) midiFraction = 0.0;
+    if (midiFraction > 1.0) midiFraction = 1.0;
 
     const Fraction requestedScoreTime = ScoreTimeFromDouble(scoreTime);
 
@@ -2395,16 +2430,32 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
 
     const bool preferSharps = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_s));
     const bool preferFlats = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_f));
-    const SpelledPitch spelled = ChooseContextualSpell(midiPitch, contextAccids, preferSharps, preferFlats);
+    const SpelledPitch spelled = ChooseContextualSpell(midiPitchInt, contextAccids, preferSharps, preferFlats);
 
     const int loc = PitchInterface::CalcLoc(spelled.pname, spelled.oct, clefOffset);
-    const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(&m_doc, loc);
+    const int yRelBase = staff->CalcPitchPosYRel(&m_doc, loc);
+    double yRel = static_cast<double>(yRelBase);
+    if (midiFraction > 0.0) {
+        const data_PITCHNAME stepPname = (spelled.pname == PITCHNAME_b)
+            ? PITCHNAME_c
+            : static_cast<data_PITCHNAME>(spelled.pname + 1);
+        const int stepOct = spelled.oct + (spelled.pname == PITCHNAME_b ? 1 : 0);
+        const int stepLoc = PitchInterface::CalcLoc(stepPname, stepOct, clefOffset);
+        const int yRelStep = staff->CalcPitchPosYRel(&m_doc, stepLoc);
+        const int stepAccid = ContextualAccidSemitone(contextAccids, stepPname, stepOct);
+        const int stepMidi = MidiPitchFromSpelled(stepPname, stepOct, stepAccid);
+        int semitoneSpan = stepMidi - midiPitchInt;
+        if (semitoneSpan <= 0) semitoneSpan = 1;
+        const double ratio = std::min(1.0, midiFraction / static_cast<double>(semitoneSpan));
+        yRel = yRelBase + (yRelStep - yRelBase) * ratio;
+    }
+    const double y = staff->GetDrawingY() + yRel;
 
     // Convert to SVG device coordinates: include page margins and flip Y from
     // Verovio's logical space (origin at bottom-left of content) to SVG space
     // (origin at top-left of the page content).
-    int xOut = x;
-    int yOut = y;
+    double xOut = x;
+    double yOut = y;
     if (page) {
         if (!m_doc.GetDrawingPage() || m_doc.GetDrawingPage()->GetIdx() != page->GetIdx()) {
             m_doc.SetDrawingPage(page->GetIdx());

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -40,6 +40,7 @@
 #include "nc.h"
 #include "neume.h"
 #include "note.h"
+#include "octave.h"
 #include "options.h"
 #include "page.h"
 #include "pitchinterface.h"
@@ -2340,12 +2341,6 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
         LogWarning("Invalid MIDI pitch '%f'", midiPitch);
         return o.json();
     }
-
-    const int midiPitchInt = static_cast<int>(std::floor(midiPitch));
-    double midiFraction = midiPitch - midiPitchInt;
-    if (midiFraction < 0.0) midiFraction = 0.0;
-    if (midiFraction > 1.0) midiFraction = 1.0;
-
     const Fraction requestedScoreTime = ScoreTimeFromDouble(scoreTime);
 
     MeasureScoreTimeComparison matchMeasureTime(requestedScoreTime);
@@ -2429,6 +2424,67 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
     const Fraction localTimeForX = localTime / SCORE_TIME_UNIT;
     const int xRel = layoutMeasure->GetXAtScoreTime(localTimeForX, interpolated);
     int x = layoutMeasure->GetDrawingX() + xRel;
+
+    int octaveShift = 0;
+    const ListOfObjects octaves = m_doc.FindAllDescendantsByType(OCTAVE, false);
+    if (!octaves.empty()) {
+        const int currentMeasureIndex = measure->GetIndex();
+        for (const Object *obj : octaves) {
+            const Octave *octave = vrv_cast<const Octave *>(obj);
+            if (!octave) continue;
+            if (!octave->HasStartAndEnd() || !octave->IsOrdered()) continue;
+            if (!octave->IsOnStaff(staffN)) continue;
+
+            const Measure *startMeasure = octave->GetStartMeasure();
+            const Measure *endMeasure = octave->GetEndMeasure();
+            if (!startMeasure || !endMeasure) continue;
+
+            const int startIndex = startMeasure->GetIndex();
+            const int endIndex = endMeasure->GetIndex();
+            if (currentMeasureIndex < startIndex || currentMeasureIndex > endIndex) continue;
+
+            bool active = false;
+            const Alignment *startAlignment = octave->GetStart()->GetAlignment();
+            const Alignment *endAlignment = octave->GetEnd()->GetAlignment();
+            if (startIndex == endIndex) {
+                if (!startAlignment || !endAlignment) {
+                    active = true;
+                }
+                else {
+                    active = (localTimeForX >= startAlignment->GetTime())
+                        && (localTimeForX <= endAlignment->GetTime());
+                }
+            }
+            else if (currentMeasureIndex == startIndex) {
+                active = (!startAlignment) || (localTimeForX >= startAlignment->GetTime());
+            }
+            else if (currentMeasureIndex == endIndex) {
+                active = (!endAlignment) || (localTimeForX <= endAlignment->GetTime());
+            }
+            else {
+                active = true;
+            }
+
+            if (!active) continue;
+
+            int shift = 0;
+            switch (octave->GetDis()) {
+                case OCTAVE_DIS_8: shift = 1; break;
+                case OCTAVE_DIS_15: shift = 2; break;
+                case OCTAVE_DIS_22: shift = 3; break;
+                default: break;
+            }
+            if (!shift) continue;
+            const bool raisePitch = (octave->GetDisPlace() != STAFFREL_basic_below);
+            octaveShift += raisePitch ? shift : -shift;
+        }
+    }
+
+    const double adjustedMidiPitch = midiPitch - static_cast<double>(octaveShift) * 12.0;
+    const int midiPitchInt = static_cast<int>(std::floor(adjustedMidiPitch));
+    double midiFraction = adjustedMidiPitch - midiPitchInt;
+    if (midiFraction < 0.0) midiFraction = 0.0;
+    if (midiFraction > 1.0) midiFraction = 1.0;
 
     AttNIntegerComparison staffCmp(STAFF, staffN);
     Staff *staff = vrv_cast<Staff *>(layoutMeasure->FindDescendantByComparison(&staffCmp, 1));

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -10,6 +10,7 @@
 //----------------------------------------------------------------------------
 
 #include <cassert>
+#include <cmath>
 #include <locale>
 #include <regex>
 
@@ -38,10 +39,12 @@
 #include "note.h"
 #include "options.h"
 #include "page.h"
+#include "pitchinterface.h"
 #include "runtimeclock.h"
+#include "staff.h"
+#include "system.h"
 #include "score.h"
 #include "slur.h"
-#include "staff.h"
 #include "svgdevicecontext.h"
 #include "timemap.h"
 #include "vrv.h"
@@ -57,6 +60,48 @@ namespace vrv {
 const char *UTF_16_BE_BOM = "\xFE\xFF";
 const char *UTF_16_LE_BOM = "\xFF\xFE";
 const char *ZIP_SIGNATURE = "\x50\x4B\x03\x04";
+
+namespace {
+
+struct PitchSpell {
+    data_PITCHNAME pname;
+    int accid;
+    int oct;
+};
+
+PitchSpell MidiToPitchSpell(int midiPitch)
+{
+    PitchSpell spell{ PITCHNAME_c, 0, 4 };
+
+    const int pclass = ((midiPitch % 12) + 12) % 12;
+    spell.oct = midiPitch / 12 - 1;
+
+    switch (pclass) {
+        case 0: spell.pname = PITCHNAME_c; spell.accid = 0; break;
+        case 1: spell.pname = PITCHNAME_c; spell.accid = 1; break;
+        case 2: spell.pname = PITCHNAME_d; spell.accid = 0; break;
+        case 3: spell.pname = PITCHNAME_e; spell.accid = -1; break;
+        case 4: spell.pname = PITCHNAME_e; spell.accid = 0; break;
+        case 5: spell.pname = PITCHNAME_f; spell.accid = 0; break;
+        case 6: spell.pname = PITCHNAME_f; spell.accid = 1; break;
+        case 7: spell.pname = PITCHNAME_g; spell.accid = 0; break;
+        case 8: spell.pname = PITCHNAME_a; spell.accid = -1; break;
+        case 9: spell.pname = PITCHNAME_a; spell.accid = 0; break;
+        case 10: spell.pname = PITCHNAME_b; spell.accid = -1; break;
+        case 11: spell.pname = PITCHNAME_b; spell.accid = 0; break;
+        default: break;
+    }
+
+    return spell;
+}
+
+Fraction ScoreTimeFromDouble(double scoreTime)
+{
+    const int denom = 1000;
+    return Fraction(static_cast<int>(std::round(scoreTime * denom)), denom);
+}
+
+} // namespace
 
 //----------------------------------------------------------------------------
 // Toolkit
@@ -2150,6 +2195,76 @@ std::string Toolkit::GetTimesForElement(const std::string &xmlId)
         o << "tstampOn" << realTimeOnsetMilliseconds;
         o << "tstampOff" << realTimeOffsetMilliseconds;
     }
+    return o.json();
+}
+
+std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staffN)
+{
+    this->ResetLogBuffer();
+
+    jsonxx::Object o;
+
+    if (staffN <= 0) {
+        LogWarning("Invalid staff number '%d'", staffN);
+        return o.json();
+    }
+
+    const Fraction requestedScoreTime = ScoreTimeFromDouble(scoreTime);
+
+    MeasureScoreTimeComparison matchMeasureTime(requestedScoreTime);
+    Measure *measure = dynamic_cast<Measure *>(m_doc.FindDescendantByComparison(&matchMeasureTime));
+    if (!measure) {
+        LogWarning("No measure found at score time '%f'", scoreTime);
+        return o.json();
+    }
+
+    int repeat = measure->EnclosesScoreTime(requestedScoreTime);
+    if (repeat == VRV_UNSET) repeat = 1;
+
+    Fraction measureOnset = measure->GetScoreTimeOnset(repeat);
+    Fraction localTime = requestedScoreTime - measureOnset;
+    if (localTime < 0) localTime = 0;
+
+    bool interpolated = false;
+    const int xRel = measure->GetXAtScoreTime(localTime, interpolated);
+    const int x = measure->GetDrawingX() + xRel;
+
+    AttNIntegerComparison staffCmp(STAFF, staffN);
+    Staff *staff = vrv_cast<Staff *>(measure->FindDescendantByComparison(&staffCmp, 1));
+    if (!staff) {
+        LogWarning("Staff '%d' not found in measure '%s'", staffN, measure->GetID().c_str());
+        return o.json();
+    }
+
+    Layer *layer = vrv_cast<Layer *>(staff->GetFirst(LAYER));
+    int clefOffset = 0;
+    if (layer) {
+        clefOffset = layer->GetClefLocOffset(NULL);
+    }
+
+    const PitchSpell spell = MidiToPitchSpell(midiPitch);
+    const int loc = PitchInterface::CalcLoc(spell.pname, spell.oct, clefOffset);
+    const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(&m_doc, loc);
+
+    Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
+    const int pageNo = (page) ? page->GetIdx() + 1 : 0;
+    System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
+    const int systemNo = (system) ? system->GetIdx() + 1 : 0;
+
+    o << "x" << x;
+    o << "y" << y;
+    o << "loc" << loc;
+    o << "midi" << midiPitch;
+    o << "staff" << staffN;
+    o << "measureId" << measure->GetID();
+    o << "page" << pageNo;
+    o << "system" << systemNo;
+    o << "scoreTime" << scoreTime;
+    o << "interpolated" << interpolated;
+    o << "pname" << static_cast<int>(spell.pname);
+    o << "accid" << spell.accid;
+    o << "oct" << spell.oct;
+
     return o.json();
 }
 

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -85,16 +85,6 @@ namespace {
         }
     }
 
-    data_ACCIDENTAL_WRITTEN SemitoneToAccidWritten(int value)
-    {
-        if (value <= -2) return ACCIDENTAL_WRITTEN_ff;
-        if (value == -1) return ACCIDENTAL_WRITTEN_f;
-        if (value == 0) return ACCIDENTAL_WRITTEN_n;
-        if (value == 1) return ACCIDENTAL_WRITTEN_s;
-        if (value >= 2) return ACCIDENTAL_WRITTEN_ss;
-        return ACCIDENTAL_WRITTEN_n;
-    }
-
     struct SpelledPitch {
         data_PITCHNAME pname;
         int accidSemitone;
@@ -2540,18 +2530,8 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
 
     o << "x" << xOut;
     o << "y" << yOut;
-    o << "loc" << loc;
-    o << "midi" << midiPitch;
-    o << "staff" << staffN;
-    o << "measureId" << measureId;
     o << "page" << pageNo;
     o << "system" << systemNo;
-    o << "scoreTime" << scoreTime;
-    o << "interpolated" << interpolated;
-    o << "pname" << static_cast<int>(spelled.pname);
-    o << "accid" << SemitoneToAccidWritten(spelled.accidSemitone);
-    o << "accidSemitone" << spelled.accidSemitone;
-    o << "oct" << spelled.oct;
 
     return o.json();
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <climits>
 #include <locale>
 #include <regex>
 
@@ -33,6 +34,7 @@
 #include "iopae.h"
 #include "iovolpiano.h"
 #include "layer.h"
+#include "keysig.h"
 #include "measure.h"
 #include "nc.h"
 #include "neume.h"
@@ -100,6 +102,72 @@ Fraction ScoreTimeFromDouble(double scoreTime)
     const int denom = 1000;
     return Fraction(static_cast<int>(std::round(scoreTime * denom)), denom);
 }
+
+int AccidWrittenToSemitone(data_ACCIDENTAL_WRITTEN accid)
+{
+    switch (accid) {
+        case ACCIDENTAL_WRITTEN_ff: return -2;
+        case ACCIDENTAL_WRITTEN_f: return -1;
+        case ACCIDENTAL_WRITTEN_n: return 0;
+        case ACCIDENTAL_WRITTEN_s: return 1;
+        case ACCIDENTAL_WRITTEN_ss: return 2;
+        default: return 0;
+    }
+}
+
+data_ACCIDENTAL_WRITTEN SemitoneToAccidWritten(int value)
+{
+    if (value <= -2) return ACCIDENTAL_WRITTEN_ff;
+    if (value == -1) return ACCIDENTAL_WRITTEN_f;
+    if (value == 0) return ACCIDENTAL_WRITTEN_n;
+    if (value == 1) return ACCIDENTAL_WRITTEN_s;
+    if (value >= 2) return ACCIDENTAL_WRITTEN_ss;
+    return ACCIDENTAL_WRITTEN_n;
+}
+
+struct SpelledPitch {
+    data_PITCHNAME pname;
+    int accidSemitone;
+    int oct;
+};
+
+SpelledPitch ChooseContextualSpell(
+    int midiPitch, const MapOfOctavedPitchAccid &contextAccids, bool preferSharps, bool preferFlats)
+{
+    const int targetPc = ((midiPitch % 12) + 12) % 12;
+    SpelledPitch best{ PITCHNAME_c, 0, midiPitch / 12 - 1 };
+    int bestCost = INT_MAX;
+
+    const data_PITCHNAME pnames[] = { PITCHNAME_c, PITCHNAME_d, PITCHNAME_e, PITCHNAME_f, PITCHNAME_g, PITCHNAME_a,
+        PITCHNAME_b };
+
+    for (data_PITCHNAME pname : pnames) {
+        const int basePc = Note::PnameToPclass(pname);
+        int accid = targetPc - basePc;
+        while (accid > 6) accid -= 12;
+        while (accid < -6) accid += 12;
+        const int naturalPc = basePc + accid;
+        const int oct = (midiPitch - naturalPc) / 12 - 1;
+        if ((oct < 0) || (oct > 9)) continue;
+
+        const int idx = pname + oct * 7;
+        int expected = 0;
+        auto found = contextAccids.find(idx);
+        if (found != contextAccids.end()) expected = AccidWrittenToSemitone(found->second);
+
+        int cost = std::abs(accid - expected) * 10 + std::abs(accid);
+        if (preferSharps && accid < 0) cost += 5;
+        if (preferFlats && accid > 0) cost += 5;
+
+        if (cost < bestCost) {
+            bestCost = cost;
+            best = { pname, accid, oct };
+        }
+    }
+
+    return best;
+}
+
 
 } // namespace
 
@@ -2238,12 +2306,34 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
 
     Layer *layer = vrv_cast<Layer *>(staff->GetFirst(LAYER));
     int clefOffset = 0;
+    const KeySig *keySig = NULL;
     if (layer) {
         clefOffset = layer->GetClefLocOffset(NULL);
+        keySig = layer->GetCurrentKeySig();
     }
 
-    const PitchSpell spell = MidiToPitchSpell(midiPitch);
-    const int loc = PitchInterface::CalcLoc(spell.pname, spell.oct, clefOffset);
+    MapOfOctavedPitchAccid contextAccids;
+    if (keySig) {
+        keySig->FillMap(contextAccids);
+    }
+
+    ListOfConstObjects notes = staff->FindAllDescendantsByType(NOTE, false);
+    for (const Object *obj : notes) {
+        const Note *note = vrv_cast<const Note *>(obj);
+        assert(note);
+        if (note->GetScoreTimeOnset() > localTime) continue;
+        const Accid *accid = note->GetDrawingAccid();
+        if (!accid) continue;
+        if (!note->HasPname() || !note->HasOct()) continue;
+        const int idx = note->GetPname() + note->GetOct() * 7;
+        contextAccids[idx] = accid->GetAccid();
+    }
+
+    const bool preferSharps = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_s));
+    const bool preferFlats = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_f));
+    const SpelledPitch spelled = ChooseContextualSpell(midiPitch, contextAccids, preferSharps, preferFlats);
+
+    const int loc = PitchInterface::CalcLoc(spelled.pname, spelled.oct, clefOffset);
     const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(&m_doc, loc);
 
     Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
@@ -2261,9 +2351,10 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
     o << "system" << systemNo;
     o << "scoreTime" << scoreTime;
     o << "interpolated" << interpolated;
-    o << "pname" << static_cast<int>(spell.pname);
-    o << "accid" << spell.accid;
-    o << "oct" << spell.oct;
+    o << "pname" << static_cast<int>(spelled.pname);
+    o << "accid" << SemitoneToAccidWritten(spelled.accidSemitone);
+    o << "accidSemitone" << spelled.accidSemitone;
+    o << "oct" << spelled.oct;
 
     return o.json();
 }

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -2428,7 +2428,7 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
     // SCORE_TIME_UNIT per quarter. Convert before looking up X.
     const Fraction localTimeForX = localTime / SCORE_TIME_UNIT;
     const int xRel = layoutMeasure->GetXAtScoreTime(localTimeForX, interpolated);
-    const int x = layoutMeasure->GetDrawingX() + xRel;
+    int x = layoutMeasure->GetDrawingX() + xRel;
 
     AttNIntegerComparison staffCmp(STAFF, staffN);
     Staff *staff = vrv_cast<Staff *>(layoutMeasure->FindDescendantByComparison(&staffCmp, 1));
@@ -2451,15 +2451,31 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
     }
 
     const ListOfObjects notes = staff->FindAllDescendantsByType(NOTE, false);
+    const Note *anchorNote = NULL;
+    Fraction anchorOnset;
+    int anchorPitchDistance = 0;
     for (const Object *obj : notes) {
         const Note *note = vrv_cast<const Note *>(obj);
         assert(note);
-        if (note->GetScoreTimeOnset() > localTime) continue;
+        const Fraction noteOnset = note->GetScoreTimeOnset();
+        if (noteOnset > localTime) continue;
         const Accid *accid = note->GetDrawingAccid();
-        if (!accid) continue;
-        if (!note->HasPname() || !note->HasOct()) continue;
-        const int idx = note->GetPname() + note->GetOct() * 7;
-        contextAccids[idx] = accid->GetAccid();
+        if (accid && note->HasPname() && note->HasOct()) {
+            const int idx = note->GetPname() + note->GetOct() * 7;
+            contextAccids[idx] = accid->GetAccid();
+        }
+
+        int distance = note->GetMIDIPitch() - midiPitchInt;
+        if (distance < 0) distance = -distance;
+        if (!anchorNote || noteOnset > anchorOnset) {
+            anchorNote = note;
+            anchorOnset = noteOnset;
+            anchorPitchDistance = distance;
+        }
+        else if (noteOnset == anchorOnset && distance < anchorPitchDistance) {
+            anchorNote = note;
+            anchorPitchDistance = distance;
+        }
     }
 
     const bool preferSharps = (keySig && (keySig->GetAccidType() == ACCIDENTAL_WRITTEN_s));
@@ -2483,6 +2499,16 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
         yRel = yRelBase + (yRelStep - yRelBase) * ratio;
     }
     const double y = staff->GetDrawingY() + yRel;
+
+    if (anchorNote) {
+        bool anchorInterpolated = false;
+        const Fraction anchorOnsetForX = anchorOnset / SCORE_TIME_UNIT;
+        const int anchorXRel = layoutMeasure->GetXAtScoreTime(anchorOnsetForX, anchorInterpolated);
+        const int anchorX = layoutMeasure->GetDrawingX() + anchorXRel;
+        const int noteHeadCenterX =
+            anchorNote->GetDrawingX() + anchorNote->GetDrawingRadius(&m_doc);
+        x += noteHeadCenterX - anchorX;
+    }
 
     // Convert to SVG device coordinates: include page margins and flip Y from
     // Verovio's logical space (origin at bottom-left of content) to SVG space

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -2280,27 +2280,91 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
     const Fraction requestedScoreTime = ScoreTimeFromDouble(scoreTime);
 
     MeasureScoreTimeComparison matchMeasureTime(requestedScoreTime);
-    Measure *measure = dynamic_cast<Measure *>(m_doc.FindDescendantByComparison(&matchMeasureTime));
+    Measure *measure = NULL;
+    if (m_doc.GetDrawingPage()) {
+        measure = dynamic_cast<Measure *>(m_doc.GetDrawingPage()->FindDescendantByComparison(&matchMeasureTime));
+    }
+    if (!measure) {
+        measure = dynamic_cast<Measure *>(m_doc.FindDescendantByComparison(&matchMeasureTime));
+    }
     if (!measure) {
         LogWarning("No measure found at score time '%f'", scoreTime);
         return o.json();
     }
 
+    // Score-time boundaries are inclusive, so exact measure offsets can map to the
+    // previous measure. If the query is at the offset, advance to the next measure
+    // to keep onset notes in their own bar.
     int repeat = measure->EnclosesScoreTime(requestedScoreTime);
     if (repeat == VRV_UNSET) repeat = 1;
 
+    const Fraction measureOffset = measure->GetScoreTimeOffset(repeat);
+    if (requestedScoreTime == measureOffset) {
+        Object *parent = measure->GetParent();
+        if (parent) {
+            Measure *nextMeasure = vrv_cast<Measure *>(parent->GetNext(measure, MEASURE));
+            if (nextMeasure) {
+                measure = nextMeasure;
+                repeat = measure->EnclosesScoreTime(requestedScoreTime);
+                if (repeat == VRV_UNSET) repeat = 1;
+            }
+        }
+    }
+
+    const std::string measureId = measure->GetID();
+
+    Measure *layoutMeasure = measure;
+    Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
+    System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
+
+    if (m_doc.GetDrawingPage()) {
+        Page *drawingPage = m_doc.GetDrawingPage();
+        for (Object *child : drawingPage->GetChildren()) {
+            if (!child->Is(SYSTEM)) continue;
+            System *candidateSystem = vrv_cast<System *>(child);
+            if (!candidateSystem) continue;
+            const ListOfObjects measures = candidateSystem->FindAllDescendantsByType(MEASURE, false);
+            for (Object *measureObj : measures) {
+                Measure *candidateMeasure = vrv_cast<Measure *>(measureObj);
+                if (!candidateMeasure) continue;
+                if (candidateMeasure->GetID() == measureId) {
+                    layoutMeasure = candidateMeasure;
+                    page = drawingPage;
+                    system = candidateSystem;
+                    break;
+                }
+                const LinkingInterface *link = candidateMeasure->GetLinkingInterface();
+                if (link && link->HasCorresp()) {
+                    const std::string correspId = ExtractIDFragment(link->GetCorresp());
+                    if (correspId == measureId) {
+                        layoutMeasure = candidateMeasure;
+                        page = drawingPage;
+                        system = candidateSystem;
+                        break;
+                    }
+                }
+            }
+            if (system == candidateSystem) break;
+        }
+    }
+
+    // Use the logical measure onset for time math, even if the layout measure is
+    // found via @corresp on the drawing page.
     Fraction measureOnset = measure->GetScoreTimeOnset(repeat);
     Fraction localTime = requestedScoreTime - measureOnset;
     if (localTime < 0) localTime = 0;
 
     bool interpolated = false;
-    const int xRel = measure->GetXAtScoreTime(localTime, interpolated);
-    const int x = measure->GetDrawingX() + xRel;
+    // Measure alignments are in quarter-note units, while Verovio score time uses
+    // SCORE_TIME_UNIT per quarter. Convert before looking up X.
+    const Fraction localTimeForX = localTime / SCORE_TIME_UNIT;
+    const int xRel = layoutMeasure->GetXAtScoreTime(localTimeForX, interpolated);
+    const int x = layoutMeasure->GetDrawingX() + xRel;
 
     AttNIntegerComparison staffCmp(STAFF, staffN);
-    Staff *staff = vrv_cast<Staff *>(measure->FindDescendantByComparison(&staffCmp, 1));
+    Staff *staff = vrv_cast<Staff *>(layoutMeasure->FindDescendantByComparison(&staffCmp, 1));
     if (!staff) {
-        LogWarning("Staff '%d' not found in measure '%s'", staffN, measure->GetID().c_str());
+        LogWarning("Staff '%d' not found in measure '%s'", staffN, measureId.c_str());
         return o.json();
     }
 
@@ -2317,7 +2381,7 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
         keySig->FillMap(contextAccids);
     }
 
-    ListOfConstObjects notes = staff->FindAllDescendantsByType(NOTE, false);
+    const ListOfObjects notes = staff->FindAllDescendantsByType(NOTE, false);
     for (const Object *obj : notes) {
         const Note *note = vrv_cast<const Note *>(obj);
         assert(note);
@@ -2336,17 +2400,42 @@ std::string Toolkit::GetPitchPosition(double scoreTime, int midiPitch, int staff
     const int loc = PitchInterface::CalcLoc(spelled.pname, spelled.oct, clefOffset);
     const int y = staff->GetDrawingY() + staff->CalcPitchPosYRel(&m_doc, loc);
 
-    Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
-    const int pageNo = (page) ? page->GetIdx() + 1 : 0;
-    System *system = vrv_cast<System *>(measure->GetFirstAncestor(SYSTEM));
-    const int systemNo = (system) ? system->GetIdx() + 1 : 0;
+    // Convert to SVG device coordinates: include page margins and flip Y from
+    // Verovio's logical space (origin at bottom-left of content) to SVG space
+    // (origin at top-left of the page content).
+    int xOut = x;
+    int yOut = y;
+    if (page) {
+        if (!m_doc.GetDrawingPage() || m_doc.GetDrawingPage()->GetIdx() != page->GetIdx()) {
+            m_doc.SetDrawingPage(page->GetIdx());
+        }
+        xOut = x + m_doc.m_drawingPageMarginLeft;
+        yOut = m_doc.m_drawingPageContentHeight - y + m_doc.m_drawingPageMarginTop;
+    }
 
-    o << "x" << x;
-    o << "y" << y;
+    const int pageNo = (page) ? page->GetIdx() + 1 : 0;
+    int systemNo = 0;
+    if (page && system) {
+        int systemIndex = 0;
+        for (Object *child : page->GetChildren()) {
+            if (!child->Is(SYSTEM)) continue;
+            systemIndex++;
+            if (child == system) {
+                systemNo = systemIndex;
+                break;
+            }
+        }
+    }
+    if (!systemNo && system) {
+        systemNo = system->GetIdx() + 1;
+    }
+
+    o << "x" << xOut;
+    o << "y" << yOut;
     o << "loc" << loc;
     o << "midi" << midiPitch;
     o << "staff" << staffN;
-    o << "measureId" << measure->GetID();
+    o << "measureId" << measureId;
     o << "page" << pageNo;
     o << "system" << systemNo;
     o << "scoreTime" << scoreTime;

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -67,74 +67,6 @@ const char *ZIP_SIGNATURE = "\x50\x4B\x03\x04";
 
 namespace {
 
-    struct PitchSpell {
-        data_PITCHNAME pname;
-        int accid;
-        int oct;
-    };
-
-    PitchSpell MidiToPitchSpell(int midiPitch)
-    {
-        PitchSpell spell{ PITCHNAME_c, 0, 4 };
-
-        const int pclass = ((midiPitch % 12) + 12) % 12;
-        spell.oct = midiPitch / 12 - 1;
-
-        switch (pclass) {
-            case 0:
-                spell.pname = PITCHNAME_c;
-                spell.accid = 0;
-                break;
-            case 1:
-                spell.pname = PITCHNAME_c;
-                spell.accid = 1;
-                break;
-            case 2:
-                spell.pname = PITCHNAME_d;
-                spell.accid = 0;
-                break;
-            case 3:
-                spell.pname = PITCHNAME_e;
-                spell.accid = -1;
-                break;
-            case 4:
-                spell.pname = PITCHNAME_e;
-                spell.accid = 0;
-                break;
-            case 5:
-                spell.pname = PITCHNAME_f;
-                spell.accid = 0;
-                break;
-            case 6:
-                spell.pname = PITCHNAME_f;
-                spell.accid = 1;
-                break;
-            case 7:
-                spell.pname = PITCHNAME_g;
-                spell.accid = 0;
-                break;
-            case 8:
-                spell.pname = PITCHNAME_a;
-                spell.accid = -1;
-                break;
-            case 9:
-                spell.pname = PITCHNAME_a;
-                spell.accid = 0;
-                break;
-            case 10:
-                spell.pname = PITCHNAME_b;
-                spell.accid = -1;
-                break;
-            case 11:
-                spell.pname = PITCHNAME_b;
-                spell.accid = 0;
-                break;
-            default: break;
-        }
-
-        return spell;
-    }
-
     Fraction ScoreTimeFromDouble(double scoreTime)
     {
         const int denom = 1000;
@@ -2341,6 +2273,15 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
         LogWarning("Invalid MIDI pitch '%f'", midiPitch);
         return o.json();
     }
+
+    if (!m_doc.HasTimemap()) {
+        // Ensure measure score-time boundaries exist for comparisons.
+        m_doc.CalculateTimemap();
+    }
+    if (!m_doc.HasTimemap()) {
+        LogWarning("Calculation of the timemap failed, pitch position is invalid.");
+        return o.json();
+    }
     const Fraction requestedScoreTime = ScoreTimeFromDouble(scoreTime);
 
     MeasureScoreTimeComparison matchMeasureTime(requestedScoreTime);
@@ -2451,8 +2392,7 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
                     active = true;
                 }
                 else {
-                    active = (localTimeForX >= startAlignment->GetTime())
-                        && (localTimeForX <= endAlignment->GetTime());
+                    active = (localTimeForX >= startAlignment->GetTime()) && (localTimeForX <= endAlignment->GetTime());
                 }
             }
             else if (currentMeasureIndex == startIndex) {
@@ -2564,8 +2504,7 @@ std::string Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int st
         const Fraction anchorOnsetForX = anchorOnset / SCORE_TIME_UNIT;
         const int anchorXRel = layoutMeasure->GetXAtScoreTime(anchorOnsetForX, anchorInterpolated);
         const int anchorX = layoutMeasure->GetDrawingX() + anchorXRel;
-        const int noteHeadCenterX =
-            anchorNote->GetDrawingX() + anchorNote->GetDrawingRadius(&m_doc);
+        const int noteHeadCenterX = anchorNote->GetDrawingX() + anchorNote->GetDrawingRadius(&m_doc);
         x += noteHeadCenterX - anchorX;
     }
 

--- a/tools/c_wrapper.cpp
+++ b/tools/c_wrapper.cpp
@@ -236,7 +236,7 @@ const char *vrvToolkit_getTimesForElement(void *tkPtr, const char *xmlId)
     return tk->GetCString();
 }
 
-const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, int midiPitch, int staff)
+const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, double midiPitch, int staff)
 {
     Toolkit *tk = static_cast<Toolkit *>(tkPtr);
     tk->SetCString(tk->GetPitchPosition(scoreTime, midiPitch, staff));

--- a/tools/c_wrapper.cpp
+++ b/tools/c_wrapper.cpp
@@ -236,6 +236,13 @@ const char *vrvToolkit_getTimesForElement(void *tkPtr, const char *xmlId)
     return tk->GetCString();
 }
 
+const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, int midiPitch, int staff)
+{
+    Toolkit *tk = static_cast<Toolkit *>(tkPtr);
+    tk->SetCString(tk->GetPitchPosition(scoreTime, midiPitch, staff));
+    return tk->GetCString();
+}
+
 const char *vrvToolkit_getVersion(void *tkPtr)
 {
     Toolkit *tk = static_cast<Toolkit *>(tkPtr);

--- a/tools/c_wrapper.h
+++ b/tools/c_wrapper.h
@@ -47,7 +47,7 @@ const char *vrvToolkit_getResourcePath(void *tkPtr);
 int vrvToolkit_getScale(void *tkPtr);
 double vrvToolkit_getTimeForElement(void *tkPtr, const char *xmlId);
 const char *vrvToolkit_getTimesForElement(void *tkPtr, const char *xmlId);
-const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, int midiPitch, int staff);
+const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, double midiPitch, int staff);
 const char *vrvToolkit_getVersion(void *tkPtr);
 bool vrvToolkit_loadData(void *tkPtr, const char *data);
 bool vrvToolkit_loadFile(void *tkPtr, const char *filename);

--- a/tools/c_wrapper.h
+++ b/tools/c_wrapper.h
@@ -47,6 +47,7 @@ const char *vrvToolkit_getResourcePath(void *tkPtr);
 int vrvToolkit_getScale(void *tkPtr);
 double vrvToolkit_getTimeForElement(void *tkPtr, const char *xmlId);
 const char *vrvToolkit_getTimesForElement(void *tkPtr, const char *xmlId);
+const char *vrvToolkit_getPitchPosition(void *tkPtr, double scoreTime, int midiPitch, int staff);
 const char *vrvToolkit_getVersion(void *tkPtr);
 bool vrvToolkit_loadData(void *tkPtr, const char *data);
 bool vrvToolkit_loadFile(void *tkPtr, const char *filename);


### PR DESCRIPTION
## Summary

Closes #4189.

This PR adds a toolkit API for querying the graphical SVG page position of a pitch at a given score-time position and staff.

The new API is exposed as:

- C++: `Toolkit::GetPitchPosition(double scoreTime, double midiPitch, int staffN)`
- C wrapper / WASM export: `vrvToolkit_getPitchPosition`
- JavaScript: `VerovioToolkit.getPitchPosition(scoreTime, midiPitch, staff = 1)`

The method returns a JSON object containing the computed SVG page coordinates and context information, including:

```json
{
  "x": 0,
  "y": 0,
  "loc": 0,
  "midi": 60,
  "staff": 1,
  "measureId": "...",
  "page": 1,
  "system": 1,
  "scoreTime": 0,
  "interpolated": true,
  "pname": 1,
  "accid": null,
  "accidSemitone": 0,
  "oct": 4
}
```

## Motivation

Issue #4189 requests a way to query the graphical position of an arbitrary pitch in an already rendered layout. This is useful for interactive applications that need to place feedback, annotations, overlays, cursors, or other UI elements on top of rendered Verovio SVG output.

The requested inputs are:

- MIDI pitch
- score-time position from the beginning of the score
- staff number

The requested output is an `(x, y)` coordinate relative to the SVG page.

## Implementation Details

This PR adds score-time-based measure lookup and layout interpolation support:

- Adds `MeasureScoreTimeComparison` to find the measure enclosing a requested score-time value.
- Adds `Measure::EnclosesScoreTime(...)` using the measure timemap onset/offset data.
- Adds `Measure::GetXAtScoreTime(...)`, which interpolates the x position between surrounding measure alignments.
- Ensures the timemap is calculated before resolving measure score-time boundaries.
- Handles exact measure-boundary queries by advancing to the next measure where appropriate, so onset queries resolve to the expected bar.
- Maps logical measures to drawing-page layout measures, including cases where rendered layout measures use `@corresp`.

Pitch-to-y placement is context-aware:

- Uses the current clef context via the active layer.
- Uses key signature accidentals as the initial accidental context.
- Updates accidental context from preceding notes in the staff up to the queried score-time.
- Chooses a contextual pitch spelling for the requested MIDI pitch, preferring the active key signature direction where relevant.
- Supports fractional MIDI pitches by interpolating vertically toward the next diatonic step.
- Accounts for active octave transposition lines on the target staff.

The returned coordinates are converted to SVG page coordinates:

- The x coordinate includes page margin offset.
- The y coordinate is converted from Verovio's internal drawing coordinate system to SVG page coordinates.
- The response also includes page number, system number, measure id, staff, pitch spelling, accidental, octave, and whether x interpolation was used.

The WASM and npm bindings are updated by:

- Adding `_vrvToolkit_getPitchPosition` to `emscripten/exports.txt`.
- Adding the C wrapper declaration and implementation.
- Adding the Emscripten proxy binding.
- Adding `VerovioToolkit.getPitchPosition(...)` to the npm toolkit wrapper.

## Tests

Added npm-side harnesses for the new API:

- `emscripten/npm/test/get-pitch-position.mjs`
  - Builds a minimal MEI example.
  - Queries `getPitchPosition`.
  - Checks measure/page/system/staff values.
  - Verifies fractional MIDI pitch changes the y coordinate.

- `emscripten/npm/test/get-pitch-position-xml.mjs`
  - Exercises the API on a MusicXML fixture.
  - Compares returned positions against rendered SVG context.
  - Prints note/timemap/SVG diagnostics useful for regression debugging.

## Verification

Verified after rebasing on current `origin/develop`:

```bash
cd emscripten
./buildNpmPackage
```

```bash
node emscripten/npm/test/get-pitch-position.mjs
node emscripten/npm/test/get-pitch-position-xml.mjs
```

```bash
cd emscripten/npm
npm pack --dry-run
```

```bash
git diff --check origin/develop..HEAD
```

All commands completed successfully.
