### PR TITLE
Fixed: Update the tag pattern to only include version-*

### DIFF
--- a/.github/workflows/python-ci-wheel.yml
+++ b/.github/workflows/python-ci-wheel.yml
@@ -3,7 +3,7 @@ name: Python Wheel Build
 on:
   push:
     branches: [develop-pypi, master]
-    tags: ["v*", "version-*"]
+    tags: ["version-*"]
   workflow_dispatch:
 
 permissions:
@@ -261,7 +261,7 @@ jobs:
   publish_pypi:
     name: Publish to PyPI
     needs: [validate, validate_linux_abi3_runtime, validate_macos_arm64_abi3_runtime, validate_windows_abi3_runtime]
-    if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/version-')
+    if: github.event_name == 'push' && github.event.created && startsWith(github.ref, 'refs/tags/version-')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -284,7 +284,7 @@ jobs:
           from pathlib import Path
 
           tag = os.environ["GITHUB_REF_NAME"]
-          tag_version = re.sub(r"^(?:v|version-)", "", tag)
+          tag_version = re.sub(r"^version-", "", tag)
           text = Path("include/vrv/vrvdef.h").read_text(encoding="utf-8")
           values = dict(re.findall(r"#define (VERSION_(?:MAJOR|MINOR|REVISION|DEV)) ([A-Za-z0-9]+)", text))
           header_version = f"{values['VERSION_MAJOR']}.{values['VERSION_MINOR']}.{values['VERSION_REVISION']}"


### PR DESCRIPTION
Previously the workflow would also accept v*, but this is not used in Verovio and was causing problems when running the workflow. This removes v* and tightens up the event trigger to only publish to PyPI when a new tag is created on master.