### PR TITLE
feat(neume): support Hufnagel @con rendering

### DIFF
--- a/include/vrv/calcligatureorneumeposfunctor.h
+++ b/include/vrv/calcligatureorneumeposfunctor.h
@@ -45,7 +45,7 @@ public:
 protected:
     //
 private:
-    //
+    void SetChantLigatureGlyphs(Nc *nc, Nc *previousNc, int pitchDifference, int unit);
 public:
     //
 private:

--- a/include/vrv/calcligatureorneumeposfunctor.h
+++ b/include/vrv/calcligatureorneumeposfunctor.h
@@ -46,6 +46,7 @@ protected:
     //
 private:
     void SetChantLigatureGlyphs(Nc *nc, Nc *previousNc, int pitchDifference, int unit);
+
 public:
     //
 private:

--- a/include/vrv/editortoolkit_neume.h
+++ b/include/vrv/editortoolkit_neume.h
@@ -64,6 +64,7 @@ public:
     bool Ungroup(std::string groupType, std::vector<std::string> elementIds);
     bool ChangeGroup(std::string elementId, std::string contour);
     bool ToggleLigature(std::vector<std::string> elementIds);
+    bool ToggleNeumeConnection(std::vector<std::string> elementIds);
     bool ChangeStaff(std::string elementId);
     bool ChangeStaffTo(std::string elementId, std::string staffId);
     bool ClefMovementHandler(Clef *clef, int x, int y);
@@ -98,6 +99,7 @@ protected:
     bool ParseUngroupAction(jsonxx::Object param, std::string *groupType, std::vector<std::string> *elementIds);
     bool ParseChangeGroupAction(jsonxx::Object param, std::string *elementId, std::string *contour);
     bool ParseToggleLigatureAction(jsonxx::Object param, std::vector<std::string> *elementIds);
+    bool ParseToggleNeumeConnectionAction(jsonxx::Object param, std::vector<std::string> *elementIds);
     bool ParseChangeStaffAction(jsonxx::Object param, std::string *elementId);
     bool ParseChangeStaffToAction(jsonxx::Object param, std::string *elementId, std::string *staffId);
     ///@}

