### PR TITLE
Support MEI staff-item ordering and vertical groups

### DIFF
--- a/include/vrv/adjustfloatingpositionerfunctor.h
+++ b/include/vrv/adjustfloatingpositionerfunctor.h
@@ -10,7 +10,12 @@
 
 #include "functor.h"
 
+#include <functional>
+#include <map>
+
 namespace vrv {
+
+class Measure;
 
 //----------------------------------------------------------------------------
 // AdjustFloatingPositionersFunctor
@@ -45,14 +50,47 @@ public:
 protected:
     //
 private:
-    //
+    FunctorCode AdjustCurrentPositioners(StaffAlignment *staffAlignment);
+    FunctorCode AdjustStaffItemOrder(StaffAlignment *staffAlignment);
+    void AdjustLegacyPlace(StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin = false);
+    void AdjustOrderedPlace(StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin = false);
+    void AdjustPositionerGroups(StaffAlignment *staffAlignment, data_STAFFREL place);
+    void BuildPositionerGroups(StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin);
+    void StabilizePositionerGroups(StaffAlignment *staffAlignment, data_STAFFREL place,
+        const ArrayOfBoundingBoxes &baseBoxes, const std::function<void()> &processPositioners);
+    bool HasExplicitPositionerGroup(StaffAlignment *staffAlignment, data_STAFFREL place) const;
+    bool HasStaffItemOrder(StaffAlignment *staffAlignment, data_STAFFREL place) const;
+    void ProcessClass(StaffAlignment *staffAlignment, ClassId classId, data_STAFFREL place,
+        data_STAFFITEM staffItem = STAFFITEM_NONE);
+    void ProcessPositioners(StaffAlignment *staffAlignment, const ArrayOfFloatingPositioners &positioners,
+        ClassId classId, data_STAFFREL place, data_STAFFITEM staffItem, bool keepGroupPosition);
+
 public:
     //
 private:
     // The class ID
     ClassId m_classId;
+    // Restrict a shared Verovio class to the exact MEI staff-item category
+    data_STAFFITEM m_staffItem;
     // Indicates if we are processing floating objects to be put in between the staff
     bool m_inBetween;
+    // Restrict processing to one placement (NONE keeps the legacy behavior)
+    data_STAFFREL m_place;
+    // Include positioners within the staff in the current below-staff pass
+    bool m_includeWithin;
+    // Restrict processing to a prepared set of positioners
+    const ArrayOfFloatingPositioners *m_positioners;
+    // Keep grouped positioners on their common baseline during collision stabilization
+    bool m_keepGroupPosition;
+    // Allow a stabilization pass to move complete groups in response to collisions
+    bool m_movePositionerGroups;
+    // Positioners indexed by their explicit or automatic drawing group
+    std::map<long long, ArrayOfFloatingPositioners> m_positionerGroups;
+    // Detect explicit vertical groups that require the ordered grouping path
+    bool m_detectExplicitGroups;
+    bool m_hasExplicitGroups;
+    // Process each staff using its effective scoreDef / staffDef order
+    bool m_useStaffItemOrder;
 };
 
 //----------------------------------------------------------------------------
@@ -83,6 +121,7 @@ public:
     ///@{
     void SetClassIDs(const std::vector<ClassId> &classIds) { m_classIds = classIds; }
     void SetPlace(data_STAFFREL place) { m_place = place; }
+    void SetGroupType(int groupType) { m_groupType = groupType; }
     ///@}
 
     /*
@@ -107,6 +146,8 @@ private:
     std::vector<ClassId> m_classIds;
     // The place w.r.t. the staff
     data_STAFFREL m_place;
+    // Negative for explicit groups, positive for automatic groups, zero for both
+    int m_groupType;
 };
 
 //----------------------------------------------------------------------------

--- a/include/vrv/breath.h
+++ b/include/vrv/breath.h
@@ -21,7 +21,7 @@ namespace vrv {
 /**
  * This class models the MEI <breath> element.
  */
