### PR TITLE
Use pitch/alter to derive accid.ges

### DIFF
--- a/include/vrv/iomusxml.h
+++ b/include/vrv/iomusxml.h
@@ -702,12 +702,8 @@ private:
     std::map<Measure *, int> m_measureCounts;
     /* measure rests */
     std::map<int, int> m_multiRests;
-    /* a map of pitch classes to their current accidental(s) */
-    std::map<data_PITCHNAME, std::vector<musicxml::Accidental>> m_currentAccids;
     /* a map of pitch/alter values to their corresponding accidental(s) */
     std::map<std::string, std::vector<musicxml::Accidental>> m_alterAccids;
-    /* current key signature */
-    KeySig *m_currentKeySig = NULL;
     /* A flag indicating we had a clef change */
     int m_clefChanged = 0;
 

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3174,33 +3174,33 @@ void MusicXmlInput::ReadMusicXmlNote(
                     try {
                         for (const auto &current : currentAccids) {
                             // Avoid adding empty accidentals
-                            if (current.m_accid == ACCIDENTAL_WRITTEN_NONE && current.m_glyphName.empty()) continue;
+                            if ((current.m_accid == ACCIDENTAL_WRITTEN_NONE || current.m_accid == ACCIDENTAL_WRITTEN_n) && current.m_glyphName.empty()) continue;
 
                             Accid *accid = new Accid();
                             note->AddChild(accid);
                             accid->SetAccidGes(Att::AccidentalWrittenToGestural(current.m_accid));
+                            accid->IsAttribute(true);
 
                             // Because gestural accidentals do not map 1:1 to written accidentals, we may be losing
                             // information if we rely only on gestural accidentals to look up tuning tones.
                             // Instead, we set the accidental's SMuFL glyph name to whatever was carried over. The
                             // custom tuning will always choose the SMuFL glyph over the written or gestural
                             // accidentals. SPECIAL CASE: When the gestural accidental is the same as the written
-                            // accidental (and not NONE), we are sure that the gestural accidental will not lose
+                            // accidental we are sure that the gestural accidental will not lose
                             // information, and therefore we don't need to explicitly set the SMuFL glyph. This ensures
                             // that scores that only feature "regular" accidentals will never have redundant SMuFL
                             // glyphs.
-                            if (current.m_accid == ACCIDENTAL_WRITTEN_NONE
-                                || Att::AccidentalGesturalToWritten(accid->GetAccidGes()) != current.m_accid) {
-                                if (!current.m_glyphName.empty()) {
-                                    accid->SetGlyphName(current.m_glyphName);
-                                    accid->SetGlyphAuth(current.m_glyphAuth);
-                                }
-                                // We have a current.m_accid
-                                else {
-                                    char32_t glyph = Accid::GetAccidGlyph(current.m_accid);
-                                    accid->SetGlyphName(CustomTuning::GetGlyphName(glyph, m_doc));
-                                    accid->SetGlyphAuth("smufl");
-                                }
+                            if (!current.m_glyphName.empty()) {
+                                accid->SetGlyphName(current.m_glyphName);
+                                accid->SetGlyphAuth(current.m_glyphAuth);
+                                accid->IsAttribute(false);
+                            }
+                            // We have a current.m_accid, avoid adding it if it's the same as the gestural accidental.
+                            else if (Att::AccidentalGesturalToWritten(accid->GetAccidGes()) != current.m_accid) {
+                                char32_t glyph = Accid::GetAccidGlyph(current.m_accid);
+                                accid->SetGlyphName(CustomTuning::GetGlyphName(glyph, m_doc));
+                                accid->SetGlyphAuth("smufl");
+                                accid->IsAttribute(false);
                             }
                         }
                     }

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -889,9 +889,6 @@ bool MusicXmlInput::ReadMusicXml(pugi::xml_node root)
 {
     assert(root);
 
-    // initialize accidentals map
-    this->ResetAccidentals();
-
     // check for multimetric music
     bool multiMetric = root.select_node("/score-partwise/part/measure[@non-controlling='yes']");
     if (multiMetric) {
@@ -1872,9 +1869,6 @@ bool MusicXmlInput::ReadMusicXmlMeasure(
 {
     assert(node);
     assert(measure);
-
-    // re-initialize the accidentals to the current key signature.
-    this->ResetAccidentals(m_currentKeySig);
 
     const std::string measureNum = node.attribute("number").as_string();
     if (node.attribute("id")) measure->SetID(node.attribute("id").as_string());
@@ -3157,23 +3151,21 @@ void MusicXmlInput::ReadMusicXmlNote(
                 std::string pitchAlter = PitchAlterToString(note->GetPname(), alterVal);
                 ListOfObjects accids = note->FindAllDescendantsByType(ACCID);
                 if (accids.empty()) {
-                    // It can happen that the doc encodes the accidentals in the pitch/alter element only,
-                    // regardless of key signature or bar lines. Handle this case here.
-                    if (alterVal != 0.0) {
-                        // In case this alter value is already associated with an accidental, use it here.
-                        if (m_alterAccids.contains(pitchAlter)) {
-                            m_currentAccids[note->GetPname()] = m_alterAccids.at(pitchAlter);
-                        }
-                        // Otherwise, deduce the generic accidental from this alter value.
-                        else {
-                            m_currentAccids[note->GetPname()].clear();
-                            m_currentAccids[note->GetPname()].push_back(musicxml::Accidental(
-                                Att::AccidentalGesturalToWritten(ConvertAlterToAccid(alterVal)), "", ""));
-                        }
+                    std::vector<musicxml::Accidental> currentAccids;
+
+                    // Use the alter value as key to the accidentals.
+                    // In case this alter value is already associated with an accidental, use it here.
+                    if (m_alterAccids.contains(pitchAlter)) {
+                        currentAccids = m_alterAccids.at(pitchAlter);
+                    }
+                    // Otherwise, deduce the generic accidental from this alter value.
+                    else {
+                        currentAccids.push_back(musicxml::Accidental(
+                            Att::AccidentalGesturalToWritten(ConvertAlterToAccid(alterVal)), "", ""));
                     }
 
                     try {
-                        for (const auto &current : m_currentAccids.at(note->GetPname())) {
+                        for (const auto &current : currentAccids) {
                             // Avoid adding empty accidentals
                             if (current.m_accid == ACCIDENTAL_WRITTEN_NONE && current.m_glyphName.empty()) continue;
 
@@ -3210,7 +3202,6 @@ void MusicXmlInput::ReadMusicXmlNote(
                     }
                 }
                 else {
-                    m_currentAccids[note->GetPname()].clear();
                     m_alterAccids[pitchAlter].clear();
                     for (Object *object : accids) {
                         Accid *accid = vrv_cast<Accid *>(object);
@@ -3218,8 +3209,6 @@ void MusicXmlInput::ReadMusicXmlNote(
                         if (Att::AccidentalGesturalToWritten(ges) != accid->GetAccid()) {
                             accid->SetAccidGes(ges);
                         }
-                        m_currentAccids[note->GetPname()].push_back(
-                            musicxml::Accidental(accid->GetAccid(), accid->GetGlyphName(), accid->GetGlyphAuth()));
                         m_alterAccids[pitchAlter].push_back(
                             musicxml::Accidental(accid->GetAccid(), accid->GetGlyphName(), accid->GetGlyphAuth()));
                     }
@@ -4478,10 +4467,6 @@ KeySig *MusicXmlInput::ConvertKey(const pugi::xml_node &key)
         }
     }
 
-    // adjust the accidentals map to this key signature
-    this->ResetAccidentals(keySig);
-    m_currentKeySig = keySig;
-
     return keySig;
 }
 
@@ -4498,33 +4483,6 @@ ScoreDef *MusicXmlInput::GetOrCreateLastScoreDef(Section *section)
         section->AddChild(scoreDef);
     }
     return scoreDef;
-}
-
-void MusicXmlInput::ResetAccidentals(const KeySig *keySig)
-{
-    // inspired by KeySig::FillMap() but without the octave repetitions
-    m_currentAccids.clear();
-    for (int i = PITCHNAME_c; i <= PITCHNAME_b; i++) {
-        m_currentAccids[static_cast<data_PITCHNAME>(i)] = { musicxml::Accidental() };
-    }
-
-    if (!keySig) return;
-
-    const ListOfConstObjects &childList = keySig->GetList(); // make sure it's initialized
-    if (!childList.empty()) {
-        for (const Object *child : childList) {
-            const KeyAccid *keyAccid = vrv_cast<const KeyAccid *>(child);
-            assert(keyAccid);
-            m_currentAccids[keyAccid->GetPname()]
-                = { musicxml::Accidental(keyAccid->GetAccid(), keyAccid->GetGlyphName(), keyAccid->GetGlyphAuth()) };
-        }
-        return;
-    }
-
-    data_ACCIDENTAL_WRITTEN accidType = keySig->GetAccidType();
-    for (int i = 0; i < keySig->GetAccidCount(true); ++i) {
-        m_currentAccids[KeySig::GetAccidPnameAt(accidType, i)] = { musicxml::Accidental(accidType, "", "") };
-    }
 }
 
 beamRend_FORM MusicXmlInput::ConvertBeamFanToForm(const std::string &value)

--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3174,7 +3174,9 @@ void MusicXmlInput::ReadMusicXmlNote(
                     try {
                         for (const auto &current : currentAccids) {
                             // Avoid adding empty accidentals
-                            if ((current.m_accid == ACCIDENTAL_WRITTEN_NONE || current.m_accid == ACCIDENTAL_WRITTEN_n) && current.m_glyphName.empty()) continue;
+                            if ((current.m_accid == ACCIDENTAL_WRITTEN_NONE || current.m_accid == ACCIDENTAL_WRITTEN_n)
+                                && current.m_glyphName.empty())
+                                continue;
 
                             Accid *accid = new Accid();
                             note->AddChild(accid);


### PR DESCRIPTION
To fix #4397 

This PR reverses the order of priority to rely primarily on `pitch/alter` to deduce the `@accid.ges`. In order to preserve microtonal accidentals, the alter-to-accidentals memoization that was added in the previous PR is kept. The mechanism of accidental carry-over is completely removed because it introduced too many regressions.

The existing tests seem to be passing, but I want to manually examine the MIDI differences and the MEI produced from the MusicXML. I am also thinking of adding unit tests to this repo that would specifically validate the MusicXML-to-MEI import.
