### PR TITLE
Fix stems of a <beamSpan> across <sb>

### DIFF
--- a/src/view_page.cpp
+++ b/src/view_page.cpp
@@ -1756,8 +1756,17 @@ void View::DrawMeasureChildren(DeviceContext *dc, Object *parent, Measure *measu
     assert(measure);
     assert(system);
 
-    ListOfObjects objects = parent->FindAllDescendantsByType(BEAMSPAN, false);
-    for (Object *element : objects) {
+    ListOfObjects beamSpans = parent->FindAllDescendantsByType(BEAMSPAN, false);
+    // A beamSpan reaches into measures it is not encoded in, and its stems are drawn with them
+    for (const Object *child : parent->GetChildren()) {
+        if (!child->Is(STAFF)) continue;
+        const Staff *staff = vrv_cast<const Staff *>(child);
+        for (Object *spanning : staff->m_timeSpanningElements) {
+            if (spanning->Is(BEAMSPAN)) beamSpans.push_back(spanning);
+        }
+    }
+
+    for (Object *element : beamSpans) {
         BeamSpan *beamSpan = vrv_cast<BeamSpan *>(element);
         BeamSpanSegment *segment = beamSpan->GetSegmentForSystem(system);
         if (segment) {


### PR DESCRIPTION
A `beamSpan` broken by a system break keeps the stems of its continuation from the layout pass, so they no longer meet the beam drawn for that system.

<img width="2400" height="629" alt="before" src="https://github.com/user-attachments/assets/d5ed6879-f95c-4434-a1f4-0f64a47f1c58" />

Fix: `View::DrawMeasureChildren` also takes the beamSpans reaching into a measure through its staves, not only those encoded in it. The stem correctly meets the beam:

<img width="2400" height="629" alt="after" src="https://github.com/user-attachments/assets/d1519301-9243-41cb-9b68-8ff1a105927f" />

Here's a test file for reproducing the issue:
<details><summary>beamspan-sb.mei</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="6.0-dev">
   <meiHead>
      <fileDesc>
         <titleStmt>
            <title>Beam span</title>
         </titleStmt>
         <pubStmt>
            <respStmt>
               <persName role="encoder">Niels Pfeffer</persName>
            </respStmt>
            <date isodate="2026-08-29" />
         </pubStmt>
         <seriesStmt>
            <title>Verovio test suite</title>
         </seriesStmt>
         <notesStmt>
            <annot>A beamSpan broken by a system break. The stems on the system it continues on have to reach the beam of that system.</annot>
         </notesStmt>
      </fileDesc>
      <extMeta>{ "breaks": "encoded" }</extMeta>
   </meiHead>
   <music>
      <body>
         <mdiv>
            <score>
               <scoreDef midi.bpm="120" meter.count="4" meter.unit="4">
                  <staffGrp>
                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                  </staffGrp>
               </scoreDef>
               <section>
                  <measure n="1">
                     <staff n="1">
                        <layer n="1">
                           <note dur="4" oct="4" pname="c" />
                           <note dur="4" oct="4" pname="d" />
                           <note dur="4" oct="4" pname="e" />
                           <note xml:id="s01" dur="8" oct="4" pname="g" />
                           <note xml:id="s02" dur="8" oct="4" pname="a" />
                        </layer>
                     </staff>
                     <beamSpan plist="#s01 #s02 #s03 #s04" startid="#s01" endid="#s04" />
                  </measure>
                  <sb />
                  <measure n="2">
                     <staff n="1">
                        <layer n="1">
                           <note xml:id="s03" dur="8" oct="4" pname="b" />
                           <note xml:id="s04" dur="8" oct="5" pname="c" />
                           <note dur="4" oct="4" pname="g" />
                           <note dur="2" oct="4" pname="e" />
                        </layer>
                     </staff>
                  </measure>
                  <sb />
                  <measure n="3" right="end">
                     <staff n="1">
                        <layer n="1">
                           <note dur="1" oct="4" pname="c" />
                        </layer>
                     </staff>
                  </measure>
               </section>
            </score>
         </mdiv>
      </body>
   </music>
</mei>
```
</details>

**Disclosure**: I used Claude Code for locating and fixing the issue. 