### PR TITLE
Fix page lookup for timed elements

### DIFF
--- a/bindings/go/verovio_test.go
+++ b/bindings/go/verovio_test.go
@@ -82,3 +82,13 @@ func TestLoadDataAndRenderSVG(t *testing.T) {
 		t.Fatal("expected SVG output")
 	}
 }
+
+func TestElementsAtTimeUsesRenderedPage(t *testing.T) {
+	tk := NewToolkitWithResourcePath("../../data")
+	defer tk.Close()
+	tk.SetOptions(`{"breaks":"encoded"}`)
+	tk.LoadData(`<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0"><music><body><mdiv><score><scoreDef><staffGrp><staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4"/></staffGrp></scoreDef><section><measure n="1"><staff n="1"><layer n="1"><note dur="4" oct="4" pname="c"/><note dur="4" oct="4" pname="d"/><note dur="4" oct="4" pname="e"/><note dur="4" oct="4" pname="f"/></layer></staff></measure><measure n="2"><staff n="1"><layer n="1"><note dur="4" oct="4" pname="g"/><note dur="4" oct="4" pname="a"/><note dur="4" oct="4" pname="b"/><note dur="4" oct="5" pname="c"/></layer></staff></measure><pb/><measure n="3"><staff n="1"><layer n="1"><note dur="4" oct="5" pname="c"/><note dur="4" oct="4" pname="b"/><note dur="4" oct="4" pname="a"/><note dur="4" oct="4" pname="g"/></layer></staff></measure></section></score></mdiv></body></music></mei>`)
+	if got := tk.ElementsAtTime(4500); !strings.Contains(got, `"page":2`) {
+		t.Fatalf("expected page 2, got %s", got)
+	}
+}

--- a/bindings/go/verovio_test.go
+++ b/bindings/go/verovio_test.go
@@ -82,13 +82,3 @@ func TestLoadDataAndRenderSVG(t *testing.T) {
 		t.Fatal("expected SVG output")
 	}
 }
-
-func TestElementsAtTimeUsesRenderedPage(t *testing.T) {
-	tk := NewToolkitWithResourcePath("../../data")
-	defer tk.Close()
-	tk.SetOptions(`{"breaks":"encoded"}`)
-	tk.LoadData(`<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0"><music><body><mdiv><score><scoreDef><staffGrp><staffDef n="1" lines="5" clef.shape="G" clef.line="2" meter.count="4" meter.unit="4"/></staffGrp></scoreDef><section><measure n="1"><staff n="1"><layer n="1"><note dur="4" oct="4" pname="c"/><note dur="4" oct="4" pname="d"/><note dur="4" oct="4" pname="e"/><note dur="4" oct="4" pname="f"/></layer></staff></measure><measure n="2"><staff n="1"><layer n="1"><note dur="4" oct="4" pname="g"/><note dur="4" oct="4" pname="a"/><note dur="4" oct="4" pname="b"/><note dur="4" oct="5" pname="c"/></layer></staff></measure><pb/><measure n="3"><staff n="1"><layer n="1"><note dur="4" oct="5" pname="c"/><note dur="4" oct="4" pname="b"/><note dur="4" oct="4" pname="a"/><note dur="4" oct="4" pname="g"/></layer></staff></measure></section></score></mdiv></body></music></mei>`)
-	if got := tk.ElementsAtTime(4500); !strings.Contains(got, `"page":2`) {
-		t.Fatalf("expected page 2, got %s", got)
-	}
-}

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -1946,8 +1946,15 @@ std::string Toolkit::GetElementsAtTime(int millisec)
 
     // Get the pageNo from the first note (if any)
     int pageNo = -1;
-    Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
-    if (page) pageNo = page->GetIdx() + 1;
+    if (m_midiDoc == &m_doc) {
+        Page *page = vrv_cast<Page *>(measure->GetFirstAncestor(PAGE));
+        if (page) pageNo = page->GetIdx() + 1;
+    }
+    else {
+        const std::string notatedId = this->GetNotatedIdForElement(measure->GetID());
+        const int notatedPageNo = this->GetPageWithElement(notatedId);
+        if (notatedPageNo > 0) pageNo = notatedPageNo;
+    }
 
     NoteOrRestOnsetOffsetComparison matchTime(millisec - measureTimeOffset);
     ListOfObjects notesOrRests;


### PR DESCRIPTION
Fixes #4395.

## What changed

When the default expansion behavior creates a separate MIDI document, `GetElementsAtTime()` now maps the timed measure back to its notated ID and asks the rendered document for that element's page. When the MIDI and rendered documents are the same object, it retains the direct ancestor lookup.

This prevents the unpaginated MIDI document from reporting page 1 for every timestamp while preserving the existing behavior for `expandAlways` and `expandNever`.

A Go binding regression test loads an encoded two-page score and verifies that a timestamp after the page break reports page 2.

## Validation

- `cmake --build build/python --config Release`
- Local Python binding reproduction: pages `1,2,2` at timestamps before and after the encoded page break
- `gofmt` on the Go regression test
- `git diff --check`

The Go test is included in the repository's Ubuntu CI job. The local Windows Go runner could not execute cgo because GCC is not installed, so upstream CI will provide the independent binding-suite result.