### PR TITLE
Fix getElementAttr for grpSym and keyAccid elements

### DIFF
--- a/include/vrv/findfunctor.h
+++ b/include/vrv/findfunctor.h
@@ -523,6 +523,7 @@ public:
     ///@{
     FunctorCode VisitLayer(const Layer *layer) override;
     FunctorCode VisitScore(const Score *score) override;
+    FunctorCode VisitSystem(const System *system) override;
     ///@}
 
 protected:

--- a/src/findfunctor.cpp
+++ b/src/findfunctor.cpp
@@ -14,8 +14,10 @@
 #include "object.h"
 #include "plistinterface.h"
 #include "score.h"
+#include "scoredef.h"
 #include "surface.h"
 #include "symboldef.h"
+#include "system.h"
 #include "zone.h"
 
 namespace vrv {
@@ -439,6 +441,11 @@ FunctorCode FindElementInLayerStaffDefFunctor::VisitLayer(const Layer *layer)
     else if (layer->GetStaffDefMeterSigGrp() && (layer->GetStaffDefMeterSigGrp()->GetID() == m_id)) {
         m_element = layer->GetStaffDefMeterSigGrp();
     }
+    // The KeyAccid children are generated from the @sig attribute and are not matched above - look for them within
+    // the KeySig
+    if (!m_element && layer->GetStaffDefKeySig()) {
+        m_element = layer->GetStaffDefKeySig()->FindDescendantByID(m_id);
+    }
 
     return m_element ? FUNCTOR_STOP : FUNCTOR_SIBLINGS;
 }
@@ -452,6 +459,18 @@ FunctorCode FindElementInLayerStaffDefFunctor::VisitScore(const Score *score)
     }
     else {
         m_element = score->GetScoreDef()->FindDescendantByID(m_id);
+    }
+
+    return (m_element) ? FUNCTOR_STOP : FUNCTOR_CONTINUE;
+}
+
+FunctorCode FindElementInLayerStaffDefFunctor::VisitSystem(const System *system)
+{
+    // The GrpSym drawn at the beginning of a system (as well as the running Clef, KeySig, etc.) is a generated element
+    // living in the drawing ScoreDef of the system, which is not part of the main document tree
+    const ScoreDef *drawingScoreDef = system->GetDrawingScoreDef();
+    if (drawingScoreDef) {
+        m_element = drawingScoreDef->FindDescendantByID(m_id);
     }
 
     return (m_element) ? FUNCTOR_STOP : FUNCTOR_CONTINUE;


### PR DESCRIPTION
### Problem

`getElementAttr` cannot resolve `grpSym` and `keyAccid` elements that appear in the rendered SVG — it logs an `Element '...' not found` warning and returns an empty object. Reported in #4084.

### Cause

Both elements are generated from attributes (`@symbol` on `staffGrp`, `@sig` on the key signature) and live outside the main document tree, so neither `FindDescendantByID` nor `FindElementInLayerStaffDefFunctor` reaches them.

### Fix

- `keyAccid`: the generated accidentals are children of the running `KeySig`, so `VisitLayer` now searches the StaffDef `KeySig` descendants.
- `grpSym`: it is drawn from the system's drawing `ScoreDef`, so a new `VisitSystem` searches it.

### Verification

Rendered a score with a braced staff group and a 3-sharp key signature, then called `getElementAttr` on every `grpSym`/`keyAccid`/`keySig` id in the SVG.

- Before: `grpSym` and `keyAccid` return `{}` with `not found` warnings.
- After: all return correct attributes (`{"symbol":"brace"}`, `{"accid":"s","pname":"f",...}`) with no warnings.

Existing `clef`/`keySig`/`meterSig`/`note` resolution is unchanged.

This change is under 20 lines of code.

Fixes #4084