### PR TITLE
Fix issue #4414 Rests missing when rendering MusicXML with a single TAB staff.

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3087,6 +3087,10 @@ void MusicXmlInput::ReadMusicXmlNote(
                 tabGrp->SetDurPpq(duration);
                 if (dots > 0) tabGrp->SetDots(dots);
                 tabGrp->AddChild(new TabDurSym());
+                // modern guitar tablature has CMN rests. Lute tablature use rhythm sign over empty tagGrp
+                if (staffDef->GetNotationtype() == NOTATIONTYPE_tab_guitar) {
+                    tabGrp->AddChild(new Rest());
+                }
                 this->AddLayerElement(layer, tabGrp, duration);
             }
             else {


### PR DESCRIPTION
Fix issue #4414 Rests missing when rendering MusicXML with a single TAB staff

Importing MusicXML. Modern guitar tablature uses CMN rests, whereas lute tablature marks a rest with a rhythm sign over an empty tabGrp.  This adds an explicit rest for modern guitar tablature.  Example from #4414 after fix:

<img width="543" height="219" alt="issue-4414" src="https://github.com/user-attachments/assets/b94535a7-0b01-416a-ba99-3bee20fc3aac" />
