### PR TITLE
Fix: Selection renders the score-initial clef instead of the running one at the selection start.

### DIFF
--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -496,7 +496,14 @@ void ScoreDef::ResetFromDrawingValues()
             meterSigGrp->ReplaceWithCopyOf(staffDef->GetCurrentMeterSigGrp());
         }
         else if (meterSig) {
-            meterSig->ReplaceWithCopyOf(staffDef->GetCurrentMeterSig());
+            // Same slicing as the clef above: ReplaceWithCopyOf drops the
+            // derived attribute values, so the meter child kept its old
+            // count / unit / sym - copy the meter-identity attributes
+            // explicitly.
+            const MeterSig *currentMeterSig = staffDef->GetCurrentMeterSig();
+            meterSig->SetCount(currentMeterSig->GetCount());
+            meterSig->SetUnit(currentMeterSig->GetUnit());
+            meterSig->SetSym(currentMeterSig->GetSym());
         }
     }
 }

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -472,7 +472,17 @@ void ScoreDef::ResetFromDrawingValues()
         assert(staffDef);
 
         Clef *clef = vrv_cast<Clef *>(staffDef->FindDescendantByType(CLEF));
-        if (clef) clef->ReplaceWithCopyOf(staffDef->GetCurrentClef());
+        if (clef) {
+            // ReplaceWithCopyOf assigns through Object::operator=, which copies
+            // the base members and cloned children but no derived attribute
+            // values, so the clef child kept its old shape and line - copy the
+            // clef-identity attributes explicitly.
+            const Clef *currentClef = staffDef->GetCurrentClef();
+            clef->SetShape(currentClef->GetShape());
+            clef->SetLine(currentClef->GetLine());
+            clef->SetDis(currentClef->GetDis());
+            clef->SetDisPlace(currentClef->GetDisPlace());
+        }
 
         KeySig *keySig = vrv_cast<KeySig *>(staffDef->FindDescendantByType(KEYSIG));
         if (keySig) keySig->ReplaceWithCopyOf(staffDef->GetCurrentKeySig());

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -488,7 +488,18 @@ void ScoreDef::ResetFromDrawingValues()
         if (keySig) keySig->ReplaceWithCopyOf(staffDef->GetCurrentKeySig());
 
         Mensur *mensur = vrv_cast<Mensur *>(staffDef->FindDescendantByType(MENSUR));
-        if (mensur) mensur->ReplaceWithCopyOf(staffDef->GetCurrentMensur());
+        if (mensur) {
+            // Same slicing as the clef above: copy the mensuration-sign
+            // attributes that View::DrawMensur reads, instead of through
+            // ReplaceWithCopyOf.
+            const Mensur *currentMensur = staffDef->GetCurrentMensur();
+            mensur->SetSign(currentMensur->GetSign());
+            mensur->SetSlash(currentMensur->GetSlash());
+            mensur->SetDot(currentMensur->GetDot());
+            mensur->SetOrient(currentMensur->GetOrient());
+            mensur->SetNum(currentMensur->GetNum());
+            mensur->SetNumbase(currentMensur->GetNumbase());
+        }
 
         MeterSigGrp *meterSigGrp = vrv_cast<MeterSigGrp *>(staffDef->FindDescendantByType(METERSIGGRP));
         MeterSig *meterSig = vrv_cast<MeterSig *>(staffDef->FindDescendantByType(METERSIG));


### PR DESCRIPTION
A selection whose measure range is preceded by a mid-piece clef change opened with the score-initial clef. `ScoreDef::ResetFromDrawingValues` wrote the running clef into the scoreDef's clef child via `Object::ReplaceWithCopyOf`, whose `Object::operator=` copies base members and cloned children but no derived attribute values - so the clef child kept its old shape and line. Copy the clef-identity attributes (shape, line, dis, dis.place) explicitly instead.

No regression on the official test suites: `_tests` (629 files) and `musicxmlTestSuite` (150 files) render byte-identical SVGs before and after (the only caller of `ResetFromDrawingValues` is the selection path).

Fixes issue  https://github.com/rism-digital/verovio/issues/4388 . (includes repro, minimal score and before/after screenshots)