### PR TITLE
Fix harmony superscript positioning

### DIFF
--- a/include/vrv/svgdevicecontext.h
+++ b/include/vrv/svgdevicecontext.h
@@ -358,6 +358,8 @@ private:
 
     bool m_committed; // did we flushed the file?
     int m_originX, m_originY;
+    /** Current text baseline, used to express vertical moves as relative SVG dy values. */
+    int m_textY;
 
     // Here we hold references to all different glyphs used so far,
     // including any glyph for the same code but from different fonts.

--- a/src/svgdevicecontext.cpp
+++ b/src/svgdevicecontext.cpp
@@ -41,6 +41,7 @@ SvgDeviceContext::SvgDeviceContext(const std::string &docId) : DeviceContext(SVG
 
     m_originX = 0;
     m_originY = 0;
+    m_textY = 0;
 
     m_smuflGlyphs.clear();
 
@@ -1016,6 +1017,7 @@ void SvgDeviceContext::StartText(int x, int y, data_HORIZONTALALIGNMENT alignmen
     m_svgNodeStack.push_back(m_currentNode);
     if (x) m_currentNode.append_attribute("x") = x;
     if (y) m_currentNode.append_attribute("y") = y;
+    m_textY = y;
     // unless dx, dy have a value they don't need to be set
     // m_currentNode.append_attribute("dx") = 0;
     // m_currentNode.append_attribute("dy") = 0;
@@ -1051,6 +1053,7 @@ void SvgDeviceContext::MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignme
 {
     m_currentNode.append_attribute("x") = x;
     m_currentNode.append_attribute("y") = y;
+    m_textY = y;
     if (alignment != HORIZONTALALIGNMENT_NONE) {
         std::string anchor = "start";
         if (alignment == HORIZONTALALIGNMENT_right) {
@@ -1065,7 +1068,10 @@ void SvgDeviceContext::MoveTextTo(int x, int y, data_HORIZONTALALIGNMENT alignme
 
 void SvgDeviceContext::MoveTextVerticallyTo(int y)
 {
-    m_currentNode.append_attribute("y") = y;
+    // An absolute y starts a new anchored text chunk in SVG. Use a relative shift so
+    // superscripts and subscripts remain part of the surrounding horizontal text run.
+    m_currentNode.append_attribute("dy") = y - m_textY;
+    m_textY = y;
 }
 
 void SvgDeviceContext::EndText()

--- a/src/view_text.cpp
+++ b/src/view_text.cpp
@@ -157,18 +157,12 @@ void View::DrawHarmString(DeviceContext *dc, const std::u32string &str, TextDraw
     assert(dc);
     assert(dc->HasFont());
 
-    int toDcX = this->ToDeviceContextX(params.m_x);
-    int toDcY = this->ToDeviceContextY(params.m_y);
-
     size_t prevPos = 0, pos;
     while ((pos = str.find_first_of(VRV_TEXT_HARM, prevPos)) != std::wstring::npos) {
         // If pos is > than the previous, it is the substring to extract
         if (pos > prevPos) {
             std::u32string substr = str.substr(prevPos, pos - prevPos);
-            dc->DrawText(UTF32to8(substr), substr, toDcX, toDcY);
-            // Once we have rendered the some text to not pass x / y anymore
-            toDcX = VRV_UNSET;
-            toDcY = VRV_UNSET;
+            dc->DrawText(UTF32to8(substr), substr);
         }
 
         // if it is the same or we still have space, it is the accidental
@@ -201,11 +195,8 @@ void View::DrawHarmString(DeviceContext *dc, const std::u32string &str, TextDraw
             bool isFallbackNeeded = (m_doc->GetResources()).IsSmuflFallbackNeeded(smuflAccid);
             vrvTxt.SetSmuflWithFallback(isFallbackNeeded);
             dc->SetFont(&vrvTxt);
-            // Once we have rendered the some text to not pass x / y anymore
-            dc->DrawText(UTF32to8(smuflAccid), smuflAccid, toDcX, toDcY);
+            dc->DrawText(UTF32to8(smuflAccid), smuflAccid);
             dc->ResetFont();
-            toDcX = VRV_UNSET;
-            toDcY = VRV_UNSET;
         }
         // Skip the accidental and continue
         prevPos = pos + 1;
@@ -213,11 +204,10 @@ void View::DrawHarmString(DeviceContext *dc, const std::u32string &str, TextDraw
     // Print the remainder of the string, or the full string if no accid
     if (prevPos < str.length()) {
         std::u32string substr = str.substr(prevPos, std::wstring::npos);
-        dc->DrawText(UTF32to8(substr), substr, toDcX, toDcY);
+        dc->DrawText(UTF32to8(substr), substr);
     }
 
-    // Disable x for what is coming next as child of <f>
-    // The value is reset in DrawFb
+    // Continue subsequent harmony children in the current text run.
     params.m_x = VRV_UNSET;
 }
 


### PR DESCRIPTION
## Summary

Fix horizontal positioning of harmony text that contains superscript or subscript fragments.

Harmony fragments previously supplied absolute text coordinates while moving between regular and vertically shifted text. In SVG, those absolute positions started new anchored text chunks, causing text following a superscript or subscript to lose its expected horizontal position.

This change:

- keeps harmony fragments in a continuous SVG text run
- tracks the current text baseline in `SvgDeviceContext`
- expresses superscript and subscript moves as relative `dy` values
- lets subsequent harmony text continue at the correct horizontal position

## Testing

- built the command-line toolkit successfully with CMake
- passed `git diff --check`
- passed the ClangFormat 22 dry-run check

## Disclosure

The process for this contribution was completed with the assistance of large language models (LLMs).
