### PR TITLE
Support `pt` and `vu` MEI font sizes

### DIFF
--- a/include/vrv/textelement.h
+++ b/include/vrv/textelement.h
@@ -100,6 +100,7 @@ public:
         m_verticalShift = false;
         m_alignment = HORIZONTALALIGNMENT_left;
         m_pointSize = 0;
+        m_staffSize = 100;
         m_actualWidth = 0;
         m_enclose = TEXTRENDITION_NONE;
         m_textEnclose = ENCLOSURE_NONE;
@@ -118,6 +119,8 @@ public:
     bool m_verticalShift;
     data_HORIZONTALALIGNMENT m_alignment;
     int m_pointSize;
+    /** Staff-size percentage used for virtual units; 100 is the unscaled fallback when no staff context exists. */
+    int m_staffSize;
     std::vector<TextElement *> m_enclosedRend;
     data_TEXTRENDITION m_enclose;
     data_ENCLOSURE m_textEnclose;

--- a/include/vrv/view.h
+++ b/include/vrv/view.h
@@ -721,9 +721,15 @@ protected:
     ScoreDef m_drawingScoreDef;
 
 private:
+    /** Convert a numeric MEI font size to Verovio drawing units. */
+    int ConvertFontSizeNumeric(const data_FONTSIZE &fontSize, int staffSize) const;
+
     //----------------//
     // Static members //
     //----------------//
+
+    /** Convert a font size in printer points to Verovio drawing units. */
+    static int ConvertFontPointSize(double pointSize);
 
     /** @name Internal values for storing temporary values for ligatures */
     ///@{

