### PR TITLE
Make object factory registrations available across threads

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -1114,10 +1114,6 @@ public:
      * Get the correspondings ClassIds from the vector of MEI element string names
      */
     void GetClassIds(const std::vector<std::string> &classStrings, std::vector<ClassId> &classIds);
-
-public:
-    static thread_local MapOfClassIdConstructors s_ctorsRegistry;
-    static thread_local MapOfStrClassIds s_classIdsRegistry;
 };
 
 //----------------------------------------------------------------------------

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -13,7 +13,9 @@
 #include <climits>
 #include <iostream>
 #include <math.h>
+#include <mutex>
 #include <random>
+#include <shared_mutex>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -1627,12 +1629,26 @@ void TextListInterface::FilterList(ListOfConstObjects &childList) const
 // ObjectFactory methods
 //----------------------------------------------------------------------------
 
-thread_local MapOfClassIdConstructors ObjectFactory::s_ctorsRegistry;
-thread_local MapOfStrClassIds ObjectFactory::s_classIdsRegistry;
+namespace {
+
+    struct ObjectFactoryRegistry {
+        MapOfClassIdConstructors constructors;
+        MapOfStrClassIds classIds;
+        std::shared_mutex mutex;
+    };
+
+    ObjectFactoryRegistry &GetObjectFactoryRegistry()
+    {
+        // Registrars run once at process startup, so their entries must be visible from every thread.
+        static ObjectFactoryRegistry registry;
+        return registry;
+    }
+
+} // namespace
 
 ObjectFactory *ObjectFactory::GetInstance()
 {
-    static thread_local ObjectFactory factory;
+    static ObjectFactory factory;
     return &factory;
 }
 
@@ -1646,13 +1662,17 @@ Object *ObjectFactory::Create(std::string name)
 
 Object *ObjectFactory::Create(ClassId classId)
 {
-    Object *object = NULL;
+    std::function<Object *()> factory;
+    ObjectFactoryRegistry &registry = GetObjectFactoryRegistry();
 
-    MapOfClassIdConstructors::iterator it = s_ctorsRegistry.find(classId);
-    if (it != s_ctorsRegistry.end()) object = it->second();
+    {
+        std::shared_lock lock(registry.mutex);
+        MapOfClassIdConstructors::iterator it = registry.constructors.find(classId);
+        if (it != registry.constructors.end()) factory = it->second;
+    }
 
-    if (object) {
-        return object;
+    if (factory) {
+        return factory();
     }
     else {
         LogError("Factory for '%d' not found", classId);
@@ -1662,24 +1682,26 @@ Object *ObjectFactory::Create(ClassId classId)
 
 ClassId ObjectFactory::GetClassId(std::string name)
 {
-    ClassId classId = OBJECT;
-
-    MapOfStrClassIds::iterator it = s_classIdsRegistry.find(name);
-    if (it != s_classIdsRegistry.end()) {
-        classId = it->second;
+    ObjectFactoryRegistry &registry = GetObjectFactoryRegistry();
+    {
+        std::shared_lock lock(registry.mutex);
+        MapOfStrClassIds::iterator it = registry.classIds.find(name);
+        if (it != registry.classIds.end()) {
+            return it->second;
+        }
     }
-    else {
-        LogError("ClassId for '%s' not found", name.c_str());
-    }
 
-    return classId;
+    LogError("ClassId for '%s' not found", name.c_str());
+    return OBJECT;
 }
 
 void ObjectFactory::GetClassIds(const std::vector<std::string> &classStrings, std::vector<ClassId> &classIds)
 {
+    ObjectFactoryRegistry &registry = GetObjectFactoryRegistry();
+    std::shared_lock lock(registry.mutex);
     for (const std::string &str : classStrings) {
-        if (s_classIdsRegistry.contains(str)) {
-            classIds.push_back(s_classIdsRegistry.at(str));
+        if (registry.classIds.contains(str)) {
+            classIds.push_back(registry.classIds.at(str));
         }
         else {
             LogDebug("Class name '%s' could not be matched", str.c_str());
@@ -1689,8 +1711,10 @@ void ObjectFactory::GetClassIds(const std::vector<std::string> &classStrings, st
 
 void ObjectFactory::Register(std::string name, ClassId classId, std::function<Object *(void)> function)
 {
-    s_ctorsRegistry[classId] = function;
-    s_classIdsRegistry[name] = classId;
+    ObjectFactoryRegistry &registry = GetObjectFactoryRegistry();
+    std::unique_lock lock(registry.mutex);
+    registry.constructors[classId] = function;
+    registry.classIds[name] = classId;
 }
 
 } // namespace vrv


### PR DESCRIPTION
The object factory's registrars run during process startup, but its registries were marked `thread_local`. As a result, toolkits running on another thread could see an empty registry.

One visible symptom was:

    ClassId for 'staff' not found

This also prevented options such as:

    {"svgAdditionalAttribute": ["staff@n"]}

from adding `data-n` attributes when SVG rendering happened on a worker thread.

This change moves the registry to process-wide, lazily initialized storage and protects it with a shared mutex. Constructor callbacks are copied while holding the read lock and invoked after releasing it, so object construction is not serialized.

I reproduced the failure before the change and checked the fix with:

- a worker-thread class lookup
- an end-to-end worker-thread SVG render using `staff@n`
- an eight-thread stress test repeatedly resolving and constructing staff objects
- a complete debug shared-library build
- clang-format and diff checks

Related to #3192.
