### PR TITLE
Guard against empty glyph code

### DIFF
--- a/src/view_element.cpp
+++ b/src/view_element.cpp
@@ -1170,8 +1170,10 @@ void View::DrawMeterSig(DeviceContext *dc, MeterSig *meterSig, Staff *staff, int
 
     if (meterSig->HasSym() || meterSig->HasGlyphNum() || meterSig->HasGlyphName()) {
         const char32_t code = meterSig->GetSymbolGlyph();
-        this->DrawSmuflCode(dc, x, y, code, glyphSize, false);
-        x += m_doc->GetGlyphWidth(code, glyphSize, false);
+        if (code) {
+            this->DrawSmuflCode(dc, x, y, code, glyphSize, false);
+            x += m_doc->GetGlyphWidth(code, glyphSize, false);
+        }
     }
     else if (meterSig->GetForm() == METERFORM_num) {
         x += this->DrawMeterSigFigures(dc, x, y, meterSig, 0, staff);


### PR DESCRIPTION
To fix the crashing part of #4430. This PR ensures that an empty glyph code does not get processed while drawing a meter signature.
