### PR TITLE
Render ending labels in preference to numbers

### DIFF
--- a/src/view_control.cpp
+++ b/src/view_control.cpp
@@ -3177,7 +3177,7 @@ void View::DrawEnding(DeviceContext *dc, Ending *ending, System *system)
 
         const int unit = m_doc->GetDrawingUnit(staffSize);
         if (ending->HasN() || ending->HasLabel()) {
-            const std::string endingText = (ending->HasN()) ? ending->GetN() : ending->GetLabel();
+            const std::string endingText = (ending->HasLabel()) ? ending->GetLabel() : ending->GetN();
             std::stringstream strStream;
             // Maybe we want to add ( ) after system breaks? Or . as a styling options?
             if ((spanningType == SPANNING_END) || (spanningType == SPANNING_MIDDLE)) strStream << "(";


### PR DESCRIPTION
## Summary

Prefer an ending's `@label` over its `@n` value when choosing the text to render.

`@n` provides the ending number, while `@label` supplies explicit display text. When both attributes are present, the label should therefore take precedence so that the encoded presentation is respected. Endings without a label continue to render their `@n` value as before.

## Testing

- built the command-line toolkit successfully with CMake
- passed `git diff --check`
- passed the ClangFormat 22 dry-run check

## Disclosure

The process for this contribution was completed with the assistance of large language models (LLMs).
