### PR TITLE
Fix: Two `static std::map` in `customtuning.{h,cpp}` should be `thread_local` to prevent race-condition which causes Segmentation Fault.

### DIFF
--- a/include/vrv/customtuning.h
+++ b/include/vrv/customtuning.h
@@ -82,8 +82,8 @@ private:
     // Static members //
     //----------------//
 
-    static std::map<std::string, char32_t> s_glyphNames;
-    static std::map<char32_t, std::string> s_glyphCodes;
+    static thread_local std::map<std::string, char32_t> s_glyphNames;
+    static thread_local std::map<char32_t, std::string> s_glyphCodes;
 };
 
 } // namespace vrv

--- a/src/customtuning.cpp
+++ b/src/customtuning.cpp
@@ -23,8 +23,8 @@ namespace vrv {
 // Static members
 //----------------------------------------------------------------------------
 
-std::map<std::string, char32_t> CustomTuning::s_glyphNames;
-std::map<char32_t, std::string> CustomTuning::s_glyphCodes;
+thread_local std::map<std::string, char32_t> CustomTuning::s_glyphNames;
+thread_local std::map<char32_t, std::string> CustomTuning::s_glyphCodes;
 
 //----------------------------------------------------------------------------
 // CustomTuning


### PR DESCRIPTION
Patch to fix the issue https://github.com/rism-digital/verovio/issues/4385