--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -306,7 +306,8 @@ std::string Att::FontsizeToStr(data_FONTSIZE data) const
 {
     std::string value;
     if (data.GetType() == FONTSIZE_fontSizeNumeric) {
-        value = StringFormat("%fpt", data.GetFontSizeNumeric());
+        const char *unit = (data.GetFontSizeNumericType() == FONTSIZENUMERIC_vu) ? "vu" : "pt";
+        value = StringFormat("%f%s", data.GetFontSizeNumeric(), unit);
     }
     else if (data.GetType() == FONTSIZE_term) {
         value = FontsizetermToStr(data.GetTerm());
@@ -321,8 +322,19 @@ std::string Att::FontsizeToStr(data_FONTSIZE data) const
 data_FONTSIZE Att::StrToFontsize(const std::string &value, bool logWarning) const
 {
     data_FONTSIZE data;
-    data.SetFontSizeNumeric(StrToFontsizenumeric(value, false));
-    if (data.HasValue()) return data;
+    const data_FONTSIZENUMERIC pointSize = StrToFontsizenumeric(value, false);
+    if (pointSize != MEI_UNSET) {
+        data.SetFontSizeNumeric(pointSize, FONTSIZENUMERIC_pt);
+        return data;
+    }
+    static const std::regex vuTest("([0-9]+(\\.[0-9]+)?|\\.[0-9]+)vu");
+    if (std::regex_match(value, vuTest)) {
+        const data_FONTSIZENUMERIC vuSize = stof(value);
+        if (vuSize > 0.0) {
+            data.SetFontSizeNumeric(vuSize, FONTSIZENUMERIC_vu);
+            return data;
+        }
+    }
     data.SetTerm(StrToFontsizeterm(value, false));
     if (data.HasValue()) return data;
     data.SetPercent(StrToPercent(value, false));
@@ -370,14 +382,21 @@ std::string Att::FontsizenumericToStr(data_FONTSIZENUMERIC data) const
 
 data_FONTSIZENUMERIC Att::StrToFontsizenumeric(const std::string &value, bool logWarning) const
 {
-    static const std::regex test("[0-9]*(\\.[0-9]+)?(pt)");
+    static const std::regex test("([0-9]+(\\.[0-9]+)?|\\.[0-9]+)pt");
     if (!std::regex_match(value, test)) {
         if (logWarning && !value.empty()) {
             LogWarning("Unsupported data.FONTSIZENUMERIC '%s'", value.c_str());
         }
         return MEI_UNSET;
     }
-    return stof(value);
+    const data_FONTSIZENUMERIC numeric = stof(value);
+    if (numeric <= 0.0) {
+        if (logWarning) {
+            LogWarning("Unsupported data.FONTSIZENUMERIC '%s'", value.c_str());
+        }
+        return MEI_UNSET;
+    }
+    return numeric;
 }
 
 std::string Att::KeysignatureToStr(data_KEYSIGNATURE data) const

--- a/libmei/addons/attalternates.h
+++ b/libmei/addons/attalternates.h
@@ -27,6 +27,7 @@ namespace vrv {
  */
 
 enum FontSizeType { FONTSIZE_NONE = 0, FONTSIZE_fontSizeNumeric, FONTSIZE_term, FONTSIZE_percent };
+enum FontSizeNumericType { FONTSIZENUMERIC_NONE = 0, FONTSIZENUMERIC_pt, FONTSIZENUMERIC_vu };
 
 class data_FONTSIZE {
 public:
@@ -37,6 +38,7 @@ public:
     {
         m_type = type;
         m_fontSizeNumeric = MEI_UNSET;
+        m_fontSizeNumericType = FONTSIZENUMERIC_NONE;
         m_term = FONTSIZETERM_NONE;
         m_percent = 0;
     }
@@ -44,10 +46,13 @@ public:
     FontSizeType GetType() const { return m_type; }
 
     data_FONTSIZENUMERIC GetFontSizeNumeric() const { return m_fontSizeNumeric; }
-    void SetFontSizeNumeric(data_FONTSIZENUMERIC value)
+    FontSizeNumericType GetFontSizeNumericType() const { return m_fontSizeNumericType; }
+    /** Default to points for programmatic callers that predate explicit numeric-unit tracking. */
+    void SetFontSizeNumeric(data_FONTSIZENUMERIC value, FontSizeNumericType numericType = FONTSIZENUMERIC_pt)
     {
         this->Reset(FONTSIZE_fontSizeNumeric);
         m_fontSizeNumeric = value;
+        m_fontSizeNumericType = numericType;
     }
 
     data_FONTSIZETERM GetTerm() const { return m_term; }
@@ -92,6 +97,7 @@ public:
     {
         if (m_type != val.GetType()) return false;
         if (m_fontSizeNumeric != val.GetFontSizeNumeric()) return false;
+        if (m_fontSizeNumericType != val.GetFontSizeNumericType()) return false;
         if (m_term != val.GetTerm()) return false;
         if (m_percent != val.GetPercent()) return false;
         return true;
@@ -101,6 +107,7 @@ public:
 protected:
     FontSizeType m_type;
     data_FONTSIZENUMERIC m_fontSizeNumeric;
+    FontSizeNumericType m_fontSizeNumericType;
     data_FONTSIZETERM m_term;
     data_PERCENT m_percent;
 };

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -10,6 +10,7 @@
 //----------------------------------------------------------------------------
 
 #include <cassert>
+#include <cmath>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -337,6 +338,26 @@ void View::CalcOffsetBezier(DeviceContext *dc, Point points[4], char spanningTyp
         this->CalcOffsetY(dc, points[2].y);
         this->CalcOffsetY(dc, points[3].y);
     }
+}
+
+int View::ConvertFontSizeNumeric(const data_FONTSIZE &fontSize, int staffSize) const
+{
+    assert(fontSize.GetType() == FONTSIZE_fontSizeNumeric);
+
+    if (fontSize.GetFontSizeNumericType() == FONTSIZENUMERIC_vu) {
+        assert(m_doc);
+        return static_cast<int>(std::lround(fontSize.GetFontSizeNumeric() * m_doc->GetDrawingUnit(staffSize)));
+    }
+    return View::ConvertFontPointSize(fontSize.GetFontSizeNumeric());
+}
+
+int View::ConvertFontPointSize(double pointSize)
+{
+    constexpr double millimetersPerInch = 25.4;
+    constexpr double pointsPerInch = 72.0;
+    constexpr double drawingUnitsPerMillimeter = 10.0 * DEFINITION_FACTOR;
+
+    return static_cast<int>(std::lround(pointSize * millimetersPerInch * drawingUnitsPerMillimeter / pointsPerInch));
 }
 
 } // namespace vrv

--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -1790,6 +1790,7 @@ void View::DrawControlElementText(DeviceContext *dc, ControlElement *element, Me
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
         params.m_pointSize = m_doc->GetDrawingLyricFont(staffSize)->GetPointSize();
 
         int xAdjust = 0;
@@ -1870,6 +1871,7 @@ void View::DrawDynam(DeviceContext *dc, Dynam *dynam, Measure *measure, System *
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
         params.m_pointSize = m_doc->GetDrawingLyricFont(staffSize)->GetPointSize();
 
         if (dynam->HasEnclose()) {
@@ -2124,6 +2126,7 @@ void View::DrawFing(DeviceContext *dc, Fing *fing, Measure *measure, System *sys
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
         params.m_pointSize = m_doc->GetFingeringFont(staffSize)->GetPointSize();
 
         fingTxt.SetPointSize(params.m_pointSize);
@@ -2324,6 +2327,7 @@ void View::DrawHarm(DeviceContext *dc, Harm *harm, Measure *measure, System *sys
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
 
         if (harm->GetFirst() && harm->GetFirst()->Is(FB)) {
             this->DrawFb(dc, staff, dynamic_cast<Fb *>(harm->GetFirst()), params);
@@ -2650,6 +2654,7 @@ void View::DrawReh(DeviceContext *dc, Reh *reh, Measure *measure, System *system
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
         params.m_pointSize = m_doc->GetDrawingLyricFont(staffSize)->GetPointSize();
 
         rehTxt.SetPointSize(params.m_pointSize);
@@ -2770,6 +2775,7 @@ void View::DrawTempo(DeviceContext *dc, Tempo *tempo, Measure *measure, System *
         TextDrawingParams params;
         params.m_x = x;
         params.m_y = y;
+        params.m_staffSize = staffSize;
         params.m_pointSize = m_doc->GetDrawingLyricFont(staffSize)->GetPointSize();
 
         tempoTxt.SetPointSize(params.m_pointSize);

--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1859,6 +1859,7 @@ void View::DrawSyl(DeviceContext *dc, LayerElement *element, Layer *layer, Staff
     TextDrawingParams params;
     params.m_x = x;
     params.m_y = y;
+    params.m_staffSize = staff->m_drawingStaffSize;
     if (m_doc->IsFacs() || m_doc->IsNeumeLines()) {
         params.m_width = syl->GetDrawingWidth();
         params.m_height = syl->GetDrawingHeight();
@@ -1951,6 +1952,7 @@ void View::DrawVerse(DeviceContext *dc, LayerElement *element, Layer *layer, Sta
         TextDrawingParams params;
         params.m_x = verse->GetDrawingX() - m_doc->GetDrawingUnit(staff->m_drawingStaffSize);
         params.m_y = staff->GetDrawingY() + this->GetSylYRel(std::max(1, verse->GetN()), staff, verse->GetPlace());
+        params.m_staffSize = staff->m_drawingStaffSize;
         params.m_pointSize = labelTxt.GetPointSize();
 
         dc->SetFont(&labelTxt);

--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -521,6 +521,7 @@ void View::DrawLabels(
     TextDrawingParams params;
     params.m_x = x;
     params.m_y = y;
+    params.m_staffSize = staffSize;
     params.m_pointSize = labelTxt.GetPointSize();
 
     dc->SetFont(&labelTxt);
@@ -1145,22 +1146,25 @@ void View::DrawMNum(DeviceContext *dc, MNum *mnum, Measure *measure, System *sys
         // we set mNum to a fixed height above the system and make it a bit smaller than other text
         params.m_x = measure->GetDrawingX();
         params.m_y = staff->GetDrawingY() + yOffset;
+        params.m_staffSize = staff->m_drawingStaffSize;
+        const int basePointSize = m_doc->GetDrawingLyricFont(staff->m_drawingStaffSize)->GetPointSize();
         if (mnum->HasFontsize()) {
             data_FONTSIZE *fs = mnum->GetFontsizeAlternate();
             if (fs->GetType() == FONTSIZE_fontSizeNumeric) {
-                mnumTxt.SetPointSize(fs->GetFontSizeNumeric());
+                mnumTxt.SetPointSize(this->ConvertFontSizeNumeric(*fs, staff->m_drawingStaffSize));
             }
             else if (fs->GetType() == FONTSIZE_term) {
                 const int percent = fs->GetPercentForTerm();
-                mnumTxt.SetPointSize(m_doc->GetDrawingLyricFont(percent)->GetPointSize());
+                mnumTxt.SetPointSize(basePointSize * percent / 100);
             }
             else if (fs->GetType() == FONTSIZE_percent) {
-                mnumTxt.SetPointSize(m_doc->GetDrawingLyricFont(fs->GetPercent())->GetPointSize());
+                mnumTxt.SetPointSize(basePointSize * fs->GetPercent() / 100);
             }
         }
         else {
             mnumTxt.SetPointSize(m_doc->GetDrawingLyricFont(80)->GetPointSize());
         }
+        params.m_pointSize = mnumTxt.GetPointSize();
 
         dc->SetFont(&mnumTxt);
 

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -391,7 +391,7 @@ void View::DrawRend(DeviceContext *dc, Rend *rend, TextDrawingParams &params)
     if (rend->HasFontsize()) {
         data_FONTSIZE *fs = rend->GetFontsizeAlternate();
         if (fs->GetType() == FONTSIZE_fontSizeNumeric) {
-            rendFont.SetPointSize(fs->GetFontSizeNumeric());
+            rendFont.SetPointSize(this->ConvertFontSizeNumeric(*fs, params.m_staffSize));
         }
         else if (fs->GetType() == FONTSIZE_term) {
             const int percent = fs->GetPercentForTerm();
@@ -604,7 +604,7 @@ void View::DrawSymbol(DeviceContext *dc, Symbol *symbol, TextDrawingParams &para
     if (symbol->HasFontsize()) {
         data_FONTSIZE *fs = symbol->GetFontsizeAlternate();
         if (fs->GetType() == FONTSIZE_fontSizeNumeric) {
-            symbolFont.SetPointSize(fs->GetFontSizeNumeric());
+            symbolFont.SetPointSize(this->ConvertFontSizeNumeric(*fs, params.m_staffSize));
         }
         else if (fs->GetType() == FONTSIZE_term) {
             const int percent = fs->GetPercentForTerm();


### PR DESCRIPTION
## Summary

Fix numeric MEI font sizes so their declared units are interpreted at rendering time instead of treating numeric values as raw Verovio drawing units.

- track whether `data.FONTSIZENUMERIC` uses `pt` or `vu`, preserving the unit during MEI round trips
- convert point values to drawing units using `points × 25.4 / 72 × 100`
- resolve `vu` values against the active staff's drawing unit and propagate the staff size through text rendering
- apply conversion consistently to `<rend>`, `<symbol>`, and `<mNum>`
- keep percentage and named sizes relative to the current base font size

This makes `fontsize="10pt"` render at 353 drawing units instead of 10, while also adding staff-scaled support for `vu` values.

Fixes #4399

## Testing

- configured and built the command-line toolkit successfully with CMake
- passed the ClangFormat 22 dry-run check for all changed C++ files
- verified an SVG render where `10pt` produces `353px`
- verified staff-scaled rendering of a `2vu` value
- verified MEI round trips preserve both `pt` and `vu` suffixes

## Disclosure

The entire process for this contribution—including issue analysis, implementation, testing, and preparation of this pull request—was completed with the assistance of large language models (LLMs).
