### PR TITLE
feat(neume): support notation subtypes

### DIFF
--- a/libmei/dist/attconverter.cpp
+++ b/libmei/dist/attconverter.cpp
@@ -2937,6 +2937,8 @@ std::string AttConverterBase::NotationtypeToStr(data_NOTATIONTYPE data) const
         case NOTATIONTYPE_mensural_black: value = "mensural.black"; break;
         case NOTATIONTYPE_mensural_white: value = "mensural.white"; break;
         case NOTATIONTYPE_neume: value = "neume"; break;
+        case NOTATIONTYPE_neume_square: value = "neume.square"; break;
+        case NOTATIONTYPE_neume_hufnagel: value = "neume.hufnagel"; break;
         case NOTATIONTYPE_tab: value = "tab"; break;
         case NOTATIONTYPE_tab_staff_like: value = "tab.staff-like"; break;
         case NOTATIONTYPE_tab_guitar: value = "tab.guitar"; break;
@@ -2958,6 +2960,8 @@ data_NOTATIONTYPE AttConverterBase::StrToNotationtype(const std::string &value, 
     if (value == "mensural.black") return NOTATIONTYPE_mensural_black;
     if (value == "mensural.white") return NOTATIONTYPE_mensural_white;
     if (value == "neume") return NOTATIONTYPE_neume;
+    if (value == "neume.square") return NOTATIONTYPE_neume_square;
+    if (value == "neume.hufnagel") return NOTATIONTYPE_neume_hufnagel;
     if (value == "tab") return NOTATIONTYPE_tab;
     if (value == "tab.staff-like") return NOTATIONTYPE_tab_staff_like;
     if (value == "tab.guitar") return NOTATIONTYPE_tab_guitar;

--- a/libmei/dist/atttypes.h
+++ b/libmei/dist/atttypes.h
@@ -1388,6 +1388,8 @@ enum data_NOTATIONTYPE : int8_t {
     NOTATIONTYPE_mensural_black,
     NOTATIONTYPE_mensural_white,
     NOTATIONTYPE_neume,
+    NOTATIONTYPE_neume_square,
+    NOTATIONTYPE_neume_hufnagel,
     NOTATIONTYPE_tab,
     NOTATIONTYPE_tab_staff_like,
     NOTATIONTYPE_tab_guitar,

--- a/libmei/mei/mei-verovio.xml
+++ b/libmei/mei/mei-verovio.xml
@@ -505,6 +505,53 @@
 					</classes>
 				</elementSpec>
 
+				<macroSpec ident="data.NOTATIONTYPE" module="MEI" type="dt" mode="replace">
+					<desc xml:lang="en">Notation type and subtype</desc>
+					<content>
+						<valList type="closed">
+							<valItem ident="cmn">
+								<desc xml:lang="en">Common Music Notation.</desc>
+							</valItem>
+							<valItem ident="mensural">
+								<desc xml:lang="en">Mensural notation.</desc>
+							</valItem>
+							<valItem ident="mensural.black">
+								<desc xml:lang="en">Black mensural notation.</desc>
+							</valItem>
+							<valItem ident="mensural.white">
+								<desc xml:lang="en">White mensural notation.</desc>
+							</valItem>
+							<valItem ident="neume">
+								<desc xml:lang="en">Neumatic notation.</desc>
+							</valItem>
+							<valItem ident="neume.square">
+								<desc xml:lang="en">Square neumatic notation.</desc>
+							</valItem>
+							<valItem ident="neume.hufnagel">
+								<desc xml:lang="en">Hufnagel neumatic notation.</desc>
+							</valItem>
+							<valItem ident="tab">
+								<desc xml:lang="en">Tablature notation.</desc>
+							</valItem>
+							<valItem ident="tab.staff-like">
+								<desc xml:lang="en">"Notehead" notation: a hybrid between staff and tablature notation consisting of solid, stemless noteheads on a CMN staff with tablature rhythm flags placed above the staff.</desc>
+							</valItem>
+							<valItem ident="tab.guitar">
+								<desc xml:lang="en">Tablature notation for guitars (includes "spanish" lute tablature). Frets are indicated using numbers. Courses closest to the player's feet are at the top of the staff.</desc>
+							</valItem>
+							<valItem ident="tab.lute.french">
+								<desc xml:lang="en">"French" tablature notation for lutes. Frets are indicated using letters. Courses closest to the player's feet are at the top of the staff.</desc>
+							</valItem>
+							<valItem ident="tab.lute.italian">
+								<desc xml:lang="en">"Italian" tablature notation for lutes. Frets are indicated using numbers. Courses closest to the player's feet are at the bottom of the staff.</desc>
+							</valItem>
+							<valItem ident="tab.lute.german">
+								<desc xml:lang="en">"German" tablature notation for lutes. Fret and course information is conveyed solely by choice of symbol (vertical position is not used for this).</desc>
+							</valItem>
+						</valList>
+					</content>
+				</macroSpec>
+
 				<classSpec ident="att.xy" module="MEI.shared" type="atts" mode="change">
 					<classes mode="change">
 						<memberOf key="att.coord.x1"/>

--- a/libmei/mei/mei-verovio_compiled.odd
+++ b/libmei/mei/mei-verovio_compiled.odd
@@ -2804,7 +2804,12 @@
         <valItem ident="neume">
           <desc xml:lang="en">Neumatic notation.</desc>
         </valItem>
-        
+        <valItem ident="neume.square">
+          <desc xml:lang="en">Square neumatic notation.</desc>
+        </valItem>
+        <valItem ident="neume.hufnagel">
+          <desc xml:lang="en">Hufnagel neumatic notation.</desc>
+        </valItem>
         <valItem ident="tab">
           <desc xml:lang="en">Tablature notation.</desc>
         </valItem>

--- a/src/accid.cpp
+++ b/src/accid.cpp
@@ -279,20 +279,17 @@ std::u32string Accid::CreateSymbolStr(data_ACCIDENTAL_WRITTEN accid, data_ENCLOS
     if (!code) {
         if (accid == ACCIDENTAL_WRITTEN_NONE) return U"";
 
-        switch (notationType) {
-            case NOTATIONTYPE_neume:
-            case NOTATIONTYPE_mensural:
-            case NOTATIONTYPE_mensural_black:
-            case NOTATIONTYPE_mensural_white:
-                switch (accid) {
-                    case ACCIDENTAL_WRITTEN_s: code = SMUFL_E9E3_medRenSharpCroix; break;
-                    case ACCIDENTAL_WRITTEN_f: code = SMUFL_E9E0_medRenFlatSoftB; break;
-                    case ACCIDENTAL_WRITTEN_n: code = SMUFL_E9E2_medRenNatural; break;
-                    // we do not want to ignore non-mensural accidentals
-                    default: code = Accid::GetAccidGlyph(accid); break;
-                }
-                break;
-            default: code = Accid::GetAccidGlyph(accid); break;
+        if (IsNeumeType(notationType) || IsMensuralType(notationType)) {
+            switch (accid) {
+                case ACCIDENTAL_WRITTEN_s: code = SMUFL_E9E3_medRenSharpCroix; break;
+                case ACCIDENTAL_WRITTEN_f: code = SMUFL_E9E0_medRenFlatSoftB; break;
+                case ACCIDENTAL_WRITTEN_n: code = SMUFL_E9E2_medRenNatural; break;
+                // we do not want to ignore non-mensural accidentals
+                default: code = Accid::GetAccidGlyph(accid); break;
+            }
+        }
+        else {
+            code = Accid::GetAccidGlyph(accid);
         }
     }
 

--- a/src/clef.cpp
+++ b/src/clef.cpp
@@ -146,17 +146,18 @@ char32_t Clef::GetClefGlyph(const data_NOTATIONTYPE notationtype) const
         if (NULL != resources->GetGlyph(code)) return code;
     }
 
+    if (IsNeumeType(notationtype)) {
+        switch (this->GetShape()) {
+            case CLEFSHAPE_F: return SMUFL_E902_chantFclef; break;
+            case CLEFSHAPE_C: return SMUFL_E906_chantCclef; break;
+            case CLEFSHAPE_G: return SMUFL_E900_mensuralGclef; break;
+            default: return SMUFL_E906_chantCclef; break;
+        }
+    }
+
     switch (notationtype) {
         case NOTATIONTYPE_tab:
         case NOTATIONTYPE_tab_guitar: return SMUFL_E06D_6stringTabClef; break;
-        case NOTATIONTYPE_neume:
-            // neume clefs
-            switch (this->GetShape()) {
-                case CLEFSHAPE_F: return SMUFL_E902_chantFclef; break;
-                case CLEFSHAPE_C: return SMUFL_E906_chantCclef; break;
-                case CLEFSHAPE_G: return SMUFL_E900_mensuralGclef; break;
-                default: return SMUFL_E906_chantCclef; break;
-            }
         case NOTATIONTYPE_mensural:
         case NOTATIONTYPE_mensural_white:
             // mensural clefs

--- a/src/custos.cpp
+++ b/src/custos.cpp
@@ -16,6 +16,7 @@
 #include "doc.h"
 #include "functor.h"
 #include "smufl.h"
+#include "vrv.h"
 
 namespace vrv {
 
@@ -85,14 +86,8 @@ char32_t Custos::GetCustosGlyph(const data_NOTATIONTYPE notationtype) const
         if (NULL != resources->GetGlyph(code)) return code;
     }
 
-    switch (notationtype) {
-        case NOTATIONTYPE_neume:
-            return SMUFL_EA06_chantCustosStemUpPosMiddle; // chantCustosStemUpPosMiddle
-            break;
-        default:
-            return SMUFL_EA02_mensuralCustosUp; // mensuralCustosUp
-            break;
-    }
+    if (IsNeumeType(notationtype)) return SMUFL_EA06_chantCustosStemUpPosMiddle; // chantCustosStemUpPosMiddle
+    return SMUFL_EA02_mensuralCustosUp; // mensuralCustosUp
 }
 
 //----------------------------------------------------------------------------

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -4889,7 +4889,7 @@ bool MEIInput::ReadSectionChildren(Object *parent, pugi::xml_node parentNode)
     }
 
     // New <measure> for blank files in neume notation
-    if (!unmeasured && parent->Is(SECTION) && (m_doc->m_notationType == NOTATIONTYPE_neume)
+    if (!unmeasured && parent->Is(SECTION) && IsNeumeType(m_doc->m_notationType)
         && !parent->FindDescendantByType(MEASURE)) {
         if (m_doc->IsNeumeLines()) {
             unmeasured = new Measure(NEUMELINE);

--- a/src/staff.cpp
+++ b/src/staff.cpp
@@ -263,8 +263,7 @@ bool Staff::IsMensural() const
 
 bool Staff::IsNeume() const
 {
-    bool isNeume = (m_drawingNotationType == NOTATIONTYPE_neume);
-    return isNeume;
+    return IsNeumeType(m_drawingNotationType);
 }
 
 bool Staff::IsTablature() const

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -502,13 +502,17 @@ void Toolkit::SetViewAndEditor()
     if (m_editorToolkit != NULL) {
         delete m_editorToolkit;
     }
-    switch (m_doc.m_notationType) {
-        case NOTATIONTYPE_neume: m_editorToolkit = new EditorToolkitNeume(&m_doc, &m_view); break;
-        case NOTATIONTYPE_mensural:
-        case NOTATIONTYPE_mensural_black:
-        case NOTATIONTYPE_mensural_white: m_editorToolkit = new EditorToolkitMensural(&m_doc, &m_view); break;
-        case NOTATIONTYPE_cmn: m_editorToolkit = new EditorToolkitCMN(&m_doc, &m_view); break;
-        default: m_editorToolkit = new EditorToolkitCMN(&m_doc, &m_view);
+    if (IsNeumeType(m_doc.m_notationType)) {
+        m_editorToolkit = new EditorToolkitNeume(&m_doc, &m_view);
+    }
+    else {
+        switch (m_doc.m_notationType) {
+            case NOTATIONTYPE_mensural:
+            case NOTATIONTYPE_mensural_black:
+            case NOTATIONTYPE_mensural_white: m_editorToolkit = new EditorToolkitMensural(&m_doc, &m_view); break;
+            case NOTATIONTYPE_cmn: m_editorToolkit = new EditorToolkitCMN(&m_doc, &m_view); break;
+            default: m_editorToolkit = new EditorToolkitCMN(&m_doc, &m_view);
+        }
     }
 #endif
 }

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -789,7 +789,7 @@ void View::DrawCustos(DeviceContext *dc, LayerElement *element, Layer *layer, St
 
     // Because SMuFL does not have the origin correpsonding to the pitch as for notes, we need to correct it.
     // This will remain approximate
-    if (staff->m_drawingNotationType != NOTATIONTYPE_neume) {
+    if (!IsNeumeType(staff->m_drawingNotationType)) {
         y -= m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
     }
 
@@ -1824,7 +1824,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     Syl *syl = vrv_cast<Syl *>(element);
     assert(syl);
 
-    if (!syl->GetStart() && !(staff->m_drawingNotationType == NOTATIONTYPE_neume)) {
+    if (!syl->GetStart() && !IsNeumeType(staff->m_drawingNotationType)) {
         LogWarning("Parent note for <syl> was not found");
         return;
     }

--- a/src/vrv.cpp
+++ b/src/vrv.cpp
@@ -478,8 +478,8 @@ bool IsMensuralType(data_NOTATIONTYPE notationType)
 
 bool IsNeumeType(data_NOTATIONTYPE notationType)
 {
-    // Maybe one day we will have other neume types too
-    return (notationType == NOTATIONTYPE_neume);
+    return (notationType == NOTATIONTYPE_neume || notationType == NOTATIONTYPE_neume_square
+        || notationType == NOTATIONTYPE_neume_hufnagel);
 }
 
 bool IsTabType(data_NOTATIONTYPE notationType)


### PR DESCRIPTION
This PR adds support for neume notation subtypes in `staffDef@notationtype`.

It recognizes:

- `neume.square`
- `neume.hufnagel`

alongside the existing generic `neume` value.

The existing `neume` behavior is preserved for backward compatibility. The new subtype values are treated as part of the same neume notation family, so they follow the existing neume rendering/editor paths.

## Motivation

This is preparatory work for #4364.

The issue concerns Hufnagel-specific `@con` rendering on `<nc>`. Before implementing that behavior, Verovio needs to distinguish generic neume notation from more specific neume notation types, especially `neume.square` and `neume.hufnagel`.

This PR does not implement `@con` rendering yet. It only adds notation type recognition and routes the new neume subtype values through the existing neume code paths.

## What changed

- Added internal notation type values for `neume.square` and `neume.hufnagel`.
- Added string conversion support for reading/writing these notation type values.
- Extended `IsNeumeType()` so `neume`, `neume.square`, and `neume.hufnagel` are treated as the neume notation family.
- Updated existing neume-specific checks to use `IsNeumeType()` where the current neume behavior should apply to all neume notation types.

## What this PR does not do

- Does not implement Hufnagel `@con` rendering.
- Does not change `@ligated` behavior.
- Does not change font selection.
- Does not bundle or require a Hufnagel font.
- Does not remove or change the existing generic `notationtype="neume"` behavior.

## Testing

Built locally with:

```bash
cmake -S cmake -B build-neume-notationtypes -DCMAKE_BUILD_TYPE=Debug
cmake --build build-neume-notationtypes -j 4
```

Also tested minimal MEI files with:

- `notationtype="neume"`
- `notationtype="neume.square"`
- `notationtype="neume.hufnagel"`

All three rendered successfully to SVG.

## Notes

CLA pending.