### PR TITLE
Fix: fontTextLiberation option silently ignored in toolkit

### DIFF
--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1272,7 +1272,7 @@ bool Toolkit::SetOptions(const std::string &jsonOptions)
         Resources &resources = m_doc.GetResourcesForModification();
         resources.LoadAll();
     }
-    if (json.has<jsonxx::String>("fontTextLiberation")) {
+    if (json.has<jsonxx::Boolean>("fontTextLiberation")) {
         Resources &resources = m_doc.GetResourcesForModification();
         resources.UseLiberationTextFont(m_options->m_fontTextLiberation.GetValue());
     }


### PR DESCRIPTION
## Problem

Setting `fontTextLiberation: true` via `Toolkit::SetOptions()` (e.g. from the JS/wasm or Python bindings) has no effect: the Liberation text font is never embedded in the SVG output, and text elements keep using the default "Times" font family.

## Root cause

`fontTextLiberation` is declared as an `OptionBool` in `options.cpp`:

```cpp
m_fontTextLiberation.SetInfo("Font text Liberation", "Use the Liberation text font");
m_fontTextLiberation.Init(false);
```

but the JSON handling in `Toolkit::SetOptions()` checks for a `jsonxx::String`:

```cpp
if (json.has<jsonxx::String>("fontTextLiberation")) {
    Resources &resources = m_doc.GetResourcesForModification();
    resources.UseLiberationTextFont(m_options->m_fontTextLiberation.GetValue());
}
```

Since a JS boolean (`true`/`false`) is serialized as a JSON boolean, not a string, this condition is always false, and `UseLiberationTextFont()` is never called — regardless of the value passed. No error or warning is raised, making the bug silent.

## Fix

Use `jsonxx::Boolean` instead, matching the type of the option.