-class Breath : public ControlElement, public TimePointInterface, public AttPlacementRelStaff {
+class Breath : public ControlElement, public TimePointInterface, public AttPlacementRelStaff, public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/caesura.h
+++ b/include/vrv/caesura.h
@@ -26,7 +26,8 @@ class Caesura : public ControlElement,
                 public TimePointInterface,
                 public AttExtSymAuth,
                 public AttExtSymNames,
-                public AttPlacementRelStaff {
+                public AttPlacementRelStaff,
+                public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/cpmark.h
+++ b/include/vrv/cpmark.h
@@ -23,7 +23,11 @@ class TextElement;
 /**
  * This class models the MEI <cpMark> element.
  */
-class CpMark : public ControlElement, public TextListInterface, public TextDirInterface, public TimeSpanningInterface {
+class CpMark : public ControlElement,
+               public TextListInterface,
+               public TextDirInterface,
+               public TimeSpanningInterface,
+               public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/fermata.h
+++ b/include/vrv/fermata.h
@@ -29,7 +29,8 @@ class Fermata : public ControlElement,
                 public AttExtSymAuth,
                 public AttExtSymNames,
                 public AttFermataVis,
-                public AttPlacementRelStaff {
+                public AttPlacementRelStaff,
+                public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/fing.h
+++ b/include/vrv/fing.h
@@ -22,7 +22,11 @@ namespace vrv {
 /**
  * This class models the MEI <fing> element.
  */
-class Fing : public ControlElement, public TimePointInterface, public TextDirInterface, public AttNNumberLike {
+class Fing : public ControlElement,
+             public TimePointInterface,
+             public TextDirInterface,
+             public AttNNumberLike,
+             public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/harm.h
+++ b/include/vrv/harm.h
@@ -29,7 +29,8 @@ class Harm : public ControlElement,
              public TextDirInterface,
              public TimeSpanningInterface,
              public AttLang,
-             public AttNNumberLike {
+             public AttNNumberLike,
+             public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/mordent.h
+++ b/include/vrv/mordent.h
@@ -30,7 +30,8 @@ class Mordent : public ControlElement,
                 public AttExtSymNames,
                 public AttOrnamentAccid,
                 public AttPlacementRelStaff,
-                public AttMordentLog {
+                public AttMordentLog,
+                public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/octave.h
+++ b/include/vrv/octave.h
@@ -28,7 +28,8 @@ class Octave : public ControlElement,
                public AttLineRend,
                public AttLineRendBase,
                public AttNNumberLike,
-               public AttOctaveDisplacement {
+               public AttOctaveDisplacement,
+               public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/ornam.h
+++ b/include/vrv/ornam.h
@@ -28,7 +28,8 @@ class Ornam : public ControlElement,
               public TextListInterface,
               public TextDirInterface,
               public TimePointInterface,
-              public AttOrnamentAccid {
+              public AttOrnamentAccid,
+              public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/preparedatafunctor.h
+++ b/include/vrv/preparedatafunctor.h
@@ -942,6 +942,7 @@ public:
     FunctorCode VisitDir(Dir *dir) override;
     FunctorCode VisitDynam(Dynam *dynam) override;
     FunctorCode VisitEnding(Ending *ending) override;
+    FunctorCode VisitFloatingObject(FloatingObject *floatingObject) override;
     FunctorCode VisitHairpin(Hairpin *hairpin) override;
     FunctorCode VisitHarm(Harm *harm) override;
     FunctorCode VisitMeasure(Measure *measure) override;

--- a/include/vrv/repeatmark.h
+++ b/include/vrv/repeatmark.h
@@ -29,7 +29,8 @@ class RepeatMark : public ControlElement,
                    public TimePointInterface,
                    public AttExtSymAuth,
                    public AttExtSymNames,
-                   public AttRepeatMarkLog {
+                   public AttRepeatMarkLog,
+                   public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/scoredef.h
+++ b/include/vrv/scoredef.h
@@ -40,7 +40,7 @@ class StaffDef;
  * information about clef, key signature, etc. This information can be either
  * attributes (implemented) of the ScoreDefInterface or elements (not implemented).
  */
-class ScoreDefElement : public Object, public ScoreDefInterface, public AttTyped {
+class ScoreDefElement : public Object, public ScoreDefInterface, public AttStaffItems, public AttTyped {
 public:
     /**
      * @name Constructors, destructors, and other standard methods.
@@ -70,6 +70,15 @@ public:
     bool HasMeterSigInfo(int depth = 1) const;
     bool HasMeterSigGrpInfo(int depth = 1) const;
     ///@}
+
+    /**
+     * Copy staff-item orders that are explicitly set on the source.
+     * Return true if at least one order was copied.
+     */
+    bool ReplaceStaffItemOrders(const ScoreDefElement *source);
+
+    /** Return the explicitly set order for the given placement, or an empty list. */
+    data_STAFFITEM_List GetStaffItemOrder(data_STAFFREL place) const;
 
     /**
      * @name Get a copy of the clef, keysig, mensur and meterSig.
@@ -206,6 +215,12 @@ public:
      * Return all the \@n values of the staffDef in a scoreDef
      */
     std::vector<int> GetStaffNs() const;
+
+    /**
+     * Return the effective staff-item order for a staff and placement.
+     * A staffDef value takes precedence over the scoreDef value.
+     */
+    data_STAFFITEM_List GetStaffItemOrder(int staffN, data_STAFFREL place) const;
 
     /**
      * Set the redraw flag to all staffDefs.

--- a/include/vrv/tempo.h
+++ b/include/vrv/tempo.h
@@ -30,7 +30,8 @@ class Tempo : public ControlElement,
               public AttExtender,
               public AttLang,
               public AttMidiTempo,
-              public AttMmTempo {
+              public AttMmTempo,
+              public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, reset methods

--- a/include/vrv/trill.h
+++ b/include/vrv/trill.h
@@ -32,7 +32,8 @@ class Trill : public ControlElement,
               public AttLineRend,
               public AttNNumberLike,
               public AttOrnamentAccid,
-              public AttPlacementRelStaff {
+              public AttPlacementRelStaff,
+              public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/include/vrv/turn.h
+++ b/include/vrv/turn.h
@@ -30,7 +30,8 @@ class Turn : public ControlElement,
              public AttExtSymNames,
              public AttOrnamentAccid,
              public AttPlacementRelStaff,
-             public AttTurnLog {
+             public AttTurnLog,
+             public AttVerticalGroup {
 public:
     /**
      * @name Constructors, destructors, and other standard methods

--- a/libmei/addons/att.cpp
+++ b/libmei/addons/att.cpp
@@ -94,6 +94,30 @@ data_ARTICULATION_List Att::StrToArticulationList(const std::string &value, bool
     return list;
 }
 
+std::string Att::StaffitemListToStr(const data_STAFFITEM_List &data) const
+{
+    std::ostringstream ss;
+    for (const data_STAFFITEM item : data) {
+        const std::string value = StaffitemToStr(item);
+        if (value.empty()) continue;
+        if (ss.tellp() > 0) ss << " ";
+        ss << value;
+    }
+    return ss.str();
+}
+
+data_STAFFITEM_List Att::StrToStaffitemList(const std::string &value, bool logWarning) const
+{
+    data_STAFFITEM_List list;
+    std::istringstream iss(value);
+    std::string token;
+    while (iss >> token) {
+        const data_STAFFITEM item = StrToStaffitem(token, logWarning);
+        if (item != STAFFITEM_NONE) list.push_back(item);
+    }
+    return list;
+}
+
 std::string Att::BeatrptRendToStr(data_BEATRPT_REND data) const
 {
     std::string value;

--- a/libmei/addons/att.h
+++ b/libmei/addons/att.h
@@ -63,6 +63,9 @@ public:
     std::string ArticulationListToStr(data_ARTICULATION_List data) const;
     data_ARTICULATION_List StrToArticulationList(const std::string &value, bool = true) const;
 
+    std::string StaffitemListToStr(const data_STAFFITEM_List &data) const;
+    data_STAFFITEM_List StrToStaffitemList(const std::string &value, bool logWarning = true) const;
+
     std::string BeatrptRendToStr(data_BEATRPT_REND data) const;
     data_BEATRPT_REND StrToBeatrptRend(const std::string &value, bool logWarning = true) const;
 

--- a/libmei/addons/attdef.h
+++ b/libmei/addons/attdef.h
@@ -56,6 +56,12 @@ typedef double data_VU;
 typedef std::vector<data_ARTICULATION> data_ARTICULATION_List;
 
 /**
+ * A typedef for an ordered list of staff items.
+ * E.g., list { data.STAFFITEM+ }
+ */
+typedef std::vector<data_STAFFITEM> data_STAFFITEM_List;
+
+/**
  * MEI data.BEATRPT_REND
  */
 enum data_BEATRPT_REND {

--- a/libmei/datatypes.yml
+++ b/libmei/datatypes.yml
@@ -189,6 +189,8 @@ defaults:
         -1.0
     data_STAFFITEM:
         data_STAFFITEM()
+    data_STAFFITEM_List:
+        std::vector<data_STAFFITEM>()
     data_STAFFREL:
         data_STAFFREL()
 
@@ -251,6 +253,13 @@ modules:
         att.staffIdent:
             staff:
                 type: xsdPositiveInteger_List
+        att.staffItems:
+            aboveorder:
+                type: data_STAFFITEM_List
+            beloworder:
+                type: data_STAFFITEM_List
+            betweenorder:
+                type: data_STAFFITEM_List
         att.stems:
             stem.len:
                 type: double

--- a/libmei/dist/attmodule.cpp
+++ b/libmei/dist/attmodule.cpp
@@ -4230,15 +4230,15 @@ bool AttModule::SetShared(Object *element, const std::string &attrType, const st
         AttStaffItems *att = dynamic_cast<AttStaffItems *>(element);
         assert(att);
         if (attrType == "aboveorder") {
-            att->SetAboveorder(att->StrToStaffitem(attrValue));
+            att->SetAboveorder(att->StrToStaffitemList(attrValue));
             return true;
         }
         if (attrType == "beloworder") {
-            att->SetBeloworder(att->StrToStaffitem(attrValue));
+            att->SetBeloworder(att->StrToStaffitemList(attrValue));
             return true;
         }
         if (attrType == "betweenorder") {
-            att->SetBetweenorder(att->StrToStaffitem(attrValue));
+            att->SetBetweenorder(att->StrToStaffitemList(attrValue));
             return true;
         }
     }
@@ -5693,13 +5693,13 @@ void AttModule::GetShared(const Object *element, ArrayOfStrAttr *attributes)
         const AttStaffItems *att = dynamic_cast<const AttStaffItems *>(element);
         assert(att);
         if (att->HasAboveorder()) {
-            attributes->push_back({ "aboveorder", att->StaffitemToStr(att->GetAboveorder()) });
+            attributes->push_back({ "aboveorder", att->StaffitemListToStr(att->GetAboveorder()) });
         }
         if (att->HasBeloworder()) {
-            attributes->push_back({ "beloworder", att->StaffitemToStr(att->GetBeloworder()) });
+            attributes->push_back({ "beloworder", att->StaffitemListToStr(att->GetBeloworder()) });
         }
         if (att->HasBetweenorder()) {
-            attributes->push_back({ "betweenorder", att->StaffitemToStr(att->GetBetweenorder()) });
+            attributes->push_back({ "betweenorder", att->StaffitemListToStr(att->GetBetweenorder()) });
         }
     }
     if (element->HasAttClass(ATT_STAFFLOC)) {

--- a/libmei/dist/atts_shared.cpp
+++ b/libmei/dist/atts_shared.cpp
@@ -5783,26 +5783,26 @@ AttStaffItems::AttStaffItems() : Att()
 
 void AttStaffItems::ResetStaffItems()
 {
-    m_aboveorder = data_STAFFITEM();
-    m_beloworder = data_STAFFITEM();
-    m_betweenorder = data_STAFFITEM();
+    m_aboveorder = std::vector<data_STAFFITEM>();
+    m_beloworder = std::vector<data_STAFFITEM>();
+    m_betweenorder = std::vector<data_STAFFITEM>();
 }
 
 bool AttStaffItems::ReadStaffItems(pugi::xml_node element, bool removeAttr)
 {
     bool hasAttribute = false;
     if (element.attribute("aboveorder")) {
-        this->SetAboveorder(StrToStaffitem(element.attribute("aboveorder").value()));
+        this->SetAboveorder(StrToStaffitemList(element.attribute("aboveorder").value()));
         if (removeAttr) element.remove_attribute("aboveorder");
         hasAttribute = true;
     }
     if (element.attribute("beloworder")) {
-        this->SetBeloworder(StrToStaffitem(element.attribute("beloworder").value()));
+        this->SetBeloworder(StrToStaffitemList(element.attribute("beloworder").value()));
         if (removeAttr) element.remove_attribute("beloworder");
         hasAttribute = true;
     }
     if (element.attribute("betweenorder")) {
-        this->SetBetweenorder(StrToStaffitem(element.attribute("betweenorder").value()));
+        this->SetBetweenorder(StrToStaffitemList(element.attribute("betweenorder").value()));
         if (removeAttr) element.remove_attribute("betweenorder");
         hasAttribute = true;
     }
@@ -5813,15 +5813,15 @@ bool AttStaffItems::WriteStaffItems(pugi::xml_node element)
 {
     bool wroteAttribute = false;
     if (this->HasAboveorder()) {
-        element.append_attribute("aboveorder") = StaffitemToStr(this->GetAboveorder()).c_str();
+        element.append_attribute("aboveorder") = StaffitemListToStr(this->GetAboveorder()).c_str();
         wroteAttribute = true;
     }
     if (this->HasBeloworder()) {
-        element.append_attribute("beloworder") = StaffitemToStr(this->GetBeloworder()).c_str();
+        element.append_attribute("beloworder") = StaffitemListToStr(this->GetBeloworder()).c_str();
         wroteAttribute = true;
     }
     if (this->HasBetweenorder()) {
-        element.append_attribute("betweenorder") = StaffitemToStr(this->GetBetweenorder()).c_str();
+        element.append_attribute("betweenorder") = StaffitemListToStr(this->GetBetweenorder()).c_str();
         wroteAttribute = true;
     }
     return wroteAttribute;
@@ -5829,17 +5829,17 @@ bool AttStaffItems::WriteStaffItems(pugi::xml_node element)
 
 bool AttStaffItems::HasAboveorder() const
 {
-    return (m_aboveorder != data_STAFFITEM());
+    return (m_aboveorder != std::vector<data_STAFFITEM>());
 }
 
 bool AttStaffItems::HasBeloworder() const
 {
-    return (m_beloworder != data_STAFFITEM());
+    return (m_beloworder != std::vector<data_STAFFITEM>());
 }
 
 bool AttStaffItems::HasBetweenorder() const
 {
-    return (m_betweenorder != data_STAFFITEM());
+    return (m_betweenorder != std::vector<data_STAFFITEM>());
 }
 
 //----------------------------------------------------------------------------

--- a/libmei/dist/atts_shared.h
+++ b/libmei/dist/atts_shared.h
@@ -6415,16 +6415,16 @@ public:
      * to the default value)
      **/
     ///@{
-    void SetAboveorder(data_STAFFITEM aboveorder_) { m_aboveorder = aboveorder_; }
-    data_STAFFITEM GetAboveorder() const { return m_aboveorder; }
+    void SetAboveorder(data_STAFFITEM_List aboveorder_) { m_aboveorder = aboveorder_; }
+    data_STAFFITEM_List GetAboveorder() const { return m_aboveorder; }
     bool HasAboveorder() const;
     //
-    void SetBeloworder(data_STAFFITEM beloworder_) { m_beloworder = beloworder_; }
-    data_STAFFITEM GetBeloworder() const { return m_beloworder; }
+    void SetBeloworder(data_STAFFITEM_List beloworder_) { m_beloworder = beloworder_; }
+    data_STAFFITEM_List GetBeloworder() const { return m_beloworder; }
     bool HasBeloworder() const;
     //
-    void SetBetweenorder(data_STAFFITEM betweenorder_) { m_betweenorder = betweenorder_; }
-    data_STAFFITEM GetBetweenorder() const { return m_betweenorder; }
+    void SetBetweenorder(data_STAFFITEM_List betweenorder_) { m_betweenorder = betweenorder_; }
+    data_STAFFITEM_List GetBetweenorder() const { return m_betweenorder; }
     bool HasBetweenorder() const;
     ///@}
 
@@ -6433,14 +6433,14 @@ private:
      * Describes vertical order of items printed above a staff, from closest to
      * farthest away from the staff.
      **/
-    data_STAFFITEM m_aboveorder;
+    data_STAFFITEM_List m_aboveorder;
     /**
      * Describes vertical order of items printed below a staff, from closest to
      * farthest away from the staff.
      **/
-    data_STAFFITEM m_beloworder;
+    data_STAFFITEM_List m_beloworder;
     /** Describes vertical order of items printed between staves, from top to bottom. **/
-    data_STAFFITEM m_betweenorder;
+    data_STAFFITEM_List m_betweenorder;
 };
 
 //----------------------------------------------------------------------------

--- a/src/adjustfloatingpositionerfunctor.cpp
+++ b/src/adjustfloatingpositionerfunctor.cpp
@@ -9,13 +9,269 @@
 
 //----------------------------------------------------------------------------
 
+#include <map>
+#include <set>
+
+//----------------------------------------------------------------------------
+
+#include "comparison.h"
+#include "dir.h"
 #include "doc.h"
+#include "measure.h"
+#include "scoredef.h"
 #include "staff.h"
+#include "staffdef.h"
 #include "system.h"
+#include "timeinterface.h"
 
 //----------------------------------------------------------------------------
 
 namespace vrv {
+
+namespace {
+
+    constexpr size_t STAFF_ITEM_GROUP_MAX_PASSES = 2;
+
+    struct StaffItemStep {
+        data_STAFFITEM item;
+        ClassId classId;
+        bool exactItem = false;
+    };
+
+    struct StaffItemPositioner {
+        FloatingPositioner *positioner;
+        ClassId classId;
+        data_STAFFITEM item;
+        int measureIndex;
+        int stepIndex;
+        int positionerIndex;
+    };
+
+    const std::vector<StaffItemStep> &GetDefaultStaffItemSteps()
+    {
+        static const std::vector<StaffItemStep> steps{
+            { STAFFITEM_lv, LV },
+            { STAFFITEM_tie, TIE },
+            { STAFFITEM_NONE, SLUR },
+            { STAFFITEM_NONE, PHRASE },
+            { STAFFITEM_accid, ACCID_FLOATING },
+            { STAFFITEM_mordent, MORDENT },
+            { STAFFITEM_turn, TURN },
+            { STAFFITEM_trill, TRILL },
+            { STAFFITEM_ornam, ORNAM },
+            { STAFFITEM_fing, FING },
+            { STAFFITEM_dynam, DYNAM },
+            { STAFFITEM_hairpin, HAIRPIN },
+            { STAFFITEM_bracketSpan, BRACKETSPAN },
+            { STAFFITEM_octave, OCTAVE },
+            { STAFFITEM_breath, BREATH },
+            { STAFFITEM_fermata, FERMATA },
+            { STAFFITEM_dir, DIR },
+            { STAFFITEM_cpMark, CPMARK },
+            { STAFFITEM_NONE, REPEATMARK },
+            { STAFFITEM_tempo, TEMPO },
+            { STAFFITEM_pedal, PEDAL },
+            { STAFFITEM_harm, HARM },
+            { STAFFITEM_NONE, ENDING },
+            { STAFFITEM_reh, REH },
+            { STAFFITEM_NONE, CAESURA },
+            { STAFFITEM_annot, ANNOTSCORE },
+        };
+        return steps;
+    }
+
+    std::vector<StaffItemStep> GetOrderedStaffItemSteps(const data_STAFFITEM_List &order)
+    {
+        const std::vector<StaffItemStep> &defaults = GetDefaultStaffItemSteps();
+        if (order.empty()) return defaults;
+
+        std::vector<StaffItemStep> steps;
+        std::set<data_STAFFITEM> used;
+        for (const data_STAFFITEM item : order) {
+            if (!used.insert(item).second) continue;
+            if (item == STAFFITEM_stageDir) {
+                steps.push_back({ STAFFITEM_stageDir, DIR, true });
+            }
+            else {
+                for (const StaffItemStep &step : defaults) {
+                    if (step.item == item) steps.push_back({ step.item, step.classId, true });
+                }
+            }
+        }
+        for (const StaffItemStep &step : defaults) {
+            if ((step.item == STAFFITEM_dir) && (used.contains(STAFFITEM_dir) || used.contains(STAFFITEM_stageDir))) {
+                if (!used.contains(STAFFITEM_dir)) steps.push_back({ STAFFITEM_dir, DIR, true });
+                if (!used.contains(STAFFITEM_stageDir)) steps.push_back({ STAFFITEM_stageDir, DIR, true });
+            }
+            else if ((step.item == STAFFITEM_NONE) || !used.contains(step.item)) {
+                steps.push_back(step);
+            }
+        }
+        return steps;
+    }
+
+    bool MatchesStaffItemStep(const FloatingPositioner *positioner, const StaffItemStep &step)
+    {
+        assert(positioner);
+        assert(positioner->GetObject());
+        if (!positioner->GetObject()->Is(step.classId)) return false;
+        if (!step.exactItem) return true;
+        if ((step.item != STAFFITEM_dir) && (step.item != STAFFITEM_stageDir)) return true;
+
+        const Dir *dir = vrv_cast<const Dir *>(positioner->GetObject());
+        assert(dir);
+        return (step.item == STAFFITEM_stageDir) ? dir->IsStageDir() : !dir->IsStageDir();
+    }
+
+    const Measure *GetPositionerMeasure(const FloatingPositioner *positioner, const Measure *fallback)
+    {
+        assert(positioner);
+        const Object *object = positioner->GetObject();
+        assert(object);
+
+        const Measure *measure = vrv_cast<const Measure *>(object->GetFirstAncestor(MEASURE));
+        if (measure) return measure;
+
+        const TimePointInterface *interface = object->GetTimePointInterface();
+        if (interface && interface->GetStartMeasure()) return interface->GetStartMeasure();
+
+        measure = vrv_cast<const Measure *>(object->FindDescendantByType(MEASURE));
+        return measure ? measure : fallback;
+    }
+
+    int GetAutomaticGroupBucket(const FloatingPositioner *positioner)
+    {
+        assert(positioner);
+        const Object *object = positioner->GetObject();
+        assert(object);
+        if (object->IsAnyOf(std::array{ DYNAM, HAIRPIN })) return 1;
+        if (object->Is(DIR)) return 2;
+        if (object->Is(PEDAL)) return 3;
+        if (object->Is(HARM)) return 4;
+        if (object->Is(ENDING)) return 5;
+        return 100 + object->GetClassId();
+    }
+
+    long long GetPositionerGroupKey(const FloatingPositioner *positioner)
+    {
+        assert(positioner);
+        assert(positioner->GetObject());
+        const int groupId = positioner->GetObject()->GetDrawingGrpId();
+        if (groupId < 0) return groupId;
+        return (static_cast<long long>(GetAutomaticGroupBucket(positioner)) << 32) | static_cast<unsigned int>(groupId);
+    }
+
+    void MovePositionerPastBoundingBox(FloatingPositioner *positioner, const BoundingBox *bbox)
+    {
+        assert(positioner);
+        assert(bbox);
+
+        if (positioner->GetDrawingPlace() == STAFFREL_above) {
+            const int shift = bbox->GetContentTop() - positioner->GetContentBottom();
+            if (shift > 0) positioner->SetDrawingYRel(positioner->GetDrawingYRel() - shift, true);
+        }
+        else {
+            const int shift = positioner->GetContentTop() - bbox->GetContentBottom();
+            if (shift > 0) positioner->SetDrawingYRel(positioner->GetDrawingYRel() + shift, true);
+        }
+    }
+
+    bool HasStaffItemOrder(const ScoreDef *scoreDef)
+    {
+        if (!scoreDef) return false;
+        if (scoreDef->HasAboveorder() || scoreDef->HasBeloworder() || scoreDef->HasBetweenorder()) return true;
+
+        for (const int staffN : scoreDef->GetStaffNs()) {
+            const StaffDef *staffDef = scoreDef->GetStaffDef(staffN);
+            if (staffDef && (staffDef->HasAboveorder() || staffDef->HasBeloworder() || staffDef->HasBetweenorder())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    const ScoreDef *GetDrawingScoreDef(const Measure *measure, int staffN, const ScoreDef *fallback)
+    {
+        if (!measure) return fallback;
+
+        AttNIntegerComparison matchN(STAFF, staffN);
+        const Staff *staff = vrv_cast<const Staff *>(measure->FindDescendantByComparison(&matchN, 1));
+        if (!staff || !staff->m_drawingStaffDef) return fallback;
+
+        return vrv_cast<const ScoreDef *>(staff->m_drawingStaffDef->GetFirstAncestor(SCOREDEF));
+    }
+
+    bool HasSystemStaffItemOrder(const System *system)
+    {
+        if (!system) return false;
+        if (HasStaffItemOrder(system->GetDrawingScoreDef())) return true;
+
+        const ListOfConstObjects staves = system->FindAllDescendantsByType(STAFF);
+        for (const Object *object : staves) {
+            const Staff *staff = vrv_cast<const Staff *>(object);
+            assert(staff);
+            if (HasStaffItemOrder(GetDrawingScoreDef(
+                    vrv_cast<const Measure *>(staff->GetFirstAncestor(MEASURE)), staff->GetN(), NULL))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::vector<StaffItemPositioner> BuildStaffItemPositioners(
+        StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin, bool useStaffItemOrder)
+    {
+        std::vector<StaffItemPositioner> result;
+        const System *system = staffAlignment->GetParentSystem();
+        const Staff *staff = staffAlignment->GetStaff();
+        if (!system || !staff) return result;
+
+        const ListOfConstObjects measures = system->FindAllDescendantsByType(MEASURE);
+        if (measures.empty()) return result;
+
+        std::map<const Measure *, int> measureIndices;
+        int measureIndex = 0;
+        for (const Object *object : measures) {
+            const Measure *measure = vrv_cast<const Measure *>(object);
+            assert(measure);
+            measureIndices[measure] = measureIndex++;
+        }
+        const Measure *fallback = vrv_cast<const Measure *>(measures.front());
+
+        const ArrayOfFloatingPositioners &positioners = staffAlignment->GetFloatingPositioners();
+        for (int positionerIndex = 0; positionerIndex < static_cast<int>(positioners.size()); ++positionerIndex) {
+            FloatingPositioner *positioner = positioners.at(positionerIndex);
+            const data_STAFFREL drawingPlace = positioner->GetDrawingPlace();
+            if ((drawingPlace != place) && !(includeWithin && (drawingPlace == STAFFREL_within))) continue;
+
+            const Measure *measure = GetPositionerMeasure(positioner, fallback);
+            const ScoreDef *scoreDef = GetDrawingScoreDef(measure, staff->GetN(), system->GetDrawingScoreDef());
+            data_STAFFITEM_List order;
+            if (useStaffItemOrder && scoreDef && (drawingPlace != STAFFREL_within)) {
+                order = scoreDef->GetStaffItemOrder(staff->GetN(), place);
+            }
+            const std::vector<StaffItemStep> steps = GetOrderedStaffItemSteps(order);
+
+            for (int stepIndex = 0; stepIndex < static_cast<int>(steps.size()); ++stepIndex) {
+                const StaffItemStep &step = steps.at(stepIndex);
+                if (!MatchesStaffItemStep(positioner, step)) continue;
+                const int index = useStaffItemOrder ? measureIndices[measure] : 0;
+                result.push_back({ positioner, step.classId, step.exactItem ? step.item : STAFFITEM_NONE, index,
+                    stepIndex, positionerIndex });
+                break;
+            }
+        }
+
+        std::stable_sort(
+            result.begin(), result.end(), [](const StaffItemPositioner &left, const StaffItemPositioner &right) {
+                if (left.measureIndex != right.measureIndex) return left.measureIndex < right.measureIndex;
+                if (left.stepIndex != right.stepIndex) return left.stepIndex < right.stepIndex;
+                return left.positionerIndex < right.positionerIndex;
+            });
+        return result;
+    }
+
+} // namespace
 
 //----------------------------------------------------------------------------
 // AdjustFloatingPositionersFunctor
@@ -24,15 +280,57 @@ namespace vrv {
 AdjustFloatingPositionersFunctor::AdjustFloatingPositionersFunctor(Doc *doc) : DocFunctor(doc)
 {
     m_classId = OBJECT;
+    m_staffItem = STAFFITEM_NONE;
     m_inBetween = false;
+    m_place = STAFFREL_NONE;
+    m_includeWithin = false;
+    m_positioners = NULL;
+    m_keepGroupPosition = false;
+    m_movePositionerGroups = true;
+    m_detectExplicitGroups = false;
+    m_hasExplicitGroups = false;
+    m_useStaffItemOrder = false;
 }
 
 FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment *staffAlignment)
 {
+    if (m_detectExplicitGroups) {
+        std::map<std::pair<data_STAFFREL, int>, std::vector<ClassId>> explicitGroups;
+        for (const FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
+            assert(positioner->GetObject());
+            const int groupId = positioner->GetObject()->GetDrawingGrpId();
+            if (groupId < 0) {
+                explicitGroups[{ positioner->GetDrawingPlace(), groupId }].push_back(
+                    positioner->GetObject()->GetClassId());
+            }
+        }
+        for (const auto &group : explicitGroups) {
+            const std::vector<ClassId> &classes = group.second;
+            if (classes.size() < 2) continue;
+
+            const bool legacyDynamGroup = std::all_of(classes.begin(), classes.end(),
+                [](ClassId classId) { return (classId == DYNAM) || (classId == HAIRPIN); });
+            const bool legacyDirGroup
+                = std::all_of(classes.begin(), classes.end(), [](ClassId classId) { return classId == DIR; });
+            const bool legacyPedalGroup
+                = std::all_of(classes.begin(), classes.end(), [](ClassId classId) { return classId == PEDAL; });
+            if (!legacyDynamGroup && !legacyDirGroup && !legacyPedalGroup) {
+                m_hasExplicitGroups = true;
+                break;
+            }
+        }
+        return FUNCTOR_SIBLINGS;
+    }
+    if (m_useStaffItemOrder) return this->AdjustStaffItemOrder(staffAlignment);
+    return this->AdjustCurrentPositioners(staffAlignment);
+}
+
+FunctorCode AdjustFloatingPositionersFunctor::AdjustCurrentPositioners(StaffAlignment *staffAlignment)
+{
     const int staffSize = staffAlignment->GetStaffSize();
     const int drawingUnit = m_doc->GetDrawingUnit(staffSize);
 
-    staffAlignment->SortPositioners();
+    if (!m_positioners) staffAlignment->SortPositioners();
 
     if (m_classId == SYL) {
         const bool verseCollapse = m_doc->GetOptions()->m_lyricVerseCollapse.GetValue();
@@ -66,11 +364,24 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
         return FUNCTOR_SIBLINGS;
     }
 
-    for (FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
+    const ArrayOfFloatingPositioners &positioners
+        = m_positioners ? *m_positioners : staffAlignment->GetFloatingPositioners();
+    for (FloatingPositioner *positioner : positioners) {
         assert(positioner->GetObject());
-        if (!m_inBetween && !positioner->GetObject()->Is(m_classId)) continue;
+        if ((m_classId != OBJECT) && !positioner->GetObject()->Is(m_classId)) continue;
+        if ((m_staffItem == STAFFITEM_stageDir) || (m_staffItem == STAFFITEM_dir)) {
+            const Dir *dir = vrv_cast<const Dir *>(positioner->GetObject());
+            assert(dir);
+            if ((m_staffItem == STAFFITEM_stageDir) != dir->IsStageDir()) continue;
+        }
 
-        if (m_inBetween) {
+        if (m_place != STAFFREL_NONE) {
+            if ((positioner->GetDrawingPlace() != m_place)
+                && !(m_includeWithin && (positioner->GetDrawingPlace() == STAFFREL_within))) {
+                continue;
+            }
+        }
+        else if (m_inBetween) {
             if (positioner->GetDrawingPlace() != STAFFREL_between) continue;
         }
         else {
@@ -119,13 +430,54 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
             continue;
         }
 
-        // This sets the default position (without considering any overflowing box)
-        positioner->CalcDrawingYRel(m_doc, staffAlignment, NULL);
-
         const data_STAFFREL place = positioner->GetDrawingPlace();
         ArrayOfBoundingBoxes &overflowBoxes = (place == STAFFREL_above)
             ? staffAlignment->GetBBoxesAboveForModification()
             : staffAlignment->GetBBoxesBelowForModification();
+
+        const long long groupKey = GetPositionerGroupKey(positioner);
+        const auto positionerGroup = m_positionerGroups.find(groupKey);
+        if (m_keepGroupPosition && (positionerGroup != m_positionerGroups.end())) {
+            if (!m_movePositionerGroups) {
+                overflowBoxes.push_back(positioner);
+                if (place == STAFFREL_above) {
+                    staffAlignment->SetOverflowAbove(staffAlignment->CalcOverflowAbove(positioner));
+                }
+                else {
+                    staffAlignment->SetOverflowBelow(staffAlignment->CalcOverflowBelow(positioner));
+                }
+                continue;
+            }
+            for (BoundingBox *bbox : overflowBoxes) {
+                const FloatingPositioner *other = dynamic_cast<const FloatingPositioner *>(bbox);
+                if (other && other->GetObject() && (other->GetObject()->GetDrawingGrpId() != 0)
+                    && (GetPositionerGroupKey(other) == groupKey)) {
+                    continue;
+                }
+                if (!positioner->HasHorizontalOverlapWith(bbox, drawingUnit)) continue;
+                const int previousYRel = positioner->GetDrawingYRel();
+                if (other) MovePositionerPastBoundingBox(positioner, other);
+                positioner->CalcDrawingYRel(m_doc, staffAlignment, bbox);
+                if (positioner->GetDrawingYRel() == previousYRel) continue;
+
+                for (FloatingPositioner *member : positionerGroup->second) {
+                    if (member == positioner) continue;
+                    member->SetDrawingYRel(member->GetDrawingYRel() + positioner->GetDrawingYRel() - previousYRel);
+                }
+            }
+
+            overflowBoxes.push_back(positioner);
+            if (place == STAFFREL_above) {
+                staffAlignment->SetOverflowAbove(staffAlignment->CalcOverflowAbove(positioner));
+            }
+            else {
+                staffAlignment->SetOverflowBelow(staffAlignment->CalcOverflowBelow(positioner));
+            }
+            continue;
+        }
+
+        // This sets the default position (without considering any overflowing box)
+        positioner->CalcDrawingYRel(m_doc, staffAlignment, NULL);
 
         // Handle within placement (ignore collisions for certain classes)
         if (place == STAFFREL_within) {
@@ -137,6 +489,12 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
         // Find all the overflowing elements from the staff that overlap horizontally
         for (BoundingBox *bbox : overflowBoxes) {
             if (positioner->HasHorizontalOverlapWith(bbox, drawingUnit)) {
+                if (m_keepGroupPosition) {
+                    const FloatingPositioner *grouped = dynamic_cast<const FloatingPositioner *>(bbox);
+                    if (grouped && grouped->GetObject() && (grouped->GetObject()->GetDrawingGrpId() != 0)) {
+                        MovePositionerPastBoundingBox(positioner, grouped);
+                    }
+                }
                 // update the yRel accordingly
                 positioner->CalcDrawingYRel(m_doc, staffAlignment, bbox);
             }
@@ -163,8 +521,325 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitStaffAlignment(StaffAlignment
     return FUNCTOR_SIBLINGS;
 }
 
+void AdjustFloatingPositionersFunctor::ProcessClass(
+    StaffAlignment *staffAlignment, ClassId classId, data_STAFFREL place, data_STAFFITEM staffItem)
+{
+    m_classId = classId;
+    m_staffItem = staffItem;
+    m_inBetween = (place == STAFFREL_between);
+    m_place = place;
+    this->AdjustCurrentPositioners(staffAlignment);
+}
+
+void AdjustFloatingPositionersFunctor::ProcessPositioners(StaffAlignment *staffAlignment,
+    const ArrayOfFloatingPositioners &positioners, ClassId classId, data_STAFFREL place, data_STAFFITEM staffItem,
+    bool keepGroupPosition)
+{
+    m_positioners = &positioners;
+    m_keepGroupPosition = keepGroupPosition;
+    this->ProcessClass(staffAlignment, classId, place, staffItem);
+    m_keepGroupPosition = false;
+    m_positioners = NULL;
+}
+
+bool AdjustFloatingPositionersFunctor::HasExplicitPositionerGroup(
+    StaffAlignment *staffAlignment, data_STAFFREL place) const
+{
+    for (const FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
+        assert(positioner->GetObject());
+        if ((positioner->GetDrawingPlace() == place) && (positioner->GetObject()->GetDrawingGrpId() < 0)) return true;
+    }
+    return false;
+}
+
+void AdjustFloatingPositionersFunctor::BuildPositionerGroups(
+    StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin)
+{
+    m_positionerGroups.clear();
+    for (FloatingPositioner *positioner : staffAlignment->GetFloatingPositioners()) {
+        assert(positioner->GetObject());
+        if ((positioner->GetDrawingPlace() != place)
+            && !(includeWithin && (positioner->GetDrawingPlace() == STAFFREL_within))) {
+            continue;
+        }
+        if (positioner->GetObject()->GetDrawingGrpId() == 0) continue;
+        m_positionerGroups[GetPositionerGroupKey(positioner)].push_back(positioner);
+    }
+    std::erase_if(m_positionerGroups, [](const auto &group) { return group.second.size() < 2; });
+}
+
+void AdjustFloatingPositionersFunctor::StabilizePositionerGroups(StaffAlignment *staffAlignment, data_STAFFREL place,
+    const ArrayOfBoundingBoxes &baseBoxes, const std::function<void()> &processPositioners)
+{
+    ArrayOfBoundingBoxes &overflowBoxes = (place == STAFFREL_above) ? staffAlignment->GetBBoxesAboveForModification()
+                                                                    : staffAlignment->GetBBoxesBelowForModification();
+
+    bool stable = false;
+    const size_t maxPasses = std::min<size_t>(m_positionerGroups.size() + 1, STAFF_ITEM_GROUP_MAX_PASSES);
+    for (size_t pass = 0; pass < maxPasses; ++pass) {
+        std::map<FloatingPositioner *, int> previousPositions;
+        for (const auto &group : m_positionerGroups) {
+            for (FloatingPositioner *positioner : group.second) {
+                previousPositions[positioner] = positioner->GetDrawingYRel();
+            }
+        }
+        overflowBoxes = baseBoxes;
+        processPositioners();
+        stable = std::all_of(previousPositions.begin(), previousPositions.end(),
+            [](const auto &entry) { return entry.first->GetDrawingYRel() == entry.second; });
+        if (stable) break;
+    }
+
+    // Conflicting category orders can create a cycle between shared groups. Preserve the group baselines selected by
+    // the stable traversal order and rebuild the remaining positioners around them without moving a group again.
+    if (!stable) {
+        m_movePositionerGroups = false;
+        overflowBoxes = baseBoxes;
+        processPositioners();
+        m_movePositionerGroups = true;
+    }
+}
+
+void AdjustFloatingPositionersFunctor::AdjustPositionerGroups(StaffAlignment *staffAlignment, data_STAFFREL place)
+{
+    AdjustFloatingPositionerGrpsFunctor adjustGroups(m_doc);
+    adjustGroups.SetPlace(place);
+
+    // Explicit MEI @vgrp values are shared across all supported floating-object classes.
+    adjustGroups.SetGroupType(-1);
+    adjustGroups.SetClassIDs({});
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    // Automatically generated groups retain their class-specific legacy behavior.
+    adjustGroups.SetGroupType(1);
+
+    if ((place == STAFFREL_above) || (place == STAFFREL_below)) {
+        adjustGroups.SetClassIDs({ DYNAM, HAIRPIN });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+        adjustGroups.SetClassIDs({ DIR });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+        adjustGroups.SetClassIDs({ PEDAL });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+        adjustGroups.SetClassIDs({ HARM });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+        adjustGroups.SetClassIDs({ ENDING });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+    }
+    else if (place == STAFFREL_between) {
+        adjustGroups.SetClassIDs({ DYNAM });
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+    }
+}
+
+bool AdjustFloatingPositionersFunctor::HasStaffItemOrder(StaffAlignment *staffAlignment, data_STAFFREL place) const
+{
+    const System *system = staffAlignment->GetParentSystem();
+    const Staff *staff = staffAlignment->GetStaff();
+    if (!system || !staff) return false;
+
+    const ListOfConstObjects measures = system->FindAllDescendantsByType(MEASURE);
+    for (const Object *object : measures) {
+        const Measure *measure = vrv_cast<const Measure *>(object);
+        assert(measure);
+        const ScoreDef *scoreDef = GetDrawingScoreDef(measure, staff->GetN(), system->GetDrawingScoreDef());
+        if (!scoreDef) continue;
+        if (!scoreDef->GetStaffItemOrder(staff->GetN(), place).empty()) return true;
+    }
+    return false;
+}
+
+void AdjustFloatingPositionersFunctor::AdjustLegacyPlace(
+    StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin)
+{
+    ArrayOfBoundingBoxes &overflowBoxes = (place == STAFFREL_above) ? staffAlignment->GetBBoxesAboveForModification()
+                                                                    : staffAlignment->GetBBoxesBelowForModification();
+    const ArrayOfBoundingBoxes baseBoxes = overflowBoxes;
+
+    m_includeWithin = includeWithin;
+    AdjustFloatingPositionerGrpsFunctor adjustGroups(m_doc);
+    adjustGroups.SetGroupType(1);
+    adjustGroups.SetPlace(place);
+
+    const auto process
+        = [this, staffAlignment, place](ClassId classId) { this->ProcessClass(staffAlignment, classId, place); };
+    process(LV);
+    process(TIE);
+    process(SLUR);
+    process(PHRASE);
+    process(ACCID_FLOATING);
+    process(MORDENT);
+    process(TURN);
+    process(TRILL);
+    process(ORNAM);
+    process(FING);
+    process(DYNAM);
+    process(HAIRPIN);
+
+    adjustGroups.SetClassIDs({ DYNAM, HAIRPIN });
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    process(BRACKETSPAN);
+    process(OCTAVE);
+    process(BREATH);
+    process(FERMATA);
+    process(DIR);
+
+    adjustGroups.SetClassIDs({ DIR });
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    process(CPMARK);
+    process(REPEATMARK);
+    process(TEMPO);
+    process(PEDAL);
+
+    adjustGroups.SetClassIDs({ PEDAL });
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    process(HARM);
+    adjustGroups.SetClassIDs({ HARM });
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    process(ENDING);
+    adjustGroups.SetClassIDs({ ENDING });
+    adjustGroups.VisitStaffAlignment(staffAlignment);
+
+    process(REH);
+    process(CAESURA);
+    process(ANNOTSCORE);
+
+    if (this->HasExplicitPositionerGroup(staffAlignment, place)) {
+        this->AdjustPositionerGroups(staffAlignment, place);
+        this->BuildPositionerGroups(staffAlignment, place, includeWithin);
+        const std::vector<StaffItemPositioner> positioners
+            = BuildStaffItemPositioners(staffAlignment, place, includeWithin, false);
+
+        const auto processPositioners = [this, staffAlignment, place, &positioners]() {
+            for (const StaffItemPositioner &entry : positioners) {
+                const ArrayOfFloatingPositioners current{ entry.positioner };
+                this->ProcessPositioners(staffAlignment, current, entry.classId, place, entry.item, true);
+            }
+        };
+        this->StabilizePositionerGroups(staffAlignment, place, baseBoxes, processPositioners);
+        m_positionerGroups.clear();
+    }
+    m_includeWithin = false;
+}
+
+void AdjustFloatingPositionersFunctor::AdjustOrderedPlace(
+    StaffAlignment *staffAlignment, data_STAFFREL place, bool includeWithin)
+{
+    ArrayOfBoundingBoxes &overflowBoxes = (place == STAFFREL_above) ? staffAlignment->GetBBoxesAboveForModification()
+                                                                    : staffAlignment->GetBBoxesBelowForModification();
+    const ArrayOfBoundingBoxes baseBoxes = overflowBoxes;
+    const std::vector<StaffItemPositioner> positioners
+        = BuildStaffItemPositioners(staffAlignment, place, includeWithin, true);
+
+    m_includeWithin = includeWithin;
+    for (const StaffItemPositioner &entry : positioners) {
+        const ArrayOfFloatingPositioners current{ entry.positioner };
+        this->ProcessPositioners(staffAlignment, current, entry.classId, place, entry.item, false);
+    }
+
+    this->AdjustPositionerGroups(staffAlignment, place);
+    this->BuildPositionerGroups(staffAlignment, place, includeWithin);
+
+    const auto processPositioners = [this, staffAlignment, place, &positioners]() {
+        for (const StaffItemPositioner &entry : positioners) {
+            const ArrayOfFloatingPositioners current{ entry.positioner };
+            this->ProcessPositioners(staffAlignment, current, entry.classId, place, entry.item, true);
+        }
+    };
+    this->StabilizePositionerGroups(staffAlignment, place, baseBoxes, processPositioners);
+    m_positionerGroups.clear();
+    m_includeWithin = false;
+}
+
+FunctorCode AdjustFloatingPositionersFunctor::AdjustStaffItemOrder(StaffAlignment *staffAlignment)
+{
+    const System *system = staffAlignment->GetParentSystem();
+    const Staff *staff = staffAlignment->GetStaff();
+    if (!system || !staff) return FUNCTOR_SIBLINGS;
+
+    staffAlignment->SortPositioners();
+
+    if (this->HasStaffItemOrder(staffAlignment, STAFFREL_above)) {
+        this->AdjustOrderedPlace(staffAlignment, STAFFREL_above);
+    }
+    else {
+        this->AdjustLegacyPlace(staffAlignment, STAFFREL_above);
+    }
+
+    if (this->HasStaffItemOrder(staffAlignment, STAFFREL_below)) {
+        this->AdjustOrderedPlace(staffAlignment, STAFFREL_below, true);
+    }
+    else {
+        this->AdjustLegacyPlace(staffAlignment, STAFFREL_below, true);
+    }
+
+    // Lyrics always retain their established processing after above/below/within positioners.
+    m_place = STAFFREL_NONE;
+    m_includeWithin = false;
+    m_inBetween = false;
+    m_classId = SYL;
+    m_staffItem = STAFFITEM_NONE;
+    this->AdjustCurrentPositioners(staffAlignment);
+
+    if (this->HasStaffItemOrder(staffAlignment, STAFFREL_between)) {
+        this->AdjustOrderedPlace(staffAlignment, STAFFREL_between);
+    }
+    else {
+        const ArrayOfBoundingBoxes baseBoxes = staffAlignment->GetBBoxesBelow();
+        m_includeWithin = false;
+        this->ProcessClass(staffAlignment, OBJECT, STAFFREL_between);
+
+        AdjustFloatingPositionerGrpsFunctor adjustGroups(m_doc);
+        adjustGroups.SetGroupType(1);
+        adjustGroups.SetClassIDs({ DYNAM });
+        adjustGroups.SetPlace(STAFFREL_between);
+        adjustGroups.VisitStaffAlignment(staffAlignment);
+
+        if (this->HasExplicitPositionerGroup(staffAlignment, STAFFREL_between)) {
+            this->AdjustPositionerGroups(staffAlignment, STAFFREL_between);
+            this->BuildPositionerGroups(staffAlignment, STAFFREL_between, false);
+            const std::vector<StaffItemPositioner> positioners
+                = BuildStaffItemPositioners(staffAlignment, STAFFREL_between, false, false);
+
+            const auto processPositioners = [this, staffAlignment, &positioners]() {
+                for (const StaffItemPositioner &entry : positioners) {
+                    const ArrayOfFloatingPositioners current{ entry.positioner };
+                    this->ProcessPositioners(
+                        staffAlignment, current, entry.classId, STAFFREL_between, entry.item, true);
+                }
+            };
+            this->StabilizePositionerGroups(staffAlignment, STAFFREL_between, baseBoxes, processPositioners);
+            m_positionerGroups.clear();
+        }
+    }
+
+    m_place = STAFFREL_NONE;
+    m_includeWithin = false;
+    m_inBetween = false;
+    m_classId = OBJECT;
+    m_staffItem = STAFFITEM_NONE;
+    return FUNCTOR_SIBLINGS;
+}
+
 FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
 {
+    m_hasExplicitGroups = false;
+    m_detectExplicitGroups = true;
+    system->m_systemAligner.Process(*this);
+    m_detectExplicitGroups = false;
+
+    if (HasSystemStaffItemOrder(system) || m_hasExplicitGroups) {
+        m_useStaffItemOrder = true;
+        system->m_systemAligner.Process(*this);
+        m_useStaffItemOrder = false;
+        return FUNCTOR_SIBLINGS;
+    }
+
+    m_place = STAFFREL_NONE;
+    m_staffItem = STAFFITEM_NONE;
     m_inBetween = false;
 
     AdjustFloatingPositionerGrpsFunctor adjustFloatingPositionerGrps(m_doc);
@@ -303,6 +978,7 @@ FunctorCode AdjustFloatingPositionersFunctor::VisitSystem(System *system)
 AdjustFloatingPositionerGrpsFunctor::AdjustFloatingPositionerGrpsFunctor(Doc *doc) : DocFunctor(doc)
 {
     m_place = STAFFREL_above;
+    m_groupType = 0;
 }
 
 FunctorCode AdjustFloatingPositionerGrpsFunctor::VisitStaffAlignment(StaffAlignment *staffAlignment)
@@ -313,41 +989,53 @@ FunctorCode AdjustFloatingPositionerGrpsFunctor::VisitStaffAlignment(StaffAlignm
     std::copy_if(allPositioners.begin(), allPositioners.end(), std::back_inserter(positioners),
         [this](FloatingPositioner *positioner) {
             assert(positioner->GetObject());
-            // search in the desired classIds
-            return ((std::find(m_classIds.begin(), m_classIds.end(), positioner->GetObject()->GetClassId())
-                        != m_classIds.end())
-                && (positioner->GetObject()->GetDrawingGrpId() != 0) && (positioner->GetDrawingPlace() == m_place)
-                && !positioner->HasEmptyBB());
+            const int groupId = positioner->GetObject()->GetDrawingGrpId();
+            const bool classMatches = m_classIds.empty()
+                || (std::find(m_classIds.begin(), m_classIds.end(), positioner->GetObject()->GetClassId())
+                    != m_classIds.end());
+            const bool groupMatches = (m_groupType == 0) || ((m_groupType < 0) ? (groupId < 0) : (groupId > 0));
+            return classMatches && groupMatches && (groupId != 0) && (positioner->GetDrawingPlace() == m_place)
+                && !positioner->HasEmptyBB();
         });
 
     if (positioners.empty()) {
         return FUNCTOR_SIBLINGS;
     }
-
-    // A vector storing a pair with the grpId and the min or max YRel
+    // A vector storing a pair with the grpId and the target relative or absolute drawing position
     ArrayOfIntPairs grpIdYRel;
 
     for (FloatingPositioner *positioner : positioners) {
         int currentGrpId = positioner->GetObject()->GetDrawingGrpId();
+        const int currentY = (m_groupType < 0) ? positioner->GetDrawingY() : positioner->GetDrawingYRel();
         // Look if we already have a pair for this grpId
         auto iter = std::find_if(grpIdYRel.begin(), grpIdYRel.end(),
             [currentGrpId](std::pair<int, int> &pair) { return (pair.first == currentGrpId); });
         // if not, then just add a new pair with the YRel of the current positioner
         if (iter == grpIdYRel.end()) {
-            grpIdYRel.push_back({ currentGrpId, positioner->GetDrawingYRel() });
+            grpIdYRel.push_back({ currentGrpId, currentY });
         }
         // else, adjust the min or max YRel of the pair if necessary
         else {
-            if (m_place == STAFFREL_above) {
-                if (positioner->GetDrawingYRel() < (*iter).second) (*iter).second = positioner->GetDrawingYRel();
+            if ((m_place == STAFFREL_above) != (m_groupType < 0)) {
+                if (currentY < (*iter).second) (*iter).second = currentY;
             }
             else {
-                if (positioner->GetDrawingYRel() > (*iter).second) (*iter).second = positioner->GetDrawingYRel();
+                if (currentY > (*iter).second) (*iter).second = currentY;
             }
         }
     }
 
-    if (std::find(m_classIds.begin(), m_classIds.end(), HARM) != m_classIds.end()) {
+    if (m_groupType < 0) {
+        for (FloatingPositioner *positioner : positioners) {
+            const int currentGrpId = positioner->GetObject()->GetDrawingGrpId();
+            const auto iter = std::find_if(grpIdYRel.begin(), grpIdYRel.end(),
+                [currentGrpId](const std::pair<int, int> &pair) { return (pair.first == currentGrpId); });
+            assert(iter != grpIdYRel.end());
+            const int drawingYRel = positioner->GetDrawingYRel() + positioner->GetDrawingY() - iter->second;
+            positioner->SetDrawingYRel(drawingYRel, true);
+        }
+    }
+    else if (std::find(m_classIds.begin(), m_classIds.end(), HARM) != m_classIds.end()) {
         // Adjust the position of groups to ensure that any group is positioned further away
         this->AdjustGroupsMonotone(staffAlignment, positioners, grpIdYRel);
         // This already moves them, so the loop below is not necessary.

--- a/src/breath.cpp
+++ b/src/breath.cpp
@@ -24,10 +24,11 @@ namespace vrv {
 
 static const ClassRegistrar<Breath> s_factory("breath", BREATH);
 
-Breath::Breath() : ControlElement(BREATH), TimePointInterface(), AttPlacementRelStaff()
+Breath::Breath() : ControlElement(BREATH), TimePointInterface(), AttPlacementRelStaff(), AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -39,6 +40,7 @@ void Breath::Reset()
     ControlElement::Reset();
     TimePointInterface::Reset();
     this->ResetPlacementRelStaff();
+    this->ResetVerticalGroup();
 }
 
 FunctorCode Breath::Accept(Functor &functor)

--- a/src/caesura.cpp
+++ b/src/caesura.cpp
@@ -27,12 +27,18 @@ namespace vrv {
 static const ClassRegistrar<Caesura> s_factory("caesura", CAESURA);
 
 Caesura::Caesura()
-    : ControlElement(CAESURA), TimePointInterface(), AttExtSymAuth(), AttExtSymNames(), AttPlacementRelStaff()
+    : ControlElement(CAESURA)
+    , TimePointInterface()
+    , AttExtSymAuth()
+    , AttExtSymNames()
+    , AttPlacementRelStaff()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_EXTSYMAUTH);
     this->RegisterAttClass(ATT_EXTSYMNAMES);
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -44,6 +50,7 @@ void Caesura::Reset()
     ControlElement::Reset();
     TimePointInterface::Reset();
     this->ResetPlacementRelStaff();
+    this->ResetVerticalGroup();
 }
 
 char32_t Caesura::GetCaesuraGlyph() const

--- a/src/cpmark.cpp
+++ b/src/cpmark.cpp
@@ -29,10 +29,12 @@ namespace vrv {
 
 static const ClassRegistrar<CpMark> s_factory("cpMark", CPMARK);
 
-CpMark::CpMark() : ControlElement(CPMARK), TextListInterface(), TextDirInterface(), TimeSpanningInterface()
+CpMark::CpMark()
+    : ControlElement(CPMARK), TextListInterface(), TextDirInterface(), TimeSpanningInterface(), AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -44,6 +46,7 @@ void CpMark::Reset()
     ControlElement::Reset();
     TextDirInterface::Reset();
     TimeSpanningInterface::Reset();
+    this->ResetVerticalGroup();
 }
 
 bool CpMark::IsSupportedChild(ClassId classId)

--- a/src/fermata.cpp
+++ b/src/fermata.cpp
@@ -33,6 +33,7 @@ Fermata::Fermata()
     , AttExtSymNames()
     , AttFermataVis()
     , AttPlacementRelStaff()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
@@ -40,6 +41,7 @@ Fermata::Fermata()
     this->RegisterAttClass(ATT_EXTSYMNAMES);
     this->RegisterAttClass(ATT_FERMATAVIS);
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -56,6 +58,7 @@ void Fermata::Reset()
     this->ResetExtSymNames();
     this->ResetFermataVis();
     this->ResetPlacementRelStaff();
+    this->ResetVerticalGroup();
 }
 
 char32_t Fermata::GetFermataGlyph() const

--- a/src/fing.cpp
+++ b/src/fing.cpp
@@ -25,11 +25,12 @@ namespace vrv {
 
 static const ClassRegistrar<Fing> s_factory("fing", FING);
 
-Fing::Fing() : ControlElement(FING), TimePointInterface(), TextDirInterface(), AttNNumberLike()
+Fing::Fing() : ControlElement(FING), TimePointInterface(), TextDirInterface(), AttNNumberLike(), AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterAttClass(ATT_NNUMBERLIKE);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -42,6 +43,7 @@ void Fing::Reset()
     TimePointInterface::Reset();
     TextDirInterface::Reset();
     this->ResetNNumberLike();
+    this->ResetVerticalGroup();
 }
 
 bool Fing::IsSupportedChild(ClassId classId)

--- a/src/harm.cpp
+++ b/src/harm.cpp
@@ -39,11 +39,13 @@ Harm::Harm()
     , TimeSpanningInterface()
     , AttLang()
     , AttNNumberLike()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_LANG);
     this->RegisterAttClass(ATT_NNUMBERLIKE);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -57,6 +59,7 @@ void Harm::Reset()
     TimeSpanningInterface::Reset();
     this->ResetLang();
     this->ResetNNumberLike();
+    this->ResetVerticalGroup();
 }
 
 bool Harm::IsSupportedChild(ClassId classId)

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -2106,6 +2106,7 @@ void MEIOutput::WriteBreath(pugi::xml_node currentNode, Breath *breath)
     this->WriteControlElement(currentNode, breath);
     this->WriteTimePointInterface(currentNode, breath);
     breath->WritePlacementRelStaff(currentNode);
+    breath->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteCaesura(pugi::xml_node currentNode, Caesura *caesura)
@@ -2117,6 +2118,7 @@ void MEIOutput::WriteCaesura(pugi::xml_node currentNode, Caesura *caesura)
     caesura->WriteExtSymAuth(currentNode);
     caesura->WriteExtSymNames(currentNode);
     caesura->WritePlacementRelStaff(currentNode);
+    caesura->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteCpMark(pugi::xml_node currentNode, CpMark *cpMark)
@@ -2126,6 +2128,7 @@ void MEIOutput::WriteCpMark(pugi::xml_node currentNode, CpMark *cpMark)
     this->WriteControlElement(currentNode, cpMark);
     this->WriteTextDirInterface(currentNode, cpMark);
     this->WriteTimeSpanningInterface(currentNode, cpMark);
+    cpMark->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteDir(pugi::xml_node currentNode, Dir *dir)
@@ -2167,6 +2170,7 @@ void MEIOutput::WriteFermata(pugi::xml_node currentNode, Fermata *fermata)
     fermata->WriteExtSymNames(currentNode);
     fermata->WriteFermataVis(currentNode);
     fermata->WritePlacementRelStaff(currentNode);
+    fermata->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteFing(pugi::xml_node currentNode, Fing *fing)
@@ -2177,6 +2181,7 @@ void MEIOutput::WriteFing(pugi::xml_node currentNode, Fing *fing)
     this->WriteTextDirInterface(currentNode, fing);
     this->WriteTimePointInterface(currentNode, fing);
     fing->WriteNNumberLike(currentNode);
+    fing->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteGliss(pugi::xml_node currentNode, Gliss *gliss)
@@ -2213,6 +2218,7 @@ void MEIOutput::WriteHarm(pugi::xml_node currentNode, Harm *harm)
     this->WriteTimeSpanningInterface(currentNode, harm);
     harm->WriteLang(currentNode);
     harm->WriteNNumberLike(currentNode);
+    harm->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteLv(pugi::xml_node currentNode, Lv *lv)
@@ -2248,6 +2254,7 @@ void MEIOutput::WriteMordent(pugi::xml_node currentNode, Mordent *mordent)
     mordent->WriteOrnamentAccid(currentNode);
     mordent->WritePlacementRelStaff(currentNode);
     mordent->WriteMordentLog(currentNode);
+    mordent->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteOctave(pugi::xml_node currentNode, Octave *octave)
@@ -2261,6 +2268,7 @@ void MEIOutput::WriteOctave(pugi::xml_node currentNode, Octave *octave)
     octave->WriteLineRendBase(currentNode);
     octave->WriteNNumberLike(currentNode);
     octave->WriteOctaveDisplacement(currentNode);
+    octave->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteOrnam(pugi::xml_node currentNode, Ornam *ornam)
@@ -2271,6 +2279,7 @@ void MEIOutput::WriteOrnam(pugi::xml_node currentNode, Ornam *ornam)
     this->WriteTextDirInterface(currentNode, ornam);
     this->WriteTimePointInterface(currentNode, ornam);
     ornam->WriteOrnamentAccid(currentNode);
+    ornam->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WritePedal(pugi::xml_node currentNode, Pedal *pedal)
@@ -2323,6 +2332,7 @@ void MEIOutput::WriteRepeatMark(pugi::xml_node currentNode, RepeatMark *repeatMa
     repeatMark->WriteExtSymAuth(currentNode);
     repeatMark->WriteExtSymNames(currentNode);
     repeatMark->WriteRepeatMarkLog(currentNode);
+    repeatMark->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteSlur(pugi::xml_node currentNode, Slur *slur)
@@ -2382,6 +2392,7 @@ void MEIOutput::WriteTempo(pugi::xml_node currentNode, Tempo *tempo)
     tempo->WriteLang(currentNode);
     tempo->WriteMidiTempo(currentNode);
     tempo->WriteMmTempo(currentNode);
+    tempo->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteTie(pugi::xml_node currentNode, Tie *tie)
@@ -2409,6 +2420,7 @@ void MEIOutput::WriteTrill(pugi::xml_node currentNode, Trill *trill)
     trill->WriteNNumberLike(currentNode);
     trill->WriteOrnamentAccid(currentNode);
     trill->WritePlacementRelStaff(currentNode);
+    trill->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteTurn(pugi::xml_node currentNode, Turn *turn)
@@ -2423,6 +2435,7 @@ void MEIOutput::WriteTurn(pugi::xml_node currentNode, Turn *turn)
     turn->WriteOrnamentAccid(currentNode);
     turn->WritePlacementRelStaff(currentNode);
     turn->WriteTurnLog(currentNode);
+    turn->WriteVerticalGroup(currentNode);
 }
 
 void MEIOutput::WriteLayer(pugi::xml_node currentNode, Layer *layer)
@@ -6092,6 +6105,7 @@ bool MEIInput::ReadBreath(Object *parent, pugi::xml_node breath)
 
     this->ReadTimePointInterface(breath, vrvBreath);
     vrvBreath->ReadPlacementRelStaff(breath);
+    vrvBreath->ReadVerticalGroup(breath);
 
     parent->AddChild(vrvBreath);
     this->ReadUnsupportedAttr(breath, vrvBreath);
@@ -6107,6 +6121,7 @@ bool MEIInput::ReadCaesura(Object *parent, pugi::xml_node caesura)
     vrvCaesura->ReadExtSymAuth(caesura);
     vrvCaesura->ReadExtSymNames(caesura);
     vrvCaesura->ReadPlacementRelStaff(caesura);
+    vrvCaesura->ReadVerticalGroup(caesura);
 
     parent->AddChild(vrvCaesura);
     this->ReadUnsupportedAttr(caesura, vrvCaesura);
@@ -6120,6 +6135,7 @@ bool MEIInput::ReadCpMark(Object *parent, pugi::xml_node cpMark)
 
     this->ReadTextDirInterface(cpMark, vrvCpMark);
     this->ReadTimeSpanningInterface(cpMark, vrvCpMark);
+    vrvCpMark->ReadVerticalGroup(cpMark);
 
     parent->AddChild(vrvCpMark);
     this->ReadUnsupportedAttr(cpMark, vrvCpMark);
@@ -6173,6 +6189,7 @@ bool MEIInput::ReadFermata(Object *parent, pugi::xml_node fermata)
     vrvFermata->ReadExtSymNames(fermata);
     vrvFermata->ReadFermataVis(fermata);
     vrvFermata->ReadPlacementRelStaff(fermata);
+    vrvFermata->ReadVerticalGroup(fermata);
 
     parent->AddChild(vrvFermata);
     this->ReadUnsupportedAttr(fermata, vrvFermata);
@@ -6187,6 +6204,7 @@ bool MEIInput::ReadFing(Object *parent, pugi::xml_node fing)
     this->ReadTextDirInterface(fing, vrvFing);
     this->ReadTimePointInterface(fing, vrvFing);
     vrvFing->ReadNNumberLike(fing);
+    vrvFing->ReadVerticalGroup(fing);
 
     parent->AddChild(vrvFing);
     this->ReadUnsupportedAttr(fing, vrvFing);
@@ -6235,6 +6253,7 @@ bool MEIInput::ReadHarm(Object *parent, pugi::xml_node harm)
     this->ReadTimeSpanningInterface(harm, vrvHarm);
     vrvHarm->ReadLang(harm);
     vrvHarm->ReadNNumberLike(harm);
+    vrvHarm->ReadVerticalGroup(harm);
 
     parent->AddChild(vrvHarm);
     this->ReadUnsupportedAttr(harm, vrvHarm);
@@ -6294,6 +6313,7 @@ bool MEIInput::ReadMordent(Object *parent, pugi::xml_node mordent)
     vrvMordent->ReadOrnamentAccid(mordent);
     vrvMordent->ReadPlacementRelStaff(mordent);
     vrvMordent->ReadMordentLog(mordent);
+    vrvMordent->ReadVerticalGroup(mordent);
 
     parent->AddChild(vrvMordent);
     this->ReadUnsupportedAttr(mordent, vrvMordent);
@@ -6311,6 +6331,7 @@ bool MEIInput::ReadOctave(Object *parent, pugi::xml_node octave)
     vrvOctave->ReadLineRendBase(octave);
     vrvOctave->ReadNNumberLike(octave);
     vrvOctave->ReadOctaveDisplacement(octave);
+    vrvOctave->ReadVerticalGroup(octave);
 
     parent->AddChild(vrvOctave);
     this->ReadUnsupportedAttr(octave, vrvOctave);
@@ -6325,6 +6346,7 @@ bool MEIInput::ReadOrnam(Object *parent, pugi::xml_node ornam)
     this->ReadTextDirInterface(ornam, vrvOrnam);
     this->ReadTimePointInterface(ornam, vrvOrnam);
     vrvOrnam->ReadOrnamentAccid(ornam);
+    vrvOrnam->ReadVerticalGroup(ornam);
 
     parent->AddChild(vrvOrnam);
     this->ReadUnsupportedAttr(ornam, vrvOrnam);
@@ -6402,6 +6424,7 @@ bool MEIInput::ReadRepeatMark(Object *parent, pugi::xml_node repeatMark)
     vrvRepeatMark->ReadExtSymAuth(repeatMark);
     vrvRepeatMark->ReadExtSymNames(repeatMark);
     vrvRepeatMark->ReadRepeatMarkLog(repeatMark);
+    vrvRepeatMark->ReadVerticalGroup(repeatMark);
 
     parent->AddChild(vrvRepeatMark);
     this->ReadUnsupportedAttr(repeatMark, vrvRepeatMark);
@@ -6435,6 +6458,7 @@ bool MEIInput::ReadTempo(Object *parent, pugi::xml_node tempo)
     vrvTempo->ReadLang(tempo);
     vrvTempo->ReadMidiTempo(tempo);
     vrvTempo->ReadMmTempo(tempo);
+    vrvTempo->ReadVerticalGroup(tempo);
 
     parent->AddChild(vrvTempo);
     this->ReadUnsupportedAttr(tempo, vrvTempo);
@@ -6470,6 +6494,7 @@ bool MEIInput::ReadTrill(Object *parent, pugi::xml_node trill)
     vrvTrill->ReadNNumberLike(trill);
     vrvTrill->ReadOrnamentAccid(trill);
     vrvTrill->ReadPlacementRelStaff(trill);
+    vrvTrill->ReadVerticalGroup(trill);
 
     parent->AddChild(vrvTrill);
     this->ReadUnsupportedAttr(trill, vrvTrill);
@@ -6492,6 +6517,7 @@ bool MEIInput::ReadTurn(Object *parent, pugi::xml_node turn)
     vrvTurn->ReadOrnamentAccid(turn);
     vrvTurn->ReadPlacementRelStaff(turn);
     vrvTurn->ReadTurnLog(turn);
+    vrvTurn->ReadVerticalGroup(turn);
 
     parent->AddChild(vrvTurn);
     this->ReadUnsupportedAttr(turn, vrvTurn);

--- a/src/iomei.cpp
+++ b/src/iomei.cpp
@@ -1816,6 +1816,7 @@ void MEIOutput::WriteScoreDefElement(pugi::xml_node currentNode, ScoreDefElement
     assert(scoreDefElement);
 
     this->WriteXmlId(currentNode, scoreDefElement);
+    scoreDefElement->WriteStaffItems(currentNode);
     scoreDefElement->WriteTyped(currentNode);
 }
 
@@ -5114,6 +5115,7 @@ bool MEIInput::ReadSystemMilestoneEnd(Object *parent, pugi::xml_node milestoneEn
 bool MEIInput::ReadScoreDefElement(pugi::xml_node element, ScoreDefElement *object)
 {
     this->SetMeiID(element, object);
+    object->ReadStaffItems(element);
     object->ReadTyped(element);
 
     if (m_meiversion <= meiVersion_MEIVERSION_5_0) {

--- a/src/mordent.cpp
+++ b/src/mordent.cpp
@@ -35,6 +35,7 @@ Mordent::Mordent()
     , AttOrnamentAccid()
     , AttPlacementRelStaff()
     , AttMordentLog()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
@@ -43,6 +44,7 @@ Mordent::Mordent()
     this->RegisterAttClass(ATT_ORNAMENTACCID);
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
     this->RegisterAttClass(ATT_MORDENTLOG);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -59,6 +61,7 @@ void Mordent::Reset()
     this->ResetOrnamentAccid();
     this->ResetPlacementRelStaff();
     this->ResetMordentLog();
+    this->ResetVerticalGroup();
 }
 
 char32_t Mordent::GetMordentGlyph() const

--- a/src/octave.cpp
+++ b/src/octave.cpp
@@ -34,6 +34,7 @@ Octave::Octave()
     , AttLineRendBase()
     , AttNNumberLike()
     , AttOctaveDisplacement()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_EXTENDER);
@@ -41,6 +42,7 @@ Octave::Octave()
     this->RegisterAttClass(ATT_LINERENDBASE);
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterAttClass(ATT_OCTAVEDISPLACEMENT);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -56,6 +58,7 @@ void Octave::Reset()
     this->ResetLineRendBase();
     this->ResetNNumberLike();
     this->ResetOctaveDisplacement();
+    this->ResetVerticalGroup();
 
     this->ResetDrawingExtenderX();
 }

--- a/src/ornam.cpp
+++ b/src/ornam.cpp
@@ -30,11 +30,17 @@ namespace vrv {
 static const ClassRegistrar<Ornam> s_factory("ornam", ORNAM);
 
 Ornam::Ornam()
-    : ControlElement(ORNAM), TextListInterface(), TextDirInterface(), TimePointInterface(), AttOrnamentAccid()
+    : ControlElement(ORNAM)
+    , TextListInterface()
+    , TextDirInterface()
+    , TimePointInterface()
+    , AttOrnamentAccid()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_ORNAMENTACCID);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -47,6 +53,7 @@ void Ornam::Reset()
     TextDirInterface::Reset();
     TimePointInterface::Reset();
     this->ResetOrnamentAccid();
+    this->ResetVerticalGroup();
 }
 
 bool Ornam::IsSupportedChild(ClassId classId)

--- a/src/preparedatafunctor.cpp
+++ b/src/preparedatafunctor.cpp
@@ -1611,24 +1611,32 @@ PrepareFloatingGrpsFunctor::PrepareFloatingGrpsFunctor()
 
 FunctorCode PrepareFloatingGrpsFunctor::VisitDir(Dir *dir)
 {
-    if (dir->HasVgrp()) {
-        dir->SetDrawingGrpId(-dir->GetVgrp());
-    }
+    this->VisitFloatingObject(dir);
 
     return FUNCTOR_CONTINUE;
 }
 
 FunctorCode PrepareFloatingGrpsFunctor::VisitDynam(Dynam *dynam)
 {
-    if (dynam->HasVgrp()) {
-        dynam->SetDrawingGrpId(-dynam->GetVgrp());
-    }
+    this->VisitFloatingObject(dynam);
 
     // Keep it for linking only if start is resolved
     if (!dynam->GetStart()) return FUNCTOR_CONTINUE;
 
     m_dynams.push_back(dynam);
 
+    return FUNCTOR_CONTINUE;
+}
+
+FunctorCode PrepareFloatingGrpsFunctor::VisitFloatingObject(FloatingObject *floatingObject)
+{
+    if (!floatingObject->HasAttClass(ATT_VERTICALGROUP)) return FUNCTOR_CONTINUE;
+
+    AttVerticalGroup *verticalGroup = dynamic_cast<AttVerticalGroup *>(floatingObject);
+    assert(verticalGroup);
+    if (verticalGroup->HasVgrp()) {
+        floatingObject->SetDrawingGrpId(-verticalGroup->GetVgrp());
+    }
     return FUNCTOR_CONTINUE;
 }
 
@@ -1650,9 +1658,7 @@ FunctorCode PrepareFloatingGrpsFunctor::VisitEnding(Ending *ending)
 
 FunctorCode PrepareFloatingGrpsFunctor::VisitHairpin(Hairpin *hairpin)
 {
-    if (hairpin->HasVgrp()) {
-        hairpin->SetDrawingGrpId(-hairpin->GetVgrp());
-    }
+    this->VisitFloatingObject(hairpin);
 
     // Only try to link them if start and end are resolved
     if (!hairpin->GetStart() || !hairpin->GetEnd()) return FUNCTOR_CONTINUE;
@@ -1664,6 +1670,9 @@ FunctorCode PrepareFloatingGrpsFunctor::VisitHairpin(Hairpin *hairpin)
 
 FunctorCode PrepareFloatingGrpsFunctor::VisitHarm(Harm *harm)
 {
+    this->VisitFloatingObject(harm);
+    if (harm->GetDrawingGrpId() < 0) return FUNCTOR_CONTINUE;
+
     std::string n = harm->GetN();
     // If there is no @n on harm we use the first @staff value as negative
     // This will not work if @staff has more than one staff id, but this is probably not going to be used
@@ -1761,9 +1770,7 @@ FunctorCode PrepareFloatingGrpsFunctor::VisitMeasureEnd(Measure *measure)
 
 FunctorCode PrepareFloatingGrpsFunctor::VisitPedal(Pedal *pedal)
 {
-    if (pedal->HasVgrp()) {
-        pedal->SetDrawingGrpId(-pedal->GetVgrp());
-    }
+    this->VisitFloatingObject(pedal);
 
     return FUNCTOR_CONTINUE;
 }

--- a/src/repeatmark.cpp
+++ b/src/repeatmark.cpp
@@ -37,12 +37,14 @@ RepeatMark::RepeatMark()
     , AttExtSymAuth()
     , AttExtSymNames()
     , AttRepeatMarkLog()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_EXTSYMAUTH);
     this->RegisterAttClass(ATT_EXTSYMNAMES);
     this->RegisterAttClass(ATT_REPEATMARKLOG);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -57,6 +59,7 @@ void RepeatMark::Reset()
     this->ResetExtSymAuth();
     this->ResetExtSymNames();
     this->ResetRepeatMarkLog();
+    this->ResetVerticalGroup();
 }
 
 bool RepeatMark::IsSupportedChild(ClassId classId)

--- a/src/scoredef.cpp
+++ b/src/scoredef.cpp
@@ -46,17 +46,19 @@ namespace vrv {
 // ScoreDefElement
 //----------------------------------------------------------------------------
 
-ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT), ScoreDefInterface(), AttTyped()
+ScoreDefElement::ScoreDefElement() : Object(SCOREDEF_ELEMENT), ScoreDefInterface(), AttStaffItems(), AttTyped()
 {
     this->RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
+    this->RegisterAttClass(ATT_STAFFITEMS);
     this->RegisterAttClass(ATT_TYPED);
 
     this->Reset();
 }
 
-ScoreDefElement::ScoreDefElement(ClassId classId) : Object(classId), ScoreDefInterface(), AttTyped()
+ScoreDefElement::ScoreDefElement(ClassId classId) : Object(classId), ScoreDefInterface(), AttStaffItems(), AttTyped()
 {
     this->RegisterInterface(ScoreDefInterface::GetAttClasses(), ScoreDefInterface::IsInterface());
+    this->RegisterAttClass(ATT_STAFFITEMS);
     this->RegisterAttClass(ATT_TYPED);
 
     this->Reset();
@@ -68,7 +70,38 @@ void ScoreDefElement::Reset()
 {
     Object::Reset();
     ScoreDefInterface::Reset();
+    this->ResetStaffItems();
     this->ResetTyped();
+}
+
+bool ScoreDefElement::ReplaceStaffItemOrders(const ScoreDefElement *source)
+{
+    assert(source);
+
+    bool replaced = false;
+    if (source->HasAboveorder()) {
+        this->SetAboveorder(source->GetAboveorder());
+        replaced = true;
+    }
+    if (source->HasBeloworder()) {
+        this->SetBeloworder(source->GetBeloworder());
+        replaced = true;
+    }
+    if (source->HasBetweenorder()) {
+        this->SetBetweenorder(source->GetBetweenorder());
+        replaced = true;
+    }
+    return replaced;
+}
+
+data_STAFFITEM_List ScoreDefElement::GetStaffItemOrder(data_STAFFREL place) const
+{
+    switch (place) {
+        case STAFFREL_above: return this->HasAboveorder() ? this->GetAboveorder() : data_STAFFITEM_List();
+        case STAFFREL_below: return this->HasBeloworder() ? this->GetBeloworder() : data_STAFFITEM_List();
+        case STAFFREL_between: return this->HasBetweenorder() ? this->GetBetweenorder() : data_STAFFITEM_List();
+        default: return data_STAFFITEM_List();
+    }
 }
 
 bool ScoreDefElement::HasClefInfo(int depth) const
@@ -290,6 +323,7 @@ void ScoreDef::ReplaceDrawingValues(const ScoreDef *newScoreDef)
 
     m_insertScoreDef = false;
     m_setAsDrawing = true;
+    this->ReplaceStaffItemOrders(newScoreDef);
 
     int redrawFlags = 0;
     const Clef *clef = NULL;
@@ -344,6 +378,7 @@ void ScoreDef::ReplaceDrawingValues(const StaffDef *newStaffDef)
 
     // if found, replace attributes
     if (staffDef) {
+        if (staffDef->ReplaceStaffItemOrders(newStaffDef)) m_setAsDrawing = true;
         if (newStaffDef->HasClefInfo()) {
             staffDef->SetDrawClef(true);
             const Clef *clef = newStaffDef->GetClef();
@@ -552,6 +587,16 @@ std::vector<int> ScoreDef::GetStaffNs() const
         staffDef->GetOssiaBelowNs(ns);
     }
     return ns;
+}
+
+data_STAFFITEM_List ScoreDef::GetStaffItemOrder(int staffN, data_STAFFREL place) const
+{
+    const StaffDef *staffDef = this->GetStaffDef(staffN);
+    if (staffDef) {
+        const data_STAFFITEM_List order = staffDef->GetStaffItemOrder(place);
+        if (!order.empty()) return order;
+    }
+    return ScoreDefElement::GetStaffItemOrder(place);
 }
 
 void ScoreDef::SetRedrawFlags(int redrawFlags)

--- a/src/setscoredeffunctor.cpp
+++ b/src/setscoredeffunctor.cpp
@@ -294,7 +294,8 @@ FunctorCode ScoreDefSetCurrentFunctor::VisitScoreDef(ScoreDef *scoreDef)
     // m_setAsDrawing to true so it will then be taken into account at the next measure
     if (scoreDef->HasClefInfo(UNLIMITED_DEPTH) || scoreDef->HasKeySigInfo(UNLIMITED_DEPTH)
         || scoreDef->HasMensurInfo(UNLIMITED_DEPTH) || scoreDef->HasMeterSigGrpInfo(UNLIMITED_DEPTH)
-        || scoreDef->HasMeterSigInfo(UNLIMITED_DEPTH)) {
+        || scoreDef->HasMeterSigInfo(UNLIMITED_DEPTH) || scoreDef->HasAboveorder() || scoreDef->HasBeloworder()
+        || scoreDef->HasBetweenorder()) {
         m_upcomingScoreDef.ReplaceDrawingValues(scoreDef);
         m_upcomingScoreDef.m_insertScoreDef = true;
     }

--- a/src/tempo.cpp
+++ b/src/tempo.cpp
@@ -38,6 +38,7 @@ Tempo::Tempo()
     , AttLang()
     , AttMidiTempo()
     , AttMmTempo()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TextDirInterface::GetAttClasses(), TextDirInterface::IsInterface());
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
@@ -45,6 +46,7 @@ Tempo::Tempo()
     this->RegisterAttClass(ATT_LANG);
     this->RegisterAttClass(ATT_MIDITEMPO);
     this->RegisterAttClass(ATT_MMTEMPO);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -60,6 +62,7 @@ void Tempo::Reset()
     this->ResetLang();
     this->ResetMidiTempo();
     this->ResetMmTempo();
+    this->ResetVerticalGroup();
 }
 
 bool Tempo::IsSupportedChild(ClassId classId)

--- a/src/trill.cpp
+++ b/src/trill.cpp
@@ -37,6 +37,7 @@ Trill::Trill()
     , AttNNumberLike()
     , AttOrnamentAccid()
     , AttPlacementRelStaff()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimeSpanningInterface::GetAttClasses(), TimeSpanningInterface::IsInterface());
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
@@ -47,6 +48,7 @@ Trill::Trill()
     this->RegisterAttClass(ATT_NNUMBERLIKE);
     this->RegisterAttClass(ATT_ORNAMENTACCID);
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -65,6 +67,7 @@ void Trill::Reset()
     this->ResetNNumberLike();
     this->ResetOrnamentAccid();
     this->ResetPlacementRelStaff();
+    this->ResetVerticalGroup();
 }
 
 char32_t Trill::GetTrillGlyph() const

--- a/src/turn.cpp
+++ b/src/turn.cpp
@@ -37,6 +37,7 @@ Turn::Turn()
     , AttOrnamentAccid()
     , AttPlacementRelStaff()
     , AttTurnLog()
+    , AttVerticalGroup()
 {
     this->RegisterInterface(TimePointInterface::GetAttClasses(), TimePointInterface::IsInterface());
     this->RegisterAttClass(ATT_ENCLOSINGCHARS);
@@ -45,6 +46,7 @@ Turn::Turn()
     this->RegisterAttClass(ATT_ORNAMENTACCID);
     this->RegisterAttClass(ATT_PLACEMENTRELSTAFF);
     this->RegisterAttClass(ATT_TURNLOG);
+    this->RegisterAttClass(ATT_VERTICALGROUP);
 
     this->Reset();
 }
@@ -61,6 +63,7 @@ void Turn::Reset()
     this->ResetOrnamentAccid();
     this->ResetPlacementRelStaff();
     this->ResetTurnLog();
+    this->ResetVerticalGroup();
 
     m_drawingEndElement = NULL;
 }


### PR DESCRIPTION
## Summary

Support MEI staff-item ordering on `scoreDef` and `staffDef`, and complete `@vgrp` support for the staff-item elements that Verovio currently renders.

This change:

- reads and writes `@aboveorder`, `@beloworder`, and `@betweenorder` as whitespace-separated `data.STAFFITEM` lists, including generic attribute copying, reset behavior, and MEI round trips
- resolves each direction per staff and measure, including direction-specific `staffDef` overrides and incremental score-definition changes within one system
- treats partial lists as a prefix followed by the existing default categories, while preserving duplicate valid tokens during round trips
- keeps the complete legacy layout path when no order attribute applies to a direction, including the existing encoding-order behavior between staves
- adds `AttVerticalGroup` to `breath`, `caesura`, `cpMark`, `fermata`, `fing`, `harm`, `mordent`, `octave`, `ornam`, `repeatMark`, `tempo`, `trill`, and `turn`; together with `dir`, `dynam`, `hairpin`, and `pedal`, this covers all 17 MEI 5.1 vertical-group carriers currently rendered by Verovio
- aligns explicit `@vgrp` members across staff-item classes without merging groups across staves or placements, while retaining the historical `reh/@vgrp` extension and the existing automatic harmony, dynamics/hairpin, pedal, and ending groups
- includes endings and other system-level positioners in the measure-specific order plan and rebuilds collision stacks when a shared group moves because of a later score-definition state

Intrinsically positioned elements such as beams, articulations, tuplets, and ligatures retain their native stacks. Explicit `@vgrp` alignment remains stronger than conflicting category ranks.

Fixes #4406

## Testing

- built the native CLI with CMake in Debug and Release configurations
- passed a focused local CTest harness covering list parsing, all valid `data.STAFFITEM` tokens, invalid tokens, duplicates, generic copying/reset, score/staff inheritance, partial lists, all three placement directions, incremental `staffDef` changes, grouped dynamics/hairpins, all 17 MEI 5.1 `@vgrp` carriers, and historical `reh/@vgrp` compatibility
- rendered and inspected an ending together with ordered overlapping control elements in the same system
- validated the public MWEs and focused fixtures against the MEI 5.1 CMN Relax NG schema and its Schematron constraints, then verified their MEI round trips
- rendered a 48-measure, two-staff fixture with 960 control elements, 480 `@vgrp` attributes, and incremental score-definition changes; verified complete output, stable group baselines, no non-finite coordinates, a complete attribute round trip, and identical repeated geometry after normalizing generated SVG IDs
- rendered unbroken 48-, 96-, and 192-measure systems; Release timings for the order/group fixture were 0.22 s, 0.79 s, and 3.02 s, compared with 0.12 s, 0.41 s, and 1.47 s for the separate `upstream/develop` baseline build
- verified identical normalized SVG output between this branch and `upstream/develop` for both a synthetic 48-measure file and a real imported score without order or vertical-group attributes
- passed the upstream Test Suite Evaluation on the final head; its only rendering update is the expected cross-class alignment in MusicXML `31a-Directions`, where a hairpin and pedals share `vgrp="2000"`, and its two round-trip updates retain newly supported `@vgrp` attributes
- regenerated LibMEI and verified that regeneration produced no tracked diff
- passed clang-format 22.1.8 in dry-run/Werror mode for all changed handwritten C++ files
- passed `git diff --check`

## Disclosure

The process for this contribution was completed with the assistance of large language models (LLMs).