--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -19,8 +19,7 @@
 
 namespace vrv {
 
-void CalcLigatureOrNeumePosFunctor::SetChantLigatureGlyphs(
-    Nc *nc, Nc *previousNc, int pitchDifference, int unit)
+void CalcLigatureOrNeumePosFunctor::SetChantLigatureGlyphs(Nc *nc, Nc *previousNc, int pitchDifference, int unit)
 {
     assert(nc);
     assert(previousNc);

--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -19,7 +19,8 @@
 
 namespace vrv {
 
-static void SetChantLigatureGlyphs(Nc *nc, Nc *previousNc, int pitchDifference, int unit)
+void CalcLigatureOrNeumePosFunctor::SetChantLigatureGlyphs(
+    Nc *nc, Nc *previousNc, int pitchDifference, int unit)
 {
     assert(nc);
     assert(previousNc);
@@ -292,8 +293,8 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
 
         int pitchDifference = (previousNc) ? nc->PitchOrLocDifferenceTo(previousNc) : 0;
         bool overlapWithPrevious = (pitchDifference == 0) ? false : true;
-        const bool connectsToPrevious = (isHufnagel && previousNc && (nc->GetCon() == ncForm_CON_e));
-        const bool startsConnection = (isHufnagel && nextNc && (nextNc->GetCon() == ncForm_CON_e));
+        const bool hufnagelToPrevious = (isHufnagel && previousNc && (nc->GetCon() == ncForm_CON_e));
+        const bool hufnagelStart = (isHufnagel && nextNc && (nextNc->GetCon() == ncForm_CON_e));
 
         if (hasLiquescent) {
             const bool gabcNoTailsOption = m_doc->GetOptions()->m_liquescentWithoutTails.GetValue();
@@ -341,10 +342,10 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
         else {
             nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E990_chantPunctum;
 
-            if (startsConnection) {
+            if (hufnagelStart) {
                 nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B4_chantEntryLineAsc2nd;
             }
-            else if (connectsToPrevious) {
+            else if (hufnagelToPrevious) {
                 overlapWithPrevious = false;
                 SetChantLigatureGlyphs(nc, previousNc, pitchDifference, unit);
             }
@@ -392,7 +393,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
             nc->SetDrawingXRel(xRel);
             // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be
             // added between the two nc
-            if (!previousLig && !startsConnection) {
+            if (!previousLig && !hufnagelStart) {
                 xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
             }
         }

--- a/src/calcligatureorneumeposfunctor.cpp
+++ b/src/calcligatureorneumeposfunctor.cpp
@@ -19,6 +19,36 @@
 
 namespace vrv {
 
+static void SetChantLigatureGlyphs(Nc *nc, Nc *previousNc, int pitchDifference, int unit)
+{
+    assert(nc);
+    assert(previousNc);
+
+    nc->m_drawingGlyphs.at(0).m_yOffset = -pitchDifference * unit;
+    previousNc->m_drawingGlyphs.at(0).m_yOffset = pitchDifference * unit;
+
+    // set the glyph for both the current and previous nc
+    switch (pitchDifference) {
+        case -1:
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B9_chantLigaturaDesc2nd;
+            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B4_chantEntryLineAsc2nd;
+            break;
+        case -2:
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BA_chantLigaturaDesc3rd;
+            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B5_chantEntryLineAsc3rd;
+            break;
+        case -3:
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BB_chantLigaturaDesc4th;
+            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B6_chantEntryLineAsc4th;
+            break;
+        case -4:
+            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BC_chantLigaturaDesc5th;
+            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B7_chantEntryLineAsc5th;
+            break;
+        default: break;
+    }
+}
+
 //----------------------------------------------------------------------------
 // CalcLigatureOrNeumePosFunctor
 //----------------------------------------------------------------------------
@@ -239,11 +269,16 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
     int xRel = 0;
     Nc *previousNc = NULL;
     bool previousLig = false;
+    const bool isHufnagel = (staff->m_drawingNotationType == NOTATIONTYPE_neume_hufnagel);
 
-    for (Object *object : ncs) {
+    for (ListOfObjects::const_iterator iter = ncs.begin(); iter != ncs.end(); ++iter) {
 
-        Nc *nc = vrv_cast<Nc *>(object);
+        Nc *nc = vrv_cast<Nc *>(*iter);
         assert(nc);
+
+        ListOfObjects::const_iterator nextIter = iter;
+        ++nextIter;
+        Nc *nextNc = (nextIter != ncs.end()) ? vrv_cast<Nc *>(*nextIter) : NULL;
 
         const bool hasLiquescent = (nc->FindDescendantByType(LIQUESCENT));
         const bool hasOriscus = (nc->FindDescendantByType(ORISCUS));
@@ -257,6 +292,8 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
 
         int pitchDifference = (previousNc) ? nc->PitchOrLocDifferenceTo(previousNc) : 0;
         bool overlapWithPrevious = (pitchDifference == 0) ? false : true;
+        const bool connectsToPrevious = (isHufnagel && previousNc && (nc->GetCon() == ncForm_CON_e));
+        const bool startsConnection = (isHufnagel && nextNc && (nextNc->GetCon() == ncForm_CON_e));
 
         if (hasLiquescent) {
             const bool gabcNoTailsOption = m_doc->GetOptions()->m_liquescentWithoutTails.GetValue();
@@ -304,7 +341,14 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
         else {
             nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E990_chantPunctum;
 
-            if (nc->GetLigated() == BOOLEAN_true) {
+            if (startsConnection) {
+                nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B4_chantEntryLineAsc2nd;
+            }
+            else if (connectsToPrevious) {
+                overlapWithPrevious = false;
+                SetChantLigatureGlyphs(nc, previousNc, pitchDifference, unit);
+            }
+            else if (nc->GetLigated() == BOOLEAN_true) {
                 // This is the first nc of a ligature
                 if (!previousLig) {
                     // Temporarily set a second line glyph
@@ -317,29 +361,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
                     overlapWithPrevious = false;
                     assert(previousNc);
                     previousLig = false;
-                    nc->m_drawingGlyphs.at(0).m_yOffset = -pitchDifference * unit;
-                    previousNc->m_drawingGlyphs.at(0).m_yOffset = pitchDifference * unit;
-
-                    // set the glyph for both the current and previous nc
-                    switch (pitchDifference) {
-                        case -1:
-                            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B9_chantLigaturaDesc2nd;
-                            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B4_chantEntryLineAsc2nd;
-                            break;
-                        case -2:
-                            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BA_chantLigaturaDesc3rd;
-                            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B5_chantEntryLineAsc3rd;
-                            break;
-                        case -3:
-                            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BB_chantLigaturaDesc4th;
-                            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B6_chantEntryLineAsc4th;
-                            break;
-                        case -4:
-                            nc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9BC_chantLigaturaDesc5th;
-                            previousNc->m_drawingGlyphs.at(0).m_fontNo = SMUFL_E9B7_chantEntryLineAsc5th;
-                            break;
-                        default: break;
-                    }
+                    SetChantLigatureGlyphs(nc, previousNc, pitchDifference, unit);
                 }
             }
             // Check if nc is part of a ligature or is an inclinatum
@@ -370,7 +392,7 @@ FunctorCode CalcLigatureOrNeumePosFunctor::VisitNeume(Neume *neume)
             nc->SetDrawingXRel(xRel);
             // The first glyph set the spacing - unless we are starting a ligature, in which case no spacing should be
             // added between the two nc
-            if (!previousLig) {
+            if (!previousLig && !startsConnection) {
                 xRel += m_doc->GetGlyphWidth(nc->m_drawingGlyphs.at(0).m_fontNo, staffSize, false);
             }
         }

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -3651,8 +3651,8 @@ bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementI
 
     if (!m_doc->GetDrawingPage()) {
         LogError("Could not get the drawing page.");
-        m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Could not get the drawing page.");
+        m_editStatus.import("status", "FAILURE");
+        m_editStatus.import("message", "Could not get the drawing page.");
         return false;
     }
 
@@ -3663,8 +3663,8 @@ bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementI
 
     if (firstNc->GetParent() != secondNc->GetParent()) {
         LogError("The selected ncs are not in the same neume.");
-        m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "The selected ncs are not in the same neume.");
+        m_editStatus.import("status", "FAILURE");
+        m_editStatus.import("message", "The selected ncs are not in the same neume.");
         return false;
     }
 
@@ -3672,8 +3672,8 @@ bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementI
     int secondIdx = secondNc->GetIdx();
     if (std::abs(firstIdx - secondIdx) != 1) {
         LogError("The selected ncs are not adjacent.");
-        m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "The selected ncs are not adjacent.");
+        m_editStatus.import("status", "FAILURE");
+        m_editStatus.import("message", "The selected ncs are not adjacent.");
         return false;
     }
 
@@ -3682,8 +3682,8 @@ bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementI
     assert(staff);
     if (staff->m_drawingNotationType != NOTATIONTYPE_neume_hufnagel) {
         LogError("Neume connections are supported only for Hufnagel notation.");
-        m_editInfo.import("status", "FAILURE");
-        m_editInfo.import("message", "Neume connections are supported only for Hufnagel notation.");
+        m_editStatus.import("status", "FAILURE");
+        m_editStatus.import("message", "Neume connections are supported only for Hufnagel notation.");
         return false;
     }
 
@@ -3692,8 +3692,8 @@ bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementI
     if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
     m_doc->GetDrawingPage()->LayOutTranscription(true);
 
-    m_editInfo.import("status", "OK");
-    m_editInfo.import("message", "");
+    m_editStatus.import("status", "OK");
+    m_editStatus.import("message", "");
     return true;
 }
 

--- a/src/editortoolkit_neume.cpp
+++ b/src/editortoolkit_neume.cpp
@@ -246,6 +246,13 @@ bool EditorToolkitNeume::ParseEditorAction(const std::string &json_editorAction)
         }
         LogWarning("Could not parse toggle ligature action");
     }
+    else if (action == "toggleNeumeConnection") {
+        std::vector<std::string> elementIds;
+        if (this->ParseToggleNeumeConnectionAction(json.get<jsonxx::Object>("param"), &elementIds)) {
+            return this->ToggleNeumeConnection(elementIds);
+        }
+        LogWarning("Could not parse toggle neume connection action");
+    }
     else if (action == "changeStaff") {
         std::string elementId;
         if (this->ParseChangeStaffAction(json.get<jsonxx::Object>("param"), &elementId)) {
@@ -3636,6 +3643,60 @@ bool EditorToolkitNeume::ToggleLigature(std::vector<std::string> elementIds)
     return success1 && success2;
 }
 
+bool EditorToolkitNeume::ToggleNeumeConnection(std::vector<std::string> elementIds)
+{
+    assert(elementIds.size() == 2);
+    std::string firstNcId = elementIds[0];
+    std::string secondNcId = elementIds[1];
+
+    if (!m_doc->GetDrawingPage()) {
+        LogError("Could not get the drawing page.");
+        m_editInfo.import("status", "FAILURE");
+        m_editInfo.import("message", "Could not get the drawing page.");
+        return false;
+    }
+
+    Nc *firstNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByID(firstNcId));
+    assert(firstNc);
+    Nc *secondNc = vrv_cast<Nc *>(m_doc->GetDrawingPage()->FindDescendantByID(secondNcId));
+    assert(secondNc);
+
+    if (firstNc->GetParent() != secondNc->GetParent()) {
+        LogError("The selected ncs are not in the same neume.");
+        m_editInfo.import("status", "FAILURE");
+        m_editInfo.import("message", "The selected ncs are not in the same neume.");
+        return false;
+    }
+
+    int firstIdx = firstNc->GetIdx();
+    int secondIdx = secondNc->GetIdx();
+    if (std::abs(firstIdx - secondIdx) != 1) {
+        LogError("The selected ncs are not adjacent.");
+        m_editInfo.import("status", "FAILURE");
+        m_editInfo.import("message", "The selected ncs are not adjacent.");
+        return false;
+    }
+
+    Nc *currentNc = (firstIdx > secondIdx) ? firstNc : secondNc;
+    Staff *staff = vrv_cast<Staff *>(currentNc->GetFirstAncestor(STAFF));
+    assert(staff);
+    if (staff->m_drawingNotationType != NOTATIONTYPE_neume_hufnagel) {
+        LogError("Neume connections are supported only for Hufnagel notation.");
+        m_editInfo.import("status", "FAILURE");
+        m_editInfo.import("message", "Neume connections are supported only for Hufnagel notation.");
+        return false;
+    }
+
+    currentNc->SetCon((currentNc->GetCon() == ncForm_CON_e) ? ncForm_CON_NONE : ncForm_CON_e);
+
+    if (m_doc->IsTranscription() && m_doc->HasFacsimile()) m_doc->SyncFromFacsimileDoc();
+    m_doc->GetDrawingPage()->LayOutTranscription(true);
+
+    m_editInfo.import("status", "OK");
+    m_editInfo.import("message", "");
+    return true;
+}
+
 bool EditorToolkitNeume::ChangeStaff(std::string elementId)
 {
     if (!m_doc->GetDrawingPage()) {
@@ -4304,6 +4365,16 @@ bool EditorToolkitNeume::ParseChangeGroupAction(jsonxx::Object param, std::strin
 }
 
 bool EditorToolkitNeume::ParseToggleLigatureAction(jsonxx::Object param, std::vector<std::string> *elementIds)
+{
+    if (!param.has<jsonxx::Array>("elementIds")) return false;
+    jsonxx::Array array = param.get<jsonxx::Array>("elementIds");
+    for (int i = 0; i < (int)array.size(); ++i) {
+        elementIds->push_back(array.get<jsonxx::String>(i));
+    }
+    return true;
+}
+
+bool EditorToolkitNeume::ParseToggleNeumeConnectionAction(jsonxx::Object param, std::vector<std::string> *elementIds)
 {
     if (!param.has<jsonxx::Array>("elementIds")) return false;
     jsonxx::Array array = param.get<jsonxx::Array>("elementIds");


### PR DESCRIPTION
## Summary

- Render `nc@con="e"` as a connection to the preceding component in `neume.hufnagel`.
- Add a separate `toggleNeumeConnection` editor action.
- Preserve the existing generic neume and square `@ligated` behavior.

## Testing

- Native CMake build passed.
- Hufnagel `@con="e"` renders with the expected ·E9B4–E9BC connection glyphs.
- Hufnagel without `@con` remains unconnected.
- Generic `neume` with `@con="e"` does not trigger Hufnagel rendering.
- Existing square `@ligated="true"` rendering still works.
- A temporary rebase onto the latest `develop` completed without conflicts and passed the same build and CLI smoke tests.
- Previous Neon local WASM integration testing covered toggle/untoggle, save, reopen, and download.

## Font used for visual testing

The Hufnagel font used for visual verification is maintained in the Neon repository: [Hufnagel.woff2 and Hufnagel.xml](https://github.com/DDMAL/Neon/tree/develop/assets/fonts)

The font is not bundled with or required by this Verovio PR.

Fixes #4364