### PR TITLE
Use the note's cross-staff number for its notations in MusicXML import

### DIFF
--- a/src/iomusxml.cpp
+++ b/src/iomusxml.cpp
@@ -3021,6 +3021,8 @@ void MusicXmlInput::ReadMusicXmlNote(
         if (chord) duration = std::min(duration, chord->GetDurPpq());
     }
     const int noteStaffNum = node.child("staff").text().as_int();
+    // Staff the note is actually on (cross-staff aware), for control events anchored to this note
+    const int notationStaffN = (noteStaffNum > 0) ? noteStaffNum + staffOffset : staff->GetN();
     const pugi::xml_node rest = node.child("rest");
     if (m_ppq < 0 && duration && !typeStr.empty()) {
         // if divisions are missing, try to calculate
@@ -3573,7 +3575,7 @@ void MusicXmlInput::ReadMusicXmlNote(
                     m_controlElements.push_back({ m_measureCounts.at(measure), fing });
                     const std::string startID = note ? ("#" + note->GetID()) : m_ID;
                     fing->SetStartid(startID);
-                    fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+                    fing->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
                     fing->SetPlace(
                         fing->AttPlacementRelStaff::StrToStaffrel(technicalChild.attribute("placement").as_string()));
                     fing->AddChild(text);
@@ -3666,7 +3668,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlBreath) {
         Breath *breath = new Breath();
         m_controlElements.push_back({ m_measureCounts.at(measure), breath });
-        breath->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        breath->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         breath->SetPlace(
             breath->AttPlacementRelStaff::StrToStaffrel(xmlBreath.node().attribute("placement").as_string()));
         breath->SetColor(xmlBreath.node().attribute("color").as_string());
@@ -3678,7 +3680,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlCaesura) {
         Caesura *caesura = new Caesura();
         m_controlElements.push_back({ m_measureCounts.at(measure), caesura });
-        caesura->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        caesura->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         caesura->SetPlace(
             caesura->AttPlacementRelStaff::StrToStaffrel(xmlCaesura.node().attribute("placement").as_string()));
         caesura->SetColor(xmlCaesura.node().attribute("color").as_string());
@@ -3693,7 +3695,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlDynam) {
         Dynam *dynam = new Dynam();
         m_controlElements.push_back({ m_measureCounts.at(measure), dynam });
-        dynam->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        dynam->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         dynam->SetStartid(m_ID);
         if (xmlDynam.attribute("id")) dynam->SetID(xmlDynam.attribute("id").as_string());
         // place
@@ -3723,7 +3725,7 @@ void MusicXmlInput::ReadMusicXmlNote(
         Fermata *fermata = new Fermata();
         m_controlElements.push_back({ m_measureCounts.at(measure), fermata });
         fermata->SetStartid(m_ID);
-        fermata->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        fermata->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         if (xmlFermata.attribute("id")) fermata->SetID(xmlFermata.attribute("id").as_string());
         this->ShapeFermata(fermata, xmlFermata);
     }
@@ -3742,7 +3744,7 @@ void MusicXmlInput::ReadMusicXmlNote(
             gliss->SetLform(gliss->AttLineRendBase::StrToLineform(xmlGlissando.attribute("line-type").as_string()));
             gliss->SetN(xmlGlissando.attribute("number").as_string());
             gliss->SetStartid(noteID);
-            gliss->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+            gliss->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
             gliss->SetType(xmlGlissando.name());
             if (xmlGlissando.attribute("id")) gliss->SetID(xmlGlissando.attribute("id").as_string());
             m_glissStack.push_back(gliss);
@@ -3767,7 +3769,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlMordent) {
         Mordent *mordent = new Mordent();
         m_controlElements.push_back({ m_measureCounts.at(measure), mordent });
-        mordent->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        mordent->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         mordent->SetStartid(m_ID);
         // color
         mordent->SetColor(xmlMordent.node().attribute("color").as_string());
@@ -3820,7 +3822,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlExtOrnament) {
         Mordent *mordent = new Mordent();
         m_controlElements.push_back({ m_measureCounts.at(measure), mordent });
-        mordent->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        mordent->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         mordent->SetStartid(m_ID);
         // color
         mordent->SetColor(xmlExtOrnament.node().attribute("color").as_string());
@@ -3838,7 +3840,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlTrill || xmlTrillLine) {
         Trill *trill = new Trill();
         m_controlElements.push_back({ m_measureCounts.at(measure), trill });
-        trill->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        trill->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         trill->SetStartid(m_ID);
         // color
         trill->SetColor(xmlTrill.node().attribute("color").as_string());
@@ -3889,7 +3891,7 @@ void MusicXmlInput::ReadMusicXmlNote(
     if (xmlTurn) {
         Turn *turn = new Turn();
         m_controlElements.push_back({ m_measureCounts.at(measure), turn });
-        turn->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(staff->GetN())));
+        turn->SetStaff(staff->AttNInteger::StrToXsdPositiveIntegerList(std::to_string(notationStaffN)));
         turn->SetStartid(m_ID);
         turn->SetColor(xmlTurn.node().attribute("color").as_string());
         turn->SetPlace(turn->AttPlacementRelStaff::StrToStaffrel(xmlTurn.node().attribute("placement").as_string()));


### PR DESCRIPTION
Fixes #4425. Drafted with an LLM agent (Claude), reviewed and tested as below.

`ReadMusicXmlNote` applies the note's `<staff>` override to the note but stamps every notation control event (fingering, breath, caesura, dynamics, fermata, glissando, mordent, schleifer/haydn, trill, turn) with the layer's staff. This computes the effective staff number once, mirroring the note's own cross-staff logic, and uses it for those ten sites. The queued direction-type elements further down deliberately keep the layer staff.

Verified on the issue's repro measure — the mordent moves from above staff 1 to above staff 2, where it is engraved; a control file with ornaments only on staff-1 notes renders identically:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/olaugh/verovio/attachments/mordent-before-white.png) | ![after](https://raw.githubusercontent.com/olaugh/verovio/attachments/mordent-after-white.png) |

No changes across the official suites (`test-suite.py` on `_tests` + `musicxmlTestSuite`, 777 files, `test-suite-diff.py` reports none) — the suites contain no cross-staff-ornament case; happy to contribute the repro measure as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168bXgjWpuzFPAT6kPNvup2
